### PR TITLE
fix: restore ValueError in font registration exception handling

### DIFF
--- a/app/routers/plan_export.py
+++ b/app/routers/plan_export.py
@@ -342,7 +342,7 @@ def _register_font() -> str:
     except (OSError, TTFError, ValueError) as e:
         # Font registration failed, fallback to default
         # Log the error for debugging but continue with fallback
-        logger.warning("Failed to register font %s: %s", FONT_NAME, e)
+        logger.warning("Failed to register font %s: %s", FONT_NAME, e, exc_info=True)
     # Use built-in Helvetica font as fallback
     return "Helvetica"
 

--- a/app/routers/plan_export.py
+++ b/app/routers/plan_export.py
@@ -339,7 +339,7 @@ def _register_font() -> str:
         if FONT_PATH.exists():
             pdfmetrics.registerFont(TTFont(FONT_NAME, str(FONT_PATH)))
             return FONT_NAME
-    except (OSError, TTFError) as e:
+    except (OSError, TTFError, ValueError) as e:
         # Font registration failed, fallback to default
         # Log the error for debugging but continue with fallback
         logger.warning("Failed to register font %s: %s", FONT_NAME, e)


### PR DESCRIPTION
## 🎯 Problem

CodeRabbit identified a critical issue in font registration exception handling from PR #179:

- **Missing ** in exception tuple, but ReportLab's  and  can raise  for legitimate font issues:
  - Missing subfont in TTC collections
  - Name-mapping conflicts in font registration  
  - Non-standard acroform fonts

## ✅ Solution

- **Add ** back to exception tuple for legitimate font errors
- **Maintain graceful fallback** to Helvetica font
- **Preserve existing logging** and error handling

## 🔧 Changes

```python
# Before (PR #179 - incorrect)
except (OSError, TTFError) as e:

# After (this PR - correct)
except (OSError, TTFError, ValueError) as e:
```

## 🧪 Testing

- Pre-commit hooks passed ✅
- All linting and security checks passed ✅
- Maintains existing fallback behavior ✅

## 📋 Addresses

- CodeRabbit critical feedback on PR #179
- Ensures proper exception handling for font registration failures
- Prevents silent failures that could break PDF generation

## ⚠️ Important

This PR addresses the incomplete fix from PR #179. The previous PR removed  but CodeRabbit analysis shows this is needed for legitimate font errors.

## Сводка от Sourcery

Исправления ошибок:
- Добавлено ValueError обратно в кортеж исключений при регистрации шрифтов для обработки конфликтов сопоставления имен и отсутствующих подшрифтов

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add ValueError back to the exception tuple when registering fonts to handle name-mapping conflicts and missing subfonts

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand font registration exception handling to include ValueError and log full traceback while retaining Helvetica fallback.
> 
> - **PDF export (`app/routers/plan_export.py`)**:
>   - **Font registration**: Catch `ValueError` in `_register_font` alongside `OSError` and `TTFError`.
>   - **Logging**: Add `exc_info=True` to `logger.warning` for full traceback on font registration failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9b9d8c7ecf167806bc950129b5453fa3c441606. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->