### PR TITLE
fix: add timeout to i18n initialization in BeforeAfter test

### DIFF
--- a/frontend/src/components/Paywall/__tests__/BeforeAfter.test.tsx
+++ b/frontend/src/components/Paywall/__tests__/BeforeAfter.test.tsx
@@ -8,21 +8,22 @@ import "../../../test/setup";
 import i18n from "../../../i18n";
 
 beforeAll(async () => {
-  await new Promise<void>((resolve) => {
-    const handler = () => {
-      i18n.off("initialized", handler);
-      resolve();
-    };
+  if (!i18n.isInitialized) {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("i18n initialization timeout"));
+      }, 5000);
 
-    // Register listener first to avoid missing events
-    i18n.on("initialized", handler);
+      const handler = () => {
+        i18n.off("initialized", handler);
+        clearTimeout(timeout);
+        resolve();
+      };
 
-    // If already initialized, resolve immediately
-    if (i18n.isInitialized) {
-      i18n.off("initialized", handler);
-      resolve();
-    }
-  });
+      // Register listener first to avoid missing events
+      i18n.on("initialized", handler);
+    });
+  }
 });
 
 


### PR DESCRIPTION
## Summary

This PR adds a 5-second timeout to the i18n initialization in the BeforeAfter test to prevent hanging tests if initialization fails.

## Changes

- Add timeout to prevent tests from hanging indefinitely
- Refactor test setup to be more robust and predictable
- Address code review feedback about potential hanging tests

## Testing

- ✅ Frontend tests pass (23/23)
- ✅ Backend tests pass (4324 passed, 96% coverage)
- ✅ ESLint passes (9 warnings, 0 errors)

This is a small, focused fix that improves test reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6679c5b7175aeb6910fa93018d70f13fc56ff8f4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Improve BeforeAfter test reliability by adding a timeout to i18n initialization and refactoring its setup

Bug Fixes:
- Add a 5-second timeout to i18n initialization in the BeforeAfter test to prevent hanging

Enhancements:
- Refactor BeforeAfter test setup for increased robustness and predictability