### PR TITLE
feat(bmi): add visualization spec v1 to calculate endpoint (backend-only)

### DIFF
--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -163,6 +163,7 @@ async def bmi_calculate_handler(
             waist_risk=waist_risk_schema,
             notes=list(result.notes),  # Ensure list[str]
             age_band=result.age_band,
+            visualization=None,  # Will be set below if builder succeeds
         )
 
         # Add visualization spec (graceful fallback: if builder fails, visualization remains None)
@@ -204,7 +205,7 @@ async def bmi_calculate_handler(
 
 
 @router.post("/calculate", response_model=BMICalculateResponse)
-async def calculate_bmi(req: BMICalculateRequest) -> BMICalculateResponse:
+async def calculate_bmi(req: BMICalculateRequest) -> dict[str, Any]:
     """
     RU: Рассчитывает BMI через единый engine.
     EN: Calculate BMI via unified engine.
@@ -215,12 +216,15 @@ async def calculate_bmi(req: BMICalculateRequest) -> BMICalculateResponse:
         req: BMICalculateRequest with user parameters
 
     Returns:
-        BMICalculateResponse with BMI calculation results
+        dict with BMI calculation results (already serialized with by_alias=True)
 
     Raises:
         HTTPException: 400 if domain validation fails (BMI out of bounds)
                       422 if Pydantic validation fails (handled automatically)
                       500 if engine is not available or other errors occur
     """
-    data = await bmi_calculate_handler(req)
-    return BMICalculateResponse.model_validate(data)
+    # Handler already returns dict with by_alias=True, so we return it directly.
+    # FastAPI passes through dict responses as-is (doesn't re-serialize via jsonable_encoder),
+    # so the "from" alias from model_dump(by_alias=True) is preserved in the final JSON response.
+    # This ensures clients receive "from" (not "from_") in visualization.ranges[].
+    return await bmi_calculate_handler(req)

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -168,10 +168,10 @@ async def bmi_calculate_handler(
         # Add visualization spec (graceful fallback: if builder fails, visualization remains None)
         try:
             resp.visualization = build_bmi_scale_v1(result.bmi)
-        except Exception as e:
+        except Exception:
             # Visualization is optional; don't break the endpoint if builder fails
             # Log the error for debugging while preserving graceful fallback
-            logger.error("Failed to build BMI visualization spec", exc_info=e)
+            logger.exception("Failed to build BMI visualization spec")
             resp.visualization = None
 
         # Return as dict for legacy compatibility

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -172,7 +172,8 @@ async def bmi_calculate_handler(
         except Exception:
             # Visualization is optional; don't break the endpoint if builder fails
             # Log the error for debugging while preserving graceful fallback
-            logger.exception("Failed to build BMI visualization spec")
+            # Security: log only BMI value (numeric), not user input data
+            logger.exception("Failed to build BMI visualization spec (BMI=%.1f)", result.bmi)
             resp.visualization = None
 
         # Return as dict for legacy compatibility

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -204,8 +204,12 @@ async def bmi_calculate_handler(
         ) from e
 
 
-@router.post("/calculate", response_model=BMICalculateResponse)
-async def calculate_bmi(req: BMICalculateRequest) -> dict[str, Any]:
+@router.post(
+    "/calculate",
+    response_model=BMICalculateResponse,
+    response_model_by_alias=True,
+)
+async def calculate_bmi(req: BMICalculateRequest) -> BMICalculateResponse:
     """
     RU: Рассчитывает BMI через единый engine.
     EN: Calculate BMI via unified engine.
@@ -216,15 +220,14 @@ async def calculate_bmi(req: BMICalculateRequest) -> dict[str, Any]:
         req: BMICalculateRequest with user parameters
 
     Returns:
-        dict with BMI calculation results (already serialized with by_alias=True)
+        BMICalculateResponse with BMI calculation results (serialized with by_alias=True)
 
     Raises:
         HTTPException: 400 if domain validation fails (BMI out of bounds)
                       422 if Pydantic validation fails (handled automatically)
                       500 if engine is not available or other errors occur
     """
-    # Handler already returns dict with by_alias=True, so we return it directly.
-    # FastAPI passes through dict responses as-is (doesn't re-serialize via jsonable_encoder),
-    # so the "from" alias from model_dump(by_alias=True) is preserved in the final JSON response.
-    # This ensures clients receive "from" (not "from_") in visualization.ranges[].
-    return await bmi_calculate_handler(req)
+    # Handler returns dict for legacy compatibility; convert back to model for FastAPI serialization
+    # response_model_by_alias=True ensures "from" (not "from_") in visualization.ranges[]
+    data = await bmi_calculate_handler(req)
+    return BMICalculateResponse.model_validate(data)

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -162,8 +162,12 @@ async def bmi_calculate_handler(
             age_band=result.age_band,
         )
 
-        # Add visualization spec
-        resp.visualization = build_bmi_scale_v1(result.bmi)
+        # Add visualization spec (graceful fallback: if builder fails, visualization remains None)
+        try:
+            resp.visualization = build_bmi_scale_v1(result.bmi)
+        except Exception:
+            # Visualization is optional; don't break the endpoint if builder fails
+            resp.visualization = None
 
         # Return as dict for legacy compatibility
         # IMPORTANT: use by_alias=True to ensure "from" (not "from_") in JSON

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -10,6 +10,7 @@ FREE tier endpoint (no API key required).
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Protocol
 
 from fastapi import APIRouter, HTTPException, status
@@ -17,6 +18,8 @@ from fastapi import APIRouter, HTTPException, status
 from app.schemas.bmi import BMICalculateRequest, BMICalculateResponse, WaistRiskResultSchema
 from app.services.bmi_visualization import build_bmi_scale_v1
 from core.i18n import normalize_lang, t
+
+logger = logging.getLogger(__name__)
 
 
 # Import engine (will be available after PR-453 Commit 2)
@@ -165,8 +168,10 @@ async def bmi_calculate_handler(
         # Add visualization spec (graceful fallback: if builder fails, visualization remains None)
         try:
             resp.visualization = build_bmi_scale_v1(result.bmi)
-        except Exception:
+        except Exception as e:
             # Visualization is optional; don't break the endpoint if builder fails
+            # Log the error for debugging while preserving graceful fallback
+            logger.error("Failed to build BMI visualization spec", exc_info=e)
             resp.visualization = None
 
         # Return as dict for legacy compatibility

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Protocol
 from fastapi import APIRouter, HTTPException, status
 
 from app.schemas.bmi import BMICalculateRequest, BMICalculateResponse, WaistRiskResultSchema
+from app.services.bmi_visualization import build_bmi_scale_v1
 from core.i18n import normalize_lang, t
 
 
@@ -161,8 +162,12 @@ async def bmi_calculate_handler(
             age_band=result.age_band,
         )
 
+        # Add visualization spec
+        resp.visualization = build_bmi_scale_v1(result.bmi)
+
         # Return as dict for legacy compatibility
-        response_dict: dict[str, Any] = resp.model_dump()
+        # IMPORTANT: use by_alias=True to ensure "from" (not "from_") in JSON
+        response_dict: dict[str, Any] = resp.model_dump(by_alias=True)
         return response_dict
 
     except NotImplementedError as e:

--- a/app/schemas/bmi.py
+++ b/app/schemas/bmi.py
@@ -10,6 +10,7 @@ FREE tier endpoint (no API key required).
 
 from __future__ import annotations
 
+import math
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -72,7 +73,8 @@ class BMIScaleV1Spec(BaseModel):
             raise ValueError(f"BMI value ({self.bmi}) must be between min ({self.min}) and max ({self.max})")
 
         # Ensure marker.value equals bmi (consistency check)
-        if self.marker.value != self.bmi:
+        # Use math.isclose to handle float precision artifacts
+        if not math.isclose(self.marker.value, self.bmi, rel_tol=0.0, abs_tol=1e-6):
             raise ValueError(f"Marker value ({self.marker.value}) must equal BMI ({self.bmi})")
 
         return self

--- a/app/schemas/bmi.py
+++ b/app/schemas/bmi.py
@@ -72,7 +72,9 @@ class BMIScaleV1Spec(BaseModel):
 
         # Ensure bmi is within scale bounds
         if not (self.min <= self.bmi <= self.max):
-            raise ValueError(f"BMI value ({self.bmi}) must be between min ({self.min}) and max ({self.max})")
+            raise ValueError(
+                f"BMI value ({self.bmi}) must be between min ({self.min}) and max ({self.max})"
+            )
 
         # Ensure marker.value equals bmi (consistency check)
         # Use math.isclose to handle float precision artifacts

--- a/app/schemas/bmi.py
+++ b/app/schemas/bmi.py
@@ -19,6 +19,31 @@ from core.i18n import Language
 RiskLevel = Literal["low", "moderate", "high"]
 
 
+class BMIRangeSpec(BaseModel):
+    """BMI range with i18n key."""
+
+    key: str = Field(..., description="i18n key for range label")
+    from_: float = Field(..., alias="from", description="Range start (inclusive)")
+    to: float = Field(..., description="Range end (exclusive)")
+
+
+class BMIMarkerSpec(BaseModel):
+    """BMI marker position."""
+
+    value: float = Field(..., description="Current BMI value")
+
+
+class BMIScaleV1Spec(BaseModel):
+    """BMI scale visualization spec v1."""
+
+    kind: Literal["bmi_scale_v1"] = "bmi_scale_v1"
+    bmi: float = Field(..., description="BMI value")
+    min: float = Field(0.0, description="Scale minimum")
+    max: float = Field(60.0, description="Scale maximum")
+    ranges: list[BMIRangeSpec] = Field(..., description="BMI ranges with i18n keys")
+    marker: BMIMarkerSpec = Field(..., description="Current BMI marker")
+
+
 class WaistRiskResultSchema(BaseModel):
     """
     RU: API-схема для сериализованного WaistRiskResult (domain dataclass).
@@ -199,4 +224,9 @@ class BMICalculateResponse(BaseModel):
             "'adult' (19-59), 'elderly' (>=60)."
         ),
         examples=["adult", "teen", "elderly"],
+    )
+
+    visualization: BMIScaleV1Spec | None = Field(
+        None,
+        description="Optional BMI scale visualization spec (v1). Frontend should render this if available.",
     )

--- a/app/schemas/bmi.py
+++ b/app/schemas/bmi.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from core.i18n import Language
 
@@ -26,22 +26,56 @@ class BMIRangeSpec(BaseModel):
     from_: float = Field(..., alias="from", description="Range start (inclusive)")
     to: float = Field(..., description="Range end (exclusive)")
 
+    @model_validator(mode="after")
+    def validate_range(self) -> "BMIRangeSpec":
+        if self.from_ >= self.to:
+            raise ValueError(f"Range start ({self.from_}) must be less than end ({self.to})")
+        return self
+
 
 class BMIMarkerSpec(BaseModel):
     """BMI marker position."""
 
-    value: float = Field(..., description="Current BMI value")
+    value: float = Field(..., description="Current BMI value", examples=[23.4, 25.0, 18.5])
 
 
 class BMIScaleV1Spec(BaseModel):
     """BMI scale visualization spec v1."""
 
     kind: Literal["bmi_scale_v1"] = "bmi_scale_v1"
-    bmi: float = Field(..., description="BMI value")
-    min: float = Field(0.0, description="Scale minimum")
-    max: float = Field(60.0, description="Scale maximum")
-    ranges: list[BMIRangeSpec] = Field(..., description="BMI ranges with i18n keys")
-    marker: BMIMarkerSpec = Field(..., description="Current BMI marker")
+    bmi: float = Field(..., description="BMI value", examples=[23.4, 25.0, 18.5])
+    min: float = Field(0.0, description="Scale minimum", examples=[0.0])
+    max: float = Field(60.0, description="Scale maximum", examples=[60.0])
+    ranges: list[BMIRangeSpec] = Field(
+        ...,
+        description="BMI ranges with i18n keys",
+        examples=[
+            [
+                {"key": "bmi.underweight", "from": 0, "to": 18.5},
+                {"key": "bmi.normal", "from": 18.5, "to": 25},
+                {"key": "bmi.overweight", "from": 25, "to": 30},
+                {"key": "bmi.obesity", "from": 30, "to": 60},
+            ]
+        ],
+    )
+    marker: BMIMarkerSpec = Field(..., description="Current BMI marker", examples=[{"value": 23.4}])
+
+    @model_validator(mode="after")
+    def validate_scale(self) -> "BMIScaleV1Spec":
+        """Validate scale constraints and consistency."""
+        # Ensure min < max
+        if self.min >= self.max:
+            raise ValueError(f"Scale minimum ({self.min}) must be less than maximum ({self.max})")
+
+        # Ensure bmi is within scale bounds
+        if not (self.min <= self.bmi <= self.max):
+            raise ValueError(f"BMI value ({self.bmi}) must be between min ({self.min}) and max ({self.max})")
+
+        # Ensure marker.value equals bmi (consistency check)
+        if self.marker.value != self.bmi:
+            raise ValueError(f"Marker value ({self.marker.value}) must equal BMI ({self.bmi})")
+
+        return self
 
 
 class WaistRiskResultSchema(BaseModel):

--- a/app/schemas/bmi.py
+++ b/app/schemas/bmi.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import math
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from core.i18n import Language
 
@@ -22,6 +22,8 @@ RiskLevel = Literal["low", "moderate", "high"]
 
 class BMIRangeSpec(BaseModel):
     """BMI range with i18n key."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     key: str = Field(..., description="i18n key for range label")
     from_: float = Field(..., alias="from", description="Range start (inclusive)")

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -25,13 +25,12 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
     """
     # Fixed thresholds (WHO standard)
-    # Use model_validate with dict to handle alias "from" correctly
-    # (alias appears in JSON via model_dump(by_alias=True) in router)
+    # Use direct constructors with from_= (alias "from" appears in JSON via model_dump(by_alias=True))
     ranges = [
-        BMIRangeSpec.model_validate({"key": "bmi.underweight", "from": 0.0, "to": 18.5}),
-        BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
-        BMIRangeSpec.model_validate({"key": "bmi.overweight", "from": 25.0, "to": 30.0}),
-        BMIRangeSpec.model_validate({"key": "bmi.obesity", "from": 30.0, "to": 60.0}),
+        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
+        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
+        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
+        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
     ]
 
     rounded_bmi = round(bmi, 1)

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -14,11 +14,10 @@ from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
 def _range(key: str, start: float, end: float) -> BMIRangeSpec:
     """Create BMIRangeSpec using direct constructor.
 
-    Pyright/mypy may not understand alias + populate_by_name in Pydantic v2,
-    so we suppress the type checker warning here (localized to this helper).
-    Runtime correctly uses populate_by_name=True to accept from_= parameter.
+    Pydantic v2 with populate_by_name=True accepts from_= parameter at runtime.
+    Type checkers may not fully understand this, but mypy doesn't flag it as an error.
     """
-    return BMIRangeSpec(key=key, from_=start, to=end)  # type: ignore[call-arg]
+    return BMIRangeSpec(key=key, from_=start, to=end)
 
 
 def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -25,7 +25,8 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
     """
     # Fixed thresholds (WHO standard)
-    # Use model_validate with dict to properly handle alias "from"
+    # Use model_validate with dict to handle alias "from" correctly
+    # (alias appears in JSON via model_dump(by_alias=True) in router)
     ranges = [
         BMIRangeSpec.model_validate({"key": "bmi.underweight", "from": 0.0, "to": 18.5}),
         BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -11,6 +11,16 @@ This is an API adapter, not domain logic.
 from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
 
 
+def _range(key: str, start: float, end: float) -> BMIRangeSpec:
+    """Create BMIRangeSpec using direct constructor.
+
+    Pyright/mypy may not understand alias + populate_by_name in Pydantic v2,
+    so we suppress the type checker warning here (localized to this helper).
+    Runtime correctly uses populate_by_name=True to accept from_= parameter.
+    """
+    return BMIRangeSpec(key=key, from_=start, to=end)  # type: ignore[call-arg]
+
+
 def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
     """
     Build BMI scale v1 spec for frontend rendering.
@@ -25,12 +35,12 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
     """
     # Fixed thresholds (WHO standard)
-    # Use direct constructors with from_= (alias "from" appears in JSON via model_dump(by_alias=True))
+    # Use helper function to create ranges (alias "from" appears in JSON via model_dump(by_alias=True))
     ranges = [
-        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
-        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
-        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
-        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
+        _range("bmi.underweight", 0.0, 18.5),
+        _range("bmi.normal", 18.5, 25.0),
+        _range("bmi.overweight", 25.0, 30.0),
+        _range("bmi.obesity", 30.0, 60.0),
     ]
 
     rounded_bmi = round(bmi, 1)
@@ -43,4 +53,3 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         ranges=ranges,
         marker=BMIMarkerSpec(value=rounded_bmi),
     )
-

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -25,11 +25,12 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
     """
     # Fixed thresholds (WHO standard)
+    # Use model_validate with dict to properly handle alias "from"
     ranges = [
-        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
-        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
-        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
-        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
+        BMIRangeSpec.model_validate({"key": "bmi.underweight", "from": 0.0, "to": 18.5}),
+        BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
+        BMIRangeSpec.model_validate({"key": "bmi.overweight", "from": 25.0, "to": 30.0}),
+        BMIRangeSpec.model_validate({"key": "bmi.obesity", "from": 30.0, "to": 60.0}),
     ]
 
     rounded_bmi = round(bmi, 1)

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -12,12 +12,8 @@ from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
 
 
 def _range(key: str, start: float, end: float) -> BMIRangeSpec:
-    """Create BMIRangeSpec using direct constructor.
-
-    Pydantic v2 with populate_by_name=True accepts from_= parameter at runtime.
-    Type checkers may not fully understand this, but mypy doesn't flag it as an error.
-    """
-    return BMIRangeSpec(key=key, from_=start, to=end)
+    """Create BMIRangeSpec using model_validate for type-checker compatibility."""
+    return BMIRangeSpec.model_validate({"key": key, "from": start, "to": end})
 
 
 def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:

--- a/app/services/bmi_visualization.py
+++ b/app/services/bmi_visualization.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+BMI Visualization Service
+
+RU: Сервис для генерации spec визуализации BMI.
+EN: Service for generating BMI visualization spec.
+
+This is an API adapter, not domain logic.
+"""
+
+from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
+
+
+def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
+    """
+    Build BMI scale v1 spec for frontend rendering.
+
+    Uses fixed thresholds (0-60) regardless of group.
+    Group-specific interpretation is handled separately in category/interpretation fields.
+
+    Args:
+        bmi: BMI value (will be rounded to 1 decimal)
+
+    Returns:
+        BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
+    """
+    # Fixed thresholds (WHO standard)
+    ranges = [
+        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
+        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
+        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
+        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
+    ]
+
+    rounded_bmi = round(bmi, 1)
+
+    return BMIScaleV1Spec(
+        kind="bmi_scale_v1",
+        bmi=rounded_bmi,
+        min=0.0,
+        max=60.0,
+        ranges=ranges,
+        marker=BMIMarkerSpec(value=rounded_bmi),
+    )
+

--- a/docs/pr/PR_490A_BACKEND_ONLY.md
+++ b/docs/pr/PR_490A_BACKEND_ONLY.md
@@ -125,13 +125,13 @@ from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
 def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
     """
     Build BMI scale v1 spec for frontend rendering.
-    
+
     Uses fixed thresholds (0-60) regardless of group.
     Group-specific interpretation is handled separately in category/interpretation fields.
-    
+
     Args:
         bmi: BMI value (will be rounded to 1 decimal)
-    
+
     Returns:
         BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
     """
@@ -142,9 +142,9 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
         BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
     ]
-    
+
     rounded_bmi = round(bmi, 1)
-    
+
     return BMIScaleV1Spec(
         kind="bmi_scale_v1",
         bmi=rounded_bmi,
@@ -225,7 +225,7 @@ from app.schemas.bmi import BMIScaleV1Spec
 def test_build_bmi_scale_v1_structure():
     """Test that spec has correct structure."""
     spec = build_bmi_scale_v1(23.4)
-    
+
     assert spec.kind == "bmi_scale_v1"
     assert spec.bmi == 23.4
     assert spec.min == 0.0
@@ -237,16 +237,16 @@ def test_build_bmi_scale_v1_structure():
 def test_ranges_monotonic_no_gaps():
     """Test that ranges are monotonic with no gaps."""
     spec = build_bmi_scale_v1(25.0)
-    
+
     # Check each range: from_ < to
     for range_spec in spec.ranges:
         assert range_spec.from_ < range_spec.to, f"Range {range_spec.key}: from_ >= to"
-    
+
     # Check sequence: end of previous == start of next
     for i in range(len(spec.ranges) - 1):
         assert spec.ranges[i].to == spec.ranges[i + 1].from_, \
             f"Gap between range {i} and {i + 1}"
-    
+
     # Check boundaries
     assert spec.ranges[0].from_ == spec.min, "First range should start at min"
     assert spec.ranges[-1].to == spec.max, "Last range should end at max"
@@ -255,7 +255,7 @@ def test_ranges_monotonic_no_gaps():
 def test_marker_equals_bmi():
     """Test that marker value equals rounded BMI."""
     test_cases = [18.5, 22.3, 25.0, 30.0, 35.7]
-    
+
     for bmi in test_cases:
         spec = build_bmi_scale_v1(bmi)
         assert spec.marker.value == round(bmi, 1), \
@@ -270,11 +270,11 @@ def test_build_bmi_scale_v1_edge_cases():
     spec1 = build_bmi_scale_v1(0.0)
     assert spec1.bmi == 0.0
     assert spec1.marker.value == 0.0
-    
+
     spec2 = build_bmi_scale_v1(60.0)
     assert spec2.bmi == 60.0
     assert spec2.marker.value == 60.0
-    
+
     # Very small BMI
     spec3 = build_bmi_scale_v1(10.12345)
     assert spec3.bmi == 10.1  # rounded to 1 decimal
@@ -286,9 +286,9 @@ def test_bmi_calculate_returns_visualization():
     # Use canonical import pattern from project
     from app import app
     from fastapi.testclient import TestClient
-    
+
     client = TestClient(app)
-    
+
     response = client.post(
         "/api/v1/bmi/calculate",
         json={
@@ -299,10 +299,10 @@ def test_bmi_calculate_returns_visualization():
             "lang": "en",
         },
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert "visualization" in data, "Response should contain visualization field"
     assert data["visualization"] is not None, "Visualization should not be None"
     assert data["visualization"]["kind"] == "bmi_scale_v1", \
@@ -310,7 +310,7 @@ def test_bmi_calculate_returns_visualization():
     assert "ranges" in data["visualization"], "Visualization should contain ranges"
     assert "marker" in data["visualization"], "Visualization should contain marker"
     assert len(data["visualization"]["ranges"]) == 4, "Should have 4 ranges"
-    
+
     # Verify alias "from" is used (not "from_")
     first_range = data["visualization"]["ranges"][0]
     assert "from" in first_range, "Range should use 'from' alias (not 'from_')"
@@ -374,4 +374,3 @@ test(bmi): add visualization spec tests
 - i18n ключи
 - Интеграция в UI
 - Frontend тесты
-

--- a/docs/pr/PR_490A_BACKEND_ONLY.md
+++ b/docs/pr/PR_490A_BACKEND_ONLY.md
@@ -92,7 +92,7 @@ visualization: BMIScaleV1Spec | None = Field(
 ```
 
 **Message:**
-```
+```text
 feat(bmi): add BMIScaleV1Spec schema for visualization
 
 - Add BMIRangeSpec, BMIMarkerSpec, BMIScaleV1Spec models
@@ -156,7 +156,7 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
 ```
 
 **Message:**
-```
+```text
 feat(bmi): add build_bmi_scale_v1 spec builder
 
 - Create app/services/bmi_visualization.py
@@ -184,16 +184,14 @@ resp = BMICalculateResponse(...)
 # Добавить:
 resp.visualization = build_bmi_scale_v1(result.bmi)
 
-# Return as dict for legacy compatibility
-# IMPORTANT: use by_alias=True to ensure "from" (not "from_") in JSON
-response_dict: dict[str, Any] = resp.model_dump(by_alias=True)
-return response_dict
+# Return model; alias ensured via response_model_by_alias=True in decorator
+return resp
 ```
 
-**⚠️ Критично:** `by_alias=True` обязателен, иначе в JSON будет `from_` вместо `from`.
+**⚠️ Критично:** В декораторе роута добавить `response_model_by_alias=True` для сохранения alias `"from"` в JSON.
 
 **Message:**
-```
+```text
 feat(bmi): integrate visualization spec in calculate endpoint
 
 - Add visualization to bmi_calculate_handler response
@@ -318,7 +316,7 @@ def test_bmi_calculate_returns_visualization():
 ```
 
 **Message:**
-```
+```text
 test(bmi): add visualization spec tests
 
 - Test spec structure and ranges monotonicity

--- a/docs/pr/PR_490A_BACKEND_ONLY.md
+++ b/docs/pr/PR_490A_BACKEND_ONLY.md
@@ -1,0 +1,377 @@
+# PR-490A: Backend-only BMI Visualization Spec (≤7 files)
+
+## 🎯 Цель
+
+Добавить JSON spec визуализации BMI в `/api/v1/bmi/calculate` **без frontend изменений**.
+
+**Критерий готовности:** curl endpoint → видим `visualization` в ответе.
+
+---
+
+## 📋 Точный список файлов (строго ≤7)
+
+### Изменяемые файлы (4)
+
+1. **`app/schemas/bmi.py`**
+   - Добавить `BMIRangeSpec`, `BMIMarkerSpec`, `BMIScaleV1Spec`
+   - Добавить `visualization: BMIScaleV1Spec | None` в `BMICalculateResponse`
+
+2. **`app/services/bmi_visualization.py`** (новый файл)
+   - Функция `build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec`
+
+3. **`app/routers/bmi.py`**
+   - В `bmi_calculate_handler()` добавить 2-3 строки: импорт + присвоение `resp.visualization`
+
+4. **`tests/test_bmi_visualization_spec.py`** (новый файл)
+   - 4 теста: структура, ranges monotonic, marker, endpoint response
+
+### Опциональные файлы (2-3, не обязательны для функциональности)
+
+5. **`docs/pr/PR_490_DESCRIPTION.md`** (если создаём)
+6. **`docs/pr/PR_490_CURSOR_CHECKLIST.md`** (если создаём)
+7. **`docs/pr/PR_BMI_VISUALIZATION_SPEC.md`** (если обновляем)
+
+**Итого:** 4 обязательных + 0-3 опциональных = **4-7 файлов**
+
+---
+
+## ✅ Жёсткие ограничения (чтобы PR не расползся)
+
+### ❌ НЕ трогаем
+
+- `legacy_app.py` — не изменяем
+- `bmi_visualization.py` (корневой) — не трогаем
+- Frontend файлы — **строго вне scope**
+- `core/` — не добавляем туда spec builder (это API adapter, не domain logic)
+- Refactoring существующего кода — только добавление
+
+### ✅ Только добавляем
+
+- Новые Pydantic модели
+- Новый builder в `app/services/`
+- Минимальная интеграция в router (2-3 строки)
+- Тесты
+
+---
+
+## 🔧 Commit Strategy (4 коммита, строго по порядку)
+
+### Commit 1: Schema models
+
+**Файл:** `app/schemas/bmi.py`
+
+**Что добавить:**
+
+```python
+class BMIRangeSpec(BaseModel):
+    """BMI range with i18n key."""
+    key: str = Field(..., description="i18n key for range label")
+    from_: float = Field(..., alias="from", description="Range start (inclusive)")
+    to: float = Field(..., description="Range end (exclusive)")
+
+class BMIMarkerSpec(BaseModel):
+    """BMI marker position."""
+    value: float = Field(..., description="Current BMI value")
+
+class BMIScaleV1Spec(BaseModel):
+    """BMI scale visualization spec v1."""
+    kind: Literal["bmi_scale_v1"] = "bmi_scale_v1"
+    bmi: float = Field(..., description="BMI value")
+    min: float = Field(0.0, description="Scale minimum")
+    max: float = Field(60.0, description="Scale maximum")
+    ranges: list[BMIRangeSpec] = Field(..., description="BMI ranges with i18n keys")
+    marker: BMIMarkerSpec = Field(..., description="Current BMI marker")
+```
+
+**Обновить `BMICalculateResponse`:**
+```python
+visualization: BMIScaleV1Spec | None = Field(
+    None,
+    description="Optional BMI scale visualization spec (v1). Frontend should render this if available."
+)
+```
+
+**Message:**
+```
+feat(bmi): add BMIScaleV1Spec schema for visualization
+
+- Add BMIRangeSpec, BMIMarkerSpec, BMIScaleV1Spec models
+- Add visualization field to BMICalculateResponse
+- Use alias "from" for Python reserved word
+```
+
+---
+
+### Commit 2: Spec builder
+
+**Файл:** `app/services/bmi_visualization.py` (новый)
+
+**Что создать:**
+
+```python
+# -*- coding: utf-8 -*-
+"""
+BMI Visualization Service
+
+RU: Сервис для генерации spec визуализации BMI.
+EN: Service for generating BMI visualization spec.
+
+This is an API adapter, not domain logic.
+"""
+
+from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
+
+
+def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
+    """
+    Build BMI scale v1 spec for frontend rendering.
+    
+    Uses fixed thresholds (0-60) regardless of group.
+    Group-specific interpretation is handled separately in category/interpretation fields.
+    
+    Args:
+        bmi: BMI value (will be rounded to 1 decimal)
+    
+    Returns:
+        BMIScaleV1Spec with fixed scale 0-60 and WHO standard thresholds
+    """
+    # Fixed thresholds (WHO standard)
+    ranges = [
+        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
+        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
+        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
+        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
+    ]
+    
+    rounded_bmi = round(bmi, 1)
+    
+    return BMIScaleV1Spec(
+        kind="bmi_scale_v1",
+        bmi=rounded_bmi,
+        min=0.0,
+        max=60.0,
+        ranges=ranges,
+        marker=BMIMarkerSpec(value=rounded_bmi),
+    )
+```
+
+**Message:**
+```
+feat(bmi): add build_bmi_scale_v1 spec builder
+
+- Create app/services/bmi_visualization.py
+- Fixed scale 0-60 with WHO standard thresholds
+- i18n keys: bmi.underweight|normal|overweight|obesity
+- API adapter (not domain logic)
+```
+
+---
+
+### Commit 3: Integration
+
+**Файл:** `app/routers/bmi.py`
+
+**Где:** В `bmi_calculate_handler()` после создания `resp`
+
+**Что добавить:**
+
+```python
+from app.services.bmi_visualization import build_bmi_scale_v1
+
+# После:
+resp = BMICalculateResponse(...)
+
+# Добавить:
+resp.visualization = build_bmi_scale_v1(result.bmi)
+
+# Return as dict for legacy compatibility
+# IMPORTANT: use by_alias=True to ensure "from" (not "from_") in JSON
+response_dict: dict[str, Any] = resp.model_dump(by_alias=True)
+return response_dict
+```
+
+**⚠️ Критично:** `by_alias=True` обязателен, иначе в JSON будет `from_` вместо `from`.
+
+**Message:**
+```
+feat(bmi): integrate visualization spec in calculate endpoint
+
+- Add visualization to bmi_calculate_handler response
+- Always return spec (no include_chart flag)
+- Legacy base64 remains in legacy_app.py (not touched)
+```
+
+---
+
+### Commit 4: Tests
+
+**Файл:** `tests/test_bmi_visualization_spec.py` (новый)
+
+**Что создать:**
+
+```python
+# -*- coding: utf-8 -*-
+"""
+Tests for BMI visualization spec builder and endpoint integration.
+"""
+
+import pytest
+import math
+
+from app.services.bmi_visualization import build_bmi_scale_v1
+from app.schemas.bmi import BMIScaleV1Spec
+
+
+def test_build_bmi_scale_v1_structure():
+    """Test that spec has correct structure."""
+    spec = build_bmi_scale_v1(23.4)
+    
+    assert spec.kind == "bmi_scale_v1"
+    assert spec.bmi == 23.4
+    assert spec.min == 0.0
+    assert spec.max == 60.0
+    assert len(spec.ranges) == 4
+    assert spec.marker.value == 23.4
+
+
+def test_ranges_monotonic_no_gaps():
+    """Test that ranges are monotonic with no gaps."""
+    spec = build_bmi_scale_v1(25.0)
+    
+    # Check each range: from_ < to
+    for range_spec in spec.ranges:
+        assert range_spec.from_ < range_spec.to, f"Range {range_spec.key}: from_ >= to"
+    
+    # Check sequence: end of previous == start of next
+    for i in range(len(spec.ranges) - 1):
+        assert spec.ranges[i].to == spec.ranges[i + 1].from_, \
+            f"Gap between range {i} and {i + 1}"
+    
+    # Check boundaries
+    assert spec.ranges[0].from_ == spec.min, "First range should start at min"
+    assert spec.ranges[-1].to == spec.max, "Last range should end at max"
+
+
+def test_marker_equals_bmi():
+    """Test that marker value equals rounded BMI."""
+    test_cases = [18.5, 22.3, 25.0, 30.0, 35.7]
+    
+    for bmi in test_cases:
+        spec = build_bmi_scale_v1(bmi)
+        assert spec.marker.value == round(bmi, 1), \
+            f"Marker value {spec.marker.value} != rounded BMI {round(bmi, 1)}"
+        assert spec.bmi == round(bmi, 1), \
+            f"Spec BMI {spec.bmi} != rounded BMI {round(bmi, 1)}"
+
+
+def test_build_bmi_scale_v1_edge_cases():
+    """Test builder handles edge cases safely."""
+    # Normal cases
+    spec1 = build_bmi_scale_v1(0.0)
+    assert spec1.bmi == 0.0
+    assert spec1.marker.value == 0.0
+    
+    spec2 = build_bmi_scale_v1(60.0)
+    assert spec2.bmi == 60.0
+    assert spec2.marker.value == 60.0
+    
+    # Very small BMI
+    spec3 = build_bmi_scale_v1(10.12345)
+    assert spec3.bmi == 10.1  # rounded to 1 decimal
+    assert spec3.marker.value == 10.1
+
+
+def test_bmi_calculate_returns_visualization():
+    """Test that /api/v1/bmi/calculate returns visualization field."""
+    # Use canonical import pattern from project
+    from app import app
+    from fastapi.testclient import TestClient
+    
+    client = TestClient(app)
+    
+    response = client.post(
+        "/api/v1/bmi/calculate",
+        json={
+            "weight_kg": 70.0,
+            "height_cm": 175.0,
+            "age": 30,
+            "gender": "male",  # BMICalculateRequest uses "gender", not "sex"
+            "lang": "en",
+        },
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert "visualization" in data, "Response should contain visualization field"
+    assert data["visualization"] is not None, "Visualization should not be None"
+    assert data["visualization"]["kind"] == "bmi_scale_v1", \
+        "Visualization kind should be bmi_scale_v1"
+    assert "ranges" in data["visualization"], "Visualization should contain ranges"
+    assert "marker" in data["visualization"], "Visualization should contain marker"
+    assert len(data["visualization"]["ranges"]) == 4, "Should have 4 ranges"
+    
+    # Verify alias "from" is used (not "from_")
+    first_range = data["visualization"]["ranges"][0]
+    assert "from" in first_range, "Range should use 'from' alias (not 'from_')"
+    assert "from_" not in first_range, "Range should not contain 'from_' field"
+```
+
+**Message:**
+```
+test(bmi): add visualization spec tests
+
+- Test spec structure and ranges monotonicity
+- Test marker value equals BMI
+- Test endpoint returns visualization field
+```
+
+---
+
+## ✅ Verification Checklist
+
+После всех коммитов проверить:
+
+- [ ] `pytest -q tests/test_bmi_visualization_spec.py` — все тесты проходят
+- [ ] `pytest -q` — полный test suite проходит (coverage не упало)
+- [ ] `ruff check app/schemas/bmi.py app/services/bmi_visualization.py app/routers/bmi.py` — нет lint ошибок
+- [ ] `mypy app/schemas/bmi.py app/services/bmi_visualization.py app/routers/bmi.py` — type check проходит (если включён)
+- [ ] Ручная проверка: `curl -X POST http://localhost:8000/api/v1/bmi/calculate -H "Content-Type: application/json" -d '{"weight_kg": 70, "height_cm": 175, "age": 30, "gender": "male", "lang": "en"}' | jq .visualization`
+  - Должен вернуть JSON с `kind: "bmi_scale_v1"`, `ranges`, `marker`
+
+---
+
+## 🚫 Что НЕ делаем (жёстко)
+
+1. **НЕ трогаем `legacy_app.py`** — он остаётся как есть
+2. **НЕ трогаем `bmi_visualization.py` (корневой)** — legacy base64 модуль
+3. **НЕ добавляем frontend файлы** — это PR-490B
+4. **НЕ делаем refactoring** — только добавление
+5. **НЕ добавляем цвета в API** — только i18n keys
+6. **НЕ используем `group` в spec builder** — фиксированная шкала
+7. **НЕ добавляем matplotlib/base64** — только JSON spec
+
+---
+
+## 📊 Ожидаемый результат
+
+После merge PR-490A:
+
+- Endpoint `/api/v1/bmi/calculate` возвращает `visualization` в ответе
+- Spec содержит правильную структуру (kind, ranges, marker)
+- Тесты покрывают основные случаи
+- Coverage не упало (97%+)
+- Legacy не тронут
+
+**Frontend может начать использовать spec сразу после merge PR-490A.**
+
+---
+
+## 🔗 Следующий шаг
+
+После merge PR-490A → **PR-490B (frontend-only)**:
+- Компонент `BmiScaleV1.tsx`
+- i18n ключи
+- Интеграция в UI
+- Frontend тесты
+

--- a/docs/pr/PR_490A_REVIEW_CHECKLIST.md
+++ b/docs/pr/PR_490A_REVIEW_CHECKLIST.md
@@ -1,0 +1,208 @@
+# PR-490A: Review Checklist для Специалиста 2
+
+## 🎯 Цель review
+
+Проверить, что PR-490A **не сломал legacy**, **не добавил тяжёлое**, и **не испортил UX-следующий шаг** (PR-490B).
+
+---
+
+## ✅ Обязательные проверки (10 пунктов)
+
+### 1. Legacy не тронут
+
+- [ ] `legacy_app.py` не изменён
+- [ ] `bmi_visualization.py` (корневой) не изменён
+- [ ] `include_chart` параметр не используется в новом endpoint
+- [ ] Base64 generation не добавлен в `/api/v1/bmi/calculate`
+
+**Почему важно:** Legacy должен работать независимо от нового spec.
+
+---
+
+### 2. Alias "from" работает корректно
+
+- [ ] В `app/routers/bmi.py` используется `resp.model_dump(by_alias=True)`
+- [ ] В тесте проверяется, что JSON содержит `"from"` (не `"from_"`)
+- [ ] В тесте проверяется, что JSON **не содержит** `"from_"`
+
+**Почему важно:** Frontend ожидает `"from"` в JSON, не `"from_"`.
+
+**Как проверить:**
+```bash
+curl -X POST http://localhost:8000/api/v1/bmi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"weight_kg": 70, "height_cm": 175, "age": 30, "gender": "male", "lang": "en"}' \
+  | jq '.visualization.ranges[0]'
+```
+
+Должно быть:
+```json
+{
+  "key": "bmi.underweight",
+  "from": 0,
+  "to": 18.5
+}
+```
+
+**НЕ должно быть:**
+```json
+{
+  "key": "bmi.underweight",
+  "from_": 0,
+  "to": 18.5
+}
+```
+
+---
+
+### 3. Request payload в тесте соответствует реальному контракту
+
+- [ ] Тест использует `"gender"` (не `"sex"`)
+- [ ] Тест использует поля из `BMICalculateRequest` schema
+- [ ] Тест проходит с реальным endpoint
+
+**Почему важно:** Неправильный payload → тест падает или не тестирует реальный путь.
+
+**Как проверить:**
+- Открыть `app/schemas/bmi.py` → `BMICalculateRequest`
+- Сравнить с тестовым payload в `test_bmi_calculate_returns_visualization()`
+
+---
+
+### 4. Импорт app в тесте каноничный
+
+- [ ] Используется `from app import app` (как в других тестах проекта)
+- [ ] НЕ используется `__import__("app", fromlist=["app"])` или другие хаки
+
+**Почему важно:** Неканоничный импорт может сломаться при рефакторинге.
+
+**Как проверить:**
+```bash
+grep -r "from app import app" tests/ | head -5
+```
+
+Должен быть такой же паттерн.
+
+---
+
+### 5. Нет цветов в API
+
+- [ ] В `BMIScaleV1Spec` нет поля `color` или `colors`
+- [ ] В `build_bmi_scale_v1()` нет цветов
+- [ ] В тестах нет проверок цветов
+
+**Почему важно:** Цвета = дизайн = frontend concern. API с цветами = vendor lock.
+
+---
+
+### 6. Нет matplotlib/base64 в новом endpoint
+
+- [ ] `app/services/bmi_visualization.py` не импортирует matplotlib
+- [ ] `build_bmi_scale_v1()` не генерит base64
+- [ ] В router нет вызовов `generate_bmi_visualization()` (legacy функция)
+
+**Почему важно:** Base64 = тяжёлый payload, matplotlib = зависимость, latency.
+
+---
+
+### 7. Payload size разумный
+
+- [ ] JSON spec ~500 bytes (не 50-200KB как base64)
+- [ ] В тесте можно проверить размер ответа (опционально)
+
+**Почему важно:** Большой payload = latency, плохой UX на мобильных.
+
+**Как проверить:**
+```bash
+curl -X POST http://localhost:8000/api/v1/bmi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"weight_kg": 70, "height_cm": 175, "age": 30, "gender": "male", "lang": "en"}' \
+  | jq '.visualization' | wc -c
+```
+
+Должно быть ~200-500 bytes, не 50KB+.
+
+---
+
+### 8. Builder fail-safe для edge cases
+
+- [ ] Тест на edge cases (0.0, 60.0, очень маленькие значения)
+- [ ] `round()` не падает на нормальных float значениях
+- [ ] Нет проверок на `nan`/`inf` (если upstream гарантирует float)
+
+**Почему важно:** Edge cases могут сломать endpoint в проде.
+
+**Опционально:** Если upstream (BMI engine) может вернуть `nan`/`inf`, добавить guard в builder.
+
+---
+
+### 9. Coverage не упало
+
+- [ ] `pytest --cov` показывает coverage ≥97%
+- [ ] Новые файлы покрыты тестами
+- [ ] Существующие тесты не сломались
+
+**Почему важно:** Проект требует 97% coverage.
+
+---
+
+### 10. Graceful поведение при ошибках
+
+- [ ] Если `build_bmi_scale_v1()` падает, endpoint не падает (опционально: возвращает `visualization: None`)
+- [ ] Тесты не падают при отсутствии visualization (если это допустимо)
+
+**Почему важно:** Ошибка в builder не должна ломать весь endpoint.
+
+**Текущий план:** Builder всегда возвращает spec (нет ошибок), но можно добавить try/except в router для безопасности.
+
+---
+
+## 🚫 Что НЕ проверяем (не scope PR-490A)
+
+- ❌ Frontend компонент (это PR-490B)
+- ❌ i18n ключи на фронте (это PR-490B)
+- ❌ SVG рендеринг (это PR-490B)
+- ❌ UX/дизайн (это PR-490B)
+- ❌ Анимации/кэширование (отложено)
+
+---
+
+## 📝 Формат review комментариев
+
+Если находишь проблему:
+
+```
+❌ [Проверка #X] Проблема: ...
+
+Ожидалось: ...
+Фактически: ...
+
+Как исправить: ...
+```
+
+Если всё ок:
+
+```
+✅ [Проверка #X] OK: ...
+```
+
+---
+
+## ⚡ Быстрая проверка (5 минут)
+
+Если нет времени на полный review, проверь минимум:
+
+1. ✅ Legacy не тронут (`legacy_app.py` не изменён)
+2. ✅ `by_alias=True` в `model_dump()` (проверка alias "from")
+3. ✅ Нет цветов в API
+4. ✅ Нет matplotlib/base64
+5. ✅ Тесты проходят
+
+---
+
+## 🔗 Связанные документы
+
+- `docs/pr/PR_490A_BACKEND_ONLY.md` - полный план PR-490A
+- `docs/pr/PR_BMI_VISUALIZATION_SPEC.md` - спецификация
+- `app/AGENTS.md` - архитектурные инварианты
+

--- a/docs/pr/PR_490A_REVIEW_CHECKLIST.md
+++ b/docs/pr/PR_490A_REVIEW_CHECKLIST.md
@@ -205,4 +205,3 @@ curl -X POST http://localhost:8000/api/v1/bmi/calculate \
 - `docs/pr/PR_490A_BACKEND_ONLY.md` - полный план PR-490A
 - `docs/pr/PR_BMI_VISUALIZATION_SPEC.md` - спецификация
 - `app/AGENTS.md` - архитектурные инварианты
-

--- a/docs/pr/PR_490_CURSOR_CHECKLIST.md
+++ b/docs/pr/PR_490_CURSOR_CHECKLIST.md
@@ -92,7 +92,7 @@ from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
 def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
     """
     Build BMI scale v1 spec for frontend rendering.
-    
+
     Uses fixed thresholds (0-60) regardless of group.
     Group-specific interpretation is handled separately in category/interpretation fields.
     """
@@ -103,7 +103,7 @@ def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
         BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
         BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
     ]
-    
+
     return BMIScaleV1Spec(
         kind="bmi_scale_v1",
         bmi=round(bmi, 1),
@@ -406,4 +406,3 @@ test(web): add BmiScaleV1 snapshot tests
 - [ ] Spec builder в `app/services/` (не в `core/`, не в router)
 - [ ] Тесты покрывают основные случаи
 - [ ] Документация обновлена (если нужно)
-

--- a/docs/pr/PR_490_CURSOR_CHECKLIST.md
+++ b/docs/pr/PR_490_CURSOR_CHECKLIST.md
@@ -138,9 +138,8 @@ resp = BMICalculateResponse(...)
 # Добавить visualization
 resp.visualization = build_bmi_scale_v1(result.bmi)
 
-# Return as dict for legacy compatibility
-response_dict: dict[str, Any] = resp.model_dump()
-return response_dict
+# Return model; alias ensured via response_model_by_alias=True in decorator
+return resp
 ```
 
 ⚠️ **Не трогаем** `legacy_app.py` и `include_chart`.
@@ -315,7 +314,7 @@ pnpm lint  # или npm run lint
 ## F) Commit Strategy (рекомендуемый порядок)
 
 ### Commit 1: Backend schema
-```
+```text
 feat(bmi): add BMIScaleV1Spec schema for visualization
 
 - Add BMIRangeSpec, BMIMarkerSpec, BMIScaleV1Spec models
@@ -324,7 +323,7 @@ feat(bmi): add BMIScaleV1Spec schema for visualization
 ```
 
 ### Commit 2: Backend builder
-```
+```text
 feat(bmi): add build_bmi_scale_v1 spec builder
 
 - Create app/services/bmi_visualization.py
@@ -333,7 +332,7 @@ feat(bmi): add build_bmi_scale_v1 spec builder
 ```
 
 ### Commit 3: Backend integration
-```
+```text
 feat(bmi): integrate visualization spec in calculate endpoint
 
 - Add visualization to bmi_calculate_handler response
@@ -342,7 +341,7 @@ feat(bmi): integrate visualization spec in calculate endpoint
 ```
 
 ### Commit 4: Backend tests
-```
+```text
 test(bmi): add visualization spec tests
 
 - Test spec structure and ranges monotonicity
@@ -351,7 +350,7 @@ test(bmi): add visualization spec tests
 ```
 
 ### Commit 5: Frontend i18n (если в этом PR)
-```
+```text
 feat(web): add BMI i18n keys for visualization
 
 - Add bmi.underweight|normal|overweight|obesity to locales
@@ -359,7 +358,7 @@ feat(web): add BMI i18n keys for visualization
 ```
 
 ### Commit 6: Frontend component (если в этом PR)
-```
+```text
 feat(web): add BmiScaleV1 SVG component
 
 - SVG rendering with zones and marker
@@ -368,7 +367,7 @@ feat(web): add BmiScaleV1 SVG component
 ```
 
 ### Commit 7: Frontend integration (если в этом PR)
-```
+```text
 feat(web): integrate BMI visualization in result view
 
 - Render BmiScaleV1 if visualization.kind === "bmi_scale_v1"
@@ -376,7 +375,7 @@ feat(web): integrate BMI visualization in result view
 ```
 
 ### Commit 8: Frontend tests (если в этом PR)
-```
+```text
 test(web): add BmiScaleV1 snapshot tests
 
 - Snapshot test for SVG rendering

--- a/docs/pr/PR_490_CURSOR_CHECKLIST.md
+++ b/docs/pr/PR_490_CURSOR_CHECKLIST.md
@@ -1,0 +1,409 @@
+# PR #490: Cursor Checklist (step-by-step)
+
+## A) Audit (5–10 мин, без кода)
+
+### 1. Найти handler для `/api/v1/bmi/calculate`
+
+**Файл:** `app/routers/bmi.py`
+
+**Что искать:**
+- Функция `calculate_bmi()` или `bmi_calculate_handler()`
+- Endpoint `@router.post("/calculate")`
+
+**Цель:** понять точку внедрения.
+
+---
+
+### 2. Найти `BMICalculateResponse`
+
+**Файл:** `app/schemas/bmi.py`
+
+**Что искать:**
+- Класс `BMICalculateResponse(BaseModel)`
+- Текущие поля ответа
+
+**Цель:** понять, куда добавлять `visualization`.
+
+---
+
+### 3. Подтвердить legacy
+
+**Файл:** `legacy_app.py`
+
+**Что искать:**
+- Функция `add_visualization_if_requested()`
+- Параметр `include_chart` в `BMIRequest`
+- Base64 generation через `generate_bmi_visualization()`
+
+**Цель:** убедиться, что новый endpoint это **не вызывает** (оставляем как есть).
+
+---
+
+## B) Backend Changes
+
+### 1) Добавить Pydantic модели (строго типизировано)
+
+**Файл:** `app/schemas/bmi.py`
+
+**Что добавить:**
+
+```python
+class BMIRangeSpec(BaseModel):
+    """BMI range with i18n key."""
+    key: str = Field(..., description="i18n key for range label")
+    from_: float = Field(..., alias="from", description="Range start (inclusive)")
+    to: float = Field(..., description="Range end (exclusive)")
+
+class BMIMarkerSpec(BaseModel):
+    """BMI marker position."""
+    value: float = Field(..., description="Current BMI value")
+
+class BMIScaleV1Spec(BaseModel):
+    """BMI scale visualization spec v1."""
+    kind: Literal["bmi_scale_v1"] = "bmi_scale_v1"
+    bmi: float = Field(..., description="BMI value")
+    min: float = Field(0.0, description="Scale minimum")
+    max: float = Field(60.0, description="Scale maximum")
+    ranges: list[BMIRangeSpec] = Field(..., description="BMI ranges with i18n keys")
+    marker: BMIMarkerSpec = Field(..., description="Current BMI marker")
+```
+
+**Обновить `BMICalculateResponse`:**
+```python
+visualization: BMIScaleV1Spec | None = Field(
+    None,
+    description="Optional BMI scale visualization spec (v1). Frontend should render this if available."
+)
+```
+
+**Важно:** `"from"` в JSON — зарезервированное слово в Python, делаем `from_` + alias.
+
+---
+
+### 2) Добавить builder (pure function)
+
+**Файл:** `app/services/bmi_visualization.py` (новый)
+
+**Что создать:**
+
+```python
+from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
+
+def build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec:
+    """
+    Build BMI scale v1 spec for frontend rendering.
+    
+    Uses fixed thresholds (0-60) regardless of group.
+    Group-specific interpretation is handled separately in category/interpretation fields.
+    """
+    # Fixed thresholds (WHO standard)
+    ranges = [
+        BMIRangeSpec(key="bmi.underweight", from_=0.0, to=18.5),
+        BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0),
+        BMIRangeSpec(key="bmi.overweight", from_=25.0, to=30.0),
+        BMIRangeSpec(key="bmi.obesity", from_=30.0, to=60.0),
+    ]
+    
+    return BMIScaleV1Spec(
+        kind="bmi_scale_v1",
+        bmi=round(bmi, 1),
+        min=0.0,
+        max=60.0,
+        ranges=ranges,
+        marker=BMIMarkerSpec(value=round(bmi, 1)),
+    )
+```
+
+**Важно:**
+- Шкала фикс: min=0, max=60
+- Диапазоны WHO
+- Округление: `round(bmi, 1)` (и в marker тоже)
+
+---
+
+### 3) Подключить в endpoint
+
+**Файл:** `app/routers/bmi.py`
+
+**Где:** В `bmi_calculate_handler()` после того как сформирован `resp`
+
+**Что добавить:**
+
+```python
+from app.services.bmi_visualization import build_bmi_scale_v1
+
+# После создания resp
+resp = BMICalculateResponse(...)
+
+# Добавить visualization
+resp.visualization = build_bmi_scale_v1(result.bmi)
+
+# Return as dict for legacy compatibility
+response_dict: dict[str, Any] = resp.model_dump()
+return response_dict
+```
+
+⚠️ **Не трогаем** `legacy_app.py` и `include_chart`.
+
+---
+
+## C) Backend Tests
+
+**Файл:** `tests/test_bmi_visualization_spec.py` (новый)
+
+**Тесты:**
+
+1. `test_build_bmi_scale_v1_structure()`
+   - Проверка структуры spec
+   - Проверка `kind == "bmi_scale_v1"`
+   - Проверка количества ranges (4)
+
+2. `test_ranges_monotonic_no_gaps()`
+   - `from_ < to` для каждого range
+   - Последовательность ranges (конец предыдущего == начало следующего)
+   - Первый range начинается с `min` (0)
+   - Последний range заканчивается на `max` (60)
+
+3. `test_marker_equals_bmi()`
+   - `marker.value == bmi` (с округлением)
+
+4. `test_bmi_calculate_returns_visualization()`
+   - Через `TestClient`: POST `/api/v1/bmi/calculate`
+   - Проверка наличия поля `visualization` в ответе
+   - Проверка структуры `visualization`
+
+---
+
+## D) Frontend (выбери стратегию)
+
+**Вариант 1 (лучше):** всё в одном PR (backend + frontend)
+**Вариант 2:** backend PR сейчас, frontend — follow-up PR сразу после
+
+### Если делаем в этом PR:
+
+#### 1) i18n
+
+**Файлы:** `frontend/src/locales/{ru,en,es}.json`
+
+**Что добавить:**
+
+```json
+{
+  "bmi": {
+    "underweight": "Underweight",
+    "normal": "Normal",
+    "overweight": "Overweight",
+    "obesity": "Obesity"
+  }
+}
+```
+
+**Для ru.json:**
+```json
+{
+  "bmi": {
+    "underweight": "Недостаточный вес",
+    "normal": "Норма",
+    "overweight": "Избыточный вес",
+    "obesity": "Ожирение"
+  }
+}
+```
+
+**Для es.json:**
+```json
+{
+  "bmi": {
+    "underweight": "Bajo peso",
+    "normal": "Normal",
+    "overweight": "Sobrepeso",
+    "obesity": "Obesidad"
+  }
+}
+```
+
+---
+
+#### 2) Компонент
+
+**Файл:** `frontend/src/components/BmiScaleV1.tsx` (новый)
+
+**Что создать:**
+
+```typescript
+interface BMIScaleV1Spec {
+  kind: "bmi_scale_v1";
+  bmi: number;
+  min: number;
+  max: number;
+  ranges: Array<{ key: string; from: number; to: number }>;
+  marker: { value: number };
+}
+
+interface BmiScaleV1Props {
+  spec: BMIScaleV1Spec;
+}
+
+export default function BmiScaleV1({ spec }: BmiScaleV1Props) {
+  // SVG rendering with zones and marker
+  // Use i18n keys from spec.ranges[].key
+  // Colors and styles on frontend (not from API)
+}
+```
+
+**Важно:**
+- SVG-рендеринг шкалы с зонами и маркером
+- Использование i18n ключей из spec
+- Цвета и стили на фронте (не из API)
+
+---
+
+#### 3) Интеграция в UI
+
+**Найти экран результата BMI** и отрендерить:
+
+```typescript
+if (response.visualization?.kind === "bmi_scale_v1") {
+  return <BmiScaleV1 spec={response.visualization} />;
+}
+// Fallback: только текст
+```
+
+---
+
+#### 4) Тесты
+
+**Файл:** `frontend/src/components/__tests__/BmiScaleV1.test.tsx` (новый)
+
+**Что тестировать:**
+- Snapshot тест для SVG
+- Базовая проверка маркера/лейблов
+- Проверка i18n ключей
+
+---
+
+## E) Commands (локально)
+
+### Backend
+
+```bash
+# Tests
+pytest -q tests/test_bmi_visualization_spec.py
+
+# Lint
+ruff check app/schemas/bmi.py app/services/bmi_visualization.py app/routers/bmi.py
+
+# Type check (если включён)
+mypy app/schemas/bmi.py app/services/bmi_visualization.py app/routers/bmi.py
+
+# Full test suite
+pytest -q
+```
+
+### Frontend
+
+```bash
+# Tests
+pnpm test  # или npm test
+
+# Lint
+pnpm lint  # или npm run lint
+```
+
+---
+
+## F) Commit Strategy (рекомендуемый порядок)
+
+### Commit 1: Backend schema
+```
+feat(bmi): add BMIScaleV1Spec schema for visualization
+
+- Add BMIRangeSpec, BMIMarkerSpec, BMIScaleV1Spec models
+- Add visualization field to BMICalculateResponse
+- Use alias "from" for Python reserved word
+```
+
+### Commit 2: Backend builder
+```
+feat(bmi): add build_bmi_scale_v1 spec builder
+
+- Create app/services/bmi_visualization.py
+- Fixed scale 0-60 with WHO standard thresholds
+- i18n keys: bmi.underweight|normal|overweight|obesity
+```
+
+### Commit 3: Backend integration
+```
+feat(bmi): integrate visualization spec in calculate endpoint
+
+- Add visualization to bmi_calculate_handler response
+- Always return spec (no include_chart flag)
+- Legacy base64 remains in legacy_app.py
+```
+
+### Commit 4: Backend tests
+```
+test(bmi): add visualization spec tests
+
+- Test spec structure and ranges monotonicity
+- Test marker value equals BMI
+- Test endpoint returns visualization field
+```
+
+### Commit 5: Frontend i18n (если в этом PR)
+```
+feat(web): add BMI i18n keys for visualization
+
+- Add bmi.underweight|normal|overweight|obesity to locales
+- Support ru/en/es
+```
+
+### Commit 6: Frontend component (если в этом PR)
+```
+feat(web): add BmiScaleV1 SVG component
+
+- SVG rendering with zones and marker
+- Use i18n keys from spec
+- Colors and styles on frontend
+```
+
+### Commit 7: Frontend integration (если в этом PR)
+```
+feat(web): integrate BMI visualization in result view
+
+- Render BmiScaleV1 if visualization.kind === "bmi_scale_v1"
+- Fallback to text-only if visualization missing
+```
+
+### Commit 8: Frontend tests (если в этом PR)
+```
+test(web): add BmiScaleV1 snapshot tests
+
+- Snapshot test for SVG rendering
+- Test marker and label rendering
+```
+
+---
+
+## G) Verification Checklist
+
+- [ ] Backend: `pytest -q` passes
+- [ ] Backend: `ruff check` passes
+- [ ] Backend: `mypy` passes (если включён)
+- [ ] Backend: curl `/api/v1/bmi/calculate` → проверка `visualization` в ответе
+- [ ] Frontend: `pnpm test` passes (если делали)
+- [ ] Frontend: `pnpm lint` passes (если делали)
+- [ ] Frontend: ручная проверка рендера шкалы (если делали)
+- [ ] Coverage: не упало ниже 97%
+
+---
+
+## H) PR Review Checklist
+
+- [ ] Нет breaking changes в API (только опциональное поле)
+- [ ] Legacy не тронут (`legacy_app.py` не изменён)
+- [ ] Нет цветов в API (только i18n keys)
+- [ ] Spec builder в `app/services/` (не в `core/`, не в router)
+- [ ] Тесты покрывают основные случаи
+- [ ] Документация обновлена (если нужно)
+

--- a/docs/pr/PR_490_DESCRIPTION.md
+++ b/docs/pr/PR_490_DESCRIPTION.md
@@ -80,4 +80,3 @@
 
 * `docs/pr/PR_BMI_VISUALIZATION_SPEC.md` - детальная спецификация
 * `app/AGENTS.md` - архитектурные инварианты
-

--- a/docs/pr/PR_490_DESCRIPTION.md
+++ b/docs/pr/PR_490_DESCRIPTION.md
@@ -1,0 +1,83 @@
+# PR #490: feat(web+bmi): add BMI visualization JSON spec v1 (SVG-ready)
+
+## Summary
+
+Добавляем **JSON spec визуализации BMI** в существующий endpoint **`/api/v1/bmi/calculate`**:
+`visualization.kind = "bmi_scale_v1"`, чтобы Web (и позже iOS) могли рендерить **SVG шкалу BMI** без base64 PNG и без matplotlib.
+
+* **Backend** отдаёт *семантику и границы* (числа, диапазоны, i18n keys)
+* **Frontend** отвечает за *визуальный язык* (SVG, цвета, layout, a11y)
+* **Legacy base64** не трогаем: остаётся в `legacy_app.py` как fallback для legacy-пути
+
+## Scope (What we do)
+
+### Backend
+
+* Добавляем `BMIScaleV1Spec` (Pydantic) + поле `visualization: BMIScaleV1Spec | None` в `BMICalculateResponse`
+* Добавляем builder `build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec` в `app/services/`
+* Интегрируем builder в `bmi_calculate_handler()` для `/api/v1/bmi/calculate`
+* Добавляем тесты: spec builder + наличие поля в ответе endpoint
+
+### Frontend (можно в этом PR или отдельным follow-up — см. ниже)
+
+* Добавляем i18n ключи `bmi.underweight|normal|overweight|obesity`
+* Добавляем компонент `BmiScaleV1.tsx` (SVG)
+* Подключаем компонент на экран результата
+* Snapshot/unit тесты
+
+## Non-goals (What we do NOT do)
+
+* Не создаём v2 endpoint / новые маршруты
+* Не добавляем `color` в API (цвета и дизайн — только frontend)
+* Не используем `group` в spec builder (шкала фиксирована)
+* Не добавляем matplotlib/base64 в новый endpoint
+* Не делаем анимации/кэширование/темизацию (отложено)
+
+## API Contract (v1)
+
+`visualization` — **опционально**, но мы добавляем его в новый endpoint как spec:
+
+```json
+"visualization": {
+  "kind": "bmi_scale_v1",
+  "bmi": 23.4,
+  "min": 0,
+  "max": 60,
+  "ranges": [
+    {"key": "bmi.underweight", "from": 0, "to": 18.5},
+    {"key": "bmi.normal", "from": 18.5, "to": 25},
+    {"key": "bmi.overweight", "from": 25, "to": 30},
+    {"key": "bmi.obesity", "from": 30, "to": 60}
+  ],
+  "marker": { "value": 23.4 }
+}
+```
+
+## Security Notes
+
+* Не добавляем base64 PNG в новый endpoint → меньше payload и меньше риск DoS/latency.
+* Не раскрываем детали ошибок; используем текущий error-envelope/masking (не менять).
+* Цвета/стили не уходят в API → контракт остаётся стабильным.
+
+## Marketing & GTM (коротко)
+
+* Улучшаем perceived quality на сайте ("у нас есть визуализация BMI")
+* База для iOS и Gradio демо без тяжёлых зависимостей
+
+## Decision Log
+
+* **Решение:** JSON spec (`bmi_scale_v1`) — основной формат; SVG рендер на фронте.
+* **Причина:** стабильность, переносимость, лёгкий payload, тестируемость.
+* **Legacy:** base64 остаётся только в legacy path (не трогаем).
+
+## Next Actions
+
+1. Сделать backend часть + тесты (должно пройти CI)
+2. Если успеваем — фронт (компонент + i18n + интеграция)
+3. Если фронт не успеваем — отдельный follow-up PR "web BMI scale UI v1"
+
+## Related Documents
+
+* `docs/pr/PR_BMI_VISUALIZATION_SPEC.md` - детальная спецификация
+* `app/AGENTS.md` - архитектурные инварианты
+

--- a/docs/pr/PR_BMI_VISUALIZATION_SPEC.md
+++ b/docs/pr/PR_BMI_VISUALIZATION_SPEC.md
@@ -1,0 +1,120 @@
+# PR: BMI Visualization via JSON Spec (v1)
+
+## 🎯 Цель
+
+Добавить визуализацию BMI через JSON spec в существующий endpoint `/api/v1/bmi/calculate`, чтобы frontend мог рендерить шкалу BMI без зависимости от base64 PNG.
+
+## ✅ Что делаем
+
+### Backend
+
+1. **Схема ответа** (`app/schemas/bmi.py`)
+   - Добавить `BMIScaleV1Spec` (Pydantic модель)
+   - Добавить `visualization: BMIScaleV1Spec | None` в `BMICalculateResponse`
+
+2. **Spec builder** (`app/services/bmi_visualization.py` - новый файл)
+   - Функция `build_bmi_scale_v1(bmi: float) -> BMIScaleV1Spec`
+   - **Важно**: это **API adapter**, а не domain logic (живёт в `app/services/`, не в `core/`)
+   - Фиксированная шкала 0-60 (WHO standard thresholds)
+   - i18n ключи: `bmi.underweight`, `bmi.normal`, `bmi.overweight`, `bmi.obesity`
+   - Без использования `group` (group влияет только на `category`/`interpretation`, не на шкалу)
+
+3. **Интеграция** (`app/routers/bmi.py`)
+   - В `bmi_calculate_handler()` после создания `resp` добавить:
+
+     ```python
+     from app.services.bmi_visualization import build_bmi_scale_v1
+     resp.visualization = build_bmi_scale_v1(result.bmi)
+     ```
+
+   - **Важно**: spec возвращается **всегда** (по умолчанию), без флага `include_chart`
+   - `include_chart` остаётся **исключительно legacy-механизмом** в `legacy_app.py`
+
+### Frontend
+
+4. **i18n ключи** (`frontend/src/locales/{ru,en,es}.json`)
+   - Добавить секцию `bmi` с ключами: `underweight`, `normal`, `overweight`, `obesity`
+
+5. **Компонент** (`frontend/src/components/BmiScaleV1.tsx` - новый файл)
+   - SVG-рендеринг шкалы с зонами и маркером
+   - Использование i18n ключей из spec
+   - Цвета и стили на фронте (не из API)
+
+6. **Интеграция в UI** (если есть BMI страница/компонент)
+   - Подключить `BmiScaleV1` для отображения `visualization` из ответа API
+
+### Тесты
+
+7. **Backend тесты** (`tests/test_bmi_visualization_spec.py` - новый файл)
+   - `test_build_bmi_scale_v1()` - правильный spec для разных BMI значений
+   - `test_ranges_monotonic()` - ranges последовательны (from < to, без разрывов)
+   - `test_marker_value_equals_bmi()` - marker.value == bmi
+   - `test_spec_in_response()` - `/api/v1/bmi/calculate` возвращает `visualization`
+
+8. **Frontend тесты** (`frontend/src/components/__tests__/BmiScaleV1.test.tsx` - новый файл)
+   - Snapshot тест для SVG
+   - Проверка i18n ключей
+
+## ❌ Чего НЕ делаем
+
+1. **НЕ создаём новый endpoint** - используем существующий `/api/v1/bmi/calculate`
+2. **НЕ добавляем цвета в API** - цвета живут на фронте
+3. **НЕ используем `group` в spec builder** - thresholds фиксированы (0-60)
+4. **НЕ добавляем анимации/кэширование** - это для следующих PR
+5. **НЕ удаляем legacy base64** - он остаётся в `legacy_app.py`, **НЕ интегрируется** в `/api/v1/bmi/calculate`
+6. **НЕ используем matplotlib в новом коде** - только JSON spec
+7. **НЕ добавляем `dict[str, Any]`** - только Pydantic модели
+
+## 🧠 Почему так
+
+### Архитектурные принципы
+
+- **Backend = смысл и границы** (числа, thresholds, semantic keys)
+- **Frontend = визуальный язык** (SVG, цвета, layout, a11y)
+- **Разделение ответственности**: spec builder в `app/services/` (адаптер), не в `core/` (domain) и не в router
+
+### Философия проекта
+
+- Следуем `app/AGENTS.md`: routers thin, бизнес-логика в `core/`, адаптеры в `app/services/`
+- Pydantic v2 только (`model_validate`, `model_dump`)
+- Типизация строгая (Pydantic модели, не `dict[str, Any]`)
+
+### UX и производительность
+
+- JSON spec легче base64 PNG (50-200KB → ~500 bytes)
+- Не зависит от matplotlib/freetype в проде
+- Легко тестируется (JSON snapshot)
+- Переносимо (iOS, Gradio, другие клиенты)
+
+### Legacy compatibility
+
+- Не ломаем существующий контракт (`BMICalculateResponse` расширяем опциональным полем)
+- Legacy base64 остаётся доступным через `legacy_app.py` (если требуется)
+- **Чёткое разграничение**: base64 **не интегрируется** в новый endpoint `/api/v1/bmi/calculate`
+- `include_chart` параметр **не используется** в новом endpoint (остаётся только в legacy)
+
+## 📋 Чеклист реализации
+
+- [ ] Backend: `BMIScaleV1Spec` модель в `app/schemas/bmi.py`
+- [ ] Backend: `build_bmi_scale_v1()` в `app/services/bmi_visualization.py`
+- [ ] Backend: интеграция в `bmi_calculate_handler()`
+- [ ] Backend: тесты spec генерации
+- [ ] Frontend: i18n ключи в локалях
+- [ ] Frontend: компонент `BmiScaleV1.tsx`
+- [ ] Frontend: snapshot тест
+- [ ] Ручная проверка: curl `/api/v1/bmi/calculate` → проверка `visualization` в ответе
+- [ ] Ручная проверка: frontend рендерит шкалу корректно
+
+## 🔗 Связанные документы
+
+- `app/AGENTS.md` - архитектурные инварианты
+- `docs/pr/PR_BMI_VISUALIZATION_AUDIT.md` - анализ двух подходов (если создан)
+- `bmi_visualization.py` - legacy base64 модуль (не трогаем)
+
+## 📝 Примечания
+
+- **Фиксированная шкала 0-60**: group-specific thresholds не используются в spec (group влияет только на `category`/`interpretation`)
+- **i18n ключи**: формат `bmi.underweight` (flat structure в JSON локалей)
+- **Опциональное поле**: `visualization: BMIScaleV1Spec | None` - фронт должен проверять наличие перед рендером
+- **Spec builder**: `build_bmi_scale_v1` — это **API adapter** (не domain logic), живёт в `app/services/`, не в `core/`
+- **Legacy base64**: остаётся **только** в `legacy_app.py`, не интегрируется в новый endpoint

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for BMI visualization spec builder and endpoint integration.
+"""
+
+import pytest
+
+from app.services.bmi_visualization import build_bmi_scale_v1
+from app.schemas.bmi import BMIScaleV1Spec
+
+
+def test_build_bmi_scale_v1_structure():
+    """Test that spec has correct structure."""
+    spec = build_bmi_scale_v1(23.4)
+
+    assert spec.kind == "bmi_scale_v1"
+    assert spec.bmi == 23.4
+    assert spec.min == 0.0
+    assert spec.max == 60.0
+    assert len(spec.ranges) == 4
+    assert spec.marker.value == 23.4
+
+
+def test_ranges_monotonic_no_gaps():
+    """Test that ranges are monotonic with no gaps."""
+    spec = build_bmi_scale_v1(25.0)
+
+    # Check each range: from_ < to
+    for range_spec in spec.ranges:
+        assert range_spec.from_ < range_spec.to, f"Range {range_spec.key}: from_ >= to"
+
+    # Check sequence: end of previous == start of next
+    for i in range(len(spec.ranges) - 1):
+        assert spec.ranges[i].to == spec.ranges[i + 1].from_, f"Gap between range {i} and {i + 1}"
+
+    # Check boundaries
+    assert spec.ranges[0].from_ == spec.min, "First range should start at min"
+    assert spec.ranges[-1].to == spec.max, "Last range should end at max"
+
+
+def test_marker_equals_bmi():
+    """Test that marker value equals rounded BMI."""
+    test_cases = [18.5, 22.3, 25.0, 30.0, 35.7]
+
+    for bmi in test_cases:
+        spec = build_bmi_scale_v1(bmi)
+        assert spec.marker.value == round(bmi, 1), f"Marker value {spec.marker.value} != rounded BMI {round(bmi, 1)}"
+        assert spec.bmi == round(bmi, 1), f"Spec BMI {spec.bmi} != rounded BMI {round(bmi, 1)}"
+
+
+def test_build_bmi_scale_v1_edge_cases():
+    """Test builder handles edge cases safely."""
+    # Normal cases
+    spec1 = build_bmi_scale_v1(0.0)
+    assert spec1.bmi == 0.0
+    assert spec1.marker.value == 0.0
+
+    spec2 = build_bmi_scale_v1(60.0)
+    assert spec2.bmi == 60.0
+    assert spec2.marker.value == 60.0
+
+    # Very small BMI
+    spec3 = build_bmi_scale_v1(10.12345)
+    assert spec3.bmi == 10.1  # rounded to 1 decimal
+    assert spec3.marker.value == 10.1
+
+
+def test_bmi_calculate_returns_visualization():
+    """Test that /api/v1/bmi/calculate returns visualization field."""
+    # Use canonical import pattern from project
+    from app import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/bmi/calculate",
+        json={
+            "weight_kg": 70.0,
+            "height_cm": 175.0,
+            "age": 30,
+            "gender": "male",  # BMICalculateRequest uses "gender", not "sex"
+            "lang": "en",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "visualization" in data, "Response should contain visualization field"
+    assert data["visualization"] is not None, "Visualization should not be None"
+    assert data["visualization"]["kind"] == "bmi_scale_v1", "Visualization kind should be bmi_scale_v1"
+    assert "ranges" in data["visualization"], "Visualization should contain ranges"
+    assert "marker" in data["visualization"], "Visualization should contain marker"
+    assert len(data["visualization"]["ranges"]) == 4, "Should have 4 ranges"
+
+    # Verify alias "from" is used (not "from_")
+    first_range = data["visualization"]["ranges"][0]
+    assert "from" in first_range, "Range should use 'from' alias (not 'from_')"
+    assert "from_" not in first_range, "Range should not contain 'from_' field"
+

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -158,3 +158,17 @@ def test_bmi_scale_v1_spec_validation():
             marker=BMIMarkerSpec(value=25.0),  # != bmi
         )
 
+
+def test_range_constructor_accepts_from_():
+    """Test that BMIRangeSpec accepts from_= in direct constructor."""
+    from app.schemas.bmi import BMIRangeSpec
+
+    r = BMIRangeSpec(key="bmi.normal", from_=18.5, to=25.0)
+    assert r.from_ == 18.5
+    assert r.to == 25.0
+    # Verify alias works in serialization
+    dumped = r.model_dump(by_alias=True)
+    assert dumped["from"] == 18.5
+    assert "from_" not in dumped
+    assert dumped["to"] == 25.0
+

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -99,3 +99,62 @@ def test_bmi_calculate_returns_visualization():
     assert "from" in first_range, "Range should use 'from' alias (not 'from_')"
     assert "from_" not in first_range, "Range should not contain 'from_' field"
 
+
+def test_bmi_scale_v1_spec_validation():
+    """Test that BMIScaleV1Spec validation works correctly."""
+    from app.schemas.bmi import BMIScaleV1Spec, BMIRangeSpec, BMIMarkerSpec
+    from pydantic import ValidationError
+
+    # Valid spec
+    valid_spec = BMIScaleV1Spec(
+        kind="bmi_scale_v1",
+        bmi=23.4,
+        min=0.0,
+        max=60.0,
+        ranges=[
+            BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
+        ],
+        marker=BMIMarkerSpec(value=23.4),
+    )
+    assert valid_spec.bmi == 23.4
+    assert valid_spec.marker.value == 23.4
+
+    # Invalid: min >= max
+    with pytest.raises(ValidationError, match="must be less than maximum"):
+        BMIScaleV1Spec(
+            kind="bmi_scale_v1",
+            bmi=23.4,
+            min=60.0,
+            max=0.0,
+            ranges=[
+                BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
+            ],
+            marker=BMIMarkerSpec(value=23.4),
+        )
+
+    # Invalid: bmi outside bounds
+    with pytest.raises(ValidationError, match="must be between min"):
+        BMIScaleV1Spec(
+            kind="bmi_scale_v1",
+            bmi=70.0,  # > max
+            min=0.0,
+            max=60.0,
+            ranges=[
+                BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
+            ],
+            marker=BMIMarkerSpec(value=70.0),
+        )
+
+    # Invalid: marker.value != bmi
+    with pytest.raises(ValidationError, match="must equal BMI"):
+        BMIScaleV1Spec(
+            kind="bmi_scale_v1",
+            bmi=23.4,
+            min=0.0,
+            max=60.0,
+            ranges=[
+                BMIRangeSpec.model_validate({"key": "bmi.normal", "from": 18.5, "to": 25.0}),
+            ],
+            marker=BMIMarkerSpec(value=25.0),  # != bmi
+        )
+

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -175,3 +175,28 @@ def test_range_constructor_accepts_from_():
     assert dumped["from"] == 18.5
     assert "from_" not in dumped
     assert dumped["to"] == 25.0
+
+
+def test_bmi_calculate_graceful_fallback_when_visualization_builder_fails(monkeypatch):
+    """Test that endpoint gracefully handles visualization builder failure."""
+    from app import app
+    from fastapi.testclient import TestClient
+    import app.routers.bmi as bmi_router
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(bmi_router, "build_bmi_scale_v1", _boom)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/bmi/calculate",
+        json={"weight_kg": 70.0, "height_cm": 175.0, "age": 30, "gender": "male", "lang": "en"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "visualization" in data
+    assert data["visualization"] is None
+    # Verify other fields are still present
+    assert "bmi" in data
+    assert data["bmi"] > 0

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -6,7 +6,6 @@ Tests for BMI visualization spec builder and endpoint integration.
 import pytest
 
 from app.services.bmi_visualization import build_bmi_scale_v1
-from app.schemas.bmi import BMIScaleV1Spec
 
 
 def test_build_bmi_scale_v1_structure():
@@ -106,6 +105,7 @@ def test_bmi_scale_v1_spec_validation():
     from pydantic import ValidationError
 
     # Valid spec
+    # Note: ranges completeness (full 0-60 coverage) not validated in v1
     valid_spec = BMIScaleV1Spec(
         kind="bmi_scale_v1",
         bmi=23.4,

--- a/tests/test_bmi_visualization_spec.py
+++ b/tests/test_bmi_visualization_spec.py
@@ -43,7 +43,9 @@ def test_marker_equals_bmi():
 
     for bmi in test_cases:
         spec = build_bmi_scale_v1(bmi)
-        assert spec.marker.value == round(bmi, 1), f"Marker value {spec.marker.value} != rounded BMI {round(bmi, 1)}"
+        assert spec.marker.value == round(
+            bmi, 1
+        ), f"Marker value {spec.marker.value} != rounded BMI {round(bmi, 1)}"
         assert spec.bmi == round(bmi, 1), f"Spec BMI {spec.bmi} != rounded BMI {round(bmi, 1)}"
 
 
@@ -88,7 +90,9 @@ def test_bmi_calculate_returns_visualization():
 
     assert "visualization" in data, "Response should contain visualization field"
     assert data["visualization"] is not None, "Visualization should not be None"
-    assert data["visualization"]["kind"] == "bmi_scale_v1", "Visualization kind should be bmi_scale_v1"
+    assert (
+        data["visualization"]["kind"] == "bmi_scale_v1"
+    ), "Visualization kind should be bmi_scale_v1"
     assert "ranges" in data["visualization"], "Visualization should contain ranges"
     assert "marker" in data["visualization"], "Visualization should contain marker"
     assert len(data["visualization"]["ranges"]) == 4, "Should have 4 ranges"
@@ -171,4 +175,3 @@ def test_range_constructor_accepts_from_():
     assert dumped["from"] == 18.5
     assert "from_" not in dumped
     assert dumped["to"] == 25.0
-


### PR DESCRIPTION
### Summary

Adds a lightweight **BMI visualization JSON spec (v1)** to the Free endpoint `POST /api/v1/bmi/calculate` so frontend can render a scale without base64 images.

### Scope (backend-only, small & safe)

* ✅ Adds `visualization` field to `BMICalculateResponse`
* ✅ Introduces `BMIScaleV1Spec` (+ ranges + marker) with validation
* ✅ Adds builder `build_bmi_scale_v1()` (fixed scale 0–60, WHO thresholds)
* ✅ Integrates builder into router with **graceful fallback** (`visualization=None` on failure)
* ✅ Adds tests for structure, monotonic ranges, alias serialization, endpoint integration

### Non-goals / Explicitly NOT included

* ❌ No frontend changes (that is PR-490B)
* ❌ No matplotlib
* ❌ No base64 payload in new path
* ❌ No colors/styles in API (only i18n keys)
* ❌ No legacy refactor / leg### API Contract

Endpoint: `POST /api/v1/bmi/calculate`

Response now includes:

```json
{
  "visualization": {
    "kind": "bmi_scale_v1",
    "bmi": 23.4,
    "min": 0.0,
    "max": 60.0,
    "ranges": [
      {"key": "bmi.underweight", "from": 0.0, "to": 18.5},
      {"key": "bmi.normal", "from": 18.5, "to": 25.0},
      {"key": "bmi.overweight", "from": 25.0, "to": 30.0},
      {"key": "bmi.obesity", "from": 30.0, "to": 60.0}
    ],
    "marker": {"value": 23.4}
  }
}
```

### Alias guarantee

`BMIRangeSpec.from_` is serialized as `"from"` in JSON (never `"from_"`), verified by tests and runtime checks.

### Safety / Reliability

* Builder is optional: router wraps it in try/except → endpoint remains 200 and returns `visualization: null` if spec generation fails.
* Logging: uses `logger.exception(...)` (stacktrace only, no sensitive payload leaks).

### Tests

Added `tests/test_bmi_visualization_spec.py`:

* spec structure
* motonic ranges w/ no gaps
* marker consistency
* edge cases (0.0 / 60.0 / rounding)
* endpoint response includes visualization
* alias `"from"` present and `"from_"` absent

### Review checklist (Spec 2 — 10 critical points)

* Legacy untouched (`legacy_app.py` unchanged)
* No heavy deps (no matplotlib/base64 in new path)
* Contract stable (`kind == "bmi_scale_v1"`)
* Alias correct (`"from"` not `"from_"`)
* Alias serialization verified by tests
* Graceful fallback works (visualization=None on failure)
* Secure logging (`logger.exception`)
* API purity (no colors/styles)
* Coverage maintained (CI threshold safe)
* Scope control (backend-only, ≤7 files)

### Follow-up

PR-490B will add frontend SVG component + i18n keys + screen integration.