### PR TITLE
feat: Add async-ready SQLAlchemy support with comprehensive tests

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -7,7 +7,7 @@ EN: Basic SQLAlchemy integration for the FastAPI app.
 from __future__ import annotations
 
 import os
-from contextlib import asynccontextmanager, contextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, AsyncGenerator, Generator, Optional, TYPE_CHECKING, cast
 
 from sqlalchemy import create_engine, text
@@ -54,14 +54,18 @@ def _derive_async_url(sync_url: str) -> Optional[str]:
     if create_async_engine is None:
         return None
 
-    if "+async" in sync_url:
+    # If already async-capable, return as-is
+    if (
+        "+async" in sync_url
+        or "aiosqlite" in sync_url
+        or "asyncpg" in sync_url
+        or "aiomysql" in sync_url
+    ):
         return sync_url
-    if sync_url.startswith("sqlite+aiosqlite"):
-        return sync_url
+
+    # Convert sync URLs to async equivalents
     if sync_url.startswith("sqlite:///"):
         return sync_url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
-    if sync_url.startswith("postgresql+asyncpg://") or sync_url.startswith("postgres+asyncpg://"):
-        return sync_url
     if sync_url.startswith("postgresql://"):
         return sync_url.replace("postgresql://", "postgresql+asyncpg://", 1)
     if sync_url.startswith("postgres://"):
@@ -120,11 +124,14 @@ engine = EngineCompat(_RAW_ENGINE)
 # Async engine configuration (optional)
 ASYNC_DATABASE_URL = None
 if create_async_engine is not None:
-    ASYNC_DATABASE_URL = (
-        os.getenv("DATABASE_ASYNC_URL")
-        or _derive_async_url(DATABASE_URL)
-        or os.getenv("DATABASE_USE_ASYNC")
-    )
+    # Check for explicit async URL first
+    async_url = os.getenv("DATABASE_ASYNC_URL")
+
+    # If no explicit URL but async is enabled, derive from sync URL
+    if not async_url and os.getenv("DATABASE_USE_ASYNC") == "1":
+        async_url = _derive_async_url(DATABASE_URL)
+
+    ASYNC_DATABASE_URL = async_url
 
 _POOL_CONFIG = {
     "pool_size": int(os.getenv("DATABASE_POOL_SIZE", "10")),
@@ -271,17 +278,13 @@ def init_db() -> None:
         setattr(metadata, "create_all", _CreateAllWrapper(create_all))
 
     # Use the raw SQLAlchemy engine to avoid any potential wrapper interference
-    if _ASYNC_ENGINE is not None and _RAW_ENGINE is None:
-        raise RuntimeError(
-            "init_db() cannot be used when only an async engine is configured. Use `await init_db_async()` instead."
-        )
     metadata.create_all(bind=_RAW_ENGINE)
 
 
 async def init_db_async() -> None:
     """Async variant of :func:`init_db` for async engines."""
 
-    import core.models  # pylint: disable=unused-import
+    import core.models  # noqa: F401  # pylint: disable=unused-import
 
     metadata = Base.metadata
 

--- a/core/db.py
+++ b/core/db.py
@@ -7,11 +7,30 @@ EN: Basic SQLAlchemy integration for the FastAPI app.
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
-from typing import Any, Generator
+from contextlib import asynccontextmanager, contextmanager, suppress
+from typing import Any, AsyncGenerator, Generator, Optional, TYPE_CHECKING, cast
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+if TYPE_CHECKING:  # pragma: no cover - type check only
+    from sqlalchemy.ext.asyncio import (
+        AsyncEngine as AsyncEngineType,
+        AsyncSession as AsyncSessionType,
+        async_sessionmaker as AsyncSessionmakerType,
+    )
+else:
+    AsyncEngineType = AsyncSessionType = Any  # type: ignore[assignment]
+    AsyncSessionmakerType = Any  # type: ignore[assignment]
+
+try:  # Optional async support
+    from sqlalchemy.ext.asyncio import (
+        async_sessionmaker,
+        create_async_engine,
+    )
+except ImportError:  # pragma: no cover - async extras not installed
+    async_sessionmaker = cast(Any, None)
+    create_async_engine = cast(Any, None)
 
 
 def _build_engine_url() -> str:
@@ -25,9 +44,33 @@ def _build_engine_url() -> str:
 def _sqlite_connect_args(url: str) -> dict[str, object]:
     """Provide SQLite-specific connection args when needed."""
 
-    if url.startswith("sqlite"):
-        return {"check_same_thread": False}
-    return {}
+    return {"check_same_thread": False} if url.startswith("sqlite") else {}
+
+
+def _derive_async_url(sync_url: str) -> Optional[str]:
+    """Derive an async-capable URL from a synchronous URL when possible."""
+
+    # Only derive async URLs if async support is available
+    if create_async_engine is None:
+        return None
+
+    if "+async" in sync_url:
+        return sync_url
+    if sync_url.startswith("sqlite+aiosqlite"):
+        return sync_url
+    if sync_url.startswith("sqlite:///"):
+        return sync_url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
+    if sync_url.startswith("postgresql+asyncpg://") or sync_url.startswith("postgres+asyncpg://"):
+        return sync_url
+    if sync_url.startswith("postgresql://"):
+        return sync_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if sync_url.startswith("postgres://"):
+        return sync_url.replace("postgres://", "postgresql+asyncpg://", 1)
+    if sync_url.startswith("mysql://"):
+        return sync_url.replace("mysql://", "mysql+aiomysql://", 1)
+    if sync_url.startswith("mysql+pymysql://"):
+        return sync_url.replace("mysql+pymysql://", "mysql+aiomysql://", 1)
+    return None
 
 
 DATABASE_URL = _build_engine_url()
@@ -74,6 +117,51 @@ _RAW_ENGINE = create_engine(
 engine = EngineCompat(_RAW_ENGINE)
 
 
+# Async engine configuration (optional)
+ASYNC_DATABASE_URL = None
+if create_async_engine is not None:
+    ASYNC_DATABASE_URL = (
+        os.getenv("DATABASE_ASYNC_URL")
+        or _derive_async_url(DATABASE_URL)
+        or os.getenv("DATABASE_USE_ASYNC")
+    )
+
+_POOL_CONFIG = {
+    "pool_size": int(os.getenv("DATABASE_POOL_SIZE", "10")),
+    "max_overflow": int(os.getenv("DATABASE_MAX_OVERFLOW", "20")),
+    "pool_pre_ping": True,
+}
+
+if ASYNC_DATABASE_URL and create_async_engine is not None:
+    try:
+        async_kwargs = {
+            "echo": False,
+            "future": True,
+        }
+
+        if ASYNC_DATABASE_URL.startswith("sqlite+aiosqlite"):
+            # SQLite async doesn't support pooling
+            pass
+        else:
+            async_kwargs.update(_POOL_CONFIG)
+
+        _ASYNC_ENGINE = create_async_engine(ASYNC_DATABASE_URL, **async_kwargs)
+        AsyncSessionLocal = async_sessionmaker(
+            bind=_ASYNC_ENGINE,
+            autoflush=False,
+            expire_on_commit=False,
+        )
+    except ImportError:
+        # Fallback if async drivers are not available
+        _ASYNC_ENGINE = None
+        AsyncSessionLocal = None
+else:
+    _ASYNC_ENGINE = None
+    AsyncSessionLocal = None
+
+async_engine: Optional[AsyncEngineType] = _ASYNC_ENGINE
+
+
 class Base(DeclarativeBase):
     """Base class for declarative SQLAlchemy models."""
 
@@ -112,6 +200,45 @@ def session_scope() -> Generator[Session, None, None]:
         session.close()
 
 
+async def get_async_session() -> AsyncGenerator[AsyncSessionType, None]:
+    """Async dependency yielding an async SQLAlchemy session when enabled."""
+
+    if AsyncSessionLocal is None:
+        if create_async_engine is None:
+            raise ImportError(
+                "SQLAlchemy async extras are not available. Install with 'pip install sqlalchemy[asyncio]'"
+            )
+        raise RuntimeError(
+            "Async SQLAlchemy is not configured. Set DATABASE_ASYNC_URL or DATABASE_USE_ASYNC=1."
+        )
+
+    session = AsyncSessionLocal()
+    try:
+        yield session
+    finally:
+        await session.close()
+
+
+@asynccontextmanager
+async def session_scope_async() -> AsyncGenerator[AsyncSessionType, None]:
+    """Async context manager for atomic DB operations."""
+
+    if AsyncSessionLocal is None:
+        raise RuntimeError(
+            "Async SQLAlchemy is not configured. Set DATABASE_ASYNC_URL or DATABASE_USE_ASYNC=1."
+        )
+
+    session = AsyncSessionLocal()
+    try:
+        yield session
+        await session.commit()
+    except Exception:  # pragma: no cover - defensive rollback
+        await session.rollback()
+        raise
+    finally:
+        await session.close()
+
+
 def init_db() -> None:
     """RU: Создаёт схему таблиц для зарегистрированных моделей (например, при старте).
 
@@ -144,4 +271,23 @@ def init_db() -> None:
         setattr(metadata, "create_all", _CreateAllWrapper(create_all))
 
     # Use the raw SQLAlchemy engine to avoid any potential wrapper interference
+    if _ASYNC_ENGINE is not None and _RAW_ENGINE is None:
+        raise RuntimeError(
+            "init_db() cannot be used when only an async engine is configured. Use `await init_db_async()` instead."
+        )
     metadata.create_all(bind=_RAW_ENGINE)
+
+
+async def init_db_async() -> None:
+    """Async variant of :func:`init_db` for async engines."""
+
+    import core.models  # pylint: disable=unused-import
+
+    metadata = Base.metadata
+
+    if _ASYNC_ENGINE is None:
+        metadata.create_all(bind=_RAW_ENGINE)
+        return
+
+    async with _ASYNC_ENGINE.begin() as conn:
+        await conn.run_sync(metadata.create_all)

--- a/tests/test_core_db_coverage.py
+++ b/tests/test_core_db_coverage.py
@@ -205,9 +205,8 @@ class TestAsyncDB:
         result = _derive_async_url(async_url)
         assert result == async_url
 
-    def test_derive_async_url_no_support(self):
-        """Test _derive_async_url works even when async support is available."""
-        # In test environment, create_async_engine is available, so it should return URL
+    def test_derive_async_url_with_support(self):
+        """Test _derive_async_url correctly derives URL when async support is available."""
         result = _derive_async_url("sqlite:///test.db")
         assert result == "sqlite+aiosqlite:///test.db"
 
@@ -218,16 +217,18 @@ class TestAsyncDB:
     @pytest.mark.asyncio
     async def test_get_async_session_not_configured(self):
         """Test get_async_session raises error when not configured."""
-        with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
-            async for session in get_async_session():
-                break
+        with patch("core.db.AsyncSessionLocal", None):
+            with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
+                async for _session in get_async_session():
+                    break
 
     @pytest.mark.asyncio
     async def test_session_scope_async_not_configured(self):
         """Test session_scope_async raises error when not configured."""
-        with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
-            async with session_scope_async():
-                pass
+        with patch("core.db.AsyncSessionLocal", None):
+            with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
+                async with session_scope_async():
+                    pass
 
     @pytest.mark.asyncio
     async def test_init_db_async_fallback(self):

--- a/tests/test_core_db_coverage.py
+++ b/tests/test_core_db_coverage.py
@@ -17,9 +17,14 @@ from core.db import (
     SessionLocal,
     _build_engine_url,
     _sqlite_connect_args,
+    _derive_async_url,
+    async_engine,
+    get_async_session,
     get_session,
     init_db,
+    init_db_async,
     session_scope,
+    session_scope_async,
 )
 
 
@@ -171,3 +176,61 @@ class TestCoreDB:
 
             args = _sqlite_connect_args(test_url)
             assert args["check_same_thread"] is False
+
+
+class TestAsyncDB:
+    """Tests for async database functions."""
+
+    def test_derive_async_url_sqlite(self):
+        """Test _derive_async_url for SQLite URLs."""
+        sqlite_url = "sqlite:///test.db"
+        async_url = _derive_async_url(sqlite_url)
+        assert async_url == "sqlite+aiosqlite:///test.db"
+
+    def test_derive_async_url_postgresql(self):
+        """Test _derive_async_url for PostgreSQL URLs."""
+        pg_url = "postgresql://user:pass@localhost/testdb"
+        async_url = _derive_async_url(pg_url)
+        assert async_url == "postgresql+asyncpg://user:pass@localhost/testdb"
+
+    def test_derive_async_url_mysql(self):
+        """Test _derive_async_url for MySQL URLs."""
+        mysql_url = "mysql://user:pass@localhost/testdb"
+        async_url = _derive_async_url(mysql_url)
+        assert async_url == "mysql+aiomysql://user:pass@localhost/testdb"
+
+    def test_derive_async_url_already_async(self):
+        """Test _derive_async_url when URL is already async."""
+        async_url = "sqlite+aiosqlite:///test.db"
+        result = _derive_async_url(async_url)
+        assert result == async_url
+
+    def test_derive_async_url_no_support(self):
+        """Test _derive_async_url works even when async support is available."""
+        # In test environment, create_async_engine is available, so it should return URL
+        result = _derive_async_url("sqlite:///test.db")
+        assert result == "sqlite+aiosqlite:///test.db"
+
+    def test_async_engine_not_configured(self):
+        """Test that async_engine is None when not configured."""
+        assert async_engine is None
+
+    @pytest.mark.asyncio
+    async def test_get_async_session_not_configured(self):
+        """Test get_async_session raises error when not configured."""
+        with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
+            async for session in get_async_session():
+                break
+
+    @pytest.mark.asyncio
+    async def test_session_scope_async_not_configured(self):
+        """Test session_scope_async raises error when not configured."""
+        with pytest.raises(RuntimeError, match="Async SQLAlchemy is not configured"):
+            async with session_scope_async():
+                pass
+
+    @pytest.mark.asyncio
+    async def test_init_db_async_fallback(self):
+        """Test init_db_async falls back to sync init when async not configured."""
+        # Should work without raising errors
+        await init_db_async()


### PR DESCRIPTION
## Summary
Add complete async SQLAlchemy support from PR #81.

## Changes
- Async DB functions: get_async_session, session_scope_async, init_db_async
- URL derivation for different database types
- Comprehensive test coverage (9 new tests)
- Backward compatibility maintained

## Summary by Sourcery

Add comprehensive async-compatible SQLAlchemy support alongside existing synchronous operations, including engine setup, session management, and database initialization, while preserving backward compatibility and covering new functionality with dedicated tests

New Features:
- Provide optional async SQLAlchemy engine configuration driven by DATABASE_ASYNC_URL or derived URL
- Introduce get_async_session and session_scope_async for async database operations
- Add init_db_async to create database schema asynchronously
- Add _derive_async_url helper to convert sync database URLs to async-compatible forms

Enhancements:
- Maintain backward compatibility by preserving existing synchronous session functions
- Guard async SQLAlchemy imports using TYPE_CHECKING to avoid runtime errors when extras are missing

Tests:
- Add tests for async URL derivation across SQLite, PostgreSQL, and MySQL
- Add tests for async_engine configuration absence and errors in get_async_session and session_scope_async
- Add test for init_db_async fallback to synchronous initialization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce optional async SQLAlchemy support (engine, sessions, init) with URL derivation and comprehensive tests, while keeping sync behavior intact.
> 
> - **Core DB (`core/db.py`)**:
>   - Add optional async setup: `async_engine`, `AsyncSessionLocal`, `get_async_session`, `session_scope_async`, `init_db_async`.
>   - Introduce `_derive_async_url` to convert sync URLs to async equivalents; derive via `DATABASE_ASYNC_URL` or `DATABASE_USE_ASYNC=1`.
>   - Configure async engine pooling (non-SQLite) via `DATABASE_POOL_SIZE`/`DATABASE_MAX_OVERFLOW`.
>   - Minor: simplify `_sqlite_connect_args`; add compatibility types/guards for async imports.
> - **Tests (`tests/test_core_db_coverage.py`)**:
>   - Add tests for `_derive_async_url` across SQLite/PostgreSQL/MySQL and already-async URLs.
>   - Validate behavior when async not configured (errors for `get_async_session`/`session_scope_async`, `async_engine is None`).
>   - Test `init_db_async` fallback to sync `create_all`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db33a52fd3fae53396e3f5d06a6d01f8c4f802eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->