### PR TITLE
fix(cd): support self-hosted production deploy mode

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,20 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - pulseplate-prod
+
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null
+
+# Configuration for file paths. The keys are glob patterns to match to file
+# paths relative to the repository root. The values are the configurations for
+# the file paths. Note that the path separator is always '/'.
+# The following configurations are available.
+#
+# "ignore" is an array of regular expression patterns. Matched error messages
+# are ignored. This is similar to the "-ignore" command line option.
+paths:
+#  .github/workflows/**/*.yml:
+#    ignore: []

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -210,7 +210,7 @@ jobs:
           target: production
 
   deploy-production:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE == 'ssh'
     needs: [production-gates, build-production]
     runs-on: ubuntu-latest
     environment:
@@ -278,3 +278,66 @@ jobs:
             done
 
             docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20
+
+  deploy-production-self-hosted:
+    if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE == 'self-hosted'
+    needs: [production-gates, build-production]
+    runs-on: [self-hosted, linux, x64, pulseplate-prod]
+    environment:
+      name: production
+      url: https://pulseplate.app
+    concurrency:
+      group: cd-deploy-production-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Deploy on self-hosted runner (pinned digest)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve deploy directory on server.
+          if [ -d "/opt/pulseplate" ]; then
+            cd "/opt/pulseplate"
+          elif [ -d "/srv/pulseplate-production" ]; then
+            cd "/srv/pulseplate-production"
+          else
+            echo "❌ Could not find deploy directory. Expected /opt/pulseplate or /srv/pulseplate-production." >&2
+            exit 1
+          fi
+
+          GHCR_USER='${{ github.actor }}'
+          GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+          if [ -n "$GHCR_TOKEN" ]; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          fi
+
+          DIGEST='${{ needs.build-production.outputs.digest }}'
+          IMAGE_NAME='${{ needs.build-production.outputs.image_name }}'
+          export IMAGE_REF="ghcr.io/${IMAGE_NAME}@${DIGEST}"
+          export TAG="prod-${{ github.ref_name }}"
+
+          docker compose pull
+          docker compose up -d --remove-orphans
+
+          PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
+          if [ -z "$PRODUCTION_DOMAIN" ]; then
+            echo "❌ PRODUCTION_DOMAIN secret is required for production health checks" >&2
+            exit 1
+          fi
+          HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
+
+          attempt=1
+          max_attempts=12
+          sleep_s=2
+          until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
+              docker compose logs --tail=200 || true
+              exit 1
+            fi
+            echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."
+            attempt=$((attempt + 1))
+            sleep "$sleep_s"
+          done
+
+          docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -286,7 +286,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          GHCR_USER='${{ github.actor }}'
+          GHCR_USER='${{ github.repository_owner }}'
           GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
           if [ -n "$GHCR_TOKEN" ]; then
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -220,64 +220,53 @@ jobs:
       group: cd-deploy-production-${{ github.ref_name }}
       cancel-in-progress: false
     steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Encode deploy script for SSH
+        id: deploy-script
+        run: |
+          echo "script_b64=$(base64 -w0 scripts/deploy_production.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to production over SSH (pinned digest)
         uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
         with:
           host: ${{ secrets.SSH_HOST_PRODUCTION }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          envs: DEPLOY_SCRIPT_B64,IMAGE_REF,TAG,PRODUCTION_DOMAIN,DEPLOY_DIR,GHCR_USER,GHCR_TOKEN
           script: |
             set -euo pipefail
 
-            # Resolve deploy directory on server (no extra secrets required).
-            if [ -d "/opt/pulseplate" ]; then
-              cd "/opt/pulseplate"
-            elif [ -d "/srv/pulseplate-production" ]; then
-              cd "/srv/pulseplate-production"
-            else
-              echo "❌ Could not find deploy directory. Expected /opt/pulseplate or /srv/pulseplate-production." >&2
+            if [ -z "${PRODUCTION_DOMAIN:-}" ]; then
+              echo "❌ PRODUCTION_DOMAIN is required for production health checks" >&2
+              exit 1
+            fi
+            if [ -z "${IMAGE_REF:-}" ]; then
+              echo "❌ IMAGE_REF is required" >&2
+              exit 1
+            fi
+            if [ -z "${TAG:-}" ]; then
+              echo "❌ TAG is required" >&2
               exit 1
             fi
 
-            GHCR_USER='${{ github.actor }}'
-            GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
-            if [ -n "$GHCR_TOKEN" ]; then
+            if [ -n "${GHCR_TOKEN:-}" ]; then
               echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
             fi
 
-            # Deploy pinned digest from the prod build job.
-            DIGEST='${{ needs.build-production.outputs.digest }}'
-            IMAGE_NAME='${{ needs.build-production.outputs.image_name }}'
-            export IMAGE_REF="ghcr.io/${IMAGE_NAME}@${DIGEST}"
-
-            # Also export TAG for backwards-compatible compose setups.
-            export TAG="prod-${{ github.ref_name }}"
-
-            docker compose pull
-            docker compose up -d --remove-orphans
-
-            PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
-            if [ -z "$PRODUCTION_DOMAIN" ]; then
-              echo "❌ PRODUCTION_DOMAIN secret is required for production health checks" >&2
-              exit 1
-            fi
-            HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
-
-            attempt=1
-            max_attempts=12
-            sleep_s=2
-            until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
-              if [ "$attempt" -ge "$max_attempts" ]; then
-                echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
-                docker compose logs --tail=200 || true
-                exit 1
-              fi
-              echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."
-              attempt=$((attempt + 1))
-              sleep "$sleep_s"
-            done
-
-            docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20
+            tmp_script="/tmp/pulseplate_deploy_production.sh"
+            echo "$DEPLOY_SCRIPT_B64" | base64 -d > "$tmp_script"
+            chmod +x "$tmp_script"
+            "$tmp_script"
+        env:
+          DEPLOY_SCRIPT_B64: ${{ steps.deploy-script.outputs.script_b64 }}
+          DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
+          PRODUCTION_DOMAIN: ${{ secrets.PRODUCTION_DOMAIN }}
+          IMAGE_REF: ghcr.io/${{ needs.build-production.outputs.image_name }}@${{ needs.build-production.outputs.digest }}
+          TAG: prod-${{ github.ref_name }}
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
 
   deploy-production-self-hosted:
     if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE == 'self-hosted'
@@ -290,54 +279,24 @@ jobs:
       group: cd-deploy-production-${{ github.ref_name }}
       cancel-in-progress: false
     steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
       - name: Deploy on self-hosted runner (pinned digest)
         shell: bash
         run: |
           set -euo pipefail
-
-          # Resolve deploy directory on server.
-          if [ -d "/opt/pulseplate" ]; then
-            cd "/opt/pulseplate"
-          elif [ -d "/srv/pulseplate-production" ]; then
-            cd "/srv/pulseplate-production"
-          else
-            echo "❌ Could not find deploy directory. Expected /opt/pulseplate or /srv/pulseplate-production." >&2
-            exit 1
-          fi
-
           GHCR_USER='${{ github.actor }}'
           GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
           if [ -n "$GHCR_TOKEN" ]; then
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
           fi
 
-          DIGEST='${{ needs.build-production.outputs.digest }}'
-          IMAGE_NAME='${{ needs.build-production.outputs.image_name }}'
-          export IMAGE_REF="ghcr.io/${IMAGE_NAME}@${DIGEST}"
+          export DEPLOY_DIR='${{ vars.DEPLOY_DIR }}'
+          export PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
+          export IMAGE_REF="ghcr.io/${{ needs.build-production.outputs.image_name }}@${{ needs.build-production.outputs.digest }}"
           export TAG="prod-${{ github.ref_name }}"
+          bash scripts/deploy_production.sh
 
-          docker compose pull
-          docker compose up -d --remove-orphans
-
-          PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
-          if [ -z "$PRODUCTION_DOMAIN" ]; then
-            echo "❌ PRODUCTION_DOMAIN secret is required for production health checks" >&2
-            exit 1
-          fi
-          HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
-
-          attempt=1
-          max_attempts=12
-          sleep_s=2
-          until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
-            if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
-              docker compose logs --tail=200 || true
-              exit 1
-            fi
-            echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."
-            attempt=$((attempt + 1))
-            sleep "$sleep_s"
-          done
-
-          docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20
+          # Clean up dangling Docker images on the self-hosted runner to prevent disk bloat over time.
+          docker image prune -f || true

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -26,8 +26,8 @@ Deployments should use a pinned digest (preferred) or `prod-v*` tags (acceptable
 On the production server:
 
 - Docker + Docker Compose v2 installed (`docker compose version`)
-- A deploy directory (default: `/srv/pulseplate-production`) containing:
-  - `docker-compose.yml` (or a compose file you run from that directory)
+- A deploy directory containing:
+  - a compose file (`docker-compose.yml`, `docker-compose.production.yaml`, etc.)
   - `.env` (application runtime env; not committed)
 - Compose must reference `IMAGE_REF` (recommended) or `TAG` (backwards-compatible):
 
@@ -57,6 +57,11 @@ Secrets (store in the `production` environment):
 - `GHCR_READ_TOKEN` (PAT with `read:packages`, if the image is private)
 - `PRODUCTION_DOMAIN` (public domain used for post-deploy healthcheck)
 
+Variables (store in the `production` environment):
+
+- `DEPLOY_DIR` (optional): absolute path to the deploy directory on the production machine.
+  If unset, the workflow auto-detects `/opt/pulseplate` then `/srv/pulseplate-production`.
+
 ## Self-hosted runner (recommended)
 
 If your server exposes only 443 publicly (common behind Cloudflare), GitHub-hosted runners cannot SSH
@@ -79,8 +84,7 @@ High-level steps (run on the production server):
 
 ## Post-merge checklist (first production auto-deploy)
 
-1. Ensure the production server deploy directory exists at either `/opt/pulseplate` or
-   `/srv/pulseplate-production` and contains the compose file + `.env`.
+1. Ensure the production server deploy directory contains the compose file + `.env`.
 2. Ensure the compose file uses `IMAGE_REF` (preferred) or `TAG` (backwards-compatible).
 3. Wait for a successful Nightly run on `main`, then create and push a new semver tag (e.g. `v0.2.2`).
 4. Ensure `PROD_DEPLOY_MODE` is set (`self-hosted` recommended).

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -3,6 +3,15 @@
 This repo publishes production images to GHCR and can optionally auto-deploy to a production server via
 SSH + `docker compose`.
 
+## Deploy mode (required)
+
+Auto-deploy is controlled by repository variable `PROD_DEPLOY_MODE`:
+
+- `ssh`: Deploy from GitHub-hosted runners over SSH (requires port 22 reachable from the internet).
+- `self-hosted`: Deploy from a self-hosted runner inside your infrastructure (recommended).
+
+If `PROD_DEPLOY_MODE` is unset or any other value, deploy jobs are skipped (images are still built).
+
 ## Source of truth: production image
 
 For any tag `vX.Y.Z`, the production build publishes:
@@ -48,14 +57,35 @@ Secrets (store in the `production` environment):
 - `GHCR_READ_TOKEN` (PAT with `read:packages`, if the image is private)
 - `PRODUCTION_DOMAIN` (public domain used for post-deploy healthcheck)
 
+## Self-hosted runner (recommended)
+
+If your server exposes only 443 publicly (common behind Cloudflare), GitHub-hosted runners cannot SSH
+into it. Use a self-hosted runner on the production machine (or inside the same network).
+
+Workflow expectation:
+
+- runner labels: `self-hosted`, `linux`, `x64`, `pulseplate-prod`
+
+High-level steps (run on the production server):
+
+1. Create a dedicated user (recommended) and allow Docker access:
+
+   - `sudo useradd -m -s /bin/bash github-runner`
+   - `sudo usermod -aG docker github-runner`
+
+2. Install and configure the GitHub Actions runner (use repo settings UI to generate the config token).
+3. Add the runner label `pulseplate-prod`.
+4. Set repository variable `PROD_DEPLOY_MODE=self-hosted`.
+
 ## Post-merge checklist (first production auto-deploy)
 
 1. Ensure the production server deploy directory exists at either `/opt/pulseplate` or
    `/srv/pulseplate-production` and contains the compose file + `.env`.
 2. Ensure the compose file uses `IMAGE_REF` (preferred) or `TAG` (backwards-compatible).
 3. Wait for a successful Nightly run on `main`, then create and push a new semver tag (e.g. `v0.2.2`).
-4. Approve the `deploy-production` job in the GitHub `production` environment prompt.
-5. Verify `/health` via `https://$PRODUCTION_DOMAIN/health` and confirm the running container uses the
+4. Ensure `PROD_DEPLOY_MODE` is set (`self-hosted` recommended).
+5. Approve the deploy job in the GitHub `production` environment prompt.
+6. Verify `/health` via `https://$PRODUCTION_DOMAIN/health` and confirm the running container uses the
    expected `ghcr.io/<owner>/<repo>@sha256:...` digest.
 
 ## Rollback

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -5,13 +5,19 @@ set -euo pipefail
 : "${TAG:?TAG is required (prod-vX.Y.Z)}"
 : "${PRODUCTION_DOMAIN:?PRODUCTION_DOMAIN is required}"
 
+export IMAGE_REF TAG PRODUCTION_DOMAIN
+
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 DEPLOY_DIR="${DEPLOY_DIR:-}"
 
 resolve_deploy_dir() {
   if [ -n "$DEPLOY_DIR" ]; then
-    echo "$DEPLOY_DIR"
-    return 0
+    if [ -d "$DEPLOY_DIR" ]; then
+      echo "$DEPLOY_DIR"
+      return 0
+    fi
+    echo "⚠️  DEPLOY_DIR is set but does not exist: $DEPLOY_DIR" >&2
+    echo "    Falling back to auto-detect..." >&2
   fi
 
   if [ -d "/opt/pulseplate" ]; then

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IMAGE_REF:?IMAGE_REF is required (ghcr.io/<image>@sha256:...)}"
+: "${TAG:?TAG is required (prod-vX.Y.Z)}"
+: "${PRODUCTION_DOMAIN:?PRODUCTION_DOMAIN is required}"
+
+COMPOSE_FILE="${COMPOSE_FILE:-}"
+DEPLOY_DIR="${DEPLOY_DIR:-}"
+
+resolve_deploy_dir() {
+  if [ -n "$DEPLOY_DIR" ]; then
+    echo "$DEPLOY_DIR"
+    return 0
+  fi
+
+  if [ -d "/opt/pulseplate" ]; then
+    echo "/opt/pulseplate"
+    return 0
+  fi
+
+  if [ -d "/srv/pulseplate-production" ]; then
+    echo "/srv/pulseplate-production"
+    return 0
+  fi
+
+  return 1
+}
+
+DEPLOY_DIR="$(resolve_deploy_dir || true)"
+if [ -z "$DEPLOY_DIR" ]; then
+  echo "❌ Could not find deploy directory." >&2
+  echo "Set DEPLOY_DIR or create /opt/pulseplate or /srv/pulseplate-production." >&2
+  exit 1
+fi
+
+cd "$DEPLOY_DIR"
+
+compose_args=()
+if [ -n "$COMPOSE_FILE" ]; then
+  compose_args=(-f "$COMPOSE_FILE")
+elif [ -f "docker-compose.production.yaml" ]; then
+  compose_args=(-f "docker-compose.production.yaml")
+elif [ -f "docker-compose.production.yml" ]; then
+  compose_args=(-f "docker-compose.production.yml")
+elif [ -f "docker-compose.yml" ]; then
+  compose_args=(-f "docker-compose.yml")
+elif [ -f "docker-compose.yaml" ]; then
+  compose_args=(-f "docker-compose.yaml")
+elif [ -f "compose.yml" ]; then
+  compose_args=(-f "compose.yml")
+elif [ -f "compose.yaml" ]; then
+  compose_args=(-f "compose.yaml")
+fi
+
+echo "Deploy dir: $DEPLOY_DIR"
+if [ ${#compose_args[@]} -gt 0 ]; then
+  echo "Compose file: ${compose_args[*]}"
+else
+  echo "Compose file: <default>"
+fi
+echo "TAG: $TAG"
+echo "IMAGE_REF: $IMAGE_REF"
+
+docker compose "${compose_args[@]}" pull
+docker compose "${compose_args[@]}" up -d --remove-orphans
+
+HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
+attempt=1
+max_attempts=12
+sleep_s=2
+until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
+    docker compose "${compose_args[@]}" logs --tail=200 || true
+    exit 1
+  fi
+  echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."
+  attempt=$((attempt + 1))
+  sleep "$sleep_s"
+done
+
+docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -68,8 +68,16 @@ fi
 echo "TAG: $TAG"
 echo "IMAGE_REF: $IMAGE_REF"
 
-docker compose "${compose_args[@]}" pull
-docker compose "${compose_args[@]}" up -d --remove-orphans
+dc() {
+  if [ ${#compose_args[@]} -gt 0 ]; then
+    docker compose "${compose_args[@]}" "$@"
+  else
+    docker compose "$@"
+  fi
+}
+
+dc pull
+dc up -d --remove-orphans
 
 HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
 attempt=1
@@ -78,7 +86,7 @@ sleep_s=2
 until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
   if [ "$attempt" -ge "$max_attempts" ]; then
     echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
-    docker compose "${compose_args[@]}" logs --tail=200 || true
+    dc logs --tail=200 || true
     exit 1
   fi
   echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."


### PR DESCRIPTION
## Why
GitHub-hosted runners cannot SSH into production (port 22 unreachable), so tag releases fail at `deploy-production` even though image builds succeed.

## What
- Gates SSH deploy behind `PROD_DEPLOY_MODE=ssh`.
- Adds self-hosted deploy job behind `PROD_DEPLOY_MODE=self-hosted` (runs on runner labeled `pulseplate-prod`).
- Keeps production deploy pinned by digest from `build-production`.
- Updates `deploy/PRODUCTION.md` with mode + runner notes.

## How to use
1. Set repo variable `PROD_DEPLOY_MODE=self-hosted`.
2. Install a self-hosted runner on the production server with label `pulseplate-prod` and docker access.
3. Push a new semver tag after a successful Nightly on `main` (e.g. `v0.2.3`).

## Notes
- If you later open SSH to the internet, you can switch to `PROD_DEPLOY_MODE=ssh`.

## Summary by Sourcery

Добавлены настраиваемые режимы продакшн-деплоя и поддержка self-hosted раннеров для продакшн-развертываний.

Новые возможности:
- Добавлена задача продакшн-деплоя на self-hosted раннере, которая запускается на помеченном self-hosted раннере и развёртывает собранный образ по его digest.

Улучшения:
- Существующая задача продакшн-деплоя по SSH теперь управляется переменной `PROD_DEPLOY_MODE`, что позволяет выбирать стратегию деплоя или полностью пропускать деплой.

Документация:
- Задокументированы варианты `PROD_DEPLOY_MODE`, рекомендуемая конфигурация self-hosted раннера и обновлённые шаги продакшн-деплоя в `deploy/PRODUCTION.md`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable production deployment modes and support self-hosted runners for production deploys.

New Features:
- Introduce a self-hosted production deployment job that runs on a labeled self-hosted runner and deploys the built image by digest.

Enhancements:
- Gate the existing SSH-based production deploy job behind a PROD_DEPLOY_MODE variable to allow selecting deployment strategy or skipping deploys entirely.

Documentation:
- Document the PROD_DEPLOY_MODE options, recommended self-hosted runner setup, and updated production deployment steps in deploy/PRODUCTION.md.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлены настраиваемые режимы продакшн-деплоя и поддержка self-hosted раннеров для продакшн-развертываний.

Новые возможности:
- Добавлена задача продакшн-деплоя на self-hosted раннере, которая запускается на помеченном self-hosted раннере и развёртывает собранный образ по его digest.

Улучшения:
- Существующая задача продакшн-деплоя по SSH теперь управляется переменной `PROD_DEPLOY_MODE`, что позволяет выбирать стратегию деплоя или полностью пропускать деплой.

Документация:
- Задокументированы варианты `PROD_DEPLOY_MODE`, рекомендуемая конфигурация self-hosted раннера и обновлённые шаги продакшн-деплоя в `deploy/PRODUCTION.md`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable production deployment modes and support self-hosted runners for production deploys.

New Features:
- Introduce a self-hosted production deployment job that runs on a labeled self-hosted runner and deploys the built image by digest.

Enhancements:
- Gate the existing SSH-based production deploy job behind a PROD_DEPLOY_MODE variable to allow selecting deployment strategy or skipping deploys entirely.

Documentation:
- Document the PROD_DEPLOY_MODE options, recommended self-hosted runner setup, and updated production deployment steps in deploy/PRODUCTION.md.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for two production deployment modes (SSH and self-hosted) and updated workflows to honor the selected mode.
  * Introduced a production deployment script and safer remote execution flow to standardize deploys and health checks.
* **Documentation**
  * Expanded deployment docs with mode configuration, deploy directory behavior, runner guidance, and post-merge checklist.

Note: No end-user visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->