### PR TITLE
fix(nightly): isolate coverage files per shard to enable combine

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -195,8 +195,7 @@ jobs:
         with:
           name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
-            .coverage*
-            **/.coverage*
+            .coverage.shard-*
             coverage-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
           if-no-files-found: warn
@@ -375,7 +374,7 @@ jobs:
           echo "=== .coverage* files ==="
           find coverage-artifacts -name ".coverage*" -print || true
           echo "=== file count check ==="
-          find coverage-artifacts -name ".coverage*" | wc -l || true
+          find coverage-artifacts -type f -name ".coverage*" | wc -l || true
 
       - name: Install coverage
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -374,7 +374,13 @@ jobs:
           echo "=== .coverage* files ==="
           find coverage-artifacts -name ".coverage*" -print || true
           echo "=== file count check ==="
-          find coverage-artifacts -type f -name ".coverage*" | wc -l || true
+          file_count=$(find coverage-artifacts -type f -name ".coverage*" | wc -l || true)
+          echo "${file_count}"
+          expected_count=6
+          if [ "${file_count}" -ne "${expected_count}" ]; then
+            echo "ERROR: Expected ${expected_count} coverage shard files, found ${file_count}."
+            exit 1
+          fi
 
       - name: Install coverage
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,6 +125,7 @@ jobs:
           PYTHONPATH: .:tests
           PYTEST_TIMEOUT: 300
           PYTHONFAULTHANDLER: 1
+          COVERAGE_FILE: .coverage.shard-${{ matrix.shard_id }}
         run: |
           START_TIME=$(date +%s)
           export START_TIME
@@ -194,9 +195,11 @@ jobs:
         with:
           name: coverage-reports-shard-${{ matrix.shard_id }}
           path: |
+            .coverage*
             **/.coverage*
             coverage-shard-${{ matrix.shard_id }}.xml
           retention-days: 30
+          if-no-files-found: warn
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
@@ -367,9 +370,12 @@ jobs:
           echo "PWD=$(pwd)"
           echo "=== coverage-artifacts tree ==="
           ls -la coverage-artifacts || true
+          echo "=== all files (max depth 3) ==="
           find coverage-artifacts -maxdepth 3 -type f -print || true
-          echo "=== looking for .coverage files ==="
-          find coverage-artifacts -maxdepth 3 -name ".coverage*" -print || true
+          echo "=== .coverage* files ==="
+          find coverage-artifacts -name ".coverage*" -print || true
+          echo "=== file count check ==="
+          find coverage-artifacts -name ".coverage*" | wc -l || true
 
       - name: Install coverage
         run: |


### PR DESCRIPTION
- Set unique COVERAGE_FILE per shard (.coverage.shard-N)
- Add .coverage* to upload path for root-level dotfiles
- Add if-no-files-found: warn for diagnostics
- Enhance debug output with file count check

Fixes 'No data to combine' error in coverage-merge job by preventing file overwrites when merge-multiple: true downloads artifacts.

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Изолировать артефакты покрытия nightly CI по шардам и улучшить диагностику при объединении покрытия.

CI:
- Устанавливать уникальный `COVERAGE_FILE` для каждого шарда, чтобы отчёты покрытия больше не перезаписывали друг друга при шардированных запусках.
- Расширить загрузку артефактов покрытия, включив в неё `.coverage*` файлы в корневом каталоге, и выводить предупреждение, если файлы не обнаружены.
- Улучшить отладочное логирование при `coverage-merge`, добавив дополнительные списки файлов и счётчик найденных `.coverage*` файлов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate nightly CI coverage artifacts per shard and improve diagnostics for coverage merging.

CI:
- Set a unique COVERAGE_FILE per shard so coverage reports no longer overwrite each other in sharded runs.
- Expand coverage artifact upload to include root-level .coverage* files and warn if no files are found.
- Enhance coverage-merge debug logging with additional file listings and a count of discovered .coverage* files.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline to store and upload shard-specific coverage files and to warn when coverage files are missing.
  * Enhanced debug visibility for coverage artifacts and added a verification that the number of coverage files matches the expected shard count.

* **Tests**
  * Strengthened coverage-reporting reliability by tightening artifact inspection and failing when coverage file counts mismatch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->