### PR TITLE
fix: require greenlet>=3.1.0 for Python 3.13+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,7 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - **Deprecated namespace:** `/api/v1/premium/*` (aliases only, must delegate to canonical `/pro/*` or `/vip/*`).
 - **OpenAPI must not expose deprecated aliases by default** (hide `/premium/*` from schema to prevent frontend from generating types for wrong paths).
 - **File naming must not imply tier unless enforced** (e.g., `bmi_pro.py` is FREE tier, not PRO).
+- **Frontend must not call `/api/v1/premium/*` endpoints** — use canonical `/api/v1/pro/*` or `/api/v1/vip/*` instead. Deprecated premium endpoints may be removed in future releases.
 
 ### Tier enforcement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ make diff-cov   # Diff-coverage ≥97% on changed lines
 - Prefer using base image pip without upgrade, or upgrade without version pin if upgrade is required.
 - If a pip version constraint is required, use a version range and document the reason + CI verification.
 - **Security fixes for Python dependencies must be done via `requirements.in`/`requirements.txt`, not via ad-hoc `pip install -U ...` in Dockerfile.** We allow unsafe packages (setuptools/pip/wheel) in lockfiles via `pip-compile --allow-unsafe` so security fixes live in `requirements.txt` and Dockerfile remains simple (no upgrade/install steps).
+- **Python 3.13+ compatibility:** If CI/main uses Python 3.13+, then `greenlet` must be `>=3.1.0,<4.0.0` (greenlet 3.1.0+ adds Python 3.13 support; 3.0.x may fail to build/run on 3.13).
 - Smoke tests must build the image on the current base image; any Python base image bumps → verify tooling compatibility (pip/setuptools/wheel).
 
 ### 4) Lint/format

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,8 @@ reportlab>=4.4.4,<5.0.0
 sqlalchemy>=2.0.44,<3.0.0
 # Required for async SQLAlchemy (create_async_engine, AsyncSession)
 # greenlet is needed for SQLAlchemy async operations on all platforms
-greenlet>=3.0.0,<4.0.0
+# greenlet>=3.1.0 required for Python 3.13+ support
+greenlet>=3.1.0,<4.0.0
 alembic>=1.17.2,<2.0.0
 # Pin to tested 3.x series; allow minor upgrades for compatibility
 psycopg[binary]>=3.2.3,<4.0.0


### PR DESCRIPTION
## Context
Main branch runs on Python 3.13 (and 3.14 in development).
`greenlet>=3.0.0` is not guaranteed to support Python 3.13.

## Change
- Require `greenlet>=3.1.0,<4.0.0`
- Regenerate requirements lockfile
- Add Python 3.13+ compatibility rule to AGENTS.md
- Add frontend premium endpoint deprecation rule to AGENTS.md

## Risk
Low — version bump within the same major release.

## Related
- Python 3.13 runtime
- Async SQLAlchemy

## Summary by Sourcery

Согласовать зависимости и документацию с совместимостью Python 3.13 и политиками деприкации premium-эндпоинтов.

Bug Fixes:
- Обеспечить, чтобы требуемая версия `greenlet` была совместима с рантаймами Python 3.13+ и предотвращала ошибки на этапе сборки/выполнения.

Build:
- Обновить ограничения Python-зависимостей и регенерировать lockfile зависимостей с `greenlet`, закреплённым в диапазоне `>=3.1.0,<4.0.0` для Python 3.13+.

Documentation:
- Задокументировать требования совместимости `greenlet` с Python 3.13+ в `AGENTS.md`.
- Уточнить, что фронтенд-клиенты не должны вызывать устаревшие эндпоинты `/api/v1/premium/*` и вместо этого должны использовать каноничные пути `/api/v1/pro/*` или `/api/v1/vip/*`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align dependencies and documentation with Python 3.13 compatibility and premium endpoint deprecation policies.

Bug Fixes:
- Ensure greenlet version requirement is compatible with Python 3.13+ runtimes to prevent build/runtime failures.

Build:
- Update Python dependency constraints and regenerate the requirements lockfile with greenlet pinned to >=3.1.0,<4.0.0 for Python 3.13+.

Documentation:
- Document Python 3.13+ greenlet compatibility requirements in AGENTS.md.
- Clarify that frontend clients must not call deprecated /api/v1/premium/* endpoints and should use canonical /api/v1/pro/* or /api/v1/vip/* paths instead.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures compatibility with Python 3.13 and clarifies API usage for clients.
> 
> - Raise `greenlet` minimum to `>=3.1.0,<4.0.0` in `requirements.in` (Python 3.13 support)
> - Update `AGENTS.md`:
>   - Dockerfile policy: Python 3.13+ requires `greenlet>=3.1.0,<4.0.0`
>   - API namespace: frontend must not call deprecated `/api/v1/premium/*`; use `/api/v1/pro/*` or `/api/v1/vip/*`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f0df24d3ad30ab32667f650077c85b50950eb1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated greenlet dependency for Python 3.13+ compatibility.

* **Documentation**
  * Added guidance on frontend API endpoint usage, noting that premium endpoints are deprecated in favor of canonical pro/vip alternatives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->