### PR TITLE
feat(shoplist-day): wire fetch_day_plan to DB (weekly/day plans tables)

### DIFF
--- a/alembic/versions/202501270002_add_weekly_day_plans.py
+++ b/alembic/versions/202501270002_add_weekly_day_plans.py
@@ -1,0 +1,112 @@
+"""Add weekly_plans and day_plans tables for day shopping list DB wiring
+
+RU: Добавление таблиц weekly_plans и day_plans для сохранения планов питания.
+EN: Add weekly_plans and day_plans tables for storing meal plans.
+
+This migration adds persistence for generated weekly/day meal plans to support
+the day shopping list feature (PR-3).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202501270002"
+down_revision = "202501270001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """RU: Создаём таблицы для weekly и day планов.
+
+    EN: Create tables for weekly and day plans.
+    """
+
+    # Create weekly_plans table
+    op.create_table(
+        "weekly_plans",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("plan_data", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint("start_date <= end_date", name="ck_weekly_plan_date_order"),
+    )
+    op.create_index("ix_weekly_plans_user_id", "weekly_plans", ["user_id"])
+    op.create_index("ix_weekly_plans_start_date", "weekly_plans", ["start_date"])
+    op.create_index(
+        "ix_weekly_plans_user_date", "weekly_plans", ["user_id", "start_date"], unique=True
+    )
+
+    # Create day_plans table
+    op.create_table(
+        "day_plans",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "weekly_plan_id",
+            sa.Integer(),
+            sa.ForeignKey("weekly_plans.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("plan_data", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_day_plans_user_id", "day_plans", ["user_id"])
+    op.create_index("ix_day_plans_date", "day_plans", ["date"])
+    op.create_index("ix_day_plans_user_date", "day_plans", ["user_id", "date"], unique=True)
+    op.create_index("ix_day_plans_weekly_plan_id", "day_plans", ["weekly_plan_id"])
+
+
+def downgrade() -> None:
+    """RU: Удаляем таблицы weekly и day планов.
+
+    EN: Drop weekly and day plans tables.
+    """
+
+    # Drop day_plans table
+    op.drop_index("ix_day_plans_weekly_plan_id", table_name="day_plans")
+    op.drop_index("ix_day_plans_user_date", table_name="day_plans")
+    op.drop_index("ix_day_plans_date", table_name="day_plans")
+    op.drop_index("ix_day_plans_user_id", table_name="day_plans")
+    op.drop_table("day_plans")
+
+    # Drop weekly_plans table
+    op.drop_index("ix_weekly_plans_user_date", table_name="weekly_plans")
+    op.drop_index("ix_weekly_plans_start_date", table_name="weekly_plans")
+    op.drop_index("ix_weekly_plans_user_id", table_name="weekly_plans")
+    op.drop_table("weekly_plans")

--- a/app/core/shoplist_day/provider.py
+++ b/app/core/shoplist_day/provider.py
@@ -1,16 +1,50 @@
+"""Provider hook for fetching day plan data.
+
+PR-3: Real DB integration for day plan retrieval.
+"""
+
 from __future__ import annotations
 
 from datetime import date
 from typing import Any, Optional
 
+from sqlalchemy import select
+
+from app.models.plans import DayPlan
+from core.db import session_scope_async
+
 
 async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
     """Fetch day plan for a given date and PRO context.
 
-    PR-2 MVP placeholder: returns None so that the router responds with
-    an empty items list and a "no_day_plan" warning.
+    PR-3: Queries day_plans table for the given date.
 
-    Real implementations may fetch from DB, cache, or external services.
+    Args:
+        day: Date to fetch plan for
+        pro_ctx: PRO tier context (contains user info)
+
+    Returns:
+        Plan data dict with daily_menus format, or None if not found
     """
+    # Extract user_id from PRO context (placeholder: assume dict-like)
+    user_id = (
+        getattr(pro_ctx, "user_id", None) or pro_ctx.get("user_id")
+        if isinstance(pro_ctx, dict)
+        else None
+    )
 
-    return None
+    if user_id is None:
+        # No user_id in context, return None (no plan available)
+        return None
+
+    # Query DB for day plan
+    async with session_scope_async() as session:
+        stmt = select(DayPlan).where(DayPlan.user_id == user_id).where(DayPlan.date == day)
+        result = await session.execute(stmt)
+        day_plan = result.scalars().first()
+
+    if day_plan is None:
+        return None
+
+    # Return plan_data from DB (already in daily_menus format)
+    return day_plan.plan_data

--- a/app/core/shoplist_day/provider.py
+++ b/app/core/shoplist_day/provider.py
@@ -27,11 +27,10 @@ async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
         Plan data dict with daily_menus format, or None if not found
     """
     # Extract user_id from PRO context (placeholder: assume dict-like)
-    user_id = (
-        getattr(pro_ctx, "user_id", None) or pro_ctx.get("user_id")
-        if isinstance(pro_ctx, dict)
-        else None
-    )
+    if isinstance(pro_ctx, dict):
+        user_id = pro_ctx.get("user_id")
+    else:
+        user_id = getattr(pro_ctx, "user_id", None)
 
     if user_id is None:
         # No user_id in context, return None (no plan available)

--- a/app/core/shoplist_day/provider.py
+++ b/app/core/shoplist_day/provider.py
@@ -1,23 +1,23 @@
 """Provider hook for fetching day plan data.
 
 PR-3: Real DB integration for day plan retrieval.
+Uses lazy imports to avoid ORM registration side-effects at module import time.
 """
 
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from sqlalchemy import select
-
-from app.models.plans import DayPlan
-from core.db import session_scope_async
+if TYPE_CHECKING:
+    from app.models.plans import DayPlan
 
 
 async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
     """Fetch day plan for a given date and PRO context.
 
     PR-3: Queries day_plans table for the given date.
+    Uses lazy imports to avoid ORM registration at app import time.
 
     Args:
         day: Date to fetch plan for
@@ -26,7 +26,7 @@ async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
     Returns:
         Plan data dict with daily_menus format, or None if not found
     """
-    # Extract user_id from PRO context (placeholder: assume dict-like)
+    # Extract user_id from PRO context
     if isinstance(pro_ctx, dict):
         user_id = pro_ctx.get("user_id")
     else:
@@ -35,6 +35,12 @@ async def fetch_day_plan(day: date, pro_ctx: Any) -> Optional[dict]:
     if user_id is None:
         # No user_id in context, return None (no plan available)
         return None
+
+    # Lazy imports to avoid ORM side-effects at module import time
+    from sqlalchemy import select
+
+    from app.models.plans import DayPlan
+    from core.db import session_scope_async
 
     # Query DB for day plan
     async with session_scope_async() as session:

--- a/app/models/plans.py
+++ b/app/models/plans.py
@@ -1,0 +1,74 @@
+"""SQLAlchemy models for weekly and day plans."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Dict
+
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from core.db import Base
+
+
+class WeeklyPlan(Base):
+    """Weekly meal plan storage.
+
+    RU: Хранение недельных планов питания.
+    EN: Storage for weekly meal plans.
+    """
+
+    __tablename__ = "weekly_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    start_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    end_date: Mapped[date] = mapped_column(Date, nullable=False)
+    plan_data: Mapped[Dict] = mapped_column(JSON, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    # Relationships
+    day_plans: Mapped[list["DayPlan"]] = relationship(
+        "DayPlan", back_populates="weekly_plan", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (CheckConstraint("start_date <= end_date", name="ck_weekly_plan_date_order"),)
+
+
+class DayPlan(Base):
+    """Day meal plan storage.
+
+    RU: Хранение дневных планов питания.
+    EN: Storage for daily meal plans.
+    """
+
+    __tablename__ = "day_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    weekly_plan_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("weekly_plans.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    plan_data: Mapped[Dict] = mapped_column(JSON, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    # Relationships
+    weekly_plan: Mapped["WeeklyPlan | None"] = relationship(
+        "WeeklyPlan", back_populates="day_plans"
+    )

--- a/app/models/plans.py
+++ b/app/models/plans.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Dict
+from typing import Any, Dict
 
-from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Integer, JSON, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -27,7 +27,7 @@ class WeeklyPlan(Base):
     )
     start_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
     end_date: Mapped[date] = mapped_column(Date, nullable=False)
-    plan_data: Mapped[Dict] = mapped_column(JSON, nullable=False, server_default="{}")
+    plan_data: Mapped[Dict[str, Any]] = mapped_column(JSON, nullable=False, server_default="{}")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -37,7 +37,7 @@ class WeeklyPlan(Base):
 
     # Relationships
     day_plans: Mapped[list["DayPlan"]] = relationship(
-        "DayPlan", back_populates="weekly_plan", cascade="all, delete-orphan"
+        "DayPlan", back_populates="weekly_plan", cascade="all"
     )
 
     __table_args__ = (CheckConstraint("start_date <= end_date", name="ck_weekly_plan_date_order"),)
@@ -60,7 +60,7 @@ class DayPlan(Base):
         Integer, ForeignKey("weekly_plans.id", ondelete="CASCADE"), nullable=True, index=True
     )
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
-    plan_data: Mapped[Dict] = mapped_column(JSON, nullable=False, server_default="{}")
+    plan_data: Mapped[Dict[str, Any]] = mapped_column(JSON, nullable=False, server_default="{}")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -72,3 +72,5 @@ class DayPlan(Base):
     weekly_plan: Mapped["WeeklyPlan | None"] = relationship(
         "WeeklyPlan", back_populates="day_plans"
     )
+
+    __table_args__ = (UniqueConstraint("user_id", "date", name="uq_day_plans_user_date"),)

--- a/conftest.py
+++ b/conftest.py
@@ -80,7 +80,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
     os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
-    os.environ["DATABASE_USE_ASYNC"] = "1"  # Enable async SQLAlchemy for tests
     os.environ["TEST_DB_PATH"] = str(db_path)
 
     # Remove stale DB file if it exists (prevent conflicts)
@@ -167,7 +166,6 @@ def init_test_database() -> None:
             # Explicitly surface unexpected FS problems to fail fast in CI/setup.
             raise
         os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"  # SQLAlchemy expects URI
-        os.environ["DATABASE_USE_ASYNC"] = "1"  # Enable async SQLAlchemy for tests
 
         # Reload core.db after wiring env to ensure engine/sessionmaker pick up test DB
         import importlib

--- a/conftest.py
+++ b/conftest.py
@@ -80,6 +80,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
     os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["DATABASE_USE_ASYNC"] = "1"  # Enable async SQLAlchemy for tests
     os.environ["TEST_DB_PATH"] = str(db_path)
 
     # Remove stale DB file if it exists (prevent conflicts)
@@ -166,6 +167,7 @@ def init_test_database() -> None:
             # Explicitly surface unexpected FS problems to fail fast in CI/setup.
             raise
         os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"  # SQLAlchemy expects URI
+        os.environ["DATABASE_USE_ASYNC"] = "1"  # Enable async SQLAlchemy for tests
 
         # Reload core.db after wiring env to ensure engine/sessionmaker pick up test DB
         import importlib

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -9,11 +9,17 @@ from types import ModuleType
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.middleware.api_tiers import require_pro_tier
 from app.models.plans import DayPlan
 from core.db import AsyncSessionLocal
+
+
+@pytest.fixture(autouse=True)
+def _force_async_db(monkeypatch):
+    """Enable async SQLAlchemy only for this test module."""
+    monkeypatch.setenv("DATABASE_USE_ASYNC", "1")
 
 
 @pytest.fixture
@@ -111,10 +117,12 @@ async def test_day_plan_model_creation():
     if AsyncSessionLocal is None:
         pytest.skip("Async SQLAlchemy not configured")
 
+    test_date = date(2025, 12, 19)
+
     async with AsyncSessionLocal() as session:
         day_plan = DayPlan(
             user_id=1,
-            date=date(2025, 12, 19),
+            date=test_date,
             plan_data={"daily_menus": []},
         )
         session.add(day_plan)
@@ -122,11 +130,60 @@ async def test_day_plan_model_creation():
 
     # Query back in separate session
     async with AsyncSessionLocal() as session:
-        stmt = select(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == date(2025, 12, 19))
+        stmt = select(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == test_date)
         result = await session.execute(stmt)
         fetched = result.scalars().first()
 
-        assert fetched is not None
-        assert fetched.user_id == 1
-        assert fetched.date == date(2025, 12, 19)
-        assert fetched.plan_data == {"daily_menus": []}
+        try:
+            assert fetched is not None
+            assert fetched.user_id == 1
+            assert fetched.date == test_date
+            assert fetched.plan_data == {"daily_menus": []}
+        finally:
+            delete_stmt = (
+                delete(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == test_date)
+            )
+            await session.execute(delete_stmt)
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_day_plan_unique_user_date_constraint():
+    """Test that (user_id, date) uniqueness is enforced."""
+    if AsyncSessionLocal is None:
+        pytest.skip("Async SQLAlchemy not configured")
+
+    from sqlalchemy.exc import IntegrityError
+
+    test_date = date(2025, 12, 21)
+    user_id = 1
+
+    # Create first day plan
+    async with AsyncSessionLocal() as session:
+        day_plan_1 = DayPlan(
+            user_id=user_id,
+            date=test_date,
+            plan_data={"daily_menus": []},
+        )
+        session.add(day_plan_1)
+        await session.commit()
+
+    # Try to create duplicate — should fail
+    try:
+        async with AsyncSessionLocal() as session:
+            day_plan_2 = DayPlan(
+                user_id=user_id,
+                date=test_date,
+                plan_data={"daily_menus": [{"meals": []}]},
+            )
+            session.add(day_plan_2)
+            with pytest.raises(IntegrityError):
+                await session.commit()
+    finally:
+        # Cleanup
+        async with AsyncSessionLocal() as session:
+            delete_stmt = (
+                delete(DayPlan).where(DayPlan.user_id == user_id).where(DayPlan.date == test_date)
+            )
+            await session.execute(delete_stmt)
+            await session.commit()

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -1,0 +1,132 @@
+"""Tests for day shopping list DB wiring (PR-3).
+
+RU: Тесты для интеграции БД для дневного списка покупок.
+EN: Tests for day shopping list database integration.
+"""
+
+from datetime import date
+from types import ModuleType
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.middleware.api_tiers import require_pro_tier
+from app.models.plans import DayPlan
+from core.db import AsyncSessionLocal
+
+
+@pytest.fixture
+def client_with_pro_access(app_module: ModuleType):
+    """Create test client with PRO tier access bypassed.
+
+    Uses app_module fixture from conftest for better test isolation.
+    """
+    # Override PRO tier requirement for testing
+    app_module.app.dependency_overrides[require_pro_tier] = lambda: "test_api_key"
+
+    client = TestClient(app_module.app)
+    yield client
+
+    # Cleanup: remove override after test
+    app_module.app.dependency_overrides.pop(require_pro_tier, None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_when_exists_in_db(client_with_pro_access):
+    """When day plan exists in DB, fetch_day_plan returns plan_data."""
+    # Seed DB with day plan
+    test_date = date(2025, 12, 20)
+    plan_data = {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "oatmeal_apple",
+                        "grams": {
+                            "oats": 60.0,
+                            "apple": 100.0,
+                            "milk": 150.0,
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+    if AsyncSessionLocal is None:
+        pytest.skip("Async SQLAlchemy not configured")
+
+    async with AsyncSessionLocal() as session:
+        day_plan = DayPlan(
+            user_id=1,  # Assume test user ID is 1
+            date=test_date,
+            plan_data=plan_data,
+        )
+        session.add(day_plan)
+        await session.commit()
+
+    # Call endpoint
+    r = client_with_pro_access.get(f"/api/v1/pro/shoplist/day?date={test_date}&lang=en")
+    assert r.status_code == 200
+    body = r.json()
+
+    # Should return items (not empty)
+    assert body["items"], "Expected items when plan exists in DB"
+    assert body["warnings"] == []
+
+    # Verify items have correct structure
+    for item in body["items"]:
+        assert item["qty"] > 0
+        assert item["unit"] in {"g", "ml", "pcs", "kg", "l"}
+        assert item["aisle"] in {
+            "produce",
+            "protein",
+            "dairy",
+            "pantry",
+            "frozen",
+            "beverages",
+            "snacks",
+            "other",
+        }
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_when_not_in_db(client_with_pro_access):
+    """When no plan in DB, fetch_day_plan returns None → empty items + warning."""
+    test_date = date(2025, 12, 25)
+
+    r = client_with_pro_access.get(f"/api/v1/pro/shoplist/day?date={test_date}&lang=en")
+    assert r.status_code == 200
+    body = r.json()
+
+    # Should return empty items with warning
+    assert body["items"] == []
+    assert body["warnings"] == ["no_day_plan"]
+
+
+@pytest.mark.asyncio
+async def test_day_plan_model_creation():
+    """Test creating DayPlan model instance."""
+    if AsyncSessionLocal is None:
+        pytest.skip("Async SQLAlchemy not configured")
+
+    async with AsyncSessionLocal() as session:
+        day_plan = DayPlan(
+            user_id=1,
+            date=date(2025, 12, 19),
+            plan_data={"daily_menus": []},
+        )
+        session.add(day_plan)
+        await session.commit()
+
+    # Query back in separate session
+    async with AsyncSessionLocal() as session:
+        stmt = select(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == date(2025, 12, 19))
+        result = await session.execute(stmt)
+        fetched = result.scalars().first()
+
+        assert fetched is not None
+        assert fetched.user_id == 1
+        assert fetched.date == date(2025, 12, 19)
+        assert fetched.plan_data == {"daily_menus": []}

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -10,6 +10,7 @@ from types import ModuleType
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 
 from app.middleware.api_tiers import require_pro_tier
 from app.models.plans import DayPlan
@@ -152,8 +153,6 @@ async def test_day_plan_unique_user_date_constraint():
     """Test that (user_id, date) uniqueness is enforced."""
     if AsyncSessionLocal is None:
         pytest.skip("Async SQLAlchemy not configured")
-
-    from sqlalchemy.exc import IntegrityError
 
     test_date = date(2025, 12, 21)
     user_id = 1

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -6,7 +6,7 @@ EN: Tests for day shopping list database integration.
 
 from datetime import date
 from types import ModuleType
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Generator
 
 import pytest
 from fastapi.testclient import TestClient
@@ -55,14 +55,19 @@ async def test_user() -> AsyncGenerator[User, None]:
 
         yield user
 
-        # Cleanup: delete test user and related day plans
-        await session.execute(delete(DayPlan).where(DayPlan.user_id == TEST_USER_ID))
-        await session.execute(delete(User).where(User.id == TEST_USER_ID))
-        await session.commit()
+    # Cleanup: delete test user and related day plans in a fresh session
+    async with AsyncSessionLocal() as session:
+        try:
+            await session.execute(delete(DayPlan).where(DayPlan.user_id == TEST_USER_ID))
+            await session.execute(delete(User).where(User.id == TEST_USER_ID))
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
 
 
 @pytest.fixture
-def client_with_pro_access(app_module: ModuleType) -> TestClient:
+def client_with_pro_access(app_module: ModuleType) -> Generator[TestClient, None, None]:
     """Create test client with PRO tier access bypassed.
 
     Returns pro_ctx with user_id for proper fetch_day_plan behavior.
@@ -214,3 +219,4 @@ async def test_day_plan_unique_user_date_constraint(test_user: User) -> None:
         session.add(day_plan_2)
         with pytest.raises(IntegrityError):
             await session.commit()
+        await session.rollback()

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -6,6 +6,7 @@ EN: Tests for day shopping list database integration.
 
 from datetime import date
 from types import ModuleType
+from typing import Any, AsyncGenerator
 
 import pytest
 from fastapi.testclient import TestClient
@@ -15,22 +16,59 @@ from sqlalchemy.exc import IntegrityError
 from app.middleware.api_tiers import require_pro_tier
 from app.models.plans import DayPlan
 from core.db import AsyncSessionLocal
+from core.models import User
+
+# Test user ID used across all tests
+TEST_USER_ID = 1
 
 
 @pytest.fixture(autouse=True)
-def _force_async_db(monkeypatch):
+def _force_async_db(monkeypatch: Any) -> None:
     """Enable async SQLAlchemy only for this test module."""
     monkeypatch.setenv("DATABASE_USE_ASYNC", "1")
 
 
 @pytest.fixture
-def client_with_pro_access(app_module: ModuleType):
+async def test_user() -> AsyncGenerator[User, None]:
+    """Create test user in DB for FK constraints.
+
+    Creates user with id=TEST_USER_ID and cleans up after test.
+    """
+    if AsyncSessionLocal is None:
+        pytest.skip("Async SQLAlchemy not configured")
+
+    async with AsyncSessionLocal() as session:
+        # Check if user already exists
+        stmt = select(User).where(User.id == TEST_USER_ID)
+        result = await session.execute(stmt)
+        user = result.scalars().first()
+
+        if user is None:
+            user = User(
+                id=TEST_USER_ID,
+                email="test@example.com",
+                name="Test User",
+            )
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+
+        yield user
+
+        # Cleanup: delete test user and related day plans
+        await session.execute(delete(DayPlan).where(DayPlan.user_id == TEST_USER_ID))
+        await session.execute(delete(User).where(User.id == TEST_USER_ID))
+        await session.commit()
+
+
+@pytest.fixture
+def client_with_pro_access(app_module: ModuleType) -> TestClient:
     """Create test client with PRO tier access bypassed.
 
-    Uses app_module fixture from conftest for better test isolation.
+    Returns pro_ctx with user_id for proper fetch_day_plan behavior.
     """
-    # Override PRO tier requirement for testing
-    app_module.app.dependency_overrides[require_pro_tier] = lambda: "test_api_key"
+    # Override PRO tier to return dict with user_id (not just string)
+    app_module.app.dependency_overrides[require_pro_tier] = lambda: {"user_id": TEST_USER_ID}
 
     client = TestClient(app_module.app)
     yield client
@@ -40,7 +78,9 @@ def client_with_pro_access(app_module: ModuleType):
 
 
 @pytest.mark.asyncio
-async def test_fetch_day_plan_when_exists_in_db(client_with_pro_access):
+async def test_fetch_day_plan_when_exists_in_db(
+    client_with_pro_access: TestClient, test_user: User
+) -> None:
     """When day plan exists in DB, fetch_day_plan returns plan_data."""
     # Seed DB with day plan
     test_date = date(2025, 12, 20)
@@ -66,7 +106,7 @@ async def test_fetch_day_plan_when_exists_in_db(client_with_pro_access):
 
     async with AsyncSessionLocal() as session:
         day_plan = DayPlan(
-            user_id=1,  # Assume test user ID is 1
+            user_id=test_user.id,
             date=test_date,
             plan_data=plan_data,
         )
@@ -99,8 +139,11 @@ async def test_fetch_day_plan_when_exists_in_db(client_with_pro_access):
 
 
 @pytest.mark.asyncio
-async def test_fetch_day_plan_when_not_in_db(client_with_pro_access):
+async def test_fetch_day_plan_when_not_in_db(
+    client_with_pro_access: TestClient, test_user: User
+) -> None:
     """When no plan in DB, fetch_day_plan returns None → empty items + warning."""
+    _ = test_user  # Ensure user exists for FK constraint
     test_date = date(2025, 12, 25)
 
     r = client_with_pro_access.get(f"/api/v1/pro/shoplist/day?date={test_date}&lang=en")
@@ -113,7 +156,7 @@ async def test_fetch_day_plan_when_not_in_db(client_with_pro_access):
 
 
 @pytest.mark.asyncio
-async def test_day_plan_model_creation():
+async def test_day_plan_model_creation(test_user: User) -> None:
     """Test creating DayPlan model instance."""
     if AsyncSessionLocal is None:
         pytest.skip("Async SQLAlchemy not configured")
@@ -122,7 +165,7 @@ async def test_day_plan_model_creation():
 
     async with AsyncSessionLocal() as session:
         day_plan = DayPlan(
-            user_id=1,
+            user_id=test_user.id,
             date=test_date,
             plan_data={"daily_menus": []},
         )
@@ -131,36 +174,30 @@ async def test_day_plan_model_creation():
 
     # Query back in separate session
     async with AsyncSessionLocal() as session:
-        stmt = select(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == test_date)
+        stmt = (
+            select(DayPlan).where(DayPlan.user_id == test_user.id).where(DayPlan.date == test_date)
+        )
         result = await session.execute(stmt)
         fetched = result.scalars().first()
 
-        try:
-            assert fetched is not None
-            assert fetched.user_id == 1
-            assert fetched.date == test_date
-            assert fetched.plan_data == {"daily_menus": []}
-        finally:
-            delete_stmt = (
-                delete(DayPlan).where(DayPlan.user_id == 1).where(DayPlan.date == test_date)
-            )
-            await session.execute(delete_stmt)
-            await session.commit()
+        assert fetched is not None
+        assert fetched.user_id == test_user.id
+        assert fetched.date == test_date
+        assert fetched.plan_data == {"daily_menus": []}
 
 
 @pytest.mark.asyncio
-async def test_day_plan_unique_user_date_constraint():
+async def test_day_plan_unique_user_date_constraint(test_user: User) -> None:
     """Test that (user_id, date) uniqueness is enforced."""
     if AsyncSessionLocal is None:
         pytest.skip("Async SQLAlchemy not configured")
 
     test_date = date(2025, 12, 21)
-    user_id = 1
 
     # Create first day plan
     async with AsyncSessionLocal() as session:
         day_plan_1 = DayPlan(
-            user_id=user_id,
+            user_id=test_user.id,
             date=test_date,
             plan_data={"daily_menus": []},
         )
@@ -168,21 +205,12 @@ async def test_day_plan_unique_user_date_constraint():
         await session.commit()
 
     # Try to create duplicate — should fail
-    try:
-        async with AsyncSessionLocal() as session:
-            day_plan_2 = DayPlan(
-                user_id=user_id,
-                date=test_date,
-                plan_data={"daily_menus": [{"meals": []}]},
-            )
-            session.add(day_plan_2)
-            with pytest.raises(IntegrityError):
-                await session.commit()
-    finally:
-        # Cleanup
-        async with AsyncSessionLocal() as session:
-            delete_stmt = (
-                delete(DayPlan).where(DayPlan.user_id == user_id).where(DayPlan.date == test_date)
-            )
-            await session.execute(delete_stmt)
+    async with AsyncSessionLocal() as session:
+        day_plan_2 = DayPlan(
+            user_id=test_user.id,
+            date=test_date,
+            plan_data={"daily_menus": [{"meals": []}]},
+        )
+        session.add(day_plan_2)
+        with pytest.raises(IntegrityError):
             await session.commit()

--- a/tests/test_shoplist_day_provider.py
+++ b/tests/test_shoplist_day_provider.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.shoplist_day import provider as provider_module
+import core.db as db
+
+
+class _FakeResult:
+    def __init__(self, day_plan):
+        self._day_plan = day_plan
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._day_plan
+
+
+class _FakeSession:
+    def __init__(self, day_plan):
+        self._day_plan = day_plan
+        self.statement = None
+
+    async def execute(self, stmt):
+        self.statement = stmt
+        return _FakeResult(self._day_plan)
+
+
+def _session_scope_factory(day_plan, holder):
+    @asynccontextmanager
+    async def _scope():
+        session = _FakeSession(day_plan)
+        holder.append(session)
+        yield session
+
+    return _scope
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_returns_none_without_user_id_dict() -> None:
+    result = await provider_module.fetch_day_plan(
+        day=date(2025, 1, 1),
+        pro_ctx={"role": "pro"},
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_returns_none_without_user_id_object() -> None:
+    result = await provider_module.fetch_day_plan(
+        day=date(2025, 1, 2),
+        pro_ctx=SimpleNamespace(user_id=None),
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_returns_none_when_missing(monkeypatch) -> None:
+    holder = []
+    monkeypatch.setattr(db, "session_scope_async", _session_scope_factory(None, holder))
+
+    result = await provider_module.fetch_day_plan(
+        day=date(2025, 1, 3),
+        pro_ctx=SimpleNamespace(user_id=10),
+    )
+
+    assert result is None
+    assert holder and holder[0].statement is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_day_plan_returns_plan_data(monkeypatch) -> None:
+    plan_data = {"daily_menus": [{"meals": []}]}
+    day_plan = SimpleNamespace(plan_data=plan_data)
+    holder = []
+    monkeypatch.setattr(db, "session_scope_async", _session_scope_factory(day_plan, holder))
+
+    result = await provider_module.fetch_day_plan(
+        day=date(2025, 1, 4),
+        pro_ctx=SimpleNamespace(user_id=42),
+    )
+
+    assert result == plan_data
+    assert holder and holder[0].statement is not None

--- a/tests/test_shoplist_day_provider.py
+++ b/tests/test_shoplist_day_provider.py
@@ -1,39 +1,56 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import date
 from types import SimpleNamespace
+from typing import Any, AsyncContextManager, Callable, Generic, List, TypeVar
 
 import pytest
 
-from app.core.shoplist_day import provider as provider_module
 import core.db as db
+from app.core.shoplist_day import provider as provider_module
 
 
-class _FakeResult:
-    def __init__(self, day_plan):
+DayPlanT = TypeVar("DayPlanT")
+
+
+class _FakeResult(Generic[DayPlanT]):
+    """Fake SQLAlchemy result for testing."""
+
+    def __init__(self, day_plan: DayPlanT) -> None:
         self._day_plan = day_plan
 
-    def scalars(self):
+    def scalars(self) -> "_FakeResult[DayPlanT]":
         return self
 
-    def first(self):
+    def first(self) -> DayPlanT:
         return self._day_plan
 
 
-class _FakeSession:
-    def __init__(self, day_plan):
-        self._day_plan = day_plan
-        self.statement = None
+class _FakeSession(Generic[DayPlanT]):
+    """Fake SQLAlchemy async session for testing."""
 
-    async def execute(self, stmt):
+    def __init__(self, day_plan: DayPlanT) -> None:
+        self._day_plan = day_plan
+        self.statement: Any = None
+        self.compiled_sql: str | None = None
+
+    async def execute(self, stmt: Any) -> _FakeResult[DayPlanT]:
         self.statement = stmt
+        # Compile SQL with literal binds for assertion
+        self.compiled_sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
         return _FakeResult(self._day_plan)
 
 
-def _session_scope_factory(day_plan, holder):
+def _session_scope_factory(
+    day_plan: DayPlanT,
+    holder: List[_FakeSession[DayPlanT]],
+) -> Callable[[], AsyncContextManager[_FakeSession[DayPlanT]]]:
+    """Create a fake session scope factory for testing."""
+
     @asynccontextmanager
-    async def _scope():
+    async def _scope() -> AsyncIterator[_FakeSession[DayPlanT]]:
         session = _FakeSession(day_plan)
         holder.append(session)
         yield session
@@ -62,8 +79,11 @@ async def test_fetch_day_plan_returns_none_without_user_id_object() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_day_plan_returns_none_when_missing(monkeypatch) -> None:
-    holder = []
+async def test_fetch_day_plan_returns_none_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test fetch_day_plan returns None when no plan exists."""
+    holder: list[_FakeSession] = []
     monkeypatch.setattr(db, "session_scope_async", _session_scope_factory(None, holder))
 
     result = await provider_module.fetch_day_plan(
@@ -73,13 +93,20 @@ async def test_fetch_day_plan_returns_none_when_missing(monkeypatch) -> None:
 
     assert result is None
     assert holder and holder[0].statement is not None
+    # Verify SQL query includes correct filters
+    sql = holder[0].compiled_sql
+    assert sql is not None
+    assert "user_id" in sql
+    assert "10" in sql  # user_id value
+    assert "date" in sql
 
 
 @pytest.mark.asyncio
-async def test_fetch_day_plan_returns_plan_data(monkeypatch) -> None:
+async def test_fetch_day_plan_returns_plan_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test fetch_day_plan returns plan_data when plan exists."""
     plan_data = {"daily_menus": [{"meals": []}]}
     day_plan = SimpleNamespace(plan_data=plan_data)
-    holder = []
+    holder: list[_FakeSession] = []
     monkeypatch.setattr(db, "session_scope_async", _session_scope_factory(day_plan, holder))
 
     result = await provider_module.fetch_day_plan(
@@ -89,3 +116,9 @@ async def test_fetch_day_plan_returns_plan_data(monkeypatch) -> None:
 
     assert result == plan_data
     assert holder and holder[0].statement is not None
+    # Verify SQL query includes correct filters
+    sql = holder[0].compiled_sql
+    assert sql is not None
+    assert "user_id" in sql
+    assert "42" in sql  # user_id value
+    assert "2025-01-04" in sql  # date value


### PR DESCRIPTION
## Что сделано

- ✅ Alembic migration: `weekly_plans` + `day_plans` tables
- ✅ SQLAlchemy models: `WeeklyPlan`, `DayPlan`
- ✅ DB wiring: `fetch_day_plan` queries DB (async session)
- ✅ Tests: DB integration tests (happy path + missing day)
- ✅ Async support: enabled `DATABASE_USE_ASYNC=1` in conftest

## Out of scope

- Day plan authoring API (create/update)
- Engine hardening for MagicMock (`menu_engine_new`)

## Related

- Follows PR #366 (Day Shopping List MVP)
- Prepares DB layer for future PRO features

## Summary by Sourcery

Интегрировать функционал списка покупок на день с базой данных, используя новую систему сохранения недельных/дневных планов и асинхронные запросы.

Новые возможности:
- Добавить ORM‑модели `WeeklyPlan` и `DayPlan` для сохранения недельных и дневных планов питания.
- Ввести миграцию Alembic, создающую таблицы `weekly_plans` и `day_plans` с индексами и ограничениями для планов, привязанных к пользователю.

Улучшения:
- Подключить провайдер `fetch_day_plan` для загрузки дневных планов из таблицы `day_plans` с использованием асинхронных сессий SQLAlchemy на основе пользователя и даты.
- Включить использование асинхронной базы данных в тестовой среде через конфигурацию `DATABASE_USE_ASYNC`.

Тесты:
- Добавить интеграционные тесты, покрывающие поведение списка покупок на день, когда дневной план существует или отсутствует в базе данных, а также базовую проверку сохранения модели `DayPlan`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the day shopping list feature with the database using new weekly/day plan persistence and async querying.

New Features:
- Add WeeklyPlan and DayPlan ORM models to persist weekly and daily meal plans.
- Introduce Alembic migration creating weekly_plans and day_plans tables with indexes and constraints for user-scoped plans.

Enhancements:
- Wire fetch_day_plan provider to load day plans from the day_plans table using async SQLAlchemy sessions based on user and date.
- Enable async database usage in the test environment via DATABASE_USE_ASYNC configuration.

Tests:
- Add integration tests covering day shopping list behavior when a day plan exists or is missing in the database, and basic DayPlan model persistence.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can save and manage meal plans at weekly and daily granularity; shopping list generation reads real saved plans.

* **Data Integrity**
  * Enforced weekly start/end date ordering and ensured one daily plan per user/date; cascaded deletions maintain relational integrity.

* **Tests**
  * Added unit and integration tests covering plan storage, retrieval, uniqueness enforcement, and shopping-list generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->