### PR TITLE
chore(ci): pre-commit autoupdate; apply black reformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^cache/
@@ -12,14 +12,14 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.9.0
     hooks:
       - id: black
         language_version: python3
         args: [--line-length=100]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.13.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -28,7 +28,7 @@ repos:
     # Re-enabled with narrowed scope to avoid legacy type errors elsewhere.
     # Follow-up: broaden coverage to entire codebase after fixing types.
     # Task: "Expand mypy coverage beyond routers once types are fixed".
-    rev: v1.11.2
+    rev: v1.18.2
     hooks:
       - id: mypy
         args:

--- a/app.py
+++ b/app.py
@@ -1339,9 +1339,9 @@ class WeeklyPlanFlexibleRequest(BaseModel):
     surplus_pct: Optional[float] = None
     bodyfat: Optional[float] = None
     diet_flags: Optional[set[DietFlag]] = None
-    life_stage: Optional[
-        Literal["child", "teen", "adult", "pregnant", "lactating", "elderly"]
-    ] = "adult"
+    life_stage: Optional[Literal["child", "teen", "adult", "pregnant", "lactating", "elderly"]] = (
+        "adult"
+    )
     lang: Optional[str] = "en"
 
 

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -65,9 +65,9 @@ class WeekPlanRequest(BaseModel):
     age: Optional[int] = Field(None, gt=10, lt=90)
     height_cm: Optional[int] = Field(None, gt=100, lt=220)
     weight_kg: Optional[int] = Field(None, gt=30, lt=300)
-    activity: Optional[
-        Literal["sedentary", "light", "moderate", "active", "very_active"]
-    ] = "moderate"
+    activity: Optional[Literal["sedentary", "light", "moderate", "active", "very_active"]] = (
+        "moderate"
+    )
     goal: Optional[Literal["loss", "maintain", "gain"]] = "maintain"
     diet_flags: List[str] = Field(default_factory=list)
     lang: Language = "en"

--- a/core/bmi_extras.py
+++ b/core/bmi_extras.py
@@ -211,11 +211,7 @@ def stage_obesity(
     bmi_category = (
         "obese"
         if bmi >= 30
-        else "overweight"
-        if bmi >= 25
-        else "normal"
-        if bmi >= 18.5
-        else "underweight"
+        else "overweight" if bmi >= 25 else "normal" if bmi >= 18.5 else "underweight"
     )
 
     return {

--- a/core/bmi_extras_pro.py
+++ b/core/bmi_extras_pro.py
@@ -207,11 +207,7 @@ def stage_obesity(
     bmi_category = (
         "obese"
         if bmi >= 30
-        else "overweight"
-        if bmi >= 25
-        else "normal"
-        if bmi >= 18.5
-        else "underweight"
+        else "overweight" if bmi >= 25 else "normal" if bmi >= 18.5 else "underweight"
     )
 
     return {


### PR DESCRIPTION
## Summary

Briefly describe the change and motivation.

## Checklist

- [ ] Tests pass locally: `pytest -q` (no new failures)
- [ ] Lint passes: `flake8 .` (or fixes applied)
- [ ] Updated docs/comments if behavior changed
- [ ] No unrelated changes mixed into this PR

## Notes

Link related issue(s), PR(s), or context.

## Summary by Sourcery

Update pre-commit hook versions and apply Black reformat across the codebase

Enhancements:
- Apply Black reformat to consolidate multi-line type annotations into single lines and simplify nested ternary conditionals in Python modules

CI:
- Bump pre-commit-hooks to v6.0.0, Black to 25.9.0, ruff to v0.13.2, and mypy to v1.18.2 in .pre-commit-config.yaml