### PR TITLE
Potential fix for code scanning alert no. 34: Information exposure through an exception

### DIFF
--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -1132,9 +1132,10 @@ def synthesize_weekly_recipes(request: Dict[str, Any]) -> Dict[str, Any]:
             "message": "Weekly recipes synthesized successfully",
         }
     except Exception as e:
+        logging.exception("Exception during recipe synthesis in /recipes/weekly:")
         return {
             "status": "error",
-            "message": f"Recipe synthesis failed: {str(e)}",
+            "message": "An internal error occurred during recipe synthesis.",
             "weekly_recipes": {},
             "total_recipes": 0,
             "echo": request,


### PR DESCRIPTION
Potential fix for [https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/34](https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/34)

To fix this issue, suppress details of the exception in the API response and replace the exposed message with a generic error string. You should still log the full exception and/or stack trace on the server side for debugging purposes, but the client should only be told that an internal error occurred. Specifically, in app/routers/vip.py, lines 1134-1141, replace the `"message"` value so that it does not use `str(e)` and instead uses a generic message (e.g., "An internal error occurred during recipe synthesis"). Before doing so, ensure the full stack trace or error is logged (using Python's logging module) for developer visibility. You may need to import the logging module if not already imported. 

No other functional changes are needed: only the error message in the returned dict and a server-side log statement need to be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Suppress detailed exception information in the weekly recipe synthesis endpoint and replace it with a generic error message while logging the full stack trace internally

Bug Fixes:
- Prevent internal exception details from being exposed to clients by returning a generic error message

Enhancements:
- Add a server-side logging.exception call to capture the full exception and stack trace