### PR TITLE
fix(tests): align VIP shoplist enrichment tests with fail-soft contract

### DIFF
--- a/tests/test_vip_shoplist_enrichment_optional.py
+++ b/tests/test_vip_shoplist_enrichment_optional.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 # The fixture properly handles both VIP tier and route-level API key dependencies
 # and cleans up overrides in teardown.
 
+from typing import Any, Mapping
+
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -20,25 +22,52 @@ from fastapi.testclient import TestClient
 from tests.conftest import _enable_vip
 
 
-def _generate_payload_minimal() -> dict:
+def _generate_payload_minimal(*, food_id: str = "carrot") -> dict[str, Any]:
     """Minimal valid payload for shoplist generation."""
     return {
         "items": [
             {
-                "food_id": "carrot",
+                "food_id": food_id,
                 "qty": {"value": "100", "unit": "G"},
                 "form": "RAW",
             }
         ],
         "packaging_rules": [
             {
-                "food_id": "carrot",
+                "food_id": food_id,
                 "pack_size": {"value": "500", "unit": "G"},
                 "rounding": "CEIL",
                 "min_packs": 1,
             }
         ],
     }
+
+
+def _force_mock_catalog_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Force deterministic catalog provider for tests.
+
+    RU: Принудительно используем mock provider, чтобы тесты не зависели от env/SQLite снапшотов.
+    EN: Force mock provider so tests are not coupled to env/SQLite snapshots.
+    """
+    from app.services.catalog_adapter import reset_catalog_provider_for_tests
+
+    monkeypatch.setenv("CATALOG_PROVIDER", "mock")
+    reset_catalog_provider_for_tests()
+
+
+def _assert_catalog_fields(
+    catalog: Mapping[str, Any],
+    *,
+    region_id: str,
+    store_id: str,
+    sku: str | None = None,
+) -> None:
+    assert catalog["region_id"] == region_id  # Contract: lowercase in DTO
+    assert catalog["store_id"] == store_id
+    if sku is not None:
+        assert "sku" in catalog
+        assert catalog["sku"] == sku
 
 
 def test_generate_without_region_store_has_no_catalog(
@@ -62,12 +91,13 @@ def test_generate_without_region_store_has_no_catalog(
     assert packed_item["catalog"] is None
 
 
-def test_generate_with_region_store_attaches_catalog(
+def test_generate_with_region_store_attaches_catalog_when_food_found(
     monkeypatch: pytest.MonkeyPatch,
     client_with_vip_access: TestClient,
 ) -> None:
     """Test that with region_id/store_id, catalog is attached when found."""
     _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
 
     # client_with_vip_access fixture handles VIP tier and API key overrides
     client = client_with_vip_access
@@ -83,19 +113,48 @@ def test_generate_with_region_store_attaches_catalog(
     # Contract: catalog field always present in schema; enrichment is fail-soft.
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    if catalog is not None:
-        assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
-        assert catalog["store_id"] == "carrefour_es"
-        assert "sku" in catalog
-        assert catalog["sku"] == "CRF-ES-000123"
+    assert catalog is not None
+    _assert_catalog_fields(
+        catalog,
+        region_id="es",
+        store_id="carrefour_es",
+        sku="CRF-ES-000123",
+    )
 
 
-def test_daily_with_enrichment_applies_to_response(
+def test_generate_with_region_store_returns_null_catalog_when_food_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Explicitly validates fail-soft branch: catalog key exists but value may be null."""
+    _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
+
+    client = client_with_vip_access
+
+    r = client.post(
+        "/api/v1/vip/shoplist/generate?region_id=es&store_id=carrefour_es",
+        json=_generate_payload_minimal(food_id="not_in_mock_catalog"),
+    )
+    assert r.status_code == status.HTTP_200_OK, r.text
+
+    data = r.json()
+    assert "packed" in data
+    assert data["packed"], data
+
+    packed_item = data["packed"][0]
+    assert packed_item["food_id"] == "not_in_mock_catalog"
+    assert "catalog" in packed_item
+    assert packed_item["catalog"] is None
+
+
+def test_daily_with_enrichment_attaches_catalog_when_food_found(
     monkeypatch: pytest.MonkeyPatch,
     client_with_vip_access: TestClient,
 ) -> None:
     """Test that /daily endpoint applies enrichment when params provided."""
     _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
 
     # client_with_vip_access fixture handles VIP tier and API key overrides
     client = client_with_vip_access
@@ -109,11 +168,37 @@ def test_daily_with_enrichment_applies_to_response(
     data = r.json()
     assert "packed" in data
     packed_item = data["packed"][0]
-    # Contract: catalog field always present in schema; enrichment is fail-soft.
+    # Contract: catalog field always present in schema; enrichment is fail-soft (covered separately).
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    if catalog is not None:
-        assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
+    assert catalog is not None
+    _assert_catalog_fields(catalog, region_id="es", store_id="carrefour_es")
+
+
+def test_daily_with_enrichment_returns_null_catalog_when_food_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Explicitly validates fail-soft branch: catalog key exists but value may be null."""
+    _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
+
+    client = client_with_vip_access
+
+    r = client.post(
+        "/api/v1/vip/shoplist/daily?region_id=es&store_id=carrefour_es",
+        json=_generate_payload_minimal(food_id="not_in_mock_catalog"),
+    )
+    assert r.status_code == status.HTTP_200_OK, r.text
+
+    data = r.json()
+    assert "packed" in data
+    assert data["packed"], data
+
+    packed_item = data["packed"][0]
+    assert packed_item["food_id"] == "not_in_mock_catalog"
+    assert "catalog" in packed_item
+    assert packed_item["catalog"] is None
 
 
 def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
@@ -122,6 +207,7 @@ def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
 ) -> None:
     """Test that region_id is normalized to lowercase in catalog response."""
     _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
 
     # client_with_vip_access fixture handles VIP tier and API key overrides
     client = client_with_vip_access
@@ -137,8 +223,6 @@ def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
     packed_item = data["packed"][0]
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    if catalog is not None:
-        # Contract: region_id always lowercase in response
-        assert (
-            catalog["region_id"] == "es"
-        ), f"Expected lowercase 'es', got '{catalog['region_id']}'"
+    # Verify catalog is attached to test normalization
+    assert catalog is not None, "Expected catalog to be attached to verify normalization"
+    _assert_catalog_fields(catalog, region_id="es", store_id="carrefour_es")

--- a/tests/test_vip_shoplist_enrichment_optional.py
+++ b/tests/test_vip_shoplist_enrichment_optional.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 # The fixture properly handles both VIP tier and route-level API key dependencies
 # and cleans up overrides in teardown.
 
-import warnings
-
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -81,25 +79,15 @@ def test_generate_with_region_store_attaches_catalog(
     assert r.status_code == status.HTTP_200_OK, r.text
 
     data = r.json()
-    packed_index = 0
-    packed_item = data["packed"][packed_index]
-    # Catalog field always present in schema (contract: never None when region/store provided)
+    packed_item = data["packed"][0]
+    # Contract: catalog field always present in schema; enrichment is fail-soft.
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    if catalog is None:
-        packed_item_id = (
-            packed_item.get("id") or packed_item.get("food_id") or packed_item.get("foodId")
-        )
-        diagnostic = (
-            "Catalog enrichment returned null; expected non-null catalog when region/store "
-            f"provided (packed_index={packed_index}, packed_item_id={packed_item_id!r})."
-        )
-        warnings.warn(diagnostic, RuntimeWarning, stacklevel=2)
-        raise AssertionError(diagnostic)
-    assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
-    assert catalog["store_id"] == "carrefour_es"
-    assert "sku" in catalog
-    assert catalog["sku"] == "CRF-ES-000123"
+    if catalog is not None:
+        assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
+        assert catalog["store_id"] == "carrefour_es"
+        assert "sku" in catalog
+        assert catalog["sku"] == "CRF-ES-000123"
 
 
 def test_daily_with_enrichment_applies_to_response(
@@ -121,13 +109,11 @@ def test_daily_with_enrichment_applies_to_response(
     data = r.json()
     assert "packed" in data
     packed_item = data["packed"][0]
-    # Catalog field always present in schema (contract: never None when region/store provided)
+    # Contract: catalog field always present in schema; enrichment is fail-soft.
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    assert (
-        catalog is not None
-    ), "Catalog enrichment should always attach metadata when region/store provided"
-    assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
+    if catalog is not None:
+        assert catalog["region_id"] == "es"  # Contract: lowercase in DTO
 
 
 def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
@@ -151,7 +137,8 @@ def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
     packed_item = data["packed"][0]
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
-    # Contract: catalog must not be None when region/store provided
-    assert catalog is not None
-    # Contract: region_id always lowercase in response
-    assert catalog["region_id"] == "es", f"Expected lowercase 'es', got '{catalog['region_id']}'"
+    if catalog is not None:
+        # Contract: region_id always lowercase in response
+        assert (
+            catalog["region_id"] == "es"
+        ), f"Expected lowercase 'es', got '{catalog['region_id']}'"

--- a/tests/test_vip_shoplist_enrichment_optional.py
+++ b/tests/test_vip_shoplist_enrichment_optional.py
@@ -63,11 +63,17 @@ def _assert_catalog_fields(
     store_id: str,
     sku: str | None = None,
 ) -> None:
-    assert catalog["region_id"] == region_id  # Contract: lowercase in DTO
-    assert catalog["store_id"] == store_id
+    assert (
+        catalog["region_id"] == region_id
+    ), f"catalog['region_id'] expected {region_id!r}, got {catalog.get('region_id')!r}"
+    assert (
+        catalog["store_id"] == store_id
+    ), f"catalog['store_id'] expected {store_id!r}, got {catalog.get('store_id')!r}"
     if sku is not None:
-        assert "sku" in catalog
-        assert catalog["sku"] == sku
+        assert (
+            "sku" in catalog
+        ), f"catalog missing 'sku' key; expected sku={sku!r} (catalog keys={list(catalog.keys())})"
+        assert catalog["sku"] == sku, f"catalog['sku'] expected {sku!r}, got {catalog.get('sku')!r}"
 
 
 def test_generate_without_region_store_has_no_catalog(
@@ -224,5 +230,29 @@ def test_generate_with_uppercase_region_id_normalizes_to_lowercase(
     assert "catalog" in packed_item
     catalog = packed_item["catalog"]
     # Verify catalog is attached to test normalization
+    assert catalog is not None, "Expected catalog to be attached to verify normalization"
+    _assert_catalog_fields(catalog, region_id="es", store_id="carrefour_es")
+
+
+def test_generate_with_uppercase_store_id_normalizes_to_lowercase(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Test that store_id is normalized to lowercase in catalog response."""
+    _enable_vip(monkeypatch)
+    _force_mock_catalog_provider(monkeypatch)
+
+    client = client_with_vip_access
+
+    r = client.post(
+        "/api/v1/vip/shoplist/generate?region_id=es&store_id=CARREFOUR_ES",
+        json=_generate_payload_minimal(),
+    )
+    assert r.status_code == status.HTTP_200_OK, r.text
+
+    data = r.json()
+    packed_item = data["packed"][0]
+    assert "catalog" in packed_item
+    catalog = packed_item["catalog"]
     assert catalog is not None, "Expected catalog to be attached to verify normalization"
     _assert_catalog_fields(catalog, region_id="es", store_id="carrefour_es")


### PR DESCRIPTION
Problem: Nightly tests failed because test_vip_shoplist_enrichment_optional.py asserted catalog is not None, but enrichment can legitimately return null when no SKU is found (fail-soft behavior).

Changes:
- Removed hard assertion 'assert catalog is not None' (lines 65, 94, 120)
- Changed to conditional validation: only check catalog fields when catalog is not None
- Simplified packed_item extraction (removed unnecessary multi-key lookup)
- Removed warnings.warn + AssertionError block that was too strict

Contract: catalog field is always present in response schema, but value can be null if provider/catalog doesn't find a match. Tests should validate fields only when enrichment actually returned an object.

This aligns tests with the documented fail-soft enrichment behavior.

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Ослабить проверки обогащения VIP shoplist, чтобы привести их в соответствие с fail-soft контрактом обогащения каталога.

Исправления ошибок:
- Исправить необязательные тесты обогащения VIP shoplist, которые некорректно предполагали, что каталог всегда не равен null, когда задан регион/магазин.

Улучшения:
- Упростить извлечение упакованных товаров и сделать проверки поля каталога условными, основываясь на ненулевом результате обогащения.

Тесты:
- Обновить тесты обогащения VIP shoplist так, чтобы обрабатывать null каталог как допустимый результат в режиме fail-soft, при этом по-прежнему валидируя поля, когда данные обогащения присутствуют.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax VIP shoplist enrichment tests to align with the fail-soft catalog enrichment contract.

Bug Fixes:
- Fix VIP shoplist enrichment optional tests that incorrectly assumed catalog is always non-null when region/store is provided.

Enhancements:
- Simplify packed item extraction and make catalog field assertions conditional on non-null enrichment results.

Tests:
- Update VIP shoplist enrichment tests to treat null catalog as a valid fail-soft outcome while still validating fields when enrichment data is present.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of catalog enrichment to gracefully handle missing or unknown catalog entries (fail-soft behavior) and replaced warning-based checks with deterministic assertions.

* **Tests**
  * Expanded test coverage for enrichment scenarios (when food is found vs unknown), added deterministic catalog mocking, normalization checks for region/store IDs, and clearer, more reliable assertion helpers and test flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->