### PR TITLE
Fix/pr 8c shoplist daily dry

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -21,6 +21,41 @@
 - Keep API schema changes in sync with `app/schemas/` and tests.
 - Apply tier guards (`require_pro_tier`, VIP) consistently on gated endpoints.
 
+## Export/PDF invariants (hard rules) (PR-8b / PR-8c)
+
+### PDF export must be import-safe
+- `reportlab` must be imported lazily (inside the handler/function), never at module import time.
+- Use `_lazy_reportlab()` helper in `app/services/shoplist_export/pdf_export.py` for lazy imports.
+- `ImportError` for optional PDF deps must return HTTP `501 Not Implemented` (no auto-install, no fallback hacks).
+- Export modules/routers must have no import-time side effects beyond normal router registration.
+
+### Determinism and data preparation
+- PDF/CSV prepared output must be deterministic (use a canonical stable sort; e.g. `store_id → aisle → food_id`).
+- Keep data preparation in a pure function (no `reportlab`) so tests can validate determinism without rendering.
+- Use `build_pdf_lines()` in `pdf_export.py` to prepare `PdfLine` objects before rendering.
+- Sorting key: `(store_id == "", store_id, aisle == "", aisle, food_id)` (non-empty values first).
+
+### Product layout (PR-8b)
+- PDF layout must group by `store → aisle` with clear visual hierarchy.
+- Include subtotals per aisle and grand total at the end.
+- Currency formatting: use `_fmt_money()` with quantize to 0.01, include currency code when available.
+- Do not include exception details in error messages (security: no info leak).
+
+### Contract freeze
+- VIP auth behavior (`403`) and the VIP error response shape are contract-frozen; do not change without a dedicated PR.
+
+## VIP contract + router invariants (PR-8c / #456)
+
+### VIP error contract (frozen)
+- VIP tier denial is `403` (do not use `401` for “has auth but not VIP”).
+- VIP error responses must preserve the established envelope contract:
+  - `status: "error"`, `code`, `message`
+  - legacy aliases must remain: `detail == message`, `error == code` (see `app/contracts/vip_contract.py`).
+
+### Router registration (centralized + idempotent)
+- VIP router registration must be centralized via `app/routers/vip_registration.py:register_vip_routes`.
+- Do not scatter conditional `include_router(...)` calls across modules; keep registration explicit and safe to call multiple times.
+
 ## No duplicated business logic (app vs core)
 
 - Routers and services must not re-implement domain logic.

--- a/app/services/shoplist_export/pdf_export.py
+++ b/app/services/shoplist_export/pdf_export.py
@@ -25,6 +25,21 @@ from app.schemas.vip_shoplist import (
 )
 
 
+_REPORTLAB_UNSET = object()
+
+# reportlab is an optional dependency; keep module import-safe by initializing these lazily
+colors: Any = _REPORTLAB_UNSET
+A4: Any = _REPORTLAB_UNSET
+getSampleStyleSheet: Any = _REPORTLAB_UNSET
+mm: Any = _REPORTLAB_UNSET
+Flowable: Any = _REPORTLAB_UNSET
+Paragraph: Any = _REPORTLAB_UNSET
+SimpleDocTemplate: Any = _REPORTLAB_UNSET
+Spacer: Any = _REPORTLAB_UNSET
+Table: Any = _REPORTLAB_UNSET
+TableStyle: Any = _REPORTLAB_UNSET
+
+
 def _fmt_decimal(value: Decimal | None) -> str:
     """
     RU: Decimal -> строка без scientific notation.
@@ -87,11 +102,56 @@ def _lazy_reportlab():
     Returns:
         Tuple of reportlab components: (colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle)
     """
-    from reportlab.lib import colors
-    from reportlab.lib.pagesizes import A4
-    from reportlab.lib.styles import getSampleStyleSheet
-    from reportlab.lib.units import mm
-    from reportlab.platypus import Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+    global A4, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle, colors, getSampleStyleSheet, mm
+
+    if any(
+        value is _REPORTLAB_UNSET
+        for value in (
+            colors,
+            A4,
+            getSampleStyleSheet,
+            mm,
+            Flowable,
+            Paragraph,
+            SimpleDocTemplate,
+            Spacer,
+            Table,
+            TableStyle,
+        )
+    ):
+        from reportlab.lib import colors as _colors
+        from reportlab.lib.pagesizes import A4 as _A4
+        from reportlab.lib.styles import getSampleStyleSheet as _getSampleStyleSheet
+        from reportlab.lib.units import mm as _mm
+        from reportlab.platypus import (
+            Flowable as _Flowable,
+            Paragraph as _Paragraph,
+            SimpleDocTemplate as _SimpleDocTemplate,
+            Spacer as _Spacer,
+            Table as _Table,
+            TableStyle as _TableStyle,
+        )
+
+        if colors is _REPORTLAB_UNSET:
+            colors = _colors
+        if A4 is _REPORTLAB_UNSET:
+            A4 = _A4
+        if getSampleStyleSheet is _REPORTLAB_UNSET:
+            getSampleStyleSheet = _getSampleStyleSheet
+        if mm is _REPORTLAB_UNSET:
+            mm = _mm
+        if Flowable is _REPORTLAB_UNSET:
+            Flowable = _Flowable
+        if Paragraph is _REPORTLAB_UNSET:
+            Paragraph = _Paragraph
+        if SimpleDocTemplate is _REPORTLAB_UNSET:
+            SimpleDocTemplate = _SimpleDocTemplate
+        if Spacer is _REPORTLAB_UNSET:
+            Spacer = _Spacer
+        if Table is _REPORTLAB_UNSET:
+            Table = _Table
+        if TableStyle is _REPORTLAB_UNSET:
+            TableStyle = _TableStyle
 
     return colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
@@ -113,6 +173,7 @@ class PdfLine:
     price: str
     subtotal: str
     subtotal_value: Decimal
+    currency_code: str | None  # Currency code (e.g., "EUR", "USD") or None
 
 
 def _sort_key(line: PackedLineDTO | UnpackedLineDTO) -> tuple[bool, str, bool, str, str]:
@@ -163,6 +224,7 @@ def build_pdf_lines(response: ShoplistGenerateResponse) -> list[PdfLine]:
         price_str = ""
         subtotal_str = ""
         subtotal_value = Decimal("0")
+        currency_code: str | None = None
 
         if isinstance(line, PackedLineDTO):
             packs = int(line.packs)
@@ -193,6 +255,7 @@ def build_pdf_lines(response: ShoplistGenerateResponse) -> list[PdfLine]:
                 price=price_str,
                 subtotal=subtotal_str,
                 subtotal_value=subtotal_value,
+                currency_code=currency_code,
             )
         )
     return out
@@ -215,9 +278,18 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
         PDF data as bytes
     """
     # Lazy import reportlab to keep module import-safe
-    colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle = (
-        _lazy_reportlab()
-    )
+    (
+        colors,
+        A4,
+        getSampleStyleSheet,
+        mm,
+        Flowable,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    ) = _lazy_reportlab()
 
     buffer: io.BytesIO | None = None
     try:
@@ -344,11 +416,9 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
                         ]
                     )
                     aisle_subtotal += pdf_line.subtotal_value
-                    if currency_code is None and pdf_line.price:
-                        # Extract currency from first price (assume all same currency)
-                        currency_code = (
-                            pdf_line.price.split()[-1] if " " in pdf_line.price else None
-                        )
+                    # Use currency_code from PdfLine (no string parsing)
+                    if currency_code is None and pdf_line.currency_code:
+                        currency_code = pdf_line.currency_code
 
                 # Aisle subtotal
                 if aisle:
@@ -398,8 +468,14 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
         # Make store/aisle headers and totals bold
         for row_idx, row in enumerate(table_data):
             if row_idx > 0:  # Skip header
-                cell_value = str(row[0]) if row else ""
-                if cell_value.startswith("STORE:") or cell_value.startswith("  Aisle:") or cell_value.startswith("Subtotal") or cell_value.startswith("GRAND TOTAL"):
+                col0 = str(row[0]) if len(row) > 0 and row[0] is not None else ""
+                col4 = str(row[4]) if len(row) > 4 and row[4] is not None else ""
+                if (
+                    col0.startswith("STORE:")
+                    or col0.startswith("  Aisle:")
+                    or col4.startswith("Subtotal")
+                    or col4.startswith("GRAND TOTAL")
+                ):
                     style_commands.append(("FONTNAME", (0, row_idx), (-1, row_idx), "Helvetica-Bold"))
         table.setStyle(TableStyle(style_commands))
         elements.append(table)

--- a/app/services/shoplist_export/pdf_export.py
+++ b/app/services/shoplist_export/pdf_export.py
@@ -16,8 +16,9 @@ import io
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Tuple, Tuple
+from typing import Any, Tuple
 
+from app.schemas.catalog import CurrencyDTO
 from app.schemas.vip_shoplist import (
     PackedLineDTO,
     ShoplistGenerateResponse,
@@ -243,11 +244,9 @@ def build_pdf_lines(response: ShoplistGenerateResponse) -> list[PdfLine]:
                 _fmt_quantity(line.pack_size.value, line.pack_size.unit) if line.pack_size else ""
             )
             if line.catalog and line.catalog.price:
-                # Get currency code (CurrencyDTO enum has .value attribute)
+                currency = line.catalog.price.currency
                 currency_code = (
-                    line.catalog.price.currency.value
-                    if hasattr(line.catalog.price.currency, "value")
-                    else str(line.catalog.price.currency)
+                    currency.value if isinstance(currency, CurrencyDTO) else str(currency)
                 )
                 price_str = _fmt_money(line.catalog.price.value, currency_code)
                 if packs > 0:

--- a/app/services/shoplist_export/pdf_export.py
+++ b/app/services/shoplist_export/pdf_export.py
@@ -16,7 +16,7 @@ import io
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any
+from typing import Any, Tuple, Tuple
 
 from app.schemas.vip_shoplist import (
     PackedLineDTO,
@@ -94,7 +94,7 @@ def _get_reason_str(line: PackedLineDTO | UnpackedLineDTO) -> str:
     return line.reason or ""
 
 
-def _lazy_reportlab():
+def _lazy_reportlab() -> Tuple[Any, ...]:
     """
     RU: Ленивый импорт reportlab (модуль должен импортироваться без reportlab).
     EN: Lazy import reportlab (module must be import-safe without reportlab).
@@ -153,7 +153,18 @@ def _lazy_reportlab():
         if TableStyle is _REPORTLAB_UNSET:
             TableStyle = _TableStyle
 
-    return colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+    return (
+        colors,
+        A4,
+        getSampleStyleSheet,
+        mm,
+        Flowable,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
 
 
 @dataclass(frozen=True)
@@ -476,7 +487,9 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
                     or col4.startswith("Subtotal")
                     or col4.startswith("GRAND TOTAL")
                 ):
-                    style_commands.append(("FONTNAME", (0, row_idx), (-1, row_idx), "Helvetica-Bold"))
+                    style_commands.append(
+                        ("FONTNAME", (0, row_idx), (-1, row_idx), "Helvetica-Bold")
+                    )
         table.setStyle(TableStyle(style_commands))
         elements.append(table)
 

--- a/app/services/shoplist_export/pdf_export.py
+++ b/app/services/shoplist_export/pdf_export.py
@@ -14,13 +14,9 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
+from dataclasses import dataclass
 from decimal import Decimal
-
-from reportlab.lib import colors
-from reportlab.lib.pagesizes import A4
-from reportlab.lib.styles import getSampleStyleSheet
-from reportlab.lib.units import mm
-from reportlab.platypus import Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from typing import Any
 
 from app.schemas.vip_shoplist import (
     PackedLineDTO,
@@ -50,6 +46,29 @@ def _fmt_quantity(value: Decimal | None, unit: str | None) -> str:
     return f"{_fmt_decimal(value)} {unit_str}".strip()
 
 
+# Money formatting constants
+MONEY_Q = Decimal("0.01")
+
+
+def _fmt_money(value: Decimal | None, currency: str | None) -> str:
+    """
+    RU: Форматирует деньги (value + currency) для PDF.
+    EN: Formats money (value + currency) for PDF.
+
+    Args:
+        value: Decimal value (quantized to 0.01)
+        currency: Currency code (e.g., "EUR", "USD") or None
+
+    Returns:
+        Formatted string (e.g., "1.50 EUR" or "1.50")
+    """
+    if value is None:
+        return ""
+    v = value.quantize(MONEY_Q)
+    cur = currency or ""
+    return f"{format(v, 'f')} {cur}".strip()
+
+
 def _get_reason_str(line: PackedLineDTO | UnpackedLineDTO) -> str:
     """
     RU: Извлекает reason как строку (для packed = reasons.join, для unpacked = reason).
@@ -58,6 +77,42 @@ def _get_reason_str(line: PackedLineDTO | UnpackedLineDTO) -> str:
     if isinstance(line, PackedLineDTO):
         return "; ".join(line.reasons) if line.reasons else ""
     return line.reason or ""
+
+
+def _lazy_reportlab():
+    """
+    RU: Ленивый импорт reportlab (модуль должен импортироваться без reportlab).
+    EN: Lazy import reportlab (module must be import-safe without reportlab).
+
+    Returns:
+        Tuple of reportlab components: (colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle)
+    """
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.lib.units import mm
+    from reportlab.platypus import Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+    return colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+
+@dataclass(frozen=True)
+class PdfLine:
+    """
+    RU: Подготовленная строка для PDF (pure data, без reportlab).
+    EN: Prepared line for PDF (pure data, no reportlab).
+    """
+
+    store_id: str
+    aisle: str
+    food_id: str
+    requested: str
+    pack_size: str
+    packs: int | None
+    reason: str
+    price: str
+    subtotal: str
+    subtotal_value: Decimal
 
 
 def _sort_key(line: PackedLineDTO | UnpackedLineDTO) -> tuple[bool, str, bool, str, str]:
@@ -80,6 +135,69 @@ def _sort_key(line: PackedLineDTO | UnpackedLineDTO) -> tuple[bool, str, bool, s
     return (store_id == "", store_id, aisle == "", aisle, line.food_id)
 
 
+def build_pdf_lines(response: ShoplistGenerateResponse) -> list[PdfLine]:
+    """
+    RU: Подготавливает строки для PDF (pure transformation, без reportlab).
+    EN: Prepares lines for PDF (pure transformation, no reportlab).
+
+    Args:
+        response: ShoplistGenerateResponse from generate endpoint
+
+    Returns:
+        List of PdfLine objects, sorted by (store_id, aisle, food_id)
+    """
+    all_lines: list[PackedLineDTO | UnpackedLineDTO] = [*response.packed, *response.unpacked]
+    sorted_lines = sorted(all_lines, key=_sort_key)
+
+    out: list[PdfLine] = []
+    for line in sorted_lines:
+        store_id = line.catalog.store_id if (line.catalog and line.catalog.store_id) else ""
+        aisle = line.catalog.aisle if (line.catalog and line.catalog.aisle) else ""
+
+        requested_qty = (
+            _fmt_quantity(line.requested.value, line.requested.unit) if line.requested else ""
+        )
+
+        pack_size_qty = ""
+        packs: int | None = None
+        price_str = ""
+        subtotal_str = ""
+        subtotal_value = Decimal("0")
+
+        if isinstance(line, PackedLineDTO):
+            packs = int(line.packs)
+            pack_size_qty = (
+                _fmt_quantity(line.pack_size.value, line.pack_size.unit) if line.pack_size else ""
+            )
+            if line.catalog and line.catalog.price:
+                # Get currency code (CurrencyDTO enum has .value attribute)
+                currency_code = (
+                    line.catalog.price.currency.value
+                    if hasattr(line.catalog.price.currency, "value")
+                    else str(line.catalog.price.currency)
+                )
+                price_str = _fmt_money(line.catalog.price.value, currency_code)
+                if packs > 0:
+                    subtotal_value = line.catalog.price.value * Decimal(packs)
+                    subtotal_str = _fmt_money(subtotal_value, currency_code)
+
+        out.append(
+            PdfLine(
+                store_id=store_id,
+                aisle=aisle,
+                food_id=line.food_id,
+                requested=requested_qty,
+                pack_size=pack_size_qty,
+                packs=packs,
+                reason=_get_reason_str(line),
+                price=price_str,
+                subtotal=subtotal_str,
+                subtotal_value=subtotal_value,
+            )
+        )
+    return out
+
+
 def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
     """
     RU: Экспортирует shoplist в PDF (строго детерминированно).
@@ -96,6 +214,11 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
     Returns:
         PDF data as bytes
     """
+    # Lazy import reportlab to keep module import-safe
+    colors, A4, getSampleStyleSheet, mm, Flowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle = (
+        _lazy_reportlab()
+    )
+
     buffer: io.BytesIO | None = None
     try:
         buffer = io.BytesIO()
@@ -108,30 +231,49 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
 
         styles = getSampleStyleSheet()
 
-        elements: list[Flowable] = []
+        # Type hint: Flowable is imported lazily, use Any for type checking
+        elements: list[Any] = []
 
         # Title
         elements.append(Paragraph("PulsePlate — VIP Shoplist", styles["Title"]))
         elements.append(Spacer(1, 5 * mm))
 
-        # Metadata (extract from first line's catalog if available)
+        # Build PDF lines (pure data preparation)
+        pdf_lines: list[PdfLine] = build_pdf_lines(response)
+
+        # Metadata (extract from first non-empty catalog if available)
         meta_info: list[str] = []
-        all_lines: list[PackedLineDTO | UnpackedLineDTO] = []
-        all_lines.extend(response.packed)
-        all_lines.extend(response.unpacked)
-        if all_lines and all_lines[0].catalog:
-            if all_lines[0].catalog.region_id:
-                meta_info.append(f"Region ID: {all_lines[0].catalog.region_id}")
-            if all_lines[0].catalog.store_id:
-                meta_info.append(f"Store ID: {all_lines[0].catalog.store_id}")
+        # Find first non-empty catalog from original response
+        all_original_lines: list[PackedLineDTO | UnpackedLineDTO] = []
+        all_original_lines.extend(response.packed)
+        all_original_lines.extend(response.unpacked)
+        first_catalog = None
+        for line in all_original_lines:
+            if line.catalog:
+                first_catalog = line.catalog
+                break
+        if first_catalog:
+            if first_catalog.region_id:
+                meta_info.append(f"Region ID: {first_catalog.region_id}")
+            if first_catalog.store_id:
+                meta_info.append(f"Store ID: {first_catalog.store_id}")
         if meta_info:
             elements.append(Paragraph(" | ".join(meta_info), styles["Normal"]))
             elements.append(Spacer(1, 5 * mm))
 
-        # Sort lines (same logic as CSV)
-        sorted_lines = sorted(all_lines, key=_sort_key)
+        # Group lines by store → aisle
+        # Structure: {store_id: {aisle: [lines]}}
+        grouped: dict[str, dict[str, list[PdfLine]]] = {}
+        for pdf_line in pdf_lines:
+            store_id = pdf_line.store_id or ""
+            aisle = pdf_line.aisle or ""
+            if store_id not in grouped:
+                grouped[store_id] = {}
+            if aisle not in grouped[store_id]:
+                grouped[store_id][aisle] = []
+            grouped[store_id][aisle].append(pdf_line)
 
-        # Table Header
+        # Build table with grouping and subtotals
         table_data: list[list[str]] = [
             [
                 "Food ID",
@@ -139,74 +281,138 @@ def export_shoplist_to_pdf(response: ShoplistGenerateResponse) -> bytes:
                 "Pack Size",
                 "Packs",
                 "Reason",
-                "Aisle",
                 "Price",
                 "Subtotal",
             ]
         ]
 
-        # Populate table data
-        for line in sorted_lines:
-            requested_qty = (
-                _fmt_quantity(line.requested.value, line.requested.unit) if line.requested else ""
-            )
-            pack_size_qty = ""
-            packs_str = ""  # empty for unpacked
-            reason_str = _get_reason_str(line)
-            aisle_str = line.catalog.aisle if (line.catalog and line.catalog.aisle) else ""
-            price_str = ""
-            subtotal_str = ""
+        grand_total = Decimal("0")
+        currency_code: str | None = None
 
-            if isinstance(line, PackedLineDTO):
-                pack_size_qty = (
-                    _fmt_quantity(line.pack_size.value, line.pack_size.unit)
-                    if line.pack_size
-                    else ""
+        # Sort stores (non-empty first)
+        sorted_stores = sorted(grouped.keys(), key=lambda s: (s == "", s))
+
+        for store_id in sorted_stores:
+            store_lines = grouped[store_id]
+            # Store header
+            if store_id:
+                table_data.append(
+                    [
+                        f"STORE: {store_id}",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                    ]
                 )
-                packs_str = str(line.packs)
 
-                if line.catalog and line.catalog.price:
-                    price_str = _fmt_decimal(line.catalog.price.value)
+            # Sort aisles (non-empty first)
+            sorted_aisles = sorted(store_lines.keys(), key=lambda a: (a == "", a))
 
-                # Calculate subtotal (price * packs)
-                if line.catalog and line.catalog.price and line.packs > 0:
-                    subtotal_str = _fmt_decimal(line.catalog.price.value * line.packs)
+            for aisle in sorted_aisles:
+                aisle_lines = store_lines[aisle]
+                aisle_subtotal = Decimal("0")
 
-            table_data.append(
-                [
-                    line.food_id,
-                    requested_qty,
-                    pack_size_qty,
-                    packs_str,
-                    reason_str,
-                    aisle_str,
-                    price_str,
-                    subtotal_str,
-                ]
-            )
+                # Aisle header
+                if aisle:
+                    table_data.append(
+                        [
+                            f"  Aisle: {aisle}",
+                            "",
+                            "",
+                            "",
+                            "",
+                            "",
+                            "",
+                        ]
+                    )
+
+                # Items in aisle
+                for pdf_line in aisle_lines:
+                    packs_str = str(pdf_line.packs) if pdf_line.packs is not None else ""
+                    table_data.append(
+                        [
+                            pdf_line.food_id,
+                            pdf_line.requested,
+                            pdf_line.pack_size,
+                            packs_str,
+                            pdf_line.reason,
+                            pdf_line.price,
+                            pdf_line.subtotal,
+                        ]
+                    )
+                    aisle_subtotal += pdf_line.subtotal_value
+                    if currency_code is None and pdf_line.price:
+                        # Extract currency from first price (assume all same currency)
+                        currency_code = (
+                            pdf_line.price.split()[-1] if " " in pdf_line.price else None
+                        )
+
+                # Aisle subtotal
+                if aisle:
+                    subtotal_str = _fmt_money(aisle_subtotal, currency_code)
+                    table_data.append(
+                        [
+                            "",
+                            "",
+                            "",
+                            "",
+                            f"Subtotal ({aisle}):",
+                            "",
+                            subtotal_str,
+                        ]
+                    )
+
+                grand_total += aisle_subtotal
+
+        # Grand total row
+        grand_total_str = _fmt_money(grand_total, currency_code)
+        table_data.append(
+            [
+                "",
+                "",
+                "",
+                "",
+                "GRAND TOTAL:",
+                "",
+                grand_total_str,
+            ]
+        )
 
         table = Table(table_data)
-        table.setStyle(
-            TableStyle(
-                [
-                    ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
-                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
-                    ("ALIGN", (0, 0), (-1, -1), "LEFT"),
-                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                    ("BOTTOMPADDING", (0, 0), (-1, 0), 6),
-                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                    ("LEFTPADDING", (0, 0), (-1, -1), 2),
-                    ("RIGHTPADDING", (0, 0), (-1, -1), 2),
-                ]
-            )
-        )
+        # Build style commands
+        style_commands: list[tuple[Any, ...]] = [
+            ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+            ("ALIGN", (5, 1), (6, -1), "RIGHT"),  # Price and Subtotal right-aligned
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+            ("BOTTOMPADDING", (0, 0), (-1, 0), 6),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ("LEFTPADDING", (0, 0), (-1, -1), 2),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 2),
+        ]
+        # Make store/aisle headers and totals bold
+        for row_idx, row in enumerate(table_data):
+            if row_idx > 0:  # Skip header
+                cell_value = str(row[0]) if row else ""
+                if cell_value.startswith("STORE:") or cell_value.startswith("  Aisle:") or cell_value.startswith("Subtotal") or cell_value.startswith("GRAND TOTAL"):
+                    style_commands.append(("FONTNAME", (0, row_idx), (-1, row_idx), "Helvetica-Bold"))
+        table.setStyle(TableStyle(style_commands))
         elements.append(table)
 
         doc.build(elements)
         return buffer.getvalue()
+    except ImportError:
+        # Re-raise ImportError so caller can handle it as 501
+        raise
     except Exception as exc:
         logging.exception("PDF generation failed")
-        raise RuntimeError(f"Failed to generate PDF: {exc}") from exc
+        # Do not include exception details in error message (security: no info leak)
+        raise RuntimeError("PDF generation failed") from exc
     finally:
         if buffer is not None:
             with contextlib.suppress(Exception):

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -16,6 +16,27 @@
 - Preserve xdist DB isolation: each worker gets its own SQLite path.
 - Prefer `monkeypatch` over global mutations; avoid real sleeps.
 
+## Coverage / diff-cover (process invariant)
+- CI uses diff coverage as a hard gate: PR-touched lines must reach 100% diff coverage (prefer small, targeted tests).
+- If CI reports diff-cover gaps, add focused `*_diff_coverage.py` tests rather than weakening production checks.
+
+## PDF export tests (PR-8b)
+
+### Test structure
+- Unit tests for data preparation: test `build_pdf_lines()` without PDF rendering (no reportlab dependency).
+- API tests for PDF bytes: verify `%PDF` header and non-empty content (no snapshot comparisons).
+- ImportError → 501 tests: verify that missing reportlab raises 501 with frozen error contract.
+
+### Key test files
+- `tests/vip/test_pdf_export_pr8b.py`: PR-8b specific tests (deterministic ordering, grouping, totals).
+- `tests/vip/test_pdf_export_diff_coverage.py`: diff-cover targeted tests.
+
+### Test invariants
+- Do NOT compare PDF bytes directly (non-deterministic due to timestamps/metadata).
+- Test data preparation (`PdfLine` objects) for determinism and correctness.
+- Test PDF generation only for basic validity (header + length).
+- Use `monkeypatch` to simulate `ImportError` for 501 tests (target `_lazy_reportlab`).
+
 ## Type hints policy (tests)
 
 ### Hard rules
@@ -56,6 +77,16 @@ If tempted to:
   (handled centrally in `pytest_configure`).
 - If a test imports symbols from `app`,
   a guard-test must assert their presence.
+
+## PDF export tests (hard rules)
+
+- ❌ No snapshot tests of raw PDF bytes (metadata/ordering/timezone/renderer variance is inherently flaky).
+- ✅ Prefer testing prepared “render rows” / data-model output for determinism and content.
+- ✅ If rendering is exercised, assert only coarse properties:
+  - `bytes` is non-empty (and optionally above a small minimum length)
+  - expected key strings are present (via text extraction or by validating prepared rows)
+- ✅ Required regression: missing optional PDF dependency (`ImportError(reportlab)`) returns HTTP `501`
+  and preserves the established error contract shape.
 
 ## No namespace duplication in tests (xdist stability)
 

--- a/tests/vip/test_pdf_export_diff_coverage.py
+++ b/tests/vip/test_pdf_export_diff_coverage.py
@@ -63,6 +63,7 @@ def test_export_shoplist_to_pdf_covers_packed_metadata_and_totals() -> None:
 
 def test_export_shoplist_to_pdf_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that exceptions in PDF generation are wrapped as RuntimeError."""
+
     class _BoomDoc:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass

--- a/tests/vip/test_pdf_export_diff_coverage.py
+++ b/tests/vip/test_pdf_export_diff_coverage.py
@@ -62,6 +62,7 @@ def test_export_shoplist_to_pdf_covers_packed_metadata_and_totals() -> None:
 
 
 def test_export_shoplist_to_pdf_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that exceptions in PDF generation are wrapped as RuntimeError."""
     class _BoomDoc:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
@@ -69,7 +70,36 @@ def test_export_shoplist_to_pdf_wraps_exceptions(monkeypatch: pytest.MonkeyPatch
         def build(self, _elements: object) -> None:
             raise ValueError("boom")
 
-    monkeypatch.setattr(pdf_export, "SimpleDocTemplate", _BoomDoc)
+    # Monkeypatch _lazy_reportlab to return _BoomDoc instead of SimpleDocTemplate
+    real_lazy = pdf_export._lazy_reportlab
+
+    def _mock_lazy_reportlab():
+        (
+            colors,
+            A4,
+            getSampleStyleSheet,
+            mm,
+            Flowable,
+            Paragraph,
+            _SimpleDocTemplate,
+            Spacer,
+            Table,
+            TableStyle,
+        ) = real_lazy()
+        return (
+            colors,
+            A4,
+            getSampleStyleSheet,
+            mm,
+            Flowable,
+            Paragraph,
+            _BoomDoc,
+            Spacer,
+            Table,
+            TableStyle,
+        )
+
+    monkeypatch.setattr(pdf_export, "_lazy_reportlab", _mock_lazy_reportlab)
 
     response = ShoplistGenerateResponse(
         packed=[],

--- a/tests/vip/test_pdf_export_diff_coverage.py
+++ b/tests/vip/test_pdf_export_diff_coverage.py
@@ -76,5 +76,5 @@ def test_export_shoplist_to_pdf_wraps_exceptions(monkeypatch: pytest.MonkeyPatch
         unpacked=[UnpackedLineDTO(food_id="carrot", requested=_qty("100"))],
     )
 
-    with pytest.raises(RuntimeError, match=r"Failed to generate PDF:"):
+    with pytest.raises(RuntimeError, match=r"PDF generation failed"):
         pdf_export.export_shoplist_to_pdf(response)

--- a/tests/vip/test_pdf_export_pr8b.py
+++ b/tests/vip/test_pdf_export_pr8b.py
@@ -92,9 +92,7 @@ class TestBuildPdfLinesDeterministic:
             catalog=catalog3,
         )
 
-        response = ShoplistGenerateResponse(
-            packed=[packed1, packed2, packed3], unpacked=[]
-        )
+        response = ShoplistGenerateResponse(packed=[packed1, packed2, packed3], unpacked=[])
 
         lines = pdf_export.build_pdf_lines(response)
 
@@ -132,9 +130,7 @@ class TestBuildPdfLinesDeterministic:
             reasons=["requested=100 G"],
             catalog=catalog1,
         )
-        unpacked1 = UnpackedLineDTO(
-            food_id="no-catalog", requested=_qty("200"), catalog=None
-        )
+        unpacked1 = UnpackedLineDTO(food_id="no-catalog", requested=_qty("200"), catalog=None)
 
         response = ShoplistGenerateResponse(packed=[packed1], unpacked=[unpacked1])
 
@@ -212,9 +208,7 @@ class TestBuildPdfLinesGrouping:
             catalog=catalog3,
         )
 
-        response = ShoplistGenerateResponse(
-            packed=[packed1, packed2, packed3], unpacked=[]
-        )
+        response = ShoplistGenerateResponse(packed=[packed1, packed2, packed3], unpacked=[])
 
         lines = pdf_export.build_pdf_lines(response)
 
@@ -330,21 +324,18 @@ class TestExportEndpointPdfImportError:
         self, monkeypatch: pytest.MonkeyPatch, client_with_vip_access
     ) -> None:
         """Test that ImportError in pdf_export raises 501 with frozen error contract."""
+
         # Monkeypatch _lazy_reportlab to raise ImportError
         def _mock_lazy_reportlab():
             raise ImportError("reportlab not available")
 
-        monkeypatch.setattr(
-            pdf_export, "_lazy_reportlab", _mock_lazy_reportlab
-        )
+        monkeypatch.setattr(pdf_export, "_lazy_reportlab", _mock_lazy_reportlab)
 
         # Enable VIP module
         monkeypatch.setattr("app.routers.vip_shoplist.is_vip_module_enabled", lambda: True)
 
         payload = {
-            "items": [
-                {"food_id": "carrot", "qty": {"value": "100", "unit": "G"}, "form": "RAW"}
-            ],
+            "items": [{"food_id": "carrot", "qty": {"value": "100", "unit": "G"}, "form": "RAW"}],
             "packaging_rules": [],
         }
 

--- a/tests/vip/test_pdf_export_pr8b.py
+++ b/tests/vip/test_pdf_export_pr8b.py
@@ -354,6 +354,18 @@ class TestExportEndpointPdfImportError:
 
         assert response.status_code == 501
         data = response.json()
-        # Verify frozen error contract
-        assert "detail" in data
-        assert data["detail"] == "PDF export is not available"
+
+        # Verify content-type is NOT application/pdf for 501
+        assert response.headers.get("content-type") != "application/pdf"
+
+        # Verify frozen error contract (supports both default FastAPI and VIP envelope)
+        assert (
+            data.get("detail") == "PDF export is not available"
+            or data.get("message") == "PDF export is not available"
+        )
+
+        # If VIP error envelope is present, verify invariants
+        if "status" in data:
+            assert data["status"] == "error"
+            assert data["detail"] == data["message"]
+            assert data["error"] == data["code"]

--- a/tests/vip/test_pdf_export_pr8b.py
+++ b/tests/vip/test_pdf_export_pr8b.py
@@ -1,0 +1,359 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for PR-8b: PDF export improvements (deterministic rows + product layout).
+
+RU: Тесты для PR-8b: улучшения PDF экспорта (детерминированные строки + product layout).
+EN: Tests for PR-8b: PDF export improvements (deterministic rows + product layout).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.schemas.catalog import CatalogInfoDTO, CurrencyDTO, MoneyDTO
+from app.schemas.vip_shoplist import (
+    PackedLineDTO,
+    QuantityDTO,
+    ShoplistGenerateResponse,
+    UnitDTO,
+    UnpackedLineDTO,
+)
+from app.services.shoplist_export import pdf_export
+
+
+def _qty(value: str, unit: UnitDTO = "G") -> QuantityDTO:
+    """Helper to create QuantityDTO."""
+    return QuantityDTO(value=Decimal(value), unit=unit)
+
+
+class TestBuildPdfLinesDeterministic:
+    """Test deterministic ordering in build_pdf_lines."""
+
+    def test_deterministic_ordering_store_aisle_food_id(self) -> None:
+        """Test that build_pdf_lines returns consistent order: store_id, aisle, food_id."""
+        catalog1 = CatalogInfoDTO(
+            sku="SKU-1",
+            store_id="store-b",
+            region_id="region-1",
+            aisle="Aisle-Z",
+            price=MoneyDTO(value=Decimal("1.50"), currency=CurrencyDTO.EUR),
+        )
+        catalog2 = CatalogInfoDTO(
+            sku="SKU-2",
+            store_id="store-a",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("2.00"), currency=CurrencyDTO.EUR),
+        )
+        catalog3 = CatalogInfoDTO(
+            sku="SKU-3",
+            store_id="store-a",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("1.00"), currency=CurrencyDTO.EUR),
+        )
+
+        packed1 = PackedLineDTO(
+            food_id="carrot-z",
+            requested=_qty("600"),
+            pack_size=_qty("500"),
+            packs=2,
+            provided=_qty("1000"),
+            overage=_qty("400"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=600 G"],
+            catalog=catalog1,
+        )
+        packed2 = PackedLineDTO(
+            food_id="apple-a",
+            requested=_qty("200"),
+            pack_size=_qty("100"),
+            packs=2,
+            provided=_qty("200"),
+            overage=_qty("0"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=200 G"],
+            catalog=catalog2,
+        )
+        packed3 = PackedLineDTO(
+            food_id="banana-a",
+            requested=_qty("300"),
+            pack_size=_qty("200"),
+            packs=2,
+            provided=_qty("400"),
+            overage=_qty("100"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=300 G"],
+            catalog=catalog3,
+        )
+
+        response = ShoplistGenerateResponse(
+            packed=[packed1, packed2, packed3], unpacked=[]
+        )
+
+        lines = pdf_export.build_pdf_lines(response)
+
+        # Expected order: store-a (before store-b), Aisle-A (before Aisle-Z), apple-a (before banana-a)
+        assert len(lines) == 3
+        assert lines[0].food_id == "apple-a"  # store-a, Aisle-A, apple-a
+        assert lines[0].store_id == "store-a"
+        assert lines[0].aisle == "Aisle-A"
+        assert lines[1].food_id == "banana-a"  # store-a, Aisle-A, banana-a
+        assert lines[1].store_id == "store-a"
+        assert lines[1].aisle == "Aisle-A"
+        assert lines[2].food_id == "carrot-z"  # store-b, Aisle-Z, carrot-z
+        assert lines[2].store_id == "store-b"
+        assert lines[2].aisle == "Aisle-Z"
+
+    def test_deterministic_ordering_empty_store_aisle_last(self) -> None:
+        """Test that empty store_id/aisle come last."""
+        catalog1 = CatalogInfoDTO(
+            sku="SKU-1",
+            store_id="store-a",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("1.50"), currency=CurrencyDTO.EUR),
+        )
+
+        packed1 = PackedLineDTO(
+            food_id="with-catalog",
+            requested=_qty("100"),
+            pack_size=_qty("100"),
+            packs=1,
+            provided=_qty("100"),
+            overage=_qty("0"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=100 G"],
+            catalog=catalog1,
+        )
+        unpacked1 = UnpackedLineDTO(
+            food_id="no-catalog", requested=_qty("200"), catalog=None
+        )
+
+        response = ShoplistGenerateResponse(packed=[packed1], unpacked=[unpacked1])
+
+        lines = pdf_export.build_pdf_lines(response)
+
+        # With catalog (store-a) should come before without catalog (empty store)
+        assert len(lines) == 2
+        assert lines[0].food_id == "with-catalog"
+        assert lines[0].store_id == "store-a"
+        assert lines[1].food_id == "no-catalog"
+        assert lines[1].store_id == ""
+
+
+class TestBuildPdfLinesGrouping:
+    """Test store→aisle grouping logic."""
+
+    def test_grouping_by_store_and_aisle(self) -> None:
+        """Test that lines are properly grouped by store and aisle."""
+        catalog1 = CatalogInfoDTO(
+            sku="SKU-1",
+            store_id="store-1",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("1.00"), currency=CurrencyDTO.EUR),
+        )
+        catalog2 = CatalogInfoDTO(
+            sku="SKU-2",
+            store_id="store-1",
+            region_id="region-1",
+            aisle="Aisle-B",
+            price=MoneyDTO(value=Decimal("2.00"), currency=CurrencyDTO.EUR),
+        )
+        catalog3 = CatalogInfoDTO(
+            sku="SKU-3",
+            store_id="store-2",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("3.00"), currency=CurrencyDTO.EUR),
+        )
+
+        packed1 = PackedLineDTO(
+            food_id="item-1",
+            requested=_qty("100"),
+            pack_size=_qty("100"),
+            packs=1,
+            provided=_qty("100"),
+            overage=_qty("0"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=100 G"],
+            catalog=catalog1,
+        )
+        packed2 = PackedLineDTO(
+            food_id="item-2",
+            requested=_qty("200"),
+            pack_size=_qty("200"),
+            packs=1,
+            provided=_qty("200"),
+            overage=_qty("0"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=200 G"],
+            catalog=catalog2,
+        )
+        packed3 = PackedLineDTO(
+            food_id="item-3",
+            requested=_qty("300"),
+            pack_size=_qty("300"),
+            packs=1,
+            provided=_qty("300"),
+            overage=_qty("0"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=300 G"],
+            catalog=catalog3,
+        )
+
+        response = ShoplistGenerateResponse(
+            packed=[packed1, packed2, packed3], unpacked=[]
+        )
+
+        lines = pdf_export.build_pdf_lines(response)
+
+        # Verify grouping: store-1 (Aisle-A, Aisle-B), store-2 (Aisle-A)
+        assert len(lines) == 3
+        # Order: store-1, Aisle-A, item-1
+        assert lines[0].store_id == "store-1"
+        assert lines[0].aisle == "Aisle-A"
+        assert lines[0].food_id == "item-1"
+        # Order: store-1, Aisle-B, item-2
+        assert lines[1].store_id == "store-1"
+        assert lines[1].aisle == "Aisle-B"
+        assert lines[1].food_id == "item-2"
+        # Order: store-2, Aisle-A, item-3
+        assert lines[2].store_id == "store-2"
+        assert lines[2].aisle == "Aisle-A"
+        assert lines[2].food_id == "item-3"
+
+
+class TestBuildPdfLinesTotals:
+    """Test subtotal and total calculations."""
+
+    def test_subtotal_calculation_packed_lines(self) -> None:
+        """Test that subtotal_value is correctly calculated (price * packs)."""
+        catalog = CatalogInfoDTO(
+            sku="SKU-1",
+            store_id="store-1",
+            region_id="region-1",
+            aisle="Aisle-A",
+            price=MoneyDTO(value=Decimal("1.50"), currency=CurrencyDTO.EUR),
+        )
+
+        packed = PackedLineDTO(
+            food_id="carrot",
+            requested=_qty("600"),
+            pack_size=_qty("500"),
+            packs=2,
+            provided=_qty("1000"),
+            overage=_qty("400"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=600 G"],
+            catalog=catalog,
+        )
+
+        response = ShoplistGenerateResponse(packed=[packed], unpacked=[])
+
+        lines = pdf_export.build_pdf_lines(response)
+
+        assert len(lines) == 1
+        line = lines[0]
+        # subtotal = 1.50 * 2 = 3.00
+        assert line.subtotal_value == Decimal("3.00")
+        assert line.subtotal == "3.00 EUR"
+        assert line.price == "1.50 EUR"
+
+    def test_subtotal_zero_for_unpacked_lines(self) -> None:
+        """Test that unpacked lines have subtotal_value = 0."""
+        unpacked = UnpackedLineDTO(food_id="tomato", requested=_qty("200"))
+
+        response = ShoplistGenerateResponse(packed=[], unpacked=[unpacked])
+
+        lines = pdf_export.build_pdf_lines(response)
+
+        assert len(lines) == 1
+        line = lines[0]
+        assert line.subtotal_value == Decimal("0")
+        assert line.subtotal == ""
+        assert line.price == ""
+
+
+class TestExportShoplistToPdfBytes:
+    """Test PDF bytes generation."""
+
+    def test_export_returns_pdf_header_and_non_empty(self) -> None:
+        """Test that export_shoplist_to_pdf returns valid PDF bytes."""
+        catalog = CatalogInfoDTO(
+            sku="SKU-1",
+            store_id="store-1",
+            region_id="region-1",
+            aisle="Aisle-1",
+            price=MoneyDTO(value=Decimal("1.50"), currency=CurrencyDTO.EUR),
+        )
+
+        packed = PackedLineDTO(
+            food_id="carrot",
+            requested=_qty("600"),
+            pack_size=_qty("500"),
+            packs=2,
+            provided=_qty("1000"),
+            overage=_qty("400"),
+            rounding="CEIL",
+            min_packs=1,
+            reasons=["requested=600 G"],
+            catalog=catalog,
+        )
+        unpacked = UnpackedLineDTO(food_id="tomato", requested=_qty("200"))
+
+        response = ShoplistGenerateResponse(packed=[packed], unpacked=[unpacked])
+
+        pdf_data = pdf_export.export_shoplist_to_pdf(response)
+
+        # Verify PDF header
+        assert pdf_data.startswith(b"%PDF")
+        # Verify non-empty (should be at least 500 bytes for a simple PDF)
+        assert len(pdf_data) > 500
+
+
+class TestExportEndpointPdfImportError:
+    """Test ImportError → 501 handling at endpoint level."""
+
+    def test_export_endpoint_pdf_importerror_returns_501(
+        self, monkeypatch: pytest.MonkeyPatch, client_with_vip_access
+    ) -> None:
+        """Test that ImportError in pdf_export raises 501 with frozen error contract."""
+        # Monkeypatch _lazy_reportlab to raise ImportError
+        def _mock_lazy_reportlab():
+            raise ImportError("reportlab not available")
+
+        monkeypatch.setattr(
+            pdf_export, "_lazy_reportlab", _mock_lazy_reportlab
+        )
+
+        # Enable VIP module
+        monkeypatch.setattr("app.routers.vip_shoplist.is_vip_module_enabled", lambda: True)
+
+        payload = {
+            "items": [
+                {"food_id": "carrot", "qty": {"value": "100", "unit": "G"}, "form": "RAW"}
+            ],
+            "packaging_rules": [],
+        }
+
+        response = client_with_vip_access.post(
+            "/api/v1/vip/shoplist/export?export_format=pdf", json=payload
+        )
+
+        assert response.status_code == 501
+        data = response.json()
+        # Verify frozen error contract
+        assert "detail" in data
+        assert data["detail"] == "PDF export is not available"


### PR DESCRIPTION
# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Уточнить экспорт PDF VIP-списка покупок, сделав его детерминированным, добавить ленивую зависимость от reportlab и сгруппированные итоги, а также ужесточить обработку ошибок и расширить тесты и документацию, связанные с экспортом PDF и требованиями по покрытию.

New Features:
- Добавить структурированную модель данных `PdfLine` и вспомогательную функцию `build_pdf_lines()` для подготовки детерминированных, тестируемых строк PDF, независимых от `reportlab`.
- Добавить группировку по магазину и отделу (aisle) с подсчётом промежуточных итогов по отделу и общего итога для макета PDF VIP-списка покупок, включая учитывающий валюту формат денег.

Bug Fixes:
- Обеспечить ленивый импорт опциональной зависимости `reportlab` и проброс `ImportError` в виде ответа 501 на уровне API.
- Обернуть сбои генерации PDF в общее сообщение `RuntimeError` без утечки деталей внутренних исключений.

Enhancements:
- Рефакторинг логики экспорта в PDF с разделением чистой подготовки данных и рендеринга, что улучшает детерминизм и тестируемость.
- Улучшить оформление таблиц в генерируемых PDF, включая выравнивание и выделение жирным заголовков магазина/отдела и строк итогов.
- Скорректировать извлечение метаданных для заголовка PDF так, чтобы использовать первую доступную запись каталога, а не предполагать наличие данных каталога в первой строке.

Documentation:
- Задокументировать жёсткие инварианты и контракты для экспорта PDF, поведения VIP и регистрации роутера в `app/AGENTS.md`, а также уточнить политику тестирования и инварианты для экспорта PDF и diff coverage в `tests/AGENTS.md`.

Tests:
- Добавить комплексные тесты для детерминизма построения строк PDF, группировки и денежных итогов, а также сквозной генерации байтов PDF и поведения ImportError→501.
- Обновить ориентированные на diff coverage тесты, чтобы проверить обёртку исключений в экспорте PDF с использованием нового механизма ленивого импорта и сообщения `RuntimeError`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine VIP shoplist PDF export to be deterministic, lazily depend on reportlab, and provide grouped totals, while tightening error handling and expanding tests and docs around PDF export and coverage requirements.

New Features:
- Add structured PdfLine data model and build_pdf_lines() helper to prepare deterministic, testable PDF rows independent of reportlab.
- Add store and aisle grouping with per-aisle subtotals and a grand total to the VIP shoplist PDF layout, including currency-aware money formatting.

Bug Fixes:
- Ensure optional reportlab dependency is imported lazily and that ImportError is surfaced as a 501 response at the API layer.
- Wrap PDF generation failures in a generic RuntimeError message without leaking internal exception details.

Enhancements:
- Refactor PDF export logic to separate pure data preparation from rendering, improving determinism and testability.
- Improve table styling in generated PDFs, including alignment and bolding of store/aisle headers and total rows.
- Adjust metadata extraction for the PDF header to use the first available catalog entry rather than assuming the first line has catalog data.

Documentation:
- Document hard invariants and contracts for PDF export, VIP behavior, and router registration in app/AGENTS.md and clarify testing policies and invariants for PDF export and diff coverage in tests/AGENTS.md.

Tests:
- Add comprehensive tests for PDF line building determinism, grouping, and money totals, along with end-to-end PDF byte generation and ImportError→501 behavior.
- Update diff-coverage-focused tests to exercise exception wrapping in PDF export using the new lazy import mechanism and RuntimeError message.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF exports now group items by store and aisle with subtotals and grand totals.
  * Enhanced currency formatting in exported PDFs.

* **Bug Fixes**
  * Improved error handling when the PDF library is unavailable (returns 501 error).

* **Documentation**
  * Added comprehensive documentation for PDF export behavior and error contracts.

* **Tests**
  * Expanded test coverage for PDF export functionality and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->