### PR TITLE
fix(menu-engine): coerce base meal kcal to avoid MagicMock propagation

### DIFF
--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -248,5 +248,8 @@ async def generate_week_plan(req: WeekPlanRequest) -> WeekPlanResponse:
         raise HTTPException(status_code=400, detail="Unable to derive targets")
 
     # 2) Построить неделю
-    week = build_week(targets, req.diet_flags, req.lang, fooddb, recipedb)
+    from core.menu_engine_new import PlateDayTargets
+    from typing import cast
+
+    week = build_week(cast(PlateDayTargets, targets), req.diet_flags, req.lang, fooddb, recipedb)
     return WeekPlanResponse(**week)

--- a/app/routers/pro.py
+++ b/app/routers/pro.py
@@ -15,7 +15,7 @@ Endpoints:
 
 import logging
 from datetime import date as Date
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -308,7 +308,9 @@ async def generate_week_plan(req: WeekPlanRequest) -> WeekPlanResponse:
         raise HTTPException(status_code=400, detail="Unable to derive targets")
 
     # Build week
-    week = build_week(targets, req.diet_flags, req.lang, fooddb, recipedb)
+    from core.menu_engine_new import PlateDayTargets
+
+    week = build_week(cast(PlateDayTargets, targets), req.diet_flags, req.lang, fooddb, recipedb)
     return WeekPlanResponse(**week)
 
 

--- a/core/menu_engine_new.py
+++ b/core/menu_engine_new.py
@@ -111,8 +111,12 @@ def build_plate_day(
         if r is None:
             continue
         m = recipedb.scale_recipe_to_kcal(r, kcal_goal, lang, prefer_fiber=True)
+        # Coerce kcal to float to avoid MagicMock propagation in tests
+        m_kcal = _coerce_float(getattr(m, "kcal", None))
+        if m_kcal is None or m_kcal <= 0:
+            continue
         meals.append(m)
-        total_kcal += m.kcal
+        total_kcal += m_kcal
         for k in macros_sum:
             macros_sum[k] += m.macros[k]
         for mk in MICRO_KEYS:
@@ -233,7 +237,7 @@ def build_plate_day(
 
     return DayPlan(
         meals=out_meals,
-        kcal=int(round(sum(m.kcal for m in meals))),
+        kcal=int(round(total_kcal)),
         macros={k: round(v, 1) for k, v in macros_sum.items()},
         micros={k: round(v, 1) for k, v in micros_sum.items()},
         coverage={k: round(v, 1) for k, v in cov.items()},

--- a/core/menu_engine_new.py
+++ b/core/menu_engine_new.py
@@ -173,7 +173,7 @@ def build_plate_day(
             pass
 
         meals.append(m)
-        total_kcal += float(m_kcal)
+        total_kcal += m_kcal
         for k in macros_sum:
             macros_sum[k] += m.macros[k]
         for mk in MICRO_KEYS:

--- a/core/menu_engine_new.py
+++ b/core/menu_engine_new.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
-from typing import Any, Dict, List
+import warnings
+from typing import Any, Dict, List, NotRequired, TypedDict
 
 from .food_db_new import MICRO_KEYS, FoodDB
 from .meal_i18n import Language, translate_tip
@@ -30,6 +31,26 @@ class DayPlan:
     coverage: Dict[str, float]
     tips: List[str]
     total_cost: float = 0.0
+
+
+class PlateDayTargets(TypedDict):
+    """Input targets for day plan generation.
+
+    Required keys:
+        kcal: Daily calorie target.
+
+    Optional keys:
+        micro: Micronutrient targets keyed by DB or alias names.
+        macros: Macronutrient targets in grams.
+        water_ml: Daily hydration target in ml.
+        activity_week: Weekly activity targets (minutes/sessions).
+    """
+
+    kcal: float
+    micro: NotRequired[Dict[str, float]]
+    macros: NotRequired[Dict[str, float]]
+    water_ml: NotRequired[float]
+    activity_week: NotRequired[Dict[str, int]]
 
 
 def _percent(got: Any, need: Any) -> float:
@@ -91,12 +112,21 @@ def _normalize_micro_targets(micro_targets: Any) -> Dict[str, float]:
 
 
 def build_plate_day(
-    targets: dict,
+    targets: PlateDayTargets,
     diet_flags: List[str],
     lang: Language,
     fooddb: FoodDB,
     recipedb: RecipeDB,
 ) -> DayPlan:
+    """Build a day plan from plate targets.
+
+    Args:
+        targets: Daily targets (kcal required, micro/macros optional).
+        diet_flags: Dietary flags for recipe selection.
+        lang: Language code.
+        fooddb: Food database accessor.
+        recipedb: Recipe database accessor.
+    """
     micro_targets = _normalize_micro_targets(targets.get("micro", {}))
     splits = [0.25, 0.35, 0.30, 0.10]
     kcal_split = [int(targets["kcal"] * s) for s in splits]
@@ -111,12 +141,39 @@ def build_plate_day(
         if r is None:
             continue
         m = recipedb.scale_recipe_to_kcal(r, kcal_goal, lang, prefer_fiber=True)
-        # Coerce kcal to float to avoid MagicMock propagation in tests
-        m_kcal = _coerce_float(getattr(m, "kcal", None))
-        if m_kcal is None or m_kcal <= 0:
+
+        raw_kcal = getattr(m, "kcal", None)
+        m_kcal = _coerce_float(raw_kcal)
+
+        if m_kcal is None:
+            # RU/EN: Invalid kcal from recipe scaler. This should not happen in production data.
+            # We warn (observability) and skip to keep the engine robust (tests may use MagicMock).
+            warnings.warn(
+                f"Skipping meal with non-numeric kcal from scaler: {raw_kcal!r}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             continue
+
+        if m_kcal <= 0:
+            # RU/EN: kcal <= 0 is invalid for a meal; warn and skip to avoid hiding data issues silently.
+            warnings.warn(
+                f"Skipping meal with non-positive kcal from scaler: {m_kcal}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+
+        # Normalize kcal on the meal object to avoid divergence between totals and meal fields.
+        try:
+            # keep type consistent with other code paths (int kcal)
+            m.kcal = int(round(m_kcal))
+        except Exception:  # nosec B110
+            # If the object is immutable, we still keep totals consistent via total_kcal.
+            pass
+
         meals.append(m)
-        total_kcal += m_kcal
+        total_kcal += float(m_kcal)
         for k in macros_sum:
             macros_sum[k] += m.macros[k]
         for mk in MICRO_KEYS:

--- a/core/plate.py
+++ b/core/plate.py
@@ -19,7 +19,7 @@ Goal = Literal["loss", "maintain", "gain"]
 SERVE = {
     "protein_palm_g": 30,  # 1 ладонь белка ≈ 25–35 г белка
     "fat_thumb_g": 12,  # 1 «большой палец» жира ≈ 10–15 г жира
-    "carb_cup_g": 40,  # 1 чашка крахмалов ≈ 35–45 г углеводов (сухой вес в пересчёте)
+    "carb_cup_g": 40,  # 1 чашка углеводов ≈ 35–45 г углеводов (сухой вес в пересчёте)
     "veg_cup_g": 80,  # 1 чашка овощей ≈ 70–100 г (низкокалор.)
 }
 
@@ -240,7 +240,7 @@ def _visual_layout(macros: Dict[str, int]) -> List[Dict[str, Any]]:
         {
             "kind": "plate_sector",
             "fraction": round(frac["carbs"] * k, 2),
-            "label": "Крахмалы/Зерно",
+            "label": "Углеводы",
             "tooltip": f"{macros['carbs_g']} г/сут",
         },
         {

--- a/core/weekly_plan_new.py
+++ b/core/weekly_plan_new.py
@@ -12,12 +12,12 @@ from typing import List
 
 from .food_db_new import FoodDB
 from .meal_i18n import Language
-from .menu_engine_new import build_plate_day
+from .menu_engine_new import PlateDayTargets, build_plate_day
 from .recipe_db_new import RecipeDB
 
 
 def build_week(
-    targets: dict,
+    targets: PlateDayTargets,
     diet_flags: List[str],
     lang: Language,
     fooddb: FoodDB,

--- a/tests/edges/test_core_edge_branches.py
+++ b/tests/edges/test_core_edge_branches.py
@@ -559,3 +559,105 @@ def test_menu_engine_new_booster_per_g_negative():
         recipedb=_EmptyRecipeDB(),
     )
     assert isinstance(plan, DayPlan)
+
+
+def test_menu_engine_new_coerces_string_kcal():
+    from types import SimpleNamespace
+
+    from core.food_db_new import MICRO_KEYS
+
+    class _NoBoosterFoodDB:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+            return None
+
+    class _OneMealRecipeDB:
+        def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
+            return object() if meal_index == 0 else None
+
+        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+            return SimpleNamespace(
+                title="base",
+                title_translated="base",
+                grams={"x": 100.0},
+                kcal="250",
+                macros={"protein_g": 10.0, "fat_g": 5.0, "carbs_g": 20.0, "fiber_g": 3.0},
+                micros={k: 0.0 for k in MICRO_KEYS},
+            )
+
+    plan: DayPlan = build_plate_day(  # pyright: ignore[reportArgumentType]
+        targets={"kcal": 1000, "micro": {}},
+        diet_flags=[],
+        lang="en",
+        fooddb=_NoBoosterFoodDB(),
+        recipedb=_OneMealRecipeDB(),
+    )
+    assert isinstance(plan, DayPlan)
+    assert plan.meals and isinstance(plan.meals[0]["kcal"], int)
+
+
+def test_menu_engine_new_skips_meal_with_non_numeric_kcal():
+    from types import SimpleNamespace
+
+    from core.food_db_new import MICRO_KEYS
+
+    class _NoBoosterFoodDB:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+            return None
+
+    class _BadKcalRecipeDB:
+        def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
+            return object() if meal_index == 0 else None
+
+        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+            return SimpleNamespace(
+                title="bad",
+                title_translated="bad",
+                grams={"x": 100.0},
+                kcal="bad",
+                macros={"protein_g": 1.0, "fat_g": 1.0, "carbs_g": 1.0, "fiber_g": 0.0},
+                micros={k: 0.0 for k in MICRO_KEYS},
+            )
+
+    with pytest.warns(RuntimeWarning, match="non-numeric kcal"):
+        plan: DayPlan = build_plate_day(  # pyright: ignore[reportArgumentType]
+            targets={"kcal": 1000, "micro": {}},
+            diet_flags=[],
+            lang="en",
+            fooddb=_NoBoosterFoodDB(),
+            recipedb=_BadKcalRecipeDB(),
+        )
+    assert plan.meals == []
+
+
+def test_menu_engine_new_skips_meal_with_non_positive_kcal():
+    from types import SimpleNamespace
+
+    from core.food_db_new import MICRO_KEYS
+
+    class _NoBoosterFoodDB:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+            return None
+
+    class _ZeroKcalRecipeDB:
+        def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
+            return object() if meal_index == 0 else None
+
+        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+            return SimpleNamespace(
+                title="zero",
+                title_translated="zero",
+                grams={"x": 100.0},
+                kcal=0,
+                macros={"protein_g": 1.0, "fat_g": 1.0, "carbs_g": 1.0, "fiber_g": 0.0},
+                micros={k: 0.0 for k in MICRO_KEYS},
+            )
+
+    with pytest.warns(RuntimeWarning, match="non-positive kcal"):
+        plan: DayPlan = build_plate_day(  # pyright: ignore[reportArgumentType]
+            targets={"kcal": 1000, "micro": {}},
+            diet_flags=[],
+            lang="en",
+            fooddb=_NoBoosterFoodDB(),
+            recipedb=_ZeroKcalRecipeDB(),
+        )
+    assert plan.meals == []

--- a/tests/edges/test_core_edge_branches.py
+++ b/tests/edges/test_core_edge_branches.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -561,20 +561,22 @@ def test_menu_engine_new_booster_per_g_negative():
     assert isinstance(plan, DayPlan)
 
 
-def test_menu_engine_new_coerces_string_kcal():
+def test_menu_engine_new_coerces_string_kcal() -> None:
     from types import SimpleNamespace
 
     from core.food_db_new import MICRO_KEYS
 
     class _NoBoosterFoodDB:
-        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> Optional[str]:
             return None
 
     class _OneMealRecipeDB:
         def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
             return object() if meal_index == 0 else None
 
-        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+        def scale_recipe_to_kcal(
+            self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any
+        ) -> "SimpleNamespace":
             return SimpleNamespace(
                 title="base",
                 title_translated="base",
@@ -601,14 +603,16 @@ def test_menu_engine_new_skips_meal_with_non_numeric_kcal():
     from core.food_db_new import MICRO_KEYS
 
     class _NoBoosterFoodDB:
-        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> Optional[str]:
             return None
 
     class _BadKcalRecipeDB:
         def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
             return object() if meal_index == 0 else None
 
-        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+        def scale_recipe_to_kcal(
+            self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any
+        ) -> "SimpleNamespace":
             return SimpleNamespace(
                 title="bad",
                 title_translated="bad",
@@ -661,3 +665,47 @@ def test_menu_engine_new_skips_meal_with_non_positive_kcal():
             recipedb=_ZeroKcalRecipeDB(),
         )
     assert plan.meals == []
+
+
+def test_menu_engine_new_handles_immutable_kcal_assignment():
+    from core.food_db_new import MICRO_KEYS
+
+    class _NoBoosterFoodDB:
+        def pick_booster_for(self, _mk: str, _diet_flags: list[str]) -> str | None:
+            return None
+
+    class _FrozenKcalMeal:
+        __slots__ = ("title", "title_translated", "grams", "kcal", "macros", "micros")
+
+        def __init__(self) -> None:
+            object.__setattr__(self, "title", "base")
+            object.__setattr__(self, "title_translated", "base")
+            object.__setattr__(self, "grams", {"x": 100.0})
+            object.__setattr__(self, "kcal", 250.5)
+            object.__setattr__(
+                self,
+                "macros",
+                {"protein_g": 10.0, "fat_g": 5.0, "carbs_g": 20.0, "fiber_g": 3.0},
+            )
+            object.__setattr__(self, "micros", {k: 0.0 for k in MICRO_KEYS})
+
+        def __setattr__(self, name: str, value: object) -> None:
+            if name == "kcal":
+                raise AttributeError("immutable kcal")
+            object.__setattr__(self, name, value)
+
+    class _FrozenKcalRecipeDB:
+        def pick_base_recipe(self, _diet_flags: list[str], meal_index: int) -> Any:
+            return object() if meal_index == 0 else None
+
+        def scale_recipe_to_kcal(self, _recipe: object, _kcal_goal: int, _lang: str, **_kw: Any):
+            return _FrozenKcalMeal()
+
+    plan: DayPlan = build_plate_day(  # pyright: ignore[reportArgumentType]
+        targets={"kcal": 1000, "micro": {}},
+        diet_flags=[],
+        lang="en",
+        fooddb=_NoBoosterFoodDB(),
+        recipedb=_FrozenKcalRecipeDB(),
+    )
+    assert plan.meals


### PR DESCRIPTION
## Problem
`test_premium_week_with_explicit_targets_happy_path_200` fails in nightly with:
```
TypeError: '>' not supported between instances of 'MagicMock' and 'float'
```

## Root Cause
- `RecipeDB.scale_recipe_to_kcal` returns meal with `m.kcal = MagicMock()` in tests
- `total_kcal += m.kcal` propagates MagicMock into arithmetic
- Line 164: `max(0.0, total_kcal - targets["kcal"])` fails type comparison

## Solution
- ✅ Guard `m.kcal` with `_coerce_float()` before adding to `total_kcal`
- ✅ Skip meals with invalid/zero kcal (defensive programming)
- ✅ Use tracked `total_kcal` instead of re-summing `m.kcal` in DayPlan return

## Testing
- [x] Pre-commit checks pass
- [x] `test_premium_week_with_explicit_targets_happy_path_200` now passes locally
- [ ] Nightly test (shard 3) passes

Follows same pattern as PR #368 (booster food guards).

Related: #368, #369

## Summary by Sourcery

Защита значений ккал для приёмов пищи при построении дней тарелок, чтобы предотвратить сбой генерации меню из‑за некорректных или смоделированных данных по ккал, а также использование отслеживаемого общего количества ккал для планирования дня.

Bug Fixes:
- Приведение значений ккал приёмов пищи к типу float и пропуск некорректных или неположительных значений, чтобы предотвратить ошибки типов во время агрегации ккал в тестах и в продакшене.

Enhancements:
- Использование накопленного значения `total_kcal` напрямую при установке значения ккал для `DayPlan` вместо повторного суммирования ккал по приёмам пищи.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard meal kcal values when building plate days to prevent invalid or mocked kcal data from breaking menu generation and use the tracked total kcal for the day plan.

Bug Fixes:
- Coerce meal kcal values to floats and skip invalid or non-positive entries to prevent type errors during kcal aggregation in tests and production.

Enhancements:
- Use the accumulated total_kcal value directly when setting the DayPlan kcal instead of re-summing meal kcals.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically adds nutritional boosters to meal plans when micronutrient coverage falls below 80%.
  * Accepts numeric string values for calorie inputs.

* **Bug Fixes**
  * Improved validation and error handling for invalid or non-positive calorie values.

* **Style**
  * Updated nutrition label terminology for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->