### PR TITLE
ci(test): stabilize nightly xdist and improve diagnostics

### DIFF
--- a/tests/test_food_apis_basic_coverage.py
+++ b/tests/test_food_apis_basic_coverage.py
@@ -1,5 +1,4 @@
-"""
-Basic tests to improve coverage for food_apis modules.
+"""Basic tests to improve coverage for food_apis modules.
 These tests focus on exercising the main functions to quickly improve coverage percentages.
 """
 
@@ -9,6 +8,10 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+# Serialize all tests in this file under xdist to prevent worker crashes
+# from scheduler/food API shared state and I/O operations
+pytestmark = [pytest.mark.xdist_group(name="food_api_scheduler")]
 
 
 # Test unified_db module

--- a/tests/test_food_apis_basic_coverage.py
+++ b/tests/test_food_apis_basic_coverage.py
@@ -9,10 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Serialize all tests in this file under xdist to prevent worker crashes
-# from scheduler/food API shared state and I/O operations
-pytestmark = [pytest.mark.xdist_group(name="food_api_scheduler")]
-
 
 # Test unified_db module
 class TestUnifiedFoodDatabase:
@@ -154,6 +150,7 @@ class TestDatabaseUpdateManager:
 
 
 # Test scheduler module
+@pytest.mark.xdist_group(name="food_api_scheduler")
 class TestDatabaseUpdateScheduler:
     """Basic tests for DatabaseUpdateScheduler to improve coverage."""
 


### PR DESCRIPTION
Serializes food API scheduler tests under xdist_group to prevent worker crashes and improves nightly visibility with durations reporting (keeps --dist=loadgroup).

## Changes
- Add pytestmark xdist_group to 
- Prevents 'node down / worker crashed' failures from scheduler/food API shared state
- No product or test logic changes, infra-only fix

## Expected Impact
- Eliminates xdist worker crashes in nightly runs
- Maintains existing parallel execution for other tests
- Preserves --dist=loadgroup and --durations=25 diagnostics

## Summary by Sourcery

Стабилизировать тесты планировщика Food API под pytest-xdist, сериализовав их в отдельную группу, чтобы избежать сбоев рабочих процессов, при этом сохранив существующий параллелизм и диагностические возможности.

Bug Fixes:
- Предотвратить сбои рабочих процессов pytest-xdist в ночных прогонах, вызванные общим состоянием и I/O в тестах планировщика Food API.

Tests:
- Пометить все базовые тесты покрытия Food API для запуска в выделенной группе pytest-xdist с сериализованным выполнением.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize food API scheduler tests under pytest-xdist by serializing them into a dedicated group to avoid worker crashes while preserving existing parallelization and diagnostics.

Bug Fixes:
- Prevent pytest-xdist worker crashes in nightly runs caused by shared state and I/O in food API scheduler tests.

Tests:
- Mark all food API basic coverage tests to run in a dedicated pytest-xdist group for serialized execution.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coordination to prevent shared-state I/O conflicts during parallel test execution.

* **Style**
  * Normalized module docstring formatting for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->