### PR TITLE
debug(nightly): add coverage artifacts diagnostics

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -164,9 +164,17 @@ jobs:
         with:
           name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
-            .coverage*
+            **/.coverage*
             coverage-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
+
+      - name: Debug coverage files (shard)
+        if: always()
+        run: |
+          echo "PWD=$(pwd)"
+          ls -la
+          echo "=== looking for .coverage files ==="
+          find . -maxdepth 3 -name ".coverage*" -print -exec ls -la {} \; || true
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
@@ -330,6 +338,15 @@ jobs:
           pattern: coverage-reports-shard-*
           merge-multiple: true
           path: coverage-artifacts
+
+      - name: Debug coverage artifacts
+        run: |
+          echo "PWD=$(pwd)"
+          echo "=== coverage-artifacts tree ==="
+          ls -la coverage-artifacts || true
+          find coverage-artifacts -maxdepth 3 -type f -print || true
+          echo "=== looking for .coverage files ==="
+          find coverage-artifacts -maxdepth 3 -name ".coverage*" -print || true
 
       - name: Install coverage
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,14 +124,28 @@ jobs:
         env:
           PYTHONPATH: .:tests
           PYTEST_TIMEOUT: 300
+          PYTHONFAULTHANDLER: 1
         run: |
           START_TIME=$(date +%s)
           export START_TIME
           echo "Running test suite (shard ${{ matrix.shard_id }}/${SHARD_TOTAL})..."
 
+          run_with_timeout() {
+            timeout --signal=SIGQUIT --kill-after=5m 30m "$@"
+            status=$?
+            if [ "$status" -eq 124 ] || [ "$status" -eq 131 ] || [ "$status" -eq 137 ]; then
+              echo "=== Pytest timeout detected (status=$status) ==="
+              echo "=== Faulthandler stack traces should appear above (SIGQUIT) ==="
+              echo "=== Process snapshot ==="
+              ps -eo pid,ppid,stat,etimes,cmd | head -200 || true
+              pgrep -fa python || true
+            fi
+            return "$status"
+          }
+
           # Step 1: Run parallel tests (exclude serial-marked tests to avoid xdist hang)
           echo "=== Running parallel tests (-n 4, excluding serial) ==="
-          pytest -c pyproject.toml tests/ \
+          run_with_timeout pytest -c pyproject.toml tests/ \
             --shard-id=${{ matrix.shard_id }} \
             --maxfail=10 \
             --cov=. \
@@ -142,11 +156,12 @@ jobs:
             -v \
             -n 4 \
             --dist loadscope \
+            -o faulthandler_timeout=300 \
             -m "not serial"
 
           # Step 2: Run serial tests (coverage-smoke imports heavy modules that hang xdist)
           echo "=== Running serial tests (-n 0, serial only) ==="
-          pytest -c pyproject.toml tests/ \
+          run_with_timeout pytest -c pyproject.toml tests/ \
             --shard-id=${{ matrix.shard_id }} \
             --maxfail=10 \
             --cov=. \
@@ -156,6 +171,7 @@ jobs:
             --tb=short \
             -v \
             -n 0 \
+            -o faulthandler_timeout=300 \
             -m serial || true  # Serial tests are coverage-only, non-blocking
 
       - name: Upload coverage reports

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -174,6 +174,14 @@ jobs:
             -o faulthandler_timeout=300 \
             -m serial || true  # Serial tests are coverage-only, non-blocking
 
+      - name: Debug coverage files (shard)
+        if: always()
+        run: |
+          echo "PWD=$(pwd)"
+          ls -la
+          echo "=== looking for .coverage files ==="
+          find . -maxdepth 3 -name ".coverage*" -print -exec ls -la {} \; || true
+
       - name: Upload coverage reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
         if: always()
@@ -183,14 +191,6 @@ jobs:
             **/.coverage*
             coverage-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
-
-      - name: Debug coverage files (shard)
-        if: always()
-        run: |
-          echo "PWD=$(pwd)"
-          ls -la
-          echo "=== looking for .coverage files ==="
-          find . -maxdepth 3 -name ".coverage*" -print -exec ls -la {} \; || true
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
@@ -356,6 +356,7 @@ jobs:
           path: coverage-artifacts
 
       - name: Debug coverage artifacts
+        if: always()
         run: |
           echo "PWD=$(pwd)"
           echo "=== coverage-artifacts tree ==="


### PR DESCRIPTION
## Problem
coverage-merge fails with "No data to combine" - need to diagnose where .coverage files are created/uploaded.

## Changes
- ✅ Use `**/.coverage*` pattern in upload (catches subdirs)
- ✅ Add debug step in shard job (after pytest, before upload)
- ✅ Add debug step in merge job (after download, before combine)

## Expected Output
Debug logs will show:
1. If .coverage files are created by pytest-cov
2. If they're uploaded to artifacts
3. If they're downloaded to coverage-artifacts/

## Next
After this PR reveals the issue, apply targeted fix (likely path/pattern adjustment).

Related: #369

## Summary by Sourcery

Добавить средства диагностики вокруг создания и сбора артефактов ночного покрытия, чтобы исследовать отсутствие данных покрытия на этапе объединения.

CI:
- Расширить шаблон загрузки артефактов ночного покрытия, чтобы захватывать файлы `.coverage` во вложенных каталогах.
- Добавить отладочные шаги в заданиях ночного шардирования и объединения для перечисления и поиска файлов `.coverage` и артефактов покрытия.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add diagnostics around nightly coverage artifact creation and collection to investigate missing coverage data in the merge step.

CI:
- Broaden nightly coverage artifact upload pattern to capture .coverage files in subdirectories.
- Add debug steps in shard and merge nightly jobs to list and locate .coverage files and coverage artifacts.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly test workflow with 30-minute timeout enforcement and improved diagnostic stack traces on timeout
  * Improved coverage artifact collection with extended path matching and added debug logging for coverage file traceability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->