### PR TITLE
fix(security): suppress glibc CVE-2026-0915 (Trivy)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1106,3 +1106,34 @@ CVE-2025-8058
 ## Remove suppression when: Debian releases security update with fixed glibc
 
 CVE-2026-0861
+
+## CVE-2026-0915 – glibc getnetbyaddr(3) stack disclosure to DNS resolver (MEDIUM)
+##
+## Calling getnetbyaddr() / getnetbyaddr_r() with a configured nsswitch.conf that specifies
+## the DNS backend for the `networks` database and querying a zero-valued network can leak
+## stack contents to the configured DNS resolver.
+##
+## Container packages (bookworm): libc6 / libc-bin 2.36-9+deb12u13
+##
+## Debian Security status:
+##   - bookworm: UNFIXED (no security update available as of 2026-01-17)
+##   - Fixed version: NOT AVAILABLE (awaiting upstream fix)
+##   - Monitor: https://security-tracker.debian.org/tracker/CVE-2026-0915
+##
+## Risk assessment:
+##   - Severity: MEDIUM
+##   - Impact: System-level (information disclosure to DNS resolver)
+##   - Attack surface: Low for typical web stacks (Python/FastAPI does not call getnetbyaddr directly)
+##   - However, native extensions/plugins/utilities may call into glibc NSS.
+##
+## Decision:
+##   - Temporary suppression with expiry date (2026-03-01)
+##   - Monitor Debian security tracker weekly for fixed version
+##   - When fixed version available: remove suppression, update base image
+##   - Documented in: docs/security/CVE-2026-0915-glibc.md
+##
+## Suppression expires: 2026-03-01
+## Review cadence: Weekly (e.g., Fridays) as part of Security triage routine
+## Remove suppression when: Debian releases security update with fixed glibc
+
+CVE-2026-0915

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -64,20 +64,20 @@ def _adapt_pro_stage_to_response(
     # Add risk factor information if available
     risk_factors = stage_dict.get("risk_factors")
     if risk_factors and risk_factors != "0":
-        notes.append(t(lang, "bmi_pro_risk_factors", count=risk_factors))  # type: ignore
+        notes.append(t(lang, "bmi_pro_risk_factors", count=risk_factors))
 
     # Add individual risk assessments (wht_risk, whr_risk) if available
     # These provide additional context from Pro tier analysis
     wht_risk = stage_dict.get("wht_risk")
     whr_risk = stage_dict.get("whr_risk")
     if wht_risk and wht_risk != "low":
-        notes.append(t(lang, "bmi_pro_wht_risk", risk=wht_risk))  # type: ignore
+        notes.append(t(lang, "bmi_pro_wht_risk", risk=wht_risk))
 
     # WHR: if unknown (missing hip), show only the translated explanation (no duplicate "WHR risk: unknown")
     if whr_risk == "unknown":
         notes.append(t(lang, "bmi_pro_whr_missing_hip"))
     elif whr_risk and whr_risk != "low":
-        notes.append(t(lang, "bmi_pro_whr_risk", risk=whr_risk))  # type: ignore
+        notes.append(t(lang, "bmi_pro_whr_risk", risk=whr_risk))
 
     return risk_level, notes
 

--- a/docs/security/CVE-2026-0915-glibc.md
+++ b/docs/security/CVE-2026-0915-glibc.md
@@ -1,0 +1,69 @@
+# CVE-2026-0915: glibc getnetbyaddr(3) stack disclosure to DNS resolver
+
+**Status:** UNFIXED (upstream glibc); UNFIXED in Debian bookworm (distro)
+**Severity:** MEDIUM (Trivy/Aqua vulnerability database)
+**Suppression Expires:** 2026-03-01
+**Monitor:** <https://security-tracker.debian.org/tracker/CVE-2026-0915>
+
+---
+
+## Summary
+
+CVE-2026-0915 affects the GNU C Library (glibc) `getnetbyaddr()` / `getnetbyaddr_r()` calls when the `networks` NSS database is configured to use DNS and the queried network is zero-valued. Under these conditions, stack contents may be leaked to the configured DNS resolver.
+
+This is a **system library vulnerability**, not application code.
+
+---
+
+## Current Status
+
+- **Debian bookworm:** UNFIXED (no security update available as of 2026-01-17)
+- **Upstream glibc:** UNFIXED (no released fix version referenced by Debian/Aqua at time of writing)
+- **Our mitigation:** Temporary suppression with expiry date
+
+---
+
+## Risk Assessment
+
+**Impact:** System-level (not application-level)
+- Affects glibc networking database resolution functions
+- Can be triggered via application code **if** the application (or a native dependency) calls `getnetbyaddr()` / `getnetbyaddr_r()` under the vulnerable NSS configuration
+- Leaks stack contents to the configured DNS resolver (information disclosure)
+
+**Attack surface:** Low for typical web stacks
+- Typical Python/FastAPI apps do not call `getnetbyaddr()` directly.
+- Risk exists for native extensions/plugins or utilities that perform network database lookups via glibc NSS.
+
+**Mitigation:**
+- Monitoring for upstream + Debian fix
+- Temporary suppression with expiry
+
+---
+
+## Action Required
+
+### Immediate (PR-SEC)
+
+1. **Document:** This security note
+2. **Suppress:** Add to `.trivyignore` with expiry date (2026-03-01)
+3. **Monitor:** Check Debian security tracker weekly
+
+### When Fixed Version Available
+
+1. **Remove suppression:** Delete CVE-2026-0915 from `.trivyignore`
+2. **Update base image:** Pull latest Debian bookworm with fixed glibc
+3. **Update this document:** Add fix date and version
+4. **Verify:** Run Trivy scan to confirm CVE is resolved
+
+---
+
+## References
+
+- [CVE-2026-0915](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-0915)
+- [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2026-0915)
+- [Aqua vulnerability database (NVD mirror)](https://avd.aquasec.com/nvd/cve-2026-0915)
+
+---
+
+**Last updated:** 2026-01-17
+**Review cadence:** Weekly (e.g., Fridays) as part of Security triage routine


### PR DESCRIPTION
Resolves Trivy code-scanning alerts:
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/507
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/508

Changes:
- Add temporary suppression for `CVE-2026-0915` in `.trivyignore` with expiry `2026-03-01`.
- Add security note `docs/security/CVE-2026-0915-glibc.md` documenting status + monitoring.
- Remove unused `# type: ignore` comments in `app/routers/bmi_pro.py` (unblocked `make typecheck`).

Local verification:
- `make verify`

## Summary by Sourcery

Подавить предупреждение о CVE в glibc в результатах сканирования Trivy и задокументировать его статус, одновременно очистив код маршрутизации BMI Pro от устаревших аннотаций `type: ignore`.

Исправления ошибок:
- Заглушить предупреждения системы безопасности Trivy, связанные с glibc CVE-2026-0915, с помощью временной записи подавления.

Улучшения:
- Удалить больше не нужные комментарии `type ignore` из логики построения risk notes для BMI Pro, чтобы поддерживать проверку типов в чистом состоянии.

Документация:
- Добавить примечание по безопасности, описывающее CVE-2026-0915, его текущий статус в Debian/glibc, подход к смягчению последствий и план мониторинга.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Suppress a glibc CVE from Trivy scans and document its status while cleaning up obsolete type-ignore annotations in BMI Pro routing code.

Bug Fixes:
- Silence Trivy security scan alerts related to glibc CVE-2026-0915 via a temporary suppression entry.

Enhancements:
- Remove now-unnecessary type ignore comments from BMI Pro risk notes construction to keep type checking clean.

Documentation:
- Add a security note documenting CVE-2026-0915, its current status in Debian/glibc, mitigation approach, and monitoring plan.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security documentation for CVE-2026-0915 affecting system libraries, including impact assessment and mitigation strategy.

* **Chores**
  * Added CVE-2026-0915 suppression to vulnerability scanner configuration with detailed risk assessment and monitoring cadence.

* **Style**
  * Improved type-checking coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->