### PR TITLE
docs(contracts): OpenAPI visibility matrix + tier map (PR-A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,7 @@ git diff --name-only origin/main...HEAD \
 This rule exists to prevent accidental regressions, keep PR reviews focused and safe, avoid CI failures caused by unrelated changes, and enforce clean separation between **documentation governance** and **runtime evolution**.
 
 **Canonical policy:** This section in `AGENTS.md` is the source of truth.
+**Last updated:** 2026-01-11
 
 Violation of this rule blocks merge.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,7 +313,7 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 
 ### 🛑 Docs-only PR Rule (Mandatory)
 
-**Docs-only PR** — это PR, который **строго ограничен документацией** и **не имеет права** изменять runtime, CI или поведение приложения.
+**Docs-only PR** — a PR strictly limited to documentation that **must not** change runtime, CI, or application behavior.
 
 **Allowed changes (docs-only):**
 * `*.md` files
@@ -342,12 +342,12 @@ git diff --name-only origin/main...HEAD \
 **Special note about legacy files:**
 * Files like `legacy_app.py` **MUST NOT** appear in docs-only PRs.
 * If a docs PR accidentally touches code, it must be **reset to `origin/main`** and removed from the diff.
-* Code cleanup related to other PRs (e.g. PR-457) **belongs only to that PR**, never to docs PRs.
+* Code cleanup related to other PRs **belongs only to that PR**, never to docs PRs.
 
 **Rationale:**
 This rule exists to prevent accidental regressions, keep PR reviews focused and safe, avoid CI failures caused by unrelated changes, and enforce clean separation between **documentation governance** and **runtime evolution**.
 
-**Policy reference:** See `docs/policy/DOCS_ONLY_PR_POLICY.md` for the canonical policy source of truth.
+**Canonical policy:** This section in `AGENTS.md` is the source of truth.
 
 Violation of this rule blocks merge.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,28 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - Pre-push backend tests are diff-based; see `scripts/AGENTS.md` for details.
 - Use Pydantic v2 APIs and FastAPI best practices for backend changes.
 
+## Product tiers and API namespaces (canonical)
+
+### Product tiers (source of truth)
+- **Tiers are: FREE / PRO / VIP** (per `SubscriptionTier` enum in `app/middleware/api_tiers.py`).
+- **`/premium/*` is a deprecated namespace** (aliases only), not a tier.
+- **VIP endpoints MUST live under `/api/v1/vip/*`** (canonical namespace).
+- **PRO endpoints MUST live under `/api/v1/pro/*`** (canonical namespace).
+- **FREE endpoints live under `/api/v1/bmi/*`** and other free paths.
+
+### API namespace policy
+- **Canonical namespaces:** `/api/v1/bmi/*` (FREE), `/api/v1/pro/*` (PRO), `/api/v1/vip/*` (VIP).
+- **Deprecated namespace:** `/api/v1/premium/*` (aliases only, must delegate to canonical `/pro/*` or `/vip/*`).
+- **OpenAPI must not expose deprecated aliases by default** (hide `/premium/*` from schema to prevent frontend from generating types for wrong paths).
+- **File naming must not imply tier unless enforced** (e.g., `bmi_pro.py` is FREE tier, not PRO).
+
+### Tier enforcement
+- PRO tier: use `require_pro_tier()` middleware (from `app.middleware.api_tiers`).
+- VIP tier: use `require_vip_tier()` middleware (from `app.middleware.api_tiers`).
+- All `/premium/*` endpoints must delegate to canonical handlers (no business logic in aliases).
+
+**See:** `docs/contracts/PRODUCT_TIER_MAP.md` for canonical tier mapping and namespace policy.
+
 ## OpenAPI generation (determinism requirement)
 
 ### Canonical source

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,9 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - VIP tier: use `require_vip_tier()` middleware (from `app.middleware.api_tiers`).
 - All `/premium/*` endpoints must delegate to canonical handlers (no business logic in aliases).
 
-**See:** `docs/contracts/PRODUCT_TIER_MAP.md` for canonical tier mapping and namespace policy.
+**See:**
+- `docs/contracts/PRODUCT_TIER_MAP.md` — contract/specification (what IS)
+- `docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md` — remediation roadmap (what we DO)
 
 ## OpenAPI generation (determinism requirement)
 

--- a/docs/audit/API_ALIGNMENT_CHECKLIST.md
+++ b/docs/audit/API_ALIGNMENT_CHECKLIST.md
@@ -1,4 +1,4 @@
-# ✅ PulsePlate — API Alignment Checklist (VIP-first, premium=shim, zero-duplication)
+# ✅ PulsePlate — API Alignment Checklist (FREE/PRO/VIP tiers, deprecated premium namespace)
 
 **Status:** Canonical alignment protocol
 **Last updated:** 2026-01-11
@@ -6,22 +6,47 @@
 
 ---
 
-## 0) Принципы (инварианты, без которых не начинаем)
+## 0) Principles (invariants — do not start without them)
 
-* **Один источник правды по контрактам:** OpenAPI из `app.main.app` + `normalize_openapi_schema()`.
-* **VIP ≠ PRO:** VIP (неделя/микро/шоплист/авто-ремонт) и PRO (питание/планы) — **разные доменные контуры**, не смешиваем.
-* **BMI core — канон:** BMI calculation engine — единый источник; роутеры/legacy — thin adapters.
-* **premium = compat shim:** premium endpoints могут жить, но **не содержат бизнес-логики**, только делегирование/адаптация.
-* **Запрещено:** новые ручные типы на фронте, если тип уже есть в OpenAPI.
-* **Запрещено:** бизнес-логика в `legacy_app.py` (кроме compatibility endpoints и тонких адаптеров).
-* **OpenAPI determinism — gate:** любой контракт должен быть детерминированным и безопасным.
-* **Любой новый endpoint** → сразу решаем: он в schema публично или скрыт.
+### English
 
-**Gate (must pass):**
+* **Single source of truth for contracts:** OpenAPI from `app.main.app` + `normalize_openapi_schema()`.
+* **Product tiers are FREE / PRO / VIP** (per `SubscriptionTier` enum in `app/middleware/api_tiers.py`).
+* **VIP ≠ PRO:** VIP (weekly/micro/shoplist/auto-repair) and PRO (nutrition/plans) are **different domain contours**; do not mix.
+* **BMI core is canonical:** the BMI calculation engine is the single source of truth; routers/legacy are thin adapters.
+* **`/premium/*` is a deprecated namespace** (aliases only), not a tier. All `/premium/*` endpoints must delegate to canonical `/pro/*` or `/vip/*`.
+* **Canonical namespaces:** `/api/v1/bmi/*` (FREE), `/api/v1/pro/*` (PRO), `/api/v1/vip/*` (VIP).
+* **Forbidden:** adding manual frontend types when the type already exists in OpenAPI.
+* **Forbidden:** business logic in `legacy_app.py` (except compatibility endpoints and thin adapters).
+* **OpenAPI determinism is a gate:** every contract must be deterministic and safe.
+* **Any new endpoint** → decide immediately: is it public in the schema or intentionally hidden.
+* **OpenAPI must not expose deprecated aliases by default** (hide `/premium/*` from schema to prevent frontend from generating types for wrong paths).
+
+**Gates (must pass):**
 
 * `make openapi` → `git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts`
 * `pytest` + `diff-cover`
-* нет новых "тихих" feature-flag веток, которые меняют контракт без отражения в docs.
+* No new "silent" feature-flag branches that change the contract without being reflected in docs.
+
+### Русский
+
+* **Один источник правды по контрактам:** OpenAPI из `app.main.app` + `normalize_openapi_schema()`.
+* **Уровни продукта: FREE / PRO / VIP** (по `SubscriptionTier` enum в `app/middleware/api_tiers.py`).
+* **VIP ≠ PRO:** VIP (неделя/микро/шоплист/авто-ремонт) и PRO (питание/планы) — **разные доменные контуры**, не смешиваем.
+* **BMI core — канон:** движок расчёта BMI — единый источник; роутеры/legacy — тонкие адаптеры.
+* **`/premium/*` — deprecated namespace** (только aliases), не уровень подписки. Все `/premium/*` endpoints должны делегировать в канонические `/pro/*` или `/vip/*`.
+* **Канонические namespaces:** `/api/v1/bmi/*` (FREE), `/api/v1/pro/*` (PRO), `/api/v1/vip/*` (VIP).
+* **Запрещено:** новые ручные типы на фронте, если тип уже есть в OpenAPI.
+* **Запрещено:** бизнес-логика в `legacy_app.py` (кроме совместимых эндпоинтов и тонких адаптеров).
+* **Детерминизм OpenAPI — жёсткий гейт:** любой контракт должен быть детерминированным и безопасным.
+* **Любой новый эндпоинт** → сразу решаем: он в schema публично или скрыт.
+* **OpenAPI не должен показывать deprecated aliases по умолчанию** (скрыть `/premium/*` из схемы, чтобы фронт не генерировал типы для неправильных путей).
+
+**Гейт (должно пройти):**
+
+* `make openapi` → `git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts`
+* `pytest` + `diff-cover`
+* нет новых "тихих" веток с фича-флагами, которые меняют контракт без отражения в документации.
 
 ---
 
@@ -29,7 +54,7 @@
 
 ### 1.1 Public schema hygiene (обязательное)
 
-**Цель:** если `/openapi.json` публичный — он не должен палить internal surface.
+**Цель:** если `/openapi.json` публичный — он не должен палить internal surface и deprecated aliases.
 
 * [ ] Все admin endpoints → `include_in_schema=False`
   * `/api/v1/admin/*`, `/admin/*` (status/db-status/check-updates/rollback/force-update/logs/cleanup)
@@ -38,8 +63,11 @@
 * [ ] Export/demo endpoints → **не в schema**, пока не "productized"
   * `/api/v1/premium/exports/*`, `/api/v1/export/pdf` и т.п.
 * [ ] Debug endpoints (`/debug_env`) → не в schema
+* [ ] **Deprecated `/premium/*` aliases → скрыть из schema по умолчанию**
+  * чтобы фронт не генерил типы для deprecated путей
+  * оставить только canonical `/pro/*` и `/vip/*`
 
-**DoD:** в `frontend/src/api/openapi.json` нет `admin`, `test`, `debug`, `exports` путей.
+**DoD:** в `frontend/src/api/openapi.json` нет `admin`, `test`, `debug`, `exports` путей, и нет `/premium/*` (или они явно помечены deprecated).
 
 ---
 
@@ -71,39 +99,49 @@
 
 ---
 
-## 2) Контракт: "VIP ≠ PRO, premium=shim" (закрываем путаницу имен/эндпоинтов)
+## 2) Контракт: "FREE / PRO / VIP tiers, `/premium/*` deprecated namespace" (закрываем путаницу имен/эндпоинтов)
 
-### 2.1 Таблица контрактов (единый mapping)
+### 2.1 Канонические namespaces (единый mapping)
 
 **Важно:** VIP и PRO — **разные доменные контуры**. Не смешиваем логику.
+
+**Canonical namespaces (source of truth):**
+
+* `/api/v1/bmi/*` → FREE tier
+* `/api/v1/pro/*` → PRO tier
+* `/api/v1/vip/*` → VIP tier
+
+**Deprecated namespace (aliases only):**
+
+* `/api/v1/premium/*` → deprecated aliases, делегируют в `/pro/*` или `/vip/*`
 
 Составляем 1 каноническую таблицу:
 
 * [ ] **Weekly plan**
-  * VIP canonical: `/api/v1/vip/meal/weekly` (или фактический VIP endpoint)
-  * PRO canonical: `/api/v1/pro/meal/weekly` (если остаётся как отдельный контур)
-  * Premium shim: `/api/v1/premium/plan/week` → **делегирует** в VIP или PRO (по продуктовой логике)
+  * VIP canonical: `/api/v1/vip/menu/weekly/plan` (фактический VIP endpoint)
+  * PRO canonical: `/api/v1/pro/meal/weekly` (фактический PRO endpoint)
+  * Premium alias (deprecated): `/api/v1/premium/plan/week` → **делегирует** в VIP (по факту требует VIP_MODULE_ENABLED)
 * [ ] **Targets**
-  * VIP canonical: `/api/v1/vip/nutrition/targets` (если микро-constraints)
-  * PRO canonical: `/api/v1/pro/nutrition/targets` (если отдельный контур)
-  * Premium shim: `/api/v1/premium/targets` → делегирует в соответствующий canonical
+  * PRO canonical: `/api/v1/pro/nutrition/targets` (planned)
+  * Premium alias (deprecated): `/api/v1/premium/targets` → делегирует в PRO canonical
 * [ ] **Daily plate**
   * PRO canonical: `/api/v1/pro/nutrition/daily` (GET)
-  * Premium shim: `/api/v1/premium/plate` (если нужен) → делегирует / адаптирует
+  * Premium alias (deprecated): `/api/v1/premium/plate` → делегирует в PRO canonical
 
-**Правило:** VIP и PRO могут иметь **разную логику** (VIP = микро/регион/шоплист, PRO = питание/планы), но premium shim **не дублирует** ни одну из них.
+**Правило:** VIP и PRO могут иметь **разную логику** (VIP = микро/регион/шоплист, PRO = питание/планы), но `/premium/*` aliases **не дублируют** ни одну из них.
 
-**DoD:** в репо есть один файл-истина (например `docs/API_CONTRACT_MAP.md`) и он совпадает с OpenAPI.
+**DoD:** в репо есть один файл-истина (`docs/contracts/PRODUCT_TIER_MAP.md`) и он совпадает с OpenAPI.
 
 ---
 
-### 2.2 Premium endpoints — только shim, никакой логики
+### 2.2 `/premium/*` endpoints — только aliases, никакой логики
 
 * [ ] Любой `/api/v1/premium/*` endpoint:
   * не считает нутриенты сам
   * не строит неделю сам
   * не содержит "rules"
-  * только вызывает canonical handler и делает маппинг ответа (если надо)
+  * только вызывает canonical handler (`/pro/*` или `/vip/*`) и делает маппинг ответа (если надо)
+  * помечен `deprecated=True` и/или `include_in_schema=False`
 
 **DoD:** grep по `legacy_app.py`/premium endpoints — нет "тяжёлых" функций, только delegation/adapter.
 
@@ -158,17 +196,23 @@
 
 ### 5.1 Repo-policy guard tests
 
-* [ ] Тест/линт: "запрещено" импортировать/вычислять нутриенты в premium shim слоях
+* [ ] Тест/линт: "запрещено" импортировать/вычислять нутриенты в `/premium/*` alias слоях
 * [ ] Тест: "запрещено" объявлять ручные типы для схем, которые есть в OpenAPI
-* [ ] Документируем в `AGENTS.md` правила:
+* [ ] Документируем в `AGENTS.md` правила (✅ уже добавлено в секцию "Product tiers and API namespaces"):
+  * Tiers are: FREE / PRO / VIP (per `SubscriptionTier` enum)
+  * `/premium/*` is a deprecated namespace (aliases only), not a tier
+  * VIP endpoints MUST live under `/api/v1/vip/*`
+  * PRO endpoints MUST live under `/api/v1/pro/*`
+  * OpenAPI must not expose deprecated aliases by default
+  * File naming must not imply tier unless enforced
   * VIP ≠ PRO (разные доменные контуры)
   * BMI core — канон; роутеры — thin adapters
-  * premium=shim only (no business logic)
+  * `/premium/*` aliases = delegation only (no business logic)
   * schema-only guards required
   * admin/test/export hidden from schema
   * OpenAPI determinism — gate для любого контракта
 
-**DoD:** новый участник не сможет случайно "написать вторую реализацию".
+**DoD:** новый участник не сможет случайно "написать вторую реализацию" или использовать deprecated namespace как canonical.
 
 ---
 
@@ -193,5 +237,7 @@
 
 **See also:**
 - `docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md` — детальный анализ legacy_app.py
+- `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping (source of truth)
+- `docs/contracts/OPENAPI_PATHS_AUDIT.md` — фактический список путей из OpenAPI
 - `docs/contracts/API_CANONICAL_MAP.md` — текущий mapping (требует обновления)
-- `AGENTS.md` — правила репозитория
+- `AGENTS.md` — правила репозитория (секция "Product tiers and API namespaces")

--- a/docs/audit/API_ALIGNMENT_CHECKLIST.md
+++ b/docs/audit/API_ALIGNMENT_CHECKLIST.md
@@ -1,0 +1,197 @@
+# ✅ PulsePlate — API Alignment Checklist (VIP-first, premium=shim, zero-duplication)
+
+**Status:** Canonical alignment protocol
+**Last updated:** 2026-01-11
+**Owner:** Backend + Frontend teams
+
+---
+
+## 0) Принципы (инварианты, без которых не начинаем)
+
+* **Один источник правды по контрактам:** OpenAPI из `app.main.app` + `normalize_openapi_schema()`.
+* **VIP ≠ PRO:** VIP (неделя/микро/шоплист/авто-ремонт) и PRO (питание/планы) — **разные доменные контуры**, не смешиваем.
+* **BMI core — канон:** BMI calculation engine — единый источник; роутеры/legacy — thin adapters.
+* **premium = compat shim:** premium endpoints могут жить, но **не содержат бизнес-логики**, только делегирование/адаптация.
+* **Запрещено:** новые ручные типы на фронте, если тип уже есть в OpenAPI.
+* **Запрещено:** бизнес-логика в `legacy_app.py` (кроме compatibility endpoints и тонких адаптеров).
+* **OpenAPI determinism — gate:** любой контракт должен быть детерминированным и безопасным.
+* **Любой новый endpoint** → сразу решаем: он в schema публично или скрыт.
+
+**Gate (must pass):**
+
+* `make openapi` → `git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts`
+* `pytest` + `diff-cover`
+* нет новых "тихих" feature-flag веток, которые меняют контракт без отражения в docs.
+
+---
+
+## 1) Схема и безопасность OpenAPI (сначала это, иначе фронт генерит мусор)
+
+### 1.1 Public schema hygiene (обязательное)
+
+**Цель:** если `/openapi.json` публичный — он не должен палить internal surface.
+
+* [ ] Все admin endpoints → `include_in_schema=False`
+  * `/api/v1/admin/*`, `/admin/*` (status/db-status/check-updates/rollback/force-update/logs/cleanup)
+* [ ] Test router → **не в schema**
+  * либо schema-only guard, либо сам router `include_in_schema=False`
+* [ ] Export/demo endpoints → **не в schema**, пока не "productized"
+  * `/api/v1/premium/exports/*`, `/api/v1/export/pdf` и т.п.
+* [ ] Debug endpoints (`/debug_env`) → не в schema
+
+**DoD:** в `frontend/src/api/openapi.json` нет `admin`, `test`, `debug`, `exports` путей.
+
+---
+
+### 1.2 Unified schema-only mode (обязательное)
+
+**Цель:** schema generation не должен импортить ORM и падать "Table already defined".
+
+* [ ] Один `is_schema_only_mode()` (например `app/utils/openapi_mode.py`)
+* [ ] Его уважают **все** conditional registration места:
+  * VIP registration
+  * test router
+  * bodyfat router
+  * bmi-pro router
+  * business router
+  * exports endpoints
+
+**DoD:** `make openapi` не зависит от "удачи", без флейков и без ORM double-load.
+
+---
+
+### 1.3 VIP default enabled — фиксируем поведение в schema-gen
+
+Сейчас `VIP_MODULE_ENABLED` default `true` → VIP цепочкой может тянуть premium_week и ORM.
+
+* [ ] В `scripts/generate_openapi.py` явно ставим `VIP_MODULE_ENABLED=false` **или** VIP registration уважает schema-only.
+* [ ] Убираем `ENABLE_TEST_ROUTES=1` из schema-gen (или делаем чтобы оно не влияло на schema).
+
+**DoD:** schema-gen всегда минимально безопасный.
+
+---
+
+## 2) Контракт: "VIP ≠ PRO, premium=shim" (закрываем путаницу имен/эндпоинтов)
+
+### 2.1 Таблица контрактов (единый mapping)
+
+**Важно:** VIP и PRO — **разные доменные контуры**. Не смешиваем логику.
+
+Составляем 1 каноническую таблицу:
+
+* [ ] **Weekly plan**
+  * VIP canonical: `/api/v1/vip/meal/weekly` (или фактический VIP endpoint)
+  * PRO canonical: `/api/v1/pro/meal/weekly` (если остаётся как отдельный контур)
+  * Premium shim: `/api/v1/premium/plan/week` → **делегирует** в VIP или PRO (по продуктовой логике)
+* [ ] **Targets**
+  * VIP canonical: `/api/v1/vip/nutrition/targets` (если микро-constraints)
+  * PRO canonical: `/api/v1/pro/nutrition/targets` (если отдельный контур)
+  * Premium shim: `/api/v1/premium/targets` → делегирует в соответствующий canonical
+* [ ] **Daily plate**
+  * PRO canonical: `/api/v1/pro/nutrition/daily` (GET)
+  * Premium shim: `/api/v1/premium/plate` (если нужен) → делегирует / адаптирует
+
+**Правило:** VIP и PRO могут иметь **разную логику** (VIP = микро/регион/шоплист, PRO = питание/планы), но premium shim **не дублирует** ни одну из них.
+
+**DoD:** в репо есть один файл-истина (например `docs/API_CONTRACT_MAP.md`) и он совпадает с OpenAPI.
+
+---
+
+### 2.2 Premium endpoints — только shim, никакой логики
+
+* [ ] Любой `/api/v1/premium/*` endpoint:
+  * не считает нутриенты сам
+  * не строит неделю сам
+  * не содержит "rules"
+  * только вызывает canonical handler и делает маппинг ответа (если надо)
+
+**DoD:** grep по `legacy_app.py`/premium endpoints — нет "тяжёлых" функций, только delegation/adapter.
+
+---
+
+## 3) Legacy app extraction (если вы сейчас в ветке 511A/511B — это сюда)
+
+### 3.1 PR-511A (extraction only) — invariants
+
+* [ ] `legacy_app.py` не создаёт `FastAPI()`
+* [ ] router registration в одном месте (registration module)
+* [ ] `legacy_app.py` хранит:
+  * публичные атрибуты `premium_week_router/pro_router/vip_router` (если нужны тестам)
+  * legacy endpoints `/api/nutrition/{date}`, `/plan`, `/bmi` (если ещё держим)
+
+**DoD:** OpenAPI byte-identical после normalize.
+
+### 3.2 PR-511B (guards) — закрываем ORM risks + schema hygiene
+
+* [ ] unified schema-only guards применены
+* [ ] admin/test/export скрыты из схемы
+
+**DoD:** openapi-sync зелёный, без флейков.
+
+---
+
+## 4) Frontend: типы и эндпоинты (после того как schema стала "правдой")
+
+### 4.1 Generated types становятся единственными
+
+* [ ] Удаляем/запрещаем ручные типы-дубли (`frontend/src/api/premium/types.ts`)
+* [ ] Все клиенты импортируют из `frontend/src/api/schema.ts`
+* [ ] Если нужна runtime валидация — Zod схемы строятся поверх generated типов, но **не заменяют** их.
+
+**DoD:** нет расхождений "тип есть в premium/types.ts, но другой в schema.ts".
+
+---
+
+### 4.2 Миграция endpoint paths в одном PR (и тесты)
+
+* [ ] `weekly-plan.ts`: premium → canonical (или premium shim, но бьёт в правильный URL)
+* [ ] `targets.ts`
+* [ ] `plate.ts` (учесть смену метода POST→GET если это правда по контракту)
+* [ ] `mocks/handlers.ts` обновлён под новые пути
+* [ ] интеграционные тесты обновлены
+
+**DoD:** `npm run test` и `npm run build` зелёные.
+
+---
+
+## 5) Anti-duplication enforcement (чтобы путаница не вернулась)
+
+### 5.1 Repo-policy guard tests
+
+* [ ] Тест/линт: "запрещено" импортировать/вычислять нутриенты в premium shim слоях
+* [ ] Тест: "запрещено" объявлять ручные типы для схем, которые есть в OpenAPI
+* [ ] Документируем в `AGENTS.md` правила:
+  * VIP ≠ PRO (разные доменные контуры)
+  * BMI core — канон; роутеры — thin adapters
+  * premium=shim only (no business logic)
+  * schema-only guards required
+  * admin/test/export hidden from schema
+  * OpenAPI determinism — gate для любого контракта
+
+**DoD:** новый участник не сможет случайно "написать вторую реализацию".
+
+---
+
+## Мини-скрипт проверки перед каждым PR (короткий, но железный)
+
+1. `make openapi && git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts`
+2. `pytest` + `diff-cover`
+3. Если PR трогает API:
+   * в описании PR есть "Contract impact" (что меняется в OpenAPI)
+   * есть ссылка на `docs/API_CONTRACT_MAP.md`
+
+---
+
+## Приоритет выполнения
+
+1. **Сначала:** Секция 1 (OpenAPI hygiene + schema-only guards) — без этого фронт будет генерить типы из небезопасной схемы.
+2. **Потом:** Секция 2 (контракты) — фиксируем mapping premium→canonical.
+3. **Параллельно/после:** Секция 3 (legacy extraction) — PR-511A/511B.
+4. **В конце:** Секция 4 (frontend migration) — только после того, как schema стала "правдой".
+
+---
+
+**See also:**
+- `docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md` — детальный анализ legacy_app.py
+- `docs/contracts/API_CANONICAL_MAP.md` — текущий mapping (требует обновления)
+- `AGENTS.md` — правила репозитория

--- a/docs/audit/API_ALIGNMENT_PR_TEMPLATE.md
+++ b/docs/audit/API_ALIGNMENT_PR_TEMPLATE.md
@@ -13,7 +13,7 @@
 
 **If any "Yes":**
 - Link to `docs/audit/API_ALIGNMENT_CHECKLIST.md` section that applies
-- Link to `docs/contracts/API_CANONICAL_MAP.md` (or note if it needs update)
+- Link to `docs/contracts/PRODUCT_TIER_MAP.md` (or note if it needs update)
 
 ---
 

--- a/docs/audit/API_ALIGNMENT_PR_TEMPLATE.md
+++ b/docs/audit/API_ALIGNMENT_PR_TEMPLATE.md
@@ -1,0 +1,37 @@
+# API Alignment PR Template
+
+**Use this template when PR touches API contracts, endpoints, or OpenAPI schema.**
+
+---
+
+## Contract Impact
+
+- [ ] **OpenAPI schema changes:** Yes / No
+- [ ] **Endpoint paths changed:** Yes / No
+- [ ] **Request/response models changed:** Yes / No
+- [ ] **VIP/PRO/premium mapping affected:** Yes / No
+
+**If any "Yes":**
+- Link to `docs/audit/API_ALIGNMENT_CHECKLIST.md` section that applies
+- Link to `docs/contracts/API_CANONICAL_MAP.md` (or note if it needs update)
+
+---
+
+## Pre-merge Checks
+
+- [ ] `make openapi && git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts`
+- [ ] `pytest` + `diff-cover` ≥97%
+- [ ] Schema-only guards applied (if adding conditional routers)
+- [ ] Admin/test/export endpoints excluded from schema (if public schema)
+
+---
+
+## VIP-first / Premium-shim Policy
+
+- [ ] New endpoint is canonical (VIP/PRO) **or** premium shim (delegates only)
+- [ ] No business logic duplication between premium and canonical
+- [ ] Frontend types use generated `schema.ts` (no manual types)
+
+---
+
+**See:** `docs/audit/API_ALIGNMENT_CHECKLIST.md` for full protocol.

--- a/docs/audit/PR_A_DESCRIPTION.md
+++ b/docs/audit/PR_A_DESCRIPTION.md
@@ -1,0 +1,82 @@
+# PR-A: docs(contracts) — Define OpenAPI Visibility Rules and Audit Current Paths
+
+**Type:** Docs-only (governance)
+**Risk:** None (no runtime changes)
+**Priority:** High (foundation for PR-B/PR-C)
+
+---
+
+## Purpose
+
+Зафиксировать **канонические правила**, *что имеет право быть в OpenAPI*, а что нет, **до любых runtime-изменений**.
+
+PR **не меняет поведение приложения**, не трогает код и не влияет на клиентов.
+
+Это governance-PR: он снимает двусмысленность и служит базой для PR-B / PR-C.
+
+---
+
+## Scope
+
+**Только документация:**
+
+* `docs/contracts/OPENAPI_VISIBILITY_MATRIX.md` — правила видимости эндпоинтов в OpenAPI
+* `docs/contracts/OPENAPI_PATHS_AUDIT.md` — фактический инвентарь путей из текущего OpenAPI
+* `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping (FREE/PRO/VIP)
+* `AGENTS.md` — добавлена секция "Product tiers and API namespaces"
+* `docs/audit/API_ALIGNMENT_CHECKLIST.md` — обновлён под FREE/PRO/VIP модель
+
+❌ **НЕТ:**
+* runtime кода
+* правок роутеров
+* feature flags
+* CI / infra
+
+---
+
+## Key Decisions (зафиксировано)
+
+1. **Product tiers:** FREE / PRO / VIP — единственные уровни продукта
+2. **`/premium/*` — deprecated namespace**, не tier
+3. **OpenAPI = публичная витрина**, не отражение legacy/alias слоёв
+4. Deprecated aliases, admin/debug/test/export **не должны быть видны в OpenAPI по умолчанию**
+5. Canonical namespaces:
+   * FREE → `/api/v1/bmi/*`
+   * PRO → `/api/v1/pro/*`
+   * VIP → `/api/v1/vip/*`
+
+---
+
+## Non-goals
+
+* ❌ не скрывает `/premium/*` из OpenAPI (это PR-B)
+* ❌ не исправляет `/premium/plan/week` (это PR-C)
+* ❌ не переименовывает роуты
+* ❌ не трогает frontend/iOS
+
+---
+
+## Verification (docs-only check)
+
+```bash
+git diff --name-only origin/main...HEAD \
+  | rg -v "\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$"
+```
+
+**Ожидание:** пустой вывод → подтверждение, что PR строго docs-only.
+
+---
+
+## Why Now
+
+Без этого PR:
+* невозможно объективно сказать, **что считается регрессией**
+* PR-B и PR-C будут спорить "по ощущениям", а не по правилам
+* frontend/iOS продолжат генерить типы из мусорной схемы
+
+---
+
+## Follow-ups
+
+* **PR-B:** schema hygiene — скрыть `/premium/*` из OpenAPI
+* **PR-C:** VIP alignment — `/premium/plan/week` = alias → `/vip/menu/weekly/plan`

--- a/docs/audit/PR_B_VIP_GUARD_CONSISTENCY_AUDIT.md
+++ b/docs/audit/PR_B_VIP_GUARD_CONSISTENCY_AUDIT.md
@@ -1,0 +1,271 @@
+# PR-B — VIP Guard Consistency Audit
+
+**Date:** 2026-01-11
+**Scope:** `app/routers/vip.py` vs `app/routers/vip_shoplist.py`
+**Goal:** Unify VIP access enforcement without breaking intended internal/service-only endpoints.
+
+---
+
+## 1) Problem Statement (Facts Only)
+
+### Finding A — Inconsistent Guard Patterns
+
+**Current state:**
+
+- `vip_shoplist.py` uses: `require_vip_tier()` ✅ (tier-aware, validates both API key AND tier)
+- `vip.py` uses: `_require_api_key_strict()` ❌ (api-key-only, tier-unaware)
+
+**Evidence:**
+
+1. **`require_vip_tier()` implementation** (`app/middleware/api_tiers.py:203-239`):
+   ```python
+   async def require_vip_tier(x_api_key: Optional[str] = Header(None)) -> str:
+       if not x_api_key:
+           raise HTTPException(status_code=403, detail="VIP access required")
+       if not _validate_api_key_tier(x_api_key, SubscriptionTier.VIP):
+           raise HTTPException(status_code=403, detail="API key does not have VIP tier access...")
+       return x_api_key
+   ```
+   **Validates:** API key presence + tier validation via `_validate_api_key_tier()`
+
+2. **`_require_api_key_strict()` implementation** (`app/routers/vip.py:403-434`):
+   ```python
+   def _require_api_key_strict(request: Request) -> str:
+       configured = _get_configured_api_key()  # from env var API_KEY
+       api_key = _extract_api_key(request)
+       if not api_key or api_key != configured:
+           raise HTTPException(status_code=403, detail="Forbidden: Invalid API key")
+       return expected
+   ```
+   **Validates:** Only API key matches env var `API_KEY` (no tier check)
+
+**Risk:** Non-VIP users with valid API key (matching `API_KEY` env var) may access user-facing VIP endpoints if tier is not enforced separately.
+
+---
+
+## 2) Inventory: vip.py Endpoints (Must Classify)
+
+> **Rule:** Every endpoint must be classified as either **User-facing VIP** (requires VIP tier) or **Internal/service** (api-key-only allowed, but must be explicit).
+
+| # | Endpoint | Method | Current Guard | Intended Class | Proposed Guard | Evidence (Code Lines / Usage) | Tests |
+|---|----------|--------|---------------|----------------|----------------|-------------------------------|-------|
+| 1 | `/api/v1/vip/health` | GET | `_require_api_key_strict` | **User-facing** (status check for clients) | `require_vip_tier` | `app/routers/vip.py:587-598` (returns module status) | add |
+| 2 | `/api/v1/vip/menu/weekly/plan` | POST | `_require_api_key_strict` | **User-facing** (main meal planning) | `require_vip_tier` | `app/routers/vip.py:601-673` (RU: "Планирование недельного меню") | add |
+| 3 | `/api/v1/vip/menu/weekly/repair` | POST | `_require_api_key_strict` | **User-facing** (auto-repair menu) | `require_vip_tier` | `app/routers/vip.py:855-876` (RU: "Авто-ремонт недельного меню") | add |
+| 4 | `/api/v1/vip/shoplist/weekly` | POST | `_require_api_key_strict` | **User-facing** (weekly shopping list) | `require_vip_tier` | `app/routers/vip.py:879-925` (RU: "Создание списка покупок на неделю") | add |
+| 5 | `/api/v1/vip/shoplist/daily` | POST | `_require_api_key_strict` | **User-facing** (daily shopping list) | `require_vip_tier` | `app/routers/vip.py:928-974` (RU: "Создание списка покупок на день") | add |
+| 6 | `/api/v1/vip/shoplist/formats` | GET | `_require_api_key_strict` | **User-facing** (export formats for clients) | `require_vip_tier` | `app/routers/vip.py:977-991` (RU: "Получить доступные форматы экспорта") | add |
+| 7 | `/api/v1/vip/regions` | GET | `_require_api_key_strict` | **User-facing** (region list for clients) | `require_vip_tier` | `app/routers/vip.py:994-1030` (RU: "Получить список доступных регионов") | add |
+| 8 | `/api/v1/vip/regions/{region}/search` | GET | `_require_api_key_strict` | **User-facing** (product search) | `require_vip_tier` | `app/routers/vip.py:1033-1103` (RU: "Поиск продуктов в региональном каталоге") | add |
+| 9 | `/api/v1/vip/regions/{region}/categories` | GET | `_require_api_key_strict` | **User-facing** (categories for clients) | `require_vip_tier` | `app/routers/vip.py:1106-1149` (RU: "Получить категории продуктов в регионе") | add |
+| 10 | `/api/v1/vip/regions/{region}/stores` | GET | `_require_api_key_strict` | **User-facing** (store chains for clients) | `require_vip_tier` | `app/routers/vip.py:1152-1195` (RU: "Получить торговые сети в регионе") | add |
+| 11 | `/api/v1/vip/regions/compare/{product_name}` | GET | `_require_api_key_strict` | **User-facing** (price comparison) | `require_vip_tier` | `app/routers/vip.py:1198-1265` (RU: "Сравнить цены продукта в разных регионах") | add |
+| 12 | `/api/v1/vip/recipes/synthesize` | POST | `_require_api_key_strict` | **User-facing** (recipe synthesis) | `require_vip_tier` | `app/routers/vip.py:1268-1292` (RU: "Синтезировать рецепт на основе ингредиентов") | add |
+| 13 | `/api/v1/vip/recipes/weekly` | POST | `_require_api_key_strict` | **User-facing** (weekly recipes) | `require_vip_tier` | `app/routers/vip.py:1295-1388` (RU: "Синтезировать рецепты для недельного плана") | add |
+| 14 | `/api/v1/vip/recipes/templates` | GET | `_require_api_key_strict` | **User-facing** (recipe templates) | `require_vip_tier` | `app/routers/vip.py:1417-1472` (RU: "Получить доступные шаблоны рецептов") | add |
+| 15 | `/api/v1/vip/auto-repair/weekly` | POST | `_require_api_key_strict` | **User-facing** (auto-repair plan) | `require_vip_tier` | `app/routers/vip.py:1475-1552` (RU: "Авто-ремонт недельного плана с UX-петлей") | add |
+| 16 | `/api/v1/vip/auto-repair/suggestions` | POST | `_require_api_key_strict` | **User-facing** (repair suggestions) | `require_vip_tier` | `app/routers/vip.py:1555-1574` (RU: "Получить предложения для ручного ремонта") | add |
+| 17 | `/api/v1/vip/auto-repair/strategies` | GET | `_require_api_key_strict` | **User-facing** (repair strategies) | `require_vip_tier` | `app/routers/vip.py:1577-1603` (RU: "Получить доступные стратегии ремонта") | add |
+| 18 | `/api/v1/vip/weekly-plan` | POST | `_require_api_key_dev_legacy` | **User-facing** (deprecated legacy) | Keep as-is (deprecated, will be removed) | `app/routers/vip.py:728-852` (marked `deprecated=True`) | skip |
+
+**Classification Summary:**
+
+- **User-facing VIP:** 17 endpoints (all except deprecated `/weekly-plan`)
+- **Internal/service:** 0 endpoints (no evidence of backend-only usage)
+
+**Evidence for user-facing classification:**
+
+- All endpoints have RU/EN docstrings describing client-facing features (meal planning, shoplist, recipes, regions, auto-repair)
+- No endpoints marked as "internal", "admin", or "service-only"
+- All endpoints return JSON responses suitable for mobile/web clients
+- No evidence of backend job usage (no cron references, no admin tooling)
+
+---
+
+## 3) Proposed Remediation (Minimal Change)
+
+### Option Chosen: Per-Endpoint Dependency Update
+
+**Rationale:**
+
+1. **Router-level dependencies** would require splitting routers (user-facing vs internal), which is out of scope for PR-B
+2. **Per-endpoint update** is explicit, testable, and preserves existing behavior for VIP users
+3. **Minimal risk:** Only changes guard pattern, no business logic changes
+
+### Decision
+
+**Replace `_require_api_key_strict` with `require_vip_tier` on all 17 user-facing endpoints.**
+
+**Why this minimizes risk:**
+
+- `require_vip_tier()` validates **both** API key (via Header) **and** tier (via `_validate_api_key_tier`)
+- Existing VIP users continue to work (same tier validation, just centralized)
+- PRO/FREE users get 403 (expected behavior, not a regression)
+- No breaking changes to response shape or error envelope
+
+**Implementation pattern:**
+
+```python
+# Before:
+@router.get("/health", dependencies=[Depends(_require_api_key_strict)])
+def vip_health() -> Dict[str, Any]:
+
+# After:
+@router.get("/health")
+def vip_health(
+    _vip: Annotated[str, Depends(require_vip_tier)],
+) -> Dict[str, Any]:
+```
+
+**Import changes:**
+
+```python
+from app.middleware.api_tiers import require_vip_tier
+from typing import Annotated
+```
+
+**Cleanup (after migration):**
+
+- Remove `_require_api_key_strict()` function (lines 403-434)
+- Remove `_require_api_key()` function (if no longer used)
+- Keep `_require_api_key_dev_legacy()` for deprecated `/weekly-plan` endpoint
+
+---
+
+## 4) Contract Expectations
+
+### Access Control
+
+- **Non-VIP (FREE/PRO)** → **403** on all user-facing VIP endpoints
+- **VIP** → **200** (or expected success code)
+- **Internal endpoints (if any)** → remain api-key-only (documented) — **N/A for PR-B** (no internal endpoints found)
+
+### Error Envelope Invariants
+
+- `status="error"`, `code`, `message` (preserved)
+- Legacy aliases preserved where required: `detail == message`, `error == code`
+- **403 response format:**
+  ```json
+  {
+    "detail": "API key does not have VIP tier access. Upgrade to VIP to access this feature."
+  }
+  ```
+
+**Evidence from `require_vip_tier()`:**
+
+- Returns 403 (not 401) for missing/invalid API key
+- Returns 403 (not 401) for insufficient tier
+- Error message: "API key does not have VIP tier access. Upgrade to VIP to access this feature."
+
+---
+
+## 5) Test Plan (Must Be Deterministic)
+
+### Required Tests
+
+1. **Parametrized test over VIP endpoints → asserts 403 for FREE/PRO, 200 for VIP**
+
+   ```python
+   @pytest.mark.parametrize("endpoint,method", [
+       ("/api/v1/vip/health", "GET"),
+       ("/api/v1/vip/menu/weekly/plan", "POST"),
+       # ... all 17 endpoints
+   ])
+   def test_vip_endpoints_require_vip_tier(endpoint, method, client, free_api_key, pro_api_key, vip_api_key):
+       # FREE tier → 403
+       response = client.request(method, endpoint, headers={"X-API-Key": free_api_key})
+       assert response.status_code == 403
+       assert "VIP tier access" in response.json()["detail"]
+
+       # PRO tier → 403
+       response = client.request(method, endpoint, headers={"X-API-Key": pro_api_key})
+       assert response.status_code == 403
+
+       # VIP tier → 200 (or expected success code)
+       response = client.request(method, endpoint, headers={"X-API-Key": vip_api_key})
+       assert response.status_code in [200, 201, 202]  # depends on endpoint
+   ```
+
+2. **If internal endpoints exist: tests prove they are intentionally api-key-only**
+
+   - **N/A for PR-B** (no internal endpoints found)
+
+3. **No network calls, stable fixtures, no time dependence**
+
+   - Use test API keys from `app/middleware/api_tiers.py`:
+     - `TEST_KEY_PRO` → PRO tier
+     - `TEST_KEY_VIP` → VIP tier
+   - Mock `_validate_api_key_tier()` if needed for deterministic tier validation
+
+---
+
+## 6) DoD Checklist
+
+- [ ] All user-facing VIP endpoints enforce VIP tier (17 endpoints migrated)
+- [ ] No accidental lockout of internal endpoints (if any) — **N/A** (no internal endpoints)
+- [ ] CI green: lint/typecheck/tests/diff-cov
+- [ ] `AGENTS.md` updated only if new canonical guard pattern introduced — **N/A** (using existing `require_vip_tier()`)
+- [ ] Unused `_require_api_key_strict` function removed
+- [ ] Tests: 403 for PRO/FREE tier on VIP endpoints
+- [ ] Tests: 200 for VIP tier on VIP endpoints
+- [ ] No breaking changes (same response shape for VIP users)
+
+---
+
+## 7) Technical Details: Guard Pattern Comparison
+
+### `require_vip_tier()` (Correct Pattern)
+
+**Location:** `app/middleware/api_tiers.py:203-239`
+
+**Validation flow:**
+1. Check API key presence (Header `X-API-Key`)
+2. Call `_validate_api_key_tier(x_api_key, SubscriptionTier.VIP)`
+3. Return 403 if missing or tier insufficient
+
+**Dependencies:**
+- Uses FastAPI `Header()` dependency injection
+- Calls `_validate_api_key_tier()` which checks tier via:
+  - Test keys in dev mode (`TEST_KEY_VIP`, `TEST_KEY_PRO`)
+  - Database lookup in production (when `SUBSCRIPTION_DB_ENABLED=true`)
+
+### `_require_api_key_strict()` (Incorrect Pattern for VIP)
+
+**Location:** `app/routers/vip.py:403-434`
+
+**Validation flow:**
+1. Extract API key from request headers
+2. Compare with env var `API_KEY` (via `_get_configured_api_key()`)
+3. Return 403 if missing or mismatch
+
+**Dependencies:**
+- Uses `Request` object directly (not FastAPI dependency injection)
+- No tier validation (only API key matching)
+
+**Why this is wrong:**
+- Any user with valid `API_KEY` env var can access VIP endpoints (even if they have PRO tier)
+- No separation between API key validation and tier validation
+
+---
+
+## 8) Risk Assessment
+
+**Risk:** Low (behavior-preserving for VIP users, stricter for non-VIP)
+
+**Mitigation:**
+
+- All changes are guard-only (no business logic changes)
+- Existing VIP users continue to work (same tier validation, just centralized)
+- PRO/FREE users get 403 (expected behavior, not a regression)
+- Tests ensure deterministic behavior
+
+**Breaking changes:** None (VIP users see no change, non-VIP users get expected 403)
+
+---
+
+## 9) Related Documents
+
+- `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping
+- `docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md` — remediation roadmap
+- `app/middleware/api_tiers.py` — `require_vip_tier()` implementation
+- `docs/audit/PR_B_VIP_GUARD_CONSISTENCY_PLAN.md` — initial plan (superseded by this audit)

--- a/docs/contracts/OPENAPI_PATHS_AUDIT.md
+++ b/docs/contracts/OPENAPI_PATHS_AUDIT.md
@@ -1,0 +1,175 @@
+# OpenAPI Paths Audit — Factual Endpoints (2026-01-11)
+
+**Source:** `frontend/src/api/openapi.json`
+**Generated:** `make openapi`
+**Purpose:** Factual inventory of all `/premium/*`, `/pro/*`, `/vip/*` endpoints currently exposed in OpenAPI schema
+
+---
+
+## Summary
+
+| Namespace | Count | Status |
+|-----------|-------|--------|
+| `/api/v1/premium/*` | 9 | ⚠️ Deprecated (should be hidden from schema) |
+| `/api/v1/pro/*` | 4 | ✅ Canonical PRO namespace |
+| `/api/v1/vip/*` | 25 | ✅ Canonical VIP namespace |
+
+**Total:** 38 endpoints
+
+---
+
+## `/api/v1/premium/*` (Deprecated namespace — 9 endpoints)
+
+### Canonical mapping table: "что есть" → "что должно быть"
+
+| Фактический путь            | Фактический tier | Статус            | Канонический target (куда делегировать)                                                       | Action (PR)                                                   |
+| --------------------------- | ---------------: | ----------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `/api/v1/premium/plate`     |              PRO | deprecated alias  | **нужен** `/api/v1/pro/nutrition/daily` (или существующий эквивалент)                         | PR-D: сделать pro canon + alias delegation                    |
+| `/api/v1/premium/targets`   |              PRO | deprecated alias  | **нужен** `/api/v1/pro/nutrition/targets`                                                     | PR-D: сделать pro canon + alias delegation                    |
+| `/api/v1/premium/bmr`       |              PRO | deprecated alias  | (опционально) `/api/v1/pro/bmr`                                                               | Решить: либо заводим pro/bmr, либо оставляем legacy-only      |
+| `/api/v1/premium/plan/week` |              VIP | 🔴 **broken naming** | `/api/v1/vip/menu/weekly/plan`                                                                | PR-C: alias → vip canon, скрыть из schema                     |
+| `/api/v1/premium/gaps`      |              VIP | deprecated alias  | (скорее) `/api/v1/vip/menu/weekly/plan` (как отдельный режим/флаг) или отдельный vip endpoint | Решить где живёт gaps                                         |
+| `/api/v1/premium/exports/day/{plan_id}.csv` | VIP | deprecated alias  | `/api/v1/vip/shoplist/export` (CSV format)                                                    | Унифицировать экспорт                                         |
+| `/api/v1/premium/exports/day/{plan_id}.pdf` | VIP | deprecated alias  | `/api/v1/vip/shoplist/export` (PDF format)                                                    | Унифицировать экспорт                                         |
+| `/api/v1/premium/exports/week/{plan_id}.csv` | VIP | deprecated alias  | `/api/v1/vip/shoplist/export` (CSV format)                                                     | Унифицировать экспорт                                         |
+| `/api/v1/premium/exports/week/{plan_id}.pdf` | VIP | deprecated alias  | `/api/v1/vip/shoplist/export` (PDF format)                                                     | Унифицировать экспорт                                         |
+
+**Critical issue:** `/api/v1/premium/plan/week` requires VIP tier (via `VIP_MODULE_ENABLED`) but lives under `/premium/*` namespace → **architectural confusion** (fixed in PR-C).
+
+---
+
+## `/api/v1/pro/*` (Canonical PRO namespace — 4 endpoints)
+
+| Endpoint | Tier | Status | Notes |
+|----------|------|--------|-------|
+| `/api/v1/pro/meal/shopping-list` | PRO | ✅ canonical | PRO shopping list |
+| `/api/v1/pro/nutrition/day-close` | PRO | ✅ canonical | Daily nutrition log close |
+| `/api/v1/pro/nutrition/meal-log` | PRO | ✅ canonical | Meal logging |
+| `/api/v1/pro/shoplist/day` | PRO | ✅ canonical | Daily shoplist |
+
+**Note:** `/api/v1/pro/meal/weekly` and `/api/v1/pro/nutrition/targets` are **not in OpenAPI** (may be in code but not exposed, or require feature flags).
+
+---
+
+## `/api/v1/vip/*` (Canonical VIP namespace — 25 endpoints)
+
+### Auto-repair (3 endpoints)
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `/api/v1/vip/auto-repair/strategies` | VIP | ✅ canonical |
+| `/api/v1/vip/auto-repair/suggestions` | VIP | ✅ canonical |
+| `/api/v1/vip/auto-repair/weekly` | VIP | ✅ canonical |
+
+### Menu/Planning (3 endpoints)
+
+| Endpoint | Tier | Status | Notes |
+|----------|------|--------|-------|
+| `/api/v1/vip/menu/weekly/plan` | VIP | ✅ canonical | Main weekly plan endpoint |
+| `/api/v1/vip/menu/weekly/repair` | VIP | ✅ canonical | Weekly plan repair |
+| `/api/v1/vip/weekly-plan` | VIP | ⚠️ deprecated | Legacy alias (should delegate to `/api/v1/vip/menu/weekly/plan`) |
+
+### Recipes (3 endpoints)
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `/api/v1/vip/recipes/synthesize` | VIP | ✅ canonical |
+| `/api/v1/vip/recipes/templates` | VIP | ✅ canonical |
+| `/api/v1/vip/recipes/weekly` | VIP | ✅ canonical |
+
+### Regions (5 endpoints)
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `/api/v1/vip/regions` | VIP | ✅ canonical |
+| `/api/v1/vip/regions/compare/{product_name}` | VIP | ✅ canonical |
+| `/api/v1/vip/regions/{region}/categories` | VIP | ✅ canonical |
+| `/api/v1/vip/regions/{region}/search` | VIP | ✅ canonical |
+| `/api/v1/vip/regions/{region}/stores` | VIP | ✅ canonical |
+
+### Shoplist (6 endpoints)
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `/api/v1/vip/shoplist/daily` | VIP | ✅ canonical |
+| `/api/v1/vip/shoplist/export` | VIP | ✅ canonical |
+| `/api/v1/vip/shoplist/formats` | VIP | ✅ canonical |
+| `/api/v1/vip/shoplist/generate` | VIP | ✅ canonical |
+| `/api/v1/vip/shoplist/preview` | VIP | ✅ canonical |
+| `/api/v1/vip/shoplist/weekly` | VIP | ✅ canonical |
+
+### Health (1 endpoint)
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `/api/v1/vip/health` | VIP | ✅ canonical |
+
+---
+
+## Recommendations (PR execution plan)
+
+### PR-A (docs-only): ✅ Done
+- `PRODUCT_TIER_MAP.md` — canonical tier mapping
+- `OPENAPI_PATHS_AUDIT.md` — this file
+- `AGENTS.md` — tiers and namespaces policy
+
+### PR-B (schema hygiene): Hide deprecated aliases from OpenAPI
+
+**Goal:** Frontend stops generating types for `/premium/*`.
+
+**Changes:**
+- Set `include_in_schema=False` on all `/premium/*` endpoints
+- Verify: `make openapi` → zero `/premium/*` paths in `openapi.json`
+
+**DoD:**
+- `make openapi` → no `/premium/*` in schema
+- Runtime: endpoints still work (backward compatible)
+- `pytest tests/test_openapi_determinism.py` passes
+
+**See:** `docs/audit/PR_B_SCHEMA_HYGIENE_DESCRIPTION.md` for full PR description.
+
+---
+
+### PR-C (VIP alignment): Fix broken naming `/premium/plan/week`
+
+**Goal:** `/api/v1/premium/plan/week` becomes clean alias to VIP canonical.
+
+**Changes:**
+- Delegate `/premium/plan/week` → `/vip/menu/weekly/plan`
+- Remove VIP business logic from premium endpoint (delegation only)
+- Parity test: responses equivalent
+
+**DoD:**
+- Parity test passes
+- No VIP logic in premium endpoint
+- `pytest` + `diff-cover` ≥97%
+
+**See:** `docs/audit/PR_C_VIP_ALIGNMENT_DESCRIPTION.md` for full PR description.
+
+---
+
+### PR-D (PRO canon exposure): Expose canonical PRO endpoints
+
+**Goal:** PRO clients have canonical paths, not legacy `/premium/*`.
+
+**Changes:**
+- Ensure `/api/v1/pro/nutrition/targets` exists and is in schema
+- Ensure `/api/v1/pro/nutrition/daily` exists and is in schema
+- Ensure `/api/v1/pro/meal/weekly` exists and is in schema (if not, add)
+
+**DoD:**
+- PRO canonical endpoints appear in `openapi.json`
+- Frontend can migrate from `/premium/*` to `/pro/*`
+
+---
+
+### Long-term (cleanup)
+
+1. **Remove `/premium/*` endpoints** after frontend/iOS migration to canonical namespaces.
+2. **Remove `/api/v1/vip/weekly-plan`** after migration to `/api/v1/vip/menu/weekly/plan`.
+
+---
+
+**See also:**
+- `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping
+- `docs/audit/API_ALIGNMENT_CHECKLIST.md` — alignment checklist

--- a/docs/contracts/OPENAPI_PATHS_AUDIT.md
+++ b/docs/contracts/OPENAPI_PATHS_AUDIT.md
@@ -12,9 +12,9 @@
 |-----------|-------|--------|
 | `/api/v1/premium/*` | 9 | ⚠️ Deprecated (should be hidden from schema) |
 | `/api/v1/pro/*` | 4 | ✅ Canonical PRO namespace |
-| `/api/v1/vip/*` | 25 | ✅ Canonical VIP namespace |
+| `/api/v1/vip/*` | 21 | ✅ Canonical VIP namespace |
 
-**Total:** 38 endpoints
+**Total:** 34 endpoints
 
 ---
 
@@ -51,7 +51,7 @@
 
 ---
 
-## `/api/v1/vip/*` (Canonical VIP namespace — 25 endpoints)
+## `/api/v1/vip/*` (Canonical VIP namespace — 21 endpoints)
 
 ### Auto-repair (3 endpoints)
 
@@ -108,11 +108,6 @@
 
 ## Recommendations (PR execution plan)
 
-### PR-A (docs-only): ✅ Done
-- `PRODUCT_TIER_MAP.md` — canonical tier mapping
-- `OPENAPI_PATHS_AUDIT.md` — this file
-- `AGENTS.md` — tiers and namespaces policy
-
 ### PR-B (schema hygiene): Hide deprecated aliases from OpenAPI
 
 **Goal:** Frontend stops generating types for `/premium/*`.
@@ -126,7 +121,7 @@
 - Runtime: endpoints still work (backward compatible)
 - `pytest tests/test_openapi_determinism.py` passes
 
-**See:** `docs/audit/PR_B_SCHEMA_HYGIENE_DESCRIPTION.md` for full PR description.
+**Note:** PR-B description will be created in PR-B branch.
 
 ---
 
@@ -144,7 +139,7 @@
 - No VIP logic in premium endpoint
 - `pytest` + `diff-cover` ≥97%
 
-**See:** `docs/audit/PR_C_VIP_ALIGNMENT_DESCRIPTION.md` for full PR description.
+**Note:** PR-C description will be created in PR-C branch.
 
 ---
 

--- a/docs/contracts/OPENAPI_PATHS_AUDIT.md
+++ b/docs/contracts/OPENAPI_PATHS_AUDIT.md
@@ -168,3 +168,5 @@
 **See also:**
 - `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping
 - `docs/audit/API_ALIGNMENT_CHECKLIST.md` — alignment checklist
+- `docs/contracts/OPENAPI_VISIBILITY_MATRIX.md` — visibility rules for public/deprecated endpoints
+- `AGENTS.md` § "Product tiers and API namespaces (canonical)" — canonical tier policy and namespace governance

--- a/docs/contracts/OPENAPI_VISIBILITY_MATRIX.md
+++ b/docs/contracts/OPENAPI_VISIBILITY_MATRIX.md
@@ -14,7 +14,7 @@
 |-----------|------|--------|-----------|
 | `/api/v1/bmi/*` | FREE | ✅ Show | Free surface (product entry point) |
 | `/api/v1/pro/*` | PRO | ✅ Show | Pro surface (canonical PRO tier) |
-| `/api/v1/vip/*` | VIP | ✅ Show | Vip surface (canonical VIP tier) |
+| `/api/v1/vip/*` | VIP | ✅ Show | VIP surface (canonical VIP tier) |
 
 **Rule:** Only canonical namespaces appear in public OpenAPI.
 
@@ -39,7 +39,7 @@
 
 ### How to hide endpoints
 
-**Option 1: Router-level (recommended for deprecated namespaces)**
+#### Option 1: Router-level (recommended for deprecated namespaces)
 
 ```python
 # app/routers/premium_week.py
@@ -50,7 +50,7 @@ router = APIRouter(
 )
 ```
 
-**Option 2: Endpoint-level (for selective hiding)**
+#### Option 2: Endpoint-level (for selective hiding)
 
 ```python
 @router.post(
@@ -113,4 +113,4 @@ If we ever need a separate OpenAPI schema for internal/ops endpoints:
 - `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping
 - `docs/contracts/OPENAPI_PATHS_AUDIT.md` — factual inventory of paths
 - `AGENTS.md` — "Product tiers and API namespaces" section
-- `docs/audit/PR_B_SCHEMA_HYGIENE_DESCRIPTION.md` — PR-B implementation guide
+- PR-B: Schema hygiene (description will be created in PR-B branch)

--- a/docs/contracts/OPENAPI_VISIBILITY_MATRIX.md
+++ b/docs/contracts/OPENAPI_VISIBILITY_MATRIX.md
@@ -1,0 +1,116 @@
+# OpenAPI Visibility Matrix — What to Show/Hide
+
+**Purpose:** Canonical policy for what endpoints appear in public OpenAPI schema
+**Last updated:** 2026-01-11
+**Source of truth:** This document + `AGENTS.md` section "Product tiers and API namespaces"
+
+---
+
+## Public OpenAPI Schema (Default)
+
+### ✅ Show (Canonical Product Surface)
+
+| Namespace | Tier | Status | Rationale |
+|-----------|------|--------|-----------|
+| `/api/v1/bmi/*` | FREE | ✅ Show | Free surface (product entry point) |
+| `/api/v1/pro/*` | PRO | ✅ Show | Pro surface (canonical PRO tier) |
+| `/api/v1/vip/*` | VIP | ✅ Show | Vip surface (canonical VIP tier) |
+
+**Rule:** Only canonical namespaces appear in public OpenAPI.
+
+---
+
+### ❌ Hide (Deprecated / Internal / Ops)
+
+| Category | Examples | Rationale |
+|----------|----------|-----------|
+| **Deprecated aliases** | `/api/v1/premium/*` | Prevent frontend from generating types for wrong paths. Force migration to canonical namespaces. |
+| **Admin/Ops** | `/api/v1/admin/*`, `/admin/*` | Security: internal operations should not be exposed. |
+| **Debug** | `/debug*`, `/debug_env` | Security: debug endpoints leak internal state. |
+| **Test routes** | `/api/v1/test/*` | Not product surface. |
+| **Internal exports/demo** | `/api/v1/*/exports/*` (if not productized) | Not ready for public consumption. |
+| **Maintenance/updaters** | `/api/v1/off/update`, `/api/v1/catalog/update` | Ops endpoints, not product API. |
+
+**Rule:** Set `include_in_schema=False` on these endpoints/routers.
+
+---
+
+## Implementation
+
+### How to hide endpoints
+
+**Option 1: Router-level (recommended for deprecated namespaces)**
+
+```python
+# app/routers/premium_week.py
+router = APIRouter(
+    prefix="/api/v1/premium",
+    tags=["premium"],
+    include_in_schema=False  # Hide entire router from OpenAPI
+)
+```
+
+**Option 2: Endpoint-level (for selective hiding)**
+
+```python
+@router.post(
+    "/api/v1/premium/plan/week",
+    include_in_schema=False,  # Hide this specific endpoint
+    deprecated=True,  # Optional: mark as deprecated if still visible
+)
+async def premium_plan_week(...):
+    ...
+```
+
+---
+
+## Verification
+
+### Check what's in OpenAPI
+
+```bash
+# List all paths in OpenAPI schema
+jq -r '.paths | keys[]' frontend/src/api/openapi.json | sort
+
+# Count deprecated paths (should be 0)
+jq -r '.paths | keys[]' frontend/src/api/openapi.json | grep -c "/premium" || echo "0"
+# Expected: 0
+
+# Count admin paths (should be 0)
+jq -r '.paths | keys[]' frontend/src/api/openapi.json | grep -c "/admin" || echo "0"
+# Expected: 0
+```
+
+### CI Gate
+
+```bash
+# In CI, fail if deprecated paths appear in schema
+make openapi
+if jq -r '.paths | keys[]' frontend/src/api/openapi.json | grep -q "/premium"; then
+    echo "ERROR: /premium/* paths found in OpenAPI schema"
+    exit 1
+fi
+```
+
+---
+
+## Exceptions (Future)
+
+### Internal/ops schema (if needed)
+
+If we ever need a separate OpenAPI schema for internal/ops endpoints:
+
+- **Separate generator:** `scripts/generate_openapi_internal.py`
+- **Separate output:** `frontend/src/api/openapi-internal.json`
+- **Separate CI check:** Only for internal tooling, not public API
+
+**Status:** Not implemented. Current policy: hide internal endpoints from public schema.
+
+---
+
+## Related Documents
+
+- `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping
+- `docs/contracts/OPENAPI_PATHS_AUDIT.md` — factual inventory of paths
+- `AGENTS.md` — "Product tiers and API namespaces" section
+- `docs/audit/PR_B_SCHEMA_HYGIENE_DESCRIPTION.md` — PR-B implementation guide

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -262,7 +262,7 @@
 
 ### Продуктовые уровни (как определено в коде)
 
-```
+```text
 FREE → PRO → VIP
 ```
 
@@ -271,7 +271,7 @@ FREE → PRO → VIP
 
 ### Технические термины (legacy)
 
-```
+```text
 pro_* = техническое имя (файлы, функции, переменные)
 premium_* = deprecated namespace или legacy файлы
 ```
@@ -283,7 +283,7 @@ premium_* = deprecated namespace или legacy файлы
 
 ### API Namespaces (фактические)
 
-```
+```text
 /api/v1/pro/*     → PRO tier (canonical)
 /api/v1/vip/*     → VIP tier (canonical)
 /api/v1/premium/* → deprecated (требует PRO или VIP, зависит от endpoint)

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -134,10 +134,10 @@
 | -------------------- | ---------------------------------- | ----------- | ------------ | ----------------------------------------- |
 | Weekly plan          | `/api/v1/vip/menu/weekly/plan`     | ✅ canonical | VIP          | `app/routers/vip.py` (main endpoint)      |
 | Weekly plan (legacy) | `/api/v1/vip/weekly-plan`         | ⚠️ deprecated | VIP        | `app/routers/vip.py:733` (deprecated)     |
-| Shoplist generate    | `/api/v1/vip/shoplist/generate`   | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:308`          |
-| Shoplist preview     | `/api/v1/vip/shoplist/preview`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:386`          |
-| Shoplist daily       | `/api/v1/vip/shoplist/daily`      | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:425`          |
-| Shoplist weekly      | `/api/v1/vip/shoplist/weekly`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:466`          |
+| Shoplist generate    | `/api/v1/vip/shoplist/generate`   | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:364`          |
+| Shoplist preview     | `/api/v1/vip/shoplist/preview`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:299`          |
+| Shoplist daily       | `/api/v1/vip/shoplist/daily`      | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:402`          |
+| Shoplist weekly      | `/api/v1/vip/shoplist/weekly`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:442`          |
 | Recipe synthesize    | `/api/v1/vip/recipes/synthesize`  | ✅ canonical | VIP          | `app/routers/vip.py`                      |
 | Auto-repair          | `/api/v1/vip/auto-repair/*`        | ✅ canonical | VIP          | `app/routers/vip.py` (via core.auto_repair) |
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -2,7 +2,7 @@
 
 **Status:** Canonical (audit-driven, based on actual codebase)
 **Last updated:** 2026-01-11
-**Source of truth:** `app/middleware/api_tiers.py`, `app/routers/*.py`, `legacy_app.py`
+**Canonical reference (derived from code):** `app/middleware/api_tiers.py`, `app/routers/*.py`, `legacy_app.py`
 
 ---
 
@@ -76,7 +76,7 @@
 | Функция             | Endpoint                      | Статус      | Требует tier | Код-доказательство                    |
 | -------------------- | ----------------------------- | ----------- | ------------ | ------------------------------------- |
 | Weekly plan          | `/api/v1/pro/meal/weekly`     | ✅ canonical | PRO          | `app/routers/pro.py:245`              |
-| Targets (WHO)       | `/api/v1/pro/nutrition/targets` | ✅ canonical | PRO          | `app/routers/pro.py` (planned)        |
+| Targets (WHO)       | `/api/v1/pro/nutrition/targets` | 📋 planned   | PRO          | `app/routers/pro.py` (planned)        |
 | Daily plate          | `/api/v1/pro/nutrition/daily` | ✅ canonical | PRO          | `app/routers/pro.py:369`              |
 | Shopping list (PRO)  | `/api/v1/pro/meal/shopping-list` | ✅ canonical | PRO          | `app/routers/shopping_list_pro.py:19` |
 | Shoplist day        | `/api/v1/pro/shoplist/*`      | ✅ canonical | PRO          | `app/routers/shoplist_day.py:22`      |

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -88,11 +88,12 @@
 
 | Функция        | Endpoint                        | Статус           | Требует tier | Код-доказательство                        |
 | -------------- | ------------------------------- | ---------------- | ------------ | ----------------------------------------- |
-| Weekly plan    | `/api/v1/premium/plan/week`     | ⚠️ deprecated    | PRO          | `app/routers/premium_week.py:178`         |
 | Weekly plan    | `/api/v1/premium/plan/week-flexible` | ⚠️ deprecated | PRO          | `app/routers/premium_week.py:290`         |
 | Targets        | `/api/v1/premium/targets`       | ⚠️ legacy shim   | PRO          | `legacy_app.py:4685`                      |
 | Daily plate    | `/api/v1/premium/plate`         | ⚠️ legacy shim   | PRO          | `legacy_app.py:3980`                      |
 | BMR            | `/premium_bmr`                  | ⚠️ legacy        | PRO          | `legacy_app.py:4148`                      |
+
+> ⚠️ **Примечание:** Endpoints под `/premium/*`, которые **фактически требуют VIP tier**, не относятся к PRO и перечислены в разделе VIP (см. секцию "Deprecated aliases with wrong namespace").
 
 > ⚠️ **Ключевое понимание:**
 > `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`),
@@ -141,16 +142,16 @@
 | Recipe synthesize    | `/api/v1/vip/recipes/synthesize`  | ✅ canonical | VIP          | `app/routers/vip.py`                      |
 | Auto-repair          | `/api/v1/vip/auto-repair/*`        | ✅ canonical | VIP          | `app/routers/vip.py` (via core.auto_repair) |
 
-### Deprecated (но требует VIP tier)
+### Deprecated aliases with wrong namespace (требуют VIP tier)
 
-| Функция       | Endpoint                     | Статус        | Требует tier | Код-доказательство                |
-| ------------- | ---------------------------- | ------------- | ------------ | ---------------------------------- |
-| Weekly plan   | `/api/v1/premium/plan/week`  | ⚠️ legacy     | VIP (через VIP_MODULE_ENABLED) | `legacy_app.py:4706`               |
-| Exports       | `/api/v1/premium/exports/*`  | ⚠️ legacy     | VIP          | `legacy_app.py:5194, 5440, 5525`  |
+| Функция       | Endpoint                     | Статус        | Требует tier | Проблема | Канонический endpoint | Код-доказательство                |
+| ------------- | ---------------------------- | ------------- | ------------ | -------- | --------------------- | ---------------------------------- |
+| Weekly plan   | `/api/v1/premium/plan/week`  | 🔴 **broken naming** | VIP (через VIP_MODULE_ENABLED) | Wrong namespace (`/premium/*` вместо `/vip/*`) | `/api/v1/vip/menu/weekly/plan` | `legacy_app.py:4706`               |
+| Exports       | `/api/v1/premium/exports/*`  | ⚠️ legacy     | VIP          | Wrong namespace | `/api/v1/vip/shoplist/export` | `legacy_app.py:5194, 5440, 5525`  |
 
 > ⚠️ **Ключевая проблема:**
-> Некоторые VIP-функции живут под `/premium/*` namespace → **это источник путаницы**,
-> но пока **не ломаем**, а **фиксируем как debt**.
+> Эти endpoints требуют **VIP tier**, но живут под `/premium/*` namespace (deprecated PRO namespace) → **архитектурная путаница**.
+> Это фиксируется как known issue и будет исправлено в PR-C (delegation pattern).
 
 ### Правила
 
@@ -192,7 +193,7 @@
 | **PRO**         | продуктовый уровень (платный, средний)      | `SubscriptionTier.PRO` (`api_tiers.py:48`)             |
 | **VIP**         | продуктовый уровень (платный, высший)       | `SubscriptionTier.VIP` (`api_tiers.py:49`)            |
 | `pro_*`         | ❗ техническое legacy-название в коде       | `pro_registration.py`, `pro_router`, `shopping_list_pro.py` |
-| `/premium/*`    | ⚠️ deprecated API namespace (требует PRO)  | `premium_week.py:31`, `legacy_app.py:3980, 4685`     |
+| `/premium/*`    | ⚠️ deprecated API namespace (требует PRO или VIP, зависит от endpoint)  | `premium_week.py:31`, `legacy_app.py:3980, 4685, 4706`     |
 | `/api/v1/pro/*` | ✅ canonical PRO namespace                   | `app/routers/pro.py:37`                               |
 | `/api/v1/vip/*` | ✅ canonical VIP namespace                   | `app/routers/vip.py`, `app/routers/vip_shoplist.py`  |
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -16,7 +16,7 @@
 
 > ⚠️ **Важно:**
 > `pro_*` в именах файлов/функций — **техническое legacy-название**,
-> но, **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
+> но **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
 >
 > `/premium/*` — **deprecated API namespace**, который требует PRO tier, но не является отдельным уровнем.
 
@@ -97,7 +97,7 @@
 
 > ⚠️ **Ключевое понимание:**
 > `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`),
-> но, namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
+> но namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
 
 ### Что НЕ входит
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -16,7 +16,7 @@
 
 > ⚠️ **Важно:**
 > `pro_*` в именах файлов/функций — **техническое legacy-название**,
-> но **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
+> но, **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
 >
 > `/premium/*` — **deprecated API namespace**, который требует PRO tier, но не является отдельным уровнем.
 
@@ -97,7 +97,7 @@
 
 > ⚠️ **Ключевое понимание:**
 > `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`),
-> но namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
+> но, namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
 
 ### Что НЕ входит
 
@@ -178,7 +178,7 @@
 
 ### Жёсткое правило
 
-> **Shim = delegation only**
+> #### Shim = delegation only
 > ❌ никакой бизнес-логики
 > ❌ никаких расчётов
 > ✅ только вызов канона + адаптация ответа
@@ -266,7 +266,7 @@
 FREE → PRO → VIP
 ```
 
-**Где определено:**
+#### Где определено
 - `app/middleware/api_tiers.py:40-49` — `SubscriptionTier` enum
 
 ### Технические термины (legacy)
@@ -276,7 +276,7 @@ pro_* = техническое имя (файлы, функции, переме�
 premium_* = deprecated namespace или legacy файлы
 ```
 
-**Где используется:**
+#### Где используется
 - `pro_registration.py` — регистрация PRO routes
 - `premium_week.py` — deprecated router (требует PRO tier)
 - `shopping_list_pro.py` — PRO shopping list (требует PRO tier)

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -54,7 +54,7 @@
 
 ## 2️⃣ PRO — Nutrition / Targets / Daily Plate
 
-_средний платный сегмент_
+### Средний платный сегмент
 
 ### Бизнес-смысл
 
@@ -93,7 +93,7 @@ _средний платный сегмент_
 | BMR            | `/premium_bmr`                  | ⚠️ legacy        | PRO          | `legacy_app.py:4148`                      |
 
 > ⚠️ **Примечание:** Endpoints под `/premium/*`, которые **фактически требуют VIP tier**, не относятся к PRO и перечислены в разделе VIP (см. секцию "Deprecated aliases with wrong namespace").
-
+>
 > ⚠️ **Ключевое понимание:**
 > `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`);
 > namespace `/premium/*` при этом **deprecated**, мигрирует на `/api/v1/pro/*`.
@@ -114,7 +114,7 @@ _средний платный сегмент_
 
 ## 3️⃣ VIP — Weekly / Micro / Shoplist
 
-_высший платный сегмент_
+### Высший платный сегмент
 
 ### Бизнес-смысл
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -1,0 +1,331 @@
+# 📊 PulsePlate — Canonical Product Tier Map (v1)
+
+**Status:** Canonical (audit-driven, based on actual codebase)
+**Last updated:** 2026-01-11
+**Source of truth:** `app/middleware/api_tiers.py`, `app/routers/*.py`, `legacy_app.py`
+
+---
+
+## Уровни продукта (зафиксировано на основе кода)
+
+| Уровень     | Статус | Роль                            | Код-доказательство                                    |
+| ----------- | ------ | ------------------------------- | ----------------------------------------------------- |
+| **FREE**    | канон  | вход в продукт, скрининг        | `SubscriptionTier.FREE` (`app/middleware/api_tiers.py:47`) |
+| **PRO**     | канон  | платное питание и цели          | `SubscriptionTier.PRO` (`app/middleware/api_tiers.py:48`), `require_pro_tier()` |
+| **VIP**     | канон  | продвинутые планы, микро-логика | `SubscriptionTier.VIP` (`app/middleware/api_tiers.py:49`), `require_vip_tier()` |
+
+> ⚠️ **Важно:**
+> `pro_*` в именах файлов/функций — **техническое legacy-название**,
+> но **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
+>
+> `/premium/*` — **deprecated API namespace**, который требует PRO tier, но не является отдельным уровнем.
+
+---
+
+## 1️⃣ FREE — BMI / Screening
+
+### Бизнес-смысл
+
+* Бесплатный вход
+* Диагностика / скрининг
+* Основа всей системы
+
+### Канонический домен
+
+`core/bmi/*`
+
+### API (канон)
+
+| Тип            | Endpoint                | Статус      | Код-доказательство                          |
+| -------------- | ----------------------- | ----------- | ------------------------------------------- |
+| BMI calculate  | `/api/v1/bmi/calculate` | ✅ canonical | `app/routers/bmi_pro.py` (но FREE, не PRO)  |
+| BMI legacy     | `/bmi`, `/api/v1/bmi`   | ⚠️ shim     | `legacy_app.py:2097, 2316`                  |
+| Insight (free) | `/api/v1/insight`       | ⚠️ flag     | `legacy_app.py:2443` (FEATURE_INSIGHT)      |
+| Foods          | `/api/v1/foods/*`       | ✅ canonical | `app/routers/foods.py`                      |
+| Recipes        | `/api/v1/recipes/*`     | ✅ canonical | `app/routers/recipes.py`                     |
+| Users          | `/api/v1/users/*`       | ✅ canonical | `app/routers/users.py`                      |
+
+### Правила
+
+* ❌ никакой логики вне `core/bmi`
+* ❌ никаких premium/vip зависимостей
+* ✅ legacy endpoints = thin proxy
+
+---
+
+## 2️⃣ PRO — Nutrition / Targets / Daily Plate
+
+*(средний платный сегмент)*
+
+### Бизнес-смысл
+
+* Питание
+* Калории / нутриенты
+* Day-level планы
+* Без микро-ремонта и shoplist
+
+### Канонический домен
+
+**PRO Nutrition** (`app/routers/pro.py`)
+
+> ✅ **Фактическое состояние:**
+> PRO — это **реальный уровень подписки**, определённый в `SubscriptionTier.PRO`.
+> Все endpoints требуют `require_pro_tier()` middleware.
+
+### API (канон)
+
+| Функция             | Endpoint                      | Статус      | Требует tier | Код-доказательство                    |
+| -------------------- | ----------------------------- | ----------- | ------------ | ------------------------------------- |
+| Weekly plan          | `/api/v1/pro/meal/weekly`     | ✅ canonical | PRO          | `app/routers/pro.py:245`              |
+| Targets (WHO)       | `/api/v1/pro/nutrition/targets` | ✅ canonical | PRO          | `app/routers/pro.py` (planned)        |
+| Daily plate          | `/api/v1/pro/nutrition/daily` | ✅ canonical | PRO          | `app/routers/pro.py:369`              |
+| Shopping list (PRO)  | `/api/v1/pro/meal/shopping-list` | ✅ canonical | PRO          | `app/routers/shopping_list_pro.py:19` |
+| Shoplist day        | `/api/v1/pro/shoplist/*`      | ✅ canonical | PRO          | `app/routers/shoplist_day.py:22`      |
+| Nutrition log       | `/api/v1/pro/nutrition/log/*` | ✅ canonical | PRO          | `app/routers/nutrition_log.py:27`     |
+| Bayes adherence     | `/api/v1/pro/bayes/*`         | ✅ canonical | PRO          | `app/routers/bayes_adherence.py:23`   |
+
+### Deprecated (но требует PRO tier)
+
+| Функция        | Endpoint                        | Статус           | Требует tier | Код-доказательство                        |
+| -------------- | ------------------------------- | ---------------- | ------------ | ----------------------------------------- |
+| Weekly plan    | `/api/v1/premium/plan/week`     | ⚠️ deprecated    | PRO          | `app/routers/premium_week.py:178`         |
+| Weekly plan    | `/api/v1/premium/plan/week-flexible` | ⚠️ deprecated | PRO          | `app/routers/premium_week.py:290`         |
+| Targets        | `/api/v1/premium/targets`       | ⚠️ legacy shim   | PRO          | `legacy_app.py:4685`                      |
+| Daily plate    | `/api/v1/premium/plate`         | ⚠️ legacy shim   | PRO          | `legacy_app.py:3980`                      |
+| BMR            | `/premium_bmr`                  | ⚠️ legacy        | PRO          | `legacy_app.py:4148`                      |
+
+> ⚠️ **Ключевое понимание:**
+> `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`),
+> но namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
+
+### Что НЕ входит
+
+* ❌ weekly plan с авто-ремонтом (это VIP)
+* ❌ shoplist с региональной логикой (это VIP)
+* ❌ микро-constraints (это VIP)
+
+### Правила
+
+* PRO endpoints используют `require_pro_tier()` middleware
+* `pro_registration.py` = **технический модуль регистрации**, не бизнес-уровень
+* `premium_week.py` = **deprecated**, мигрирует на `pro.py`
+
+---
+
+## 3️⃣ VIP — Weekly / Micro / Shoplist
+
+*(высший платный сегмент)*
+
+### Бизнес-смысл
+
+* Weekly plan с микро-constraints
+* Auto-repair
+* Shoplist / region
+* Recipe synthesis
+* Exports
+
+### Канонический домен
+
+**VIP Planning Engine** (`app/routers/vip.py`, `app/routers/vip_shoplist.py`)
+
+### API (канон)
+
+| Функция              | Endpoint                           | Статус      | Требует tier | Код-доказательство                        |
+| -------------------- | ---------------------------------- | ----------- | ------------ | ----------------------------------------- |
+| Weekly plan          | `/api/v1/vip/menu/weekly/plan`     | ✅ canonical | VIP          | `app/routers/vip.py` (main endpoint)      |
+| Weekly plan (legacy) | `/api/v1/vip/weekly-plan`         | ⚠️ deprecated | VIP        | `app/routers/vip.py:733` (deprecated)     |
+| Shoplist generate    | `/api/v1/vip/shoplist/generate`   | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:308`          |
+| Shoplist preview     | `/api/v1/vip/shoplist/preview`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:386`          |
+| Shoplist daily       | `/api/v1/vip/shoplist/daily`      | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:425`          |
+| Shoplist weekly      | `/api/v1/vip/shoplist/weekly`     | ✅ canonical | VIP          | `app/routers/vip_shoplist.py:466`          |
+| Recipe synthesize    | `/api/v1/vip/recipes/synthesize`  | ✅ canonical | VIP          | `app/routers/vip.py`                      |
+| Auto-repair          | `/api/v1/vip/auto-repair/*`        | ✅ canonical | VIP          | `app/routers/vip.py` (via core.auto_repair) |
+
+### Deprecated (но требует VIP tier)
+
+| Функция       | Endpoint                     | Статус        | Требует tier | Код-доказательство                |
+| ------------- | ---------------------------- | ------------- | ------------ | ---------------------------------- |
+| Weekly plan   | `/api/v1/premium/plan/week`  | ⚠️ legacy     | VIP (через VIP_MODULE_ENABLED) | `legacy_app.py:4706`               |
+| Exports       | `/api/v1/premium/exports/*`  | ⚠️ legacy     | VIP          | `legacy_app.py:5194, 5440, 5525`  |
+
+> ⚠️ **Ключевая проблема:**
+> Некоторые VIP-функции живут под `/premium/*` namespace → **это источник путаницы**,
+> но пока **не ломаем**, а **фиксируем как debt**.
+
+### Правила
+
+* VIP ≠ PRO
+* VIP может зависеть от PRO данных
+* ❌ PRO не может реализовывать VIP-логику
+* VIP endpoints используют `require_vip_tier()` middleware
+
+---
+
+## 4️⃣ Legacy / Shim слой (явно признаём)
+
+### Что сюда относится
+
+* `legacy_app.py` endpoints
+* `/premium_*` (без `/api/v1/`)
+* `/plan`, `/api/nutrition/{date}`
+* `/bmi`, `/premium_bmr`
+
+### Назначение
+
+* Совместимость
+* Переходный слой
+
+### Жёсткое правило
+
+> **Shim = delegation only**
+> ❌ никакой бизнес-логики
+> ❌ никаких расчётов
+> ✅ только вызов канона + адаптация ответа
+
+---
+
+## 5️⃣ Терминология — фиксируем раз и навсегда
+
+| Термин          | Значение                                    | Код-доказательство                                    |
+| --------------- | ------------------------------------------- | ----------------------------------------------------- |
+| **FREE**        | продуктовый уровень                         | `SubscriptionTier.FREE` (`api_tiers.py:47`)           |
+| **PRO**         | продуктовый уровень (платный, средний)      | `SubscriptionTier.PRO` (`api_tiers.py:48`)             |
+| **VIP**         | продуктовый уровень (платный, высший)       | `SubscriptionTier.VIP` (`api_tiers.py:49`)            |
+| `pro_*`         | ❗ техническое legacy-название в коде       | `pro_registration.py`, `pro_router`, `shopping_list_pro.py` |
+| `/premium/*`    | ⚠️ deprecated API namespace (требует PRO)  | `premium_week.py:31`, `legacy_app.py:3980, 4685`     |
+| `/api/v1/pro/*` | ✅ canonical PRO namespace                   | `app/routers/pro.py:37`                               |
+| `/api/v1/vip/*` | ✅ canonical VIP namespace                   | `app/routers/vip.py`, `app/routers/vip_shoplist.py`  |
+
+> ❗ **Запрещено** использовать "Premium" как название отдельного тарифа в документации.
+> "Premium" = deprecated namespace, который требует PRO tier.
+
+---
+
+## 6️⃣ Аудит по наименованиям (фактические находки)
+
+### ✅ Правильные паттерны
+
+1. **`app/middleware/api_tiers.py`**:
+   - ✅ `SubscriptionTier.FREE`, `SubscriptionTier.PRO`, `SubscriptionTier.VIP` — канонические уровни
+   - ✅ `require_pro_tier()`, `require_vip_tier()` — чёткие middleware
+
+2. **`app/routers/pro.py`**:
+   - ✅ Комментарии: "PRO Tier Router", "PRO subscription tier"
+   - ✅ Endpoints: `/api/v1/pro/*`
+   - ✅ Требует: `require_pro_tier()`
+
+3. **`app/routers/vip.py`**:
+   - ✅ Комментарии: "VIP Module Router"
+   - ✅ Endpoints: `/api/v1/vip/*`
+   - ✅ Требует: `require_vip_tier()` (через `api_key_header`)
+
+### ⚠️ Источники путаницы
+
+1. **`app/routers/premium_week.py`**:
+   - ⚠️ Название файла: `premium_week.py`
+   - ⚠️ Namespace: `/api/v1/premium/*`
+   - ✅ Но требует: `require_pro_tier()` (PRO tier)
+   - ✅ Комментарий: "DEPRECATED: Use app.routers.pro instead"
+
+2. **`app/routers/pro_registration.py`**:
+   - ⚠️ Название: `pro_registration.py`
+   - ✅ Регистрирует: PRO router + premium_week router
+   - ✅ Комментарий: "PRO and premium_week router registration"
+
+3. **`legacy_app.py`**:
+   - ⚠️ Много endpoints под `/api/v1/premium/*`
+   - ⚠️ Некоторые требуют VIP_MODULE_ENABLED (VIP tier)
+   - ⚠️ Некоторые требуют PRO tier
+   - ⚠️ Нет единообразия
+
+### 🔴 Критические несоответствия
+
+1. **`/api/v1/premium/plan/week`** (`legacy_app.py:4706`):
+   - Требует: `VIP_MODULE_ENABLED` (VIP tier)
+   - Но namespace: `/premium/*` (deprecated PRO namespace)
+   - **Путаница:** premium namespace, но VIP tier
+
+2. **`/api/v1/premium/exports/*`** (`legacy_app.py:5194, 5440, 5525`):
+   - Требует: `EXPORTS_ENABLED` flag
+   - Но namespace: `/premium/*`
+   - **Путаница:** неясно, какой tier требуется
+
+3. **`premium_week.py`**:
+   - Файл называется `premium_week.py`
+   - Но требует PRO tier (не "premium tier")
+   - **Путаница:** название файла не соответствует tier
+
+---
+
+## 7️⃣ Каноническая модель (на основе кода)
+
+### Продуктовые уровни (как определено в коде)
+
+```
+FREE → PRO → VIP
+```
+
+**Где определено:**
+- `app/middleware/api_tiers.py:40-49` — `SubscriptionTier` enum
+
+### Технические термины (legacy)
+
+```
+pro_* = техническое имя (файлы, функции, переменные)
+premium_* = deprecated namespace или legacy файлы
+```
+
+**Где используется:**
+- `pro_registration.py` — регистрация PRO routes
+- `premium_week.py` — deprecated router (требует PRO tier)
+- `shopping_list_pro.py` — PRO shopping list (требует PRO tier)
+
+### API Namespaces (фактические)
+
+```
+/api/v1/pro/*     → PRO tier (canonical)
+/api/v1/vip/*     → VIP tier (canonical)
+/api/v1/premium/* → deprecated (требует PRO или VIP, зависит от endpoint)
+```
+
+---
+
+## 8️⃣ Рекомендации по исправлению (без breaking changes)
+
+### Приоритет 1: Документация
+
+* [ ] Зафиксировать в `AGENTS.md`: PRO и VIP — реальные уровни, premium — deprecated namespace
+* [ ] Обновить `API_CANONICAL_MAP.md` с этой таблицей
+* [ ] Добавить deprecation warnings в OpenAPI schema для `/premium/*`
+
+### Приоритет 2: Код (постепенно)
+
+* [ ] Переименовать `premium_week.py` → `pro_week_legacy.py` (или удалить после миграции)
+* [ ] Унифицировать tier requirements для `/premium/*` endpoints:
+  * Либо все требуют PRO tier
+  * Либо мигрируют на `/api/v1/vip/*` если требуют VIP
+* [ ] Добавить `require_pro_tier()` ко всем `/premium/*` endpoints, которые его не имеют
+
+### Приоритет 3: OpenAPI Schema
+
+* [ ] Явно пометить `/premium/*` как deprecated в schema
+* [ ] Добавить `x-deprecated: true` и `x-migration-path: /api/v1/pro/*`
+
+---
+
+## 9️⃣ Что это даёт сразу
+
+* 🔒 Убираем путаницу в голове и в PR-ах
+* 🔧 PR-511A/511B получают **чёткие границы**
+* 📱 Frontend и iOS знают, **что есть что**
+* 🧠 Новый разработчик не изобретёт "четвёртый уровень"
+* 📊 Единый source of truth для контрактов
+
+---
+
+## 🔟 Связь с другими документами
+
+* `docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md` — детальный анализ legacy_app.py
+* `docs/audit/API_ALIGNMENT_CHECKLIST.md` — checklist для alignment
+* `docs/contracts/API_CANONICAL_MAP.md` — текущий mapping (требует обновления)
+* `app/middleware/api_tiers.py` — source of truth для уровней подписки

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -15,9 +15,8 @@
 | **VIP**     | канон  | продвинутые планы, микро-логика | `SubscriptionTier.VIP` (`app/middleware/api_tiers.py:49`), `require_vip_tier()` |
 
 > ⚠️ **Важно:**
-> `pro_*` в именах файлов/функций — **техническое legacy-название**,
-> но **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
->
+> `pro_*` в именах файлов/функций — **техническое legacy-название**.
+> При этом **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
 > `/premium/*` — **deprecated API namespace**, который требует PRO tier, но не является отдельным уровнем.
 
 ---
@@ -55,7 +54,7 @@
 
 ## 2️⃣ PRO — Nutrition / Targets / Daily Plate
 
-*(средний платный сегмент)*
+_средний платный сегмент_
 
 ### Бизнес-смысл
 
@@ -96,8 +95,8 @@
 > ⚠️ **Примечание:** Endpoints под `/premium/*`, которые **фактически требуют VIP tier**, не относятся к PRO и перечислены в разделе VIP (см. секцию "Deprecated aliases with wrong namespace").
 
 > ⚠️ **Ключевое понимание:**
-> `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`),
-> но namespace `/premium/*` — **deprecated**, мигрирует на `/api/v1/pro/*`.
+> `/premium/*` endpoints **требуют PRO tier** (через `require_pro_tier()`);
+> namespace `/premium/*` при этом **deprecated**, мигрирует на `/api/v1/pro/*`.
 
 ### Что НЕ входит
 
@@ -115,7 +114,7 @@
 
 ## 3️⃣ VIP — Weekly / Micro / Shoplist
 
-*(высший платный сегмент)*
+_высший платный сегмент_
 
 ### Бизнес-смысл
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -16,8 +16,8 @@
 
 > ⚠️ **Важно:**
 > `pro_*` в именах файлов/функций — **техническое legacy-название**.
-> При этом **PRO — это реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
-> `/premium/*` — **deprecated API namespace**, который требует PRO tier, но не является отдельным уровнем.
+> **PRO — реальный продуктовый уровень** (определён в `SubscriptionTier` enum).
+> `/premium/*` — **deprecated API namespace**; он требует PRO tier (а для части legacy aliases — VIP), но не является отдельным уровнем.
 
 ---
 
@@ -150,7 +150,7 @@
 
 > ⚠️ **Ключевая проблема:**
 > Эти endpoints требуют **VIP tier**, но живут под `/premium/*` namespace (deprecated PRO namespace) → **архитектурная путаница**.
-> Это фиксируется как known issue и будет исправлено в PR-C (delegation pattern).
+> **Remediation:** See `docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md` (PR-C: delegation pattern).
 
 ### Правила
 
@@ -290,36 +290,12 @@ premium_* = deprecated namespace или legacy файлы
 
 ---
 
-## 8️⃣ Рекомендации по исправлению (без breaking changes)
+## Remediation Roadmap
 
-### Приоритет 1: Документация
+This document is a **contract/specification** (what IS), not a remediation plan.
 
-* [ ] Зафиксировать в `AGENTS.md`: PRO и VIP — реальные уровни, premium — deprecated namespace
-* [ ] Обновить `API_CANONICAL_MAP.md` с этой таблицей
-* [ ] Добавить deprecation warnings в OpenAPI schema для `/premium/*`
-
-### Приоритет 2: Код (постепенно)
-
-* [ ] Переименовать `premium_week.py` → `pro_week_legacy.py` (или удалить после миграции)
-* [ ] Унифицировать tier requirements для `/premium/*` endpoints:
-  * Либо все требуют PRO tier
-  * Либо мигрируют на `/api/v1/vip/*` если требуют VIP
-* [ ] Добавить `require_pro_tier()` ко всем `/premium/*` endpoints, которые его не имеют
-
-### Приоритет 3: OpenAPI Schema
-
-* [ ] Явно пометить `/premium/*` как deprecated в schema
-* [ ] Добавить `x-deprecated: true` и `x-migration-path: /api/v1/pro/*`
-
----
-
-## 9️⃣ Что это даёт сразу
-
-* 🔒 Убираем путаницу в голове и в PR-ах
-* 🔧 PR-511A/511B получают **чёткие границы**
-* 📱 Frontend и iOS знают, **что есть что**
-* 🧠 Новый разработчик не изобретёт "четвёртый уровень"
-* 📊 Единый source of truth для контрактов
+For action items, PR sequencing, and remediation steps, see:
+- `docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md`
 
 ---
 

--- a/docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md
+++ b/docs/contracts/PRODUCT_TIER_REMEDIATION_PLAN.md
@@ -1,0 +1,89 @@
+# Product Tier Remediation Plan
+
+**Status:** Action plan (derived from `PRODUCT_TIER_MAP.md` audit)
+**Last updated:** 2026-01-11
+**Purpose:** Sequence remediation PRs to fix tier/namespace confusion
+
+---
+
+## Overview
+
+This document outlines the remediation plan to fix architectural confusion between product tiers (FREE/PRO/VIP) and deprecated `/premium/*` namespace.
+
+**Source:** Findings from `docs/contracts/PRODUCT_TIER_MAP.md` audit.
+
+---
+
+## Priority 1: Documentation (✅ Done in PR-A)
+
+* [x] Зафиксировать в `AGENTS.md`: PRO и VIP — реальные уровни, premium — deprecated namespace
+* [ ] Обновить `API_CANONICAL_MAP.md` с этой таблицей
+* [ ] Добавить deprecation warnings в OpenAPI schema для `/premium/*`
+
+---
+
+## Priority 2: Code (Gradual, PR-B/PR-C/PR-D)
+
+### PR-B: Schema Hygiene
+
+* [ ] Set `include_in_schema=False` on all `/premium/*` endpoints
+* [ ] Verify: `make openapi` → zero `/premium/*` paths in schema
+* [ ] Runtime: endpoints still work (backward compatible)
+
+### PR-C: VIP Alignment
+
+* [ ] Fix `/api/v1/premium/plan/week` → delegate to `/api/v1/vip/menu/weekly/plan`
+* [ ] Remove VIP business logic from premium endpoint (delegation only)
+* [ ] Parity test: responses equivalent
+
+### PR-D: PRO Canon Exposure
+
+* [ ] Ensure `/api/v1/pro/nutrition/targets` exists and is in schema
+* [ ] Ensure `/api/v1/pro/nutrition/daily` exists and is in schema
+* [ ] Ensure `/api/v1/pro/meal/weekly` exists and is in schema
+
+### Future: Code Cleanup
+
+* [ ] Переименовать `premium_week.py` → `pro_week_legacy.py` (или удалить после миграции)
+* [ ] Унифицировать tier requirements для `/premium/*` endpoints:
+  * Либо все требуют PRO tier
+  * Либо мигрируют на `/api/v1/vip/*` если требуют VIP
+* [ ] Добавить `require_pro_tier()` ко всем `/premium/*` endpoints, которые его не имеют
+
+---
+
+## Priority 3: OpenAPI Schema
+
+* [ ] Явно пометить `/premium/*` как deprecated в schema
+* [ ] Добавить `x-deprecated: true` и `x-migration-path: /api/v1/pro/*` (или `/api/v1/vip/*`)
+
+---
+
+## Benefits (Why This Matters)
+
+* 🔒 Убираем путаницу в голове и в PR-ах
+* 🔧 PR-511A/511B получают **чёткие границы**
+* 📱 Frontend и iOS знают, **что есть что**
+* 🧠 Новый разработчик не изобретёт "четвёртый уровень"
+* 📊 Единый source of truth для контрактов
+
+---
+
+## Known Issues (Fixed in Remediation PRs)
+
+### `/api/v1/premium/plan/week` — Broken Naming
+
+**Issue:** Requires VIP tier but lives under `/premium/*` namespace (deprecated PRO namespace).
+
+**Fix:** PR-C (delegation to `/api/v1/vip/menu/weekly/plan`).
+
+**Source:** `docs/contracts/PRODUCT_TIER_MAP.md` section "Deprecated aliases with wrong namespace"
+
+---
+
+## Related Documents
+
+* `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping (contract/specification)
+* `docs/contracts/OPENAPI_PATHS_AUDIT.md` — factual inventory of paths
+* `docs/contracts/OPENAPI_VISIBILITY_MATRIX.md` — visibility rules
+* `docs/audit/API_ALIGNMENT_CHECKLIST.md` — alignment checklist


### PR DESCRIPTION
# PR-A: docs(contracts) — Define OpenAPI Visibility Rules and Audit Current Paths

**Type:** Docs-only (governance)
**Risk:** None (no runtime changes)
**Priority:** High (foundation for PR-B/PR-C)

---

## Purpose

Зафиксировать **канонические правила**, *что имеет право быть в OpenAPI*, а что нет, **до любых runtime-изменений**.

PR **не меняет поведение приложения**, не трогает код и не влияет на клиентов.

Это governance-PR: он снимает двусмысленность и служит базой для PR-B / PR-C.

---

## Scope

**Только документация:**

* `docs/contracts/OPENAPI_VISIBILITY_MATRIX.md` — правила видимости эндпоинтов в OpenAPI
* `docs/contracts/OPENAPI_PATHS_AUDIT.md` — фактический инвентарь путей из текущего OpenAPI
* `docs/contracts/PRODUCT_TIER_MAP.md` — canonical tier mapping (FREE/PRO/VIP)
* `AGENTS.md` — добавлена секция "Product tiers and API namespaces"
* `docs/audit/API_ALIGNMENT_CHECKLIST.md` — обновлён под FREE/PRO/VIP модель

❌ **НЕТ:**
* runtime кода
* правок роутеров
* feature flags
* CI / infra

---

## Key Decisions (зафиксировано)

1. **Product tiers:** FREE / PRO / VIP — единственные уровни продукта
2. **`/premium/*` — deprecated namespace**, не tier
3. **OpenAPI = публичная витрина**, не отражение legacy/alias слоёв
4. Deprecated aliases, admin/debug/test/export **не должны быть видны в OpenAPI по умолчанию**
5. Canonical namespaces:
   * FREE → `/api/v1/bmi/*`
   * PRO → `/api/v1/pro/*`
   * VIP → `/api/v1/vip/*`

---

## Non-goals

* ❌ не скрывает `/premium/*` из OpenAPI (это PR-B)
* ❌ не исправляет `/premium/plan/week` (это PR-C)
* ❌ не переименовывает роуты
* ❌ не трогает frontend/iOS

---

## Verification (docs-only check)

```bash
git diff --name-only origin/main...HEAD \
  | rg -v "\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$"
```

**Ожидание:** пустой вывод → подтверждение, что PR строго docs-only.

---

## Why Now

Без этого PR:
* невозможно объективно сказать, **что считается регрессией**
* PR-B и PR-C будут спорить "по ощущениям", а не по правилам
* frontend/iOS продолжат генерить типы из мусорной схемы

---

## Follow-ups

* **PR-B:** schema hygiene — скрыть `/premium/*` из OpenAPI
* **PR-C:** VIP alignment — `/premium/plan/week` = alias → `/vip/menu/weekly/plan`

## Summary by Sourcery

Задокументировать канонические продуктовые тарифы и их отображение на пространства имён API, а также установить правила видимости OpenAPI и управления согласованностью без изменения поведения во время выполнения.

Документация:
- Добавить каноническое сопоставление продуктовых тарифов FREE/PRO/VIP с привязкой к пространствам имён API и устаревшим shim-слоям.
- Определить матрицу видимости OpenAPI, указывающую, какие канонические, устаревшие и внутренние эндпоинты должны отображаться или скрываться в публичной схеме.
- Зафиксировать фактический аудит текущих путей OpenAPI в пространствах имён /premium, /pro и /vip и наметить последующие PR для очистки.
- Ввести чек-лист согласования API и шаблон PR, чтобы стандартизировать процесс проектирования и валидации изменений, влияющих на контракт.
- Расширить AGENTS.md репозиторными правилами для продуктовых тарифов, пространств имён API и поведения делегирования алиасов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document canonical product tiers and their mapping to API namespaces, and establish OpenAPI visibility and alignment governance without changing runtime behavior.

Documentation:
- Add canonical FREE/PRO/VIP product tier mapping tied to API namespaces and legacy shims.
- Define an OpenAPI visibility matrix specifying which canonical, deprecated, and internal endpoints must be shown or hidden in the public schema.
- Record a factual audit of current OpenAPI paths across /premium, /pro, and /vip namespaces and outline follow-up PRs for cleanup.
- Introduce an API alignment checklist and PR template to standardize how contract-impacting changes are designed and validated.
- Extend AGENTS.md with repository-wide rules for product tiers, API namespaces, and alias delegation behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Defined product tiers (FREE/PRO/VIP), marked /premium/* as a deprecated alias, and added a canonical API namespace mapping with migration guidance.
  * Added OpenAPI visibility rules, a comprehensive paths audit, deterministic OpenAPI generation guidance, and schema hygiene recommendations.
  * Added an API alignment checklist, PR template, remediation plan, and contract verification steps.
  * Clarified docs-only PR guidance, harmonized terminology, translated content to English, and added update timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->