### PR TITLE
ci: make LLM secrets optional in production validation

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           ENVIRONMENT: production
           GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
+          LLM_ENABLED: "false"  # LLM not required for production validation
 
       - name: Production validation complete
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # Project standard: maintain 97% coverage for PR branches before merge
           # See .github/copilot-instructions.md and .cursorrules for coverage requirements
-          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy --cov-context=test -n auto
+          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -215,7 +215,7 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # Project standard: maintain 97% coverage for feature branches before merge
           # See .github/copilot-instructions.md and .cursorrules for coverage requirements
-          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy --cov-context=test -n auto
+          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -303,7 +303,7 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # IMPORTANT: main branch must maintain 97% coverage per project standards
           # See .github/copilot-instructions.md and .cursorrules
-          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy --cov-context=test -n auto
+          python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,11 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # Project standard: maintain 97% coverage for PR branches before merge
           # See .github/copilot-instructions.md and .cursorrules for coverage requirements
+          #
+          # CI stability: fix xdist workers to `-n 4` (avoid `-n auto`) to prevent intermittent
+          # worker crashes and missing coverage data seen with Hypothesis/property-based suites.
+          # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
+          # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
           python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)
@@ -215,6 +220,11 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # Project standard: maintain 97% coverage for feature branches before merge
           # See .github/copilot-instructions.md and .cursorrules for coverage requirements
+          #
+          # CI stability: fix xdist workers to `-n 4` (avoid `-n auto`) to prevent intermittent
+          # worker crashes and missing coverage data seen with Hypothesis/property-based suites.
+          # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
+          # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
           python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)
@@ -303,6 +313,11 @@ jobs:
           # Use pytest-xdist for parallel execution with proper coverage collection
           # IMPORTANT: main branch must maintain 97% coverage per project standards
           # See .github/copilot-instructions.md and .cursorrules
+          #
+          # CI stability: fix xdist workers to `-n 4` (avoid `-n auto`) to prevent intermittent
+          # worker crashes and missing coverage data seen with Hypothesis/property-based suites.
+          # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
+          # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
           python -m pytest -m "not slow" tests --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy -n 4
 
       - name: Clean Python cache (post-test)

--- a/scripts/validate-ci-environment.sh
+++ b/scripts/validate-ci-environment.sh
@@ -95,11 +95,24 @@ validate_required_secret() {
     fi
 }
 
-# Check OLLAMA_API_KEY (only for production)
-validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
-
-# Check PULSEPLATE_OPENAI (only for production)
-validate_required_secret "PULSEPLATE_OPENAI" "production" "$ENVIRONMENT"
+# Check LLM secrets (only for production if LLM is enabled)
+# Only validate if LLM_ENABLED is set to true or if LLM_PROVIDER is configured
+if [ "${LLM_ENABLED:-false}" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
+    # Require secrets based on configured provider
+    if [ "${LLM_PROVIDER:-}" = "openai" ]; then
+        validate_required_secret "PULSEPLATE_OPENAI" "production" "$ENVIRONMENT"
+    elif [ "${LLM_PROVIDER:-}" = "ollama" ]; then
+        validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
+    elif [ "${LLM_ENABLED}" = "true" ]; then
+        # LLM enabled but provider not specified - fail with clear configuration error
+        err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai' or 'ollama' (or disable LLM_ENABLED)."
+        echo "::error::$err_msg"
+        ERRORS+=("$err_msg")
+    fi
+else
+    echo "ℹ️  LLM secrets not required (LLM_ENABLED is not true and LLM_PROVIDER not set)."
+    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true or configure LLM_PROVIDER (openai|ollama)."
+fi
 
 # Check SSH secrets (required for both staging and production when deploying)
 # Only validate if DEPLOY_ENABLED is set to true or if we're explicitly deploying

--- a/scripts/validate-ci-environment.sh
+++ b/scripts/validate-ci-environment.sh
@@ -95,23 +95,41 @@ validate_required_secret() {
     fi
 }
 
+# Normalize LLM_ENABLED (accept only explicit "true")
+LLM_ENABLED_NORMALIZED="false"
+if [[ "${LLM_ENABLED:-false}" == "true" ]]; then
+    LLM_ENABLED_NORMALIZED="true"
+fi
+
 # Check LLM secrets (only for production if LLM is enabled)
 # Only validate if LLM_ENABLED is set to true or if LLM_PROVIDER is configured
-if [ "${LLM_ENABLED:-false}" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
+if [ "$LLM_ENABLED_NORMALIZED" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
     # Require secrets based on configured provider
-    if [ "${LLM_PROVIDER:-}" = "openai" ]; then
-        validate_required_secret "PULSEPLATE_OPENAI" "production" "$ENVIRONMENT"
-    elif [ "${LLM_PROVIDER:-}" = "ollama" ]; then
-        validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
-    elif [ "${LLM_ENABLED}" = "true" ]; then
-        # LLM enabled but provider not specified - fail with clear configuration error
-        err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai' or 'ollama' (or disable LLM_ENABLED)."
-        echo "::error::$err_msg"
-        ERRORS+=("$err_msg")
-    fi
+    case "${LLM_PROVIDER:-}" in
+        openai)
+            validate_required_secret "PULSEPLATE_OPENAI" "production" "$ENVIRONMENT"
+            ;;
+        ollama)
+            validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
+            ;;
+        "")
+            # LLM enabled but provider not specified - fail with clear configuration error
+            if [ "$LLM_ENABLED_NORMALIZED" = "true" ]; then
+                err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai' or 'ollama' (or disable LLM_ENABLED)."
+                echo "::error::$err_msg"
+                ERRORS+=("$err_msg")
+            fi
+            ;;
+        *)
+            # LLM_PROVIDER set but not recognized
+            err_msg="Unsupported LLM_PROVIDER='${LLM_PROVIDER}'. Supported values: openai, ollama."
+            echo "::error::$err_msg"
+            ERRORS+=("$err_msg")
+            ;;
+    esac
 else
     echo "ℹ️  LLM secrets not required (LLM_ENABLED is not true and LLM_PROVIDER not set)."
-    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true or configure LLM_PROVIDER (openai|ollama)."
+    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true and LLM_PROVIDER=openai|ollama."
 fi
 
 # Check SSH secrets (required for both staging and production when deploying)

--- a/tests/test_plate_targets_micros_hypothesis.py
+++ b/tests/test_plate_targets_micros_hypothesis.py
@@ -15,6 +15,7 @@ from tests.test_helpers import skip_if_no_plate_micros
 
 
 @pytest.mark.slow
+@pytest.mark.serial  # Hypothesis tests not xdist-safe due to heavy state/randomness
 class TestPlateTargetsMicrosHypothesis:
     """Hypothesis-based tests for Plate → Targets micros integration."""
 


### PR DESCRIPTION
## Problem
CD-Test `production-validation` job fails on tag releases (e.g., v0.2.0) because it unconditionally requires `OLLAMA_API_KEY` and `PULSEPLATE_OPENAI` secrets, even when LLM is not enabled in production.

## Root Cause
- Validation script had fallback logic: if `LLM_ENABLED=true` but `LLM_PROVIDER` unset → require **both** LLM secrets
- This created ambiguous failure when LLM config is incomplete

## Solution
**Workflow**:
- Explicitly set `LLM_ENABLED=false` in production-validation job env
- Makes intent clear: LLM not required for production deployment validation

**Script**:
- Changed fallback: if `LLM_ENABLED=true` but `LLM_PROVIDER` unset → **fail with clear config error** instead of requiring both secrets
- Prevents silent misconfiguration

## Testing
✅ Local validation with `ENVIRONMENT=production LLM_ENABLED=false` passes
✅ Script properly skips LLM secret checks when disabled
✅ Shell and YAML syntax validated

## Impact
- ✅ production-validation will pass on tag releases without LLM secrets
- ✅ Clear error if LLM enabled incorrectly (missing provider)
- ✅ No changes to actual deployment logic

## Summary by Sourcery

Сделать проверку продакшн-деплоя такой, чтобы конфигурация LLM считалась необязательной и зависела от провайдера, избегая сбоев, когда LLM отключён.

Улучшения:
- Ограничить валидацию секретов LLM флагами `LLM_ENABLED`/`LLM_PROVIDER` и требовать только секрет, специфичный для выбранного провайдера, предоставляя понятные ошибки при неправильной конфигурации.
- Явно отключить LLM в CI‑джобе `production-validation`, чтобы прояснить, что LLM не требуется для проверок перед выпуском тегов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make production deployment validation treat LLM configuration as optional and provider-specific, avoiding failures when LLM is disabled.

Enhancements:
- Gate LLM secret validation behind LLM_ENABLED/LLM_PROVIDER and require only the provider-specific secret with clear errors when misconfigured.
- Explicitly disable LLM in the production-validation CI job to clarify that LLM is not required for tag release checks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD updated to make LLM checks optional, add provider-aware secret validation, and set LLM_ENABLED defaults for production validation.
  * Test runner commands adjusted to use fixed parallelism and remove a coverage-context option.

* **Tests**
  * Marked a set of Hypothesis-based tests as serial to avoid parallel execution issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->