### PR TITLE
feat(vip): add explainability layer for shoplist generation (PR-1)

### DIFF
--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -81,6 +81,22 @@ def _map_form(dto_form: str) -> FoodForm:
         ) from exc
 
 
+def _build_reasons(p: PackPlan, rule: PackageRule) -> list[str]:
+    """
+    Build explainability reasons for packed line in fixed order.
+
+    RU: Фиксированный порядок — тест на детерминизм.
+    EN: Fixed order — determinism test relies on it.
+    """
+    return [
+        f"rounding={rule.rounding.name}",
+        f"min_packs={rule.min_packs}",
+        f"requested={p.requested.value} {p.requested.unit.name}",
+        f"provided={p.provided.value} {p.provided.unit.name}",
+        f"overage={p.overage.value} {p.overage.unit.name}",
+    ]
+
+
 @router.get("/preview", response_model=ShoplistPreviewResponse)
 async def vip_shoplist_preview(
     _enabled: Annotated[None, Depends(require_vip_module_enabled)],
@@ -149,21 +165,6 @@ async def vip_shoplist_generate(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Packed item {p.food.food_id} missing packaging rule",
             )
-
-    def _build_reasons(p: PackPlan, rule: PackageRule) -> list[str]:
-        """
-        Build explainability reasons for packed line in fixed order.
-
-        RU: Фиксированный порядок — тест на детерминизм.
-        EN: Fixed order — determinism test relies on it.
-        """
-        return [
-            f"rounding={rule.rounding.name}",
-            f"min_packs={rule.min_packs}",
-            f"requested={p.requested.value} {p.requested.unit.name}",
-            f"provided={p.provided.value} {p.provided.unit.name}",
-            f"overage={p.overage.value} {p.overage.unit.name}",
-        ]
 
     # Map core result -> DTO response
     packed_dto = [

--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -16,6 +16,7 @@ from app.middleware.api_tiers import require_vip_tier
 from app.schemas.vip_shoplist import (
     PackedLineDTO,
     QuantityDTO,
+    REASON_NO_PACKAGING_RULE,
     RoundingModeDTO,
     ShoplistGenerateRequest,
     ShoplistGenerateResponse,
@@ -140,17 +141,25 @@ async def vip_shoplist_generate(
     # Build rules index for lookup (rounding, min_packs, explainability)
     rules_index = {r.food_id: r for r in rules}
 
-    def _build_reasons(p: PackPlan) -> list[str]:
-        """Build explainability reasons for packed line in fixed order."""
-        rule = rules_index.get(p.food.food_id)
-        rounding = rule.rounding.name if rule else "UNKNOWN"
-        min_packs = rule.min_packs if rule else 1
+    # RU: Контракт: packed линии возможны только при наличии rule.
+    # EN: Contract: packed lines require a packaging rule.
+    for p in result.packed:
+        if p.food.food_id not in rules_index:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Packed item {p.food.food_id} missing packaging rule",
+            )
 
-        # RU: Фиксированный порядок для determinism теста
-        # EN: Fixed order for determinism test
+    def _build_reasons(p: PackPlan, rule: PackageRule) -> list[str]:
+        """
+        Build explainability reasons for packed line in fixed order.
+
+        RU: Фиксированный порядок — тест на детерминизм.
+        EN: Fixed order — determinism test relies on it.
+        """
         return [
-            f"rounding={rounding}",
-            f"min_packs={min_packs}",
+            f"rounding={rule.rounding.name}",
+            f"min_packs={rule.min_packs}",
             f"requested={p.requested.value} {p.requested.unit.name}",
             f"provided={p.provided.value} {p.provided.unit.name}",
             f"overage={p.overage.value} {p.overage.unit.name}",
@@ -171,7 +180,7 @@ async def vip_shoplist_generate(
             overage=QuantityDTO(value=p.overage.value, unit=cast(UnitDTO, p.overage.unit.name)),
             rounding=cast(RoundingModeDTO, rules_index[p.food.food_id].rounding.name),
             min_packs=rules_index[p.food.food_id].min_packs,
-            reasons=_build_reasons(p),
+            reasons=_build_reasons(p, rules_index[p.food.food_id]),
         )
         for p in result.packed
     ]
@@ -180,7 +189,7 @@ async def vip_shoplist_generate(
         UnpackedLineDTO(
             food_id=u.food.food_id,
             requested=QuantityDTO(value=u.qty.value, unit=cast(UnitDTO, u.qty.unit.name)),
-            reason="no_packaging_rule",
+            reason=REASON_NO_PACKAGING_RULE,
         )
         for u in result.unpacked
     ]

--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -30,6 +30,7 @@ from core.shoplist_engine.models import (
     FoodForm,
     FoodRef,
     IngredientSpec,
+    PackPlan,
     PackageRule,
     Quantity,
     RoundingMode,
@@ -136,8 +137,24 @@ async def vip_shoplist_generate(
     # Run engine pipeline
     result = ShoplistEngine.generate(specs, packaging_rules=rules)
 
-    # Build rules index for lookup (rounding, min_packs)
+    # Build rules index for lookup (rounding, min_packs, explainability)
     rules_index = {r.food_id: r for r in rules}
+
+    def _build_reasons(p: PackPlan) -> list[str]:
+        """Build explainability reasons for packed line in fixed order."""
+        rule = rules_index.get(p.food.food_id)
+        rounding = rule.rounding.name if rule else "UNKNOWN"
+        min_packs = rule.min_packs if rule else 1
+
+        # RU: Фиксированный порядок для determinism теста
+        # EN: Fixed order for determinism test
+        return [
+            f"rounding={rounding}",
+            f"min_packs={min_packs}",
+            f"requested={p.requested.value} {p.requested.unit.name}",
+            f"provided={p.provided.value} {p.provided.unit.name}",
+            f"overage={p.overage.value} {p.overage.unit.name}",
+        ]
 
     # Map core result -> DTO response
     packed_dto = [
@@ -154,6 +171,7 @@ async def vip_shoplist_generate(
             overage=QuantityDTO(value=p.overage.value, unit=cast(UnitDTO, p.overage.unit.name)),
             rounding=cast(RoundingModeDTO, rules_index[p.food.food_id].rounding.name),
             min_packs=rules_index[p.food.food_id].min_packs,
+            reasons=_build_reasons(p),
         )
         for p in result.packed
     ]
@@ -162,6 +180,7 @@ async def vip_shoplist_generate(
         UnpackedLineDTO(
             food_id=u.food.food_id,
             requested=QuantityDTO(value=u.qty.value, unit=cast(UnitDTO, u.qty.unit.name)),
+            reason="no_packaging_rule",
         )
         for u in result.unpacked
     ]

--- a/app/schemas/vip_shoplist.py
+++ b/app/schemas/vip_shoplist.py
@@ -57,11 +57,13 @@ class PackedLineDTO(BaseModel):
     overage: QuantityDTO
     rounding: RoundingModeDTO
     min_packs: int
+    reasons: list[str] = Field(default_factory=list)
 
 
 class UnpackedLineDTO(BaseModel):
     food_id: str
     requested: QuantityDTO
+    reason: str
 
 
 class ShoplistGenerateResponse(BaseModel):

--- a/app/schemas/vip_shoplist.py
+++ b/app/schemas/vip_shoplist.py
@@ -17,6 +17,10 @@ from pydantic import BaseModel, Field
 # RU: DTO слой — адаптер над core моделями. Здесь можно использовать Decimal.
 # EN: DTO layer — adapter over core models. Decimal is allowed.
 
+# RU: Константа для explainability (один источник правды).
+# EN: Constant for explainability (single source of truth).
+REASON_NO_PACKAGING_RULE = "no_packaging_rule"
+
 UnitDTO = Literal["G", "ML", "PCS", "KG", "L"]  # расширишь по мере надобности
 FoodFormDTO = Literal["RAW", "COOKED", "FROZEN", "DRIED", "CANNED"]  # расширится позже
 RoundingModeDTO = Literal["CEIL", "NEAREST", "NONE"]
@@ -63,7 +67,9 @@ class PackedLineDTO(BaseModel):
 class UnpackedLineDTO(BaseModel):
     food_id: str
     requested: QuantityDTO
-    reason: str
+    # RU: Default, чтобы не ломать старые конструкторы и гарантировать стабильный API контракт.
+    # EN: Default to keep backward compatibility and stable API contract.
+    reason: str = Field(default=REASON_NO_PACKAGING_RULE)
 
 
 class ShoplistGenerateResponse(BaseModel):

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -269,9 +269,7 @@ def test_generate_accepts_missing_packaging_rules_field(
 
     mock_result = PackagingResult(
         packed=[],
-        unpacked=[
-            ShoplistLine(food=FoodRef(food_id="salt"), qty=Quantity(Decimal("10"), Unit.G))
-        ],
+        unpacked=[ShoplistLine(food=FoodRef(food_id="salt"), qty=Quantity(Decimal("10"), Unit.G))],
     )
 
     def mock_generate(

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -11,8 +11,14 @@ added to packed and unpacked lines without modifying core engine logic.
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
+
+from app.schemas.vip_shoplist import REASON_NO_PACKAGING_RULE
+
+if TYPE_CHECKING:
+    from core.shoplist_engine.packager import PackagingResult
 
 
 def _enable_vip(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -23,7 +29,7 @@ def _enable_vip(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _mock_engine_result_with_one_packed_one_unpacked():
+def _mock_engine_result_with_one_packed_one_unpacked() -> PackagingResult:
     """
     RU: Возвращаем реальный core-модельный результат, чтобы роутер прошёл свой mapping как в проде.
     EN: Return real core model objects to exercise router mapping (adapter-only tests).
@@ -154,7 +160,7 @@ def test_generate_sets_reason_for_unpacked_lines(
     assert len(unpacked) >= 1
 
     u0 = unpacked[0]
-    assert u0.get("reason") == "no_packaging_rule"
+    assert u0.get("reason") == REASON_NO_PACKAGING_RULE
 
 
 def test_generate_reasons_are_deterministic(

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -11,7 +11,7 @@ added to packed and unpacked lines without modifying core engine logic.
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -63,7 +63,7 @@ def _mock_engine_result_with_one_packed_one_unpacked() -> PackagingResult:
     )
 
 
-def _payload_one_rule() -> dict:
+def _payload_one_rule() -> dict[str, Any]:
     """RU: Держим payload минимальным, но валидным для текущего request DTO."""
     return {
         "items": [
@@ -81,7 +81,7 @@ def _payload_one_rule() -> dict:
     }
 
 
-def _extract_packed_and_unpacked(data: dict) -> tuple[list, list]:
+def _extract_packed_and_unpacked(data: dict) -> tuple[list[dict], list[dict]]:
     """
     RU: На всякий случай поддерживаем оба ключа ответа:
         - packed/unpacked
@@ -200,3 +200,4 @@ def test_generate_reasons_are_deterministic(
     # RU: Если в роутере зафиксируешь порядок reasons — это цементируем.
     assert reasons[0].startswith("rounding=")
     assert reasons[1].startswith("min_packs=")
+

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -16,9 +16,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from app.schemas.vip_shoplist import REASON_NO_PACKAGING_RULE
-
-if TYPE_CHECKING:
-    from core.shoplist_engine.packager import PackagingResult
+from core.shoplist_engine.packager import PackagingResult
 
 
 def _enable_vip(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,7 +101,10 @@ def test_generate_returns_reasons_for_packed_lines(
 
     mock_result = _mock_engine_result_with_one_packed_one_unpacked()
 
-    def mock_generate(specs, packaging_rules=None):
+    def mock_generate(
+        specs: list,
+        packaging_rules: list | None = None,
+    ) -> PackagingResult:
         return mock_result
 
     monkeypatch.setattr(
@@ -141,7 +142,10 @@ def test_generate_sets_reason_for_unpacked_lines(
 
     mock_result = _mock_engine_result_with_one_packed_one_unpacked()
 
-    def mock_generate(specs, packaging_rules=None):
+    def mock_generate(
+        specs: list,
+        packaging_rules: list | None = None,
+    ) -> PackagingResult:
         return mock_result
 
     monkeypatch.setattr(
@@ -172,7 +176,10 @@ def test_generate_reasons_are_deterministic(
 
     mock_result = _mock_engine_result_with_one_packed_one_unpacked()
 
-    def mock_generate(specs, packaging_rules=None):
+    def mock_generate(
+        specs: list,
+        packaging_rules: list | None = None,
+    ) -> PackagingResult:
         return mock_result
 
     monkeypatch.setattr(

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""Tests for VIP shoplist explainability (reasons for packed/unpacked lines).
+
+RU: Тесты для explainability VIP списка покупок (причины упаковки/неупаковки).
+EN: Tests for VIP shoplist explainability (reasons for packed/unpacked lines).
+
+These tests verify that the explainability layer (reasons) is correctly
+added to packed and unpacked lines without modifying core engine logic.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+
+def _enable_vip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable VIP module flag via router module patch."""
+    monkeypatch.setattr(
+        "app.routers.vip_shoplist.is_vip_module_enabled",
+        lambda: True,
+    )
+
+
+def _mock_engine_result_with_one_packed_one_unpacked():
+    """
+    RU: Возвращаем реальный core-модельный результат, чтобы роутер прошёл свой mapping как в проде.
+    EN: Return real core model objects to exercise router mapping (adapter-only tests).
+    """
+    from core.shoplist_engine.models import (
+        FoodRef,
+        PackPlan,
+        Quantity,
+        ShoplistLine,
+        Unit,
+    )
+    from core.shoplist_engine.packager import PackagingResult
+
+    return PackagingResult(
+        packed=[
+            PackPlan(
+                food=FoodRef(food_id="flour"),
+                requested=Quantity(Decimal("1800"), Unit.G),
+                pack_size=Quantity(Decimal("1000"), Unit.G),
+                packs=2,
+                provided=Quantity(Decimal("2000"), Unit.G),
+                overage=Quantity(Decimal("200"), Unit.G),
+            )
+        ],
+        unpacked=[
+            ShoplistLine(
+                food=FoodRef(food_id="salt"),
+                qty=Quantity(Decimal("10"), Unit.G),
+            )
+        ],
+    )
+
+
+def _payload_one_rule() -> dict:
+    """RU: Держим payload минимальным, но валидным для текущего request DTO."""
+    return {
+        "items": [
+            {"food_id": "flour", "qty": {"value": "1.8", "unit": "KG"}, "form": "RAW"},
+            {"food_id": "salt", "qty": {"value": "10", "unit": "G"}, "form": "RAW"},
+        ],
+        "packaging_rules": [
+            {
+                "food_id": "flour",
+                "pack_size": {"value": "1000", "unit": "G"},
+                "rounding": "CEIL",
+                "min_packs": 1,
+            }
+        ],
+    }
+
+
+def _extract_packed_and_unpacked(data: dict) -> tuple[list, list]:
+    """
+    RU: На всякий случай поддерживаем оба ключа ответа:
+        - packed/unpacked
+        - packed_lines/unpacked_lines
+    """
+    packed = data.get("packed", data.get("packed_lines", []))
+    unpacked = data.get("unpacked", data.get("unpacked_lines", []))
+    assert isinstance(packed, list), "packed must be a list"
+    assert isinstance(unpacked, list), "unpacked must be a list"
+    return packed, unpacked
+
+
+def test_generate_returns_reasons_for_packed_lines(
+    client_with_vip_access,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that packed lines include reasons."""
+    _enable_vip(monkeypatch)
+
+    mock_result = _mock_engine_result_with_one_packed_one_unpacked()
+
+    def mock_generate(specs, packaging_rules=None):
+        return mock_result
+
+    monkeypatch.setattr(
+        "app.routers.vip_shoplist.ShoplistEngine.generate",
+        mock_generate,
+    )
+
+    r = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/generate",
+        json=_payload_one_rule(),
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    packed, _ = _extract_packed_and_unpacked(data)
+    assert len(packed) >= 1
+
+    p0 = packed[0]
+    assert "reasons" in p0
+    assert isinstance(p0["reasons"], list)
+    assert len(p0["reasons"]) > 0
+
+    reasons = p0["reasons"]
+    assert any(str(x).startswith("rounding=") for x in reasons)
+    assert any(str(x).startswith("min_packs=") for x in reasons)
+    assert any(str(x).startswith("overage=") for x in reasons)
+
+
+def test_generate_sets_reason_for_unpacked_lines(
+    client_with_vip_access,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that unpacked lines include reason."""
+    _enable_vip(monkeypatch)
+
+    mock_result = _mock_engine_result_with_one_packed_one_unpacked()
+
+    def mock_generate(specs, packaging_rules=None):
+        return mock_result
+
+    monkeypatch.setattr(
+        "app.routers.vip_shoplist.ShoplistEngine.generate",
+        mock_generate,
+    )
+
+    r = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/generate",
+        json=_payload_one_rule(),
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    _, unpacked = _extract_packed_and_unpacked(data)
+    assert len(unpacked) >= 1
+
+    u0 = unpacked[0]
+    assert u0.get("reason") == "no_packaging_rule"
+
+
+def test_generate_reasons_are_deterministic(
+    client_with_vip_access,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that reasons are deterministic (same input -> same output)."""
+    _enable_vip(monkeypatch)
+
+    mock_result = _mock_engine_result_with_one_packed_one_unpacked()
+
+    def mock_generate(specs, packaging_rules=None):
+        return mock_result
+
+    monkeypatch.setattr(
+        "app.routers.vip_shoplist.ShoplistEngine.generate",
+        mock_generate,
+    )
+
+    payload = _payload_one_rule()
+
+    r1 = client_with_vip_access.post("/api/v1/vip/shoplist/generate", json=payload)
+    assert r1.status_code == 200, r1.text
+    j1 = r1.json()
+
+    r2 = client_with_vip_access.post("/api/v1/vip/shoplist/generate", json=payload)
+    assert r2.status_code == 200, r2.text
+    j2 = r2.json()
+
+    # RU: В этом endpoint не должно быть случайных полей (timestamps/ids) → строгое равенство.
+    assert j1 == j2
+
+    packed, _ = _extract_packed_and_unpacked(j1)
+    assert len(packed) >= 1
+    reasons = packed[0]["reasons"]
+
+    # RU: Если в роутере зафиксируешь порядок reasons — это цементируем.
+    assert reasons[0].startswith("rounding=")
+    assert reasons[1].startswith("min_packs=")

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -207,4 +207,3 @@ def test_generate_reasons_are_deterministic(
     # RU: Если в роутере зафиксируешь порядок reasons — это цементируем.
     assert reasons[0].startswith("rounding=")
     assert reasons[1].startswith("min_packs=")
-

--- a/tests/test_vip_shoplist_explainability.py
+++ b/tests/test_vip_shoplist_explainability.py
@@ -207,3 +207,89 @@ def test_generate_reasons_are_deterministic(
     # RU: Если в роутере зафиксируешь порядок reasons — это цементируем.
     assert reasons[0].startswith("rounding=")
     assert reasons[1].startswith("min_packs=")
+
+
+def test_generate_raises_when_packed_item_missing_rule(
+    client_with_vip_access,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract: packed lines require a rule -> 500 if missing."""
+    _enable_vip(monkeypatch)
+
+    from core.shoplist_engine.models import (
+        FoodRef,
+        PackPlan,
+        Quantity,
+        Unit,
+    )
+    from core.shoplist_engine.packager import PackagingResult
+
+    # packed has "flour", but payload.packaging_rules is empty -> rules_index empty
+    mock_result = PackagingResult(
+        packed=[
+            PackPlan(
+                food=FoodRef(food_id="flour"),
+                requested=Quantity(Decimal("1800"), Unit.G),
+                pack_size=Quantity(Decimal("1000"), Unit.G),
+                packs=2,
+                provided=Quantity(Decimal("2000"), Unit.G),
+                overage=Quantity(Decimal("200"), Unit.G),
+            )
+        ],
+        unpacked=[],
+    )
+
+    def mock_generate(
+        specs: list,
+        packaging_rules: list | None = None,
+    ) -> PackagingResult:
+        return mock_result
+
+    monkeypatch.setattr("app.routers.vip_shoplist.ShoplistEngine.generate", mock_generate)
+
+    payload = {
+        "items": [{"food_id": "flour", "qty": {"value": "1.8", "unit": "KG"}, "form": "RAW"}],
+        "packaging_rules": [],  # <--- key point (rules_index empty)
+    }
+
+    r = client_with_vip_access.post("/api/v1/vip/shoplist/generate", json=payload)
+    assert r.status_code == 500, r.text
+    assert "missing packaging rule" in r.json()["detail"]
+
+
+def test_generate_accepts_missing_packaging_rules_field(
+    client_with_vip_access,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If packaging_rules omitted (None), endpoint still works and returns unpacked."""
+    _enable_vip(monkeypatch)
+
+    from core.shoplist_engine.models import FoodRef, Quantity, ShoplistLine, Unit
+    from core.shoplist_engine.packager import PackagingResult
+
+    mock_result = PackagingResult(
+        packed=[],
+        unpacked=[
+            ShoplistLine(food=FoodRef(food_id="salt"), qty=Quantity(Decimal("10"), Unit.G))
+        ],
+    )
+
+    def mock_generate(
+        specs: list,
+        packaging_rules: list | None = None,
+    ) -> PackagingResult:
+        return mock_result
+
+    monkeypatch.setattr("app.routers.vip_shoplist.ShoplistEngine.generate", mock_generate)
+
+    # packaging_rules intentionally omitted -> payload.packaging_rules == None
+    payload = {
+        "items": [{"food_id": "salt", "qty": {"value": "10", "unit": "G"}, "form": "RAW"}],
+    }
+
+    r = client_with_vip_access.post("/api/v1/vip/shoplist/generate", json=payload)
+    assert r.status_code == 200, r.text
+    data = r.json()
+    _, unpacked = _extract_packed_and_unpacked(data)
+    assert len(unpacked) == 1
+    assert unpacked[0]["reason"] == REASON_NO_PACKAGING_RULE


### PR DESCRIPTION
- Add reasons field to PackedLineDTO (list of explanation strings)
- Add reason field to UnpackedLineDTO (single explanation string)
- Build explainability in router after engine call (adapter-only)
- Fixed order reasons for determinism: rounding, min_packs, requested, provided, overage
- Unpacked reason: "no_packaging_rule"
- Add comprehensive tests for explainability (3 test cases)
- Core engine unchanged (adapter-only implementation)

This provides transparency into packaging decisions without modifying core domain logic.

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Добавлен слой объяснимости в ответ генерации VIP списка покупок, чтобы показать причины упаковочных решений, при этом основной движок остаётся неизменным.

Новые возможности:
- В ответе эндпоинта VIP generate для упакованных строк списка покупок возвращается список причин (explainability reasons).
- В ответе эндпоинта VIP generate для неупакованных строк списка покупок возвращается строка с причиной.

Улучшения:
- Метаданные объяснимости вычисляются в VIP router на основе правил упаковки и количеств без изменения основного движка.
- Обеспечен детерминированный порядок сгенерированных причин для стабильности ответов API.

Тесты:
- Добавлены интеграционные тесты для генерации VIP списка покупок, проверяющие наличие, содержание и детерминизм причин объяснимости для упакованных и неупакованных строк.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an explainability layer to the VIP shoplist generation response to surface reasons for packaging decisions while keeping the core engine unchanged.

New Features:
- Expose a list of explainability reasons on packed shoplist lines in the VIP generate endpoint response.
- Expose a reason string on unpacked shoplist lines in the VIP generate endpoint response.

Enhancements:
- Derive explainability metadata in the VIP router based on packaging rules and quantities without modifying the core engine.
- Ensure deterministic ordering of generated reasons to produce stable API responses.

Tests:
- Add integration-style tests for VIP shoplist generation to verify presence, content, and determinism of explainability reasons for packed and unpacked lines.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shoplist responses now include explainability: packed lines carry an ordered list of reasons; unpacked lines include a specific reason value ("no_packaging_rule").

* **Bug Fixes**
  * Validation added: packed items lacking a packaging rule now trigger a clear server error.

* **Tests**
  * New tests verify reasons are present, deterministically ordered, consistent across identical requests, and that unpacked lines use the expected reason.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->