### PR TITLE
feat(shoplist-day): generate real day shopping list items (MVP, no DB yet)

### DIFF
--- a/app/core/shoplist_day/__init__.py
+++ b/app/core/shoplist_day/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .day_generator import generate_day_items
+
+__all__ = ["generate_day_items"]

--- a/app/core/shoplist_day/day_generator.py
+++ b/app/core/shoplist_day/day_generator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from app.core.shopping_list.generator import generate_shopping_list_from_plan
+from app.schemas.shopping_list import ShoplistDayItemDTO, ShoppingListPreferences
+
+from .flatten import flatten_weekly_to_day_items
+
+
+def generate_day_items(plan_data: Dict[str, Any], lang: str) -> List[ShoplistDayItemDTO]:
+    """Generate flat day shopping list items from a day plan.
+
+    This adapter reuses the existing weekly shopping list generator and
+    then flattens its DTO into the iOS day item format.
+    """
+
+    prefs = ShoppingListPreferences(
+        group_by="category",
+        unit_system="metric",
+        merge_similar_items=True,
+        round_quantities=True,
+    )
+
+    weekly_dto = generate_shopping_list_from_plan(
+        plan_data=plan_data,
+        preferences=prefs,
+        source="day_plan",
+    )
+
+    return flatten_weekly_to_day_items(weekly_dto, lang=lang)

--- a/app/core/shoplist_day/flatten.py
+++ b/app/core/shoplist_day/flatten.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import math
+
+from app.schemas.shopping_list import ShopAisle, ShopUnit, ShoplistDayItemDTO, ShoppingListDTO
+
+
+_CATEGORY_TO_AISLE: dict[str, ShopAisle] = {
+    # Fresh produce
+    "produce": ShopAisle.produce,
+    "vegetables": ShopAisle.produce,
+    "fruits": ShopAisle.produce,
+    # Proteins
+    "proteins": ShopAisle.protein,
+    "protein": ShopAisle.protein,
+    "meat": ShopAisle.protein,
+    "fish": ShopAisle.protein,
+    # Dairy
+    "dairy": ShopAisle.dairy,
+    # Pantry / dry goods
+    "pantry": ShopAisle.pantry,
+    "grains": ShopAisle.pantry,
+    "spices": ShopAisle.pantry,
+    # Frozen
+    "frozen": ShopAisle.frozen,
+}
+
+
+def _aisle_from_category(category: str | None) -> ShopAisle:
+    if not category:
+        return ShopAisle.other
+    key = category.strip().lower()
+    return _CATEGORY_TO_AISLE.get(key, ShopAisle.other)
+
+
+def flatten_weekly_to_day_items(dto: ShoppingListDTO, lang: str) -> list[ShoplistDayItemDTO]:
+    """Flatten weekly ShoppingListDTO into flat day items for iOS.
+
+    The lang parameter is threaded for future localization, but not yet
+    used in PR-2 to keep the implementation minimal and safe.
+    """
+
+    _ = lang
+    items: list[ShoplistDayItemDTO] = []
+
+    for category in getattr(dto, "categories", []):
+        cat_key = getattr(category, "key", None) or getattr(category, "title", None)
+        aisle = _aisle_from_category(cat_key)
+
+        for it in getattr(category, "items", []):
+            key = str(
+                getattr(it, "key", "")
+                or getattr(it, "name", "")
+                or getattr(it, "title", "")
+                or "item"
+            )
+            title = str(getattr(it, "name", "") or getattr(it, "title", "") or key)
+
+            quantity = getattr(it, "quantity", None)
+            try:
+                qty = float(quantity) if quantity is not None else 1.0
+            except (TypeError, ValueError):
+                qty = 1.0
+            if not math.isfinite(qty) or qty <= 0:
+                qty = 1.0
+
+            raw_unit = getattr(it, "unit", None) or ShopUnit.pcs.value
+            try:
+                unit = ShopUnit(str(raw_unit))
+            except (ValueError, TypeError):
+                unit = ShopUnit.pcs
+
+            items.append(
+                ShoplistDayItemDTO(
+                    key=key[:128],
+                    title=title[:256],
+                    qty=qty,
+                    unit=unit,
+                    aisle=aisle,
+                    notes=None,
+                    source=None,
+                )
+            )
+
+    return items

--- a/app/core/shoplist_day/provider.py
+++ b/app/core/shoplist_day/provider.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Optional
+
+
+async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
+    """Fetch day plan for a given date and PRO context.
+
+    PR-2 MVP placeholder: returns None so that the router responds with
+    an empty items list and a "no_day_plan" warning.
+
+    Real implementations may fetch from DB, cache, or external services.
+    """
+
+    return None

--- a/app/routers/shoplist_day.py
+++ b/app/routers/shoplist_day.py
@@ -16,6 +16,8 @@ from fastapi import APIRouter, Depends, Query
 
 from app.middleware.api_tiers import require_pro_tier
 from app.schemas.shopping_list import ShopLang, ShoplistDayResponse
+from app.core.shoplist_day.day_generator import generate_day_items
+from app.core.shoplist_day.provider import fetch_day_plan
 
 router = APIRouter(prefix="/api/v1/pro/shoplist", tags=["pro", "shoplist-day"])
 
@@ -30,46 +32,24 @@ async def get_shoplist_day(
     day: Annotated[date, Query(alias="date", description="YYYY-MM-DD")],
     lang: Annotated[ShopLang, Query(description="Language code")] = ShopLang.en,
 ) -> ShoplistDayResponse:
-    """MVP placeholder endpoint for day shopping list.
+    """MVP endpoint for day shopping list.
 
-    Returns empty list for now (real implementation coming in PR-2).
-    Later: fetch actual day plan from database and generate real items.
+    PR-2: fetches day plan (if available) and generates real items.
 
-    **URL:** `GET /api/v1/pro/shoplist/day?date=YYYY-MM-DD&lang=ru`
-
-    **Input:**
-    - `date`: Date for shopping list (YYYY-MM-DD, required)
-    - `lang`: Language for item titles (ru|en|es, default: en)
-
-    **Output:**
-    - Flat list of shopping items (client groups by aisle)
-    - Empty warnings array
-
-    **PRO tier required.**
-
-    **Implementation roadmap (PR-2):**
-    1. Fetch day_plan from DB (format: {"daily_menus": [{"meals": [...]}]})
-    2. Call core engine: aggregate_ingredients(day_plan) + round_to_packages()
-    3. Transform to flat day items with aisle mapping (no weekly DTO dependency)
-    4. Localize titles using lang parameter
-    5. Map category → ShopAisle enum (Produce/Protein/Dairy/Pantry/Frozen/Other)
+    If no plan is found, returns empty items with a "no_day_plan" warning
+    to keep the iOS client stable.
     """
-    # TODO: Real implementation in PR-2
-    # from core.shoplist import ShoplistGenerator  # or existing core engine
-    #
-    # # Fetch day plan from database
-    # day_plan = fetch_day_plan_from_db(day)
-    #
-    # # Use core engine directly (not weekly DTO)
-    # generator = ShoplistGenerator()
-    # aggregated = generator.aggregate_ingredients(day_plan)
-    # items_with_packages = generator.round_to_packages(aggregated)
-    #
-    # # Transform to flat ShoplistDayItemDTO format
-    # items = transform_to_day_items(items_with_packages, lang=lang)
-    # return ShoplistDayResponse(date=day.isoformat(), lang=lang, items=items, warnings=[])
+    plan = await fetch_day_plan(day=day, pro_ctx=_pro)
+    if plan is None:
+        return ShoplistDayResponse(
+            date=day.isoformat(),
+            lang=lang,
+            items=[],
+            warnings=["no_day_plan"],
+        )
 
-    return ShoplistDayResponse(date=day.isoformat(), lang=lang, items=[], warnings=[])
+    items = generate_day_items(plan_data=plan, lang=lang.value)
+    return ShoplistDayResponse(date=day.isoformat(), lang=lang, items=items, warnings=[])
 
 
 __all__ = ["router"]

--- a/app/schemas/shopping_list.py
+++ b/app/schemas/shopping_list.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Literal, Optional, TypeAlias
 from pydantic import BaseModel, Field, model_validator
 
 # Type alias for source validation
-SourceType: TypeAlias = Literal["weekly_plan_id", "inline_plan"]
+SourceType: TypeAlias = Literal["weekly_plan_id", "inline_plan", "day_plan"]
 
 
 class ShoppingListPreferences(BaseModel):

--- a/core/menu_engine_new.py
+++ b/core/menu_engine_new.py
@@ -31,8 +31,14 @@ class DayPlan:
     total_cost: float = 0.0
 
 
-def _percent(got: float, need: float) -> float:
-    return 0.0 if need <= 0 else min(200.0, 100.0 * got / need)
+def _percent(got: Any, need: Any) -> float:
+    got_f = _coerce_float(got)
+    need_f = _coerce_float(need)
+
+    if got_f is None or need_f is None or need_f <= 0:
+        return 0.0
+
+    return min(200.0, 100.0 * got_f / need_f)
 
 
 _DB_MICRO_TO_ALIAS: Dict[str, str] = {

--- a/core/menu_engine_new.py
+++ b/core/menu_engine_new.py
@@ -12,6 +12,7 @@ for nutrient deficiencies.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import Any, Dict, List
 
 from .food_db_new import MICRO_KEYS, FoodDB
@@ -58,12 +59,13 @@ def _coerce_float(value: Any) -> float | None:
         return None
     if isinstance(value, bool):
         return None
-    if isinstance(value, (int, float)):
-        return float(value)
     try:
-        return float(str(value).strip())
+        f = float(value)
     except (TypeError, ValueError):
         return None
+    if not math.isfinite(f):
+        return None
+    return f
 
 
 def _normalize_micro_targets(micro_targets: Any) -> Dict[str, float]:

--- a/tests/test_shoplist_day_endpoint.py
+++ b/tests/test_shoplist_day_endpoint.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.middleware.api_tiers import require_pro_tier
+from app.schemas.shopping_list import ShopAisle, ShopUnit
 
 
 @pytest.fixture
@@ -29,8 +30,8 @@ def client_with_pro_access(app_module: ModuleType):
     app_module.app.dependency_overrides.pop(require_pro_tier, None)
 
 
-def test_shoplist_day_ok(client_with_pro_access):
-    """Test successful day shoplist request returns empty placeholder."""
+def test_shoplist_day_no_day_plan_returns_warning(client_with_pro_access):
+    """When no day plan is available, return empty items and no_day_plan warning."""
     r = client_with_pro_access.get("/api/v1/pro/shoplist/day?date=2025-12-17&lang=ru")
 
     assert r.status_code == 200
@@ -38,7 +39,7 @@ def test_shoplist_day_ok(client_with_pro_access):
     assert body["date"] == "2025-12-17"
     assert body["lang"] == "ru"
     assert body["items"] == []
-    assert body["warnings"] == []
+    assert "no_day_plan" in body["warnings"]
 
 
 def test_shoplist_day_default_lang(client_with_pro_access):
@@ -48,6 +49,46 @@ def test_shoplist_day_default_lang(client_with_pro_access):
     assert r.status_code == 200
     body = r.json()
     assert body["lang"] == "en"
+    assert body["warnings"]
+
+
+def test_shoplist_day_generates_items_when_plan_available(client_with_pro_access, monkeypatch):
+    """When a day plan is available, endpoint returns non-empty items with valid aisles/units."""
+    from app.routers import shoplist_day as shoplist_day_module
+
+    day_plan = {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "oatmeal_banana",
+                        "grams": {
+                            "oats": 80.0,
+                            "banana": 120.0,
+                            "milk": 200.0,
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+    async def _fake_fetch_day_plan(day, pro_ctx):  # type: ignore[unused-argument]
+        return day_plan
+
+    monkeypatch.setattr(shoplist_day_module, "fetch_day_plan", _fake_fetch_day_plan)
+
+    r = client_with_pro_access.get("/api/v1/pro/shoplist/day?date=2025-12-17&lang=en")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["items"], "Expected non-empty items when day plan is available"
+    assert body["warnings"] == []
+
+    for item in body["items"]:
+        assert item["qty"] > 0
+        assert item["unit"] in {u.value for u in ShopUnit}
+        assert item["aisle"] in {a.value for a in ShopAisle}
 
 
 @pytest.mark.parametrize("lang_code", ["ru", "en", "es"])

--- a/tests/test_shoplist_day_endpoint.py
+++ b/tests/test_shoplist_day_endpoint.py
@@ -49,7 +49,7 @@ def test_shoplist_day_default_lang(client_with_pro_access):
     assert r.status_code == 200
     body = r.json()
     assert body["lang"] == "en"
-    assert body["warnings"]
+    assert body["warnings"] == ["no_day_plan"]
 
 
 def test_shoplist_day_generates_items_when_plan_available(client_with_pro_access, monkeypatch):

--- a/tests/test_shoplist_day_endpoint.py
+++ b/tests/test_shoplist_day_endpoint.py
@@ -54,6 +54,8 @@ def test_shoplist_day_default_lang(client_with_pro_access):
 
 def test_shoplist_day_generates_items_when_plan_available(client_with_pro_access, monkeypatch):
     """When a day plan is available, endpoint returns non-empty items with valid aisles/units."""
+    from typing import Any
+
     from app.routers import shoplist_day as shoplist_day_module
 
     day_plan = {
@@ -73,7 +75,7 @@ def test_shoplist_day_generates_items_when_plan_available(client_with_pro_access
         ]
     }
 
-    async def _fake_fetch_day_plan(day, pro_ctx):  # type: ignore[unused-argument]
+    async def _fake_fetch_day_plan(day: str, pro_ctx: Any) -> dict[str, Any]:  # type: ignore[unused-argument]
         return day_plan
 
     monkeypatch.setattr(shoplist_day_module, "fetch_day_plan", _fake_fetch_day_plan)

--- a/tests/test_shoplist_day_flatten.py
+++ b/tests/test_shoplist_day_flatten.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.core.shoplist_day.flatten import flatten_weekly_to_day_items
+from app.schemas.shopping_list import ShopAisle, ShopUnit
+
+
+def test_flatten_weekly_to_day_items_sanitizes_bad_inputs() -> None:
+    items = [
+        SimpleNamespace(key="bad_qty", name="Bad Qty", quantity="oops", unit="kg"),
+        SimpleNamespace(key="nonfinite", name="Nonfinite", quantity=float("inf"), unit="kg"),
+        SimpleNamespace(key="bad_unit", name="Bad Unit", quantity=2, unit="nope"),
+    ]
+    category = SimpleNamespace(key=None, title=None, items=items)
+    dto = SimpleNamespace(categories=[category])
+
+    results = flatten_weekly_to_day_items(dto, lang="en")
+
+    assert len(results) == 3
+    assert results[0].qty == 1.0
+    assert results[1].qty == 1.0
+    assert results[2].unit == ShopUnit.pcs
+    for result in results:
+        assert result.aisle == ShopAisle.other

--- a/tests/test_unified_db_coverage.py
+++ b/tests/test_unified_db_coverage.py
@@ -24,14 +24,18 @@ class TestUnifiedDBCoverage:
                 UnifiedFoodDatabase()
 
     @pytest.mark.asyncio
-    async def test_unified_db_cache_handling_coverage(self):
-        """Тест покрытия unified_db.py cache handling - проверяем кэширование экземпляра"""
-        # Перезагружаем модуль, чтобы сбросить состояние вместо патчинга приватной переменной
-        import importlib
+    async def test_unified_db_cache_handling_coverage(self, monkeypatch):
+        """Тест покрытия unified_db.py cache handling - проверяем кэширование экземпляра
 
+        Uses monkeypatch to reset the singleton instance instead of reload to avoid
+        cross-module isinstance mismatches when other tests import UnifiedFoodItem
+        or UnifiedFoodDatabase.
+        """
         import core.food_apis.unified_db as unified_db
 
-        importlib.reload(unified_db)
+        # Reset the singleton instance in-place without reloading the module
+        monkeypatch.setattr(unified_db, "_unified_db_instance", None, raising=False)
+
         get_unified_food_db = unified_db.get_unified_food_db
 
         result1 = await get_unified_food_db()


### PR DESCRIPTION
### Summary

- Implement real item generation for `GET /api/v1/pro/shoplist/day`.
- Reuse the existing weekly shopping list engine with a thin day-level adapter.
- Keep iOS DTO/enums stable: return `items[]` when a day plan exists, otherwise return an empty list with `no_day_plan` warning.

### Implementation Details

- New core module: `app/core/shoplist_day/`
  - `provider.py`: `fetch_day_plan(day, pro_ctx)` provider hook (MVP returns `None`, DB wiring later; tests monkeypatch it).
  - `day_generator.py`: `generate_day_items(plan_data, lang)` builds `ShoppingListPreferences`, calls `generate_shopping_list_from_plan(..., source="day_plan")`, then flattens to iOS DTO.
  - `flatten.py`: maps categories to `ShopAisle`, parses `key`/`title` with fallbacks and length limits, parses `qty` defensively (float + finite/positive guard, default 1.0), parses `unit` as `ShopUnit` with fallback to `pcs`, builds `ShoplistDayItemDTO` with `source=None`.
- Schema: `SourceType` in `app/schemas/shopping_list.py` extended to include `"day_plan"` (metadata only; iOS DTO unchanged).
- Router: `app/routers/shoplist_day.py` updates `GET /api/v1/pro/shoplist/day` to:
  - return `items=[]`, `warnings=["no_day_plan"]` when `fetch_day_plan()` returns `None`.
  - otherwise generate items via `generate_day_items()` and return `warnings=[]`.
- Stability fixes bundled in this PR:
  - `core/menu_engine_new.py`: harden `_percent` to use `_coerce_float` and avoid `TypeError` for mocked/non-numeric inputs.
  - `tests/test_unified_db_coverage.py`: replace `importlib.reload(unified_db)` with monkeypatch reset of `_unified_db_instance` to avoid class identity issues.

### Tests

- `tests/test_shoplist_day_endpoint.py`:
  - `test_shoplist_day_no_day_plan_returns_warning`: `items == []`, `"no_day_plan" in warnings`.
  - `test_shoplist_day_generates_items_when_plan_available`: monkeypatch provider to return minimal valid `plan_data`; asserts non-empty items, `qty > 0`, `unit` in `ShopUnit`, `aisle` in `ShopAisle`.
  - `test_shoplist_day_lang_echo`: validates `ru/en/es` accepted and echoed.
- Local sanity runs executed before opening this PR:
  - `pytest -q tests/test_shoplist_day_endpoint.py`
  - `pytest -q tests/test_shopping_list_pro.py`
  - `pytest -q tests/test_extractor.py`
  - `pytest -q tests/test_shoplist_day_endpoint.py -k generates_items -vv`

### Risk & Rollout

- DB-agnostic MVP: provider returns `None` in production until DB wiring is added.
- iOS contract unchanged; endpoint returns either empty list + `no_day_plan` warning, or a flat list of day items using existing DTO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Day shopping-list endpoint now returns generated, itemized per-day lists for PRO users and accepts "day_plan" as a valid source.
  * Added day-item generation and flattening to present weekly plan data as per-day shopping items.
* **Improvements**
  * More robust quantity/unit parsing, aisle resolution, and safer numeric handling in calculations.
* **Tests**
  * New and updated tests cover day-plan flows, flattening/sanitization, and endpoint warning behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->