### PR TITLE
ui: add Liquid Glass cards to weekly plan and shoplist

### DIFF
--- a/frontend/frontend/src/components/GlassCard.tsx
+++ b/frontend/frontend/src/components/GlassCard.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+/**
+ * RU: Универсальная «стеклянная» карточка под iOS Liquid Glass.
+ * EN: Reusable glass-like card (Liquid Glass style).
+ */
+export default function GlassCard({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={`rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl shadow-[0_8px_30px_rgba(0,0,0,0.12)] ${className}`}
+      role="group"
+      aria-label="Content card"
+    >
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}

--- a/frontend/frontend/src/components/__tests__/GlassCard.test.tsx
+++ b/frontend/frontend/src/components/__tests__/GlassCard.test.tsx
@@ -1,0 +1,17 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import GlassCard from "../GlassCard";
+
+describe("GlassCard", () => {
+  it("renders children without crashing", () => {
+    render(
+      <GlassCard>
+        <div>hello</div>
+      </GlassCard>
+    );
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+});

--- a/frontend/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { components, paths } from "../../api/schema";
 import { fetchJson } from "../../api/client";
+import GlassCard from "../../components/GlassCard";
 
 type SignedLink = {
   relative: string;
@@ -171,61 +172,66 @@ export default function WeeklyPlanViewer() {
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Мой недельный план</h2>
-        <div className="flex gap-2">
-          <button
-            type="button"
-            className="border rounded-xl px-3 py-2 text-sm"
-            onClick={() => handleDownload("/api/v1/plan/week/export.csv", "week_plan.csv")}
-          >
-            Export Week CSV
-          </button>
-          <button
-            type="button"
-            className="border rounded-xl px-3 py-2 text-sm"
-            onClick={() => handleDownload("/api/v1/plan/week/export.pdf", "week_plan.pdf")}
-          >
-            Export Week PDF
-          </button>
-          <button
-            type="button"
-            className="border rounded-xl px-3 py-2 text-sm"
-            onClick={openSheetsHelp}
-            title="Откроет пустой Google Sheets"
-          >
-            Open in Google Sheets
-          </button>
-          <button
-            type="button"
-            className="border rounded-xl px-3 py-2 text-sm"
-            onClick={copyLink}
-            title="Скопировать прямую CSV-ссылку"
-          >
-            Copy CSV Link
-          </button>
-          <button
-            type="button"
-            className="border rounded-xl px-3 py-2 text-sm"
-            onClick={openPrivateCsv}
-          >
-            Open Private CSV
-          </button>
+      <GlassCard>
+        <div className="flex flex-wrap items-center justify-between gap-3 text-white drop-shadow-sm">
+          <h2 className="text-xl font-semibold">Мой недельный план</h2>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="border rounded-xl px-3 py-2 text-sm"
+              onClick={() => handleDownload("/api/v1/plan/week/export.csv", "week_plan.csv")}
+            >
+              Export Week CSV
+            </button>
+            <button
+              type="button"
+              className="border rounded-xl px-3 py-2 text-sm"
+              onClick={() => handleDownload("/api/v1/plan/week/export.pdf", "week_plan.pdf")}
+            >
+              Export Week PDF
+            </button>
+            <button
+              type="button"
+              className="border rounded-xl px-3 py-2 text-sm"
+              onClick={openSheetsHelp}
+              title="Откроет пустой Google Sheets"
+            >
+              Open in Google Sheets
+            </button>
+            <button
+              type="button"
+              className="border rounded-xl px-3 py-2 text-sm"
+              onClick={copyLink}
+              title="Скопировать прямую CSV-ссылку"
+            >
+              Copy CSV Link
+            </button>
+            <button
+              type="button"
+              className="border rounded-xl px-3 py-2 text-sm"
+              onClick={openPrivateCsv}
+            >
+              Open Private CSV
+            </button>
+          </div>
         </div>
-      </div>
-      {hint && (
-        <div className="text-sm opacity-80">
-          {hint}
-          {lastSignedLink && (
-            <div>
-              Приватная ссылка: <code>{lastSignedLink}</code>
-            </div>
-          )}
-        </div>
-      )}
-      {dailyMenus.length === 0 && <div className="opacity-70">Пока пусто.</div>}
-      <ul className="space-y-4">
-        {dailyMenus.map((menu, idx) => {
+        {hint && (
+          <div className="mt-3 text-sm text-white/80">
+            {hint}
+            {lastSignedLink && (
+              <div>
+                Приватная ссылка: <code>{lastSignedLink}</code>
+              </div>
+            )}
+          </div>
+        )}
+      </GlassCard>
+      <GlassCard>
+        {dailyMenus.length === 0 ? (
+          <div className="opacity-80">Пока пусто.</div>
+        ) : (
+          <ul className="space-y-4">
+            {dailyMenus.map((menu, idx) => {
           const day = menu as UnknownRecord;
           const dayTitle =
             typeof day.date === "string"
@@ -245,7 +251,7 @@ export default function WeeklyPlanViewer() {
             : [];
 
           return (
-            <li key={dayTitle} className="border rounded-2xl p-4 space-y-2">
+            <li key={dayTitle} className="border border-white/15 rounded-2xl bg-white/5 p-4 space-y-2 backdrop-blur-sm">
               <div className="flex items-center justify-between">
                 <div className="font-medium">{dayTitle}</div>
                 {typeof dayEnergy === "number" && (
@@ -290,7 +296,10 @@ export default function WeeklyPlanViewer() {
                   const items = rawItems.length > 0 ? rawItems : fallbackItem;
 
                   return (
-                    <li key={`${mealName}-${mi}`} className="rounded-xl border p-3">
+                    <li
+                      key={`${mealName}-${mi}`}
+                      className="rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-sm"
+                    >
                       <div className="flex items-center justify-between">
                         <div className="font-medium">{mealName}</div>
                         {typeof mealEnergy === "number" && (
@@ -335,7 +344,9 @@ export default function WeeklyPlanViewer() {
             </li>
           );
         })}
-      </ul>
+          </ul>
+        )}
+      </GlassCard>
     </div>
   );
 }

--- a/frontend/frontend/src/features/shoplist/ShoplistPreview.tsx
+++ b/frontend/frontend/src/features/shoplist/ShoplistPreview.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { fetchJson } from "../../api/client";
+import GlassCard from "../../components/GlassCard";
 
 type ShopItem = {
   id?: string;
@@ -100,65 +101,72 @@ export default function ShoplistPreview() {
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Список покупок</h2>
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="opacity-70">
-            {data.store ? `Магазин: ${data.store}` : ""}
-            {typeof data.total_estimated === "number" && (
-              <>
-                {data.store ? " • " : ""}≈ {data.total_estimated}
-                {data.currency ? ` ${data.currency}` : ""}
-              </>
-            )}
-          </span>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => handleDownload("csv")}
-              disabled={downloading === "csv"}
-              className="border rounded-xl px-3 py-2 text-sm"
-            >
-              {downloading === "csv" ? "Скачиваем CSV…" : "Export CSV"}
-            </button>
-            <button
-              type="button"
-              onClick={() => handleDownload("pdf")}
-              disabled={downloading === "pdf"}
-              className="border rounded-xl px-3 py-2 text-sm"
-            >
-              {downloading === "pdf" ? "Скачиваем PDF…" : "Export PDF"}
-            </button>
+      <GlassCard>
+        <div className="flex flex-wrap items-center justify-between gap-3 text-white drop-shadow-sm">
+          <h2 className="text-xl font-semibold">Список покупок</h2>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="opacity-80">
+              {data.store ? `Магазин: ${data.store}` : ""}
+              {typeof data.total_estimated === "number" && (
+                <>
+                  {data.store ? " • " : ""}≈ {data.total_estimated}
+                  {data.currency ? ` ${data.currency}` : ""}
+                </>
+              )}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => handleDownload("csv")}
+                disabled={downloading === "csv"}
+                className="border rounded-xl px-3 py-2 text-sm"
+              >
+                {downloading === "csv" ? "Скачиваем CSV…" : "Export CSV"}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDownload("pdf")}
+                disabled={downloading === "pdf"}
+                className="border rounded-xl px-3 py-2 text-sm"
+              >
+                {downloading === "pdf" ? "Скачиваем PDF…" : "Export PDF"}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-      {downloadError && (
-        <div className="text-sm text-red-600">Ошибка загрузки: {downloadError}</div>
-      )}
-      <ul className="space-y-3">
-        {groups.map((group, gi) => (
-          <li key={group.aisle ?? gi} className="border rounded-2xl p-4">
-            <div className="font-medium">{group.aisle ?? "Категория"}</div>
-            <ul className="mt-2 grid gap-1">
-              {(group.items ?? []).map((item, ii) => (
-                <li key={item.id ?? `${item.name}-${ii}`} className="text-sm">
-                  • {item.name ?? "—"}
-                  {typeof item.qty === "number" && (
-                    <span>
-                      {" "}— {item.qty}
-                      {item.unit ? ` ${item.unit}` : ""}
-                    </span>
-                  )}
-                  {item.note && <span className="opacity-60"> ({item.note})</span>}
-                </li>
-              ))}
-              {(!group.items || group.items.length === 0) && (
-                <li className="text-sm opacity-60">Нет позиций</li>
-              )}
-            </ul>
-          </li>
-        ))}
-      </ul>
+        {downloadError && (
+          <div className="mt-3 text-sm text-red-300">Ошибка загрузки: {downloadError}</div>
+        )}
+      </GlassCard>
+      <GlassCard>
+        <ul className="space-y-3">
+          {groups.map((group, gi) => (
+            <li
+              key={group.aisle ?? gi}
+              className="border border-white/15 rounded-2xl bg-white/5 p-4 backdrop-blur-sm"
+            >
+              <div className="font-medium">{group.aisle ?? "Категория"}</div>
+              <ul className="mt-2 grid gap-1">
+                {(group.items ?? []).map((item, ii) => (
+                  <li key={item.id ?? `${item.name}-${ii}`} className="text-sm">
+                    • {item.name ?? "—"}
+                    {typeof item.qty === "number" && (
+                      <span>
+                        {" "}— {item.qty}
+                        {item.unit ? ` ${item.unit}` : ""}
+                      </span>
+                    )}
+                    {item.note && <span className="opacity-60"> ({item.note})</span>}
+                  </li>
+                ))}
+                {(!group.items || group.items.length === 0) && (
+                  <li className="text-sm opacity-60">Нет позиций</li>
+                )}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </GlassCard>
     </div>
   );
 }

--- a/frontend/frontend/src/index.css
+++ b/frontend/frontend/src/index.css
@@ -82,3 +82,15 @@ select:focus {
   background-color: var(--surface-dark);
   box-shadow: var(--shadow-soft);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid #339FFF;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

Briefly describe the change and motivation.

## Checklist

- [ ] Tests pass locally: `pytest -q` (no new failures)
- [ ] Lint passes: `flake8 .` (or fixes applied)
- [ ] Updated docs/comments if behavior changed
- [ ] No unrelated changes mixed into this PR

## Notes

Link related issue(s), PR(s), or context.

## Summary by Sourcery

Introduce a reusable GlassCard component and refactor the weekly plan and shoplist views to use glass-style cards, improve global CSS accessibility with reduced-motion and focus-visible support, and add tests for the new component.

New Features:
- Introduce GlassCard component for Liquid Glass-style UI cards
- Wrap weekly plan and shoplist sections in glass cards with updated styling
- Add CSS media query for reduced-motion preference and focus-visible outline support

Enhancements:
- Apply backdrop blur, border, and drop-shadow styling to menus and list items using GlassCard

Tests:
- Add unit tests for GlassCard component