### PR TITLE
fix(ci): enable tenant-based test sharding for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -297,6 +297,7 @@ jobs:
 
   coverage-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # Combining coverage should be fast; timeout detects hangs
     needs: test
 
     steps:
@@ -325,3 +326,12 @@ jobs:
         run: |
           coverage combine coverage-artifacts
           coverage report --fail-under=97
+          coverage xml -o coverage-combined.xml
+
+      - name: Upload combined coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
+        if: always()
+        with:
+          name: coverage-combined
+          path: coverage-combined.xml
+          retention-days: 30

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60  # Each shard should complete in 15-25min; 60min provides buffer for slow runners
     env:
-      SHARD_TOTAL: 6  # Total number of test shards (update matrix.shard_id if changed)
+      SHARD_TOTAL: 6  # Total number of test shards (MUST match matrix.shard_id array length below)
     strategy:
       fail-fast: false  # Run all shards even if one fails
       matrix:
-        shard_id: [1, 2, 3, 4, 5, 6]  # Tenant-based sharding (see pytest_sharding.py)
+        shard_id: [1, 2, 3, 4, 5, 6]  # Tenant-based sharding; update SHARD_TOTAL above if adding/removing shards
 
     steps:
       - name: Checkout code
@@ -124,6 +124,7 @@ jobs:
         env:
           PYTHONPATH: .:app:core:tests
           PYTEST_TIMEOUT: 300
+          COVERAGE_FILE: .coverage.shard-${{ matrix.shard_id }}
         run: |
           START_TIME=$(date +%s)
           export START_TIME
@@ -150,6 +151,7 @@ jobs:
           name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
             coverage-shard-${{ matrix.shard_id }}.xml
+            .coverage.shard-${{ matrix.shard_id }}
           retention-days: 30
 
       - name: Upload test results
@@ -292,3 +294,34 @@ jobs:
           name: performance-report
           path: performance-report.md
           retention-days: 30
+
+  coverage-merge:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.1.7
+
+      - name: Set up Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        with:
+          pattern: coverage-reports-shard-*
+          merge-multiple: true
+          path: coverage-artifacts
+
+      - name: Install coverage
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install coverage -c constraints.txt
+
+      - name: Combine coverage and enforce threshold
+        run: |
+          coverage combine coverage-artifacts
+          coverage report --fail-under=97

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 180  # Full test suite can take 90-120min, buffer for slower runners
+    strategy:
+      fail-fast: false  # Run all shards even if one fails
+      matrix:
+        shard_id: [1, 2, 3, 4, 5, 6]  # Tenant-based sharding (see pytest_sharding.py)
 
     steps:
       - name: Checkout code
@@ -111,57 +115,44 @@ jobs:
             exit 1
           fi
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage (shard ${{ matrix.shard_id }}/6)
         env:
           PYTHONPATH: .:app:core:tests
           PYTEST_TIMEOUT: 300
         run: |
           START_TIME=$(date +%s)
           export START_TIME
-          echo "Running test suite..."
-          # Use -c pyproject.toml to ensure pytest config is loaded (markers, filterwarnings, etc)
-          # Nightly: fail after 10 failures to collect multiple issues (not just first one)
+          echo "Running test suite (shard ${{ matrix.shard_id }}/6)..."
+          # Use tenant-based sharding from pytest_sharding.py
+          # Each shard runs tests for specific functional domain
+          # -n 4: fixed workers for predictable performance
           pytest -c pyproject.toml tests/ \
+            --shard-id=${{ matrix.shard_id }} \
             --maxfail=10 \
             --cov=. \
-            --cov-report=xml \
+            --cov-report=xml:coverage-shard-${{ matrix.shard_id }}.xml \
             --cov-report=term-missing \
-            --cov-report=html \
-            --junitxml=tests/results.xml \
+            --junitxml=tests/results-shard-${{ matrix.shard_id }}.xml \
             --tb=short \
             -v \
-            -n auto
-
-      - name: Check test coverage
-        run: |
-          echo "Checking test coverage..."
-          python -c "
-          import xml.etree.ElementTree as ET
-          tree = ET.parse('coverage.xml')
-          root = tree.getroot()
-          coverage = float(root.attrib['line-rate']) * 100
-          print(f'Coverage: {coverage:.2f}%')
-          if coverage < 97:
-              print(f'Coverage {coverage:.2f}% is below 97% threshold')
-              exit(1)
-          "
+            -n 4 \
+            --dist loadscope
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
         if: always()
         with:
-          name: coverage-reports
+          name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
-            coverage.xml
-            htmlcov/
+            coverage-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
         if: always()
         with:
-          name: test-results
-          path: tests/results.xml
+          name: test-results-shard-${{ matrix.shard_id }}
+          path: tests/results-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
 
       - name: Upload security reports

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 180  # Full test suite can take 90-120min, buffer for slower runners
+    timeout-minutes: 60  # Each shard should complete in 15-25min; 60min provides buffer for slow runners
+    env:
+      SHARD_TOTAL: 6  # Total number of test shards (update matrix.shard_id if changed)
     strategy:
       fail-fast: false  # Run all shards even if one fails
       matrix:
@@ -46,12 +48,14 @@ jobs:
           pip list
 
       - name: Run linting
+        if: matrix.shard_id == 1  # Run once (shard 1 only) - codebase-wide check
         run: |
           echo "Running linting checks..."
           ruff check . --config pyproject.toml
           black --check . --config pyproject.toml
 
       - name: Run type checking (non-blocking)
+        if: matrix.shard_id == 1  # Run once (shard 1 only) - codebase-wide check
         continue-on-error: true
         run: |
           echo "Running type checking..."
@@ -62,6 +66,7 @@ jobs:
           mypy $(scripts/discover_mypy_targets.sh) --config-file pyproject.toml
 
       - name: Run security checks
+        if: matrix.shard_id == 1  # Run once (shard 1 only) - codebase-wide check
         run: |
           set +e  # Отключаем немедленный выход при ошибке
           set -u  # Проверяем неопределённые переменные
@@ -115,14 +120,14 @@ jobs:
             exit 1
           fi
 
-      - name: Run tests with coverage (shard ${{ matrix.shard_id }}/6)
+      - name: Run tests with coverage (shard ${{ matrix.shard_id }}/${{ env.SHARD_TOTAL }})
         env:
           PYTHONPATH: .:app:core:tests
           PYTEST_TIMEOUT: 300
         run: |
           START_TIME=$(date +%s)
           export START_TIME
-          echo "Running test suite (shard ${{ matrix.shard_id }}/6)..."
+          echo "Running test suite (shard ${{ matrix.shard_id }}/${SHARD_TOTAL})..."
           # Use tenant-based sharding from pytest_sharding.py
           # Each shard runs tests for specific functional domain
           # -n 4: fixed workers for predictable performance
@@ -157,7 +162,7 @@ jobs:
 
       - name: Upload security reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
-        if: always()
+        if: always() && matrix.shard_id == 1  # Upload once (shard 1 only) to avoid duplicates
         with:
           name: security-reports
           path: |

--- a/tests/test_targeted_coverage.py
+++ b/tests/test_targeted_coverage.py
@@ -38,6 +38,8 @@ class TestTargetedCoverage:
         # Remove the test API key
         if "API_KEY" in os.environ:
             del os.environ["API_KEY"]
+        # Remove feature flag to prevent env leakage
+        os.environ.pop("FEATURE_PREMIUM_NUTRITION", None)
 
     def test_bmi_endpoint_visualization_error_path(self):
         """Test BMI endpoint visualization error path - covers lines 346-351."""

--- a/tests/test_targeted_coverage.py
+++ b/tests/test_targeted_coverage.py
@@ -27,14 +27,10 @@ class TestTargetedCoverage:
     """Targeted tests to improve coverage for specific missing lines in main.py."""
 
     def setup_method(self):
-        """Setup test environment"""
-        os.environ["API_KEY"] = "test_key"
-        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
-
-    def setup_method(self):
         """Set up test environment."""
-        # Set a test API key for testing
+        # Set test environment variables
         os.environ["API_KEY"] = "test-key"
+        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
 
     def teardown_method(self):


### PR DESCRIPTION
## Problem
Nightly job exceeded GitHub Actions **hard limit of 90 minutes** (organization policy overrides workflow `timeout-minutes: 180`):
- Job cancelled: `The job has exceeded the maximum execution time of 1h30m0s`
- Coverage artifacts not created due to premature cancellation
- Unable to identify which tests failed

## Solution
Enable **existing tenant-based sharding** from `pytest_sharding.py` (6 functional shards running in parallel):

### Shard Distribution
- **Shard 1 (app_api)**: Application and API layer tests
- **Shard 2 (database)**: Food/recipe data management 
- **Shard 3 (vip_premium)**: VIP and premium features
- **Shard 4 (analytics)**: Bayesian analytics and recommendations
- **Shard 5 (core)**: BMI, nutrition core logic
- **Shard 6 (planning_export)**: Meal planning and export

## Changes
- ✅ Add matrix strategy with `shard_id: [1,2,3,4,5,6]`
- ✅ Use `--shard-id` flag from existing `pytest_sharding.py`
- ✅ Fixed workers: `-n 4 --dist loadscope` (predictable performance)
- ✅ Per-shard coverage/junit artifacts for observability
- ✅ Remove global coverage check (add combine step later if needed)
- ✅ `fail-fast: false` to complete all shards even if one fails

## Benefits
- Each shard runs ~15-25min (well under 90min GitHub limit)
- Logical test grouping for easier debugging
- Leverages existing, documented infrastructure
- No new dependencies (uses existing `pytest_sharding.py`)

## Testing
- Monitor next nightly run to confirm all shards complete under 90min
- Verify per-shard artifacts are uploaded correctly

## References
- `docs/TESTING_MEMORY_OPTIMIZATION.md`
- `pytest_sharding.py`
- Previous timeout run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/20358715221

## Summary by Sourcery

Включить шардирование тестов по арендаторам (tenant-based) в ночном workflow GitHub Actions, чтобы удерживать полный набор тестов в пределах лимитов по времени выполнения и улучшить наблюдаемость по каждому шарду.

New Features:
- Ввести стратегию матрицы из шести шардов функциональных тестов в ночном workflow, каждый из которых запускает поднабор тестового набора параллельно.

Enhancements:
- Настроить pytest на запуск с фиксированным числом воркеров и шардированием по доменам для более предсказуемых и удобных для отладки ночных прогонов.
- Генерировать артефакты покрытия и результатов тестов в формате JUnit для каждого шарда (coverage XML и JUnit) для улучшения видимости сбоев и покрытия, специфичных для конкретного шарда.

Build:
- Скорректировать ночной CI workflow, чтобы убрать глобальную проверку порога покрытия и вместо этого полагаться на отчёты о покрытии по шардом.

CI:
- Обновить ночной job тестов для использования матричной стратегии с отключённым режимом fail-fast, чтобы все шарды завершались, даже если некоторые из них падают.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable tenant-based test sharding for the nightly GitHub Actions workflow to keep the full suite within runtime limits and improve observability per shard.

New Features:
- Introduce a matrix strategy over six functional test shards in the nightly workflow, each running a subset of the test suite in parallel.

Enhancements:
- Configure pytest to run with fixed worker count and domain-based sharding for more predictable and debuggable nightly runs.
- Generate per-shard coverage XML and JUnit test result artifacts to improve visibility into shard-specific failures and coverage.

Build:
- Adjust nightly CI workflow to remove the global coverage threshold check and rely on per-shard coverage reporting instead.

CI:
- Update the nightly test job to use a matrix strategy with fail-fast disabled so that all shards complete even if some fail.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added 6-way test sharding with parallel shard execution, per-shard 60-minute timeouts, and fail-fast disabled so all shards complete.
  * Global checks (lint/type/security) run once on shard 1; tests produce per-shard coverage and test artifacts which are uploaded per shard.
  * New coverage-merge step downloads shard artifacts, combines them, and enforces a 97% overall coverage threshold; security report upload remains on shard 1.

* **Tests**
  * Standardized test API key value, enabled premium-nutrition feature in setup, and added teardown cleanup for the feature env var.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->