### PR TITLE
auth: re-export AuthContext from lib/auth

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,1 @@
+export { AuthProvider, useAuth, AuthError } from '../lib/auth';

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,1 +1,1 @@
-export { AuthProvider, useAuth, AuthError, AuthContext } from '../lib/auth';
+export { AuthProvider, useAuth, AuthError, AuthContext, AuthContextType } from '../lib/auth';

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,1 +1,1 @@
-export { AuthProvider, useAuth, AuthError } from '../lib/auth';
+export { AuthProvider, useAuth, AuthError, AuthContext } from '../lib/auth';

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -25,7 +25,7 @@ interface AuthContextType {
   setShowAuthPrompt: (show: boolean) => void;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {
   children: ReactNode;

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -15,7 +15,7 @@ export class AuthError extends Error {
   }
 }
 
-interface AuthContextType {
+export interface AuthContextType {
   apiKey: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
@@ -25,7 +25,7 @@ interface AuthContextType {
   setShowAuthPrompt: (show: boolean) => void;
 }
 
-export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {
   children: ReactNode;


### PR DESCRIPTION
---
name: General PR
about: Default template for most pull requests
labels: []
---

# Title
<!-- Conventional commit: feat|fix|chore|docs|refactor|test|perf(scope): ... -->

## Summary
- Что изменилось?
- Почему / ссылка на задачу.

## Scope & Files
- Основные изменения (файлы, модули).
- Out of scope / TODO (кратко).

## Acceptance Criteria
- Перечисли ключевые критерии завершенности.

## Tests
- [ ] Unit / logic
- [ ] Integration / e2e
- [ ] Manual / QA steps (ниже)

```bash
# команды для локальной проверки
npm run lint
npm test
npm run build
```

## QA Checklist
- [ ] Happy-path сценарии
- [ ] Ошибки / таймауты / фоллбек
- [ ] Доступность / UX проверены

## Risks & Next Steps
- Риски / фичефлаги / мониторинг
- Следующие шаги после мержа

<details>
<summary>Optional: a11y / Security / Performance / Marketing / Docs</summary>

См. [docs/pr-checks.md](../docs/pr-checks.md) — общие требования и подсказки.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `AuthContext` and related APIs via `frontend/src/auth/AuthContext.tsx` and make `AuthContextType` publicly exported.
> 
> - **Frontend**:
>   - **Auth exports**:
>     - Add `frontend/src/auth/AuthContext.tsx` to re-export `AuthProvider`, `useAuth`, `AuthError`, `AuthContext`, `AuthContextType` from `../lib/auth`.
>     - Change `AuthContextType` in `frontend/src/lib/auth.tsx` to `export interface` for external use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acc47573e5904085209282425013d86696a3d782. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->