### PR TITLE
Feat/pr 457 plan delegation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1599,16 +1599,9 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/test_targeted_coverage_improvement.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 20
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_targeted_coverage_improvement.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 20
       }
     ],
     "tests/test_targets_coverage.py": [
@@ -1823,5 +1816,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-04T18:03:02Z"
+  "generated_at": "2026-01-06T07:05:32Z"
 }

--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ Production deployments are automated via GitHub Actions with manual approval gat
 
 ### Production Prerequisites
 
-- Production server configured (see [[PRODUCTION.md](docs/deploy/PRODUCTION.md)]([PRODUCTION.md](docs/deploy/PRODUCTION.md)))
+- Production server configured (see [PRODUCTION.md](docs/deploy/PRODUCTION.md))
 - GitHub environment `production` configured with required secrets
 - Protection rules enabled for manual approval
 
@@ -686,7 +686,7 @@ Production deployments are automated via GitHub Actions with manual approval gat
 - ✅ **Security headers** (HSTS, CSP, X-Frame-Options, etc.)
 - ✅ **Server hardening** (UFW, fail2ban, SSH key-only access)
 - ✅ **Resource limits** and monitoring
-- ✅ **Monitoring & alerting** (Prometheus, Grafana, PagerDuty) - see [[PRODUCTION.md](docs/deploy/PRODUCTION.md)]([PRODUCTION.md](docs/deploy/PRODUCTION.md)#monitoring)
+- ✅ **Monitoring & alerting** (Prometheus, Grafana, PagerDuty) - see [PRODUCTION.md](docs/deploy/PRODUCTION.md#monitoring)
 
 For detailed setup instructions, see:
 

--- a/core/bmi/compat_plan.py
+++ b/core/bmi/compat_plan.py
@@ -66,6 +66,10 @@ def _category_slug_from_bmi(*, bmi: Decimal, group: str) -> str | None:
     Used for minors when canonical engine returns category=None.
     Uses Decimal comparisons (policy-compliant: no float in core/).
     """
+    # too_young (age < 12): no category classification (canonical policy)
+    if group == "too_young":
+        return None
+
     # Legacy thresholds (from bmi_core.py and legacy_app.py)
     if group == "athlete":
         # Athlete threshold: 27.0

--- a/core/bmi/compat_plan.py
+++ b/core/bmi/compat_plan.py
@@ -1,0 +1,111 @@
+"""Compatibility helpers for legacy /plan.
+
+This module provides a small, policy-compliant bridge between the canonical BMI engine output
+and the legacy `/plan` endpoint contract in `legacy_app.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from core.i18n import Language, normalize_lang, t
+
+# Decimal thresholds (policy-compliant: no float in core/)
+D17_5 = Decimal("17.5")
+D18_5 = Decimal("18.5")
+D24_5 = Decimal("24.5")
+D25_0 = Decimal("25.0")
+D26_0 = Decimal("26.0")
+D27_0 = Decimal("27.0")
+D30_0 = Decimal("30.0")
+D35_0 = Decimal("35.0")
+D40_0 = Decimal("40.0")
+
+
+@dataclass(frozen=True)
+class LegacyPlanCategoryResult:
+    category: str | None
+
+
+def legacy_plan_category(
+    *,
+    engine_category: str | None,
+    bmi: Decimal,
+    age: int,
+    lang: str | Language | None,
+    group: str,
+) -> LegacyPlanCategoryResult:
+    """Return the legacy `/plan` category display string.
+
+    The canonical BMI engine returns category slugs (e.g. "normal") and may return None for
+    minors/pregnancy. The legacy `/plan` endpoint historically returns a string category for minors
+    (pregnancy is handled earlier in the endpoint).
+    """
+    # Normalize lang: normalize_lang handles str | None and returns Language
+    lang_norm = normalize_lang(lang)
+
+    category_slug = engine_category
+    if category_slug is None and age < 18:
+        # Legacy /plan parity: minors still receive a category string.
+        category_slug = _category_slug_from_bmi(bmi=bmi, group=group)
+
+    if category_slug is None:
+        return LegacyPlanCategoryResult(category=None)
+
+    i18n_key = _CATEGORY_I18N_KEY.get(category_slug)
+    if i18n_key is None:
+        return LegacyPlanCategoryResult(category=str(category_slug))
+
+    return LegacyPlanCategoryResult(category=t(lang_norm, i18n_key))
+
+
+def _category_slug_from_bmi(*, bmi: Decimal, group: str) -> str | None:
+    """Map BMI value to category slug based on legacy thresholds.
+
+    Used for minors when canonical engine returns category=None.
+    Uses Decimal comparisons (policy-compliant: no float in core/).
+    """
+    # Legacy thresholds (from bmi_core.py and legacy_app.py)
+    if group == "athlete":
+        # Athlete threshold: 27.0
+        if bmi < D27_0:
+            return "normal"
+        return "overweight"
+    elif group == "elderly":
+        # Elderly thresholds: 17.5 / 26.0
+        if bmi < D17_5:
+            return "underweight"
+        elif bmi < D26_0:
+            return "normal"
+        return "overweight"
+    elif group in ("child", "teen"):
+        # Child/teen thresholds: 17.5 / 24.5
+        if bmi < D17_5:
+            return "underweight"
+        elif bmi < D24_5:
+            return "normal"
+        return "overweight"
+    else:
+        # General thresholds: 18.5 / 25.0 / 30.0 / 35.0 / 40.0
+        if bmi < D18_5:
+            return "underweight"
+        elif bmi < D25_0:
+            return "normal"
+        elif bmi < D30_0:
+            return "overweight"
+        elif bmi < D35_0:
+            return "obesity_1"
+        elif bmi < D40_0:
+            return "obesity_2"
+        return "obesity_3"
+
+
+_CATEGORY_I18N_KEY: dict[str, str] = {
+    "underweight": "bmi_underweight",
+    "normal": "bmi_normal",
+    "overweight": "bmi_overweight",
+    "obesity_1": "bmi_obese_1",
+    "obesity_2": "bmi_obese_2",
+    "obesity_3": "bmi_obese_3",
+}

--- a/core/bmi/compat_plan.py
+++ b/core/bmi/compat_plan.py
@@ -17,7 +17,6 @@ D18_5 = Decimal("18.5")
 D24_5 = Decimal("24.5")
 D25_0 = Decimal("25.0")
 D26_0 = Decimal("26.0")
-D27_0 = Decimal("27.0")
 D30_0 = Decimal("30.0")
 D35_0 = Decimal("35.0")
 D40_0 = Decimal("40.0")
@@ -72,10 +71,19 @@ def _category_slug_from_bmi(*, bmi: Decimal, group: str) -> str | None:
 
     # Legacy thresholds (from bmi_core.py and legacy_app.py)
     if group == "athlete":
-        # Athlete threshold: 27.0
-        if bmi < D27_0:
+        # Legacy /plan parity: athlete still uses full adult BMI buckets.
+        # Underweight/obesity tiers must remain reachable.
+        if bmi < D18_5:
+            return "underweight"
+        elif bmi < D25_0:
             return "normal"
-        return "overweight"
+        elif bmi < D30_0:
+            return "overweight"
+        elif bmi < D35_0:
+            return "obesity_1"
+        elif bmi < D40_0:
+            return "obesity_2"
+        return "obesity_3"
     elif group == "elderly":
         # Elderly thresholds: 17.5 / 26.0
         if bmi < D17_5:

--- a/docs/runbooks/TESTING_BEST_PRACTICES.md
+++ b/docs/runbooks/TESTING_BEST_PRACTICES.md
@@ -41,10 +41,7 @@ pplint    # Run linting
 ppformat  # Format code
 ppcheck   # Full quality check
 
-	# Specific test analysis
-	pytest --maxfail=10 --junit-xml=test_results.xml --tb=short
-	pytest --cov=. --cov-fail-under=97 -q
-	```
+### 4. Project-Specific Commands
 
 ## Key Issues Identified in Current Test Run
 

--- a/docs/runbooks/TESTING_BEST_PRACTICES.md
+++ b/docs/runbooks/TESTING_BEST_PRACTICES.md
@@ -33,6 +33,7 @@ pytest-report --xml=test_results.xml
 - Save results to files instead of piping to commands
 
 ### 4. Project-Specific Commands
+
 ```bash
 # Project CLI commands
 pptest    # Run all tests
@@ -40,8 +41,7 @@ ppcov     # Run tests with coverage
 pplint    # Run linting
 ppformat  # Format code
 ppcheck   # Full quality check
-
-### 4. Project-Specific Commands
+```
 
 ## Key Issues Identified in Current Test Run
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -131,7 +131,7 @@ except ImportError:
 slowapi_available = Limiter is not None
 
 vip_router: Optional[APIRouter] = None
-_scheduler_getter: Optional[Callable[[], Awaitable[Any]]] = None
+_scheduler_getter: Optional[Callable[[], Awaitable[DatabaseUpdateScheduler]]] = None
 
 # Track whether the app is running on a degraded/fallback database so /health/db
 # can report an accurate status (used by tests simulating DB failures).
@@ -396,7 +396,7 @@ def _calculate_all_tdee_wrapper(
 
 
 # Test hook for overriding get_update_scheduler (used by rollback endpoint tests)
-_test_scheduler_override: Optional[Callable[[], Awaitable[Any]]] = None
+_test_scheduler_override: Optional[Callable[[], Awaitable[DatabaseUpdateScheduler]]] = None
 
 
 async def get_update_scheduler() -> DatabaseUpdateScheduler:
@@ -404,13 +404,19 @@ async def get_update_scheduler() -> DatabaseUpdateScheduler:
     # Check test override first (for FastAPI endpoint testing via TestClient)
     import sys as _sys
 
-    pkg_override = getattr(_sys.modules.get("app"), "_test_scheduler_override", None)
-    active_override = pkg_override if pkg_override is not None else _test_scheduler_override
+    pkg_override_raw = getattr(_sys.modules.get("app"), "_test_scheduler_override", None)
+    pkg_override = cast(
+        Optional[Callable[[], Awaitable[DatabaseUpdateScheduler]]],
+        pkg_override_raw,
+    )
+    active_override: Optional[Callable[[], Awaitable[DatabaseUpdateScheduler]]] = (
+        pkg_override if pkg_override is not None else _test_scheduler_override
+    )
 
     if active_override is not None:
         logger.debug(f"Using test scheduler override: {active_override}")
         override_scheduler = await active_override()
-        return cast(DatabaseUpdateScheduler, override_scheduler)
+        return override_scheduler
 
     if _scheduler_getter is None:
         from core.food_apis.scheduler import get_update_scheduler as _late_getter

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -416,7 +416,7 @@ async def get_update_scheduler() -> DatabaseUpdateScheduler:
         from core.food_apis.scheduler import get_update_scheduler as _late_getter
 
         result = await _late_getter()
-        return result
+        return cast(DatabaseUpdateScheduler, result)
     result = await _scheduler_getter()
     return cast(DatabaseUpdateScheduler, result)
 
@@ -1427,14 +1427,15 @@ class BMIRequest(BaseModel):
             values["gender"] = mapping.get(s, s)
         # Normalize string booleans for pregnant/athlete
         # IMPORTANT: athlete keywords must NEVER imply pregnant=True
-        _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-        _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
+        _YES_VALUES_BASE = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+        _YES_VALUES_PREGNANT = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
+        _YES_VALUES_ATHLETE = _YES_VALUES_BASE | {"спортсмен", "athlete"}
 
-        # Normalize pregnant (default yes values only)
+        # Normalize pregnant (pregnancy synonyms supported)
         v_pregnant = values.get("pregnant")
         if isinstance(v_pregnant, str):
             vs = v_pregnant.strip().lower()
-            values["pregnant"] = vs in _YES_VALUES_DEFAULT
+            values["pregnant"] = vs in _YES_VALUES_PREGNANT
 
         # Normalize athlete (includes sport keywords)
         v_athlete = values.get("athlete")
@@ -1496,7 +1497,7 @@ class BMIRequestV1(BaseModel):
         """Validate that weight and height are realistic."""
         # Check for unrealistic weight (too low for height)
         height_m = self.height_cm / 100.0
-        bmi = self.weight_kg / (height_m**2)
+        bmi = float(self.weight_kg) / (height_m**2)
 
         if bmi < 10:  # Unrealistically low BMI
             raise ValueError("Weight is unrealistically low for the given height")
@@ -2240,16 +2241,12 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     engine_category = canonical.get("category")
 
     # For pregnant, legacy /plan returns category=None (preserved)
-    # Normalize pregnant flag inline for category=None check only
+    # Normalize pregnant for category=None decision (legacy parity + synonym support).
     # IMPORTANT: athlete keywords must NEVER imply pregnant=True
-    _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+    _YES_VALUES_BASE = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+    _YES_VALUES_PREGNANT = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
 
-    def _normalize_bool_inline(value: str | bool, *, yes_values: set[str]) -> bool:
-        """Thin wrapper over canonical bool normalization (no duplication)."""
-        return _normalize_bool_flag(value, yes_values=yes_values)
-
-    # IMPORTANT: athlete keywords must NEVER imply pregnant=True
-    pregnant_bool = _normalize_bool_inline(req.pregnant, yes_values=_YES_VALUES_DEFAULT)
+    pregnant_bool = _normalize_bool_flag(req.pregnant, yes_values=_YES_VALUES_PREGNANT)
     if pregnant_bool:
         cat = None
     else:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2193,8 +2193,12 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     # 3) Preserve legacy /plan category behavior
     # RU: minors должны получать строковую категорию, даже если engine.category=None.
     # EN: minors must receive a string category even if engine.category=None.
-    # Normalize flags inline (no legacy helper in request-path, PR-457=A)
-    # Use same logic as canonical handler for consistency
+    # Use canonical group (engine is SoT for group determination)
+    canonical_group = canonical.get("group") or "general"
+    engine_category = canonical.get("category")
+
+    # For pregnant, legacy /plan returns category=None (preserved)
+    # Normalize pregnant flag inline for category=None check only
     def _normalize_bool_inline(value: str | bool) -> bool:
         """Inline bool normalization (matches canonical handler logic)."""
         if isinstance(value, bool):
@@ -2205,10 +2209,6 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
         return s in {"yes", "y", "true", "1", "да", "д", "si", "sí", "спортсмен", "athlete"}
 
     pregnant_bool = _normalize_bool_inline(req.pregnant)
-    athlete_bool = _normalize_bool_inline(req.athlete)
-    engine_category = canonical.get("category")
-    group = "athlete" if athlete_bool else "general"
-    # For pregnant, legacy /plan returns category=None (preserved)
     if pregnant_bool:
         cat = None
     else:
@@ -2217,7 +2217,7 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
             bmi=bmi_dec,
             age=req.age,
             lang=req.lang,
-            group=group,
+            group=canonical_group,  # Use engine-decided group (child/teen/elderly/athlete/pregnant/general)
         )
         cat = cat_result.category
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1425,14 +1425,21 @@ class BMIRequest(BaseModel):
             }
             values["gender"] = mapping.get(s, s)
         # Normalize string booleans for pregnant/athlete
-        for k in ("pregnant", "athlete"):
-            v = values.get(k)
-            if isinstance(v, str):
-                vs = v.strip().lower()
-                if vs in {"yes", "y", "да", "si", "sí", "true"}:
-                    values[k] = True
-                elif vs in {"no", "n", "нет", "false"}:
-                    values[k] = False
+        # IMPORTANT: athlete keywords must NEVER imply pregnant=True
+        _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+        _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
+
+        # Normalize pregnant (default yes values only)
+        v_pregnant = values.get("pregnant")
+        if isinstance(v_pregnant, str):
+            vs = v_pregnant.strip().lower()
+            values["pregnant"] = vs in _YES_VALUES_DEFAULT
+
+        # Normalize athlete (includes sport keywords)
+        v_athlete = values.get("athlete")
+        if isinstance(v_athlete, str):
+            vs = v_athlete.strip().lower()
+            values["athlete"] = vs in _YES_VALUES_ATHLETE
         if "with_visualization" in values:
             raw_visualization = values.get("with_visualization")
             include_chart = False
@@ -1567,6 +1574,21 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 
 
 # ---------- Core logic ----------
+
+
+def calc_bmi(weight_kg: StrictFloat, height_m: float) -> float:
+    """
+    COMPAT: legacy public API.
+    Kept for backward compatibility (import surface), not used in request-path.
+
+    Uses canonical engine for calculation (policy-compliant: no duplicate BMI math).
+    """
+    # Import here to avoid circular dependencies
+    from core.bmi.engine import _compute_bmi  # compat import (core-only)
+
+    # Canonical compute returns float; legacy surface returns float rounded to 1dp
+    bmi = _compute_bmi(weight_kg=weight_kg, height_m=height_m)
+    return round(bmi, 1)
 
 
 def waist_risk(waist_cm: Optional[float], gender_male: bool, lang: Language) -> str:
@@ -2162,16 +2184,21 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
 
     # For pregnant, legacy /plan returns category=None (preserved)
     # Normalize pregnant flag inline for category=None check only
-    def _normalize_bool_inline(value: str | bool) -> bool:
+    # IMPORTANT: athlete keywords must NEVER imply pregnant=True
+    _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+    _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
+
+    def _normalize_bool_inline(value: str | bool, *, yes_values: set[str]) -> bool:
         """Inline bool normalization (matches canonical handler logic)."""
         if isinstance(value, bool):
             return value
         if not isinstance(value, str):
             return False
         s = value.strip().lower()
-        return s in {"yes", "y", "true", "1", "да", "д", "si", "sí", "спортсмен", "athlete"}
+        return s in yes_values
 
-    pregnant_bool = _normalize_bool_inline(req.pregnant)
+    # IMPORTANT: athlete keywords must NEVER imply pregnant=True
+    pregnant_bool = _normalize_bool_inline(req.pregnant, yes_values=_YES_VALUES_DEFAULT)
     if pregnant_bool:
         cat = None
     else:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -418,7 +418,7 @@ async def get_update_scheduler() -> DatabaseUpdateScheduler:
         scheduler = await _late_getter()
         return scheduler
     scheduler = await _scheduler_getter()
-    return cast(DatabaseUpdateScheduler, scheduler)
+    return scheduler
 
 
 # Stable reference to the original getter for comparisons when monkeypatched in tests
@@ -2213,8 +2213,9 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     from app.routers.bmi import bmi_calculate_handler
 
     # 1) Delegate to canonical BMI handler (engine is SoT)
-    # Convert BMIRequest (height_m) to BMICalculateRequest (height_cm)
-    height_cm = req.height_m * 100.0
+    # Convert BMIRequest (height_m) to BMICalculateRequest (height_cm).
+    # Keep rounding consistent with /bmi shim to avoid boundary drift.
+    height_cm = round(req.height_m * 100.0, 1)
     bmi_payload = {
         "weight_kg": req.weight_kg,
         "height_cm": height_cm,
@@ -2226,7 +2227,8 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
         "waist_cm": req.waist_cm,
     }
 
-    # Call canonical handler (returns dict)
+    # Call canonical handler (returns dict).
+    # NOTE: /plan now inherits canonical validation (e.g., BMI bounds) from the handler.
     canonical = await bmi_calculate_handler(bmi_payload)
 
     # 2) Extract BMI (as Decimal for compat mapping)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2127,7 +2127,7 @@ async def bmi_endpoint(req: BMIRequest) -> Dict[str, Any]:
         canonical_req = BMICalculateRequest.model_validate(shim_payload)
     except ValidationError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=e.errors(),
         ) from e
 
@@ -2341,7 +2341,7 @@ async def bmi_endpoint_v1(req: BMIRequestV1) -> Dict[str, Any]:
         canonical_req = BMICalculateRequest.model_validate(shim_payload)
     except ValidationError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=e.errors(),
         ) from e
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1591,6 +1591,37 @@ def calc_bmi(weight_kg: StrictFloat, height_m: float) -> float:
     return round(bmi, 1)
 
 
+def normalize_flags(
+    gender: str, pregnant: Union[str, bool], athlete: Union[str, bool]
+) -> Dict[str, bool]:
+    """
+    COMPAT: legacy public API.
+    Kept for backward compatibility (import surface), not used in request-path.
+
+    Normalizes gender, pregnant, and athlete flags to boolean dict.
+    Uses canonical normalization logic (policy-compliant: no duplicate logic).
+    """
+    # Import here to avoid circular dependencies
+    from core.bmi.engine import _normalize_gender, _normalize_bool_flag
+
+    gender_norm = _normalize_gender(gender)
+    gender_male = gender_norm == "male"
+
+    # Normalize pregnant (default yes values only - athlete keywords must NOT imply pregnant)
+    _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+    is_pregnant = _normalize_bool_flag(pregnant, yes_values=_YES_VALUES_DEFAULT) and not gender_male
+
+    # Normalize athlete (includes sport keywords)
+    _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
+    is_athlete = _normalize_bool_flag(athlete, yes_values=_YES_VALUES_ATHLETE)
+
+    return {
+        "gender_male": gender_male,
+        "is_pregnant": is_pregnant,
+        "is_athlete": is_athlete,
+    }
+
+
 def waist_risk(waist_cm: Optional[float], gender_male: bool, lang: Language) -> str:
     if waist_cm is None:
         return ""

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2217,7 +2217,6 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     # Normalize pregnant flag inline for category=None check only
     # IMPORTANT: athlete keywords must NEVER imply pregnant=True
     _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-    _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
 
     def _normalize_bool_inline(value: str | bool, *, yes_values: set[str]) -> bool:
         """Inline bool normalization (matches canonical handler logic)."""

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1569,43 +1569,6 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 # ---------- Core logic ----------
 
 
-def calc_bmi(weight_kg: StrictFloat, height_m: float) -> float:
-    return round(float(weight_kg) / (height_m**2), 1)
-
-
-def normalize_flags(
-    gender: str, pregnant: Union[str, bool], athlete: Union[str, bool]
-) -> Dict[str, bool]:
-    gender_norm = {
-        "male": "male",
-        "муж": "male",
-        "м": "male",
-        "female": "female",
-        "жен": "female",
-        "ж": "female",
-    }.get(gender, gender)
-
-    # Handle boolean values directly, otherwise parse strings
-    if isinstance(pregnant, bool):
-        is_pregnant = pregnant and gender_norm == "female"
-    else:
-        preg_true = pregnant in {"да", "беременна", "pregnant", "yes", "y"}
-        preg_false = pregnant in {"нет", "no", "not", "n"}
-        is_pregnant = preg_true and gender_norm == "female" and not preg_false
-
-    # Handle boolean values directly, otherwise parse strings
-    if isinstance(athlete, bool):
-        is_athlete = athlete
-    else:
-        is_athlete = athlete in {"спортсмен", "да", "yes", "y", "athlete"}
-
-    return {
-        "gender_male": gender_norm == "male",
-        "is_pregnant": is_pregnant,
-        "is_athlete": is_athlete,
-    }
-
-
 def waist_risk(waist_cm: Optional[float], gender_male: bool, lang: Language) -> str:
     if waist_cm is None:
         return ""

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1474,14 +1474,16 @@ class BMIRequest(BaseModel):
     @model_validator(mode="after")
     def validate_realistic_values(self) -> "BMIRequest":
         """Validate that weight and height are realistic."""
-        # Check for unrealistic BMI values
-        MIN_BMI = 10
-        MAX_BMI = 50
-        bmi = self.weight_kg / (self.height_m**2)
+        # Check for unrealistic BMI values.
+        # Delegate BMI computation to canonical engine to avoid duplicate BMI math here.
+        from core.bmi.engine import _compute_bmi  # local import to avoid import-time cycles
 
-        if bmi < MIN_BMI:  # Unrealistically low BMI
+        bmi = _compute_bmi(weight_kg=self.weight_kg, height_m=self.height_m)
+
+        if bmi < 10.0:  # Unrealistically low BMI
             raise ValueError("Weight is unrealistically low for the given height")
-        if bmi > MAX_BMI:  # Unrealistically high BMI
+        # Align bounds with canonical engine (10–100) to avoid hidden contract drift.
+        if bmi > 100.0:  # Unrealistically high BMI
             raise ValueError(f"Weight is unrealistically high for the given height (BMI={bmi:.1f})")
 
         return self

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -64,7 +64,12 @@ from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
 from app.services import recipe_store
 from app.services.food_store import get_food
-from bmi_core import bmi_category
+
+# Legacy BMI helpers removed from request-path (PR-457=A)
+# /plan now delegates to canonical BMI engine via compat layer
+from decimal import Decimal
+
+from core.bmi.compat_plan import legacy_plan_category
 from bmi_visualization import MATPLOTLIB_AVAILABLE, generate_bmi_visualization
 from core.fingerprint_security import compute_fingerprint
 from core.log_retention import (
@@ -2155,22 +2160,78 @@ async def bmi_endpoint(req: BMIRequest) -> Dict[str, Any]:
 
 @app.post("/plan")
 async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
-    """Generate a personal plan based on BMI and user profile."""
-    flags = normalize_flags(req.gender, req.pregnant, req.athlete)
-    bmi = calc_bmi(req.weight_kg, req.height_m)
-    category = (
-        None
-        if flags["is_pregnant"]
-        else bmi_category(bmi, req.lang, req.age, "athlete" if flags["is_athlete"] else "general")
-    )
+    """
+    RU: Legacy endpoint /plan (contract must remain stable in PR-457=A).
+    EN: Legacy /plan endpoint (contract must remain stable in PR-457=A).
 
+    PR-457=A: Delegates to canonical BMI engine but preserves legacy response contract.
+    """
+    # Local import to avoid import cycles on app startup
+    from app.routers.bmi import bmi_calculate_handler
+
+    # 1) Delegate to canonical BMI handler (engine is SoT)
+    # Convert BMIRequest (height_m) to BMICalculateRequest (height_cm)
+    height_cm = req.height_m * 100.0
+    bmi_payload = {
+        "weight_kg": req.weight_kg,
+        "height_cm": height_cm,
+        "age": req.age,
+        "gender": req.gender,
+        "pregnant": req.pregnant,
+        "athlete": req.athlete,
+        "lang": req.lang,
+        "waist_cm": req.waist_cm,
+    }
+
+    # Call canonical handler (returns dict)
+    canonical = await bmi_calculate_handler(bmi_payload)
+
+    # 2) Extract BMI (as Decimal for compat mapping)
+    bmi_value = canonical.get("bmi")
+    bmi_dec = Decimal(str(bmi_value)) if bmi_value is not None else Decimal("0")
+
+    # 3) Preserve legacy /plan category behavior
+    # RU: minors должны получать строковую категорию, даже если engine.category=None.
+    # EN: minors must receive a string category even if engine.category=None.
+    # Normalize flags inline (no legacy helper in request-path, PR-457=A)
+    # Use same logic as canonical handler for consistency
+    def _normalize_bool_inline(value: str | bool) -> bool:
+        """Inline bool normalization (matches canonical handler logic)."""
+        if isinstance(value, bool):
+            return value
+        if not isinstance(value, str):
+            return False
+        s = value.strip().lower()
+        return s in {"yes", "y", "true", "1", "да", "д", "si", "sí", "спортсмен", "athlete"}
+
+    pregnant_bool = _normalize_bool_inline(req.pregnant)
+    athlete_bool = _normalize_bool_inline(req.athlete)
+    engine_category = canonical.get("category")
+    group = "athlete" if athlete_bool else "general"
+    # For pregnant, legacy /plan returns category=None (preserved)
+    if pregnant_bool:
+        cat = None
+    else:
+        cat_result = legacy_plan_category(
+            engine_category=engine_category,
+            bmi=bmi_dec,
+            age=req.age,
+            lang=req.lang,
+            group=group,
+        )
+        cat = cat_result.category
+
+    # 4) Build legacy /plan response shape (unchanged)
     healthy_bmi = {"min": 18.5, "max": 24.9}
 
-    if req.lang == "ru":
+    # ES fallback to EN (legacy behavior preserved)
+    lang_for_response = req.lang if req.lang in ("ru", "en") else "en"
+
+    if lang_for_response == "ru":
         base = {
             "summary": "Персональный план (MVP)",
-            "bmi": bmi,
-            "category": category,
+            "bmi": float(bmi_dec),
+            "category": cat,
             "premium": bool(req.premium),
             "next_steps": [
                 "Шаги: 7–10 тыс/день",
@@ -2188,8 +2249,8 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     else:
         base = {
             "summary": "Personal plan (MVP)",
-            "bmi": bmi,
-            "category": category,
+            "bmi": float(bmi_dec),
+            "category": cat,
             "premium": bool(req.premium),
             "next_steps": ["Steps: 7–10k/day", "Protein: 1.2–1.6 g/kg", "Sleep: 7–9 h"],
             "healthy_bmi": healthy_bmi,

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1610,15 +1610,34 @@ def normalize_flags(
 
     # Pregnant yes-values: includes pregnancy synonyms, but NOT athlete keywords
     _PREGNANT_YES_VALUES = {
-        "yes", "y", "true", "1", "да", "д", "si", "sí",
-        "pregnant", "беременна", "беременная",  # legacy pregnancy synonyms
+        "yes",
+        "y",
+        "true",
+        "1",
+        "да",
+        "д",
+        "si",
+        "sí",
+        "pregnant",
+        "беременна",
+        "беременная",  # legacy pregnancy synonyms
     }
-    is_pregnant = _normalize_bool_flag(pregnant, yes_values=_PREGNANT_YES_VALUES) and not gender_male
+    is_pregnant = (
+        _normalize_bool_flag(pregnant, yes_values=_PREGNANT_YES_VALUES) and not gender_male
+    )
 
     # Athlete yes-values: includes athlete keywords, but NOT pregnancy synonyms
     _ATHLETE_YES_VALUES = {
-        "yes", "y", "true", "1", "да", "д", "si", "sí",
-        "athlete", "спортсмен",  # athlete-only keywords
+        "yes",
+        "y",
+        "true",
+        "1",
+        "да",
+        "д",
+        "si",
+        "sí",
+        "athlete",
+        "спортсмен",  # athlete-only keywords
     }
     is_athlete = _normalize_bool_flag(athlete, yes_values=_ATHLETE_YES_VALUES)
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -409,16 +409,16 @@ async def get_update_scheduler() -> DatabaseUpdateScheduler:
 
     if active_override is not None:
         logger.debug(f"Using test scheduler override: {active_override}")
-        result = await active_override()
-        return cast(DatabaseUpdateScheduler, result)
+        override_scheduler = await active_override()
+        return cast(DatabaseUpdateScheduler, override_scheduler)
 
     if _scheduler_getter is None:
         from core.food_apis.scheduler import get_update_scheduler as _late_getter
 
-        result = await _late_getter()
-        return cast(DatabaseUpdateScheduler, result)
-    result = await _scheduler_getter()
-    return cast(DatabaseUpdateScheduler, result)
+        scheduler = await _late_getter()
+        return scheduler
+    scheduler = await _scheduler_getter()
+    return cast(DatabaseUpdateScheduler, scheduler)
 
 
 # Stable reference to the original getter for comparisons when monkeypatched in tests
@@ -2246,7 +2246,10 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     _YES_VALUES_BASE = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
     _YES_VALUES_PREGNANT = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
 
-    pregnant_bool = _normalize_bool_flag(req.pregnant, yes_values=_YES_VALUES_PREGNANT)
+    # Legacy parity: pregnancy only applies to female gender.
+    pregnant_bool = _normalize_bool_flag(req.pregnant, yes_values=_YES_VALUES_PREGNANT) and (
+        req.gender == "female"
+    )
     if pregnant_bool:
         cat = None
     else:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -70,6 +70,7 @@ from app.services.food_store import get_food
 from decimal import Decimal
 
 from core.bmi.compat_plan import legacy_plan_category
+from core.bmi.engine import _normalize_bool_flag
 from bmi_visualization import MATPLOTLIB_AVAILABLE, generate_bmi_visualization
 from core.fingerprint_security import compute_fingerprint
 from core.log_retention import (
@@ -2219,13 +2220,8 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
 
     def _normalize_bool_inline(value: str | bool, *, yes_values: set[str]) -> bool:
-        """Inline bool normalization (matches canonical handler logic)."""
-        if isinstance(value, bool):
-            return value
-        if not isinstance(value, str):
-            return False
-        s = value.strip().lower()
-        return s in yes_values
+        """Thin wrapper over canonical bool normalization (no duplication)."""
+        return _normalize_bool_flag(value, yes_values=yes_values)
 
     # IMPORTANT: athlete keywords must NEVER imply pregnant=True
     pregnant_bool = _normalize_bool_inline(req.pregnant, yes_values=_YES_VALUES_DEFAULT)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1608,13 +1608,19 @@ def normalize_flags(
     gender_norm = _normalize_gender(gender)
     gender_male = gender_norm == "male"
 
-    # Normalize pregnant (default yes values only - athlete keywords must NOT imply pregnant)
-    _YES_VALUES_DEFAULT = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-    is_pregnant = _normalize_bool_flag(pregnant, yes_values=_YES_VALUES_DEFAULT) and not gender_male
+    # Pregnant yes-values: includes pregnancy synonyms, but NOT athlete keywords
+    _PREGNANT_YES_VALUES = {
+        "yes", "y", "true", "1", "да", "д", "si", "sí",
+        "pregnant", "беременна", "беременная",  # legacy pregnancy synonyms
+    }
+    is_pregnant = _normalize_bool_flag(pregnant, yes_values=_PREGNANT_YES_VALUES) and not gender_male
 
-    # Normalize athlete (includes sport keywords)
-    _YES_VALUES_ATHLETE = _YES_VALUES_DEFAULT | {"спортсмен", "athlete"}
-    is_athlete = _normalize_bool_flag(athlete, yes_values=_YES_VALUES_ATHLETE)
+    # Athlete yes-values: includes athlete keywords, but NOT pregnancy synonyms
+    _ATHLETE_YES_VALUES = {
+        "yes", "y", "true", "1", "да", "д", "si", "sí",
+        "athlete", "спортсмен",  # athlete-only keywords
+    }
+    is_athlete = _normalize_bool_flag(athlete, yes_values=_ATHLETE_YES_VALUES)
 
     return {
         "gender_male": gender_male,

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1503,13 +1503,16 @@ class BMIRequestV1(BaseModel):
     @model_validator(mode="after")
     def validate_realistic_values(self) -> "BMIRequestV1":
         """Validate that weight and height are realistic."""
-        # Check for unrealistic weight (too low for height)
-        height_m = self.height_cm / 100.0
-        bmi = float(self.weight_kg) / (height_m**2)
+        # Check for unrealistic BMI values.
+        # Delegate BMI computation to canonical engine to avoid duplicate BMI math here.
+        from core.bmi.engine import _compute_bmi  # local import to avoid import-time cycles
 
-        if bmi < 10:  # Unrealistically low BMI
+        height_m = self.height_cm / 100.0
+        bmi = _compute_bmi(weight_kg=self.weight_kg, height_m=height_m)
+
+        if bmi < 10.0:  # Unrealistically low BMI
             raise ValueError("Weight is unrealistically low for the given height")
-        if bmi > 100:  # Unrealistically high BMI
+        if bmi > 100.0:  # Unrealistically high BMI
             raise ValueError("Weight is unrealistically high for the given height")
 
         return self

--- a/tests/test_compat_plan_category_mapping.py
+++ b/tests/test_compat_plan_category_mapping.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Таргетные тесты для покрытия compat слоя /plan category mapping.
+EN: Targeted coverage tests for compat /plan category mapping.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from core.bmi.compat_plan import legacy_plan_category
+from core.i18n import t
+
+
+@pytest.mark.parametrize(
+    "group,bmi,expected_i18n_key",
+    [
+        # athlete: full adult buckets must be reachable
+        ("athlete", Decimal("18.4"), "bmi_underweight"),
+        ("athlete", Decimal("24.9"), "bmi_normal"),
+        ("athlete", Decimal("29.9"), "bmi_overweight"),
+        ("athlete", Decimal("34.9"), "bmi_obese_1"),
+        ("athlete", Decimal("39.9"), "bmi_obese_2"),
+        ("athlete", Decimal("40.0"), "bmi_obese_3"),
+        # elderly
+        ("elderly", Decimal("17.4"), "bmi_underweight"),
+        ("elderly", Decimal("25.9"), "bmi_normal"),
+        ("elderly", Decimal("26.0"), "bmi_overweight"),
+        # teen/child thresholds
+        ("teen", Decimal("17.4"), "bmi_underweight"),
+        ("teen", Decimal("24.4"), "bmi_normal"),
+        ("teen", Decimal("24.5"), "bmi_overweight"),
+        # general thresholds full buckets
+        ("general", Decimal("18.4"), "bmi_underweight"),
+        ("general", Decimal("24.9"), "bmi_normal"),
+        ("general", Decimal("29.9"), "bmi_overweight"),
+        ("general", Decimal("34.9"), "bmi_obese_1"),
+        ("general", Decimal("39.9"), "bmi_obese_2"),
+        ("general", Decimal("40.0"), "bmi_obese_3"),
+    ],
+)
+def test_legacy_plan_category_minors_bucket_mapping(
+    group: str, bmi: Decimal, expected_i18n_key: str
+) -> None:
+    """
+    RU: Для minors (age<18) engine_category=None → compat вычисляет slug по bmi+group
+    и возвращает локализованную строку.
+    EN: For minors, compat computes slug by bmi+group and returns a localized string.
+    """
+    res = legacy_plan_category(
+        engine_category=None,  # force mapping path for minors
+        bmi=bmi,
+        age=15,
+        lang="en",
+        group=group,
+    )
+    assert res.category == t("en", expected_i18n_key)
+
+
+def test_legacy_plan_category_too_young_returns_none() -> None:
+    """
+    RU: group=too_young (age<12) не должен классифицироваться (category=None).
+    EN: too_young group should not be classified (category=None).
+    """
+    res = legacy_plan_category(
+        engine_category=None,
+        bmi=Decimal("19.0"),
+        age=11,
+        lang="en",
+        group="too_young",
+    )
+    assert res.category is None
+
+
+def test_legacy_plan_category_keeps_engine_category_when_present() -> None:
+    """
+    RU: Если engine_category задан, compat не должен пересчитывать по BMI.
+    EN: If engine_category is present, compat must not recompute it.
+    """
+    res = legacy_plan_category(
+        engine_category="normal",
+        bmi=Decimal("100.0"),
+        age=15,  # even for minors: do not recompute when engine_category is present
+        lang="en",
+        group="teen",
+    )
+    assert res.category == t("en", "bmi_normal")
+
+
+def test_legacy_plan_category_unknown_slug_falls_back_to_string() -> None:
+    """
+    RU: Если slug не известен _CATEGORY_I18N_KEY → вернуть как строку.
+    EN: If slug is not known to _CATEGORY_I18N_KEY, return it as string.
+    """
+    res = legacy_plan_category(
+        engine_category="custom_slug",
+        bmi=Decimal("22.0"),
+        age=30,
+        lang="en",
+        group="general",
+    )
+    assert res.category == "custom_slug"
+
+
+def test_legacy_plan_category_adult_with_none_engine_category_returns_none() -> None:
+    """
+    RU: engine_category=None + age>=18 → вернуть None (для взрослых этот слой не маппит по BMI).
+    EN: engine_category=None + age>=18 should return None (no BMI mapping for adults here).
+    """
+    res = legacy_plan_category(
+        engine_category=None,
+        bmi=Decimal("22.0"),
+        age=30,
+        lang="en",
+        group="general",
+    )
+    assert res.category is None

--- a/tests/test_legacy_bmi_shims.py
+++ b/tests/test_legacy_bmi_shims.py
@@ -228,6 +228,28 @@ def test_bmi_endpoint_v1_validation_error_maps_to_422(client: TestClient) -> Non
     assert isinstance(detail, list)
 
 
+def test_bmi_endpoint_v1_unrealistic_bmi_is_422(client: TestClient) -> None:
+    """
+    RU: BMIRequestV1 должен отклонять нереалистичный BMI > 100.
+    EN: BMIRequestV1 must reject unrealistic BMI > 100.
+
+    Regression: V1 validation now delegates BMI computation to core.bmi.engine._compute_bmi.
+    """
+    payload = {
+        "weight_kg": 320.0,  # BMI ~ 125 for 160cm
+        "height_cm": 160.0,
+        "age": 30,
+        "gender": "male",
+        "pregnant": "no",
+        "athlete": "no",
+        "waist_cm": 84.0,
+        "lang": "en",
+    }
+
+    resp = client.post("/api/v1/bmi", json=payload)
+    assert resp.status_code == 422
+
+
 def test_bmi_endpoint_v1_athlete_note_appends_waist_risk_notes_and_unknown_category_fallback(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_no_legacy_bmi_helpers_request_path.py
+++ b/tests/test_no_legacy_bmi_helpers_request_path.py
@@ -55,8 +55,7 @@ def test_no_legacy_bmi_imports_in_request_path() -> None:
                 for alias in node.names:
                     if alias.name in FORBIDDEN_IMPORT_MODULES:
                         violations.append(
-                            f"Forbidden import '{alias.name}' in {path} "
-                            f"(line {node.lineno})"
+                            f"Forbidden import '{alias.name}' in {path} " f"(line {node.lineno})"
                         )
 
             # Check: from bmi_core import ...
@@ -64,12 +63,11 @@ def test_no_legacy_bmi_imports_in_request_path() -> None:
                 mod = node.module or ""
                 if mod in FORBIDDEN_IMPORT_FROM:
                     violations.append(
-                        f"Forbidden import-from '{mod}' in {path} "
-                        f"(line {node.lineno})"
+                        f"Forbidden import-from '{mod}' in {path} " f"(line {node.lineno})"
                     )
 
-    assert not violations, (
-        "Legacy BMI helper imports found in request-path files:\n" + "\n".join(violations)
+    assert not violations, "Legacy BMI helper imports found in request-path files:\n" + "\n".join(
+        violations
     )
 
 
@@ -91,8 +89,7 @@ def test_no_legacy_bmi_calls_in_request_path() -> None:
                 if isinstance(fn, ast.Name):
                     if fn.id in FORBIDDEN_CALL_NAMES:
                         violations.append(
-                            f"Forbidden call '{fn.id}()' in {path} "
-                            f"(line {node.lineno})"
+                            f"Forbidden call '{fn.id}()' in {path} " f"(line {node.lineno})"
                         )
 
                 # Check: legacy_app.calc_bmi(...) or bmi_core.bmi_category(...)
@@ -103,7 +100,6 @@ def test_no_legacy_bmi_calls_in_request_path() -> None:
                             f"(line {node.lineno})"
                         )
 
-    assert not violations, (
-        "Legacy BMI helper calls found in request-path files:\n" + "\n".join(violations)
+    assert not violations, "Legacy BMI helper calls found in request-path files:\n" + "\n".join(
+        violations
     )
-

--- a/tests/test_no_legacy_bmi_helpers_request_path.py
+++ b/tests/test_no_legacy_bmi_helpers_request_path.py
@@ -32,8 +32,8 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def _parse(path: Path) -> ast.AST:
-    """Parse Python source file into AST."""
+def _parse(path: Path) -> ast.Module:
+    """Parse Python source file into AST Module."""
     full_path = _repo_root() / path
     src = full_path.read_text(encoding="utf-8")
     return ast.parse(src, filename=str(full_path))

--- a/tests/test_no_legacy_bmi_helpers_request_path.py
+++ b/tests/test_no_legacy_bmi_helpers_request_path.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Guard-тесты для предотвращения возврата legacy BMI helpers в request-path.
+EN: Guard tests to prevent legacy BMI helpers from returning to request-path.
+
+PR-457 Commit 4: Enforce that request-path endpoints do not use legacy BMI helpers.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# Request-path files that must not use legacy BMI helpers
+REQUEST_PATH_FILES = [
+    Path("legacy_app.py"),
+    Path("app/routers/bmi.py"),
+]
+
+# Forbidden import modules
+FORBIDDEN_IMPORT_MODULES = {"bmi_core"}
+
+# Forbidden import-from modules
+FORBIDDEN_IMPORT_FROM = {"bmi_core"}
+
+# Forbidden function call names
+FORBIDDEN_CALL_NAMES = {"calc_bmi", "normalize_flags", "bmi_category", "waist_risk"}
+
+
+def _repo_root() -> Path:
+    """Return repository root directory."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _parse(path: Path) -> ast.AST:
+    """Parse Python source file into AST."""
+    full_path = _repo_root() / path
+    src = full_path.read_text(encoding="utf-8")
+    return ast.parse(src, filename=str(full_path))
+
+
+def test_no_legacy_bmi_imports_in_request_path() -> None:
+    """
+    RU: Проверка, что request-path файлы не импортируют legacy BMI helpers.
+    EN: Verify request-path files do not import legacy BMI helpers.
+    """
+    violations: list[str] = []
+
+    for path in REQUEST_PATH_FILES:
+        tree = _parse(path)
+
+        for node in ast.walk(tree):
+            # Check: import bmi_core
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in FORBIDDEN_IMPORT_MODULES:
+                        violations.append(
+                            f"Forbidden import '{alias.name}' in {path} "
+                            f"(line {node.lineno})"
+                        )
+
+            # Check: from bmi_core import ...
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if mod in FORBIDDEN_IMPORT_FROM:
+                    violations.append(
+                        f"Forbidden import-from '{mod}' in {path} "
+                        f"(line {node.lineno})"
+                    )
+
+    assert not violations, (
+        "Legacy BMI helper imports found in request-path files:\n" + "\n".join(violations)
+    )
+
+
+def test_no_legacy_bmi_calls_in_request_path() -> None:
+    """
+    RU: Проверка, что request-path файлы не вызывают legacy BMI helpers.
+    EN: Verify request-path files do not call legacy BMI helpers.
+    """
+    violations: list[str] = []
+
+    for path in REQUEST_PATH_FILES:
+        tree = _parse(path)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                fn = node.func
+
+                # Check: calc_bmi(...) - direct call
+                if isinstance(fn, ast.Name):
+                    if fn.id in FORBIDDEN_CALL_NAMES:
+                        violations.append(
+                            f"Forbidden call '{fn.id}()' in {path} "
+                            f"(line {node.lineno})"
+                        )
+
+                # Check: legacy_app.calc_bmi(...) or bmi_core.bmi_category(...)
+                if isinstance(fn, ast.Attribute):
+                    if fn.attr in FORBIDDEN_CALL_NAMES:
+                        violations.append(
+                            f"Forbidden call '{fn.attr}()' via attribute in {path} "
+                            f"(line {node.lineno})"
+                        )
+
+    assert not violations, (
+        "Legacy BMI helper calls found in request-path files:\n" + "\n".join(violations)
+    )
+

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -233,9 +233,7 @@ def test_plan_contract_teen_threshold_uses_canonical_group(
     # With teen threshold 24.5, BMI=24.7 should be "overweight" (not "normal")
     category_lower = data["category"].lower()
     # Check for overweight indicators (EN: "overweight", "избыточ" for RU)
-    assert (
-        "over" in category_lower or "избыточ" in category_lower or "избыт" in category_lower
-    ), (
+    assert "over" in category_lower or "избыточ" in category_lower or "избыт" in category_lower, (
         f"Expected overweight category for teen BMI=24.7 (threshold 24.5), "
         f"got '{data['category']}'. This indicates group was not taken from canonical engine."
     )

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -266,3 +266,52 @@ def test_plan_contract_teen_threshold_uses_canonical_group(
         f"Expected overweight category for teen BMI=24.7 (threshold 24.5), "
         f"got '{data['category']}'. This indicates group was not taken from canonical engine."
     )
+
+
+def test_plan_contract_too_young_returns_category_none(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    RU: Проверка, что group="too_young" (age < 12) возвращает category=None.
+    EN: Verify group="too_young" (age < 12) returns category=None.
+
+    Regression test: canonical engine returns group="too_young" for children under 12.
+    The compat layer must NOT apply adult thresholds and must return category=None.
+    """
+    import core.bmi.engine as engine
+    import app.routers.bmi as bmi_router
+
+    # Fixed result for too_young child (age < 12)
+    fixed_result = BMICalculateResult(
+        bmi=18.8,  # Would be "Normal" with adult thresholds (18.5-25.0)
+        category=None,  # Canonical engine returns None for too_young
+        group="too_young",  # Engine returns too_young for age < 12
+        group_display="Too young",
+        interpretation="Too young for standard BMI classification.",
+        wht_ratio=None,
+        waist_risk=None,
+        notes=(),
+        age_band="too_young",
+    )
+
+    def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
+        return fixed_result
+
+    # Patch at source (engine module)
+    monkeypatch.setattr(engine, "calculate_bmi_result", _fixed_engine, raising=True)
+    # Patch the already-imported reference in bmi_router (required for runtime)
+    monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine, raising=True)
+
+    # Request for 10-year-old (too_young)
+    payload = _base_payload(age=10, weight_kg=30.0, height_m=1.30)
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+
+    # too_young should return category=None (no adult thresholds applied)
+    assert data["category"] is None, (
+        f"Expected category=None for too_young (age < 12), "
+        f"got '{data['category']}'. This indicates adult thresholds were incorrectly applied."
+    )

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -43,9 +43,13 @@ def _assert_plan_contract_shape(data: dict, lang: str, premium: bool) -> None:
         data["category"], str
     ), f"category must be str | None, got {type(data['category'])}"
     assert isinstance(data["premium"], bool), f"premium must be bool, got {type(data['premium'])}"
-    assert isinstance(data["next_steps"], list), f"next_steps must be list, got {type(data['next_steps'])}"
+    assert isinstance(
+        data["next_steps"], list
+    ), f"next_steps must be list, got {type(data['next_steps'])}"
     assert all(isinstance(step, str) for step in data["next_steps"]), "next_steps must be list[str]"
-    assert isinstance(data["healthy_bmi"], dict), f"healthy_bmi must be dict, got {type(data['healthy_bmi'])}"
+    assert isinstance(
+        data["healthy_bmi"], dict
+    ), f"healthy_bmi must be dict, got {type(data['healthy_bmi'])}"
     assert "min" in data["healthy_bmi"] and "max" in data["healthy_bmi"]
     assert isinstance(data["healthy_bmi"]["min"], (int, float))
     assert isinstance(data["healthy_bmi"]["max"], (int, float))
@@ -55,7 +59,9 @@ def _assert_plan_contract_shape(data: dict, lang: str, premium: bool) -> None:
     if premium:
         assert PREMIUM_KEY in data, "premium_reco must be present when premium=True"
         assert isinstance(data[PREMIUM_KEY], list), "premium_reco must be list"
-        assert all(isinstance(reco, str) for reco in data[PREMIUM_KEY]), "premium_reco must be list[str]"
+        assert all(
+            isinstance(reco, str) for reco in data[PREMIUM_KEY]
+        ), "premium_reco must be list[str]"
     else:
         # premium_reco may or may not be present when premium=False (backward compat)
         pass
@@ -175,4 +181,3 @@ def test_plan_contract_premium_reco_when_premium(client: TestClient) -> None:
     assert PREMIUM_KEY in data, "premium_reco must be present when premium=True"
     assert isinstance(data[PREMIUM_KEY], list)
     assert len(data[PREMIUM_KEY]) > 0
-

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -142,15 +142,29 @@ def test_plan_contract_shape_es_falls_back_to_en(client: TestClient) -> None:
 @pytest.mark.parametrize("pregnant_value", ["yes", "pregnant", "беременна", "беременная"])
 def test_plan_contract_category_none_for_pregnant(client: TestClient, pregnant_value: str) -> None:
     """
-    RU: Проверка, что category=None для pregnant пользователей (canonical поведение).
-    EN: Verify category=None for pregnant users (canonical behavior).
+    RU: Проверка, что category=None для pregnant пользователей (legacy parity: только female).
+    EN: Verify category=None for pregnant users (legacy parity: female only).
     """
-    payload = _base_payload(pregnant=pregnant_value)
+    payload = _base_payload(gender="female", pregnant=pregnant_value)
     resp = client.post("/plan", json=payload)
     assert resp.status_code == 200
 
     data = resp.json()
     assert data["category"] is None, "category must be None for pregnant users"
+
+
+def test_plan_contract_male_pregnant_flag_does_not_clear_category(client: TestClient) -> None:
+    """
+    RU: Legacy parity: pregnant=True не должен работать для male (category остаётся строкой).
+    EN: Legacy parity: pregnant=True must not apply to male (category remains a string).
+    """
+    payload = _base_payload(gender="male", pregnant="yes", age=30, lang="en")
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["category"] is not None, "male + pregnant=yes must NOT force category=None"
+    assert isinstance(data["category"], str)
 
 
 def test_plan_contract_minors_legacy_behavior_is_preserved(client: TestClient) -> None:

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -8,8 +8,12 @@ PR-457 Commit 2: Verify that /plan contract is preserved after migration to cano
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
+
+from core.bmi.engine import BMICalculateResult
 
 # Required keys for /plan contract (from legacy_app.py and test_app_comprehensive_97_final.py)
 REQUIRED_KEYS = {
@@ -181,3 +185,57 @@ def test_plan_contract_premium_reco_when_premium(client: TestClient) -> None:
     assert PREMIUM_KEY in data, "premium_reco must be present when premium=True"
     assert isinstance(data[PREMIUM_KEY], list)
     assert len(data[PREMIUM_KEY]) > 0
+
+
+def test_plan_contract_teen_threshold_uses_canonical_group(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    RU: Проверка, что /plan использует canonical group для пороговых значений.
+    EN: Verify /plan uses canonical group for threshold values.
+
+    Regression test: teen (age=15) с BMI=24.7 должен использовать teen threshold 24.5,
+    а не adult threshold 25.0. Если group пересчитывается локально, teen будет классифицирован
+    как "normal" вместо "overweight".
+    """
+    # Patch engine to return teen group and BMI=24.7
+    import core.bmi.engine as engine
+
+    fixed_result = BMICalculateResult(
+        bmi=24.7,
+        category=None,  # Canonical engine returns None for minors
+        group="teen",  # Engine decides group based on age
+        group_display="Teen",
+        interpretation="Test teen threshold regression.",
+        wht_ratio=None,
+        waist_risk=None,
+        notes=(),
+        age_band="teen",
+    )
+
+    def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
+        return fixed_result
+
+    monkeypatch.setattr(engine, "calculate_bmi_result", _fixed_engine, raising=True)
+
+    # Request for 15-year-old (teen)
+    payload = _base_payload(age=15, weight_kg=70.0, height_m=1.70)  # BMI ≈ 24.7
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+
+    # Legacy /plan must return string category for minors
+    assert isinstance(data["category"], str), "legacy /plan must return string category for minors"
+    assert len(data["category"]) > 0
+
+    # With teen threshold 24.5, BMI=24.7 should be "overweight" (not "normal")
+    category_lower = data["category"].lower()
+    # Check for overweight indicators (EN: "overweight", "избыточ" for RU)
+    assert (
+        "over" in category_lower or "избыточ" in category_lower or "избыт" in category_lower
+    ), (
+        f"Expected overweight category for teen BMI=24.7 (threshold 24.5), "
+        f"got '{data['category']}'. This indicates group was not taken from canonical engine."
+    )

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -187,6 +187,31 @@ def test_plan_contract_premium_reco_when_premium(client: TestClient) -> None:
     assert len(data[PREMIUM_KEY]) > 0
 
 
+def test_plan_pregnant_flag_does_not_accept_athlete_keywords(client: TestClient) -> None:
+    """
+    RU: pregnant не должен принимать athlete/спортсмен как truthy.
+    EN: pregnant must not treat athlete keywords as truthy.
+
+    Regression test: если pregnant="athlete", это НЕ должно давать pregnant=True.
+    """
+    payload = _base_payload(
+        pregnant="athlete",  # BUG bait: must be treated as False
+        athlete="no",
+        age=30,
+        lang="en",
+    )
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # If pregnant was mis-normalized to True, legacy contract would return category=None
+    assert data["category"] is not None, (
+        "pregnant='athlete' must NOT normalize to True. "
+        "If category is None, pregnant was incorrectly normalized."
+    )
+    assert isinstance(data["category"], str), "category must be string (not None)"
+
+
 def test_plan_contract_teen_threshold_uses_canonical_group(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -81,7 +81,7 @@ def _assert_plan_contract_shape(data: dict, lang: str, premium: bool) -> None:
         assert len(data["action"]) > 0
 
 
-def _base_payload(**overrides: dict) -> dict:
+def _base_payload(**overrides: Any) -> dict:
     """Helper to build base /plan payload."""
     base = {
         "weight_kg": 70.0,

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -377,3 +377,21 @@ def test_plan_contract_athlete_minor_allows_obesity_tiers_via_compat(
 
     # BMI=35.1 maps to obesity_2 tier (adult bucket: 35.0–40.0).
     assert data["category"] == t("en", "bmi_obese_2")
+
+
+def test_plan_contract_allows_bmi_above_50_without_422(client: TestClient) -> None:
+    """
+    RU: Регрессия: legacy /plan не должен внезапно ужесточаться (BMI>50 → 422).
+    EN: Regression: legacy /plan must not unexpectedly tighten validation (BMI>50 → 422).
+
+    Canonical engine allows BMI up to 100.0; /plan should accept BMI≈50.1.
+    """
+    payload = _base_payload(
+        height_m=1.6,
+        weight_kg=128.3,  # BMI ~= 50.12
+        lang="en",
+    )
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    _assert_plan_contract_shape(data, lang="en", premium=False)

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -157,7 +157,9 @@ def test_plan_contract_minors_legacy_behavior_is_preserved(client: TestClient) -
     data = resp.json()
     # Legacy /plan contract: minors receive a string category (not None)
     assert "category" in data, "category field must exist"
-    # Note: category may be a string (legacy behavior preserved via compat_plan)
+    # Legacy contract: minors must get string category (not None)
+    assert isinstance(data["category"], str), "legacy /plan must return string category for minors"
+    assert len(data["category"]) > 0, "category string must not be empty"
 
 
 def test_plan_contract_premium_reco_when_premium(client: TestClient) -> None:

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -139,12 +139,13 @@ def test_plan_contract_shape_es_falls_back_to_en(client: TestClient) -> None:
     assert es_data["action"] == en_data["action"], "ES should fallback to EN action"
 
 
-def test_plan_contract_category_none_for_pregnant(client: TestClient) -> None:
+@pytest.mark.parametrize("pregnant_value", ["yes", "pregnant", "беременна", "беременная"])
+def test_plan_contract_category_none_for_pregnant(client: TestClient, pregnant_value: str) -> None:
     """
     RU: Проверка, что category=None для pregnant пользователей (canonical поведение).
     EN: Verify category=None for pregnant users (canonical behavior).
     """
-    payload = _base_payload(pregnant="yes")
+    payload = _base_payload(pregnant=pregnant_value)
     resp = client.post("/plan", json=payload)
     assert resp.status_code == 200
 

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -315,3 +315,49 @@ def test_plan_contract_too_young_returns_category_none(
         f"Expected category=None for too_young (age < 12), "
         f"got '{data['category']}'. This indicates adult thresholds were incorrectly applied."
     )
+
+
+def test_plan_contract_athlete_minor_allows_obesity_tiers_via_compat(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    RU: Для minors athlete compat-категоризация должна уметь underweight/obesity tiers.
+    EN: Athlete minors must be able to hit underweight/obesity tiers via compat mapping.
+
+    Regression: previously athlete mapping only returned normal/overweight, which broke legacy parity
+    for minors when engine_category=None.
+    """
+    import app.routers.bmi as bmi_router
+    import core.bmi.engine as engine
+    from core.i18n import t
+
+    fixed_result = BMICalculateResult(
+        bmi=35.1,  # should map to obesity_2 (adult buckets)
+        category=None,  # force compat mapping for minors
+        group="athlete",
+        group_display="Athlete",
+        interpretation="Athlete minor obesity-tier regression marker.",
+        wht_ratio=None,
+        waist_risk=None,
+        notes=(),
+        age_band="teen",
+    )
+
+    def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
+        return fixed_result
+
+    # Patch canonical engine entrypoint + router reference (handler wiring)
+    monkeypatch.setattr(engine, "calculate_bmi_result", _fixed_engine, raising=True)
+    monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine, raising=True)
+
+    payload = _base_payload(
+        age=15,  # minor => compat mapping active when category=None
+        athlete="yes",
+        lang="en",
+    )
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["category"] == t("en", "bmi_obese_2")

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Регрессионные тесты для сохранения контракта /plan endpoint.
+EN: Regression tests for preserving /plan endpoint contract.
+
+PR-457 Commit 2: Verify that /plan contract is preserved after migration to canonical handler.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Required keys for /plan contract (from legacy_app.py and test_app_comprehensive_97_final.py)
+REQUIRED_KEYS = {
+    "summary",
+    "bmi",
+    "category",
+    "premium",
+    "next_steps",
+    "healthy_bmi",
+    "action",
+}
+
+# Conditional key (only when premium=True)
+PREMIUM_KEY = "premium_reco"
+
+
+def _assert_plan_contract_shape(data: dict, lang: str, premium: bool) -> None:
+    """
+    RU: Проверка формы контракта /plan (все обязательные поля присутствуют и правильных типов).
+    EN: Assert /plan contract shape (all required fields present and correct types).
+    """
+    # Check all required keys are present
+    assert set(data.keys()).issuperset(
+        REQUIRED_KEYS
+    ), f"Missing required keys. Got: {set(data.keys())}, Expected: {REQUIRED_KEYS}"
+
+    # Check types
+    assert isinstance(data["summary"], str), f"summary must be str, got {type(data['summary'])}"
+    assert isinstance(data["bmi"], (int, float)), f"bmi must be number, got {type(data['bmi'])}"
+    assert data["category"] is None or isinstance(
+        data["category"], str
+    ), f"category must be str | None, got {type(data['category'])}"
+    assert isinstance(data["premium"], bool), f"premium must be bool, got {type(data['premium'])}"
+    assert isinstance(data["next_steps"], list), f"next_steps must be list, got {type(data['next_steps'])}"
+    assert all(isinstance(step, str) for step in data["next_steps"]), "next_steps must be list[str]"
+    assert isinstance(data["healthy_bmi"], dict), f"healthy_bmi must be dict, got {type(data['healthy_bmi'])}"
+    assert "min" in data["healthy_bmi"] and "max" in data["healthy_bmi"]
+    assert isinstance(data["healthy_bmi"]["min"], (int, float))
+    assert isinstance(data["healthy_bmi"]["max"], (int, float))
+    assert isinstance(data["action"], str), f"action must be str, got {type(data['action'])}"
+
+    # Check conditional premium_reco
+    if premium:
+        assert PREMIUM_KEY in data, "premium_reco must be present when premium=True"
+        assert isinstance(data[PREMIUM_KEY], list), "premium_reco must be list"
+        assert all(isinstance(reco, str) for reco in data[PREMIUM_KEY]), "premium_reco must be list[str]"
+    else:
+        # premium_reco may or may not be present when premium=False (backward compat)
+        pass
+
+    # Check localization (summary and action should be localized)
+    if lang == "ru":
+        assert "Персональный план" in data["summary"] or "план" in data["summary"].lower()
+        assert len(data["summary"]) > 0
+        assert len(data["action"]) > 0
+    elif lang == "en":
+        assert "plan" in data["summary"].lower() or "Personal" in data["summary"]
+        assert len(data["summary"]) > 0
+        assert len(data["action"]) > 0
+
+
+def _base_payload(**overrides: dict) -> dict:
+    """Helper to build base /plan payload."""
+    base = {
+        "weight_kg": 70.0,
+        "height_m": 1.75,
+        "age": 30,
+        "gender": "male",
+        "pregnant": "no",
+        "athlete": "no",
+        "lang": "en",
+        "premium": False,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize("lang", ["en", "ru"])
+def test_plan_contract_shape_by_language(client: TestClient, lang: str) -> None:
+    """
+    RU: Проверка контракта /plan для разных языков (EN/RU).
+    EN: Verify /plan contract shape for different languages (EN/RU).
+    """
+    payload = _base_payload(lang=lang)
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    _assert_plan_contract_shape(data, lang=lang, premium=False)
+
+    # Verify localized content differs between languages
+    if lang == "ru":
+        assert "Персональный план" in data["summary"] or "план" in data["summary"].lower()
+    else:
+        assert "plan" in data["summary"].lower() or "Personal" in data["summary"]
+
+
+def test_plan_contract_shape_es_falls_back_to_en(client: TestClient) -> None:
+    """
+    RU: Проверка, что ES запросы fallback к EN (legacy поведение).
+    EN: Verify ES requests fallback to EN (legacy behavior).
+    """
+    payload_en = _base_payload(lang="en")
+    payload_es = _base_payload(lang="es")
+
+    resp_en = client.post("/plan", json=payload_en)
+    resp_es = client.post("/plan", json=payload_es)
+
+    assert resp_en.status_code == 200
+    assert resp_es.status_code == 200
+
+    en_data = resp_en.json()
+    es_data = resp_es.json()
+
+    # ES should fallback to EN (legacy behavior)
+    assert es_data["summary"] == en_data["summary"], "ES should fallback to EN summary"
+    assert es_data["action"] == en_data["action"], "ES should fallback to EN action"
+
+
+def test_plan_contract_category_none_for_pregnant(client: TestClient) -> None:
+    """
+    RU: Проверка, что category=None для pregnant пользователей (canonical поведение).
+    EN: Verify category=None for pregnant users (canonical behavior).
+    """
+    payload = _base_payload(pregnant="yes")
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["category"] is None, "category must be None for pregnant users"
+
+
+def test_plan_contract_minors_legacy_behavior_is_preserved(client: TestClient) -> None:
+    """
+    RU: Проверка, что legacy поведение для minors сохранено (category не None).
+    EN: Verify legacy behavior for minors is preserved (category is not None).
+
+    This is legacy /plan contract. PR-457=A must preserve it.
+    Canonical engine returns category=None for minors, but legacy /plan returns a string category.
+    """
+    payload = _base_payload(age=15)  # Minor
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    # Legacy /plan contract: minors receive a string category (not None)
+    assert "category" in data, "category field must exist"
+    # Note: category may be a string (legacy behavior preserved via compat_plan)
+
+
+def test_plan_contract_premium_reco_when_premium(client: TestClient) -> None:
+    """
+    RU: Проверка, что premium_reco присутствует когда premium=True.
+    EN: Verify premium_reco is present when premium=True.
+    """
+    payload = _base_payload(premium=True)
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert PREMIUM_KEY in data, "premium_reco must be present when premium=True"
+    assert isinstance(data[PREMIUM_KEY], list)
+    assert len(data[PREMIUM_KEY]) > 0
+

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -226,6 +226,7 @@ def test_plan_contract_teen_threshold_uses_canonical_group(
     """
     # Patch engine to return teen group and BMI=24.7
     import core.bmi.engine as engine
+    import app.routers.bmi as bmi_router
 
     fixed_result = BMICalculateResult(
         bmi=24.7,
@@ -242,7 +243,10 @@ def test_plan_contract_teen_threshold_uses_canonical_group(
     def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
         return fixed_result
 
+    # Patch at source (engine module)
     monkeypatch.setattr(engine, "calculate_bmi_result", _fixed_engine, raising=True)
+    # Patch the already-imported reference in bmi_router (required for runtime)
+    monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine, raising=True)
 
     # Request for 15-year-old (teen)
     payload = _base_payload(age=15, weight_kg=70.0, height_m=1.70)  # BMI ≈ 24.7

--- a/tests/test_plan_contract_regression.py
+++ b/tests/test_plan_contract_regression.py
@@ -375,4 +375,5 @@ def test_plan_contract_athlete_minor_allows_obesity_tiers_via_compat(
     assert resp.status_code == 200
     data = resp.json()
 
+    # BMI=35.1 maps to obesity_2 tier (adult bucket: 35.0–40.0).
     assert data["category"] == t("en", "bmi_obese_2")

--- a/tests/test_plan_delegation_proof.py
+++ b/tests/test_plan_delegation_proof.py
@@ -27,10 +27,12 @@ def test_plan_delegates_to_canonical_engine(
     Monkeypatch calculate_bmi_result to return fixed BMICalculateResult with marker BMI,
     then verify endpoint returns those exact values (proving shim delegation).
     """
-    import app.routers.bmi as bmi_router
+    # Patch the actual engine function (most reliable)
+    import core.bmi.engine as engine
 
     # Marker BMI to prove delegation (unlikely to occur naturally)
-    marker_bmi = 12.345
+    # Use value that survives rounding: 12.3 (1 decimal) or 12.35 (2 decimals)
+    marker_bmi = 12.35
 
     # Fixed result to verify it "flows through" the shim
     fixed_result = BMICalculateResult(
@@ -48,7 +50,16 @@ def test_plan_delegates_to_canonical_engine(
     def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
         return fixed_result
 
-    monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine)
+    # Patch engine at source (most reliable)
+    monkeypatch.setattr(engine, "calculate_bmi_result", _fixed_engine, raising=True)
+    # Optional fallback: patch module-level alias in router (if handler keeps ref)
+    try:
+        import app.routers.bmi as bmi_router
+
+        monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine, raising=False)
+    except (AttributeError, ImportError):
+        # Router may not have module-level alias, that's OK
+        pass
 
     payload = {
         "weight_kg": 70.0,

--- a/tests/test_plan_delegation_proof.py
+++ b/tests/test_plan_delegation_proof.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Доказательный тест для делегации /plan в canonical BMI engine.
+EN: Proof test for /plan delegation to canonical BMI engine.
+
+PR-457 Commit 1: Verify that /plan delegates to canonical handler before migration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.bmi.engine import BMICalculateResult
+
+
+def test_plan_delegates_to_canonical_engine(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    RU: Доказательный тест: /plan использует engine через handler (shim работает).
+    EN: Proof test: /plan uses engine via handler (shim works).
+
+    Monkeypatch calculate_bmi_result to return fixed BMICalculateResult with marker BMI,
+    then verify endpoint returns those exact values (proving shim delegation).
+    """
+    import app.routers.bmi as bmi_router
+
+    # Marker BMI to prove delegation (unlikely to occur naturally)
+    marker_bmi = 12.345
+
+    # Fixed result to verify it "flows through" the shim
+    fixed_result = BMICalculateResult(
+        bmi=marker_bmi,
+        category="underweight",
+        group="general",
+        group_display="General",
+        interpretation="Test marker BMI for delegation proof.",
+        wht_ratio=None,
+        waist_risk=None,
+        notes=(),
+        age_band="adult",
+    )
+
+    def _fixed_engine(**kwargs: Any) -> BMICalculateResult:
+        return fixed_result
+
+    monkeypatch.setattr(bmi_router, "calculate_bmi_result", _fixed_engine)
+
+    payload = {
+        "weight_kg": 70.0,
+        "height_m": 1.75,
+        "age": 30,
+        "gender": "male",
+        "pregnant": "no",
+        "athlete": "no",
+        "lang": "en",
+        "premium": False,
+    }
+
+    resp = client.post("/plan", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Verify marker BMI flows through (proves canonical handler was called)
+    assert data["bmi"] == marker_bmi, (
+        f"Expected marker BMI {marker_bmi}, got {data['bmi']}. "
+        "This means /plan is NOT delegating to canonical engine (yet)."
+    )
+

--- a/tests/test_plan_delegation_proof.py
+++ b/tests/test_plan_delegation_proof.py
@@ -81,4 +81,3 @@ def test_plan_delegates_to_canonical_engine(
         f"Expected marker BMI {marker_bmi}, got {data['bmi']}. "
         "This means /plan is NOT delegating to canonical engine (yet)."
     )
-

--- a/tests/test_targeted_coverage_improvement.py
+++ b/tests/test_targeted_coverage_improvement.py
@@ -16,13 +16,9 @@ class TestTargetedCoverageImprovement:
     """Targeted tests to improve coverage for uncovered lines."""
 
     def setup_method(self):
-        """Setup test environment"""
-        os.environ["API_KEY"] = "test_key"
-        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
-
-    def setup_method(self):
         """Set up test environment."""
         os.environ["API_KEY"] = "test-key"
+        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
 
     def teardown_method(self):

--- a/tests/test_targeted_coverage_improvement.py
+++ b/tests/test_targeted_coverage_improvement.py
@@ -78,6 +78,32 @@ class TestTargetedCoverageImprovement:
         result = normalize_flags("male", "no", "athlete")
         assert result["is_athlete"] is True
 
+    @pytest.mark.parametrize("pregnant_value", ["pregnant", "беременна", "беременная"])
+    def test_normalize_flags_pregnant_synonyms_are_true_for_female(
+        self, pregnant_value: str
+    ) -> None:
+        """
+        RU: Legacy public API: беременность должна распознаваться по строковым синонимам.
+        EN: Legacy public API: pregnancy synonyms must be treated as true.
+        """
+        from app import normalize_flags
+
+        result = normalize_flags(gender="female", pregnant=pregnant_value, athlete="no")
+        assert result["is_pregnant"] is True
+
+    @pytest.mark.parametrize("bad_pregnant_value", ["athlete", "спортсмен"])
+    def test_normalize_flags_pregnant_must_not_accept_athlete_keywords(
+        self, bad_pregnant_value: str
+    ) -> None:
+        """
+        RU: Athlete keywords MUST NOT imply pregnant=True.
+        EN: Athlete keywords MUST NOT imply pregnant=True.
+        """
+        from app import normalize_flags
+
+        result = normalize_flags(gender="female", pregnant=bad_pregnant_value, athlete="no")
+        assert result["is_pregnant"] is False
+
     def test_waist_risk_edge_cases(self):
         """Test edge cases for waist_risk function."""
         from app import waist_risk


### PR DESCRIPTION
# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Делегировать устаревший эндпоинт `/plan` каноническому ядру BMI, сохранив его текущий контракт ответа и языковое поведение.

Новые возможности:
- Добавить слой совместимости, который отображает вывод канонического ядра BMI в устаревшие строковые категории эндпоинта `/plan`, включая специальную обработку для несовершеннолетних и групп спортсменов/пожилых.

Улучшения:
- Рефакторинг реализации эндпоинта `/plan` для вызова общего обработчика расчёта BMI и нормализации булевых флагов «на лету» при сохранении прежней структуры ответа.
- Исправить ссылки в README на документацию по боевому (production) деплою для улучшения понятности.

Документация:
- Скорректировать структуру runbook по тестированию, чтобы отделить общие команды от специфичных для проекта команд тестирования.

Тесты:
- Добавить регрессионные тесты, фиксирующие контракт ответа устаревшего эндпоинта `/plan`, включая локализацию, беременность, несовершеннолетних и премиальное поведение.
- Добавить тест-доказательство делегирования, который проверяет, что эндпоинт `/plan` направляет расчёты BMI через каноническое ядро BMI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delegate the legacy /plan endpoint to the canonical BMI engine while preserving its existing response contract and language behavior.

New Features:
- Add a compatibility layer that maps canonical BMI engine output into the legacy /plan category strings, including special handling for minors and athlete/elderly groups.

Enhancements:
- Refactor /plan endpoint implementation to call the shared BMI calculation handler and normalize boolean flags inline while keeping the legacy response shape unchanged.
- Fix README links to the production deployment documentation for clarity.

Documentation:
- Adjust testing runbook structure to separate generic commands from project-specific test commands.

Tests:
- Add regression tests to lock in the legacy /plan endpoint response contract, including localization, pregnancy, minors, and premium behavior.
- Add a delegation proof test that verifies the /plan endpoint routes BMI calculations through the canonical BMI engine.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legacy BMI/category responses preserved while delegating calculations to the canonical BMI engine.

* **Bug Fixes**
  * More consistent pregnancy/athlete flag normalization, minors/age-group threshold handling, and locale fallbacks.
  * Validation error status standardized for BMI input validation.

* **Documentation**
  * Fixed production link formatting and simplified project-specific test command examples.

* **Tests**
  * Added extensive regression, delegation, mapping, localization, guardrail, and targeted coverage tests for /plan and BMI behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->