### PR TITLE
fix(cd): healthcheck via --resolve to avoid DNS dependency

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -102,14 +102,26 @@ else
 fi
 
 echo "[post] Smoke check with retry"
+# Healthcheck using --resolve to avoid DNS dependency (works even if DNS is temporarily unavailable)
+# This checks locally via 127.0.0.1 but uses the domain for Host/SNI headers (TLS works correctly)
+DOMAIN="${STAGING_DOMAIN}"
+HEALTH_URL="https://${DOMAIN}/health"
 max_attempts=30
 attempt=0
+
+# Quick smoke check on HTTP (should return 308 redirect to HTTPS)
+echo "Smoke check HTTP..."
+curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
+  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time 10 || true
+
+# Main healthcheck on HTTPS (does not depend on external DNS)
 while [ $attempt -lt $max_attempts ]; do
   attempt=$((attempt + 1))
   echo "Health check attempt $attempt/$max_attempts..."
 
-  # Capture curl output and errors
-  curl_output=$(curl -fsS "https://${STAGING_DOMAIN}/health" 2>&1)
+  # Use --resolve to avoid DNS dependency
+  curl_output=$(curl -fsS --max-time 10 "${HEALTH_URL}" \
+    --resolve "${DOMAIN}:443:127.0.0.1" 2>&1)
   curl_exit_code=$?
 
   if [ $curl_exit_code -eq 0 ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -113,7 +113,7 @@ DOMAIN="${STAGING_DOMAIN}"
 HEALTH_URL="https://${DOMAIN}/health"
 attempt=0
 
-# Quick smoke check on HTTP (should return 308 redirect to HTTPS)
+# Quick non-blocking HTTP smoke check (diagnostic only; expected 308 -> HTTPS redirect)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
   "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,11 @@ STAGING_DOMAIN=${STAGING_DOMAIN:?"STAGING_DOMAIN not set"}
 GHCR_TOKEN=${GHCR_TOKEN:?"GHCR_TOKEN not set"}
 GHCR_USER=${GHCR_USER:?"GHCR_USER not set"}
 
+# Healthcheck configuration
+HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-30}"
+HEALTH_SLEEP_S="${HEALTH_SLEEP_S:-2}"
+HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
+
 IMG_REF="${1:-latest}"         # тег/диджест образа
 COMPOSE="docker compose -f /srv/pulseplate-staging/docker-compose.staging.yaml"
 
@@ -106,21 +111,20 @@ echo "[post] Smoke check with retry"
 # This checks locally via 127.0.0.1 but uses the domain for Host/SNI headers (TLS works correctly)
 DOMAIN="${STAGING_DOMAIN}"
 HEALTH_URL="https://${DOMAIN}/health"
-max_attempts=30
 attempt=0
 
 # Quick smoke check on HTTP (should return 308 redirect to HTTPS)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
-  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time 10 || true
+  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
 
 # Main healthcheck on HTTPS (does not depend on external DNS)
-while [ $attempt -lt $max_attempts ]; do
+while [ $attempt -lt "$HEALTH_MAX_ATTEMPTS" ]; do
   attempt=$((attempt + 1))
-  echo "Health check attempt $attempt/$max_attempts..."
+  echo "Health check attempt $attempt/$HEALTH_MAX_ATTEMPTS..."
 
   # Use --resolve to avoid DNS dependency
-  curl_output=$(curl -fsS --max-time 10 "${HEALTH_URL}" \
+  curl_output=$(curl -fsS --max-time "${HEALTH_CURL_MAX_TIME_S}" "${HEALTH_URL}" \
     --resolve "${DOMAIN}:443:127.0.0.1" 2>&1)
   curl_exit_code=$?
 
@@ -131,15 +135,17 @@ while [ $attempt -lt $max_attempts ]; do
     echo "❌ Health check failed (exit code: $curl_exit_code)" >&2
     echo "Error details: $curl_output" >&2
 
-    if [ $attempt -eq $max_attempts ]; then
-      echo "❌ Health check failed after ${max_attempts} attempts" >&2
+    if [ $attempt -eq "$HEALTH_MAX_ATTEMPTS" ]; then
+      echo "❌ Health check failed after ${HEALTH_MAX_ATTEMPTS} attempts" >&2
       echo "Final error: $curl_output" >&2
       exit 1
     fi
 
-    echo "Waiting 2 seconds before retry..."
-    sleep 2
+    echo "Waiting ${HEALTH_SLEEP_S} seconds before retry..."
+    sleep "${HEALTH_SLEEP_S}"
   fi
 done
+
+echo "✅ Healthcheck OK"
 
 echo "✅ Staging deployed: $IMG_REF"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -90,7 +90,7 @@ DOMAIN="${PRODUCTION_DOMAIN}"
 HEALTH_URL="https://${DOMAIN}/health"
 attempt=1
 
-# Quick smoke check on HTTP (should return 308 redirect to HTTPS)
+# Quick non-blocking HTTP smoke check (diagnostic only; expected 308 -> HTTPS redirect)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
   "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 
 export IMAGE_REF TAG PRODUCTION_DOMAIN
 
+# Healthcheck configuration
+HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-12}"
+HEALTH_SLEEP_S="${HEALTH_SLEEP_S:-2}"
+HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
+
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 DEPLOY_DIR="${DEPLOY_DIR:-}"
 
@@ -84,29 +89,27 @@ dc up -d --remove-orphans
 DOMAIN="${PRODUCTION_DOMAIN}"
 HEALTH_URL="https://${DOMAIN}/health"
 attempt=1
-max_attempts=12
-sleep_s=2
 
 # Quick smoke check on HTTP (should return 308 redirect to HTTPS)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
-  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time 10 || true
+  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
 
 # Main healthcheck on HTTPS (does not depend on external DNS)
-echo "Healthcheck HTTPS (attempt ${attempt}/${max_attempts})..."
-until curl -fsS --max-time 10 "$HEALTH_URL" \
+echo "Healthcheck HTTPS (attempt ${attempt}/${HEALTH_MAX_ATTEMPTS})..."
+until curl -fsS --max-time "${HEALTH_CURL_MAX_TIME_S}" "$HEALTH_URL" \
     --resolve "${DOMAIN}:443:127.0.0.1" > /dev/null; do
-  if [ "$attempt" -ge "$max_attempts" ]; then
-    echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
+  if [ "$attempt" -ge "$HEALTH_MAX_ATTEMPTS" ]; then
+    echo "❌ Healthcheck failed after ${HEALTH_MAX_ATTEMPTS} attempts: $HEALTH_URL" >&2
     echo "Container status:"
     dc ps || true
     echo "Container logs (last 200 lines):"
     dc logs --tail=200 || true
     exit 1
   fi
-  echo "Healthcheck not ready (attempt ${attempt}/${max_attempts}), retrying in ${sleep_s}s..."
+  echo "Healthcheck not ready (attempt ${attempt}/${HEALTH_MAX_ATTEMPTS}), retrying in ${HEALTH_SLEEP_S}s..."
   attempt=$((attempt + 1))
-  sleep "$sleep_s"
+  sleep "${HEALTH_SLEEP_S}"
 done
 
 echo "✅ Healthcheck OK"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -79,13 +79,28 @@ dc() {
 dc pull
 dc up -d --remove-orphans
 
-HEALTH_URL="https://${PRODUCTION_DOMAIN}/health"
+# Healthcheck using --resolve to avoid DNS dependency (works even if DNS is temporarily unavailable)
+# This checks locally via 127.0.0.1 but uses the domain for Host/SNI headers (TLS works correctly)
+DOMAIN="${PRODUCTION_DOMAIN}"
+HEALTH_URL="https://${DOMAIN}/health"
 attempt=1
 max_attempts=12
 sleep_s=2
-until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
+
+# Quick smoke check on HTTP (should return 308 redirect to HTTPS)
+echo "Smoke check HTTP..."
+curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
+  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time 10 || true
+
+# Main healthcheck on HTTPS (does not depend on external DNS)
+echo "Healthcheck HTTPS (attempt ${attempt}/${max_attempts})..."
+until curl -fsS --max-time 10 "$HEALTH_URL" \
+    --resolve "${DOMAIN}:443:127.0.0.1" > /dev/null; do
   if [ "$attempt" -ge "$max_attempts" ]; then
     echo "❌ Healthcheck failed after ${max_attempts} attempts: $HEALTH_URL" >&2
+    echo "Container status:"
+    dc ps || true
+    echo "Container logs (last 200 lines):"
     dc logs --tail=200 || true
     exit 1
   fi
@@ -93,5 +108,7 @@ until curl -fsS --max-time 10 "$HEALTH_URL" > /dev/null; do
   attempt=$((attempt + 1))
   sleep "$sleep_s"
 done
+
+echo "✅ Healthcheck OK"
 
 docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | head -n 20


### PR DESCRIPTION
- Update deploy_production.sh to use --resolve for local healthcheck
- Update deploy.sh (staging) to use --resolve for local healthcheck
- Healthchecks now work even if external DNS is temporarily unavailable
- Uses 127.0.0.1 locally but domain for Host/SNI headers (TLS works correctly)

Fixes: 'Could not resolve host' errors in CI/CD deploy jobs

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Сделать healthcheck-и в CI/CD деплоях независимыми от внешнего DNS, используя локальные проверки `curl` к `127.0.0.1` с сохранением доменных заголовков для staging и production.

Исправления ошибок:
- Предотвратить сбои деплоя в CI/CD, вызываемые временными ошибками внешнего разрешения DNS во время healthcheck-ов.

Улучшения:
- Добавить HTTP- и HTTPS-smoke/healthcheck-и при помощи `curl --resolve` для деплоев на staging и production.
- Улучшить диагностику production-деплоя за счёт вывода статуса контейнера и последних логов при сбоях healthcheck-ов.
- Выводить явное сообщение об успехе, когда production healthcheck завершается успешно.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make CI/CD deployment healthchecks independent of external DNS by using local 127.0.0.1 curl checks with preserved domain headers for staging and production.

Bug Fixes:
- Prevent deploy failures in CI/CD caused by temporary external DNS resolution errors during healthchecks.

Enhancements:
- Add HTTP and HTTPS smoke/health checks using curl --resolve for staging and production deployments.
- Improve production deploy diagnostics by printing container status and recent logs when healthchecks fail.
- Print an explicit success message when the production healthcheck completes successfully.

</details>

Исправления ошибок:
- Предотвращение сбоев деплоя в CI/CD, вызываемых временными ошибками внешнего DNS‑резолвинга во время проверок работоспособности.

Улучшения:
- Добавлены HTTP‑ и HTTPS‑smoke‑проверки с использованием `curl --resolve` для обращения к `127.0.0.1` при сохранении доменных Host/SNI‑заголовков.
- Улучшена диагностика во время деплоя за счёт вывода статуса контейнера и последних логов при сбое production‑проверки работоспособности.
- Выводится явное сообщение об успешном завершении, когда production‑проверка работоспособности проходит успешно.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Сделать healthcheck-и в CI/CD деплоях независимыми от внешнего DNS, используя локальные проверки `curl` к `127.0.0.1` с сохранением доменных заголовков для staging и production.

Исправления ошибок:
- Предотвратить сбои деплоя в CI/CD, вызываемые временными ошибками внешнего разрешения DNS во время healthcheck-ов.

Улучшения:
- Добавить HTTP- и HTTPS-smoke/healthcheck-и при помощи `curl --resolve` для деплоев на staging и production.
- Улучшить диагностику production-деплоя за счёт вывода статуса контейнера и последних логов при сбоях healthcheck-ов.
- Выводить явное сообщение об успехе, когда production healthcheck завершается успешно.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make CI/CD deployment healthchecks independent of external DNS by using local 127.0.0.1 curl checks with preserved domain headers for staging and production.

Bug Fixes:
- Prevent deploy failures in CI/CD caused by temporary external DNS resolution errors during healthchecks.

Enhancements:
- Add HTTP and HTTPS smoke/health checks using curl --resolve for staging and production deployments.
- Improve production deploy diagnostics by printing container status and recent logs when healthchecks fail.
- Print an explicit success message when the production healthcheck completes successfully.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment validation with DNS-independent, two-phase health checks and configurable retry/timeout settings.
  * Added a short HTTP smoke check before final HTTPS verification to validate redirects and SNI/Host behavior.
  * Improved retry feedback by referencing configurable attempt and sleep values.
  * Expanded production failure diagnostics: outputs container status and recent logs for easier troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->