### PR TITLE
fix(ci): resolve nightly mypy duplicate module detection

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,9 @@ jobs:
           echo "Running type checking..."
           # NOTE: mypy is enforced in PR CI via lint/pre-commit.
           # Nightly is focused on long-running tests; mypy is non-blocking here by design.
-          mypy app tests --config-file pyproject.toml
+          # Use the same discovery script as PR workflow to avoid duplicate module detection
+          # shellcheck disable=SC2046
+          mypy $(scripts/discover_mypy_targets.sh) --config-file pyproject.toml
 
       - name: Run security checks
         run: |


### PR DESCRIPTION
## Problem
Nightly CI failed with mypy error:
```
app/routers/__init__.py: error: Source file found twice under different module names: 
"app.routers" and "app.routers.__init__"
```

## Root Cause
- `app/routers/__init__.py` uses lazy loading with `__getattr__`
- When mypy scans `app tests` as directories, it detects both:
  - `app.routers` (the package)
  - `app.routers.__init__` (the file)

## Solution
✅ Use `scripts/discover_mypy_targets.sh` (same as PR workflow) to provide specific module paths instead of directory scanning

## Verification
```bash
$ mypy $(scripts/discover_mypy_targets.sh) --config-file pyproject.toml
Success: no issues found in 155 source files
```

## Impact
- Fixes nightly CI mypy check
- Aligns nightly workflow with PR workflow
- No functional changes to code

Closes: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/20290417434

## Summary by Sourcery

CI:
- Обновлён ночной workflow, чтобы запускать mypy с использованием общего скрипта обнаружения целей вместо прямого сканирования каталогов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update nightly workflow to run mypy using the shared target discovery script instead of scanning directories directly.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to use dynamic discovery for type checking targets, improving maintainability of the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->