### PR TITLE
fix(ci): avoid duplicate module loads from PYTHONPATH in nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,11 @@ jobs:
         env:
           APP_ENV: test
           ENVIRONMENT: test
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app"
+          PYTHONPATH: "${{ github.workspace }}"
 
       - name: Run tests with coverage
         env:
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app:${{ github.workspace }}/tests"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
           VIP_MODULE_ENABLED: "true"
           APP_ENV: test
           ENVIRONMENT: test
@@ -201,11 +201,11 @@ jobs:
         env:
           APP_ENV: test
           ENVIRONMENT: test
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app"
+          PYTHONPATH: "${{ github.workspace }}"
 
       - name: Run tests with coverage
         env:
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app:${{ github.workspace }}/tests"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
           VIP_MODULE_ENABLED: "true"
           APP_ENV: test
           ENVIRONMENT: test
@@ -288,11 +288,11 @@ jobs:
         env:
           APP_ENV: test
           ENVIRONMENT: test
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app"
+          PYTHONPATH: "${{ github.workspace }}"
 
       - name: Run tests with coverage
         env:
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app:${{ github.workspace }}/tests"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
           VIP_MODULE_ENABLED: "true"
           # Force test-like environment for deterministic behavior
           APP_ENV: test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run tests with coverage (shard ${{ matrix.shard_id }}/${{ env.SHARD_TOTAL }})
         env:
-          PYTHONPATH: .:app:core:tests
+          PYTHONPATH: .:tests
           PYTEST_TIMEOUT: 300
           COVERAGE_FILE: .coverage.shard-${{ matrix.shard_id }}
         run: |
@@ -197,7 +197,7 @@ jobs:
 
       - name: Run performance tests
         env:
-          PYTHONPATH: .:app:core:tests
+          PYTHONPATH: .:tests
         run: |
           echo "Running performance benchmarks..."
           pytest tests/ \
@@ -253,7 +253,7 @@ jobs:
 
       - name: Run integration tests
         env:
-          PYTHONPATH: .:app:core:tests
+          PYTHONPATH: .:tests
           DATABASE_URL: postgresql+psycopg://testuser:testpass@localhost:5432/testdb
         run: |
           START_TIME=$(date +%s)

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -67,6 +67,15 @@ jobs:
           # Use pytest-xdist for parallel execution (2-3x faster)
           pytest -q --disable-warnings --cov=. --cov-report=xml -n auto
 
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run tests with coverage (xml)
         env:
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app:${{ github.workspace }}/tests"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
           VIP_MODULE_ENABLED: "true"
           APP_ENV: test
           ENVIRONMENT: test

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -144,7 +144,7 @@ jobs:
         env:
           APP_ENV: test
           ENVIRONMENT: test
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/core:${{ github.workspace }}/app"
+          PYTHONPATH: "${{ github.workspace }}"
         run: |
           # Ensure database directory exists
           mkdir -p cache

--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,12 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage*.xml
+*.cov.xml
 junit.xml
 pytest_report.xml
 test_results.xml
+tests/results*.xml
 frontend/tests/*.xml
 frontend/test-results/
 *.cover

--- a/tests/test_conftest_environment_coverage.py
+++ b/tests/test_conftest_environment_coverage.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from pathlib import Path
 from fastapi.testclient import TestClient
 
 
@@ -110,20 +111,46 @@ class TestConftestEnvironmentCoverage:
         assert os.environ.get("APP_ENV") in ["test", "ci"]
         assert os.environ.get("ALLOW_DEV_API_KEY") == "true"
 
-        # PYTHONPATH can be relative (.:core:app:tests) or absolute (CI) or just "." (CI)
+        # PYTHONPATH contract is enforced by CI workflows.
+        # It must include the repo root and tests, but not standalone 'core' or 'app' entries
+        # to avoid duplicate module loading (e.g. food_apis.* vs core.food_apis.*).
         pythonpath = os.environ.get("PYTHONPATH", "")
-        # Check that PYTHONPATH is set (either "." or explicit paths)
         assert pythonpath, "PYTHONPATH must be set"
-        # If PYTHONPATH is just ".", it's valid (CI mode) - skip directory check
-        if pythonpath.strip() == ".":
+
+        path_segments = [segment for segment in pythonpath.split(os.pathsep) if segment]
+
+        # Allow simple local runs where PYTHONPATH is just "."
+        if path_segments == ["."]:
             return
-        # Verify that key directories are included (when explicit paths are set)
-        required_dirs = ["core", "app", "tests"]
-        path_segments = pythonpath.split(os.pathsep)
-        for dir_name in required_dirs:  # sourcery skip: no-loop-in-tests
-            assert any(
-                dir_name in segment for segment in path_segments
-            ), f"'{dir_name}' not found in PYTHONPATH: {pythonpath}"
+
+        # Allow legacy local layout like ".:core:app:tests" without enforcing CI-specific invariants
+        if "." in path_segments and ("core" in path_segments or "app" in path_segments):
+            return
+
+        repo_root = str(Path(__file__).resolve().parents[1])
+        tests_dir = os.path.join(repo_root, "tests")
+
+        # Repo root must be present explicitly
+        assert any(
+            segment == repo_root for segment in path_segments
+        ), f"Repo root not found in PYTHONPATH: {pythonpath}"
+
+        # Tests directory should be present (either as absolute path or trailing '/tests')
+        assert any(
+            segment == tests_dir or segment.endswith(os.path.sep + "tests")
+            for segment in path_segments
+        ), f"'tests' not found in PYTHONPATH: {pythonpath}"
+
+        # Standalone 'core' and 'app' entries must NOT be present to avoid module duplication
+        assert not any(
+            segment.endswith(os.path.sep + "core") or segment == os.path.join(repo_root, "core")
+            for segment in path_segments
+        ), f"'core' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
+
+        assert not any(
+            segment.endswith(os.path.sep + "app") or segment == os.path.join(repo_root, "app")
+            for segment in path_segments
+        ), f"'app' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
 
     def test_conftest_sys_modules_coverage(self):
         """Тест покрытия conftest.py sys.modules"""

--- a/tests/test_conftest_environment_coverage.py
+++ b/tests/test_conftest_environment_coverage.py
@@ -8,6 +8,50 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 
+def _validate_pythonpath(pythonpath: str, repo_root: str) -> None:
+    assert pythonpath, "PYTHONPATH must be set"
+
+    path_segments = [segment for segment in pythonpath.split(os.pathsep) if segment]
+
+    # Allow simple local runs where PYTHONPATH is just "."
+    if path_segments == ["."]:
+        return
+
+    # Allow legacy local layout like ".:core:app:tests" without enforcing CI-specific invariants
+    if "." in path_segments and ("core" in path_segments or "app" in path_segments):
+        return
+
+    root_path = Path(repo_root).resolve()
+    tests_dir = root_path / "tests"
+
+    # Normalize all segments to absolute paths relative to repo_root when needed
+    normalized_segments = []
+    for segment in path_segments:
+        segment_path = Path(segment)
+        if not segment_path.is_absolute():
+            segment_path = (root_path / segment_path).resolve()
+        normalized_segments.append(segment_path)
+
+    # Repo root must be present explicitly
+    assert any(
+        segment == root_path for segment in normalized_segments
+    ), f"Repo root not found in PYTHONPATH: {pythonpath}"
+
+    # Tests directory should be present (either as absolute path or trailing '/tests')
+    assert any(
+        segment == tests_dir for segment in normalized_segments
+    ), f"'tests' not found in PYTHONPATH: {pythonpath}"
+
+    # Standalone 'core' and 'app' entries must NOT be present to avoid module duplication
+    assert not any(
+        segment == root_path / "core" for segment in normalized_segments
+    ), f"'core' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
+
+    assert not any(
+        segment == root_path / "app" for segment in normalized_segments
+    ), f"'app' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
+
+
 class TestConftestEnvironmentCoverage:
     def test_conftest_reset_environment_fixture_coverage(self):
         """Тест покрытия conftest.py reset_environment fixture (строки 41-44)"""
@@ -100,7 +144,7 @@ class TestConftestEnvironmentCoverage:
         for var in required_vars:  # sourcery skip: no-loop-in-tests
             assert var in os.environ, f"Environment variable {var} not set"
 
-    def test_conftest_environment_values_coverage(self):
+    def test_conftest_environment_values_coverage(self) -> None:
         """Тест покрытия conftest.py environment values"""
         # Тестируем значения переменных окружения
         assert os.environ.get("FEATURE_PREMIUM_NUTRITION") == "true"
@@ -114,43 +158,8 @@ class TestConftestEnvironmentCoverage:
         # PYTHONPATH contract is enforced by CI workflows.
         # It must include the repo root and tests, but not standalone 'core' or 'app' entries
         # to avoid duplicate module loading (e.g. food_apis.* vs core.food_apis.*).
-        pythonpath = os.environ.get("PYTHONPATH", "")
-        assert pythonpath, "PYTHONPATH must be set"
-
-        path_segments = [segment for segment in pythonpath.split(os.pathsep) if segment]
-
-        # Allow simple local runs where PYTHONPATH is just "."
-        if path_segments == ["."]:
-            return
-
-        # Allow legacy local layout like ".:core:app:tests" without enforcing CI-specific invariants
-        if "." in path_segments and ("core" in path_segments or "app" in path_segments):
-            return
-
         repo_root = str(Path(__file__).resolve().parents[1])
-        tests_dir = os.path.join(repo_root, "tests")
-
-        # Repo root must be present explicitly
-        assert any(
-            segment == repo_root for segment in path_segments
-        ), f"Repo root not found in PYTHONPATH: {pythonpath}"
-
-        # Tests directory should be present (either as absolute path or trailing '/tests')
-        assert any(
-            segment == tests_dir or segment.endswith(os.path.sep + "tests")
-            for segment in path_segments
-        ), f"'tests' not found in PYTHONPATH: {pythonpath}"
-
-        # Standalone 'core' and 'app' entries must NOT be present to avoid module duplication
-        assert not any(
-            segment.endswith(os.path.sep + "core") or segment == os.path.join(repo_root, "core")
-            for segment in path_segments
-        ), f"'core' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
-
-        assert not any(
-            segment.endswith(os.path.sep + "app") or segment == os.path.join(repo_root, "app")
-            for segment in path_segments
-        ), f"'app' must NOT be a standalone PYTHONPATH entry: {pythonpath}"
+        _validate_pythonpath(os.environ.get("PYTHONPATH", ""), repo_root)
 
     def test_conftest_sys_modules_coverage(self):
         """Тест покрытия conftest.py sys.modules"""


### PR DESCRIPTION
Problem:
- Nightly shard 2 on CI intermittently fails with isinstance checks for UnifiedFoodItem/UnifiedFoodDatabase
- Objects print as core.food_apis.unified_db.UnifiedFoodItem but isinstance(..., UnifiedFoodItem) == False
- Classic symptom of duplicate module loading under different import paths (two copies of the class)

Root cause (CI-specific):
- PYTHONPATH in nightly was set to '.:app:core:tests'
- This allows importing both 'core.food_apis.unified_db' and 'food_apis.unified_db' as distinct modules
- Under xdist/sharded runs, order of imports can lead to mixed-class identities and isinstance failures

Fix:
- Restrict PYTHONPATH to project root + tests only: '.:tests'
- Remove 'app' and 'core' entries that could create alternate top-level modules
- Applied consistently to:
  - test shards job (Run tests with coverage)
  - performance-test job
  - integration-test job

Notes:
- Locally re-ran the failing tests directly and under xdist; both pass with this configuration
- This keeps imports canonical via top-level 'app.*' and 'core.*' from repo root, avoiding duplicate module objects

## Summary by Sourcery

CI:
- Обновить задания ночного тестирования, измерения производительности и интеграционного тестирования, чтобы устанавливать PYTHONPATH только в корневой каталог проекта и каталог с тестами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update nightly test, performance, and integration jobs to set PYTHONPATH to project root plus tests only.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Narrowed module import/search paths used by CI and workflow test runs to reduce runtime module resolution surface.
  * Ignored additional coverage and test-result artifact files in version control.
  * Added automatic upload of coverage results as a CI artifact.

* **Tests**
  * Updated environment validation tests to use a centralized validator and reflect the narrower import-path rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->