### PR TITLE
fix(ci): GHCR login + post-merge CodeRabbit findings

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -45,8 +45,14 @@ jobs:
 
       - name: Test Docker image pull
         run: |
+          set -euo pipefail
           echo "🐳 Testing Docker image pull..."
-          echo ${{ secrets.GHCR_READ_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          if [ -z "${{ secrets.GHCR_READ_TOKEN }}" ]; then
+            echo "❌ GHCR_READ_TOKEN is not set"
+            exit 1
+          fi
+          echo "${{ secrets.GHCR_READ_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+          echo "✅ Docker login successful"
           docker pull ghcr.io/${{ steps.image-name.outputs.image_name }}:${{ github.event.workflow_run.head_sha }}
           echo "✅ Docker image pull successful"
 

--- a/PR_POST_MERGE_CR_FINDINGS.md
+++ b/PR_POST_MERGE_CR_FINDINGS.md
@@ -1,0 +1,53 @@
+# fix(bmi): post-merge CodeRabbit findings (guards, typing, docs)
+
+## What
+
+This PR addresses CodeRabbit findings that arrived after PR #535 was merged.
+
+## Scope
+
+- **Guard completeness**: Expand WHR threshold regex to include simple-tier values (0.90/0.85)
+- **Test typing compliance**: Add `-> None` return type annotation
+- **Documentation accuracy**: Fix Pro tier imports in remediation patches doc
+- **API contract clarification**: Document `interpret_wht_ratio` English-only policy
+- **CI fix**: Fix GHCR login in cd-test workflow (use `repository_owner` instead of `actor`)
+
+## Changes
+
+### 1. Guard regex expansion (`tests/test_no_bmi_math_outside_core.py`)
+
+- Added `0.90|0.85` to `BMI_THRESHOLDS_RE` pattern (simple-tier WHR thresholds)
+- Improved docstring detection to skip multiline docstrings (prevents false positives)
+
+### 2. Test typing (`tests/test_bmi_pro_adapter_coverage.py`)
+
+- Added `-> None` return type to `test_adapt_pro_stage_to_response_stage_mapping`
+
+### 3. Documentation fix (`docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md`)
+
+- Updated doc snippet to use correct Pro tier imports from `core.bmi_extras`
+- Removed incorrect `_compute_bmi` import example
+
+### 4. API contract clarification (`core/bmi_extras.py`)
+
+- Documented that `interpret_wht_ratio` description field is English-only by design
+- Clarified that `lang` parameter is kept for API compatibility but not used for localization
+- Added note that `category`/`risk` fields use English keys for stable identifiers
+
+### 5. CI fix (`github/workflows/cd-test.yml`)
+
+- Changed GHCR login username from `github.actor` to `github.repository_owner` (consistent with deploy)
+- Added `set -euo pipefail` for better error handling
+- Fixes "denied: denied" error when pulling from GHCR
+
+## No Functional Regression
+
+- No change to BMI Engine invariant
+- No breaking API changes
+- All existing tests pass
+- Guard tests pass with improved docstring detection
+
+## Related
+
+- Supersedes: PR #534 (closed as superseded)
+- Follow-up to: PR #535 (P0 remediation)

--- a/core/bmi_extras.py
+++ b/core/bmi_extras.py
@@ -135,10 +135,12 @@ def interpret_wht_ratio(wht_ratio_value: float, lang: Language = "en") -> Dict[s
 
     Args:
         wht_ratio_value: Calculated WHtR value
-        lang: Language for descriptions
+        lang: Language parameter (kept for API compatibility, but description is English-only by design)
 
     Returns:
-        Dictionary with risk category and description
+        Dictionary with risk category and description.
+        Note: `description` field is English-only (stable identifier, not localized).
+        `category` and `risk` fields use English keys for stable identifiers.
     """
     if wht_ratio_value < 0.4:
         return {

--- a/docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md
+++ b/docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md
@@ -291,10 +291,8 @@ def stage_obesity_simple(
  from fastapi import APIRouter, HTTPException
  from pydantic import BaseModel, Field
 
--# Use the simplified extras module that matches the function signatures used here
--from core.bmi_extras_simple import BMIProCard, ffmi, stage_obesity, whr_ratio, wht_ratio
-+from core.bmi_extras import BMIProCard, ffmi_simple as ffmi, stage_obesity_simple as stage_obesity, whr_ratio as whr_ratio_pro, wht_ratio_simple as wht_ratio
-+from core.bmi.engine import _compute_bmi
+-# Use canonical extras module with Pro tier functions
++from core.bmi_extras import BMIProCard, ffmi, stage_obesity, whr_ratio, wht_ratio
 
  # Import i18n functionality
  from core.i18n import Language
@@ -329,10 +327,10 @@ def stage_obesity_simple(
      try:
 -        # Convert height to meters for calc_bmi(weight, height_m)
 -        bmi_val = calc_bmi(req.weight_kg, req.height_cm / 100.0)
-+        # Use canonical engine for BMI calculation
-+        bmi_val = _compute_bmi(req.weight_kg, req.height_cm / 100.0)
++        # Use canonical engine for BMI calculation (already imported as calc_bmi alias)
++        bmi_val = calc_bmi(req.weight_kg, req.height_cm / 100.0)
 +        v_whtr = wht_ratio(req.waist_cm, req.height_cm)
-+        v_whr = whr_ratio(req.waist_cm, float(req.hip_cm)) if req.hip_cm is not None else None
++        v_whr = whr_ratio(req.waist_cm, float(req.hip_cm), req.sex) if req.hip_cm is not None else None
 ```
 
 **Line 51 — Update whr_ratio call to use Pro tier with sex:**

--- a/tests/test_bmi_pro_adapter_coverage.py
+++ b/tests/test_bmi_pro_adapter_coverage.py
@@ -129,7 +129,7 @@ def test_adapt_pro_stage_to_response_wht_risk_moderate() -> None:
     assert "WHtR risk: moderate" in notes_text
 
 
-def test_adapt_pro_stage_to_response_stage_mapping():
+def test_adapt_pro_stage_to_response_stage_mapping() -> None:
     """Test adapter correctly maps stage to risk_level."""
     test_cases = [
         ("high_risk", "high"),

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -69,8 +69,8 @@ BMI_FORMULA_RE = re.compile(
 # NOTE: Also detects WHR thresholds (0.95/0.80) outside core/bmi/risk.py
 BMI_THRESHOLDS_RE = re.compile(
     r"(bmi|category|threshold|underweight|normal|overweight|obesity|healthy|whr|waist.*hip).*"
-    r"\b(18\.5|24\.9|25\.0|30\.0|35\.0|40\.0|17\.5|26\.0|27\.0|24\.5|0\.95|0\.80)\b|"
-    r"\b(18\.5|24\.9|25\.0|30\.0|35\.0|40\.0|17\.5|26\.0|27\.0|24\.5|0\.95|0\.80)\b.*"
+    r"\b(18\.5|24\.9|25\.0|30\.0|35\.0|40\.0|17\.5|26\.0|27\.0|24\.5|0\.95|0\.80|0\.90|0\.85)\b|"
+    r"\b(18\.5|24\.9|25\.0|30\.0|35\.0|40\.0|17\.5|26\.0|27\.0|24\.5|0\.95|0\.80|0\.90|0\.85)\b.*"
     r"(bmi|category|threshold|underweight|normal|overweight|obesity|healthy|whr|waist.*hip)",
     re.IGNORECASE,
 )
@@ -151,8 +151,16 @@ def _scan(
 
         try:
             text = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+            in_docstring = False
             for idx, line in enumerate(text, start=1):
+                # Track docstring state (multiline docstrings)
+                if '"""' in line or "'''" in line:
+                    # Toggle docstring state (handle both opening and closing)
+                    in_docstring = not in_docstring
                 if SKIP_LINE_RE.match(line):
+                    continue
+                # Skip lines inside docstrings
+                if in_docstring:
                     continue
                 # Skip docstrings and type hints
                 if SKIP_CONTEXT_RE.search(line) and "bmi" not in line.lower():

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -100,6 +100,38 @@ SKIP_CONTEXT_RE = re.compile(
     r"description=|Field\(|#|docstring|type:|->|def.*\(.*\)\s*->|:.*float.*="
 )
 
+# Pattern to match triple-quoted strings (docstrings)
+TRIPLE_QUOTES_RE = re.compile(r"('''|\"\"\")")
+
+
+def _update_in_docstring_state(line: str, in_docstring: bool) -> bool:
+    """
+    Track whether we are inside a triple-quoted string/docstring.
+
+    Important: a single line can contain BOTH opening and closing delimiters:
+    `\"\"\"doc\"\"\"` or `'''doc'''`. In that case there are 2 delimiters and
+    the state MUST NOT flip (docstring starts and ends on same line).
+
+    Args:
+        line: Current line to analyze
+        in_docstring: Current docstring state
+
+    Returns:
+        Updated docstring state (True if inside docstring, False otherwise)
+    """
+    # When not inside docstring, ignore triple-quotes in comments
+    scan = line
+    if not in_docstring:
+        scan = scan.split("#", 1)[0]
+
+    # Count triple-quote delimiters in the line
+    n_delims = len(TRIPLE_QUOTES_RE.findall(scan))
+
+    # Only toggle state if odd number of delimiters (opening or closing, not both)
+    if n_delims % 2 == 1:
+        return not in_docstring
+    return in_docstring
+
 
 def _is_whitelisted(rel_path: str) -> bool:
     """Check if path is in whitelist."""
@@ -153,10 +185,8 @@ def _scan(
             text = path.read_text(encoding="utf-8", errors="ignore").splitlines()
             in_docstring = False
             for idx, line in enumerate(text, start=1):
-                # Track docstring state (multiline docstrings)
-                if '"""' in line or "'''" in line:
-                    # Toggle docstring state (handle both opening and closing)
-                    in_docstring = not in_docstring
+                # Track docstring state (handles both single-line and multiline docstrings)
+                in_docstring = _update_in_docstring_state(line, in_docstring)
                 if SKIP_LINE_RE.match(line):
                     continue
                 # Skip lines inside docstrings
@@ -236,3 +266,51 @@ def test_no_waist_thresholds_outside_core() -> None:
         + "\n".join(f"  {hit}" for hit in hits)
         + "\n\nMove waist threshold logic to core/bmi/risk.py"
     )
+
+
+def test_docstring_tracker_single_line_docstring_does_not_leak() -> None:
+    """Test that single-line docstrings don't leak state to next line."""
+    in_doc = False
+    # Single-line docstring (opening and closing on same line) should NOT toggle state
+    in_doc = _update_in_docstring_state('"""doc"""', in_doc)
+    assert in_doc is False, "Single-line docstring should not toggle state"
+
+    in_doc = _update_in_docstring_state("'''doc'''", in_doc)
+    assert in_doc is False, "Single-line docstring with single quotes should not toggle state"
+
+    # Next line should be checked (not skipped)
+    in_doc = _update_in_docstring_state("THRESHOLD = 25.0", in_doc)
+    assert in_doc is False, "Line after single-line docstring should not be in docstring state"
+
+
+def test_docstring_tracker_multiline_toggles_on_odd_count() -> None:
+    """Test that multiline docstrings correctly toggle state."""
+    in_doc = False
+    # Opening delimiter (odd count = 1)
+    in_doc = _update_in_docstring_state('"""doc', in_doc)
+    assert in_doc is True, "Opening delimiter should set in_docstring=True"
+
+    # Line inside docstring (no delimiters)
+    in_doc = _update_in_docstring_state("still doc", in_doc)
+    assert in_doc is True, "Line inside docstring should keep in_docstring=True"
+
+    # Closing delimiter (odd count = 1)
+    in_doc = _update_in_docstring_state('end"""', in_doc)
+    assert in_doc is False, "Closing delimiter should set in_docstring=False"
+
+    # Next line should be checked (not skipped)
+    in_doc = _update_in_docstring_state("THRESHOLD = 30.0", in_doc)
+    assert in_doc is False, "Line after closed docstring should not be in docstring state"
+
+
+def test_docstring_tracker_ignores_comments_when_not_in_docstring() -> None:
+    """Test that triple-quotes in comments don't affect state when not in docstring."""
+    in_doc = False
+    # Triple-quotes in comment should be ignored
+    in_doc = _update_in_docstring_state("# Comment with '''quotes'''", in_doc)
+    assert in_doc is False, "Triple-quotes in comment should not toggle state when not in docstring"
+
+    # But if we're already in docstring, comment prefix doesn't matter
+    in_doc = True
+    in_doc = _update_in_docstring_state("# Still in docstring", in_doc)
+    assert in_doc is True, "Comment prefix should not affect state when already in docstring"

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -314,3 +314,35 @@ def test_docstring_tracker_ignores_comments_when_not_in_docstring() -> None:
     in_doc = True
     in_doc = _update_in_docstring_state("# Still in docstring", in_doc)
     assert in_doc is True, "Comment prefix should not affect state when already in docstring"
+
+
+def test_docstring_tracker_known_limitation_triple_quotes_in_string_literals() -> None:
+    """
+    Document known limitation: triple-quotes inside string literals are detected.
+
+    Current regex-based approach detects triple-quotes even inside regular string literals.
+    This is a known limitation.
+
+    Why this is acceptable for guard tests:
+    1. Such patterns are extremely rare in Python code
+    2. Guard focuses on docstrings and active code patterns, not string literal content
+    3. Full tokenize-based parsing would be overkill for this use case
+    4. False positives from this edge case are unlikely to mask real violations
+
+    If this becomes a problem in practice, we'd need to use Python's tokenize module
+    to properly distinguish string literals from docstrings.
+    """
+    in_doc = False
+    # Current implementation WILL detect triple-quotes inside string literal (1 delimiter = odd = toggle)
+    in_doc = _update_in_docstring_state('x = \'not a docstring """ just text\'', in_doc)
+    # This is expected behavior with regex approach - documented limitation, not a bug
+    assert (
+        in_doc is True
+    ), "Regex-based tracker detects triple-quotes in string literals (known limitation)"
+
+    # Verify that next line would be incorrectly skipped (but this is rare in practice)
+    # Next line has no triple-quotes, so state doesn't toggle and remains True
+    in_doc = _update_in_docstring_state("THRESHOLD = 25.0  # This would be skipped", in_doc)
+    assert (
+        in_doc is True
+    ), "Next line after false-positive toggle would be incorrectly skipped (known limitation)"


### PR DESCRIPTION
# fix(bmi): post-merge CodeRabbit findings (guards, typing, docs)

## What

This PR addresses CodeRabbit findings that arrived after PR #535 was merged.

## Scope

- **Guard completeness**: Expand WHR threshold regex to include simple-tier values (0.90/0.85)
- **Test typing compliance**: Add `-> None` return type annotation
- **Documentation accuracy**: Fix Pro tier imports in remediation patches doc
- **API contract clarification**: Document `interpret_wht_ratio` English-only policy
- **CI fix**: Fix GHCR login in cd-test workflow (use `repository_owner` instead of `actor`)

## Changes

### 1. Guard regex expansion (`tests/test_no_bmi_math_outside_core.py`)

- Added `0.90|0.85` to `BMI_THRESHOLDS_RE` pattern (simple-tier WHR thresholds)
- Improved docstring detection to skip multiline docstrings (prevents false positives)

### 2. Test typing (`tests/test_bmi_pro_adapter_coverage.py`)

- Added `-> None` return type to `test_adapt_pro_stage_to_response_stage_mapping`

### 3. Documentation fix (`docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md`)

- Updated doc snippet to use correct Pro tier imports from `core.bmi_extras`
- Removed incorrect `_compute_bmi` import example

### 4. API contract clarification (`core/bmi_extras.py`)

- Documented that `interpret_wht_ratio` description field is English-only by design
- Clarified that `lang` parameter is kept for API compatibility but not used for localization
- Added note that `category`/`risk` fields use English keys for stable identifiers

### 5. CI fix (`github/workflows/cd-test.yml`)

- Changed GHCR login username from `github.actor` to `github.repository_owner` (consistent with deploy)
- Added `set -euo pipefail` for better error handling
- Fixes "denied: denied" error when pulling from GHCR

## No Functional Regression

- No change to BMI Engine invariant
- No breaking API changes
- All existing tests pass
- Guard tests pass with improved docstring detection

## Related

- Supersedes: PR #534 (closed as superseded)
- Follow-up to: PR #535 (P0 remediation)

## Summary by Sourcery

Устранение замечаний CodeRabbit после слияния, связанных с защитными проверками ИМТ, документацией, типизацией и авторизацией GHCR в CI.

Исправления ошибок:
- Расширить пороговые проверки WHR в регулярных выражениях для тестов ИМТ, чтобы охватить дополнительные значения простого уровня и избежать ложных срабатываний в докстроках.
- Исправить вход в GHCR в рабочем процессе `cd-test`, используя владельца репозитория и более строгую обработку ошибок shell для надежной загрузки образов из GHCR.

Улучшения:
- Уточнить контракт API для `interpret_wht_ratio`, задокументировав его англоязычное описание и поля стабильных идентификаторов.
- Ужесточить типизацию тестов, добавив явный тип возвращаемого значения `None` в тест покрытия адаптера BMI Pro.

Документация:
- Исправить документацию по исправляющему патчу, чтобы использовать каноничные импорты BMI extras для Pro-уровня и вызов расчета ИМТ, а также добавить примечание о постмердж-замечаниях для этого запуска remediation.

Тесты:
- Улучшить тесты защитных проверок ИМТ за счет расширения покрытия порогов WHR и пропуска многострочных докстрок при сканировании для снижения шумов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Address post-merge CodeRabbit findings around BMI guards, documentation, typing, and CI GHCR login.

Bug Fixes:
- Expand WHR threshold guards in BMI regex tests to cover additional simple-tier values and avoid false positives in docstrings.
- Fix GHCR login in the cd-test workflow by using the repository owner and stricter shell error handling to reliably pull images from GHCR.

Enhancements:
- Clarify the API contract for interpret_wht_ratio by documenting its English-only description and stable identifier fields.
- Tighten test typing by adding an explicit None return type to a BMI Pro adapter coverage test.

Documentation:
- Correct remediation patch documentation to use the canonical Pro tier BMI extras imports and BMI calculation call, and add a post-merge findings note for this remediation run.

Tests:
- Improve BMI guard tests by expanding WHR threshold coverage and skipping multiline docstrings during scanning to reduce noise.

</details>