### PR TITLE
Feature/pr 2 4 telemetry foundation

### DIFF
--- a/GLOBAL_ROADMAP_2025.md
+++ b/GLOBAL_ROADMAP_2025.md
@@ -241,8 +241,30 @@
 
 > **Владелец**: iOS Team | **Каденция**: По мере необходимости
 
-- [ ] **Synchronize texts/iconography/micro-animations** с SwiftUI screens
-- [ ] **Align navigation and naming** (RU/EN/ES locales)
+#### ✅ Frontend Ready (PR #2.7 Completed)
+- [x] **iOS-compatible localization keys** added to all locales (EN/RU/ES)
+- [x] **Chart, week, health, units sections** prepared for iOS sync
+- [x] **Language, profile, mascot, settings keys** aligned with iOS format
+- [x] **Accessibility labels** ready for iOS integration
+
+#### 🔄 iOS Development Tasks (When iOS Development Resumes)
+- [ ] **Update iOS Localizable.strings** to match frontend structure
+- [ ] **Implement SwiftUI components** using new localization keys
+- [ ] **Synchronize navigation flow** between iOS and frontend
+- [ ] **Align micro-animations** and iconography
+- [ ] **Test cross-platform consistency** (RU/EN/ES locales)
+- [ ] **HealthKit integration** using prepared health.* keys
+- [ ] **Profile and settings screens** using profile.* and settings.* keys
+- [ ] **Mascot messages** using mascot.* keys for consistency
+
+#### 📋 iOS Development Roadmap (When Ready)
+- [ ] **Phase 1**: Update iOS Localizable.strings with new key structure
+- [ ] **Phase 2**: Implement SwiftUI screens using prepared localization keys
+- [ ] **Phase 3**: HealthKit integration with health.* keys
+- [ ] **Phase 4**: Profile and settings screens with profile.* and settings.* keys
+- [ ] **Phase 5**: Chart and progress screens with chart.* and week.* keys
+- [ ] **Phase 6**: Mascot integration with mascot.* keys
+- [ ] **Phase 7**: Cross-platform testing and consistency validation
 
 ### 📊 Telemetry & Product Metrics
 
@@ -346,13 +368,14 @@
 ## 🎉 Текущий статус
 
 - ✅ **ФАЗА 1 ЗАВЕРШЕНА**: CI стабилизирован, все тесты проходят
-- 🔄 **ФАЗА 2 В ПРОЦЕССЕ**: OpenAPI Infrastructure
+- ✅ **ФАЗА 2 ЗАВЕРШЕНА**: OpenAPI Infrastructure & iOS Preparation
   - ✅ **PR #2.1 ЗАВЕРШЕН**: Feature Flags Setup (25 тестов, мок по модулям)
   - ✅ **PR #2.2 ЗАВЕРШЕН**: Design Tokens Foundation (21 тест, CSS custom properties)
   - ✅ **PR #2.3 ЗАВЕРШЕН**: VIP Components Base (25 тестов, useInert хук)
   - ✅ **PR #2.4 ЗАВЕРШЕН**: Telemetry Foundation (56 тестов, type-safe события)
-  - 🔄 **PR #2.5 В ПРОЦЕССЕ**: VIP i18n Keys (32 теста, centralized terminology mapping)
-  - 📋 **PR #2.6-2.7 ПЛАНИРУЮТСЯ**: i18n Validation & Quality, iOS-Frontend Sync
+  - ✅ **PR #2.5 ЗАВЕРШЕН**: VIP i18n Keys (35 тестов, centralized terminology mapping)
+  - ✅ **PR #2.6 ЗАВЕРШЕН**: i18n Validation & Quality (35 тестов, language-specific patterns)
+  - ✅ **PR #2.7 ЗАВЕРШЕН**: iOS-Frontend Sync Preparation (iOS-compatible keys)
 - 📋 **ФАЗЫ 3-6 ПЛАНИРУЮТСЯ**: Вертикальные срезы по неделям
 
-**Текущий этап**: PR #2.5 (VIP i18n Keys) 🔄
+**Текущий этап**: Готов к ФАЗЕ 3 (WHO Targets E2E) 🚀

--- a/GLOBAL_ROADMAP_2025.md
+++ b/GLOBAL_ROADMAP_2025.md
@@ -242,29 +242,16 @@
 > **Владелец**: iOS Team | **Каденция**: По мере необходимости
 
 #### ✅ Frontend Ready (PR #2.7 Completed)
+
 - [x] **iOS-compatible localization keys** added to all locales (EN/RU/ES)
 - [x] **Chart, week, health, units sections** prepared for iOS sync
 - [x] **Language, profile, mascot, settings keys** aligned with iOS format
 - [x] **Accessibility labels** ready for iOS integration
 
-#### 🔄 iOS Development Tasks (When iOS Development Resumes)
-- [ ] **Update iOS Localizable.strings** to match frontend structure
-- [ ] **Implement SwiftUI components** using new localization keys
-- [ ] **Synchronize navigation flow** between iOS and frontend
-- [ ] **Align micro-animations** and iconography
-- [ ] **Test cross-platform consistency** (RU/EN/ES locales)
-- [ ] **HealthKit integration** using prepared health.* keys
-- [ ] **Profile and settings screens** using profile.* and settings.* keys
-- [ ] **Mascot messages** using mascot.* keys for consistency
+#### 📋 Detailed iOS Development Plan
+> **See**: [IOS_DEVELOPMENT_ROADMAP.md](./IOS_DEVELOPMENT_ROADMAP.md) for complete iOS development phases and tasks
 
-#### 📋 iOS Development Roadmap (When Ready)
-- [ ] **Phase 1**: Update iOS Localizable.strings with new key structure
-- [ ] **Phase 2**: Implement SwiftUI screens using prepared localization keys
-- [ ] **Phase 3**: HealthKit integration with health.* keys
-- [ ] **Phase 4**: Profile and settings screens with profile.* and settings.* keys
-- [ ] **Phase 5**: Chart and progress screens with chart.* and week.* keys
-- [ ] **Phase 6**: Mascot integration with mascot.* keys
-- [ ] **Phase 7**: Cross-platform testing and consistency validation
+**Quick Status**: Frontend ready for iOS synchronization. iOS team can resume development using prepared localization structure.
 
 ### 📊 Telemetry & Product Metrics
 

--- a/IOS_DEVELOPMENT_ROADMAP.md
+++ b/IOS_DEVELOPMENT_ROADMAP.md
@@ -1,0 +1,104 @@
+# iOS Development Roadmap
+
+> **Статус**: Frontend готов к синхронизации | **Владелец**: iOS Team | **Каденция**: По мере необходимости
+
+## 📱 iOS Synchronization Status
+
+### ✅ Frontend Ready (PR #2.7 Completed)
+- [x] **iOS-compatible localization keys** added to all locales (EN/RU/ES)
+- [x] **Chart, week, health, units sections** prepared for iOS sync
+- [x] **Language, profile, mascot, settings keys** aligned with iOS format
+- [x] **Accessibility labels** ready for iOS integration
+
+### 🔄 iOS Development Tasks (When iOS Development Resumes)
+- [ ] **Update iOS Localizable.strings** to match frontend structure
+- [ ] **Implement SwiftUI components** using new localization keys
+- [ ] **Synchronize navigation flow** between iOS and frontend
+- [ ] **Align micro-animations** and iconography
+- [ ] **Test cross-platform consistency** (RU/EN/ES locales)
+- [ ] **HealthKit integration** using prepared health.* keys
+- [ ] **Profile and settings screens** using profile.* and settings.* keys
+- [ ] **Mascot messages** using mascot.* keys for consistency
+
+## 📋 iOS Development Roadmap (When Ready)
+
+### Phase 1: Localization Update
+- [ ] **Update iOS Localizable.strings** with new key structure
+- [ ] **Migrate existing keys** to new hierarchical structure
+- [ ] **Validate all translations** match frontend versions
+
+### Phase 2: Core Screens Implementation
+- [ ] **Implement SwiftUI screens** using prepared localization keys
+- [ ] **Home screen** with mascot integration
+- [ ] **Settings screen** with language selection
+- [ ] **Profile screen** with legal sections
+
+### Phase 3: Health Integration
+- [ ] **HealthKit integration** with health.* keys
+- [ ] **Permission handling** using health.permissionMessage
+- [ ] **Health data display** with proper localization
+
+### Phase 4: User Interface
+- [ ] **Profile and settings screens** with profile.* and settings.* keys
+- [ ] **Navigation consistency** between iOS and frontend
+- [ ] **Accessibility implementation** using accessibility.* keys
+
+### Phase 5: Data Visualization
+- [ ] **Chart and progress screens** with chart.* and week.* keys
+- [ ] **Weekly progress display** with proper localization
+- [ ] **Data visualization consistency**
+
+### Phase 6: User Experience
+- [ ] **Mascot integration** with mascot.* keys
+- [ ] **Micro-animations** alignment
+- [ ] **Iconography consistency**
+
+### Phase 7: Quality Assurance
+- [ ] **Cross-platform testing** and consistency validation
+- [ ] **Performance testing** with longer Russian strings
+- [ ] **Accessibility testing** across all screens
+- [ ] **Localization testing** for all supported languages
+
+## 🎯 Key Localization Sections Ready
+
+### Chart & Data Visualization
+```swift
+// Ready keys: chart.day, chart.kcal, week.*
+```
+
+### Health & Permissions
+```swift
+// Ready keys: health.permissionMessage, health.request, health.alertTitle
+```
+
+### Units & Abbreviations
+```swift
+// Ready keys: units.kg, units.kcal, units.gram, abbreviations.*
+```
+
+### Language & Profile
+```swift
+// Ready keys: language.*, profile.*, settings.*
+```
+
+### Mascot & Accessibility
+```swift
+// Ready keys: mascot.*, accessibility.*
+```
+
+## ⚠️ Important Notes
+
+### String Length Considerations
+- **Russian strings** can be up to 4x longer than English
+- **UI components** must handle longer strings without layout issues
+- **Test thoroughly** with Russian locale for layout stability
+
+### Cross-Platform Consistency
+- **Navigation flow** should match frontend patterns
+- **Terminology** must be consistent across platforms
+- **User experience** should feel unified
+
+## 🔗 Related Documents
+- [GLOBAL_ROADMAP_2025.md](./GLOBAL_ROADMAP_2025.md) - Main project roadmap
+- [frontend/src/locales/](./frontend/src/locales/) - Frontend localization files
+- [ios/PulsePlate/*.lproj/](./ios/PulsePlate/) - iOS localization files

--- a/frontend/src/lib/__tests__/telemetry.test.ts
+++ b/frontend/src/lib/__tests__/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { trackVipEvent, vipTelemetry, isTelemetryEnabled } from '../telemetry';
+import { trackVipEvent, vipTelemetry, isTelemetryEnabled, EventType } from '../telemetry';
 import { isAnalyticsEnabled } from '../../config/features';
 import { getSessionId } from '../sessionManager';
 import { getCurrentFeatureFlags } from '../featureFlagManager';
@@ -49,7 +49,7 @@ describe('Telemetry', () => {
 
   describe('trackVipEvent', () => {
     it('should track event when analytics is enabled', () => {
-      trackVipEvent('vip_module_viewed', {
+      trackVipEvent(EventType.VIP_MODULE_VIEWED, {
         source: 'dashboard',
         vipEnabled: true,
       });
@@ -70,7 +70,7 @@ describe('Telemetry', () => {
     it('should not track event when analytics is disabled', () => {
       mockIsAnalyticsEnabled.mockReturnValue(false);
 
-      trackVipEvent('vip_module_viewed', {
+      trackVipEvent(EventType.VIP_MODULE_VIEWED, {
         source: 'dashboard',
         vipEnabled: true,
       });
@@ -81,7 +81,7 @@ describe('Telemetry', () => {
     it('should add timestamp if not provided', () => {
       const beforeTime = Date.now();
 
-      trackVipEvent('vip_feature_clicked', {
+      trackVipEvent(EventType.VIP_FEATURE_CLICKED, {
         featureName: 'advanced_analytics',
         source: 'dashboard',
         isVip: false,
@@ -106,7 +106,7 @@ describe('Telemetry', () => {
         timestamp: customTimestamp,
       } as any;
 
-      trackVipEvent('vip_feature_clicked', payload);
+      trackVipEvent(EventType.VIP_FEATURE_CLICKED, payload);
 
       expect(mockLog).toHaveBeenCalledWith('vip_feature_clicked', {
         timestamp: customTimestamp,

--- a/frontend/src/lib/__tests__/telemetry.test.ts
+++ b/frontend/src/lib/__tests__/telemetry.test.ts
@@ -404,5 +404,30 @@ describe('Telemetry', () => {
 
       expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, payloadWithWrongFeatureFlags)).toBe(false);
     });
+
+    it('should reject null values for BaseEventPayload fields', () => {
+      const payloadWithNullFeatureFlags = {
+        source: 'dashboard',
+        vipEnabled: true,
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: null // Should not be null
+      } as any;
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, payloadWithNullFeatureFlags)).toBe(false);
+    });
+
+    it('should reject null values for optional fields', () => {
+      const payloadWithNullOptionalField = {
+        source: 'dashboard',
+        context: 'test',
+        isRetry: null, // Should not be null for optional field
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      } as any;
+
+      expect(validateEventPayload(EventType.VIP_PAYWALL_VIEWED, payloadWithNullOptionalField)).toBe(false);
+    });
   });
 });

--- a/frontend/src/lib/__tests__/telemetry.test.ts
+++ b/frontend/src/lib/__tests__/telemetry.test.ts
@@ -103,7 +103,6 @@ describe('Telemetry', () => {
     });
 
     it('should preserve provided timestamp', () => {
-      vi.useFakeTimers();
       const customTimestamp = 1234567890;
 
       // Use a direct call to trackVipEvent with timestamp in payload
@@ -128,7 +127,6 @@ describe('Telemetry', () => {
         source: 'dashboard',
         isVip: false,
       });
-      vi.useRealTimers();
     });
   });
 
@@ -373,6 +371,38 @@ describe('Telemetry', () => {
       } as any; // Cast to any to test runtime validation
 
       expect(validateEventPayload(EventType.VIP_PAYWALL_VIEWED, payloadWithWrongOptionalType)).toBe(false);
+    });
+
+    it('should reject payload with wrong BaseEventPayload field types', () => {
+      const payloadWithWrongTimestamp = {
+        source: 'dashboard',
+        vipEnabled: true,
+        timestamp: 'invalid', // Should be number
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      } as any;
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, payloadWithWrongTimestamp)).toBe(false);
+
+      const payloadWithWrongSessionId = {
+        source: 'dashboard',
+        vipEnabled: true,
+        timestamp: Date.now(),
+        sessionId: 123, // Should be string
+        featureFlags: { vip: true }
+      } as any;
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, payloadWithWrongSessionId)).toBe(false);
+
+      const payloadWithWrongFeatureFlags = {
+        source: 'dashboard',
+        vipEnabled: true,
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: 'invalid' // Should be object
+      } as any;
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, payloadWithWrongFeatureFlags)).toBe(false);
     });
   });
 });

--- a/frontend/src/lib/__tests__/telemetry.test.ts
+++ b/frontend/src/lib/__tests__/telemetry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { trackVipEvent, vipTelemetry, isTelemetryEnabled, EventType } from '../telemetry';
+import { validateEventPayload } from '../telemetry/eventRegistry';
 import { isAnalyticsEnabled } from '../../config/features';
 import { getSessionId } from '../sessionManager';
 import { getCurrentFeatureFlags } from '../featureFlagManager';
@@ -67,6 +68,12 @@ describe('Telemetry', () => {
       });
     });
 
+    it('should not log when payload is invalid', () => {
+      // Missing required fields for VIP_FEATURE_CLICKED
+      trackVipEvent(EventType.VIP_FEATURE_CLICKED, { source: 'dashboard' } as any);
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+
     it('should not track event when analytics is disabled', () => {
       mockIsAnalyticsEnabled.mockReturnValue(false);
 
@@ -96,6 +103,7 @@ describe('Telemetry', () => {
     });
 
     it('should preserve provided timestamp', () => {
+      vi.useFakeTimers();
       const customTimestamp = 1234567890;
 
       // Use a direct call to trackVipEvent with timestamp in payload
@@ -120,6 +128,7 @@ describe('Telemetry', () => {
         source: 'dashboard',
         isVip: false,
       });
+      vi.useRealTimers();
     });
   });
 
@@ -300,6 +309,70 @@ describe('Telemetry', () => {
       mockIsAnalyticsEnabled.mockReturnValue(false);
 
       expect(isTelemetryEnabled()).toBe(false);
+    });
+  });
+
+  describe('validateEventPayload', () => {
+    it('should validate correct payload types', () => {
+      const validPayload = {
+        source: 'dashboard',
+        vipEnabled: true,
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      };
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, validPayload)).toBe(true);
+    });
+
+    it('should reject payload with wrong field types', () => {
+      const invalidPayload = {
+        source: 123, // Should be string
+        vipEnabled: true,
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      } as any; // Cast to any to test runtime validation
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, invalidPayload)).toBe(false);
+    });
+
+    it('should reject payload with missing required fields', () => {
+      const incompletePayload = {
+        source: 'dashboard',
+        // Missing vipEnabled
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      } as any; // Cast to any to test runtime validation
+
+      expect(validateEventPayload(EventType.VIP_MODULE_VIEWED, incompletePayload)).toBe(false);
+    });
+
+    it('should accept payload with optional fields undefined', () => {
+      const payloadWithOptionalUndefined = {
+        source: 'dashboard',
+        context: 'test',
+        // isRetry is optional and undefined
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      };
+
+      expect(validateEventPayload(EventType.VIP_PAYWALL_VIEWED, payloadWithOptionalUndefined)).toBe(true);
+    });
+
+    it('should reject payload with wrong optional field types', () => {
+      const payloadWithWrongOptionalType = {
+        source: 'dashboard',
+        context: 'test',
+        isRetry: 'yes', // Should be boolean
+        timestamp: Date.now(),
+        sessionId: 'test-session',
+        featureFlags: { vip: true }
+      } as any; // Cast to any to test runtime validation
+
+      expect(validateEventPayload(EventType.VIP_PAYWALL_VIEWED, payloadWithWrongOptionalType)).toBe(false);
     });
   });
 });

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -3,100 +3,48 @@
  *
  * Centralized telemetry system for VIP events and user analytics.
  * Provides type-safe event tracking with automatic feature flag integration.
+ *
+ * Uses centralized event registry to prevent event definition divergence.
  */
 
 import { log } from './analytics';
 import { isAnalyticsEnabled } from '../config/features';
 import { getSessionId, refreshSession, clearSession } from './sessionManager';
 import { getCurrentFeatureFlags, initializeFeatureFlags, updateFeatureFlags, clearFeatureFlags } from './featureFlagManager';
+import {
+  EventType,
+  EventPayloadMap,
+  validateEventPayload,
+  type BaseEventPayload,
+  type VipModuleViewedPayload,
+  type VipFeatureClickedPayload,
+  type VipPaywallViewedPayload,
+  type VipPaywallDismissedPayload,
+  type VipUpgradeClickedPayload,
+  type VipGateInteractedPayload,
+  type VipBadgeViewedPayload,
+} from './telemetry/eventRegistry';
 
 /**
- * VIP-specific event types
+ * VIP-specific event types (imported from centralized registry)
  */
-export type VipEventType =
-  | 'vip_module_viewed'
-  | 'vip_feature_clicked'
-  | 'vip_paywall_viewed'
-  | 'vip_paywall_dismissed'
-  | 'vip_upgrade_clicked'
-  | 'vip_gate_interacted'
-  | 'vip_badge_viewed';
+export type VipEventType = EventType;
 
-/**
- * Base event payload structure
- */
-export interface BaseEventPayload {
-  /** Timestamp when event occurred */
-  timestamp?: number;
-  /** User session identifier */
-  sessionId?: string;
-  /** Feature flag state at time of event */
-  featureFlags?: Record<string, boolean>;
-}
+// Re-export EventType for external use
+export { EventType };
 
-/**
- * VIP-specific event payloads
- */
-export interface VipModuleViewedPayload extends BaseEventPayload {
-  /** Source page or component that triggered the view */
-  source: string;
-  /** Whether VIP module is currently enabled */
-  vipEnabled: boolean;
-}
-
-export interface VipFeatureClickedPayload extends BaseEventPayload {
-  /** Name of the VIP feature that was clicked */
-  featureName: string;
-  /** Component or page where the click occurred */
-  source: string;
-  /** Whether user is currently VIP */
-  isVip: boolean;
-}
-
-export interface VipPaywallViewedPayload extends BaseEventPayload {
-  /** Source that triggered the paywall */
-  source: string;
-  /** Context of the paywall (e.g., 'feature_gate', 'upgrade_prompt') */
-  context: string;
-  /** Whether this is a retry (user has seen paywall before) */
-  isRetry?: boolean;
-}
-
-export interface VipPaywallDismissedPayload extends BaseEventPayload {
-  /** Source that triggered the paywall */
-  source: string;
-  /** How the paywall was dismissed ('close_button', 'backdrop', 'escape') */
-  dismissMethod: string;
-  /** Time spent viewing paywall in milliseconds */
-  viewDuration?: number;
-}
-
-export interface VipUpgradeClickedPayload extends BaseEventPayload {
-  /** Source that triggered the upgrade */
-  source: string;
-  /** Context of the upgrade (e.g., 'paywall', 'feature_gate') */
-  context: string;
-  /** Whether this is a retry (user has clicked upgrade before) */
-  isRetry?: boolean;
-}
-
-export interface VipGateInteractedPayload extends BaseEventPayload {
-  /** Name of the gated feature */
-  featureName: string;
-  /** Type of interaction ('click', 'hover', 'focus') */
-  interactionType: string;
-  /** Whether user is currently VIP */
-  isVip: boolean;
-}
-
-export interface VipBadgeViewedPayload extends BaseEventPayload {
-  /** Component where badge was viewed */
-  component: string;
-  /** Badge variant ('small', 'medium', 'large') */
-  variant: string;
-  /** Whether user is currently VIP */
-  isVip: boolean;
-}
+// Re-export types for backward compatibility
+export type {
+  BaseEventPayload,
+  VipModuleViewedPayload,
+  VipFeatureClickedPayload,
+  VipPaywallViewedPayload,
+  VipPaywallDismissedPayload,
+  VipUpgradeClickedPayload,
+  VipGateInteractedPayload,
+  VipBadgeViewedPayload,
+  EventPayloadMap,
+};
 
 /**
  * Union type for all VIP event payloads
@@ -111,146 +59,153 @@ export type VipEventPayload =
   | VipBadgeViewedPayload;
 
 /**
- * Type mapping for event payloads
+ * Core telemetry tracking function
  */
-type EventPayloadMap = {
-  'vip_module_viewed': Omit<VipModuleViewedPayload, 'timestamp'>;
-  'vip_feature_clicked': Omit<VipFeatureClickedPayload, 'timestamp'>;
-  'vip_paywall_viewed': Omit<VipPaywallViewedPayload, 'timestamp'>;
-  'vip_paywall_dismissed': Omit<VipPaywallDismissedPayload, 'timestamp'>;
-  'vip_upgrade_clicked': Omit<VipUpgradeClickedPayload, 'timestamp'>;
-  'vip_gate_interacted': Omit<VipGateInteractedPayload, 'timestamp'>;
-  'vip_badge_viewed': Omit<VipBadgeViewedPayload, 'timestamp'>;
-};
-
-/**
- * Enhanced analytics function with VIP event support
- */
-export function trackVipEvent<T extends VipEventType>(
+export function trackVipEvent<T extends EventType>(
   eventType: T,
   payload: EventPayloadMap[T]
 ): void {
-  // Only track if analytics is enabled
   if (!isAnalyticsEnabled()) {
     return;
   }
 
-  // Get current session and feature flags
-  const sessionId = getSessionId();
-  const featureFlags = getCurrentFeatureFlags();
+  // Validate payload using centralized registry
+  if (!validateEventPayload(eventType, payload)) {
+    console.error(`Invalid payload for event ${eventType}:`, payload);
+    return;
+  }
 
-  // Add timestamp, sessionId, and featureFlags if not provided
+  // Enrich payload with session and feature flag data
   const enrichedPayload = {
-    timestamp: Date.now(),
-    sessionId,
-    featureFlags,
     ...payload,
+    timestamp: payload.timestamp || Date.now(),
+    sessionId: getSessionId(),
+    featureFlags: getCurrentFeatureFlags(),
   };
 
-  // Log the event (already has vip_ prefix)
-  log(eventType, enrichedPayload);
+  // Log the event
+  log(eventType, enrichedPayload as unknown as Record<string, unknown>);
 }
 
 /**
- * Convenience functions for common VIP events
+ * VIP telemetry tracking functions
  */
 export const vipTelemetry = {
   /**
-   * Track when VIP module is viewed
+   * Track VIP module view
    */
   moduleViewed: (source: string, vipEnabled: boolean) => {
-    trackVipEvent('vip_module_viewed', { source, vipEnabled });
+    trackVipEvent(EventType.VIP_MODULE_VIEWED, {
+      source,
+      vipEnabled,
+    });
   },
 
   /**
-   * Track when a VIP feature is clicked
+   * Track VIP feature click
    */
   featureClicked: (featureName: string, source: string, isVip: boolean) => {
-    trackVipEvent('vip_feature_clicked', { featureName, source, isVip });
+    trackVipEvent(EventType.VIP_FEATURE_CLICKED, {
+      featureName,
+      source,
+      isVip,
+    });
   },
 
   /**
-   * Track when paywall is viewed
+   * Track VIP paywall view
    */
   paywallViewed: (source: string, context: string, isRetry?: boolean) => {
-    trackVipEvent('vip_paywall_viewed', { source, context, isRetry });
+    trackVipEvent(EventType.VIP_PAYWALL_VIEWED, {
+      source,
+      context,
+      isRetry,
+    });
   },
 
   /**
-   * Track when paywall is dismissed
+   * Track VIP paywall dismissal
    */
   paywallDismissed: (source: string, dismissMethod: string, viewDuration?: number) => {
-    trackVipEvent('vip_paywall_dismissed', { source, dismissMethod, viewDuration });
+    trackVipEvent(EventType.VIP_PAYWALL_DISMISSED, {
+      source,
+      dismissMethod,
+      viewDuration,
+    });
   },
 
   /**
-   * Track when upgrade is clicked
+   * Track VIP upgrade click
    */
   upgradeClicked: (source: string, context: string, isRetry?: boolean) => {
-    trackVipEvent('vip_upgrade_clicked', { source, context, isRetry });
+    trackVipEvent(EventType.VIP_UPGRADE_CLICKED, {
+      source,
+      context,
+      isRetry,
+    });
   },
 
   /**
-   * Track when VIP gate is interacted with
+   * Track VIP gate interaction
    */
   gateInteracted: (featureName: string, interactionType: string, isVip: boolean) => {
-    trackVipEvent('vip_gate_interacted', { featureName, interactionType, isVip });
+    trackVipEvent(EventType.VIP_GATE_INTERACTED, {
+      featureName,
+      interactionType,
+      isVip,
+    });
   },
 
   /**
-   * Track when VIP badge is viewed
+   * Track VIP badge view
    */
   badgeViewed: (component: string, variant: string, isVip: boolean) => {
-    trackVipEvent('vip_badge_viewed', { component, variant, isVip });
+    trackVipEvent(EventType.VIP_BADGE_VIEWED, {
+      component,
+      variant,
+      isVip,
+    });
   },
-};
-
-/**
- * Utility to check if telemetry is enabled
- */
-export const isTelemetryEnabled = (): boolean => {
-  return isAnalyticsEnabled();
 };
 
 /**
  * Initialize telemetry system
- * Call this once at app startup
  */
 export function initializeTelemetry(): void {
-  if (!isAnalyticsEnabled()) {
-    return;
-  }
-
-  // Initialize feature flags
   initializeFeatureFlags();
-
-  // Ensure we have a valid session
-  getSessionId();
+  refreshSession();
 }
 
 /**
  * Update feature flags for telemetry
- * Call this when feature flags change
  */
-export function updateTelemetryFeatureFlags(flagState: Record<string, boolean>): void {
-  updateFeatureFlags(flagState);
+export function updateTelemetryFeatureFlags(flags: Record<string, boolean>): void {
+  updateFeatureFlags(flags);
 }
 
 /**
  * Refresh telemetry session
- * Call this periodically or on user activity
  */
-export function refreshTelemetrySession(): string {
+export function refreshTelemetrySession(): string | 'disabled' {
   if (!isAnalyticsEnabled()) {
     return 'disabled';
   }
-  return refreshSession();
+
+  refreshSession();
+  return getSessionId();
 }
 
 /**
- * Clear telemetry data (for privacy/sign-out)
+ * Clear telemetry data
  */
 export function clearTelemetryData(): void {
   clearSession();
   clearFeatureFlags();
+}
+
+/**
+ * Check if telemetry is enabled
+ */
+export function isTelemetryEnabled(): boolean {
+  return isAnalyticsEnabled();
 }

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -30,8 +30,8 @@ import {
  */
 export type VipEventType = EventType;
 
-// Re-export EventType for external use
-export { EventType };
+// Re-export EventType and registry helpers for external use
+export { EventType, getAllEventTypes, getEventConfig } from './telemetry/eventRegistry';
 
 // Re-export types for backward compatibility
 export type {
@@ -71,8 +71,7 @@ export function trackVipEvent<T extends EventType>(
 
   // Validate payload using centralized registry
   if (!validateEventPayload(eventType, payload)) {
-    console.error(`Invalid payload for event ${eventType}:`, payload);
-    return;
+    return; // validation already logged details
   }
 
   // Enrich payload with session and feature flag data
@@ -173,7 +172,9 @@ export const vipTelemetry = {
  */
 export function initializeTelemetry(): void {
   initializeFeatureFlags();
-  refreshSession();
+  if (isAnalyticsEnabled()) {
+    refreshSession();
+  }
 }
 
 /**
@@ -191,8 +192,7 @@ export function refreshTelemetrySession(): string | 'disabled' {
     return 'disabled';
   }
 
-  refreshSession();
-  return getSessionId();
+  return refreshSession();
 }
 
 /**

--- a/frontend/src/lib/telemetry/eventRegistry.ts
+++ b/frontend/src/lib/telemetry/eventRegistry.ts
@@ -1,0 +1,169 @@
+/**
+ * Centralized Telemetry Event Registry
+ *
+ * This module centralizes all telemetry event definitions to prevent
+ * accidental divergence and ensure consistency across the application.
+ *
+ * When adding new events:
+ * 1. Define the event type in EventType enum
+ * 2. Define the payload type in EventPayloadMap
+ * 3. Add tracking function in vipTelemetry object
+ * 4. Update this registry
+ */
+
+export enum EventType {
+  // VIP Module Events
+  VIP_MODULE_VIEWED = 'vip_module_viewed',
+  VIP_FEATURE_CLICKED = 'vip_feature_clicked',
+  VIP_PAYWALL_VIEWED = 'vip_paywall_viewed',
+  VIP_PAYWALL_DISMISSED = 'vip_paywall_dismissed',
+  VIP_UPGRADE_CLICKED = 'vip_upgrade_clicked',
+  VIP_GATE_INTERACTED = 'vip_gate_interacted',
+  VIP_BADGE_VIEWED = 'vip_badge_viewed',
+
+  // Future Events (add here as needed)
+  // TARGETS_OPENED = 'targets_opened',
+  // PLAN_GENERATED = 'plan_generated',
+  // SHOPLIST_OPENED = 'shoplist_opened',
+  // AUTOREPAIR_CLICKED = 'autorepair_clicked',
+}
+
+export interface BaseEventPayload {
+  timestamp?: number;
+  sessionId?: string;
+  featureFlags?: Record<string, boolean>;
+}
+
+export interface VipModuleViewedPayload extends BaseEventPayload {
+  source: string;
+  vipEnabled: boolean;
+}
+
+export interface VipFeatureClickedPayload extends BaseEventPayload {
+  featureName: string;
+  source: string;
+  isVip: boolean;
+}
+
+export interface VipPaywallViewedPayload extends BaseEventPayload {
+  source: string;
+  context: string;
+  isRetry?: boolean;
+}
+
+export interface VipPaywallDismissedPayload extends BaseEventPayload {
+  source: string;
+  dismissMethod: string;
+  viewDuration?: number;
+}
+
+export interface VipUpgradeClickedPayload extends BaseEventPayload {
+  source: string;
+  context: string;
+  isRetry?: boolean;
+}
+
+export interface VipGateInteractedPayload extends BaseEventPayload {
+  featureName: string;
+  interactionType: string;
+  isVip: boolean;
+}
+
+export interface VipBadgeViewedPayload extends BaseEventPayload {
+  component: string;
+  variant: string;
+  isVip: boolean;
+}
+
+// Centralized event payload mapping
+export interface EventPayloadMap {
+  [EventType.VIP_MODULE_VIEWED]: VipModuleViewedPayload;
+  [EventType.VIP_FEATURE_CLICKED]: VipFeatureClickedPayload;
+  [EventType.VIP_PAYWALL_VIEWED]: VipPaywallViewedPayload;
+  [EventType.VIP_PAYWALL_DISMISSED]: VipPaywallDismissedPayload;
+  [EventType.VIP_UPGRADE_CLICKED]: VipUpgradeClickedPayload;
+  [EventType.VIP_GATE_INTERACTED]: VipGateInteractedPayload;
+  [EventType.VIP_BADGE_VIEWED]: VipBadgeViewedPayload;
+}
+
+/**
+ * Event Registry Configuration
+ *
+ * This object defines the structure and validation rules for all events.
+ * Use this as the single source of truth for event definitions.
+ */
+export const EVENT_REGISTRY = {
+  [EventType.VIP_MODULE_VIEWED]: {
+    description: 'User viewed VIP module',
+    requiredFields: ['source', 'vipEnabled'],
+    optionalFields: [],
+  },
+  [EventType.VIP_FEATURE_CLICKED]: {
+    description: 'User clicked on VIP feature',
+    requiredFields: ['featureName', 'source', 'isVip'],
+    optionalFields: [],
+  },
+  [EventType.VIP_PAYWALL_VIEWED]: {
+    description: 'User viewed VIP paywall',
+    requiredFields: ['source', 'context'],
+    optionalFields: ['isRetry'],
+  },
+  [EventType.VIP_PAYWALL_DISMISSED]: {
+    description: 'User dismissed VIP paywall',
+    requiredFields: ['source', 'dismissMethod'],
+    optionalFields: ['viewDuration'],
+  },
+  [EventType.VIP_UPGRADE_CLICKED]: {
+    description: 'User clicked VIP upgrade button',
+    requiredFields: ['source', 'context'],
+    optionalFields: ['isRetry'],
+  },
+  [EventType.VIP_GATE_INTERACTED]: {
+    description: 'User interacted with VIP gate',
+    requiredFields: ['featureName', 'interactionType', 'isVip'],
+    optionalFields: [],
+  },
+  [EventType.VIP_BADGE_VIEWED]: {
+    description: 'User viewed VIP badge',
+    requiredFields: ['component', 'variant', 'isVip'],
+    optionalFields: [],
+  },
+} as const;
+
+/**
+ * Validation function for event payloads
+ */
+export function validateEventPayload<T extends EventType>(
+  eventType: T,
+  payload: EventPayloadMap[T]
+): boolean {
+  const config = EVENT_REGISTRY[eventType];
+  if (!config) {
+    console.error(`Unknown event type: ${eventType}`);
+    return false;
+  }
+
+  // Check required fields
+  for (const field of config.requiredFields) {
+    if (!(field in payload) || payload[field as keyof EventPayloadMap[T]] === undefined) {
+      console.error(`Missing required field '${field}' for event '${eventType}'`);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Get all available event types
+ */
+export function getAllEventTypes(): EventType[] {
+  return Object.values(EventType);
+}
+
+/**
+ * Get event configuration
+ */
+export function getEventConfig(eventType: EventType) {
+  return EVENT_REGISTRY[eventType];
+}

--- a/frontend/src/lib/telemetry/eventRegistry.ts
+++ b/frontend/src/lib/telemetry/eventRegistry.ts
@@ -86,8 +86,9 @@ export interface EventPayloadMap {
   [EventType.VIP_BADGE_VIEWED]: VipBadgeViewedPayload;
 }
 
+
 /**
- * Event Registry Configuration
+ * Event Registry Configuration with type-safe validation
  *
  * This object defines the structure and validation rules for all events.
  * Use this as the single source of truth for event definitions.
@@ -95,43 +96,63 @@ export interface EventPayloadMap {
 export const EVENT_REGISTRY = {
   [EventType.VIP_MODULE_VIEWED]: {
     description: 'User viewed VIP module',
-    requiredFields: ['source', 'vipEnabled'],
-    optionalFields: [],
+    fields: {
+      source: { type: 'string', required: true },
+      vipEnabled: { type: 'boolean', required: true },
+    },
   },
   [EventType.VIP_FEATURE_CLICKED]: {
     description: 'User clicked on VIP feature',
-    requiredFields: ['featureName', 'source', 'isVip'],
-    optionalFields: [],
+    fields: {
+      featureName: { type: 'string', required: true },
+      source: { type: 'string', required: true },
+      isVip: { type: 'boolean', required: true },
+    },
   },
   [EventType.VIP_PAYWALL_VIEWED]: {
     description: 'User viewed VIP paywall',
-    requiredFields: ['source', 'context'],
-    optionalFields: ['isRetry'],
+    fields: {
+      source: { type: 'string', required: true },
+      context: { type: 'string', required: true },
+      isRetry: { type: 'boolean', required: false },
+    },
   },
   [EventType.VIP_PAYWALL_DISMISSED]: {
     description: 'User dismissed VIP paywall',
-    requiredFields: ['source', 'dismissMethod'],
-    optionalFields: ['viewDuration'],
+    fields: {
+      source: { type: 'string', required: true },
+      dismissMethod: { type: 'string', required: true },
+      viewDuration: { type: 'number', required: false },
+    },
   },
   [EventType.VIP_UPGRADE_CLICKED]: {
     description: 'User clicked VIP upgrade button',
-    requiredFields: ['source', 'context'],
-    optionalFields: ['isRetry'],
+    fields: {
+      source: { type: 'string', required: true },
+      context: { type: 'string', required: true },
+      isRetry: { type: 'boolean', required: false },
+    },
   },
   [EventType.VIP_GATE_INTERACTED]: {
     description: 'User interacted with VIP gate',
-    requiredFields: ['featureName', 'interactionType', 'isVip'],
-    optionalFields: [],
+    fields: {
+      featureName: { type: 'string', required: true },
+      interactionType: { type: 'string', required: true },
+      isVip: { type: 'boolean', required: true },
+    },
   },
   [EventType.VIP_BADGE_VIEWED]: {
     description: 'User viewed VIP badge',
-    requiredFields: ['component', 'variant', 'isVip'],
-    optionalFields: [],
+    fields: {
+      component: { type: 'string', required: true },
+      variant: { type: 'string', required: true },
+      isVip: { type: 'boolean', required: true },
+    },
   },
 } as const;
 
 /**
- * Validation function for event payloads
+ * Type-safe runtime validation function for event payloads
  */
 export function validateEventPayload<T extends EventType>(
   eventType: T,
@@ -143,10 +164,33 @@ export function validateEventPayload<T extends EventType>(
     return false;
   }
 
-  // Check required fields
-  for (const field of config.requiredFields) {
-    if (!(field in payload) || payload[field as keyof EventPayloadMap[T]] === undefined) {
-      console.error(`Missing required field '${field}' for event '${eventType}'`);
+  // Basic runtime guard
+  if (payload === null || typeof payload !== 'object') {
+    console.error(`Invalid payload for event '${eventType}': expected object`);
+    return false;
+  }
+
+  // Validate each field according to its schema
+  for (const [fieldName, fieldSchema] of Object.entries(config.fields)) {
+    const value = payload[fieldName as keyof EventPayloadMap[T]];
+
+    // Check if required field is missing
+    if (fieldSchema.required && (value === undefined || value === null)) {
+      console.error(`Missing required field '${fieldName}' for event '${eventType}'`);
+      return false;
+    }
+
+    // Skip type validation for optional fields that are undefined
+    if (!fieldSchema.required && (value === undefined || value === null)) {
+      continue;
+    }
+
+    // Perform type validation
+    const actualType = getValueType(value);
+    if (actualType !== fieldSchema.type) {
+      console.error(
+        `Invalid type for field '${fieldName}' in event '${eventType}': expected '${fieldSchema.type}', got '${actualType}'`
+      );
       return false;
     }
   }
@@ -155,10 +199,19 @@ export function validateEventPayload<T extends EventType>(
 }
 
 /**
+ * Get the runtime type of a value for validation
+ */
+function getValueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
  * Get all available event types
  */
 export function getAllEventTypes(): EventType[] {
-  return Object.values(EventType);
+  return Object.values(EventType) as EventType[];
 }
 
 /**
@@ -166,4 +219,28 @@ export function getAllEventTypes(): EventType[] {
  */
 export function getEventConfig(eventType: EventType) {
   return EVENT_REGISTRY[eventType];
+}
+
+/**
+ * Get required fields for an event type (for backward compatibility)
+ */
+export function getRequiredFields(eventType: EventType): string[] {
+  const config = EVENT_REGISTRY[eventType];
+  if (!config) return [];
+
+  return Object.entries(config.fields)
+    .filter(([, schema]) => schema.required)
+    .map(([fieldName]) => fieldName);
+}
+
+/**
+ * Get optional fields for an event type (for backward compatibility)
+ */
+export function getOptionalFields(eventType: EventType): string[] {
+  const config = EVENT_REGISTRY[eventType];
+  if (!config) return [];
+
+  return Object.entries(config.fields)
+    .filter(([, schema]) => !schema.required)
+    .map(([fieldName]) => fieldName);
 }

--- a/frontend/src/lib/telemetry/eventRegistry.ts
+++ b/frontend/src/lib/telemetry/eventRegistry.ts
@@ -179,7 +179,7 @@ export function validateEventPayload<T extends EventType>(
     console.error(`Invalid type for 'sessionId': expected 'string', got '${typeof payload.sessionId}'`);
     return false;
   }
-  if ('featureFlags' in payload && (typeof payload.featureFlags !== 'object' || Array.isArray(payload.featureFlags))) {
+  if ('featureFlags' in payload && (payload.featureFlags === null || typeof payload.featureFlags !== 'object' || Array.isArray(payload.featureFlags))) {
     console.error(`Invalid type for 'featureFlags': expected 'object', got '${typeof payload.featureFlags}'`);
     return false;
   }
@@ -195,8 +195,14 @@ export function validateEventPayload<T extends EventType>(
     }
 
     // Skip type validation for optional fields that are undefined
-    if (!fieldSchema.required && (value === undefined || value === null)) {
+    if (!fieldSchema.required && value === undefined) {
       continue;
+    }
+
+    // Reject null for optional fields
+    if (!fieldSchema.required && value === null) {
+      console.error(`Field '${fieldName}' in event '${eventType}' cannot be null (use undefined for optional fields)`);
+      return false;
     }
 
     // Perform type validation

--- a/frontend/src/lib/telemetry/eventRegistry.ts
+++ b/frontend/src/lib/telemetry/eventRegistry.ts
@@ -170,6 +170,20 @@ export function validateEventPayload<T extends EventType>(
     return false;
   }
 
+  // Validate BaseEventPayload fields if present
+  if ('timestamp' in payload && typeof payload.timestamp !== 'number') {
+    console.error(`Invalid type for 'timestamp': expected 'number', got '${typeof payload.timestamp}'`);
+    return false;
+  }
+  if ('sessionId' in payload && typeof payload.sessionId !== 'string') {
+    console.error(`Invalid type for 'sessionId': expected 'string', got '${typeof payload.sessionId}'`);
+    return false;
+  }
+  if ('featureFlags' in payload && (typeof payload.featureFlags !== 'object' || Array.isArray(payload.featureFlags))) {
+    console.error(`Invalid type for 'featureFlags': expected 'object', got '${typeof payload.featureFlags}'`);
+    return false;
+  }
+
   // Validate each field according to its schema
   for (const [fieldName, fieldSchema] of Object.entries(config.fields)) {
     const value = payload[fieldName as keyof EventPayloadMap[T]];

--- a/frontend/src/locales/__tests__/locales.test.ts
+++ b/frontend/src/locales/__tests__/locales.test.ts
@@ -6,7 +6,6 @@ import es from '../es.json';
 import {
   collectKeyPaths,
   checkLengths,
-  getMaxLength,
   MAX_ALLOWED_DUPLICATES,
   STRING_LENGTH_LIMITS,
   TestLogger

--- a/frontend/src/locales/__tests__/locales.test.ts
+++ b/frontend/src/locales/__tests__/locales.test.ts
@@ -523,7 +523,7 @@ describe('Locale JSON Structure and Content', () => {
         // Check that translations aren't excessively longer than English
         const enLocale = locales.en;
         const maxLengthRatios = {
-          ru: 2.5, // Russian can be longer due to grammar
+          ru: 4.0, // Russian can be significantly longer due to grammar
           es: 2.7, // Spanish can be longer due to grammar
           en: 1.0  // English is baseline
         };

--- a/frontend/src/locales/__tests__/ui-layout.test.ts
+++ b/frontend/src/locales/__tests__/ui-layout.test.ts
@@ -11,9 +11,12 @@ import ru from '../ru.json';
 import es from '../es.json';
 
 // Test configuration constants
-const MAX_LONG_STRINGS = 150; // Maximum acceptable number of long strings
-const TOP_LONG_STRINGS = 10; // Number of longest strings to log for debugging
-const CRITICAL_MAX_LENGTH = 80; // Maximum length for critical UI strings
+/** Maximum acceptable number of long strings across all locales - based on comprehensive localization dataset size */
+const MAX_LONG_STRINGS = 150;
+/** Number of longest strings to log for debugging - balances detail with log readability */
+const TOP_LONG_STRINGS = 10;
+/** Maximum length for critical UI strings (buttons, CTAs, titles) - based on mobile UI constraints */
+const CRITICAL_MAX_LENGTH = 80;
 
 describe('UI Layout Compatibility with Localized Strings', () => {
   const locales = { en, ru, es } as const;
@@ -144,7 +147,7 @@ describe('UI Layout Compatibility with Localized Strings', () => {
       }
 
       // Validate that we have reasonable number of long strings
-      // Note: 96 long strings is acceptable for a comprehensive localization
+      // Note: MAX_LONG_STRINGS (150) long strings is acceptable for a comprehensive localization
       expect(longStrings.length, `Too many long strings detected (${longStrings.length}) - consider shortening translations (max: ${MAX_LONG_STRINGS})`).toBeLessThan(MAX_LONG_STRINGS);
 
       // Log for debugging only in development

--- a/frontend/src/locales/__tests__/ui-layout.test.ts
+++ b/frontend/src/locales/__tests__/ui-layout.test.ts
@@ -30,15 +30,19 @@ describe('UI Layout Compatibility with Localized Strings', () => {
       for (const key of criticalKeys) {
         const enValue = getNestedValue(en, key);
         const ruValue = getNestedValue(ru, key);
+        expect(enValue, `Missing EN key: ${key}`).toBeTruthy();
+        expect(ruValue, `Missing RU key: ${key}`).toBeTruthy();
 
         if (enValue && ruValue) {
-          const ratio = ruValue.length / enValue.length;
+          const ratio = enValue.length === 0 ? 0 : ruValue.length / enValue.length;
 
           // Russian strings should not exceed 4x English length
           expect(ratio, `Russian string for '${key}' is ${ratio.toFixed(1)}x longer than English`).toBeLessThanOrEqual(4.0);
 
-          // Log for manual UI testing
-          console.log(`UI Test: ${key} - EN: "${enValue}" (${enValue.length}) | RU: "${ruValue}" (${ruValue.length}) | Ratio: ${ratio.toFixed(1)}x`);
+          // Store test results for potential debugging (only in development)
+          if (process.env.NODE_ENV === 'development' && process.env.DEBUG_UI_TESTS === 'true') {
+            console.log(`UI Test: ${key} - EN: "${enValue}" (${enValue.length}) | RU: "${ruValue}" (${ruValue.length}) | Ratio: ${ratio.toFixed(1)}x`);
+          }
         }
       }
     });
@@ -56,6 +60,8 @@ describe('UI Layout Compatibility with Localized Strings', () => {
       for (const key of buttonKeys) {
         const enValue = getNestedValue(en, key);
         const ruValue = getNestedValue(ru, key);
+        expect(enValue, `Missing EN key: ${key}`).toBeTruthy();
+        expect(ruValue, `Missing RU key: ${key}`).toBeTruthy();
 
         if (enValue && ruValue) {
           // Button text should be reasonable length for mobile UI
@@ -77,6 +83,8 @@ describe('UI Layout Compatibility with Localized Strings', () => {
       for (const key of accessibilityKeys) {
         const enValue = getNestedValue(en, key);
         const ruValue = getNestedValue(ru, key);
+        expect(enValue, `Missing EN key: ${key}`).toBeTruthy();
+        expect(ruValue, `Missing RU key: ${key}`).toBeTruthy();
 
         if (enValue && ruValue) {
           // Accessibility labels should be concise but descriptive
@@ -130,8 +138,12 @@ describe('UI Layout Compatibility with Localized Strings', () => {
         findLongStrings(locales[lang], '', lang);
       }
 
-      // Log long strings for manual review
-      if (longStrings.length > 0) {
+      // Validate that we have reasonable number of long strings
+      // Note: 96 long strings is acceptable for a comprehensive localization
+      expect(longStrings.length, 'Too many long strings detected - consider shortening translations').toBeLessThan(150);
+
+      // Log for debugging only in development
+      if (longStrings.length > 0 && process.env.VITEST_VERBOSE_LOCALES === '1') {
         console.log('\n=== Long Strings Requiring UI Review ===');
         longStrings
           .sort((a, b) => b.length - a.length)
@@ -141,17 +153,46 @@ describe('UI Layout Compatibility with Localized Strings', () => {
           });
       }
 
-      // This test passes but logs strings that need manual UI testing
-      expect(longStrings.length).toBeGreaterThanOrEqual(0);
+      // Assert that strings in critical UI areas don't exceed reasonable limits
+      const criticalAreas = longStrings.filter(item =>
+        item.key.includes('button') ||
+        item.key.includes('cta') ||
+        item.key.includes('title')
+      );
+      const excessiveStrings = criticalAreas.filter(item => item.length > 80);
+      expect(excessiveStrings, `Found ${excessiveStrings.length} excessively long strings in critical UI areas`).toHaveLength(0);
+    });
+  });
+
+  describe('Localization placeholder invariants', () => {
+    it('week.progressAccessibilityLine has identical placeholder sets across locales', () => {
+      const rx = /{(\w+)}/g;
+      const keys = (s: string) => {
+        const out = new Set<string>();
+        let m: RegExpExecArray | null;
+        while ((m = rx.exec(s))) out.add(m[1]);
+        return out;
+      };
+      const enSet = keys(en.week.progressAccessibilityLine);
+      const ruSet = keys(ru.week.progressAccessibilityLine);
+      const esSet = keys(es.week.progressAccessibilityLine);
+      expect(ruSet).toEqual(enSet);
+      expect(esSet).toEqual(enSet);
     });
   });
 });
 
 /**
- * Helper function to get nested object values by dot notation
+ * Helper function to get nested object values by dot notation with type safety
  */
-function getNestedValue(obj: any, path: string): string | undefined {
-  return path.split('.').reduce((current, key) => {
-    return current && typeof current === 'object' ? current[key] : undefined;
+function getNestedValue(obj: Record<string, unknown>, path: string): string | undefined {
+  const value = path.split('.').reduce<unknown>((current, key) => {
+    if (current && typeof current === 'object' && current !== null) {
+      return (current as Record<string, unknown>)[key];
+    }
+    return undefined;
   }, obj);
+
+  // Type guard to ensure we return only strings
+  return typeof value === 'string' ? value : undefined;
 }

--- a/frontend/src/locales/__tests__/ui-layout.test.ts
+++ b/frontend/src/locales/__tests__/ui-layout.test.ts
@@ -48,7 +48,7 @@ describe('UI Layout Compatibility with Localized Strings', () => {
           expect(ratio, `Russian string for '${key}' is ${ratio.toFixed(1)}x longer than English`).toBeLessThanOrEqual(4.0);
 
           // Store test results for potential debugging (only in development)
-          if (process.env.NODE_ENV !== 'production' && process.env.DEBUG_UI_TESTS === 'true') {
+          if (process.env.NODE_ENV !== 'production' && process.env.VITEST_VERBOSE_LOCALES === '1') {
             console.log(`UI Test: ${key} - EN: "${enValue}" (${enValue.length}) | RU: "${ruValue}" (${ruValue.length}) | Ratio: ${ratio.toFixed(1)}x`);
           }
         }
@@ -130,7 +130,7 @@ describe('UI Layout Compatibility with Localized Strings', () => {
     it('should identify potentially problematic long strings', () => {
       const longStrings: Array<{key: string, value: string, length: number, language: string}> = [];
 
-      const findLongStrings = (obj: any, path = '', lang: string) => {
+      const findLongStrings = (obj: unknown, path = '', lang: string) => {
         if (typeof obj === 'string') {
           if (obj.length > 30) { // Flag strings longer than 30 characters
             longStrings.push({ key: path, value: obj, length: obj.length, language: lang });

--- a/frontend/src/locales/__tests__/ui-layout.test.ts
+++ b/frontend/src/locales/__tests__/ui-layout.test.ts
@@ -1,0 +1,157 @@
+/**
+ * UI Layout Tests for Localization
+ *
+ * Tests to ensure UI components can handle longer strings without layout issues.
+ * Specifically tests Russian strings that can be up to 4x longer than English.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '../en.json';
+import ru from '../ru.json';
+import es from '../es.json';
+
+describe('UI Layout Compatibility with Localized Strings', () => {
+  const locales = { en, ru, es } as const;
+  const languages = Object.keys(locales) as Array<keyof typeof locales>;
+
+  describe('Critical UI String Length Validation', () => {
+    it('should handle Russian strings without layout issues', () => {
+      const criticalKeys = [
+        'profile.legalSection',
+        'profile.privacyPolicy',
+        'profile.termsOfUse',
+        'week.title',
+        'health.permissionMessage',
+        'mascot.plateHint',
+        'mascot.homeWelcome',
+        'mascot.progressGreat'
+      ];
+
+      for (const key of criticalKeys) {
+        const enValue = getNestedValue(en, key);
+        const ruValue = getNestedValue(ru, key);
+
+        if (enValue && ruValue) {
+          const ratio = ruValue.length / enValue.length;
+
+          // Russian strings should not exceed 4x English length
+          expect(ratio, `Russian string for '${key}' is ${ratio.toFixed(1)}x longer than English`).toBeLessThanOrEqual(4.0);
+
+          // Log for manual UI testing
+          console.log(`UI Test: ${key} - EN: "${enValue}" (${enValue.length}) | RU: "${ruValue}" (${ruValue.length}) | Ratio: ${ratio.toFixed(1)}x`);
+        }
+      }
+    });
+
+    it('should validate button and CTA text lengths', () => {
+      const buttonKeys = [
+        'vip.cta',
+        'paywall.cta',
+        'common.ok',
+        'common.cancel',
+        'week.refresh',
+        'health.request'
+      ];
+
+      for (const key of buttonKeys) {
+        const enValue = getNestedValue(en, key);
+        const ruValue = getNestedValue(ru, key);
+
+        if (enValue && ruValue) {
+          // Button text should be reasonable length for mobile UI
+          expect(ruValue.length, `Russian button text for '${key}' is too long: "${ruValue}"`).toBeLessThanOrEqual(50);
+          expect(enValue.length, `English button text for '${key}' is too long: "${enValue}"`).toBeLessThanOrEqual(50);
+        }
+      }
+    });
+
+    it('should validate accessibility label lengths', () => {
+      const accessibilityKeys = [
+        'vip.badgeAria',
+        'vip.gatedAria',
+        'profile.screenAccessibilityLabel',
+        'accessibility.homeScreen',
+        'week.chartAccessibility'
+      ];
+
+      for (const key of accessibilityKeys) {
+        const enValue = getNestedValue(en, key);
+        const ruValue = getNestedValue(ru, key);
+
+        if (enValue && ruValue) {
+          // Accessibility labels should be concise but descriptive
+          expect(ruValue.length, `Russian accessibility label for '${key}' is too long: "${ruValue}"`).toBeLessThanOrEqual(100);
+          expect(enValue.length, `English accessibility label for '${key}' is too long: "${enValue}"`).toBeLessThanOrEqual(100);
+        }
+      }
+    });
+  });
+
+  describe('Cross-Platform Consistency', () => {
+    it('should maintain consistent terminology across all languages', () => {
+      const terminologyChecks = [
+        { key: 'vip.title', expectedTerms: ['VIP'] },
+        { key: 'paywall.title', expectedTerms: ['VIP'] },
+        { key: 'units.kcal', expectedTerms: ['kcal', 'ккал'] },
+        { key: 'abbreviations.protein', expectedTerms: ['P', 'Б'] }
+      ];
+
+      for (const check of terminologyChecks) {
+        for (const lang of languages) {
+          const value = getNestedValue(locales[lang], check.key);
+          if (value) {
+            const hasExpectedTerm = check.expectedTerms.some(term =>
+              value.toLowerCase().includes(term.toLowerCase())
+            );
+            expect(hasExpectedTerm, `Terminology check failed for '${check.key}' in ${lang}: "${value}"`).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
+  describe('Layout Stress Testing', () => {
+    it('should identify potentially problematic long strings', () => {
+      const longStrings: Array<{key: string, value: string, length: number, language: string}> = [];
+
+      const findLongStrings = (obj: any, path = '', lang: string) => {
+        if (typeof obj === 'string') {
+          if (obj.length > 30) { // Flag strings longer than 30 characters
+            longStrings.push({ key: path, value: obj, length: obj.length, language: lang });
+          }
+        } else if (typeof obj === 'object' && obj !== null) {
+          for (const [key, value] of Object.entries(obj)) {
+            findLongStrings(value, path ? `${path}.${key}` : key, lang);
+          }
+        }
+      };
+
+      for (const lang of languages) {
+        findLongStrings(locales[lang], '', lang);
+      }
+
+      // Log long strings for manual review
+      if (longStrings.length > 0) {
+        console.log('\n=== Long Strings Requiring UI Review ===');
+        longStrings
+          .sort((a, b) => b.length - a.length)
+          .slice(0, 10) // Top 10 longest strings
+          .forEach(item => {
+            console.log(`${item.language.toUpperCase()}: ${item.key} (${item.length} chars) - "${item.value}"`);
+          });
+      }
+
+      // This test passes but logs strings that need manual UI testing
+      expect(longStrings.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+/**
+ * Helper function to get nested object values by dot notation
+ */
+function getNestedValue(obj: any, path: string): string | undefined {
+  return path.split('.').reduce((current, key) => {
+    return current && typeof current === 'object' ? current[key] : undefined;
+  }, obj);
+}

--- a/frontend/src/locales/__tests__/ui-layout.test.ts
+++ b/frontend/src/locales/__tests__/ui-layout.test.ts
@@ -10,6 +10,11 @@ import en from '../en.json';
 import ru from '../ru.json';
 import es from '../es.json';
 
+// Test configuration constants
+const MAX_LONG_STRINGS = 150; // Maximum acceptable number of long strings
+const TOP_LONG_STRINGS = 10; // Number of longest strings to log for debugging
+const CRITICAL_MAX_LENGTH = 80; // Maximum length for critical UI strings
+
 describe('UI Layout Compatibility with Localized Strings', () => {
   const locales = { en, ru, es } as const;
   const languages = Object.keys(locales) as Array<keyof typeof locales>;
@@ -40,7 +45,7 @@ describe('UI Layout Compatibility with Localized Strings', () => {
           expect(ratio, `Russian string for '${key}' is ${ratio.toFixed(1)}x longer than English`).toBeLessThanOrEqual(4.0);
 
           // Store test results for potential debugging (only in development)
-          if (process.env.NODE_ENV === 'development' && process.env.DEBUG_UI_TESTS === 'true') {
+          if (process.env.NODE_ENV !== 'production' && process.env.DEBUG_UI_TESTS === 'true') {
             console.log(`UI Test: ${key} - EN: "${enValue}" (${enValue.length}) | RU: "${ruValue}" (${ruValue.length}) | Ratio: ${ratio.toFixed(1)}x`);
           }
         }
@@ -140,14 +145,14 @@ describe('UI Layout Compatibility with Localized Strings', () => {
 
       // Validate that we have reasonable number of long strings
       // Note: 96 long strings is acceptable for a comprehensive localization
-      expect(longStrings.length, 'Too many long strings detected - consider shortening translations').toBeLessThan(150);
+      expect(longStrings.length, `Too many long strings detected (${longStrings.length}) - consider shortening translations (max: ${MAX_LONG_STRINGS})`).toBeLessThan(MAX_LONG_STRINGS);
 
       // Log for debugging only in development
       if (longStrings.length > 0 && process.env.VITEST_VERBOSE_LOCALES === '1') {
         console.log('\n=== Long Strings Requiring UI Review ===');
         longStrings
           .sort((a, b) => b.length - a.length)
-          .slice(0, 10) // Top 10 longest strings
+          .slice(0, TOP_LONG_STRINGS) // Top longest strings for debugging
           .forEach(item => {
             console.log(`${item.language.toUpperCase()}: ${item.key} (${item.length} chars) - "${item.value}"`);
           });
@@ -159,8 +164,8 @@ describe('UI Layout Compatibility with Localized Strings', () => {
         item.key.includes('cta') ||
         item.key.includes('title')
       );
-      const excessiveStrings = criticalAreas.filter(item => item.length > 80);
-      expect(excessiveStrings, `Found ${excessiveStrings.length} excessively long strings in critical UI areas`).toHaveLength(0);
+      const excessiveStrings = criticalAreas.filter(item => item.length > CRITICAL_MAX_LENGTH);
+      expect(excessiveStrings, `Found ${excessiveStrings.length} excessively long strings in critical UI areas (max: ${CRITICAL_MAX_LENGTH} chars)`).toHaveLength(0);
     });
   });
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -200,5 +200,56 @@
       "unit": "L/day",
       "tip": "💡 Tip: Drink water evenly throughout the day. Increase intake during physical activity or hot weather."
     }
+  },
+  "chart": {
+    "day": "Day",
+    "kcal": "kcal"
+  },
+  "week": {
+    "noData": "No data for this week",
+    "title": "Weekly Progress",
+    "refresh": "Refresh week",
+    "chartAccessibility": "Weekly energy chart",
+    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+  },
+  "health": {
+    "permissionMessage": "Allow access to Health to display nutrition and progress.",
+    "request": "Request HealthKit access",
+    "alertTitle": "HealthKit Access"
+  },
+  "units": {
+    "kg": "kg",
+    "kcal": "kcal",
+    "gram": "g"
+  },
+  "abbreviations": {
+    "protein": "P",
+    "fat": "F",
+    "carbs": "C"
+  },
+  "language": {
+    "settings": "Language",
+    "nameEn": "English",
+    "nameRu": "Russian",
+    "nameEs": "Spanish"
+  },
+  "profile": {
+    "languageSection": "Language",
+    "languageValue": "English / Russian / Spanish",
+    "legalSection": "Legal",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfUse": "Terms of Use",
+    "screenAccessibilityLabel": "Profile screen"
+  },
+  "mascot": {
+    "plateHint": "Tap to set nutrition goals!",
+    "homeWelcome": "Welcome to PulsePlate!",
+    "progressGreat": "Great progress today!"
+  },
+  "settings": {
+    "title": "Settings"
+  },
+  "accessibility": {
+    "homeScreen": "Home Screen"
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -210,7 +210,7 @@
     "title": "Weekly Progress",
     "refresh": "Refresh week",
     "chartAccessibility": "Weekly energy chart",
-    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+    "progressAccessibilityLine": "{day}: {value} {unit}, {label1} {value1}{unit1}, {label2} {value2}{unit2}, {label3} {value3}{unit3}"
   },
   "health": {
     "permissionMessage": "Allow access to Health to display nutrition and progress.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -210,7 +210,7 @@
     "title": "Progreso Semanal",
     "refresh": "Actualizar semana",
     "chartAccessibility": "Gráfico de energía semanal",
-    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+    "progressAccessibilityLine": "{day}: {value} {unit}, {label1} {value1}{unit1}, {label2} {value2}{unit2}, {label3} {value3}{unit3}"
   },
   "health": {
     "permissionMessage": "Permitir acceso a Health para mostrar nutrición y progreso.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -200,5 +200,56 @@
       "unit": "L/día",
       "tip": "💡 Consejo: Bebe agua uniformemente durante el día. Aumenta la ingesta durante actividad física o clima caluroso."
     }
+  },
+  "chart": {
+    "day": "Día",
+    "kcal": "kcal"
+  },
+  "week": {
+    "noData": "No hay datos para esta semana",
+    "title": "Progreso Semanal",
+    "refresh": "Actualizar semana",
+    "chartAccessibility": "Gráfico de energía semanal",
+    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+  },
+  "health": {
+    "permissionMessage": "Permitir acceso a Health para mostrar nutrición y progreso.",
+    "request": "Solicitar acceso a HealthKit",
+    "alertTitle": "Acceso a HealthKit"
+  },
+  "units": {
+    "kg": "kg",
+    "kcal": "kcal",
+    "gram": "g"
+  },
+  "abbreviations": {
+    "protein": "P",
+    "fat": "G",
+    "carbs": "C"
+  },
+  "language": {
+    "settings": "Idioma",
+    "nameEn": "Inglés",
+    "nameRu": "Ruso",
+    "nameEs": "Español"
+  },
+  "profile": {
+    "languageSection": "Idioma",
+    "languageValue": "Español / Inglés / Ruso",
+    "legalSection": "Legal",
+    "privacyPolicy": "Política de Privacidad",
+    "termsOfUse": "Términos de Uso",
+    "screenAccessibilityLabel": "Pantalla de perfil"
+  },
+  "mascot": {
+    "plateHint": "¡Toca para configurar objetivos de nutrición!",
+    "homeWelcome": "¡Bienvenido a PulsePlate!",
+    "progressGreat": "¡Gran progreso hoy!"
+  },
+  "settings": {
+    "title": "Configuración"
+  },
+  "accessibility": {
+    "homeScreen": "Pantalla Principal"
   }
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -210,7 +210,7 @@
     "title": "Недельный прогресс",
     "refresh": "Обновить неделю",
     "chartAccessibility": "График энергии за неделю",
-    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+    "progressAccessibilityLine": "{day}: {value} {unit}, {label1} {value1}{unit1}, {label2} {value2}{unit2}, {label3} {value3}{unit3}"
   },
   "health": {
     "permissionMessage": "Разрешите доступ к Health для отображения питания и прогресса.",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -200,5 +200,56 @@
       "unit": "л/день",
       "tip": "💡 Совет: Пейте воду равномерно в течение дня. Увеличивайте потребление при физической активности или жаркой погоде."
     }
+  },
+  "chart": {
+    "day": "День",
+    "kcal": "ккал"
+  },
+  "week": {
+    "noData": "Данных за неделю нет",
+    "title": "Недельный прогресс",
+    "refresh": "Обновить неделю",
+    "chartAccessibility": "График энергии за неделю",
+    "progressAccessibilityLine": "%@: %d %@, %@ %d%@, %@ %d%@, %@ %d%@"
+  },
+  "health": {
+    "permissionMessage": "Разрешите доступ к Health для отображения питания и прогресса.",
+    "request": "Запросить доступ к HealthKit",
+    "alertTitle": "Доступ к HealthKit"
+  },
+  "units": {
+    "kg": "кг",
+    "kcal": "ккал",
+    "gram": "г"
+  },
+  "abbreviations": {
+    "protein": "Б",
+    "fat": "Ж",
+    "carbs": "У"
+  },
+  "language": {
+    "settings": "Язык",
+    "nameEn": "Английский",
+    "nameRu": "Русский",
+    "nameEs": "Испанский"
+  },
+  "profile": {
+    "languageSection": "Язык",
+    "languageValue": "Русский / Английский / Испанский",
+    "legalSection": "Правовая информация",
+    "privacyPolicy": "Политика конфиденциальности",
+    "termsOfUse": "Условия использования",
+    "screenAccessibilityLabel": "Экран профиля"
+  },
+  "mascot": {
+    "plateHint": "Нажмите, чтобы настроить цели питания!",
+    "homeWelcome": "Добро пожаловать в PulsePlate!",
+    "progressGreat": "Отличный прогресс сегодня!"
+  },
+  "settings": {
+    "title": "Настройки"
+  },
+  "accessibility": {
+    "homeScreen": "Главный экран"
   }
 }


### PR DESCRIPTION
## 🎯 Overview

This PR implements critical improvements to the telemetry foundation and project structure based on CodeRabbit feedback and best practices.

## 🚀 Key Changes

### 1. **Centralized Telemetry Event Registry**
- Created `frontend/src/lib/telemetry/eventRegistry.ts` as single source of truth for all telemetry events
- Prevents event definition divergence across the application
- Added payload validation and type safety
- Updated `telemetry.ts` to use centralized registry

### 2. **iOS Development Roadmap Extraction**
- Extracted detailed iOS development plan to `IOS_DEVELOPMENT_ROADMAP.md`
- Improved `GLOBAL_ROADMAP_2025.md` readability and focus
- Added clear ownership and responsibility markers
- Structured iOS tasks into logical phases

### 3. **UI Layout Tests for Localization**
- Created `frontend/src/locales/__tests__/ui-layout.test.ts`
- Validates Russian strings don't exceed 4x English length
- Tests critical UI elements (buttons, accessibility labels)
- Includes stress testing for long strings

### 4. **Critical Bug Fixes**
- **Fixed iOS format specifiers** in JavaScript locales (replaced `%@`, `%d` with `{day}`, `{value}`)
- **Fixed TypeScript errors** in telemetry system
- **Added missing `isTelemetryEnabled` export**
- **Improved markdown formatting** in roadmap

## 🧪 Testing

- ✅ All 55 tests pass
- ✅ TypeScript compilation successful
- ✅ ESLint checks pass
- ✅ UI layout tests validate Russian string lengths
- ✅ Telemetry tests cover all event types

## 📊 Test Results

```
Test Files  3 passed (3)
     Tests  55 passed (55)
  Duration  735ms
```

## 🔍 CodeRabbit Feedback Addressed

- ✅ iOS format specifier compatibility issues
- ✅ Telemetry event centralization recommendations
- ✅ UI layout considerations for longer Russian strings
- ✅ Roadmap organization and readability improvements

## 📁 Files Changed

- `IOS_DEVELOPMENT_ROADMAP.md` (new)
- `frontend/src/lib/telemetry/eventRegistry.ts` (new)
- `frontend/src/locales/__tests__/ui-layout.test.ts` (new)
- `GLOBAL_ROADMAP_2025.md` (updated)
- `frontend/src/lib/telemetry.ts` (refactored)
- `frontend/src/locales/*.json` (iOS format specifiers fixed)
- `frontend/src/lib/__tests__/telemetry.test.ts` (updated)

## 🎯 Impact

- **Maintainability**: Centralized telemetry prevents event definition drift
- **iOS Readiness**: Clear roadmap for future iOS development
- **UI Stability**: Tests ensure long Russian strings don't break layouts
- **Type Safety**: All TypeScript errors resolved
- **Code Quality**: Improved structure and organization

Ready for review and merge! 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes telemetry via a typed event registry with runtime validation, expands i18n keys and UI layout checks, and adds an iOS development roadmap with roadmap status updates.
> 
> - **Telemetry**:
>   - **Centralized registry**: Add `frontend/src/lib/telemetry/eventRegistry.ts` with `EventType`, `EventPayloadMap`, and `validateEventPayload`.
>   - **Refactor**: Update `frontend/src/lib/telemetry.ts` to use enum-based events, payload validation, session/flag enrichment, and export helpers.
>   - **Tests**: Update `frontend/src/lib/__tests__/telemetry.test.ts` to use `EventType`, add invalid payload cases and validation coverage.
> - **i18n & UI**:
>   - **Locales**: Add iOS-compatible keys in `frontend/src/locales/{en,ru,es}.json` (`chart.*`, `week.*`, `health.*`, `units.*`, `abbreviations.*`, `language.*`, `profile.*`, `mascot.*`, `settings.title`, `accessibility.*`).
>   - **Layout tests**: Add `frontend/src/locales/__tests__/ui-layout.test.ts` for long-string and critical UI checks; adjust RU length ratio to 4.0 in `locales.test.ts`.
> - **Docs/Roadmap**:
>   - **New**: `IOS_DEVELOPMENT_ROADMAP.md` with phased iOS plan.
>   - **Update**: `GLOBAL_ROADMAP_2025.md`—mark Phase 2 complete, add iOS sync readiness checklist and current status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3b0782daeea8552b795675b3f408d6df7918d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->