### PR TITLE
feat(nutrition-log): add minimal meal/day logging endpoints wired to …

### DIFF
--- a/app.py
+++ b/app.py
@@ -996,11 +996,12 @@ if pro_router is not None:
 
 # Include Bayesian adherence router (PRO/VIP tier)
 try:
-    from app.routers import bayes_adherence
+    from app.routers import bayes_adherence, nutrition_log
 
     app.include_router(bayes_adherence.router)
+    app.include_router(nutrition_log.router)
 except ImportError as e:
-    logger.warning("Bayesian adherence router not loaded: %s", e)
+    logger.warning("Bayesian adherence or nutrition_log router not loaded: %s", e)
 
 # Include PRO Shopping List Generator router
 app.include_router(shopping_list_pro_router)

--- a/app/routers/nutrition_log.py
+++ b/app/routers/nutrition_log.py
@@ -1,0 +1,98 @@
+"""Nutrition logging endpoints (meal/day).
+
+RU: PRO эндпоинты логирования (meal-log / day-close), которые обновляют байесовскую микромодель adherence.
+EN: PRO nutrition logging endpoints that feed the adherence micro-model.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+
+from app.middleware.api_tiers import CurrentUser, get_current_user, require_pro_tier
+from app.routers.bayes_adherence import get_adherence_service
+from app.schemas.bayes_adherence import AdherenceResponse
+from app.schemas.nutrition_log import DayCloseRequest, MealLogRequest
+from core.bayes.adherence_adapter import DomainEvent
+from core.bayes.adherence_service import AdherenceService
+
+router = APIRouter(
+    prefix="/api/v1/pro/nutrition",
+    tags=["pro", "nutrition-log"],
+    dependencies=[Depends(require_pro_tier)],
+)
+
+
+def _event_from_meal_log(payload: MealLogRequest) -> DomainEvent:
+    """Map MealLogRequest to DomainEvent.
+
+    RU: Маппинг payload -> DomainEvent.
+    EN: Map payload -> DomainEvent.
+    """
+
+    if payload.log_type == "meal_logged":
+        return DomainEvent(name="meal_logged", weight=1.0)
+
+    if payload.log_type == "slip":
+        return DomainEvent(name="slip", weight=1.0)
+
+    # partial
+    score = payload.adherence_score if payload.adherence_score is not None else 0.0
+    weight = max(0.01, 1.0 - score)
+    return DomainEvent(name="slip", weight=weight)
+
+
+def _event_from_day_close(payload: DayCloseRequest) -> DomainEvent:
+    """Map DayCloseRequest to DomainEvent.
+
+    RU: Маппинг закрытия дня в событие adherence.
+    EN: Map day-close payload to adherence event.
+    """
+
+    score = payload.adherence_score
+    weight = max(0.01, 1.0 - score)
+    if weight <= 0.01:
+        return DomainEvent(name="meal_logged", weight=1.0)
+    return DomainEvent(name="slip", weight=weight)
+
+
+@router.post("/meal-log", response_model=AdherenceResponse, summary="Log meal event (PRO)")
+async def log_meal(
+    payload: MealLogRequest,
+    current_user: CurrentUser = Depends(get_current_user),
+    service: AdherenceService = Depends(get_adherence_service),
+) -> AdherenceResponse:
+    """Log a meal event and update adherence micro-model.
+
+    RU: Логировать событие приёма пищи и обновить микромодель adherence.
+    EN: Log a meal event and update adherence micro-model.
+    """
+
+    event = _event_from_meal_log(payload)
+    result = await run_in_threadpool(
+        service.record_domain_event,
+        current_user.user_id,
+        event,
+    )
+    return AdherenceResponse(**result.__dict__)
+
+
+@router.post("/day-close", response_model=AdherenceResponse, summary="Close day (PRO)")
+async def close_day(
+    payload: DayCloseRequest,
+    current_user: CurrentUser = Depends(get_current_user),
+    service: AdherenceService = Depends(get_adherence_service),
+) -> AdherenceResponse:
+    """Close a day and update adherence micro-model.
+
+    RU: Закрыть день и обновить микромодель adherence.
+    EN: Close a day and update adherence micro-model.
+    """
+
+    event = _event_from_day_close(payload)
+    result = await run_in_threadpool(
+        service.record_domain_event,
+        current_user.user_id,
+        event,
+    )
+    return AdherenceResponse(**result.__dict__)

--- a/app/schemas/nutrition_log.py
+++ b/app/schemas/nutrition_log.py
@@ -1,0 +1,40 @@
+"""Schemas for meal/day logging endpoints.
+
+RU: Схемы для эндпоинтов логирования приёмов пищи и закрытия дня.
+EN: Schemas for meal/day logging endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+MealType = Literal["breakfast", "lunch", "dinner", "snack"]
+MealLogType = Literal["meal_logged", "slip", "partial"]
+
+
+class MealLogRequest(BaseModel):
+    """Log a meal-related event.
+
+    RU: Логировать событие приёма пищи.
+    EN: Log a meal event.
+    """
+
+    occurred_at: Optional[datetime] = None
+    meal_type: Optional[MealType] = None
+    log_type: MealLogType = "meal_logged"
+    adherence_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+class DayCloseRequest(BaseModel):
+    """Close a day with an adherence score.
+
+    RU: Закрыть день с оценкой выполнения.
+    EN: Close day with adherence score.
+    """
+
+    day: date
+    adherence_score: float = Field(..., ge=0.0, le=1.0)

--- a/tests/test_nutrition_log_api.py
+++ b/tests/test_nutrition_log_api.py
@@ -1,0 +1,84 @@
+"""Tests for nutrition logging endpoints.
+
+RU: Тесты для /api/v1/pro/nutrition/meal-log и /day-close.
+EN: Tests for nutrition log endpoints.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import app as fastapi_app
+from app.middleware.api_tiers import TEST_KEY_PRO, derive_subject_id_from_api_key
+
+
+class TestNutritionLogAPI:
+    def setup_method(self) -> None:
+        self.headers = {"X-API-Key": TEST_KEY_PRO}
+        self.client = TestClient(fastapi_app, headers=self.headers)
+        self.user_id = derive_subject_id_from_api_key(TEST_KEY_PRO)
+
+    def teardown_method(self) -> None:
+        fastapi_app.dependency_overrides.clear()
+
+        # Clean up analyzer state for this test subject to avoid cross-test interference
+        from core.db import SessionLocal
+        from core.models import AnalyzerStateModel
+
+        session = SessionLocal()
+        try:
+            session.query(AnalyzerStateModel).filter(
+                AnalyzerStateModel.user_id == self.user_id
+            ).delete(synchronize_session=False)
+            session.commit()
+        finally:
+            session.close()
+
+    def test_meal_log_updates_adherence_state(self) -> None:
+        response = self.client.post(
+            "/api/v1/pro/nutrition/meal-log",
+            json={"log_type": "meal_logged"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["n"] >= 1
+        assert data["alpha"] > 0
+        assert data["beta"] > 0
+
+        # Verify risk endpoint uses auth-derived identity (no user_id param)
+        risk_resp = self.client.get(
+            "/api/v1/bayes/adherence/risk",
+            params={"analyzer_key": "v1:adherence"},
+        )
+        assert risk_resp.status_code == 200
+        risk = risk_resp.json()
+        assert risk["n"] >= 1
+        assert 0.0 <= risk["risk_slip"] <= 1.0
+        assert 0.0 <= risk["confidence"] <= 1.0
+
+    def test_day_close_with_zero_score_increases_slip_risk(self) -> None:
+        response = self.client.post(
+            "/api/v1/pro/nutrition/day-close",
+            json={"day": "2025-01-01", "adherence_score": 0.0},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["n"] >= 1
+        assert data["beta"] >= data["alpha"]
+
+    def test_partial_meal_uses_weighted_slip(self) -> None:
+        response = self.client.post(
+            "/api/v1/pro/nutrition/meal-log",
+            json={"log_type": "partial", "adherence_score": 0.8},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["n"] >= 1
+        assert data["beta"] > 1.0
+
+    def test_validation_of_adherence_score(self) -> None:
+        response = self.client.post(
+            "/api/v1/pro/nutrition/meal-log",
+            json={"log_type": "partial", "adherence_score": 1.1},
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
…adherence model

- Add MealLogRequest/DayCloseRequest schemas for logging
- Add PRO endpoints /api/v1/pro/nutrition/meal-log and /day-close
- Reuse get_adherence_service from bayes_adherence and auth-derived CurrentUser
- Integrate with AdherenceService.record_domain_event via DomainEvent adapter
- Add tests to verify logging updates adherence state and validation

All nutrition-log + bayes tests passing locally.

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Добавить PRO API-эндпоинты для логирования питания, которые записывают события приёмов пищи и дней в байесовскую микро-модель приверженности и предоставляют обновлённое состояние приверженности.

Новые функции:
- Ввести эндпоинты `/api/v1/pro/nutrition/meal-log` и `/api/v1/pro/nutrition/day-close` для PRO-пользователей, чтобы логировать события приёмов пищи и ежедневной приверженности.
- Добавить схемы `MealLogRequest` и `DayCloseRequest` для структурированных payload-ов логирования приверженности по приёму пищи/дню.

Улучшения:
- Подключить эндпоинты логирования питания к существующему `AdherenceService` через отображение `DomainEvent` и переиспользовать общую конфигурацию роутера/сервиса приверженности.
- Зарегистрировать новый роутер `nutrition_log` вместе с существующим роутером байесовской приверженности в основном приложении FastAPI.

Тесты:
- Добавить API-тесты, покрывающие поведение логирования питания, его влияние на состояние приверженности, обработку взвешенных срывов и валидацию `adherence_score`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add PRO nutrition logging API endpoints that record meal and day events into the Bayesian adherence micro-model and expose updated adherence state.

New Features:
- Introduce /api/v1/pro/nutrition/meal-log and /api/v1/pro/nutrition/day-close endpoints for PRO users to log meal and daily adherence events.
- Add MealLogRequest and DayCloseRequest schemas for structured meal/day adherence logging payloads.

Enhancements:
- Wire nutrition logging endpoints into the existing AdherenceService via DomainEvent mapping and reuse the shared adherence router/service setup.
- Register the new nutrition_log router alongside the existing Bayesian adherence router in the main FastAPI application.

Tests:
- Add API tests covering nutrition logging behavior, its effect on adherence state, weighted slip handling, and adherence_score validation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PRO-tier nutrition logging with two endpoints: log meal events (breakfast, lunch, dinner, snack) and close day tracking with automatic adherence score validation (0-1 range).

* **Tests**
  * Added comprehensive test suite for nutrition logging API endpoints, validating endpoint accessibility, response structure, authentication flow, and input validation constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->