### PR TITLE
feat(infra): add /ready readiness alias and document health contracts

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -19,9 +19,9 @@
 
 | Endpoint | Purpose | DB I/O | Response |
 |----------|---------|--------|----------|
-| `/health` | Liveness probe | ❌ No | 200 + version/timestamp |
+| `/health` | Liveness probe | ❌ No | 200 + status/version/git_sha/timestamp |
 | `/health/db` | DB readiness | ✅ Yes | 200 or 503 |
-| `/ready` | Readiness probe (alias) | ✅ Yes | 200 or 503 |
+| `/ready` | Readiness alias (hidden from OpenAPI) | ✅ Yes | 200 or 503 |
 
 **Usage:**
 - Use `/health` for liveness checks (process alive, no dependencies).

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -15,6 +15,27 @@
 - Lint/format: `make lint`, `make fmt`, `make fmt-check`
 - Pre-commit: `make pre-commit`
 
+## Health endpoints contract (PR-504)
+
+| Endpoint | Purpose | DB I/O | Response |
+|----------|---------|--------|----------|
+| `/health` | Liveness probe | ❌ No | 200 + version/timestamp |
+| `/health/db` | DB readiness | ✅ Yes | 200 or 503 |
+| `/ready` | Readiness probe (alias) | ✅ Yes | 200 or 503 |
+
+**Usage:**
+- Use `/health` for liveness checks (process alive, no dependencies).
+- Use `/ready` or `/health/db` for readiness checks (DB available).
+- Orchestrators (K8s, Docker, Caddy) should use `/ready` for traffic gating.
+
+**Verification:**
+```bash
+curl -fsS https://.../health   # liveness
+curl -fsS https://.../ready    # readiness (503 if DB down)
+```
+
+---
+
 ## Conventions
 
 - FastAPI + Pydantic v2 only; prefer `model_validator`/`field_validator`.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1325,6 +1325,18 @@ async def database_health(session: Session = Depends(get_session)) -> Dict[str, 
     return {"status": "ok"}
 
 
+@app.get("/ready")
+async def ready(session: Session = Depends(get_session)) -> Dict[str, str]:
+    """RU: Readiness probe (alias для /health/db).
+
+    EN: Readiness probe for orchestrators (alias for /health/db).
+
+    Returns 200 if DB is available, 503 otherwise.
+    Use this for Kubernetes/Docker readiness checks.
+    """
+    return await database_health(session)
+
+
 # ---------- Helpers ----------
 
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1325,7 +1325,7 @@ async def database_health(session: Session = Depends(get_session)) -> Dict[str, 
     return {"status": "ok"}
 
 
-@app.get("/ready")
+@app.get("/ready", include_in_schema=False)
 async def ready(session: Session = Depends(get_session)) -> Dict[str, str]:
     """RU: Readiness probe (alias для /health/db).
 
@@ -1333,8 +1333,9 @@ async def ready(session: Session = Depends(get_session)) -> Dict[str, str]:
 
     Returns 200 if DB is available, 503 otherwise.
     Use this for Kubernetes/Docker readiness checks.
+    Hidden from OpenAPI — semantics live in /health/db.
     """
-    return await database_health(session)
+    return await database_health(session=session)
 
 
 # ---------- Helpers ----------

--- a/tests/test_health_db.py
+++ b/tests/test_health_db.py
@@ -14,7 +14,7 @@ from core import db as db_module
 
 # RU: /ready - alias для /health/db, тестируем оба пути.
 # EN: /ready is an alias for /health/db, test both paths.
-READINESS_PATHS = ["/health/db", "/ready"]
+READINESS_PATHS: list[str] = ["/health/db", "/ready"]
 
 
 @pytest.mark.parametrize("path", READINESS_PATHS)
@@ -30,7 +30,7 @@ def test_readiness_ok(path: str) -> None:
 
 
 @pytest.mark.parametrize("path", READINESS_PATHS)
-def test_readiness_failure(monkeypatch, path: str) -> None:
+def test_readiness_failure(monkeypatch: pytest.MonkeyPatch, path: str) -> None:
     """RU: Ошибка БД приводит к 503.
 
     EN: DB failure surfaces as 503 on readiness endpoints.

--- a/tests/test_health_db.py
+++ b/tests/test_health_db.py
@@ -1,9 +1,10 @@
-"""Database health endpoint tests."""
+"""Database health and readiness endpoint tests."""
 
 from __future__ import annotations
 
 from typing import cast
 
+import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
@@ -11,22 +12,34 @@ import app
 from core import db as db_module
 
 
-def test_health_db_ok() -> None:
-    """RU: Проверка, что /health/db возвращает 200. EN: Ensure /health/db succeeds."""
+# RU: /ready - alias для /health/db, тестируем оба пути.
+# EN: /ready is an alias for /health/db, test both paths.
+READINESS_PATHS = ["/health/db", "/ready"]
 
+
+@pytest.mark.parametrize("path", READINESS_PATHS)
+def test_readiness_ok(path: str) -> None:
+    """RU: Проверка, что readiness endpoints возвращают 200.
+
+    EN: Ensure readiness endpoints succeed when DB is available.
+    """
     with TestClient(cast(ASGIApp, app.app)) as client:
-        response = client.get("/health/db")
+        response = client.get(path)
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 
-def test_health_db_failure(monkeypatch) -> None:
-    """RU: Ошибка БД приводит к 503. EN: DB failure surfaces as 503."""
+@pytest.mark.parametrize("path", READINESS_PATHS)
+def test_readiness_failure(monkeypatch, path: str) -> None:
+    """RU: Ошибка БД приводит к 503.
+
+    EN: DB failure surfaces as 503 on readiness endpoints.
+    """
     with TestClient(cast(ASGIApp, app.app)) as client:
         # legacy_app.lifespan clears DB_HEALTH_DEGRADED on successful init_db()
         # so we must set it AFTER startup to exercise the 503 branch.
         monkeypatch.setenv("DB_HEALTH_DEGRADED", "1")
-        response = client.get("/health/db")
+        response = client.get(path)
 
     assert response.status_code == 503
     assert response.json()["detail"].lower().startswith("database")


### PR DESCRIPTION
## Summary

Add `/ready` readiness endpoint and document health contracts for orchestrator integration.

### Changes

1. **legacy_app.py:**
   - Add `/ready` endpoint as alias for `/health/db`
   - Returns 200 if DB available, 503 otherwise

2. **tests/test_health_db.py:**
   - Parametrize tests to cover both `/health/db` and `/ready` paths
   - 4 tests total (2 endpoints × 2 scenarios)

3. **app/AGENTS.md:**
   - Document health endpoints contract table
   - Add verification commands

### Health endpoints contract

| Endpoint | Purpose | DB I/O | Response |
|----------|---------|--------|----------|
| `/health` | Liveness probe | ❌ No | 200 + version/timestamp |
| `/health/db` | DB readiness | ✅ Yes | 200 or 503 |
| `/ready` | Readiness probe (alias) | ✅ Yes | 200 or 503 |

### Usage

- **Liveness:** `curl -fsS https://.../health`
- **Readiness:** `curl -fsS https://.../ready`

### Test plan

- [x] `/ready` returns 200 when DB available
- [x] `/ready` returns 503 when DB unavailable
- [x] Tests parametrized for both paths
- [x] Pre-push hooks pass
- [ ] CI pipeline

## Summary by Sourcery

Добавить выделенную точку готовности `/ready`, согласованную с задокументированными контрактами health-check, и покрыть её тестами.

Новые возможности:
- Добавлен HTTP-эндпоинт `/ready` в качестве пробника готовности, являющийся алиасом существующей проверки состояния базы данных.

Улучшения:
- Задокументирован контракт health-check и использование эндпоинтов liveness и readiness в `AGENTS.md`.

Тесты:
- Параметризованы тесты проверки базы данных, чтобы проверять как `/health/db`, так и `/ready` в сценариях успешного и неуспешного выполнения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated /ready readiness endpoint aligned with documented health-check contracts and ensure it is covered by tests.

New Features:
- Add a /ready HTTP endpoint as a readiness probe aliasing the existing database health check.

Enhancements:
- Document the health-check contract and usage for liveness and readiness endpoints in AGENTS.md.

Tests:
- Parametrize database health tests to exercise both /health/db and /ready across success and failure scenarios.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/ready` readiness endpoint alongside existing health checks.

* **Documentation**
  * Expanded health endpoints documentation with endpoint descriptions, expected responses, usage, and verification guidance.

* **Tests**
  * Broadened readiness test coverage to validate both health and readiness paths using parameterized tests for success and failure cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->