### PR TITLE
fix(tests): avoid delattr on PEP 562 app shim

### DIFF
--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -397,8 +397,10 @@ async def test_premium_bmr_resolve_wrapper_uses_pkg_candidates(
     # Ensure sys.modules["app"] doesn't short-circuit the resolution
     import app as app_pkg
 
-    monkeypatch.delattr(app_pkg, "_calculate_all_bmr_wrapper", raising=False)
-    monkeypatch.delattr(app_pkg, "_calculate_all_tdee_wrapper", raising=False)
+    # app is a PEP 562 forwarding module; delattr() would trigger __getattr__ and fail even when
+    # the attribute is not actually present on the module. Remove only real module attributes.
+    monkeypatch.delitem(app_pkg.__dict__, "_calculate_all_bmr_wrapper", raising=False)
+    monkeypatch.delitem(app_pkg.__dict__, "_calculate_all_tdee_wrapper", raising=False)
 
     monkeypatch.setattr(legacy_app, "_iter_app_modules", lambda: [dummy_mod])
 

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -850,8 +850,10 @@ async def test_premium_bmr_legacy_hits_globals_fallback_path(
 
     import app as app_pkg
 
-    monkeypatch.delattr(app_pkg, "_calculate_all_bmr_wrapper", raising=False)
-    monkeypatch.delattr(app_pkg, "_calculate_all_tdee_wrapper", raising=False)
+    # app is a PEP 562 forwarding module; delattr() would trigger __getattr__ and fail even when
+    # the attribute is not actually present on the module. Remove only real module attributes.
+    monkeypatch.delitem(app_pkg.__dict__, "_calculate_all_bmr_wrapper", raising=False)
+    monkeypatch.delitem(app_pkg.__dict__, "_calculate_all_tdee_wrapper", raising=False)
 
     monkeypatch.setattr(
         legacy_app, "_calculate_all_bmr_wrapper", lambda *_a, **_k: {"mifflin": 1000.0}


### PR DESCRIPTION
## Why
Nightly/CI can fail in `tests/test_legacy_app_diff_coverage.py` because `app` is a PEP 562 forwarding module: `monkeypatch.delattr(app_pkg, ...)` triggers `__getattr__`, so `hasattr()` is True but `delattr()` fails.

## What
- Delete only real module attributes via `monkeypatch.delitem(app_pkg.__dict__, ...)` (no `__getattr__` side effects).

## Verification
- `pytest -q tests/test_legacy_app_diff_coverage.py::test_premium_bmr_resolve_wrapper_uses_pkg_candidates`
- `pytest -q -n 2 --dist=loadgroup -m "not demo" tests/test_nutrition_log_api.py tests/test_legacy_app_diff_coverage.py::test_premium_bmr_resolve_wrapper_uses_pkg_candidates`

## Summary by Sourcery

Отрегулировать тест покрытия различий для устаревшего приложения, чтобы безопасно удалять атрибуты-обёртки из модуля перенаправления по PEP 562, не вызывая сбоев `__getattr__`.

Исправления ошибок:
- Предотвратить периодические сбои тестов, удаляя только реальные атрибуты из модуля перенаправления приложения по PEP 562 вместо использования `delattr` для объекта модуля.

Тесты:
- Обновить настройку теста покрытия различий устаревшего приложения, чтобы очищать атрибуты-обёртки через `__dict__` модуля, а не путём удаления атрибутов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust legacy app diff coverage test to safely remove wrapper attributes from a PEP 562 forwarding module without triggering __getattr__ failures.

Bug Fixes:
- Prevent intermittent test failures by removing only real attributes from the PEP 562 app forwarding module instead of using delattr on the module object.

Tests:
- Update legacy app diff coverage test setup to clear wrapper attributes via the module __dict__ rather than attribute deletion.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to adjust how attributes are removed from modules to avoid triggering module-level attribute forwarding, improving reliability of wrapper-patching scenarios. Observable behavior and test outcomes remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->