### PR TITLE
feat(vip): add CSV export for shoplist (PR-8a)

### DIFF
--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -305,6 +305,38 @@ async def vip_shoplist_preview(
     )
 
 
+async def _generate_vip_shoplist(
+    payload: ShoplistGenerateRequest,
+    *,
+    region_id: Optional[str] = None,
+    store_id: Optional[str] = None,
+) -> ShoplistGenerateResponse:
+    """
+    Internal function to generate VIP shoplist (shared by /generate and /export).
+
+    RU: Внутренняя функция генерации shoplist (используется /generate и /export).
+    EN: Internal shoplist generation function (used by /generate and /export).
+    """
+    # Map DTO -> core models
+    specs = _map_dto_to_engine_specs(payload.items)
+    rules = _map_dto_to_engine_rules(payload.packaging_rules)
+
+    # Run engine pipeline
+    result = ShoplistEngine.generate(specs, packaging_rules=rules)
+
+    # Build response
+    response = _build_shoplist_response(result, rules, include_analytics=True)
+
+    # Enrichment (fail-soft, adapter-only)
+    response = enrich_shoplist_response(
+        response,
+        region_id=region_id,
+        store_id=store_id,
+        provider=_get_catalog_provider(),
+    )
+    return response
+
+
 @router.post(
     "/generate",
     response_model=ShoplistGenerateResponse,
@@ -340,24 +372,7 @@ async def vip_shoplist_generate(
 
     No prices, no stores, no external calls - pure deterministic calculation.
     """
-    # Map DTO -> core models
-    specs = _map_dto_to_engine_specs(payload.items)
-    rules = _map_dto_to_engine_rules(payload.packaging_rules)
-
-    # Run engine pipeline
-    result = ShoplistEngine.generate(specs, packaging_rules=rules)
-
-    # Build response
-    response = _build_shoplist_response(result, rules, include_analytics=True)
-
-    # Enrichment (fail-soft, adapter-only)
-    response = enrich_shoplist_response(
-        response,
-        region_id=region_id,
-        store_id=store_id,
-        provider=_get_catalog_provider(),
-    )
-    return response
+    return await _generate_vip_shoplist(payload, region_id=region_id, store_id=store_id)
 
 
 @router.post(
@@ -485,13 +500,19 @@ async def vip_shoplist_weekly(
     summary="Export VIP shoplist to CSV",
     description=(
         "Export shoplist in CSV format. "
-        "PR-8a: CSV only. Uses same generation logic as /generate endpoint. "
+        "CSV only. Uses same generation logic as /generate endpoint. "
         "Deterministic ordering: store_id, aisle, food_id."
     ),
 )
 async def vip_shoplist_export(
     payload: ShoplistGenerateRequest,
-    format: Annotated[str, Query(description="Export format (PR-8a: csv only)")] = "csv",
+    export_format: Annotated[
+        str | None, Query(description="Export format (export_format; csv only)")
+    ] = None,
+    _legacy_format: Annotated[
+        str | None,
+        Query(alias="format", include_in_schema=False, description="Deprecated: use export_format"),
+    ] = None,
     region_id: Annotated[
         Optional[str],
         Query(description="Optional region id (e.g. 'es', 'us')"),
@@ -512,19 +533,15 @@ async def vip_shoplist_export(
     This endpoint reuses the /generate logic without duplicating engine code.
     No engine changes, pure export function.
     """
-    if format.lower() != "csv":
+
+    export_format = export_format or _legacy_format or "csv"
+    if export_format.lower() != "csv":
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Only csv supported in PR-8a"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Only csv format is supported"
         )
 
-    # Важно: НЕ дублируем логику, не трогаем engine — переиспользуем generate.
-    result = await vip_shoplist_generate(
-        payload=payload,
-        region_id=region_id,
-        store_id=store_id,
-        _enabled=_enabled,
-        _vip=_vip,
-    )
+    # Важно: НЕ дублируем логику, не трогаем engine — переиспользуем внутреннюю функцию.
+    result = await _generate_vip_shoplist(payload, region_id=region_id, store_id=store_id)
 
     csv_data = export_shoplist_to_csv(result)
 

--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Annotated, Any, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.middleware.api_tiers import require_vip_tier
 from app.schemas.vip_shoplist import (
@@ -33,6 +33,7 @@ from app.schemas.vip_shoplist import (
     UnitDTO,
 )
 from app.services.catalog_adapter import CatalogProvider, _get_provider, enrich_shoplist_response
+from app.services.shoplist_export.csv_export import export_shoplist_to_csv
 from app.utils.feature_flags import is_vip_module_enabled
 from core.shoplist_engine.engine import ShoplistEngine
 from core.shoplist_engine.models import (
@@ -476,6 +477,62 @@ async def vip_shoplist_weekly(
         days.append(day_response)
 
     return ShoplistWeeklyResponse(days=days)
+
+
+@router.post(
+    "/export",
+    responses=COMMON_VIP_SHOPLIST_RESPONSES,
+    summary="Export VIP shoplist to CSV",
+    description=(
+        "Export shoplist in CSV format. "
+        "PR-8a: CSV only. Uses same generation logic as /generate endpoint. "
+        "Deterministic ordering: store_id, aisle, food_id."
+    ),
+)
+async def vip_shoplist_export(
+    payload: ShoplistGenerateRequest,
+    format: Annotated[str, Query(description="Export format (PR-8a: csv only)")] = "csv",
+    region_id: Annotated[
+        Optional[str],
+        Query(description="Optional region id (e.g. 'es', 'us')"),
+    ] = None,
+    store_id: Annotated[
+        Optional[str],
+        Query(description="Optional store id (e.g. 'carrefour_es', 'walmart_us')"),
+    ] = None,
+    _enabled: Annotated[None, Depends(require_vip_module_enabled)] = None,
+    _vip: Annotated[str, Depends(require_vip_tier)] = "",
+) -> Response:
+    """
+    Export shopping list to CSV format.
+
+    RU: Экспортирует список покупок в CSV.
+    EN: Exports shopping list to CSV.
+
+    This endpoint reuses the /generate logic without duplicating engine code.
+    No engine changes, pure export function.
+    """
+    if format.lower() != "csv":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Only csv supported in PR-8a"
+        )
+
+    # Важно: НЕ дублируем логику, не трогаем engine — переиспользуем generate.
+    result = await vip_shoplist_generate(
+        payload=payload,
+        region_id=region_id,
+        store_id=store_id,
+        _enabled=_enabled,
+        _vip=_vip,
+    )
+
+    csv_data = export_shoplist_to_csv(result, region_id=region_id)
+
+    return Response(
+        content=csv_data,
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="shoplist.csv"'},
+    )
 
 
 __all__ = ["router"]

--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -526,7 +526,7 @@ async def vip_shoplist_export(
         _vip=_vip,
     )
 
-    csv_data = export_shoplist_to_csv(result, region_id=region_id)
+    csv_data = export_shoplist_to_csv(result)
 
     return Response(
         content=csv_data,

--- a/app/services/shoplist_export/__init__.py
+++ b/app/services/shoplist_export/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Экспорт shoplist (CSV/PDF) — слой сервисов (без FastAPI).
+EN: Shoplist export utilities (CSV/PDF) — service layer (no FastAPI).
+"""
+

--- a/app/services/shoplist_export/__init__.py
+++ b/app/services/shoplist_export/__init__.py
@@ -3,4 +3,3 @@
 RU: Экспорт shoplist (CSV/PDF) — слой сервисов (без FastAPI).
 EN: Shoplist export utilities (CSV/PDF) — service layer (no FastAPI).
 """
-

--- a/app/services/shoplist_export/csv_export.py
+++ b/app/services/shoplist_export/csv_export.py
@@ -82,14 +82,22 @@ def _get_reason_str(line: PackedLineDTO | UnpackedLineDTO) -> str:
     return line.reason or ""
 
 
+def _cell(value: str | None) -> str:
+    """
+    RU: Применяет CSV sanitize к строковому значению.
+    EN: Applies CSV sanitize to string value.
+    """
+    return _sanitize_csv_cell(value or "")
+
+
 def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
     """
     RU: Экспортирует shoplist в CSV (строго детерминированно).
     EN: Exports shoplist to CSV (strictly deterministic).
 
     Ordering:
-    - store_id (empty last via "")
-    - aisle (empty last via "")
+    - store_id (non-empty first; empty last)
+    - aisle (non-empty first; empty last)
     - food_id
 
     Args:
@@ -107,8 +115,10 @@ def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
     all_lines.extend(response.packed)
     all_lines.extend(response.unpacked)
 
-    # Детерминированная сортировка
-    def sort_key(line: PackedLineDTO | UnpackedLineDTO) -> tuple[str, str, str]:
+    # Детерминированная сортировка: empty values last
+    def sort_key(
+        line: PackedLineDTO | UnpackedLineDTO,
+    ) -> tuple[bool, str, bool, str, str]:
         # Извлекаем store_id из catalog или используем пустую строку
         store_id = ""
         if line.catalog and line.catalog.store_id:
@@ -117,7 +127,9 @@ def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
         aisle = ""
         if line.catalog and line.catalog.aisle:
             aisle = line.catalog.aisle
-        return (store_id, aisle, line.food_id)
+
+        # False < True => непустые значения раньше, пустые позже
+        return (store_id == "", store_id, aisle == "", aisle, line.food_id)
 
     sorted_lines = sorted(all_lines, key=sort_key)
 
@@ -159,22 +171,22 @@ def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
         if catalog_price_value is not None and packs > 0:
             subtotal_value = catalog_price_value * Decimal(packs)
 
-        # Формируем строку CSV
+        # Формируем строку CSV (sanitize для всех строковых полей)
         writer.writerow(
             [
-                line.food_id,
+                _cell(line.food_id),
                 "",  # name - нет в DTO, оставляем пустым
                 _fmt_decimal(requested_value),
-                requested_unit or "",
+                _cell(requested_unit),
                 _fmt_quantity(pack_size_value, pack_size_unit),
                 str(packs),
                 str(min_packs),
-                _sanitize_csv_cell(_get_reason_str(line)),
-                _sanitize_csv_cell(catalog_aisle),
+                _cell(_get_reason_str(line)),
+                _cell(catalog_aisle),
                 _fmt_decimal(catalog_price_value),
                 _fmt_decimal(subtotal_value),
-                catalog_store_id,
-                final_region_id,
+                _cell(catalog_store_id),
+                _cell(final_region_id),
             ]
         )
 

--- a/app/services/shoplist_export/csv_export.py
+++ b/app/services/shoplist_export/csv_export.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Детерминированный CSV-экспорт из ShoplistGenerateResponse.
+EN: Deterministic CSV export from ShoplistGenerateResponse.
+
+Инварианты:
+- НЕ меняет packs / reasons / analytics
+- НЕ трогает core engine
+- Чистая функция (no I/O, no time, no env)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from decimal import Decimal
+
+from app.schemas.vip_shoplist import (
+    PackedLineDTO,
+    ShoplistGenerateResponse,
+    UnpackedLineDTO,
+)
+
+CSV_HEADER = [
+    "food_id",
+    "name",
+    "requested",
+    "unit",
+    "pack_size",
+    "packs",
+    "min_packs",
+    "reason",
+    "aisle",
+    "price",
+    "subtotal",
+    "store_id",
+    "region_id",
+]
+
+# CSV injection protection: prefix dangerous formulas
+DANGEROUS_CSV_PREFIXES = ("=", "+", "-", "@")
+
+
+def _sanitize_csv_cell(value: str) -> str:
+    """
+    RU: Защита от CSV injection (формулы в Excel/Sheets).
+    EN: CSV injection protection (formulas in Excel/Sheets).
+
+    Prefixes values starting with =, +, -, @ with single quote.
+    """
+    if value and value.startswith(DANGEROUS_CSV_PREFIXES):
+        return f"'{value}"
+    return value
+
+
+def _fmt_decimal(value: Decimal | None) -> str:
+    """
+    RU: Decimal -> строка без scientific notation.
+    EN: Decimal -> plain string without scientific notation.
+    """
+    return "" if value is None else format(value, "f")
+
+
+def _fmt_quantity(value: Decimal | None, unit: str | None) -> str:
+    """
+    RU: Форматирует Quantity (value + unit) для CSV.
+    EN: Formats Quantity (value + unit) for CSV.
+    """
+    if value is None:
+        return ""
+    unit_str = unit or ""
+    return f"{_fmt_decimal(value)} {unit_str}".strip()
+
+
+def _get_reason_str(line: PackedLineDTO | UnpackedLineDTO) -> str:
+    """
+    RU: Извлекает reason как строку (для packed = reasons.join, для unpacked = reason).
+    EN: Extracts reason as string (for packed = reasons.join, for unpacked = reason).
+    """
+    if isinstance(line, PackedLineDTO):
+        return "; ".join(line.reasons) if line.reasons else ""
+    return line.reason or ""
+
+
+def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
+    """
+    RU: Экспортирует shoplist в CSV (строго детерминированно).
+    EN: Exports shoplist to CSV (strictly deterministic).
+
+    Ordering:
+    - store_id (empty last via "")
+    - aisle (empty last via "")
+    - food_id
+
+    Args:
+        response: ShoplistGenerateResponse from generate endpoint (already enriched with catalog)
+
+    Returns:
+        CSV string with header and rows
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(CSV_HEADER)
+
+    # Объединяем packed и unpacked в один список для сортировки
+    all_lines: list[PackedLineDTO | UnpackedLineDTO] = []
+    all_lines.extend(response.packed)
+    all_lines.extend(response.unpacked)
+
+    # Детерминированная сортировка
+    def sort_key(line: PackedLineDTO | UnpackedLineDTO) -> tuple[str, str, str]:
+        # Извлекаем store_id из catalog или используем пустую строку
+        store_id = ""
+        if line.catalog and line.catalog.store_id:
+            store_id = line.catalog.store_id
+        # Извлекаем aisle из catalog или используем пустую строку
+        aisle = ""
+        if line.catalog and line.catalog.aisle:
+            aisle = line.catalog.aisle
+        return (store_id, aisle, line.food_id)
+
+    sorted_lines = sorted(all_lines, key=sort_key)
+
+    for line in sorted_lines:
+        # Извлекаем данные из line
+        requested_value = line.requested.value if line.requested else None
+        requested_unit = line.requested.unit if line.requested else None
+
+        # Для packed: pack_size, packs, min_packs
+        # Для unpacked: pack_size = None, packs = 0, min_packs = 0
+        if isinstance(line, PackedLineDTO):
+            pack_size_value = line.pack_size.value if line.pack_size else None
+            pack_size_unit = line.pack_size.unit if line.pack_size else None
+            packs = line.packs
+            min_packs = line.min_packs
+        else:
+            pack_size_value = None
+            pack_size_unit = None
+            packs = 0
+            min_packs = 0
+
+        # Извлекаем catalog данные
+        catalog_store_id = ""
+        catalog_region_id = ""
+        catalog_aisle = ""
+        catalog_price_value = None
+        if line.catalog:
+            catalog_store_id = line.catalog.store_id or ""
+            catalog_region_id = line.catalog.region_id or ""
+            catalog_aisle = line.catalog.aisle or ""
+            if line.catalog.price:
+                catalog_price_value = line.catalog.price.value
+
+        # Используем region_id из catalog (enrichment уже применён в endpoint)
+        final_region_id = catalog_region_id or ""
+
+        # Вычисляем subtotal (price * packs, если price есть)
+        subtotal_value = None
+        if catalog_price_value is not None and packs > 0:
+            subtotal_value = catalog_price_value * Decimal(packs)
+
+        # Формируем строку CSV
+        writer.writerow(
+            [
+                line.food_id,
+                "",  # name - нет в DTO, оставляем пустым
+                _fmt_decimal(requested_value),
+                requested_unit or "",
+                _fmt_quantity(pack_size_value, pack_size_unit),
+                str(packs),
+                str(min_packs),
+                _sanitize_csv_cell(_get_reason_str(line)),
+                _sanitize_csv_cell(catalog_aisle),
+                _fmt_decimal(catalog_price_value),
+                _fmt_decimal(subtotal_value),
+                catalog_store_id,
+                final_region_id,
+            ]
+        )
+
+    return buf.getvalue()
+

--- a/app/services/shoplist_export/csv_export.py
+++ b/app/services/shoplist_export/csv_export.py
@@ -179,4 +179,3 @@ def export_shoplist_to_csv(response: ShoplistGenerateResponse) -> str:
         )
 
     return buf.getvalue()
-

--- a/tests/vip/test_csv_export_unit.py
+++ b/tests/vip/test_csv_export_unit.py
@@ -1,0 +1,445 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for CSV export functions.
+
+RU: Unit-тесты для функций CSV экспорта.
+EN: Unit tests for CSV export functions.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from decimal import Decimal
+
+import pytest
+
+from app.schemas.catalog import CatalogInfoDTO, CurrencyDTO, MoneyDTO
+from app.schemas.vip_shoplist import (
+    PackedLineDTO,
+    QuantityDTO,
+    ShoplistGenerateResponse,
+    UnpackedLineDTO,
+)
+from app.services.shoplist_export.csv_export import (
+    _cell,
+    _fmt_decimal,
+    _fmt_quantity,
+    _get_reason_str,
+    _sanitize_csv_cell,
+    export_shoplist_to_csv,
+)
+
+
+class TestSanitizeCSVCell:
+    """Tests for _sanitize_csv_cell function."""
+
+    def test_sanitize_equals_prefix(self) -> None:
+        """Test that = prefix is escaped."""
+        assert _sanitize_csv_cell("=SUM(A1:A10)") == "'=SUM(A1:A10)"
+
+    def test_sanitize_plus_prefix(self) -> None:
+        """Test that + prefix is escaped."""
+        assert _sanitize_csv_cell("+123") == "'+123"
+
+    def test_sanitize_minus_prefix(self) -> None:
+        """Test that - prefix is escaped."""
+        assert _sanitize_csv_cell("-456") == "'-456"
+
+    def test_sanitize_at_prefix(self) -> None:
+        """Test that @ prefix is escaped."""
+        assert _sanitize_csv_cell("@evil") == "'@evil"
+
+    def test_sanitize_normal_string(self) -> None:
+        """Test that normal strings are not escaped."""
+        assert _sanitize_csv_cell("carrot") == "carrot"
+        assert _sanitize_csv_cell("normal text") == "normal text"
+
+    def test_sanitize_empty_string(self) -> None:
+        """Test that empty string is not escaped."""
+        assert _sanitize_csv_cell("") == ""
+
+
+class TestCell:
+    """Tests for _cell helper function."""
+
+    def test_cell_with_value(self) -> None:
+        """Test _cell with non-empty value."""
+        assert _cell("test") == "test"
+
+    def test_cell_with_dangerous_prefix(self) -> None:
+        """Test _cell with dangerous prefix."""
+        assert _cell("=SUM(1,1)") == "'=SUM(1,1)"
+
+    def test_cell_with_none(self) -> None:
+        """Test _cell with None."""
+        assert _cell(None) == ""
+
+    def test_cell_with_empty_string(self) -> None:
+        """Test _cell with empty string."""
+        assert _cell("") == ""
+
+
+class TestFmtDecimal:
+    """Tests for _fmt_decimal function."""
+
+    def test_fmt_decimal_with_value(self) -> None:
+        """Test formatting Decimal value."""
+        assert _fmt_decimal(Decimal("123.45")) == "123.45"
+        assert _fmt_decimal(Decimal("0")) == "0"
+        assert _fmt_decimal(Decimal("1000")) == "1000"
+
+    def test_fmt_decimal_with_none(self) -> None:
+        """Test formatting None."""
+        assert _fmt_decimal(None) == ""
+
+
+class TestFmtQuantity:
+    """Tests for _fmt_quantity function."""
+
+    def test_fmt_quantity_with_value_and_unit(self) -> None:
+        """Test formatting quantity with value and unit."""
+        assert _fmt_quantity(Decimal("500"), "G") == "500 G"
+        assert _fmt_quantity(Decimal("1"), "KG") == "1 KG"
+
+    def test_fmt_quantity_with_value_no_unit(self) -> None:
+        """Test formatting quantity with value but no unit."""
+        assert _fmt_quantity(Decimal("500"), None) == "500"
+        assert _fmt_quantity(Decimal("500"), "") == "500"
+
+    def test_fmt_quantity_with_none(self) -> None:
+        """Test formatting None quantity."""
+        assert _fmt_quantity(None, "G") == ""
+        assert _fmt_quantity(None, None) == ""
+
+
+class TestGetReasonStr:
+    """Tests for _get_reason_str function."""
+
+    def test_get_reason_str_packed_with_reasons(self) -> None:
+        """Test getting reason string from PackedLineDTO with reasons."""
+        line = PackedLineDTO(
+            food_id="carrot",
+            requested=QuantityDTO(value=Decimal("100"), unit="G"),
+            pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+            packs=1,
+            provided=QuantityDTO(value=Decimal("500"), unit="G"),
+            overage=QuantityDTO(value=Decimal("400"), unit="G"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["rounding=CEIL", "min_packs=1"],
+        )
+        assert _get_reason_str(line) == "rounding=CEIL; min_packs=1"
+
+    def test_get_reason_str_packed_without_reasons(self) -> None:
+        """Test getting reason string from PackedLineDTO without reasons."""
+        line = PackedLineDTO(
+            food_id="carrot",
+            requested=QuantityDTO(value=Decimal("100"), unit="G"),
+            pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+            packs=1,
+            provided=QuantityDTO(value=Decimal("500"), unit="G"),
+            overage=QuantityDTO(value=Decimal("400"), unit="G"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=[],
+        )
+        assert _get_reason_str(line) == ""
+
+    def test_get_reason_str_unpacked_with_reason(self) -> None:
+        """Test getting reason string from UnpackedLineDTO with reason."""
+        line = UnpackedLineDTO(
+            food_id="tomato",
+            requested=QuantityDTO(value=Decimal("200"), unit="G"),
+            reason="no_packaging_rule",
+        )
+        assert _get_reason_str(line) == "no_packaging_rule"
+
+    def test_get_reason_str_unpacked_without_reason(self) -> None:
+        """Test getting reason string from UnpackedLineDTO without reason."""
+        line = UnpackedLineDTO(
+            food_id="tomato",
+            requested=QuantityDTO(value=Decimal("200"), unit="G"),
+            reason="",
+        )
+        assert _get_reason_str(line) == ""
+
+
+class TestExportShoplistToCSV:
+    """Tests for export_shoplist_to_csv function."""
+
+    def test_export_empty_response(self) -> None:
+        """Test exporting empty shoplist response."""
+        response = ShoplistGenerateResponse(packed=[], unpacked=[])
+        csv_data = export_shoplist_to_csv(response)
+
+        rows = list(csv.reader(io.StringIO(csv_data)))
+        assert len(rows) == 1  # Only header
+        assert rows[0] == [
+            "food_id",
+            "name",
+            "requested",
+            "unit",
+            "pack_size",
+            "packs",
+            "min_packs",
+            "reason",
+            "aisle",
+            "price",
+            "subtotal",
+            "store_id",
+            "region_id",
+        ]
+
+    def test_export_packed_line_without_catalog(self) -> None:
+        """Test exporting packed line without catalog."""
+        response = ShoplistGenerateResponse(
+            packed=[
+                PackedLineDTO(
+                    food_id="carrot",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=["min_packs=1"],
+                )
+            ],
+            unpacked=[],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 2  # Header + 1 data row
+        data_row = rows[1]
+        assert data_row[0] == "carrot"  # food_id
+        assert data_row[1] == ""  # name
+        assert data_row[2] == "100"  # requested value
+        assert data_row[3] == "G"  # requested unit
+        assert data_row[4] == "500 G"  # pack_size
+        assert data_row[5] == "1"  # packs
+        assert data_row[6] == "1"  # min_packs
+        assert data_row[7] == "min_packs=1"  # reason
+        assert data_row[8] == ""  # aisle (no catalog)
+        assert data_row[9] == ""  # price (no catalog)
+        assert data_row[10] == ""  # subtotal (no price)
+        assert data_row[11] == ""  # store_id (no catalog)
+        assert data_row[12] == ""  # region_id (no catalog)
+
+    def test_export_packed_line_with_catalog_and_price(self) -> None:
+        """Test exporting packed line with catalog and price (subtotal calculation)."""
+        catalog = CatalogInfoDTO(
+            sku="SKU_TEST",
+            store_id="carrefour_es",
+            region_id="es",
+            pack_label="500 G",
+            aisle="Vegetables",
+            price=MoneyDTO(value=Decimal("1.29"), currency=CurrencyDTO.EUR),
+        )
+
+        response = ShoplistGenerateResponse(
+            packed=[
+                PackedLineDTO(
+                    food_id="carrot",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=2,  # 2 packs for subtotal calculation
+                    provided=QuantityDTO(value=Decimal("1000"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("900"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=["min_packs=1"],
+                    catalog=catalog,
+                )
+            ],
+            unpacked=[],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 2
+        data_row = rows[1]
+        assert data_row[8] == "Vegetables"  # aisle
+        assert data_row[9] == "1.29"  # price
+        assert data_row[10] == "2.58"  # subtotal (1.29 * 2)
+        assert data_row[11] == "carrefour_es"  # store_id
+        assert data_row[12] == "es"  # region_id
+
+    def test_export_unpacked_line(self) -> None:
+        """Test exporting unpacked line."""
+        response = ShoplistGenerateResponse(
+            packed=[],
+            unpacked=[
+                UnpackedLineDTO(
+                    food_id="tomato",
+                    requested=QuantityDTO(value=Decimal("200"), unit="G"),
+                    reason="no_packaging_rule",
+                )
+            ],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 2
+        data_row = rows[1]
+        assert data_row[0] == "tomato"  # food_id
+        assert data_row[4] == ""  # pack_size (unpacked)
+        assert data_row[5] == "0"  # packs (unpacked)
+        assert data_row[6] == "0"  # min_packs (unpacked)
+        assert data_row[7] == "no_packaging_rule"  # reason
+
+    def test_export_sorting_empty_values_last(self) -> None:
+        """Test that sorting puts empty values last."""
+        catalog_with_data = CatalogInfoDTO(
+            sku="SKU_A",
+            store_id="store_a",
+            region_id="es",
+            pack_label="500 G",
+            aisle="Aisle A",
+            price=None,
+        )
+
+        response = ShoplistGenerateResponse(
+            packed=[
+                # Line with empty catalog (should be last)
+                PackedLineDTO(
+                    food_id="z_empty",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=[],
+                    catalog=None,  # Empty catalog
+                ),
+                # Line with catalog (should be first)
+                PackedLineDTO(
+                    food_id="a_with_catalog",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=[],
+                    catalog=catalog_with_data,
+                ),
+            ],
+            unpacked=[],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 3  # Header + 2 data rows
+        # First row should have catalog (non-empty store_id)
+        assert rows[1][0] == "a_with_catalog"
+        # Second row should be empty catalog (empty store_id last)
+        assert rows[2][0] == "z_empty"
+
+    def test_export_with_dangerous_characters_in_food_id(self) -> None:
+        """Test that dangerous characters in food_id are sanitized."""
+        response = ShoplistGenerateResponse(
+            packed=[
+                PackedLineDTO(
+                    food_id="=SUM(A1:A10)",  # Dangerous prefix
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=[],
+                )
+            ],
+            unpacked=[],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 2
+        # food_id should be sanitized
+        assert rows[1][0].startswith("'=")
+
+    def test_export_with_catalog_empty_fields(self) -> None:
+        """Test export with catalog that has empty store_id/aisle."""
+        catalog_empty = CatalogInfoDTO(
+            sku="SKU_TEST",
+            store_id="",  # Empty store_id
+            region_id="es",
+            pack_label="500 G",
+            aisle="",  # Empty aisle
+            price=None,
+        )
+
+        response = ShoplistGenerateResponse(
+            packed=[
+                PackedLineDTO(
+                    food_id="carrot",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=[],
+                    catalog=catalog_empty,
+                )
+            ],
+            unpacked=[],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 2
+        data_row = rows[1]
+        assert data_row[8] == ""  # aisle (empty)
+        assert data_row[11] == ""  # store_id (empty)
+        assert data_row[12] == "es"  # region_id (not empty)
+
+    def test_export_packed_and_unpacked_mixed(self) -> None:
+        """Test export with both packed and unpacked lines."""
+        response = ShoplistGenerateResponse(
+            packed=[
+                PackedLineDTO(
+                    food_id="carrot",
+                    requested=QuantityDTO(value=Decimal("100"), unit="G"),
+                    pack_size=QuantityDTO(value=Decimal("500"), unit="G"),
+                    packs=1,
+                    provided=QuantityDTO(value=Decimal("500"), unit="G"),
+                    overage=QuantityDTO(value=Decimal("400"), unit="G"),
+                    rounding="CEIL",
+                    min_packs=1,
+                    reasons=["min_packs=1"],
+                )
+            ],
+            unpacked=[
+                UnpackedLineDTO(
+                    food_id="tomato",
+                    requested=QuantityDTO(value=Decimal("200"), unit="G"),
+                    reason="no_packaging_rule",
+                )
+            ],
+        )
+
+        csv_data = export_shoplist_to_csv(response)
+        rows = list(csv.reader(io.StringIO(csv_data)))
+
+        assert len(rows) == 3  # Header + 2 data rows
+        # Both lines should be present
+        food_ids = [row[0] for row in rows[1:]]
+        assert "carrot" in food_ids
+        assert "tomato" in food_ids
+

--- a/tests/vip/test_csv_export_unit.py
+++ b/tests/vip/test_csv_export_unit.py
@@ -442,4 +442,3 @@ class TestExportShoplistToCSV:
         food_ids = [row[0] for row in rows[1:]]
         assert "carrot" in food_ids
         assert "tomato" in food_ids
-

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -8,6 +8,9 @@ EN: Tests for VIP shoplist CSV export endpoint.
 
 from __future__ import annotations
 
+import csv
+import io
+
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -45,7 +48,7 @@ def test_vip_shoplist_export_csv_basic(
 
     payload = _generate_payload_minimal()
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?format=csv",
+        "/api/v1/vip/shoplist/export?export_format=csv",
         json=payload,
     )
 
@@ -54,12 +57,12 @@ def test_vip_shoplist_export_csv_basic(
     assert "Content-Disposition" in resp.headers
     assert 'filename="shoplist.csv"' in resp.headers["Content-Disposition"]
 
-    # Проверяем структуру CSV
-    lines = resp.text.strip().split("\n")
-    assert len(lines) >= 2  # header + at least one data row
+    # Парсим CSV через csv.reader
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    assert len(rows) >= 2  # header + at least one data row
 
     # Проверяем header
-    header = lines[0]
+    header = rows[0]
     expected_columns = [
         "food_id",
         "name",
@@ -75,11 +78,11 @@ def test_vip_shoplist_export_csv_basic(
         "store_id",
         "region_id",
     ]
-    assert header == ",".join(expected_columns)
+    assert header == expected_columns
 
     # Проверяем, что есть данные
-    if len(lines) > 1:
-        data_row = lines[1].split(",")
+    if len(rows) > 1:
+        data_row = rows[1]
         assert len(data_row) == len(expected_columns)
         assert data_row[0] == "carrot"  # food_id
 
@@ -88,7 +91,7 @@ def test_vip_shoplist_export_csv_deterministic_ordering(
     monkeypatch: pytest.MonkeyPatch,
     client_with_vip_access: TestClient,
 ) -> None:
-    """Test that CSV export has deterministic ordering (store_id, aisle, food_id)."""
+    """Test that CSV export has deterministic ordering (empty values last)."""
     _enable_vip(monkeypatch)
 
     payload = {
@@ -112,20 +115,31 @@ def test_vip_shoplist_export_csv_deterministic_ordering(
         ],
     }
 
-    resp1 = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?format=csv",
-        json=payload,
-    )
-    resp2 = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?format=csv",
+    resp = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?export_format=csv",
         json=payload,
     )
 
-    assert resp1.status_code == status.HTTP_200_OK
-    assert resp2.status_code == status.HTTP_200_OK
+    assert resp.status_code == status.HTTP_200_OK
 
-    # Детерминированность: два запроса дают одинаковый результат
-    assert resp1.text == resp2.text
+    # Парсим CSV
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    header = rows[0]
+    data = rows[1:]
+
+    # Проверяем сортировку: empty values last
+    store_i = header.index("store_id")
+    aisle_i = header.index("aisle")
+    food_i = header.index("food_id")
+
+    # Извлекаем ключи сортировки
+    keys = [(r[store_i], r[aisle_i], r[food_i]) for r in data]
+
+    # Проверяем, что сортировка соответствует правилу: empty last
+    expected_keys = sorted(
+        keys, key=lambda k: (k[0] == "", k[0], k[1] == "", k[1], k[2])
+    )
+    assert keys == expected_keys, "Sorting should put empty values last"
 
 
 def test_vip_shoplist_export_csv_invalid_format(
@@ -137,12 +151,12 @@ def test_vip_shoplist_export_csv_invalid_format(
 
     payload = _generate_payload_minimal()
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?format=pdf",
+        "/api/v1/vip/shoplist/export?export_format=pdf",
         json=payload,
     )
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
-    assert "csv supported" in resp.json()["detail"].lower()
+    assert "csv" in resp.json()["detail"].lower()
 
 
 def test_vip_shoplist_export_csv_injection_protection(
@@ -152,15 +166,24 @@ def test_vip_shoplist_export_csv_injection_protection(
     """Test that CSV injection is prevented (formulas starting with =, +, -, @)."""
     _enable_vip(monkeypatch)
 
-    # Используем food_id, который может содержать опасные символы
-    # (в реальности это будет в reason или aisle из catalog)
+    # Используем food_id с опасными символами (проверяем sanitize для food_id)
     payload = _generate_payload_minimal(food_id="=SUM(A1:A10)")
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?format=csv",
+        "/api/v1/vip/shoplist/export?export_format=csv",
         json=payload,
     )
 
     assert resp.status_code == status.HTTP_200_OK
-    # CSV injection protection is tested implicitly:
-    # if formulas appear in reason/aisle fields, they should be prefixed with '
-    # This test verifies the endpoint works; detailed injection tests are in unit tests
+
+    # Парсим CSV
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    header = rows[0]
+    data = rows[1:]
+
+    # Проверяем, что food_id с формулой экранирован
+    food_i = header.index("food_id")
+    if data:
+        food_id_cell = data[0][food_i]
+        # Если food_id начинается с опасного символа, он должен быть экранирован
+        if food_id_cell and food_id_cell[0] in ("=", "+", "-", "@"):
+            assert food_id_cell.startswith("'"), f"CSV injection not prevented: {food_id_cell}"

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -161,12 +161,6 @@ def test_vip_shoplist_export_csv_injection_protection(
     )
 
     assert resp.status_code == status.HTTP_200_OK
-    # Проверяем, что food_id не экранирован (это нормально, т.к. food_id не должен содержать формулы)
-    # Но если в reason/aisle есть формулы - они должны быть экранированы
-    csv_text = resp.text
-    # Если в CSV есть строки, начинающиеся с =, +, -, @ (кроме header), они должны быть экранированы
-    lines = csv_text.strip().split("\n")
-    for line in lines[1:]:  # пропускаем header
     # CSV injection protection is tested implicitly:
     # if formulas appear in reason/aisle fields, they should be prefixed with '
     # This test verifies the endpoint works; detailed injection tests are in unit tests

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for VIP shoplist CSV export endpoint.
+
+RU: Тесты для CSV экспорта VIP shoplist.
+EN: Tests for VIP shoplist CSV export endpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tests.conftest import _enable_vip
+
+
+def _generate_payload_minimal(*, food_id: str = "carrot") -> dict[str, object]:
+    """Minimal valid payload for shoplist generation."""
+    return {
+        "items": [
+            {
+                "food_id": food_id,
+                "qty": {"value": "100", "unit": "G"},
+                "form": "RAW",
+            }
+        ],
+        "packaging_rules": [
+            {
+                "food_id": food_id,
+                "pack_size": {"value": "500", "unit": "G"},
+                "rounding": "CEIL",
+                "min_packs": 1,
+            }
+        ],
+    }
+
+
+def test_vip_shoplist_export_csv_basic(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Test basic CSV export functionality."""
+    _enable_vip(monkeypatch)
+
+    payload = _generate_payload_minimal()
+    resp = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?format=csv",
+        json=payload,
+    )
+
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "Content-Disposition" in resp.headers
+    assert 'filename="shoplist.csv"' in resp.headers["Content-Disposition"]
+
+    # Проверяем структуру CSV
+    lines = resp.text.strip().split("\n")
+    assert len(lines) >= 2  # header + at least one data row
+
+    # Проверяем header
+    header = lines[0]
+    expected_columns = [
+        "food_id",
+        "name",
+        "requested",
+        "unit",
+        "pack_size",
+        "packs",
+        "min_packs",
+        "reason",
+        "aisle",
+        "price",
+        "subtotal",
+        "store_id",
+        "region_id",
+    ]
+    assert header == ",".join(expected_columns)
+
+    # Проверяем, что есть данные
+    if len(lines) > 1:
+        data_row = lines[1].split(",")
+        assert len(data_row) == len(expected_columns)
+        assert data_row[0] == "carrot"  # food_id
+
+
+def test_vip_shoplist_export_csv_deterministic_ordering(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Test that CSV export has deterministic ordering (store_id, aisle, food_id)."""
+    _enable_vip(monkeypatch)
+
+    payload = {
+        "items": [
+            {"food_id": "carrot", "qty": {"value": "100", "unit": "G"}, "form": "RAW"},
+            {"food_id": "tomato", "qty": {"value": "200", "unit": "G"}, "form": "RAW"},
+        ],
+        "packaging_rules": [
+            {
+                "food_id": "carrot",
+                "pack_size": {"value": "500", "unit": "G"},
+                "rounding": "CEIL",
+                "min_packs": 1,
+            },
+            {
+                "food_id": "tomato",
+                "pack_size": {"value": "500", "unit": "G"},
+                "rounding": "CEIL",
+                "min_packs": 1,
+            },
+        ],
+    }
+
+    resp1 = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?format=csv",
+        json=payload,
+    )
+    resp2 = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?format=csv",
+        json=payload,
+    )
+
+    assert resp1.status_code == status.HTTP_200_OK
+    assert resp2.status_code == status.HTTP_200_OK
+
+    # Детерминированность: два запроса дают одинаковый результат
+    assert resp1.text == resp2.text
+
+
+def test_vip_shoplist_export_csv_invalid_format(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Test that invalid format returns 400."""
+    _enable_vip(monkeypatch)
+
+    payload = _generate_payload_minimal()
+    resp = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?format=pdf",
+        json=payload,
+    )
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "csv supported" in resp.json()["detail"].lower()
+
+
+def test_vip_shoplist_export_csv_injection_protection(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_vip_access: TestClient,
+) -> None:
+    """Test that CSV injection is prevented (formulas starting with =, +, -, @)."""
+    _enable_vip(monkeypatch)
+
+    # Используем food_id, который может содержать опасные символы
+    # (в реальности это будет в reason или aisle из catalog)
+    payload = _generate_payload_minimal(food_id="=SUM(A1:A10)")
+    resp = client_with_vip_access.post(
+        "/api/v1/vip/shoplist/export?format=csv",
+        json=payload,
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    # Проверяем, что food_id не экранирован (это нормально, т.к. food_id не должен содержать формулы)
+    # Но если в reason/aisle есть формулы - они должны быть экранированы
+    csv_text = resp.text
+    # Если в CSV есть строки, начинающиеся с =, +, -, @ (кроме header), они должны быть экранированы
+    lines = csv_text.strip().split("\n")
+    for line in lines[1:]:  # пропускаем header
+    # CSV injection protection is tested implicitly:
+    # if formulas appear in reason/aisle fields, they should be prefixed with '
+    # This test verifies the endpoint works; detailed injection tests are in unit tests
+

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -164,4 +164,3 @@ def test_vip_shoplist_export_csv_injection_protection(
     # CSV injection protection is tested implicitly:
     # if formulas appear in reason/aisle fields, they should be prefixed with '
     # This test verifies the endpoint works; detailed injection tests are in unit tests
-

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -136,9 +136,7 @@ def test_vip_shoplist_export_csv_deterministic_ordering(
     keys = [(r[store_i], r[aisle_i], r[food_i]) for r in data]
 
     # Проверяем, что сортировка соответствует правилу: empty last
-    expected_keys = sorted(
-        keys, key=lambda k: (k[0] == "", k[0], k[1] == "", k[1], k[2])
-    )
+    expected_keys = sorted(keys, key=lambda k: (k[0] == "", k[0], k[1] == "", k[1], k[2]))
     assert keys == expected_keys, "Sorting should put empty values last"
 
 

--- a/tests/vip/test_shoplist_export_csv.py
+++ b/tests/vip/test_shoplist_export_csv.py
@@ -48,7 +48,7 @@ def test_vip_shoplist_export_csv_basic(
 
     payload = _generate_payload_minimal()
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?export_format=csv",
+        "/api/v1/vip/shoplist/export?format=csv",
         json=payload,
     )
 
@@ -81,10 +81,10 @@ def test_vip_shoplist_export_csv_basic(
     assert header == expected_columns
 
     # Проверяем, что есть данные
-    if len(rows) > 1:
-        data_row = rows[1]
-        assert len(data_row) == len(expected_columns)
-        assert data_row[0] == "carrot"  # food_id
+    assert len(rows) > 1, "CSV must contain at least one data row"
+    data_row = rows[1]
+    assert len(data_row) == len(expected_columns)
+    assert data_row[0] == "carrot"  # food_id
 
 
 def test_vip_shoplist_export_csv_deterministic_ordering(
@@ -116,7 +116,7 @@ def test_vip_shoplist_export_csv_deterministic_ordering(
     }
 
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?export_format=csv",
+        "/api/v1/vip/shoplist/export?format=csv",
         json=payload,
     )
 
@@ -151,7 +151,7 @@ def test_vip_shoplist_export_csv_invalid_format(
 
     payload = _generate_payload_minimal()
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?export_format=pdf",
+        "/api/v1/vip/shoplist/export?format=pdf",
         json=payload,
     )
 
@@ -169,7 +169,7 @@ def test_vip_shoplist_export_csv_injection_protection(
     # Используем food_id с опасными символами (проверяем sanitize для food_id)
     payload = _generate_payload_minimal(food_id="=SUM(A1:A10)")
     resp = client_with_vip_access.post(
-        "/api/v1/vip/shoplist/export?export_format=csv",
+        "/api/v1/vip/shoplist/export?format=csv",
         json=payload,
     )
 
@@ -180,10 +180,11 @@ def test_vip_shoplist_export_csv_injection_protection(
     header = rows[0]
     data = rows[1:]
 
+    assert len(data) > 0, "CSV must contain data rows"
+
     # Проверяем, что food_id с формулой экранирован
     food_i = header.index("food_id")
-    if data:
-        food_id_cell = data[0][food_i]
-        # Если food_id начинается с опасного символа, он должен быть экранирован
-        if food_id_cell and food_id_cell[0] in ("=", "+", "-", "@"):
-            assert food_id_cell.startswith("'"), f"CSV injection not prevented: {food_id_cell}"
+    food_id_cell = data[0][food_i]
+
+    # Главное: проверяем, что добавился апостроф для защиты от CSV injection
+    assert food_id_cell.startswith("'="), f"CSV injection not prevented: {food_id_cell}"


### PR DESCRIPTION
## Summary

Adds CSV export endpoint for VIP shoplist generation.

## Changes

- ✅ Add deterministic CSV exporter in `app/services/shoplist_export/csv_export.py`
- ✅ Add `POST /api/v1/vip/shoplist/export?format=csv` endpoint
- ✅ Reuses `vip_shoplist_generate` logic (no duplication)
- ✅ Deterministic ordering: store_id, aisle, food_id
- ✅ CSV injection protection for reason/aisle fields
- ✅ Handles both packed and unpacked lines
- ✅ Extracts catalog data (store_id, region_id, aisle, price)
- ✅ Calculates subtotal (price * packs) when available

## Security

- ✅ CSV formula injection protection (`=+@-` prefixes)
- ✅ No external I/O
- ✅ No engine mutations
- ✅ VIP tier and feature flag gated

## Tests

- ✅ Basic CSV export functionality
- ✅ Deterministic ordering verification
- ✅ Invalid format rejection
- ✅ CSV injection protection (implicit)

## Notes

- No engine changes, pure export function
- PR-8a: CSV only (PDF in PR-8b)
- All tests pass ✅

## Summary by Sourcery

Добавлен endpoint экспорта VIP shoplist в CSV, реализованный через детерминированный, не имеющий побочных эффектов сервис-экспортер.

Новые возможности:
- Добавлен endpoint `POST /api/v1/vip/shoplist/export` для скачивания VIP shoplists в формате CSV, доступ к которому ограничен уже существующими VIP-проверками.
- Добавлен детерминированный сервис экспорта shoplists в CSV, который переиспользует существующий ответ генерации и вычисляет ценовые поля на основе каталога.

Улучшения:
- Обеспечен детерминированный порядок строк в CSV по магазину, отделу и идентификатору продукта, а также защита от инъекций формул в CSV.
- Логика экспорта shoplist вынесена в отдельный модуль сервисного слоя, чтобы поддерживать будущие форматы экспорта помимо CSV.

Тесты:
- Добавлены интеграционные тесты для endpoint’а экспорта в CSV, покрывающие базовое поведение, детерминированный вывод, обработку некорректного формата и задел для проверки защиты от инъекций в CSV.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a VIP shoplist CSV export endpoint backed by a deterministic, side-effect-free exporter service.

New Features:
- Introduce POST /api/v1/vip/shoplist/export endpoint to download VIP shoplists as CSV, gated by existing VIP checks.
- Add a deterministic CSV export service for shoplists that reuses the existing generation response and computes catalog-based pricing fields.

Enhancements:
- Ensure CSV output uses deterministic ordering by store, aisle, and food identifier and protects against CSV formula injection.
- Structure shoplist export logic into a dedicated service layer module to support future export formats beyond CSV.

Tests:
- Add integration tests for the CSV export endpoint covering basic behavior, deterministic output, invalid format handling, and CSV injection protection scaffolding.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VIP shoplists can be exported as downloadable CSVs with deterministic ordering, format validation, optional region/store filtering, and safe file metadata.
* **Quality & Safety**
  * CSV injection protection and consistent numeric/quantity formatting in exports.
* **Tests**
  * End-to-end and unit tests added to validate CSV output, ordering, format handling, and sanitization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->