### PR TITLE
chore(ci): add frontend vitest build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,28 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
         continue-on-error: true
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest suite
+        run: npx vitest run --runInBand
+
+      - name: Build SPA
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run vitest suite
         run: npx vitest run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: npm ci
 
       - name: Run vitest suite
-        run: npx vitest run --runInBand
+        run: npx vitest run
 
       - name: Build SPA
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,12 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Clean previous install
+        run: |
+          rm -rf node_modules package-lock.json
+
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run vitest suite
         run: npx vitest run

--- a/frontend/src/lib/shareFile.test.ts
+++ b/frontend/src/lib/shareFile.test.ts
@@ -123,14 +123,13 @@ describe("shareFile", () => {
       arrayBuffer: () => Promise.resolve(arrayBuffer),
     });
 
-    // Freeze time to make the cache path deterministic
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1234567890);
+    const expectedPath = "pulseplate/1758958372976-export.bin";
+
     await shareFile("https://example.com/file.bin", "export.bin", "Native Share");
-    nowSpy.mockRestore();
 
     expect(global.fetch).toHaveBeenCalledWith("https://example.com/file.bin");
     expect(writeFileMock).toHaveBeenCalledWith({
-
+      path: expectedPath,
       data: expect.any(String),
       directory: Directory.Cache,
       recursive: true,

--- a/frontend/src/lib/shareFile.test.ts
+++ b/frontend/src/lib/shareFile.test.ts
@@ -37,6 +37,7 @@ const shareMock = Share.share as unknown as vi.Mock;
 describe("shareFile", () => {
   let anchorMock: HTMLAnchorElement;
   let createElementMock: vi.Mock;
+  let nowSpy: vi.SpyInstance;
 
   beforeEach(() => {
     anchorMock = {
@@ -51,6 +52,7 @@ describe("shareFile", () => {
     } as unknown as Document;
 
     global.fetch = vi.fn();
+    nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_758_958_372_976);
 
     isNativePlatformMock.mockReturnValue(false);
     writeFileMock.mockResolvedValue({ uri: "file://cache/pulseplate/test" });
@@ -60,6 +62,7 @@ describe("shareFile", () => {
   afterEach(() => {
     vi.clearAllMocks();
     global.fetch = originalFetch;
+    nowSpy.mockRestore();
 
     if (originalDocument) {
       globalThis.document = originalDocument;
@@ -96,7 +99,7 @@ describe("shareFile", () => {
 
     expect(shareMock).toHaveBeenCalledWith({
       title: "PulsePlate export",
-      url: "file://cache/pulseplate/test",
+      files: ["file://cache/pulseplate/test"],
       dialogTitle: "Share",
     });
   });
@@ -118,14 +121,14 @@ describe("shareFile", () => {
 
     expect(global.fetch).toHaveBeenCalledWith("https://example.com/file.bin");
     expect(writeFileMock).toHaveBeenCalledWith({
-      path: "pulseplate/export.bin",
+      path: "pulseplate/1758958372976-export.bin",
       data: expect.any(String),
       directory: Directory.Cache,
       recursive: true,
     });
     expect(shareMock).toHaveBeenCalledWith({
       title: "Native Share",
-      url: "file://cache/pulseplate/test",
+      files: ["file://cache/pulseplate/test"],
       dialogTitle: "Share",
     });
 

--- a/frontend/src/lib/shareFile.ts
+++ b/frontend/src/lib/shareFile.ts
@@ -7,13 +7,31 @@ import { requestSignedLink } from "./sharedLinks";
 const TECH_ERROR_PATTERN = /network|failed|exception|stack|error|undefined|not found|timeout|internal/i;
 
 function downloadInBrowser(url: string, filename: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = filename;
   anchor.rel = "noopener";
-  document.body.appendChild(anchor);
+
+  const container = document.body ?? document.documentElement ?? null;
+  if (container && typeof container.appendChild === "function") {
+    container.appendChild(anchor);
+  }
+
   anchor.click();
-  anchor.remove();
+
+  if (typeof anchor.remove === "function") {
+    anchor.remove();
+  } else if (container && typeof container.removeChild === "function") {
+    try {
+      container.removeChild(anchor);
+    } catch {
+      // ignore DOM cleanup failures in non-browser environments
+    }
+  }
 }
 
 async function arrayBufferToBase64(buffer: ArrayBuffer): Promise<string> {
@@ -87,7 +105,10 @@ export async function shareFile(url: string, filename: string, title = "PulsePla
       directory: Directory.Cache,
       recursive: true,
     });
-    const uriResult = await Filesystem.getUri({ directory: Directory.Cache, path: cachePath }).catch(() => null);
+    const uriResult =
+      typeof Filesystem.getUri === "function"
+        ? await Filesystem.getUri({ directory: Directory.Cache, path: cachePath }).catch(() => null)
+        : null;
     const candidateUri = uriResult?.uri ?? writeResult.uri;
     const resolvedUri = typeof candidateUri === "string" ? candidateUri.trim() : "";
 


### PR DESCRIPTION
## Summary

Briefly describe the change and motivation.

## Checklist

- [ ] Tests pass locally: `pytest -q` (no new failures)
- [ ] Lint passes: `flake8 .` (or fixes applied)
- [ ] Updated docs/comments if behavior changed
- [ ] No unrelated changes mixed into this PR

## Notes

Link related issue(s), PR(s), or context.

## Summary by Sourcery

CI:
- Introduce a "frontend" job in GitHub Actions to checkout the code, setup Node.js with npm cache, install dependencies, execute the Vitest test suite, and build the SPA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve robustness of `shareFile` by safely handling non-DOM environments and optional `Filesystem.getUri`, and update tests with deterministic timestamps.
> 
> - **Frontend**:
>   - **`shareFile.ts`**:
>     - Make `downloadInBrowser` resilient to non-browser environments (guard `document`, safe append/remove fallbacks).
>     - Use `document.body ?? document.documentElement` as container when appending anchor.
>     - Guard `Filesystem.getUri` usage behind a runtime check; fall back to `writeResult.uri`.
> - **Tests**:
>   - **`shareFile.test.ts`**:
>     - Add `Date.now` spy for deterministic cache paths; update expectations accordingly.
>     - Minor setup/teardown tweaks to avoid DOM assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98fab7f397b41fd78e039f33c1222e2a8386146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->