### PR TITLE
chore(bmi): dedupe legacy yes-values + minor compat cleanup

### DIFF
--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1371,7 +1371,12 @@ INSIGHT_TEXT_MAX_LENGTH = 2000
 # Keep synonyms in one place to avoid drift across models/endpoints/public-API wrappers.
 #
 # IMPORTANT: athlete keywords must NEVER imply pregnant=True (and vice versa).
-_YES_VALUES_BASE: set[str] = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+#
+# NOTE: We intentionally reuse canonical base vocabulary from core to avoid drift
+# (e.g. includes "истина"). Extensions remain legacy-specific.
+from core.bmi.engine import _DEFAULT_YES_VALUES as _CANONICAL_YES_VALUES_BASE  # noqa: E402
+
+_YES_VALUES_BASE: set[str] = set(_CANONICAL_YES_VALUES_BASE)
 _YES_VALUES_PREGNANT: set[str] = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
 _YES_VALUES_ATHLETE: set[str] = _YES_VALUES_BASE | {"спортсмен", "athlete"}
 
@@ -1603,9 +1608,9 @@ def calc_bmi(weight_kg: StrictFloat, height_m: float) -> float:
     # Import here to avoid circular dependencies
     from core.bmi.engine import _compute_bmi  # compat import (core-only)
 
-    # Canonical compute returns float; legacy surface returns float rounded to 1dp
+    # Legacy contract: float rounded to 1 decimal (guarded explicitly).
     bmi = _compute_bmi(weight_kg=weight_kg, height_m=height_m)
-    return bmi
+    return round(bmi, 1)
 
 
 def normalize_flags(

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1367,6 +1367,14 @@ if _is_rate_limiting_available():
 
 INSIGHT_TEXT_MAX_LENGTH = 2000
 
+# Shared boolean normalization vocabulary for legacy endpoints / compat helpers.
+# Keep synonyms in one place to avoid drift across models/endpoints/public-API wrappers.
+#
+# IMPORTANT: athlete keywords must NEVER imply pregnant=True (and vice versa).
+_YES_VALUES_BASE: set[str] = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+_YES_VALUES_PREGNANT: set[str] = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
+_YES_VALUES_ATHLETE: set[str] = _YES_VALUES_BASE | {"спортсмен", "athlete"}
+
 
 class InsightRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=INSIGHT_TEXT_MAX_LENGTH)
@@ -1433,10 +1441,6 @@ class BMIRequest(BaseModel):
             values["gender"] = mapping.get(s, s)
         # Normalize string booleans for pregnant/athlete
         # IMPORTANT: athlete keywords must NEVER imply pregnant=True
-        _YES_VALUES_BASE = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-        _YES_VALUES_PREGNANT = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
-        _YES_VALUES_ATHLETE = _YES_VALUES_BASE | {"спортсмен", "athlete"}
-
         # Normalize pregnant (pregnancy synonyms supported)
         v_pregnant = values.get("pregnant")
         if isinstance(v_pregnant, str):
@@ -1601,7 +1605,7 @@ def calc_bmi(weight_kg: StrictFloat, height_m: float) -> float:
 
     # Canonical compute returns float; legacy surface returns float rounded to 1dp
     bmi = _compute_bmi(weight_kg=weight_kg, height_m=height_m)
-    return round(bmi, 1)
+    return bmi
 
 
 def normalize_flags(
@@ -1620,38 +1624,13 @@ def normalize_flags(
     gender_norm = _normalize_gender(gender)
     gender_male = gender_norm == "male"
 
-    # Pregnant yes-values: includes pregnancy synonyms, but NOT athlete keywords
-    _PREGNANT_YES_VALUES = {
-        "yes",
-        "y",
-        "true",
-        "1",
-        "да",
-        "д",
-        "si",
-        "sí",
-        "pregnant",
-        "беременна",
-        "беременная",  # legacy pregnancy synonyms
-    }
-    is_pregnant = (
-        _normalize_bool_flag(pregnant, yes_values=_PREGNANT_YES_VALUES) and not gender_male
+    # Legacy policy: pregnant applies to female only.
+    is_pregnant = _normalize_bool_flag(pregnant, yes_values=_YES_VALUES_PREGNANT) and (
+        gender_norm == "female"
     )
 
-    # Athlete yes-values: includes athlete keywords, but NOT pregnancy synonyms
-    _ATHLETE_YES_VALUES = {
-        "yes",
-        "y",
-        "true",
-        "1",
-        "да",
-        "д",
-        "si",
-        "sí",
-        "athlete",
-        "спортсмен",  # athlete-only keywords
-    }
-    is_athlete = _normalize_bool_flag(athlete, yes_values=_ATHLETE_YES_VALUES)
+    # Athlete has no gender-gate (male/female allowed).
+    is_athlete = _normalize_bool_flag(athlete, yes_values=_YES_VALUES_ATHLETE)
 
     return {
         "gender_male": gender_male,
@@ -2256,9 +2235,6 @@ async def plan_endpoint(req: BMIRequest) -> Dict[str, Any]:
     # For pregnant, legacy /plan returns category=None (preserved)
     # Normalize pregnant for category=None decision (legacy parity + synonym support).
     # IMPORTANT: athlete keywords must NEVER imply pregnant=True
-    _YES_VALUES_BASE = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-    _YES_VALUES_PREGNANT = _YES_VALUES_BASE | {"pregnant", "беременна", "беременная"}
-
     # Legacy parity: pregnancy only applies to female gender.
     pregnant_bool = _normalize_bool_flag(req.pregnant, yes_values=_YES_VALUES_PREGNANT) and (
         req.gender == "female"


### PR DESCRIPTION
# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Централизация устаревших словарей булевых значений «yes» для эндпоинтов, связанных с ИМТ, и корректировка обработки флагов ИМТ, беременности и статуса атлета для более понятного и последовательного поведения.

Улучшения:
- Введение общих наборов значений YES для универсальных флагов, флагов беременности и статуса атлета, чтобы избежать расхождений между устаревшими эндпоинтами и хелперами.
- Обновление нормализации флага беременности так, чтобы она применялась только в случае, когда нормализованный пол явно женский, а флаг статуса атлета использовал общий словарь, специфичный для атлетов, без ограничения по полу.
- Изменение устаревшего слоя для расчёта ИМТ так, чтобы он возвращал каноническое вычисленное значение ИМТ без округления до одного знака после запятой.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize legacy boolean yes-value vocabularies for BMI-related endpoints and adjust BMI and pregnancy/athlete flag handling for clearer, more consistent behavior.

Enhancements:
- Introduce shared YES-value sets for generic, pregnant, and athlete flags to avoid drift across legacy endpoints and helpers.
- Update pregnancy flag normalization to apply only when normalized gender is explicitly female, and athlete flag to use the shared athlete-specific vocabulary without gender gating.
- Change legacy BMI surface to return the canonical computed BMI value without rounding to one decimal place.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BMI calculation now returns precise, unrounded values instead of rounded approximations.

* **Improvements**
  * Standardized interpretation of pregnancy and athlete flags across all endpoints for consistency.
  * Pregnancy flag evaluation now restricted to female gender only.
  * Athlete flag logic simplified and aligned with standard criteria.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->