### PR TITLE
test: add isolated TestClient coverage for users router

### DIFF
--- a/tests/test_users_router.py
+++ b/tests/test_users_router.py
@@ -22,6 +22,16 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import OperationalError
 
+import app.routers.users as users_mod
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent time.sleep in retry logic to avoid test hangs."""
+    import time
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
 
 class TestUsersRouter:
     """Test users router with isolated FastAPI app."""
@@ -129,6 +139,10 @@ class TestUsersRouter:
             resp = self.client.get("/api/v1/users/1")
 
             assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] == 1
+            assert data["email"] == "test@example.com"
+            assert data["name"] == "Test User"
 
     def test_delete_user_success_204(self) -> None:
         """DELETE /api/v1/users/{user_id} returns 204 on success."""
@@ -166,3 +180,20 @@ class TestUsersRouter:
 
             assert resp.status_code == 503
             assert "unavailable" in resp.json()["detail"].lower()
+
+    def test_db_operational_error_then_success(self) -> None:
+        """Test retry recovery: OperationalError on first attempt, then succeeds."""
+        with patch.object(users_mod.db_module, "get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+
+            # First call fails, second succeeds
+            mock_session.execute.side_effect = [
+                OperationalError("DB locked", None, None),
+                MagicMock(scalars=lambda: MagicMock(all=lambda: [])),
+            ]
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users")
+
+            assert resp.status_code == 200
+            assert resp.json() == []

--- a/tests/test_users_router.py
+++ b/tests/test_users_router.py
@@ -1,0 +1,168 @@
+"""
+Tests for Users Router using isolated TestClient
+
+RU: Тесты роутера users через изолированный TestClient.
+EN: Users router tests via isolated TestClient.
+
+Covers:
+- POST /api/v1/users (create user)
+- GET /api/v1/users (list users)
+- GET /api/v1/users/{user_id} (get user)
+- DELETE /api/v1/users/{user_id} (delete user)
+- Validation errors (422/400)
+- Database retry logic (503 on exhaustion)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+
+class TestUsersRouter:
+    """Test users router with isolated FastAPI app."""
+
+    def setup_method(self) -> None:
+        """Set up test client with isolated router."""
+        from app.routers.users import router
+
+        self.app = FastAPI()
+        self.app.include_router(router)
+        self.client = TestClient(self.app)
+
+    def teardown_method(self) -> None:
+        """Clean up test client."""
+        self.client.close()
+
+    def test_list_users_default_pagination(self) -> None:
+        """GET /api/v1/users returns list with default limit/offset."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_session.execute.return_value.scalars.return_value.all.return_value = []
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users")
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, list)
+
+    def test_list_users_custom_pagination(self) -> None:
+        """GET /api/v1/users respects limit/offset params."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_session.execute.return_value.scalars.return_value.all.return_value = []
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users?limit=10&offset=5")
+
+            assert resp.status_code == 200
+
+    def test_list_users_invalid_pagination_422(self) -> None:
+        """GET /api/v1/users with invalid pagination returns 422."""
+        # limit too high
+        resp = self.client.get("/api/v1/users?limit=2000")
+        assert resp.status_code == 422
+
+        # negative offset
+        resp = self.client.get("/api/v1/users?offset=-1")
+        assert resp.status_code == 422
+
+    def test_create_user_success(self) -> None:
+        """POST /api/v1/users with valid payload returns 201."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+
+            # Mock User object with proper attributes
+            from app.schemas.users import UserRead
+
+            def mock_validate(user):
+                return UserRead(id=1, email="test@example.com", name="Test User")
+
+            with patch.object(UserRead, "model_validate", side_effect=mock_validate):
+                mock_factory.return_value = lambda: mock_session
+
+                resp = self.client.post(
+                    "/api/v1/users",
+                    json={"email": "test@example.com", "name": "Test User"},
+                )
+
+                assert resp.status_code == 201
+
+    def test_create_user_missing_email_422(self) -> None:
+        """POST /api/v1/users without email returns 422."""
+        resp = self.client.post("/api/v1/users", json={"name": "Test User"})
+        assert resp.status_code == 422
+
+    def test_create_user_empty_payload_422(self) -> None:
+        """POST /api/v1/users with empty payload returns 422."""
+        resp = self.client.post("/api/v1/users", json={})
+        assert resp.status_code == 422
+
+    def test_get_user_not_found_404(self) -> None:
+        """GET /api/v1/users/{user_id} returns 404 when user doesn't exist."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_session.get.return_value = None  # User not found
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users/999")
+
+            assert resp.status_code == 404
+            assert "not found" in resp.json()["detail"].lower()
+
+    def test_get_user_success(self) -> None:
+        """GET /api/v1/users/{user_id} returns 200 when user exists."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_user = MagicMock()
+            mock_user.id = 1
+            mock_user.email = "test@example.com"
+            mock_user.name = "Test User"
+            mock_session.get.return_value = mock_user
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users/1")
+
+            assert resp.status_code == 200
+
+    def test_delete_user_success_204(self) -> None:
+        """DELETE /api/v1/users/{user_id} returns 204 on success."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_user = MagicMock()
+            mock_session.get.return_value = mock_user
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.delete("/api/v1/users/1")
+
+            assert resp.status_code == 204
+
+    def test_delete_user_not_found_still_204(self) -> None:
+        """DELETE /api/v1/users/{user_id} returns 204 even if user doesn't exist (idempotent)."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            mock_session.get.return_value = None  # User not found
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.delete("/api/v1/users/999")
+
+            # Idempotent delete design per docstring
+            assert resp.status_code == 204
+
+    def test_db_operational_error_retry_then_503(self) -> None:
+        """Test that OperationalError triggers retry logic and eventually returns 503."""
+        with patch("app.routers.users.db_module.get_session_factory") as mock_factory:
+            mock_session = MagicMock()
+            # Simulate persistent OperationalError (all retries fail)
+            mock_session.execute.side_effect = OperationalError("DB locked", None, None)
+            mock_factory.return_value = lambda: mock_session
+
+            resp = self.client.get("/api/v1/users")
+
+            assert resp.status_code == 503
+            assert "unavailable" in resp.json()["detail"].lower()


### PR DESCRIPTION
- Covers POST /users (create, validation 422)
- Covers GET /users (pagination + invalid params)
- Covers GET /users/{id} (404 + success)
- Covers DELETE /users/{id} (idempotent design)
- Covers DB retry logic (OperationalError → 503)
- Uses mocked session factory for fast deterministic tests

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Добавлено изолированное покрытие FastAPI TestClient для эндпоинтов и ошибок роутера `users`.

Тесты:
- Добавлены тесты для получения списка пользователей с параметрами пагинации по умолчанию и пользовательскими параметрами.
- Добавлены тесты валидации для некорректной пагинации и тел запросов на создание пользователя, возвращающих ошибку 422.
- Добавлены тесты для получения пользователей по ID, покрывающие как успешное получение, так и ответ 404 not found.
- Добавлены тесты для удаления пользователей по ID, включая идемпотентное поведение, когда пользователь не существует.
- Добавлены тесты, проверяющие, что `OperationalError` базы данных запускает логику повторных попыток и приводит к ответу 503, когда попытки исчерпаны.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add isolated FastAPI TestClient coverage for the users router endpoints and error paths.

Tests:
- Add tests for listing users with default and custom pagination parameters.
- Add validation tests for invalid pagination and user creation payloads returning 422 errors.
- Add tests for fetching users by ID covering both successful retrieval and 404 not found responses.
- Add tests for deleting users by ID, including idempotent behavior when the user does not exist.
- Add tests verifying database OperationalError triggers retry logic and results in a 503 response when retries are exhausted.

</details>