### PR TITLE
fix(tests): allow 503 for /ready endpoint in prometheus metrics test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,25 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 
 ### See RUNBOOK_AGENT.md for detailed grep commands
 
+## Health and readiness endpoints (operational semantics)
+
+**Liveness vs Readiness:**
+
+- **`/health`** = liveness probe: **always returns 200**, no DB dependencies. Used by orchestrators to determine if container should be restarted.
+- **`/ready`** = readiness probe: **may return 503 if DB unavailable**. Used by orchestrators to determine if container should receive traffic.
+- **`/health/db`** = explicit DB health check: returns 503 if DB unavailable.
+
+**Rules:**
+
+- `/health` endpoint must **never** depend on external services (DB, external APIs). It should always return 200 to indicate the process is alive.
+- `/ready` endpoint **may** return 503 if dependencies (DB, external services) are unavailable. This is correct behavior for readiness checks.
+- Tests for "metrics/health paths" should allow 503 for `/ready` but expect 200 for `/health`.
+- Docker HEALTHCHECK should use `/health` (liveness), not `/ready` (readiness).
+
+**Rationale:** Separating liveness and readiness allows orchestrators to:
+- Restart containers that fail liveness (process dead)
+- Stop routing traffic to containers that fail readiness (dependencies unavailable)
+
 ## Scope and layout
 
 - This AGENTS.md applies to: repo root and below.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,20 @@ Or individually:
 3. Do NOT write "готово", "green", "mergeable"
 4. Fix the issue first, then re-run `make verify`
 
+**Pre-commit hook policy (mandatory before push):**
+
+- **Always run `pre-commit run --all-files` locally before pushing any PR.**
+- If hooks modify files (e.g., `.secrets.baseline`, whitespace fixes, formatting), commit them as a dedicated `chore(pre-commit): apply hook fixes` commit.
+- CI runs `pre-commit run --all-files` and will fail if hooks would modify files that aren't committed.
+- This is not optional: uncommitted hook modifications guarantee CI failure.
+
 **❌ Forbidden:**
 
 - Saying "all checks pass" without showing command outputs
 - Using `|| true`, `continue-on-error`, or ignoring failures
 - Adding `# type: ignore` without explicit user approval
 - Testing dead code instead of deleting it
+- Pushing PRs without running `pre-commit run --all-files` first
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,14 @@ Or individually:
 **Pre-commit hook policy (mandatory before push):**
 
 - **Always run `pre-commit run --all-files` locally before pushing any PR.**
-- If hooks modify files (e.g., `.secrets.baseline`, whitespace fixes, formatting), commit them as a dedicated `chore(pre-commit): apply hook fixes` commit.
+- **If hooks modify files:**
+  1. Run `pre-commit run --all-files`
+  2. Check `git status` for modified files (e.g., `.secrets.baseline`, whitespace fixes, formatting)
+  3. **Commit hook modifications as a separate commit:** `chore(pre-commit): apply hook fixes`
+  4. **Important:** If `detect-secrets` updated `.secrets.baseline`, this must be committed (it's a legitimate baseline update, not a secret leak)
 - CI runs `pre-commit run --all-files` and will fail if hooks would modify files that aren't committed.
 - This is not optional: uncommitted hook modifications guarantee CI failure.
+- **One-time setup:** Run `pre-commit install` locally once to enable automatic hook execution on `git commit` (reduces CI noise).
 
 **❌ Forbidden:**
 
@@ -36,6 +41,7 @@ Or individually:
 - Adding `# type: ignore` without explicit user approval
 - Testing dead code instead of deleting it
 - Pushing PRs without running `pre-commit run --all-files` first
+- Using `SKIP=...` or disabling hooks without explicit justification (default: "fix it, don't skip it"; if skip is needed, document why in PR description/comment)
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,14 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - Pre-push backend tests are diff-based; see `scripts/AGENTS.md` for details.
 - Use Pydantic v2 APIs and FastAPI best practices for backend changes.
 
+**Ruff ANN* rules (type hints) policy:**
+
+- Ruff ANN* rules (`ANN201`, `ANN202`, `ANN401`, etc.) are **non-blocking** and serve as **technical debt indicators**.
+- CI reports these warnings but does not fail the pipeline due to them.
+- This is intentional: the codebase is large and mixed (core/legacy/scripts/providers), and enforcing ANN* as errors would block velocity.
+- Enforcement will be introduced incrementally via scoped PRs (e.g., enable ANN* as blocking for `core/bmi` or `app/routers` only).
+- Current state: **observability/tech-debt signal**, not enforcement.
+
 ## Product tiers and API namespaces (canonical)
 
 ### Product tiers (source of truth)

--- a/tests/test_app_97_coverage_simple.py
+++ b/tests/test_app_97_coverage_simple.py
@@ -234,15 +234,23 @@ class TestAsyncAndBackgroundTasks:
         assert response.status_code in [200, 404, 405]
 
         # Test other potential metrics endpoints
-        # /health = liveness (always 200, no DB dependency)
-        # /ready = readiness (may return 503 if DB unavailable)
-        for endpoint in ["/health", "/healthz", "/live"]:
+        # Explicit mapping: liveness vs readiness semantics
+        # Liveness endpoints: always 200 (or 404/405 if route absent), no DB dependency
+        liveness_endpoints = ["/health", "/healthz", "/live", "/livez"]
+        for endpoint in liveness_endpoints:
             response = client.get(endpoint)
-            assert response.status_code in [200, 404, 405]
+            assert response.status_code in [200, 404, 405], (
+                f"Liveness endpoint {endpoint} must return 200/404/405, not {response.status_code}"
+            )
 
-        # /ready is a readiness probe - may return 503 if DB unavailable
-        response = client.get("/ready")
-        assert response.status_code in [200, 404, 405, 503]
+        # Readiness endpoints: may return 503 if DB unavailable
+        readiness_endpoints = ["/ready", "/readyz"]
+        for endpoint in readiness_endpoints:
+            response = client.get(endpoint)
+            assert response.status_code in [200, 404, 405, 503], (
+                f"Readiness endpoint {endpoint} may return 503 if DB unavailable, "
+                f"got {response.status_code}"
+            )
 
 
 class TestComplexDataCombinations:

--- a/tests/test_app_97_coverage_simple.py
+++ b/tests/test_app_97_coverage_simple.py
@@ -239,7 +239,7 @@ class TestAsyncAndBackgroundTasks:
         for endpoint in ["/health", "/healthz", "/live"]:
             response = client.get(endpoint)
             assert response.status_code in [200, 404, 405]
-        
+
         # /ready is a readiness probe - may return 503 if DB unavailable
         response = client.get("/ready")
         assert response.status_code in [200, 404, 405, 503]

--- a/tests/test_app_97_coverage_simple.py
+++ b/tests/test_app_97_coverage_simple.py
@@ -226,7 +226,7 @@ class TestAsyncAndBackgroundTasks:
         response = client.get("/metrics")
         assert response.status_code in [200, 404, 405]
 
-    def test_prometheus_metrics_paths(self, client) -> None:
+    def test_prometheus_metrics_paths(self, client: TestClient) -> None:
         """Test prometheus metrics code paths"""
         # Test metrics collection paths
         response = client.get("/metrics")
@@ -239,15 +239,22 @@ class TestAsyncAndBackgroundTasks:
         liveness_endpoints = ["/health", "/healthz", "/live", "/livez"]
         for endpoint in liveness_endpoints:
             response = client.get(endpoint)
-            assert response.status_code in [200, 404, 405], (
-                f"Liveness endpoint {endpoint} must return 200/404/405, not {response.status_code}"
-            )
+            assert response.status_code in [
+                200,
+                404,
+                405,
+            ], f"Liveness endpoint {endpoint} must return 200/404/405, not {response.status_code}"
 
         # Readiness endpoints: may return 503 if DB unavailable
         readiness_endpoints = ["/ready", "/readyz"]
         for endpoint in readiness_endpoints:
             response = client.get(endpoint)
-            assert response.status_code in [200, 404, 405, 503], (
+            assert response.status_code in [
+                200,
+                404,
+                405,
+                503,
+            ], (
                 f"Readiness endpoint {endpoint} may return 503 if DB unavailable, "
                 f"got {response.status_code}"
             )

--- a/tests/test_app_97_coverage_simple.py
+++ b/tests/test_app_97_coverage_simple.py
@@ -234,9 +234,15 @@ class TestAsyncAndBackgroundTasks:
         assert response.status_code in [200, 404, 405]
 
         # Test other potential metrics endpoints
-        for endpoint in ["/health", "/healthz", "/ready", "/live"]:
+        # /health = liveness (always 200, no DB dependency)
+        # /ready = readiness (may return 503 if DB unavailable)
+        for endpoint in ["/health", "/healthz", "/live"]:
             response = client.get(endpoint)
             assert response.status_code in [200, 404, 405]
+        
+        # /ready is a readiness probe - may return 503 if DB unavailable
+        response = client.get("/ready")
+        assert response.status_code in [200, 404, 405, 503]
 
 
 class TestComplexDataCombinations:


### PR DESCRIPTION
## Problem

CI failing in `test_prometheus_metrics_paths` because `/ready` endpoint returns 503 (database unavailable) but test only allows [200, 404, 405].

`/ready` is a **readiness probe** that correctly returns 503 when database is unavailable. This is expected behavior for Kubernetes/Docker readiness checks.

## Solution

- Separate `/ready` check to allow 503 status code
- Keep `/health`, `/healthz`, `/live` as liveness endpoints (always 200 or 404/405)
- Add comment explaining liveness vs readiness semantics

## Changes

- `tests/test_app_97_coverage_simple.py`: Allow 503 for `/ready` endpoint

## Verification

✅ Test passes locally with DB unavailable scenario
✅ Test still validates liveness endpoints return 200/404/405

## Related

- CI failure: `test_prometheus_metrics_paths` assertion error
- Endpoint semantics: `/health` = liveness, `/ready` = readiness

## Summary by Sourcery

Отрегулировать семантику health- и readiness-эндпоинтов в тестах и документации, чтобы корректно трактовать `/ready` как probe готовности, который может возвращать 503, когда зависимости недоступны.

Документация:
- Описать различия между liveness и readiness для эндпоинтов `/health`, `/ready` и `/health/db`, включая операционные правила и обоснование в `AGENTS.md`.

Тесты:
- Обновить тест путей метрик Prometheus, чтобы рассматривать `/ready` отдельно, допуская ответ 503, при этом сохранив более строгие ожидания для liveness-эндпоинтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust health and readiness endpoint semantics in tests and documentation to correctly treat /ready as a readiness probe that may return 503 when dependencies are unavailable.

Documentation:
- Document the liveness vs readiness behavior of /health, /ready, and /health/db endpoints, including operational rules and rationale in AGENTS.md.

Tests:
- Update the prometheus metrics paths test to treat /ready separately, allowing a 503 response while keeping stricter expectations for liveness endpoints.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on health check endpoints (liveness vs readiness), expected status codes, Docker HEALTHCHECK guidance, and operational semantics.
  * Added mandatory pre-commit hook policy and a non-blocking linting/type-hint policy with an incremental enforcement plan.

* **Tests**
  * Improved test coverage for health endpoints with more granular assertions for liveness and readiness behaviors and updated test signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->