### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text storage of sensitive information

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.118.0
+cryptography==46.0.2
 uvicorn==0.37.0
 pydantic==2.11.9
 openai==1.109.1

--- a/update_api_key.py
+++ b/update_api_key.py
@@ -4,10 +4,29 @@ Update API key in MCP configuration
 """
 import json
 from pathlib import Path
+from cryptography.fernet import Fernet
+import base64
+
+def load_or_generate_key(key_file: Path):
+    if not key_file.exists():
+        key = Fernet.generate_key()
+        with open(key_file, "wb") as f:
+            f.write(key)
+        return key
+    else:
+        with open(key_file, "rb") as f:
+            return f.read()
 
 
 def update_api_key(api_key: str):
     """Update API key in MCP configuration"""
+
+    # Use a persistent .key file in .cursor directory
+    cursor_dir = Path.home() / ".cursor"
+    key_file = cursor_dir / ".key"
+    key = load_or_generate_key(key_file)
+    fernet = Fernet(key)
+    encrypted_api_key = fernet.encrypt(api_key.encode()).decode()
 
     # Validate API key: must start with 'sk-', be at least 20 chars, and max 256 chars
     if not api_key or not api_key.startswith("sk-") or len(api_key) < 20 or len(api_key) > 256:
@@ -28,7 +47,7 @@ def update_api_key(api_key: str):
         config["mcpServers"]["pulseplate-chatgpt"].setdefault("env", {})
 
         # Update API key in MCP config
-        config["mcpServers"]["pulseplate-chatgpt"]["env"]["OPENAI_API_KEY"] = api_key
+        config["mcpServers"]["pulseplate-chatgpt"]["env"]["OPENAI_API_KEY"] = encrypted_api_key
 
         with open(mcp_file, "w") as f:
             json.dump(config, f, indent=2)
@@ -46,13 +65,13 @@ def update_api_key(api_key: str):
         key_replaced = False
         for i, line in enumerate(lines):
             if line.startswith("OPENAI_API_KEY="):
-                lines[i] = f"OPENAI_API_KEY={api_key}"
+                lines[i] = f"OPENAI_API_KEY={encrypted_api_key}"
                 key_replaced = True
                 break
 
         # If no existing key found, append it
         if not key_replaced:
-            lines.append(f"OPENAI_API_KEY={api_key}")
+            lines.append(f"OPENAI_API_KEY={encrypted_api_key}")
 
         with open(env_file, "w") as f:
             f.write("\n".join(lines))
@@ -65,7 +84,7 @@ def update_api_key(api_key: str):
         with open(settings_file, "r") as f:
             settings = json.load(f)
 
-        settings["cursor.ai.openaiApiKey"] = api_key
+        settings["cursor.ai.openaiApiKey"] = encrypted_api_key
 
         with open(settings_file, "w") as f:
             json.dump(settings, f, indent=2)


### PR DESCRIPTION
Potential fix for [https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/38](https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/38)

The most robust fix is to encrypt the API key before writing it to the `.env`, `settings.json`, and `mcp.json` files and to decrypt it when reading. To accomplish this, we can use the standard Python `cryptography` library (`Fernet` symmetric encryption). The encryption key can be stored in a user-restricted file under `~/.cursor/`, or—if that is infeasible for this snippet—we should at least obfuscate/encode the key so it is not trivially readable. For this code snippet, we should:
- Generate or load an encryption key from a local file like `~/.cursor/.key`.
- Encrypt the API key with Fernet before writing to config or env files.
- Write the encrypted API key string in place of the original.
- Output instructions for the user accordingly.

You should add the necessary import for `cryptography.fernet.Fernet`. If the key file doesn't exist, generate and write it; if it exists, load it. Encrypt incoming API keys before writing and base64-encode the ciphertext for textual config files. Since we only have the update function and not the code that reads/decrypts the API key, we will note that decryption must be handled elsewhere. All changes should be within `update_api_key.py`, modifying only directly shown code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Secure API key storage by integrating Fernet-based encryption and key management into the update_api_key workflow

New Features:
- Encrypt API key before storing it in configuration files using Fernet symmetric encryption

Enhancements:
- Add utility to load or generate a persistent encryption key in ~/.cursor/.key
- Update API key update function to replace plaintext values with encrypted values in .env, settings.json, and mcp.json

Build:
- Add cryptography==46.0.2 dependency