### PR TITLE
Docs/pr 492 bmi visualization contract

### DIFF
--- a/docs/bmi/visualization.md
+++ b/docs/bmi/visualization.md
@@ -1,0 +1,304 @@
+# BMI Visualization — Contract (BMIScaleV1Spec)
+
+## Purpose
+
+The `/api/v1/bmi/calculate` endpoint may return an optional `visualization` field.
+This object is a UI-friendly, group-aware BMI scale spec derived from the canonical BMI engine
+thresholds (single source of truth: `core/bmi/engine.py`).
+
+Clients (iOS/Web) must treat `visualization` as **optional**.
+
+---
+
+## Where it appears
+
+Endpoint:
+- `POST /api/v1/bmi/calculate`
+
+Response DTO:
+- `BMICalculateResponse.visualization: BMIScaleV1Spec | None`
+
+Schema location:
+- `app/schemas/bmi.py` → `BMIScaleV1Spec`, `BMIRangeSpec`, `BMIMarkerSpec`
+
+---
+
+## When `visualization` is `null`
+
+`visualization` is **null** when any of the following applies:
+
+1. The computed BMI group has no compatible adult-style category mapping
+   (e.g., **too_young/child/teen/pregnant** outputs where category logic differs).
+2. Visualization builder fails (should be fail-soft):
+   - The endpoint must still return **200**
+   - `visualization` is set to **null**
+
+> Contract invariant: visualization is "best-effort UI sugar", not a critical field.
+
+**Groups that return `visualization: null`:**
+- `too_young` (age < 12)
+- `child` (age == 12)
+- `teen` (age 13-19)
+- `pregnant` (any age, if `pregnant=True`)
+
+**Groups that return `visualization` spec:**
+- `general` (adult, age 20-59)
+- `athlete` (adult with `athlete=True`)
+- `elderly` (age >= 60)
+
+---
+
+## BMIScaleV1Spec — structure
+
+`BMIScaleV1Spec` describes a continuous BMI scale with labeled ranges and a BMI marker.
+
+### Fields
+
+- `kind` (string, literal): `"bmi_scale_v1"` (constant)
+- `bmi` (number): BMI value used for the marker (rounded to 1 decimal)
+- `min` (number): scale minimum (default: `0.0`)
+- `max` (number): scale maximum (default: `60.0`)
+- `ranges` (array): ordered, contiguous segments of the scale (exactly 4 ranges)
+- `marker` (object): current BMI marker (at least `{ "value": <bmi> }`)
+
+### Range objects (BMIRangeSpec)
+
+Each range is:
+- `key` (string): i18n key for the label (e.g., `"bmi.normal"`)
+- `from` (number): inclusive start (serialized as `"from"` via Pydantic alias)
+- `to` (number): exclusive end (or inclusive end; clients should render as segment boundary)
+
+**i18n keys used:**
+- `"bmi.underweight"` — underweight range
+- `"bmi.normal"` — normal range
+- `"bmi.overweight"` — overweight range
+- `"bmi.obesity"` — obesity range (aggregates obesity_1/2/3)
+
+### Required invariants
+
+1. `ranges` are sorted by `from` (ascending)
+2. Ranges are contiguous (no gaps):
+   - `ranges[i].to == ranges[i+1].from` for all `i < len(ranges) - 1`
+3. Coverage:
+   - `ranges[0].from == min`
+   - `ranges[-1].to == max`
+4. `marker.value == bmi` (exact match, validated by Pydantic)
+5. `min < max`, `min <= bmi <= max` (validated by Pydantic)
+6. Exactly 4 ranges (underweight, normal, overweight, obesity)
+
+---
+
+## Group-aware ranges
+
+Visualization ranges reflect the BMI engine thresholds **for the resolved group**.
+
+The ranges are derived from `core/bmi/engine.py` → `get_bmi_visual_ranges()` which uses
+the centralized `_BMI_BREAKPOINTS` registry.
+
+**Key differences by group:**
+
+| Group | Underweight → Normal | Normal → Overweight | Notes |
+|-------|---------------------|---------------------|-------|
+| **Adult (general)** | 0 → 18.5 | 18.5 → 25.0 | WHO standard |
+| **Athlete** | 0 → 18.5 | 18.5 → 27.0 | Normal extends to 27.0 |
+| **Elderly** | 0 → 17.5 | 17.5 → 26.0 | Lower underweight threshold, higher normal upper |
+
+> Clients must not hardcode WHO adult ranges. Always render what API returns.
+
+---
+
+## Examples
+
+> Note: Numbers below illustrate shape + group differences. Always trust API output.
+
+### Example A — Adult (general)
+
+```json
+{
+  "bmi": 23.4,
+  "category": "normal",
+  "group": "general",
+  "visualization": {
+    "kind": "bmi_scale_v1",
+    "bmi": 23.4,
+    "min": 0.0,
+    "max": 60.0,
+    "ranges": [
+      {"key": "bmi.underweight", "from": 0.0, "to": 18.5},
+      {"key": "bmi.normal",      "from": 18.5, "to": 25.0},
+      {"key": "bmi.overweight",  "from": 25.0, "to": 30.0},
+      {"key": "bmi.obesity",     "from": 30.0, "to": 60.0}
+    ],
+    "marker": {"value": 23.4}
+  }
+}
+```
+
+### Example B — Athlete (normal upper bound differs)
+
+```json
+{
+  "bmi": 26.2,
+  "category": "normal",
+  "group": "athlete",
+  "visualization": {
+    "kind": "bmi_scale_v1",
+    "bmi": 26.2,
+    "min": 0.0,
+    "max": 60.0,
+    "ranges": [
+      {"key": "bmi.underweight", "from": 0.0, "to": 18.5},
+      {"key": "bmi.normal",      "from": 18.5, "to": 27.0},
+      {"key": "bmi.overweight",  "from": 27.0, "to": 30.0},
+      {"key": "bmi.obesity",     "from": 30.0, "to": 60.0}
+    ],
+    "marker": {"value": 26.2}
+  }
+}
+```
+
+**Note:** Athlete normal range extends to 27.0 (vs 25.0 for adult general).
+
+### Example C — Elderly (bounds differ)
+
+```json
+{
+  "bmi": 18.2,
+  "category": "normal",
+  "group": "elderly",
+  "visualization": {
+    "kind": "bmi_scale_v1",
+    "bmi": 18.2,
+    "min": 0.0,
+    "max": 60.0,
+    "ranges": [
+      {"key": "bmi.underweight", "from": 0.0, "to": 17.5},
+      {"key": "bmi.normal",      "from": 17.5, "to": 26.0},
+      {"key": "bmi.overweight",  "from": 26.0, "to": 30.0},
+      {"key": "bmi.obesity",     "from": 30.0, "to": 60.0}
+    ],
+    "marker": {"value": 18.2}
+  }
+}
+```
+
+**Note:** Elderly has lower underweight threshold (17.5) and higher normal upper (26.0).
+
+### Example D — Child/Teen/Too Young/Pregnant (no visualization)
+
+```json
+{
+  "bmi": 18.5,
+  "category": null,
+  "group": "child",
+  "visualization": null
+}
+```
+
+**Note:** Groups with `category=None` return `visualization: null` to avoid misleading
+adult-style ranges for users where BMI categories don't apply.
+
+---
+
+## Client guidance (iOS/Web)
+
+### Handling `visualization`
+
+* Treat `visualization` as optional (`nil` / `null` / `Optional`)
+* Check `if visualization is not None` before rendering
+* If `null`, show BMI value and category text only (no scale visualization)
+
+### Rendering the scale
+
+When `visualization` is present:
+
+1. **Render segments** from `ranges[]`:
+   - Each range is a segment from `from` to `to`
+   - Use `key` to look up localized label (e.g., `"bmi.normal"` → "Normal" / "Норма")
+   - Apply colors/styles on client (not from API)
+
+2. **Render marker** at `marker.value`:
+   - Position marker at BMI value on the scale
+   - Ensure marker is within `[min, max]` bounds
+
+3. **Scale bounds**:
+   - Use `min` and `max` for scale axis
+   - Default: `0.0` to `60.0`
+
+### Do not
+
+* ❌ Infer thresholds from BMI category strings
+* ❌ Hardcode WHO adult ranges (use API ranges)
+* ❌ Assume all groups have same ranges
+* ❌ Render visualization when `visualization` is `null`
+
+---
+
+## Implementation references
+
+### Backend
+
+* **Canonical engine thresholds:**
+  * `core/bmi/engine.py`:
+    - `_BMI_BREAKPOINTS` — centralized threshold registry
+    - `get_bmi_visual_ranges()` — derives visualization ranges from thresholds
+    - `_age_band()` — age band mapping (too_young/child/teen/adult/elderly)
+
+* **Visualization builder:**
+  * `app/services/bmi_visualization.py`:
+    - `build_bmi_scale_v1()` — builds spec from `BMICalculateResult`
+    - Returns `None` for groups with `category=None`
+
+* **Endpoint:**
+  * `app/routers/bmi.py`:
+    - `POST /api/v1/bmi/calculate`
+    - Graceful fallback: returns `200` with `visualization: null` if builder fails
+
+* **Schemas:**
+  * `app/schemas/bmi.py`:
+    - `BMIScaleV1Spec` — visualization spec model
+    - `BMIRangeSpec` — range model (with `from` alias)
+    - `BMIMarkerSpec` — marker model
+    - `BMICalculateResponse` — response model with `visualization` field
+
+### Age band mapping
+
+From `core/bmi/engine.py` → `_age_band()`:
+
+- `age < 12` → `too_young`
+- `age == 12` → `child`
+- `13 <= age <= 19` → `teen`
+- `20 <= age < 60` → `adult`
+- `age >= 60` → `elderly`
+
+---
+
+## Contract invariants (for testing)
+
+1. **Structure:**
+   - `visualization` field exists in response (may be `null`)
+   - If not `null`, has `kind`, `bmi`, `min`, `max`, `ranges`, `marker`
+   - `kind == "bmi_scale_v1"` (constant)
+
+2. **Ranges:**
+   - Exactly 4 ranges
+   - Sorted by `from` (ascending)
+   - Contiguous (no gaps)
+   - Covers `[min, max]` completely
+
+3. **Group awareness:**
+   - Athlete normal upper != adult normal upper
+   - Elderly underweight threshold != adult underweight threshold
+
+4. **Null cases:**
+   - `visualization: null` for too_young/child/teen/pregnant
+   - `visualization: null` if builder fails (endpoint still returns 200)
+
+---
+
+## Related documentation
+
+- `docs/pr/PR_490B_COVERAGE_NOTE.md` — PR-490B implementation notes
+- `docs/pr/HANDOFF_PR_490_491.md` — Architecture handoff
+- `docs/audit/PROJECT_AUDIT_2026_Q1.md` — Project audit
+

--- a/docs/bmi/visualization.md
+++ b/docs/bmi/visualization.md
@@ -301,4 +301,3 @@ From `core/bmi/engine.py` → `_age_band()`:
 - `docs/pr/PR_490B_COVERAGE_NOTE.md` — PR-490B implementation notes
 - `docs/pr/HANDOFF_PR_490_491.md` — Architecture handoff
 - `docs/audit/PROJECT_AUDIT_2026_Q1.md` — Project audit
-

--- a/tests/test_bmi_contract_visualization.py
+++ b/tests/test_bmi_contract_visualization.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+"""
+RU: Контрактные тесты для поля visualization в BMICalculateResponse.
+EN: Contract tests for BMICalculateResponse.visualization.
+
+Важно:
+- Не тестируем "математику" BMI (это покрыто engine/визуализацией).
+- Тестируем структуру и инварианты контракта ответа для клиентов (iOS/Web).
+
+Contract invariants tested:
+1. Structure: visualization field exists, has correct shape when not null
+2. Ranges: exactly 4, sorted, contiguous, cover [min, max]
+3. Group awareness: athlete vs adult ranges differ
+4. Null cases: visualization is null for category=None groups
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _valid_payload(**overrides: Any) -> dict[str, Any]:
+    """
+    RU: Валидный payload для BMICalculateRequest (совместим с существующими тестами).
+    EN: Valid payload for BMICalculateRequest (compatible with existing tests).
+    """
+    base: dict[str, Any] = {
+        "weight_kg": 70.0,
+        "height_cm": 170.0,
+        "age": 30,
+        "gender": "male",
+        "pregnant": "no",
+        "athlete": "no",
+        "lang": "en",
+    }
+    base.update(overrides)
+    return base
+
+
+def _post_bmi(client: TestClient, payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    RU: POST helper для BMI calculate endpoint.
+    EN: POST helper for BMI calculate endpoint.
+    """
+    r = client.post("/api/v1/bmi/calculate", json=payload)
+    assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+    return r.json()
+
+
+def _assert_ranges_invariants(spec: dict[str, Any]) -> None:
+    """
+    RU: Проверка инвариантов диапазонов шкалы.
+    EN: Validate scale range invariants.
+
+    Contract:
+    - Exactly 4 ranges
+    - Sorted by 'from' (ascending)
+    - Contiguous (no gaps)
+    - Covers [min, max] completely
+    """
+    assert spec["min"] < spec["max"], "min must be less than max"
+    ranges = spec["ranges"]
+    assert isinstance(ranges, list), "ranges must be a list"
+    assert len(ranges) == 4, f"Expected exactly 4 ranges, got {len(ranges)}"
+
+    # Sorted + contiguous + covers [min, max]
+    # Use pytest.approx for float comparisons (handles precision artifacts)
+    assert ranges[0]["from"] == pytest.approx(spec["min"]), "First range must start at min"
+    assert ranges[-1]["to"] == pytest.approx(spec["max"]), "Last range must end at max"
+
+    prev_to = None
+    for i, rr in enumerate(ranges):
+        assert (
+            rr["from"] < rr["to"]
+        ), f"Range {i}: from ({rr['from']}) must be less than to ({rr['to']})"
+        assert isinstance(rr["key"], str) and rr["key"], f"Range {i}: key must be non-empty string"
+        if i == 0:
+            prev_to = rr["to"]
+            continue
+        # Use pytest.approx for float comparison (handles precision artifacts)
+        assert rr["from"] == pytest.approx(
+            prev_to
+        ), f"Range {i}: from ({rr['from']}) must equal previous to ({prev_to})"
+        prev_to = rr["to"]
+
+    # Marker consistency
+    assert "marker" in spec, "marker field must exist"
+    assert isinstance(spec["marker"], dict), "marker must be a dict"
+    assert "value" in spec["marker"], "marker must have 'value' field"
+    # Use pytest.approx for float comparison (handles precision)
+    assert (
+        pytest.approx(spec["bmi"], rel=0, abs=1e-6) == spec["marker"]["value"]
+    ), f"marker.value ({spec['marker']['value']}) must equal bmi ({spec['bmi']})"
+
+
+def _find_range_to(spec: dict[str, Any], key: str) -> float:
+    """
+    RU: Найти верхнюю границу диапазона по i18n ключу.
+    EN: Find range upper bound by i18n key.
+    """
+    for rr in spec["ranges"]:
+        if rr["key"] == key:
+            return float(rr["to"])
+    raise AssertionError(f"Range key not found: {key}")
+
+
+def test_visualization_contract_adult_has_spec(client: TestClient) -> None:
+    """
+    RU: Контракт: adult group возвращает visualization spec с корректной структурой.
+    EN: Contract: adult group returns visualization spec with correct structure.
+    """
+    payload = _valid_payload(
+        weight_kg=70.0,
+        height_cm=175.0,
+        age=30,  # adult
+        gender="male",
+        athlete="no",
+    )
+
+    data = _post_bmi(client, payload)
+    spec = data.get("visualization")
+
+    # Contract: visualization exists and is not null for adult
+    assert spec is not None, "visualization must not be null for adult group"
+    assert spec["kind"] == "bmi_scale_v1", "kind must be 'bmi_scale_v1'"
+    assert isinstance(spec["bmi"], (int, float)), "bmi must be a number"
+    assert isinstance(spec["min"], (int, float)), "min must be a number"
+    assert isinstance(spec["max"], (int, float)), "max must be a number"
+
+    # Contract: ranges structure
+    _assert_ranges_invariants(spec)
+
+
+def test_visualization_contract_child_is_null(client: TestClient) -> None:
+    """
+    RU: Контракт: child group (age 12) возвращает visualization null.
+    EN: Contract: child group (age 12) returns visualization null.
+    """
+    payload = _valid_payload(
+        weight_kg=40.0,
+        height_cm=140.0,
+        age=12,  # child (age == 12 maps to "child" age_band)
+        gender="male",
+    )
+
+    data = _post_bmi(client, payload)
+
+    # Contract: visualization is null for child (category=None group)
+    assert "visualization" in data, "visualization field must exist in response"
+    assert data["visualization"] is None, "visualization must be null for child group"
+    # Verify category is None (for documentation)
+    assert data.get("category") is None, "category must be None for child group"
+
+
+def test_visualization_contract_teen_is_null(client: TestClient) -> None:
+    """
+    RU: Контракт: teen group (age 13-19) возвращает visualization null.
+    EN: Contract: teen group (age 13-19) returns visualization null.
+    """
+    payload = _valid_payload(
+        weight_kg=50.0,
+        height_cm=160.0,
+        age=16,  # teen (13 <= age <= 19)
+        gender="female",
+    )
+
+    data = _post_bmi(client, payload)
+
+    # Contract: visualization is null for teen (category=None group)
+    assert "visualization" in data, "visualization field must exist in response"
+    assert data["visualization"] is None, "visualization must be null for teen group"
+    assert data.get("category") is None, "category must be None for teen group"
+
+
+def test_visualization_contract_pregnant_is_null(client: TestClient) -> None:
+    """
+    RU: Контракт: pregnant group возвращает visualization null.
+    EN: Contract: pregnant group returns visualization null.
+    """
+    payload = _valid_payload(
+        weight_kg=65.0,
+        height_cm=165.0,
+        age=25,
+        gender="female",
+        pregnant="yes",  # pregnant group
+    )
+
+    data = _post_bmi(client, payload)
+
+    # Contract: visualization is null for pregnant (category=None group)
+    assert "visualization" in data, "visualization field must exist in response"
+    assert data["visualization"] is None, "visualization must be null for pregnant group"
+    assert data.get("category") is None, "category must be None for pregnant group"
+
+
+def test_visualization_ranges_are_group_aware_athlete_vs_adult(client: TestClient) -> None:
+    """
+    RU: Контракт: athlete group имеет другие ranges чем adult (normal upper bound отличается).
+    EN: Contract: athlete group has different ranges than adult (normal upper bound differs).
+
+    We only assert "different normal upper" (not the exact number),
+    to keep this contract test stable and non-math.
+    """
+    base = {
+        "weight_kg": 85.0,
+        "height_cm": 180.0,
+        "age": 30,  # adult
+        "gender": "male",
+        "lang": "en",
+    }
+
+    adult_data = _post_bmi(client, {**base, "athlete": "no"})
+    athlete_data = _post_bmi(client, {**base, "athlete": "yes"})
+
+    adult_spec = adult_data.get("visualization")
+    athlete_spec = athlete_data.get("visualization")
+
+    # Contract: both groups return visualization (not null)
+    assert adult_spec is not None, "adult group must have visualization"
+    assert athlete_spec is not None, "athlete group must have visualization"
+
+    # Contract: athlete normal range upper bound differs from adult
+    adult_normal_to = _find_range_to(adult_spec, "bmi.normal")
+    athlete_normal_to = _find_range_to(athlete_spec, "bmi.normal")
+
+    assert (
+        athlete_normal_to != adult_normal_to
+    ), f"Athlete normal upper ({athlete_normal_to}) must differ from adult ({adult_normal_to})"
+    # Expected: athlete_normal_to == 27.0, adult_normal_to == 25.0
+    assert (
+        athlete_normal_to > adult_normal_to
+    ), f"Athlete normal upper ({athlete_normal_to}) should be higher than adult ({adult_normal_to})"
+
+
+def test_visualization_ranges_are_group_aware_elderly_vs_adult(client: TestClient) -> None:
+    """
+    RU: Контракт: elderly group имеет другие ranges чем adult (underweight и normal thresholds отличаются).
+    EN: Contract: elderly group has different ranges than adult (underweight and normal thresholds differ).
+    """
+    base = {
+        "weight_kg": 60.0,
+        "height_cm": 180.0,
+        "gender": "male",
+        "lang": "en",
+    }
+
+    adult_data = _post_bmi(client, {**base, "age": 30})  # adult
+    elderly_data = _post_bmi(client, {**base, "age": 75})  # elderly (age >= 60)
+
+    adult_spec = adult_data.get("visualization")
+    elderly_spec = elderly_data.get("visualization")
+
+    # Contract: both groups return visualization (not null)
+    assert adult_spec is not None, "adult group must have visualization"
+    assert elderly_spec is not None, "elderly group must have visualization"
+
+    # Contract: elderly underweight threshold differs from adult
+    adult_underweight_to = _find_range_to(adult_spec, "bmi.underweight")
+    elderly_underweight_to = _find_range_to(elderly_spec, "bmi.underweight")
+
+    assert (
+        elderly_underweight_to != adult_underweight_to
+    ), f"Elderly underweight upper ({elderly_underweight_to}) must differ from adult ({adult_underweight_to})"
+    # Expected: elderly_underweight_to == 17.5, adult_underweight_to == 18.5
+    assert (
+        elderly_underweight_to < adult_underweight_to
+    ), f"Elderly underweight upper ({elderly_underweight_to}) should be lower than adult ({adult_underweight_to})"
+
+    # Contract: elderly normal upper bound differs from adult
+    adult_normal_to = _find_range_to(adult_spec, "bmi.normal")
+    elderly_normal_to = _find_range_to(elderly_spec, "bmi.normal")
+
+    assert (
+        elderly_normal_to != adult_normal_to
+    ), f"Elderly normal upper ({elderly_normal_to}) must differ from adult ({adult_normal_to})"
+    # Expected: elderly_normal_to == 26.0, adult_normal_to == 25.0
+    assert (
+        elderly_normal_to > adult_normal_to
+    ), f"Elderly normal upper ({elderly_normal_to}) should be higher than adult ({adult_normal_to})"
+
+
+def test_visualization_contract_graceful_fallback_on_builder_failure(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    RU: Контракт: endpoint возвращает 200 с visualization null если builder падает.
+    EN: Contract: endpoint returns 200 with visualization null if builder fails.
+    """
+    import app.routers.bmi as bmi_router
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Builder failure (test)")
+
+    monkeypatch.setattr(bmi_router, "build_bmi_scale_v1", _boom)
+
+    payload = _valid_payload()
+
+    data = _post_bmi(client, payload)
+
+    # Contract: endpoint still returns 200
+    # Contract: visualization is null on builder failure
+    assert "visualization" in data, "visualization field must exist in response"
+    assert data["visualization"] is None, "visualization must be null on builder failure"
+    # Contract: other fields still present
+    assert "bmi" in data, "bmi field must still be present"
+    assert data["bmi"] > 0, "bmi must be positive"


### PR DESCRIPTION
# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Определить и задокументировать контракт ответа визуализации ИМТ для эндпоинта расчёта ИМТ и добавить тесты для его проверки.

Документация:
- Добавить документацию контракта визуализации ИМТ, описывающую структуру `BMIScaleV1Spec`, диапазоны для отдельных групп, правила nullability и рекомендации по использованию для клиентов.

Тесты:
- Ввести контрактные тесты для `BMICalculateResponse.visualization`, чтобы проверить структуру, инварианты диапазонов, поведение для отдельных групп и корректный переход к резервному варианту при сбое построителя визуализации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define and document the BMI visualization response contract for the BMI calculate endpoint and add tests to enforce it.

Documentation:
- Add BMI visualization contract documentation describing BMIScaleV1Spec structure, group-specific ranges, nullability rules, and client usage guidance.

Tests:
- Introduce contract tests for BMICalculateResponse.visualization to validate structure, range invariants, group-specific behavior, and graceful fallback when the visualization builder fails.

</details>