### PR TITLE
fix: Stabilize VipGate inert test for future browser compatibility

### DIFF
--- a/frontend/src/components/__tests__/VipFeature.test.tsx
+++ b/frontend/src/components/__tests__/VipFeature.test.tsx
@@ -131,7 +131,10 @@ describe('VipFeature', () => {
       );
 
       const previewWrapper = screen.getByTestId('vip-content').parentElement;
-      expect(previewWrapper).toHaveAttribute('aria-hidden', 'true');
+      expect(
+        previewWrapper?.hasAttribute('inert') ||
+        previewWrapper?.getAttribute('aria-hidden') === 'true'
+      ).toBe(true);
 
       // Check for offscreen description (mocked translation keys)
       const description = screen.getByText(/vip\.title.*vip\.subtitle/);


### PR DESCRIPTION
## 🧪 Test Stability Improvement

### Problem
The VipGate accessibility test was hardcoded to expect `aria-hidden='true'` which will fail when browsers add native inert support (already in modern browsers and coming to jsdom).

### Solution
- **frontend/src/components/__tests__/VipFeature.test.tsx**: Updated inert assertion to accept either native inert attribute or fallback aria-hidden
- Test now checks for both `inert` attribute OR `aria-hidden='true'` to ensure compatibility with both current fallback and future native support

### Technical Details
- Uses logical OR to check both possible states: `hasAttribute('inert') || getAttribute('aria-hidden') === 'true'`
- Maintains test coverage while ensuring future compatibility
- Prevents test failures when jsdom adds native inert support

### Testing
- ✅ All 20 VipFeature tests pass
- ✅ Pre-commit checks pass
- ✅ Test is now future-proof for native inert support

Addresses CodeRabbit feedback for test stability and future-proofing.

## 📋 Checklist
- [x] Tests pass
- [x] No breaking changes
- [x] Future compatibility ensured
- [x] CodeRabbit feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 325cc3223403ef6d631d90986e6c5782cc6d4989. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Сводка от Sourcery

Тесты:
- Позволить VipFeature test пройти, когда элемент имеет inert attribute или aria-hidden='true'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Allow VipFeature test to pass when element has inert attribute or aria-hidden='true'

</details>