### PR TITLE
chore(frontend): add package.json for Vite + React + TS setup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pulseplate-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.8",
+    "vitest": "^3.2.4"
+  }
+}


### PR DESCRIPTION
## Summary
Добавлен `frontend/package.json` для запуска фронтенда на **Vite + React + TypeScript**.

## Motivation
Ранее в `frontend/` отсутствовал `package.json`, из-за этого `npm run dev` не работал. Этот PR создаёт минимальную конфигурацию, чтобы поднять дев-сервер и запускать тесты (vitest).

## Changes
- `frontend/package.json`:
  - scripts: `"dev"`, `"build"`, `"preview"`, `"test"`
  - deps: `react`, `react-dom`
  - devDeps: `vite`, `vitest`, `@vitejs/plugin-react`, `typescript`, `@types/react`, `@types/react-dom`

## How to Test
1. `cd frontend && npm install`
2. `npm run dev` → dev-сервер поднимается (http://localhost:5173)
3. `npx vitest run src/components/__tests__/GlassCard.test.tsx` → тест проходит

## Risks & Rollback
- Риск: минимальный, затрагивается только фронтенд-скриптинг.
- Откат: `git revert <merge-commit>`.

## Checklist
- [x] CI проходит (линт/тесты/coverage)
- [x] Добавлены/обновлены скрипты npm
- [x] Локально проверено `npm run dev`
- [x] Описание PR заполнено

