### PR TITLE
Fix insight provider handling and ensure full coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     tests/*
+    tests_strict/*
     providers/*
     llm.py
 

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import time
@@ -376,7 +377,8 @@ async def api_v1_insight(req: InsightRequest):
         )
 
     try:
-        txt = await provider.generate(req.text)
+        result = provider.generate(req.text)
+        txt = await result if inspect.isawaitable(result) else result
     except Exception:
         raise HTTPException(
             status_code=503,
@@ -390,8 +392,8 @@ async def api_v1_insight(req: InsightRequest):
 
 @app.post("/insight")
 async def insight(req: InsightRequest):
-    flag = str(os.getenv("FEATURE_INSIGHT", "")).strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    flag = str(os.getenv("FEATURE_INSIGHT", "true")).strip().lower()
+    if flag in {"0", "false", "no", "off"}:
         raise HTTPException(status_code=503, detail="insight feature disabled")
 
     if not os.getenv("LLM_PROVIDER", "").strip():
@@ -422,7 +424,8 @@ async def insight(req: InsightRequest):
         )
 
     try:
-        txt = await provider.generate(req.text)
+        result = provider.generate(req.text)
+        txt = await result if inspect.isawaitable(result) else result
     except Exception:
         raise HTTPException(
             status_code=503,

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -15,6 +15,12 @@ def test_health_ok():
     assert isinstance(data, dict) and data.get("status") == "ok"
 
 
+def test_root_page_smoke():
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "<html" in r.text.lower()
+
+
 def test_bmi_smoke_ok():
     payload = {
         "height_m": 1.70,

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -7,7 +7,7 @@ with random inputs.
 
 import pytest
 from fastapi.testclient import TestClient
-from hypothesis import assume, given
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
 try:
@@ -149,6 +149,7 @@ def test_api_bmi_property(weight, height):
     assert data["bmi"] > 0
 
 
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(text=st.text(min_size=1, max_size=100))
 def test_api_insight_property(monkeypatch, text):
     """Test /api/v1/insight endpoint with random text inputs."""


### PR DESCRIPTION
## Summary
- allow insight endpoints to work with sync or async providers and enable insight feature unless explicitly disabled
- add root page smoke test and suppress Hypothesis fixture health check
- exclude strict test suite from coverage reporting

## Testing
- `pre-commit run --files app.py tests/test_property_based.py tests/test_api_smoke.py .coveragerc`
- `pytest --maxfail=1 --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68b554ea60148333a9065aaf0a7a1ce1

## Summary by Sourcery

Enable more flexible insight provider handling and bolster test coverage.

Enhancements:
- Support both synchronous and asynchronous results from provider.generate in insight endpoints
- Treat FEATURE_INSIGHT as enabled by default and disable it only when explicitly set to false
- Suppress Hypothesis function-scoped fixture health check in property-based insight test

Tests:
- Add a smoke test to verify the root (/) page
- Exclude the strict test suite from coverage reporting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endpoints now handle both synchronous and asynchronous provider responses seamlessly.
  * Insight feature is enabled by default; can be disabled via common falsey values in the environment.

* **Tests**
  * Added a smoke test for the root page to verify basic availability and HTML response.
  * Stabilized a property-based test by adjusting test settings to work with function-scoped fixtures.

* **Chores**
  * Updated coverage configuration to exclude an additional test directory, keeping coverage reports focused on application code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->