### PR TITLE
fix: refine exception handling based on AI feedback

### DIFF
--- a/app/routers/plan_export.py
+++ b/app/routers/plan_export.py
@@ -339,7 +339,7 @@ def _register_font() -> str:
         if FONT_PATH.exists():
             pdfmetrics.registerFont(TTFont(FONT_NAME, str(FONT_PATH)))
             return FONT_NAME
-    except (OSError, IOError, ValueError, TTFError) as e:
+    except (OSError, TTFError) as e:
         # Font registration failed, fallback to default
         # Log the error for debugging but continue with fallback
         logger.warning("Failed to register font %s: %s", FONT_NAME, e)


### PR DESCRIPTION
- Remove redundant IOError (alias for OSError in Python 3)
- Remove overly broad ValueError to prevent masking unrelated errors
- Keep only OSError and TTFError for font registration specific errors
- Address Copilot and Sourcery-AI feedback for better error handling precision

This addresses:
- Copilot: IOError is redundant in Python 3
- Sourcery-AI: ValueError too broad for font registration errors

---
name: General PR
about: Default template for most pull requests
labels: []
---

# Title
<!-- Conventional commit: feat|fix|chore|docs|refactor|test|perf(scope): ... -->

## Summary
- Что изменилось?
- Почему / ссылка на задачу.

## Scope & Files
- Основные изменения (файлы, модули).
- Out of scope / TODO (кратко).

## Acceptance Criteria
- Перечисли ключевые критерии завершенности.

## Tests
- [ ] Unit / logic
- [ ] Integration / e2e
- [ ] Manual / QA steps (ниже)

```bash
# команды для локальной проверки
npm run lint
npm test
npm run build
```

## QA Checklist
- [ ] Happy-path сценарии
- [ ] Ошибки / таймауты / фоллбек
- [ ] Доступность / UX проверены

## Risks & Next Steps
- Риски / фичефлаги / мониторинг
- Следующие шаги после мержа

<details>
<summary>Optional: a11y / Security / Performance / Marketing / Docs</summary>

См. [docs/pr-checks.md](../docs/pr-checks.md) — общие требования и подсказки.

</details>

## Сводка от Sourcery

Исправления ошибок:
- Сузить блок обработки исключений в `_register_font` только до `OSError` и `TTFError`, удалив `IOError` и `ValueError`, чтобы избежать маскировки других ошибок

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Narrow the exception clause in _register_font to only OSError and TTFError, removing IOError and ValueError to avoid masking other errors

</details>