### PR TITLE
fix(tests): avoid SQLAlchemy table redefinition from sys.modules churn

### DIFF
--- a/tests/test_test_router.py
+++ b/tests/test_test_router.py
@@ -21,7 +21,7 @@ def _import_fresh_app() -> FastAPI:
     # all of its submodules. That can leave a half-loaded state where `app.models.*`
     # is still loaded while `app` is re-imported, which then causes SQLAlchemy model
     # redefinition ("Table already defined") later in the suite.
-    purge_modules(prefixes=("app.main", "app.routers.test"))
+    purge_modules(prefixes=("legacy_app", "app.main", "app.routers.test"))
 
     # IMPORTANT:
     # `legacy_app` decides whether to include the test router at import time, based on env.
@@ -33,7 +33,18 @@ def _import_fresh_app() -> FastAPI:
 
     importlib.reload(legacy_app)
 
-    from app import app
+    app = legacy_app.app  # canonical app instance after env-driven wiring
+
+    # Fail fast with a clear message if staging claims test routes should exist but doesn't.
+    if os.getenv("APP_ENV") == "staging" and os.getenv("ENABLE_TEST_ROUTES") == "1":
+        has_test_routes = any(
+            getattr(route, "path", "").startswith("/api/v1/test/")
+            for route in getattr(app, "routes", [])
+        )
+        assert has_test_routes, (
+            "Test router routes are missing after legacy_app reload. "
+            f"APP_ENV={os.getenv('APP_ENV')}, ENABLE_TEST_ROUTES={os.getenv('ENABLE_TEST_ROUTES')}"
+        )
 
     return app
 

--- a/tests/test_test_router.py
+++ b/tests/test_test_router.py
@@ -7,22 +7,13 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 import os
 
-from module_purge import purge_modules
-
 
 def _import_fresh_app() -> FastAPI:
-    """Import FastAPI app after clearing cached modules.
+    """Import FastAPI app after ensuring env-based wiring is re-evaluated.
 
-    RU: Импортируем app после очистки кэша модулей, чтобы учесть переменные окружения.
-    EN: Import app after clearing module cache so env var patches take effect.
+    RU: Перезагружаем legacy_app, чтобы он перечитал env и заново настроил wiring.
+    EN: Reload legacy_app so it re-reads env and rebuilds router wiring.
     """
-    # NOTE:
-    # Do NOT delete the top-level "app" package from sys.modules without also deleting
-    # all of its submodules. That can leave a half-loaded state where `app.models.*`
-    # is still loaded while `app` is re-imported, which then causes SQLAlchemy model
-    # redefinition ("Table already defined") later in the suite.
-    purge_modules(prefixes=("legacy_app", "app.main", "app.routers.test"))
-
     # IMPORTANT:
     # `legacy_app` decides whether to include the test router at import time, based on env.
     # In CI, it may already be imported under a different APP_ENV/ENABLE_TEST_ROUTES state.

--- a/tests/test_test_router.py
+++ b/tests/test_test_router.py
@@ -4,7 +4,6 @@ import pytest
 from datetime import datetime
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
 import os
 
 
@@ -41,33 +40,34 @@ def _import_fresh_app() -> FastAPI:
 
 
 @pytest.fixture
-def mock_env_staging():
+def mock_env_staging(monkeypatch: pytest.MonkeyPatch):
     """Mock environment to staging for test router inclusion.
 
     Note: Staging requires ENABLE_TEST_ROUTES=1 to include test endpoints
     for security (staging may be externally accessible).
     """
-    with patch.dict(os.environ, {"APP_ENV": "staging", "ENABLE_TEST_ROUTES": "1"}):
-        yield
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.setenv("ENABLE_TEST_ROUTES", "1")
+    yield
 
 
 @pytest.fixture
-def mock_env_production():
+def mock_env_production(monkeypatch: pytest.MonkeyPatch):
     """Mock environment to production to exclude test router."""
-    with patch.dict(os.environ, {"APP_ENV": "production"}):
-        yield
+    monkeypatch.setenv("APP_ENV", "production")
+    yield
 
 
 @pytest.fixture
-def mock_env_staging_disabled():
+def mock_env_staging_disabled(monkeypatch: pytest.MonkeyPatch):
     """Mock environment to staging without explicit enable flag.
 
     RU: В staging тестовые ручки должны быть выключены по умолчанию.
     EN: In staging, test endpoints must be disabled by default.
     """
-    with patch.dict(os.environ, {"APP_ENV": "staging"}, clear=False):
-        os.environ.pop("ENABLE_TEST_ROUTES", None)
-        yield
+    monkeypatch.setenv("APP_ENV", "staging")
+    monkeypatch.delenv("ENABLE_TEST_ROUTES", raising=False)
+    yield
 
 
 def test_rate_limit_endpoint(mock_env_staging):

--- a/tests/test_vip_simple_working.py
+++ b/tests/test_vip_simple_working.py
@@ -3,7 +3,6 @@
 """
 
 import os
-import sys
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -16,16 +15,14 @@ class TestVIPRouterWorking:
     """Простые рабочие тесты для VIP роутера"""
 
     @pytest.fixture(autouse=True)
-    def setup_vip_environment(self):
-        """Устанавливаем VIP модуль как включенный"""
-        with patch.dict(os.environ, {"VIP_MODULE_ENABLED": "true"}):
-            # Перезагружаем модули с правильной переменной окружения
-            modules_to_remove = [k for k in sys.modules.keys() if k.startswith("app")]
-            for module in modules_to_remove:
-                if module in sys.modules:
-                    del sys.modules[module]
+    def setup_vip_environment(self, monkeypatch: pytest.MonkeyPatch):
+        """Устанавливаем VIP модуль как включенный.
 
-            yield
+        ВАЖНО: не мутируем sys.modules (это вызывает повторную регистрацию моделей
+        SQLAlchemy и флейки вида "Table already defined").
+        """
+        monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+        yield
 
     def test_vip_endpoints_with_environment_enabled(self):
         """Тест VIP endpoints когда VIP_MODULE_ENABLED=true"""
@@ -87,12 +84,6 @@ class TestVIPRouterWorking:
     def test_vip_module_disabled_fallback(self):
         """Тест fallback когда VIP модуль отключен"""
         with patch.dict(os.environ, {"VIP_MODULE_ENABLED": "false"}):
-            # Перезагружаем app с отключенным VIP
-            modules_to_remove = [k for k in sys.modules.keys() if k.startswith("app")]
-            for module in modules_to_remove:
-                if module in sys.modules:
-                    del sys.modules[module]
-
             import app
 
             client = TestClient(cast(ASGIApp, app.app))


### PR DESCRIPTION
Fixes flaky/ordering-dependent failure in main:

-  was deleting all  modules from .
- That caused  to be re-imported later while  was still alive, triggering .

Change: stop mutating  and use  only.

Repro (before): run VIP test then .
After: both pass.

## Summary by Sourcery

Тесты:
- Обновить тесты VIP‑роутера, чтобы настраивать модуль VIP через `monkeypatch.setenv` вместо удаления записей, связанных с приложением, из `sys.modules`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Update VIP router tests to configure the VIP module via monkeypatch.setenv instead of deleting app-related entries from sys.modules.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved fixture environment handling by using pytest’s monkeypatch for safer env var control and clearer dependency injection.
  * Removed direct module cache manipulation and manual cleanup to simplify test lifecycle.
  * Added a fail-fast check to ensure expected test routes are present in staging runs.
  * Tidied docstrings/comments for clarity.

*Note: Internal testing improvements only — no end-user-facing changes.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->