### PR TITLE
fix(tests): stabilize main after #406

### DIFF
--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -552,7 +552,8 @@ class TestDatabaseAdminEndpoints:
                 "/api/v1/admin/rollback?source=test&target_version=1.0", headers=headers
             )
             assert response.status_code == 500
-            assert "Rollback operation failed" in response.json()["detail"]
+            detail = str(response.json().get("detail", ""))
+            assert "rollback operation failed" in detail.lower()
 
 
 class TestDebugEndpoint:

--- a/tests/test_import_errors_coverage.py
+++ b/tests/test_import_errors_coverage.py
@@ -18,54 +18,33 @@ class TestImportErrorPaths:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    def test_prometheus_import_error_path(self) -> None:
+    def test_prometheus_import_error_path(self, monkeypatch) -> None:
         """Тест import error для prometheus_client (строки 12-15)"""
-        # Временно удаляем prometheus_client из sys.modules
-        original_modules = sys.modules.copy()
+        # IMPORTANT: do not mutate sys.modules directly; use monkeypatch so pytest
+        # automatically restores state after the test (repo rule after #406).
+        prometheus_modules = [
+            name for name in list(sys.modules.keys()) if name.startswith("prometheus_client")
+        ]
+        for name in prometheus_modules:
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
-        # Удаляем prometheus_client если он был импортирован
-        prometheus_modules = [m for m in sys.modules if m.startswith("prometheus_client")]
-        for mod in prometheus_modules:
-            del sys.modules[mod]
-
+        # This mirrors the main.py fallback behavior:
+        # - if prometheus_client is available, import succeeds
+        # - otherwise ImportError -> sentinel variables set to None
         try:
-            # Теперь симулируем ImportError при попытке импорта prometheus_client
-            original_module = sys.modules.get("prometheus_client")
-            if "prometheus_client" in sys.modules:
-                del sys.modules["prometheus_client"]
-            try:
-                # Этот код должен обработать ImportError и установить переменные в None
-                try:
-                    from prometheus_client import Counter, Histogram, generate_latest
+            from prometheus_client import Counter, Histogram, generate_latest
 
-                    # Если импорт успешен, это нормально
-                    assert Counter is not None
-                except ImportError:
-                    # Устанавливаем None как в коде main.py
-                    counter_cls = None
-                    histogram_cls = None
-                    generate_latest_func = None
+            assert Counter is not None
+            assert Histogram is not None
+            assert generate_latest is not None
+        except ImportError:
+            counter_cls = None
+            histogram_cls = None
+            generate_latest_func = None
 
-                    # Проверяем что переменные установлены в None
-                    assert counter_cls is None
-                    assert histogram_cls is None
-                    assert generate_latest_func is None
-            finally:
-                # Restore original module if it existed
-                if original_module is not None:
-                    sys.modules["prometheus_client"] = original_module
-                elif "prometheus_client" in sys.modules:
-                    del sys.modules["prometheus_client"]
-
-        finally:
-            # Restore only the modules we touched; do NOT clear sys.modules globally,
-            # otherwise later tests may see split-brain imports (dual Base / model redefinition).
-            for name in list(sys.modules.keys()):
-                if name.startswith("prometheus_client"):
-                    sys.modules.pop(name, None)
-            for name, mod in original_modules.items():
-                if name.startswith("prometheus_client"):
-                    sys.modules[name] = mod
+            assert counter_cls is None
+            assert histogram_cls is None
+            assert generate_latest_func is None
 
 
 class TestVIPRouterImportPath:

--- a/tests/test_import_errors_coverage.py
+++ b/tests/test_import_errors_coverage.py
@@ -58,9 +58,14 @@ class TestImportErrorPaths:
                     del sys.modules["prometheus_client"]
 
         finally:
-            # Восстанавливаем оригинальные модули
-            sys.modules.clear()
-            sys.modules.update(original_modules)
+            # Restore only the modules we touched; do NOT clear sys.modules globally,
+            # otherwise later tests may see split-brain imports (dual Base / model redefinition).
+            for name in list(sys.modules.keys()):
+                if name.startswith("prometheus_client"):
+                    sys.modules.pop(name, None)
+            for name, mod in original_modules.items():
+                if name.startswith("prometheus_client"):
+                    sys.modules[name] = mod
 
 
 class TestVIPRouterImportPath:

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -67,10 +67,15 @@ class TestImportFallbacks:
                     del sys.modules["providers.grok"]
 
         finally:
-            # Восстанавливаем оригинальные модули
-            sys.modules.clear()
-            sys.modules.update(original_modules)
-            # Перезагружаем llm в оригинальном состоянии
+            # Restore only the modules we touched; do NOT clear sys.modules globally,
+            # otherwise later tests may see split-brain imports (dual Base / model redefinition).
+            for name in list(sys.modules.keys()):
+                if name.startswith("providers"):
+                    sys.modules.pop(name, None)
+            for name, mod in original_modules.items():
+                if name.startswith("providers"):
+                    sys.modules[name] = mod
+            # Reload llm back to a stable baseline.
             reload(llm)
 
     @pytest.mark.asyncio

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -22,61 +22,37 @@ class TestImportFallbacks:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    def test_grok_import_exception_coverage(self):
+    def test_grok_import_exception_coverage(self, monkeypatch):
         """Тест покрытия GrokLiteProvider при ошибке импорта providers.grok"""
-        # Сохраняем оригинальные модули
-        original_modules = sys.modules.copy()
+        # IMPORTANT: do not mutate sys.modules directly; use monkeypatch so pytest
+        # automatically restores state after the test (repo rule after #406).
+        provider_modules = [
+            name for name in list(sys.modules.keys()) if name.startswith("providers")
+        ]
+        for name in provider_modules:
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
-        try:
-            # Удаляем модули провайдеров если они загружены
-            modules_to_remove = [
-                name for name in sys.modules.keys() if name.startswith("providers")
-            ]
-            for mod_name in modules_to_remove:
-                del sys.modules[mod_name]
+        original_import = builtins.__import__
 
-            # Мокаем импорт providers.grok чтобы вызвать исключение
-            # Remove module from sys.modules to simulate it's not available
-            original_module = sys.modules.get("providers.grok")
-            if "providers.grok" in sys.modules:
-                del sys.modules["providers.grok"]
-            try:
-                original_import = builtins.__import__
+        def side_effect(name, *args, **kwargs):
+            if "providers.grok" in name:
+                raise ImportError("No module named providers.grok")
+            return original_import(name, *args, **kwargs)
 
-                def side_effect(name, *args, **kwargs):
-                    if "providers.grok" in name:
-                        raise ImportError("No module named providers.grok")
-                    return original_import(name, *args, **kwargs)
-
-                with patch("builtins.__import__", side_effect=side_effect):
-                    # Перезагружаем модуль llm чтобы активировать except блок
-                    if "llm" in sys.modules:
-                        reload(llm)
-
-                    # Теперь GrokLiteProvider должен быть доступен
-                    assert hasattr(llm, "GrokLiteProvider")
-
-                    # Тестируем создание и использование GrokLiteProvider
-                    provider = llm.GrokLiteProvider()
-                    assert provider.name == "grok"
-            finally:
-                # Restore original module
-                if original_module is not None:
-                    sys.modules["providers.grok"] = original_module
-                elif "providers.grok" in sys.modules:
-                    del sys.modules["providers.grok"]
-
-        finally:
-            # Restore only the modules we touched; do NOT clear sys.modules globally,
-            # otherwise later tests may see split-brain imports (dual Base / model redefinition).
-            for name in list(sys.modules.keys()):
-                if name.startswith("providers"):
-                    sys.modules.pop(name, None)
-            for name, mod in original_modules.items():
-                if name.startswith("providers"):
-                    sys.modules[name] = mod
-            # Reload llm back to a stable baseline.
+        with patch("builtins.__import__", side_effect=side_effect):
+            # Перезагружаем модуль llm чтобы активировать except блок
             reload(llm)
+
+            # Теперь GrokLiteProvider должен быть доступен
+            assert hasattr(llm, "GrokLiteProvider")
+
+            # Тестируем создание и использование GrokLiteProvider
+            provider = llm.GrokLiteProvider()
+            assert provider.name == "grok"
+
+        # Восстанавливаем "стабильную" версию llm после теста.
+        # sys.modules будет восстановлен pytest monkeypatch автоматически.
+        reload(llm)
 
     @pytest.mark.asyncio
     async def test_grok_lite_provider_generate_coverage(self):


### PR DESCRIPTION
Post-#406 main CI regressions hotfix (no scope expansion):

- Make rollback error assertion case-insensitive (message got more specific).
- Stop using sys.modules.clear() in import-coverage tests; restore only touched prefixes to avoid split-brain imports (dual Base / model redefinition).

Targeted regressions fixed:
- test_rollback_error detail mismatch
- weekly_plans already defined (dual model import due to sys.modules clear)
- list_users retry integration patch mismatch (same root cause)

Quick checks:
- pytest -q -p no:xdist tests/test_app_extended_coverage.py::TestDatabaseAdminEndpoints::test_rollback_error
- pytest -q -p no:xdist tests/test_import_hygiene_single_base.py::test_single_base_instance
- pytest -q -p no:xdist tests/test_shoplist_day_provider_diff_coverage.py::test_fetch_day_plan_imports_models_and_returns_none
- pytest -q -p no:xdist tests/test_users_router_retry_logic.py::TestUsersEndpointRetryIntegration::test_list_users_no_fallback_on_db_failure

## Summary by Sourcery

Стабилизировать ненадёжные тесты за счёт более точечной очистки `sys.modules` в тестах покрытия импорта и ослабления проверки ошибки отката, сделав её регистронезависимой.

Bug Fixes:
- Предотвратить «split-brain» импорт и дублирующиеся определения model/base, восстанавливая только модули, связанные с provider и prometheus, в тестах покрытия импорта вместо глобальной очистки `sys.modules`.
- Исправить сбой теста ошибки отката, сделав проверку сообщения с деталями ошибки регистронезависимой.

Tests:
- Скорректировать тесты покрытия импорта так, чтобы после патчинга восстанавливать только релевантные модули provider и prometheus, избегая вмешательства в последующие тесты.
- Обновить тест endpoint’а ошибки отката, чтобы проверять детали ошибки без учёта регистра для более надёжного сопоставления.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize flaky tests by narrowing sys.modules cleanup in import coverage tests and relaxing the rollback error assertion to be case-insensitive.

Bug Fixes:
- Prevent split-brain imports and dual model/base definitions by restoring only provider- and prometheus-related modules in import coverage tests instead of clearing sys.modules globally.
- Fix rollback error test failure by making the assertion on the error detail message case-insensitive.

Tests:
- Adjust import coverage tests to restore only the relevant provider and prometheus modules after patching, avoiding interference with subsequent tests.
- Update the rollback error endpoint test to assert the error detail in a case-insensitive manner for more robust matching.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened error assertions to be resilient to case differences and missing detail fields.
  * Improved test isolation and import-fallback simulation by adopting safer, scoped cleanup and mocking approaches to avoid cross-test contamination and preserve global state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->