### PR TITLE
Pr 50

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,28 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
         continue-on-error: true
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest suite
+        run: npx vitest run --runInBand
+
+      - name: Build SPA
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,8 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Clean previous install
-        run: |
-          rm -rf node_modules package-lock.json
-
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run vitest suite
         run: npx vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: npm ci
 
       - name: Run vitest suite
-        run: npx vitest run --runInBand
+        run: npx vitest run
 
       - name: Build SPA
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,12 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Clean previous install
+        run: |
+          rm -rf node_modules package-lock.json
+
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run vitest suite
         run: npx vitest run

--- a/frontend/src/lib/shareFile.test.ts
+++ b/frontend/src/lib/shareFile.test.ts
@@ -16,6 +16,8 @@ vi.mock("@capacitor/share", () => ({
 vi.mock("@capacitor/filesystem", () => ({
   Filesystem: {
     writeFile: vi.fn(() => Promise.resolve({ uri: "file://cache/pulseplate/test" })),
+    getUri: vi.fn(() => Promise.resolve({ uri: "file://cache/pulseplate/test" })),
+    deleteFile: vi.fn(() => Promise.resolve()),
   },
   Directory: {
     Cache: "cache",
@@ -43,11 +45,15 @@ describe("shareFile", () => {
       href: "",
       download: "",
       click: vi.fn(),
+      remove: vi.fn(),
     } as unknown as HTMLAnchorElement;
 
     createElementMock = vi.fn().mockReturnValue(anchorMock);
     globalThis.document = {
       createElement: createElementMock,
+      body: {
+        appendChild: vi.fn(),
+      },
     } as unknown as Document;
 
     global.fetch = vi.fn();
@@ -96,7 +102,7 @@ describe("shareFile", () => {
 
     expect(shareMock).toHaveBeenCalledWith({
       title: "PulsePlate export",
-      url: "file://cache/pulseplate/test",
+      files: ["file://cache/pulseplate/test"],
       dialogTitle: "Share",
     });
   });
@@ -114,18 +120,21 @@ describe("shareFile", () => {
       arrayBuffer: () => Promise.resolve(arrayBuffer),
     });
 
+    // Freeze time to make the cache path deterministic
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1234567890);
     await shareFile("https://example.com/file.bin", "export.bin", "Native Share");
+    nowSpy.mockRestore();
 
     expect(global.fetch).toHaveBeenCalledWith("https://example.com/file.bin");
     expect(writeFileMock).toHaveBeenCalledWith({
-      path: "pulseplate/export.bin",
+      path: "pulseplate/1234567890-export.bin",
       data: expect.any(String),
       directory: Directory.Cache,
       recursive: true,
     });
     expect(shareMock).toHaveBeenCalledWith({
       title: "Native Share",
-      url: "file://cache/pulseplate/test",
+      files: ["file://cache/pulseplate/test"],
       dialogTitle: "Share",
     });
 


### PR DESCRIPTION
## Summary

Briefly describe the change and motivation.

## Checklist

- [ ] Tests pass locally: `pytest -q` (no new failures)
- [ ] Lint passes: `flake8 .` (or fixes applied)
- [ ] Updated docs/comments if behavior changed
- [ ] No unrelated changes mixed into this PR

## Notes

Link related issue(s), PR(s), or context.

## Summary by Sourcery

Add a dedicated frontend CI job and enhance shareFile unit tests

Build:
- Add frontend job to CI workflow with Node.js setup, dependency caching, vitest test suite, and SPA build

Tests:
- Update shareFile tests to mock new filesystem APIs and document interactions, expect files arrays in share calls, and use frozen timestamps for deterministic file paths