### PR TITLE
fix(nightly): remove COVERAGE_FILE to fix coverage combine

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,7 +124,6 @@ jobs:
         env:
           PYTHONPATH: .:tests
           PYTEST_TIMEOUT: 300
-          COVERAGE_FILE: .coverage.shard-${{ matrix.shard_id }}
         run: |
           START_TIME=$(date +%s)
           export START_TIME
@@ -165,8 +164,8 @@ jobs:
         with:
           name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
+            .coverage*
             coverage-shard-${{ matrix.shard_id }}.xml
-            .coverage.shard-${{ matrix.shard_id }}
           retention-days: 30
 
       - name: Upload test results


### PR DESCRIPTION
## Problem
`coverage-merge` job fails with "No data to combine" because `COVERAGE_FILE` env var is incompatible with pytest-cov + xdist.

## Root Cause
- pytest-cov with xdist manages `.coverage.*` files automatically
- Setting `COVERAGE_FILE` breaks this mechanism
- Shards create XML but no data files for combine

## Solution
- ✅ Remove `COVERAGE_FILE` env var from test job
- ✅ Upload `.coverage*` (auto-generated) instead of `.coverage.shard-<id>`
- ✅ pytest-cov handles data file naming with xdist workers

## Testing
- [x] Pre-commit checks pass
- [ ] Nightly shards create `.coverage*` files
- [ ] coverage-merge successfully combines data

Fixes the "No data to combine" error in nightly workflow.

Related: #368

## Summary by Sourcery

Настроить обработку артефактов покрытия в ночных CI-сборках так, чтобы она была совместима с pytest-cov и xdist.

CI:
- Удалить явную переменную окружения `COVERAGE_FILE` из ночных шардов тестов, чтобы pytest-cov мог автоматически управлять файлами данных покрытия.
- Обновить загрузку артефактов покрытия в ночных сборках, чтобы собирать автоматически сгенерированные файлы `.coverage*` вместо шард-специфичных путей `.coverage.shard-<id>`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI coverage artifact handling to be compatible with pytest-cov and xdist.

CI:
- Remove explicit COVERAGE_FILE environment variable from nightly test shards so pytest-cov can manage coverage data files automatically.
- Update nightly coverage artifact upload to collect auto-generated .coverage* files instead of shard-specific .coverage.shard-<id> paths.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage file handling in continuous integration workflows to improve efficiency in collecting test coverage reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->