### PR TITLE
ci: make cache restore/save non-blocking to suppress infra warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Cache pip dependencies
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.1.0
+        continue-on-error: true  # GitHub Actions cache service may be unavailable
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -181,6 +182,7 @@ jobs:
 
       - name: Cache pip dependencies
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.1.0
+        continue-on-error: true  # GitHub Actions cache service may be unavailable
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -264,6 +266,7 @@ jobs:
 
       - name: Cache pip dependencies
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.1.0
+        continue-on-error: true  # GitHub Actions cache service may be unavailable
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}


### PR DESCRIPTION
## Problem
GitHub Actions cache service intermittently returns 400 errors with "Our services aren't available right now" HTML responses, causing noisy annotations in otherwise-green builds.

## Solution
- Add `continue-on-error: true` to all pip cache steps in CI workflow
- Tests proceed without cache if GitHub Actions cache service is unavailable
- No functional impact: cache is an optimization, not a requirement

## Testing
- YAML syntax validated locally
- Will verify in CI that cache failures no longer create error annotations

## Related
Closes #391

## Impact
- ✅ Eliminates cache-related noise in CI logs
- ✅ Builds remain green during GitHub cache service degradation
- ✅ No changes to test logic or product code

## Summary by Sourcery

CI:
- Разрешить шагам кеширования pip в CI-пайплайне продолжать выполнение при ошибках, чтобы сбои кеша больше не приводили к ошибкам сборки или аннотациям.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Allow pip cache steps in CI workflow to continue on error so cache outages no longer surface as build errors or annotations.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline resilience by allowing build workflows to continue if the cache service is temporarily unavailable, reducing false job failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->