### PR TITLE
fix(security): remove setuptools from runtime venv (GHSA-58pv-8j8x-9vj2)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '16 15 * * 6'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt && \
     # Remove setuptools from runtime image to fix GHSA-58pv-8j8x-9vj2 (jaraco.context vulnerability)
     # setuptools is only needed for build-time (pip install), not runtime
     /opt/venv/bin/pip uninstall -y setuptools wheel && \
-    /opt/venv/bin/python -c "import importlib.util; assert importlib.util.find_spec('setuptools') is None, 'setuptools leaked into runtime venv'"
+    /opt/venv/bin/python - <<'PY'
+import importlib.util, sys
+if importlib.util.find_spec("setuptools") is not None:
+    sys.stderr.write("setuptools leaked into runtime venv\n")
+    sys.exit(1)
+PY
 
 # Stage 2: Runtime base stage
 # NOTE: Keep system package manager tools here so the development stage can install tools via apt.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ ENV PIP_NO_PYTHON_VERSION_WARNING=1
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt requirements-dev.txt ./
-RUN python -m pip install --no-cache-dir -r requirements.txt && \
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt && \
     # Remove setuptools from runtime image to fix GHSA-58pv-8j8x-9vj2 (jaraco.context vulnerability)
     # setuptools is only needed for build-time (pip install), not runtime
-    python -m pip uninstall -y setuptools wheel || true
+    /opt/venv/bin/pip uninstall -y setuptools wheel && \
+    /opt/venv/bin/python -c "import importlib.util; assert importlib.util.find_spec('setuptools') is None, 'setuptools leaked into runtime venv'"
 
 # Stage 2: Runtime base stage
 # NOTE: Keep system package manager tools here so the development stage can install tools via apt.

--- a/scripts/verify_setuptools_removed.sh
+++ b/scripts/verify_setuptools_removed.sh
@@ -31,7 +31,7 @@ echo "🔍 Checking if setuptools is present in image: $IMAGE_TAG"
 # Check 1: Try to import setuptools (should fail)
 # NOTE: 2>/dev/null only suppresses Python import error, not docker errors
 echo "Test 1: Import setuptools (should fail)..."
-if docker run --rm "$IMAGE_TAG" python -c "import setuptools" 2>/dev/null; then
+if docker run --rm "$IMAGE_TAG" /opt/venv/bin/python -c "import setuptools" 2>/dev/null; then
     echo "❌ FAIL: setuptools can be imported"
     exit 1
 else


### PR DESCRIPTION
## Problem

Trivy security alert #502 finds vendored `jaraco.context` (v5.3.0) in runtime venv:
- Path: `/opt/venv/lib/python3.13/site-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info/METADATA`
- Vulnerability: GHSA-58pv-8j8x-9vj2 (path traversal in jaraco.context < 6.1.0)

Previous fix attempted to remove setuptools, but uninstall used `python -m pip` which could target wrong environment. setuptools remained in runtime venv.

## Solution

- Use `/opt/venv/bin/pip` explicitly for uninstall to target correct venv
- Add assert to fail build if setuptools leaks into runtime venv
- Update verify script to use `/opt/venv/bin/python` for import check

## Verification

✅ Build succeeds with assert passing
✅ `docker run --rm <image> /opt/venv/bin/python -c 'import setuptools'` → ModuleNotFoundError
✅ `./scripts/verify_setuptools_removed.sh <image>` → all 3 tests pass
✅ `jaraco.context` dist-info not found in runtime image

## Post-merge steps (required)

After merging this PR:
1. Actions → `trivy` workflow → Run workflow on `main` (manual trigger)
2. Wait for SARIF upload to complete
3. Security alert #502 should close automatically after Trivy scan

Related: Security alert #502, PR #527 (setuptools removal attempt)

## Summary by Sourcery

Обеспечить удаление `setuptools` из виртуального окружения в runtime Docker-образе для устранения уязвимости в безопасности.

Исправления ошибок:
- Использовать бинарник `pip`, специфичный для `venv`, при сборке Docker-образа, чтобы надёжно удалять `setuptools` и `wheel` из runtime-окружения.
- Добавить проверку во время выполнения (runtime assertion), которая будет завершать сборку образа с ошибкой, если `setuptools` по-прежнему можно импортировать в виртуальном окружении.
- Обновить скрипт проверки, чтобы он тестировал возможность импорта `setuptools` с помощью интерпретатора Python из виртуального окружения внутри контейнера.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the runtime Docker image removes setuptools from the virtual environment to address a security vulnerability.

Bug Fixes:
- Use the venv-specific pip binary in the Docker build to reliably uninstall setuptools and wheel from the runtime environment.
- Add a runtime assertion to fail the image build if setuptools is still importable in the virtualenv.
- Update the verification script to check setuptools importability using the virtualenv Python interpreter inside the container.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now uses the runtime virtual environment for package installation and cleanup.
  * Runtime verification added to detect and fail the build if undesired packaging libraries remain.
* **CI**
  * Workflow can now be triggered manually in addition to existing triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->