### PR TITLE
Potential fix for code scanning alert no. 338: Information exposure through an exception

### DIFF
--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -1258,7 +1258,7 @@ async def get_recipe_templates(
         logging.exception("Error retrieving recipe templates: %s", e)
         return {
             "status": "error",
-            "message": f"Error retrieving recipe templates: {str(e)}",
+            "message": "An internal error occurred while retrieving recipe templates.",
             "templates": [],
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/338](https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/338)

To fix the problem, modify the response to users so that no details of the exception (`e`) are exposed in the message field. Replace any usage of `str(e)` in client-facing responses with a fixed, generic message such as `"An internal error occurred while retrieving recipe templates."`. The exception details should continue to be logged internally for debugging purposes. The only necessary edit is to line 1261 in the except block of `get_recipe_templates` in app/routers/vip.py. No new methods or imports are required, as logging is already in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Сводка от Sourcery

Исправления ошибок:
- Заменить str(e) в ответе об ошибке get_recipe_templates на общее сообщение, чтобы избежать раскрытия внутренних деталей исключения

<details>
<summary>Original summary in English</summary>

## Сводка от Sourcery

Исправления ошибок:
- Удалить подробное сообщение об исключении из ответа клиента в `get_recipe_templates` и заменить его на фиксированное общее сообщение об ошибке.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove detailed exception message from client response in get_recipe_templates and replace it with a fixed generic error message.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recipe template retrieval now provides consistent error messaging without exposing internal system details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->