### PR TITLE
chore(security): document unresolved libtasn1 CVE and remove redundant install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,14 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH="/app"
 
 # Install runtime dependencies only (curl removed - using Python for healthcheck)
-# Security: explicit libtasn1-6 install for CVE-2025-13151 (stack-based buffer overflow)
+# NOTE: libtasn1-6 comes transitively via libgnutls30 (required for TLS/HTTPS).
+# CVE-2025-13151 is NOT fixed in Debian bookworm as of 2026-01 (no patched version available).
+# Tracking: https://security-tracker.debian.org/tracker/CVE-2025-13151
+# Revisit when bookworm publishes a fixed package.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         libc6 \
-        libtasn1-6 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -185,12 +185,8 @@ PY
 ### Dockerfile runtime stage
 
 - __No blanket `apt-get upgrade`__ in runtime — reduces drift and improves reproducibility.
-- For CVE fixes: install the affected package explicitly after `apt-get update`.
+- For CVE fixes with available patches: install the affected package explicitly after `apt-get update`.
 - After update, `apt-get install <pkg>` fetches the latest patched version from Debian repos.
-- Example (CVE-2025-13151):
-  ```dockerfile
-  apt-get install -y --no-install-recommends libtasn1-6
-  ```
 
 ### Frontend-generated artifacts
 
@@ -203,3 +199,17 @@ PY
 - Do not claim a CVE is "fixed" unless the distro security tracker shows a fixed version for our base distribution.
 - Check: [Debian Security Tracker](https://security-tracker.debian.org/) before claiming remediation.
 - If no fixed version exists yet: document as "unpatched/mitigation", add tracking issue, schedule base image bump once fixed lands.
+
+### No-fix-yet CVE policy
+
+When a CVE has no fix available in the base distro:
+
+1. **Do NOT** add fake "install/upgrade" commands — they don't help and add churn.
+2. **Document** in Dockerfile with tracking link.
+3. **Dismiss** GitHub alert with reason "Fix not available / vulnerable in distro".
+4. **Create tracking issue** to revisit on base image bump.
+
+Example (CVE-2025-13151 / libtasn1):
+- Package comes transitively via `libgnutls30` (required for TLS)
+- No patched version in Debian bookworm as of 2026-01
+- Documented in Dockerfile, tracking issue created, revisit monthly


### PR DESCRIPTION
## Summary

Document CVE-2025-13151 (libtasn1) as unresolved and remove misleading "fix" from Dockerfile.

### Background

- **CVE-2025-13151**: Stack-based buffer overflow in libtasn1
- **Status**: Vulnerable in Debian bookworm (no patched version available as of 2026-01)
- **Source**: [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2025-13151)

### Changes

1. **Dockerfile:**
   - Remove explicit `libtasn1-6` install (transitive via `libgnutls30`; no version change)
   - Add honest documentation with CVE tracking link

2. **app/AGENTS.md:**
   - Add "No-fix-yet CVE policy" section
   - Remove misleading example that implied CVE was fixed
   - Document proper handling for CVEs without available patches

### Why this matters

- **Honesty > theater**: Adding `apt-get install libtasn1-6` didn't fix anything (same version)
- **Reproducibility**: Removing unnecessary install reduces drift
- **Process**: Establishes clear policy for handling "no fix available" CVEs

### What to do with GitHub alert

After merge, **dismiss** alert #500 with:
- Reason: "Fix not available / vulnerable in distro"
- Comment: "libtasn1-6 comes transitively via libgnutls30 (required for TLS). No patched version in Debian bookworm. Tracking issue created."

### Test plan
- [x] Docker build passes
- [x] Pre-push hooks pass
- [ ] CI pipeline

## Summary by Sourcery

Уточнение обработки нерешённой уязвимости libtasn1 CVE-2025-13151 и упорядочивание конфигурации зависимостей Docker-образа.

Улучшения:
- Удалить из Docker-runtime-образа избыточную явную установку `libtasn1-6`, при этом сохранив необходимую транзитивную зависимость через `libgnutls30`.
- Добавить встроенную документацию в Dockerfile, объясняющую статус нерешённой уязвимости libtasn1 CVE-2025-13151 и содержащую ссылку на трекер безопасности Debian.

Документация:
- Обновить рекомендации для AGENTS, чтобы различать CVE с доступными патчами и нерешённые CVE в базовых дистрибутивах.
- Задокументировать политику по CVE в статусе "no-fix-yet", включая порядок документирования, отслеживания и отклонения алертов по уязвимостям, для которых ещё нет исправлений upstream.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify handling of unresolved libtasn1 CVE-2025-13151 and clean up Docker image dependency configuration.

Enhancements:
- Remove redundant explicit installation of libtasn1-6 from the Docker runtime image while retaining required transitive dependency via libgnutls30.
- Add inline Dockerfile documentation explaining the unresolved libtasn1 CVE-2025-13151 and linking to the Debian security tracker.

Documentation:
- Update AGENTS guidance to distinguish between CVEs with available patches and unresolved CVEs in base distributions.
- Document a "no-fix-yet" CVE policy, including how to document, track, and dismiss alerts for vulnerabilities without upstream fixes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security vulnerability handling guidance with detailed procedures for managing unpatched CVEs in dependencies.
  * Established explicit policy procedures for handling vulnerabilities without available patches, including documentation and alert management steps.

* **Chores**
  * Simplified build configuration by streamlining dependency declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->