### PR TITLE
chore(ci): gate Docker publish and harden CD gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
           scan-type: 'fs'
           format: 'sarif'
           output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        if: ${{ always() }}
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -152,7 +153,6 @@ jobs:
             type=raw,value=${{ github.sha }}
             type=raw,value=sha-${{ github.sha }}
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      first_tag: ${{ steps.validate-tags.outputs.first_tag }}
 
     steps:
       - name: Checkout repository
@@ -35,137 +32,28 @@ jobs:
         run: |
           echo "image_name=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
-      - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
-          tags: |
-            type=raw,value=${{ github.sha }}
-            type=raw,value=sha-${{ github.sha }}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Validate metadata tags
-        id: validate-tags
-        if: github.event_name != 'pull_request'
-        run: |
-          tags_output='${{ steps.meta.outputs.tags }}'
-          echo "Tags output: $tags_output"
-
-          # Parse newline-separated tags
-          if [ -z "$tags_output" ]; then
-            echo "Error: No tags found"
-            exit 1
-          fi
-
-          # Get first tag (first line)
-          first_tag=$(echo "$tags_output" | head -n1)
-          if [ -z "$first_tag" ]; then
-            echo "Error: No valid tags found"
-            exit 1
-          fi
-
-          echo "First tag: $first_tag"
-          echo "first_tag=$first_tag" >> $GITHUB_OUTPUT
-
-      - name: Build and push Docker image
+      - name: Build Docker image (local, for tests)
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: pulseplate:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: production
-
-      - name: Generate SBOM
-        if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
-        with:
-          image: ${{ steps.validate-tags.outputs.first_tag }}
-          format: spdx-json
-          output-file: sbom.spdx.json
-
-      - name: Upload SBOM
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: sbom
-          path: sbom.spdx.json
-          retention-days: 30
-
-  # Security scan
-  security-scan:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-
-      - name: Run Trivy vulnerability scanner (PR filesystem scan)
-        if: github.event_name == 'pull_request'
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
-        with:
-          scan-type: 'fs'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Run Trivy vulnerability scanner (image scan)
-        if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
-        with:
-          image-ref: ${{ needs.build.outputs.first_tag }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
-        with:
-          sarif_file: 'trivy-results.sarif'
-
-  # Test Docker image
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
-      - name: Build test image
-        run: |
-          docker build -t pulseplate:test --target production .
 
       - name: Test Docker image
         run: |
           # Set up cleanup trap to ensure container is always removed
           trap "docker stop pulseplate-test 2>/dev/null || true; docker rm pulseplate-test 2>/dev/null || true" EXIT
 
-          # Start container
-          docker run -d --name pulseplate-test -p 8000:8000 pulseplate:test
+          # Start container with tightened security
+          docker run -d --name pulseplate-test -p 8000:8000 \
+            --cap-drop=ALL \
+            --security-opt no-new-privileges \
+            pulseplate:test
 
           # Wait for container to start
           echo "Waiting for container to start..."
@@ -200,6 +88,121 @@ jobs:
           curl -f http://localhost:8000/health || exit 1
 
           echo "✅ Docker image test completed successfully"
+
+  # Security scan
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Run Trivy vulnerability scanner (filesystem scan)
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
+        with:
+          scan-type: 'fs'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  # Publish tested Docker image
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build, security-scan]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Set lowercase image name
+        id: image-name
+        run: |
+          echo "image_name=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=sha-${{ github.sha }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Validate metadata tags
+        id: validate-tags
+        run: |
+          tags_output='${{ steps.meta.outputs.tags }}'
+          echo "Tags output: $tags_output"
+
+          # Parse newline-separated tags
+          if [ -z "$tags_output" ]; then
+            echo "Error: No tags found"
+            exit 1
+          fi
+
+          # Get first tag (first line)
+          first_tag=$(echo "$tags_output" | head -n1)
+          if [ -z "$first_tag" ]; then
+            echo "Error: No valid tags found"
+            exit 1
+          fi
+
+          echo "First tag: $first_tag"
+          echo "first_tag=$first_tag" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image (multi-arch)
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: production
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        with:
+          image: ${{ steps.validate-tags.outputs.first_tag }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: sbom
+          path: sbom.spdx.json
+          retention-days: 30
 
   # Deploy to staging (if on main branch)
   # TODO: Enable when staging deployment is ready

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
-      - name: Set lowercase image name
-        id: image-name
-        run: |
-          echo "image_name=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
       - name: Build Docker image (local, for tests)
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,7 @@ jobs:
         continue-on-error: true
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
         with:
+          scan-type: 'image'
           image-ref: ${{ steps.image-ref.outputs.ref }}
           format: 'sarif'
           output: 'trivy-image.sarif'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -158,27 +157,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Validate metadata tags
-        id: validate-tags
-        run: |
-          tags_output='${{ steps.meta.outputs.tags }}'
-          echo "Tags output: $tags_output"
-
-          # Parse newline-separated tags
-          if [ -z "$tags_output" ]; then
-            echo "Error: No tags found"
-            exit 1
-          fi
-
-          # Get first tag (first line)
-          first_tag=$(echo "$tags_output" | head -n1)
-          if [ -z "$first_tag" ]; then
-            echo "Error: No valid tags found"
-            exit 1
-          fi
-
-          echo "First tag: $first_tag"
-          echo "first_tag=$first_tag" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image (multi-arch)
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -192,10 +170,29 @@ jobs:
           cache-to: type=gha,mode=max
           target: production
 
+      - name: Set image ref for SBOM and image scan
+        id: image-ref
+        run: |
+          echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy vulnerability scanner (image scan, report-only)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
+        with:
+          image-ref: ${{ steps.image-ref.outputs.ref }}
+          format: 'sarif'
+          output: 'trivy-image.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy image scan results
+        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        with:
+          sarif_file: 'trivy-image.sarif'
+
       - name: Generate SBOM
         uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
         with:
-          image: ${{ steps.validate-tags.outputs.first_tag }}
+          image: ${{ steps.image-ref.outputs.ref }}
           format: spdx-json
           output-file: sbom.spdx.json
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
@@ -102,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
 
       - name: Verify semantic version tag
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-        with:
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435


### PR DESCRIPTION
- Build and smoke-test production image locally before any push
- Run Trivy filesystem scan as a gate before publish
- Move multi-arch push + SBOM generation into a dedicated publish job
- Ensure cd.yml checkouts use fetch-depth=0 so nightly/CI gates can compare tag commit coverage reliably

## Summary by Sourcery

Ограничение публикации Docker-образов успешной локальной сборкой/тестами и проверкой безопасности, а также корректировка CD‑воркфлоу для надежного управления выпуском на основе тегов.

Новые возможности:
- Добавлен выделенный job `publish`, который выполняет мультиархитектурную отправку Docker-образов и генерацию SBOM только после успешного завершения задач сборки и сканирования безопасности.

Улучшения:
- Локальная сборка и smoke‑тестирование продукционного Docker-образа в рамках build‑воркфлоу до выполнения любого push.
- Запуск файлового сканирования уязвимостей с помощью Trivy в качестве обязательного шлюза перед публикацией Docker-образов.
- Консолидация и упрощение логики воркфлоу за счет удаления отдельных путей `image-test` и `image-scan` в пользу унифицированной последовательности файлового сканирования и тестирования.
- Ужесточение конфигурации контейнерного рантайма в CI‑тестах путем урезания прав (capabilities) и применения `no-new-privileges` при запуске тестового контейнера.
- Обеспечение того, чтобы CD‑воркфлоу выполняли checkout полной истории git (`fetch-depth=0`), чтобы ночные сборки и CI‑шлюзы могли надежно сравнивать покрытие коммитов по тегам.

CI:
- Уточнение воркфлоу GitHub Actions для разделения задач сборки, сканирования безопасности и публикации с явными зависимостями для управления выпуском Docker-образов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate Docker image publication on successful local build/test and security scanning, and adjust CD workflows to support reliable tag-based gating.

New Features:
- Add a dedicated publish job that performs multi-architecture Docker image pushes and SBOM generation only after build and security scan jobs succeed.

Enhancements:
- Build and smoke-test the production Docker image locally in the build workflow before any push occurs.
- Run a Trivy filesystem vulnerability scan as a required gate prior to publishing Docker images.
- Consolidate and simplify workflow logic by removing separate image-test and image-scan paths in favor of a unified filesystem scan and test sequence.
- Tighten the container runtime configuration in CI tests by dropping capabilities and enforcing no-new-privileges when running the test container.
- Ensure CD workflows checkout the full git history (fetch-depth=0) so nightly and CI gates can reliably compare tag commit coverage.

CI:
- Refine GitHub Actions workflows to separate build, security scan, and publish responsibilities with explicit dependencies for Docker image release gating.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ограничение публикации Docker-образов успешной локальной сборкой/тестами и проверкой безопасности, а также корректировка CD‑воркфлоу для надежного управления выпуском на основе тегов.

Новые возможности:
- Добавлен выделенный job `publish`, который выполняет мультиархитектурную отправку Docker-образов и генерацию SBOM только после успешного завершения задач сборки и сканирования безопасности.

Улучшения:
- Локальная сборка и smoke‑тестирование продукционного Docker-образа в рамках build‑воркфлоу до выполнения любого push.
- Запуск файлового сканирования уязвимостей с помощью Trivy в качестве обязательного шлюза перед публикацией Docker-образов.
- Консолидация и упрощение логики воркфлоу за счет удаления отдельных путей `image-test` и `image-scan` в пользу унифицированной последовательности файлового сканирования и тестирования.
- Ужесточение конфигурации контейнерного рантайма в CI‑тестах путем урезания прав (capabilities) и применения `no-new-privileges` при запуске тестового контейнера.
- Обеспечение того, чтобы CD‑воркфлоу выполняли checkout полной истории git (`fetch-depth=0`), чтобы ночные сборки и CI‑шлюзы могли надежно сравнивать покрытие коммитов по тегам.

CI:
- Уточнение воркфлоу GitHub Actions для разделения задач сборки, сканирования безопасности и публикации с явными зависимостями для управления выпуском Docker-образов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate Docker image publication on successful local build/test and security scanning, and adjust CD workflows to support reliable tag-based gating.

New Features:
- Add a dedicated publish job that performs multi-architecture Docker image pushes and SBOM generation only after build and security scan jobs succeed.

Enhancements:
- Build and smoke-test the production Docker image locally in the build workflow before any push occurs.
- Run a Trivy filesystem vulnerability scan as a required gate prior to publishing Docker images.
- Consolidate and simplify workflow logic by removing separate image-test and image-scan paths in favor of a unified filesystem scan and test sequence.
- Tighten the container runtime configuration in CI tests by dropping capabilities and enforcing no-new-privileges when running the test container.
- Ensure CD workflows checkout the full git history (fetch-depth=0) so nightly and CI gates can reliably compare tag commit coverage.

CI:
- Refine GitHub Actions workflows to separate build, security scan, and publish responsibilities with explicit dependencies for Docker image release gating.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated publish: unified login/metadata, multi-arch build-and-push, dynamic tagging, SBOM generation/upload, image-scan inputs and image-reference propagation; expanded publish permissions.
  * Converted build to a local, test-focused Docker run with tightened runtime security, health-check polling, and container cleanup.
  * Ensured full repo history is fetched for production gates.

* **Security**
  * Always run filesystem scans for changes; run image scans and produce SARIF/SBOM artifacts during publish (report-only).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->