### PR TITLE
refactor(routers): add shared bmi helpers to _helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -765,6 +765,14 @@ import { NumberInput } from "@/components/ui/number-input";
 - Do NOT copy logic into a second place.
 - Move shared logic into `core/` and call it from both sides.
 
+### Router helper policy (FREE/PRO)
+
+- **Shared helpers MUST live in `app/routers/_helpers.py`**.
+- **Do not copy/paste helper logic between routers** (`bmi.py`, `bmi_pro.py`, etc.).
+- **Soft paywall hook builder lives only in `app/routers/_helpers.py`** and must not import `core.bmi.*`.
+- **Default for `SOFT_PAYWALL_ENABLED`:** FREE `True`, PRO `False` (via `default_enabled` parameter).
+- **Guard test enforces:** routers must not define local `_build_soft_paywall_hook`; must import from `_helpers`.
+
 ## Git workflow (single-developer safe mode)
 
 This workflow is the default while the project is maintained by a single developer and branch protection blocks force-pushes.

--- a/app/routers/_helpers.py
+++ b/app/routers/_helpers.py
@@ -66,11 +66,16 @@ def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) 
         s = value.strip().lower()
         if not s:
             return False
-        allowed = yes_values or {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+        # Preserve empty set() semantics: if yes_values is explicitly set() (empty), no values match
+        # Only use default if yes_values is None
+        if yes_values is not None:
+            allowed = {v.strip().lower() for v in yes_values}
+        else:
+            allowed = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
         return s in allowed
 
 
-def _build_soft_paywall_hook(lang: str, *, default_enabled: bool) -> "SoftPaywallHook | None":
+def _build_soft_paywall_hook(lang: str, *, default_enabled: bool) -> SoftPaywallHook | None:
     """
     Build text-only soft paywall hook (no BMI logic).
 

--- a/app/routers/_helpers.py
+++ b/app/routers/_helpers.py
@@ -8,6 +8,10 @@ EN: Shared helper functions for routers.
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.schemas.bmi import SoftPaywallHook
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -25,3 +29,95 @@ def _env_bool(name: str, default: bool) -> bool:
     if value in {"0", "false", "f", "no", "n", "off"}:
         return False
     return default
+
+
+def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) -> bool:
+    """
+    Normalize boolean flag from string or bool.
+
+    RU: Нормализует флаг yes/no (pregnant/athlete и т.п.) в bool.
+    EN: Normalize yes/no-ish flag to bool.
+
+    Uses canonical implementation from core.bmi.engine with fallback.
+    This ensures consistent normalization across FREE and PRO routers.
+
+    Args:
+        value: String or bool value to normalize
+        yes_values: Optional custom set of truthy strings (defaults to engine's _DEFAULT_YES_VALUES)
+
+    Returns:
+        bool: Normalized boolean value
+
+    Note:
+        Falls back to local implementation if engine is not available (development/testing).
+    """
+    try:
+        from core.bmi.engine import (
+            _normalize_bool_flag as _engine_normalize_bool_flag,
+        )  # noqa: WPS433
+
+        return _engine_normalize_bool_flag(value, yes_values)
+    except ImportError:  # pragma: no cover
+        # Fallback for development/testing when engine is not yet available
+        if isinstance(value, bool):
+            return value
+        if not isinstance(value, str):
+            return False
+        s = value.strip().lower()
+        if not s:
+            return False
+        allowed = yes_values or {"yes", "y", "true", "1", "да", "д", "si", "sí"}
+        return s in allowed
+
+
+def _build_soft_paywall_hook(lang: str, *, default_enabled: bool) -> "SoftPaywallHook | None":
+    """
+    Build text-only soft paywall hook (no BMI logic).
+
+    IMPORTANT:
+    - No BMI-dependent logic.
+    - No imports from core/bmi/*.
+
+    Args:
+        lang: Language code for i18n
+        default_enabled: Default value if SOFT_PAYWALL_ENABLED env var is not set
+                         (FREE tier: True, PRO tier: False)
+
+    Returns:
+        SoftPaywallHook if enabled, None otherwise
+
+    Note:
+        Uses lazy imports to avoid circular dependencies.
+    """
+    # Lazy imports to avoid circular dependencies
+    from app.schemas.bmi import (
+        SoftPaywallAvailability,
+        SoftPaywallHook,
+        SoftPaywallMessage,
+    )
+    from core.i18n import normalize_lang, t
+
+    enabled = _env_bool("SOFT_PAYWALL_ENABLED", default=default_enabled)
+    if not enabled:
+        return None
+
+    safe_lang = normalize_lang(lang)
+
+    message = SoftPaywallMessage(
+        lang=safe_lang,
+        title_key="soft_paywall.title",
+        body_key="soft_paywall.body",
+        cta_key="soft_paywall.cta",
+        default_title=t(safe_lang, "soft_paywall.title"),
+        default_body=t(safe_lang, "soft_paywall.body"),
+        default_cta=t(safe_lang, "soft_paywall.cta"),
+    )
+
+    availability = SoftPaywallAvailability(pro_available=True, reason_key=None)
+
+    return SoftPaywallHook(
+        id="bmi.pro_interpretation_v1",
+        message=message,
+        availability=availability,
+        target="pro_paywall",
+    )

--- a/app/routers/_helpers.py
+++ b/app/routers/_helpers.py
@@ -8,10 +8,13 @@ EN: Shared helper functions for routers.
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from app.schemas.bmi import SoftPaywallHook
+
+# Keep fallback defaults aligned with core.bmi.engine defaults.
+_DEFAULT_YES_VALUES: set[str] = {"yes", "y", "true", "1", "да", "д", "истина", "si", "sí"}
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -29,6 +32,22 @@ def _env_bool(name: str, default: bool) -> bool:
     if value in {"0", "false", "f", "no", "n", "off"}:
         return False
     return default
+
+
+def _get_engine_normalize_bool_flag() -> Callable[[str | bool, set[str] | None], bool] | None:
+    """
+    Internal helper to isolate engine import.
+
+    Test can monkeypatch this to force fallback without mocking builtins import.
+    """
+    try:
+        from core.bmi.engine import (
+            _normalize_bool_flag as _engine_normalize_bool_flag,
+        )  # noqa: WPS433
+
+        return _engine_normalize_bool_flag
+    except ImportError:
+        return None
 
 
 def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) -> bool:
@@ -51,28 +70,24 @@ def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) 
     Note:
         Falls back to local implementation if engine is not available (development/testing).
     """
-    try:
-        from core.bmi.engine import (
-            _normalize_bool_flag as _engine_normalize_bool_flag,
-        )  # noqa: WPS433
+    engine_fn = _get_engine_normalize_bool_flag()
+    if engine_fn is not None:
+        return engine_fn(value, yes_values)
 
-        return _engine_normalize_bool_flag(value, yes_values)
-    except ImportError:  # pragma: no cover
-        # Fallback for development/testing when engine is not yet available
-        if isinstance(value, bool):
-            return value
-        if not isinstance(value, str):
-            return False
-        s = value.strip().lower()
-        if not s:
-            return False
-        # Preserve empty set() semantics: if yes_values is explicitly set() (empty), no values match
-        # Only use default if yes_values is None
-        if yes_values is not None:
-            allowed = {v.strip().lower() for v in yes_values}
-        else:
-            allowed = {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-        return s in allowed
+    # Fallback path (dev/partial checkouts): keep behavior aligned with engine defaults.
+    if isinstance(value, bool):
+        return value
+    if not isinstance(value, str):
+        return False
+    s = value.strip().lower()
+    if not s:
+        return False
+
+    # Preserve explicit empty set semantics (set() stays empty).
+    allowed = (
+        {v.strip().lower() for v in yes_values} if yes_values is not None else _DEFAULT_YES_VALUES
+    )
+    return s in allowed
 
 
 def _build_soft_paywall_hook(lang: str, *, default_enabled: bool) -> SoftPaywallHook | None:

--- a/app/routers/_helpers.py
+++ b/app/routers/_helpers.py
@@ -41,13 +41,17 @@ def _get_engine_normalize_bool_flag() -> Callable[[str | bool, set[str] | None],
     Test can monkeypatch this to force fallback without mocking builtins import.
     """
     try:
-        from core.bmi.engine import (
-            _normalize_bool_flag as _engine_normalize_bool_flag,
-        )  # noqa: WPS433
-
-        return _engine_normalize_bool_flag
+        return _import_engine_normalize_bool_flag()
     except ImportError:
         return None
+
+
+def _import_engine_normalize_bool_flag() -> Callable[[str | bool, set[str] | None], bool]:
+    from core.bmi.engine import (
+        _normalize_bool_flag as _engine_normalize_bool_flag,
+    )  # noqa: WPS433
+
+    return _engine_normalize_bool_flag
 
 
 def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) -> bool:
@@ -83,10 +87,9 @@ def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) 
     if not s:
         return False
 
-    # Preserve explicit empty set semantics (set() stays empty).
-    allowed = (
-        {v.strip().lower() for v in yes_values} if yes_values is not None else _DEFAULT_YES_VALUES
-    )
+    # Preserve explicit empty set semantics (set() stays empty) and mirror engine:
+    # custom yes_values are used as-is.
+    allowed = yes_values if yes_values is not None else _DEFAULT_YES_VALUES
     return s in allowed
 
 

--- a/app/routers/_helpers.py
+++ b/app/routers/_helpers.py
@@ -76,7 +76,7 @@ def _build_soft_paywall_hook(lang: str, *, default_enabled: bool) -> "SoftPaywal
 
     IMPORTANT:
     - No BMI-dependent logic.
-    - No imports from core/bmi/*.
+    - Must not depend on BMI calculation modules.
 
     Args:
         lang: Language code for i18n

--- a/app/routers/bmi.py
+++ b/app/routers/bmi.py
@@ -11,17 +11,14 @@ FREE tier endpoint (no API key required).
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 from fastapi import APIRouter, HTTPException, status
 
-from app.routers._helpers import _env_bool
+from app.routers._helpers import _build_soft_paywall_hook, _normalize_bool_flag
 from app.schemas.bmi import (
     BMICalculateRequest,
     BMICalculateResponse,
-    SoftPaywallAvailability,
-    SoftPaywallHook,
-    SoftPaywallMessage,
     WaistRiskResultSchema,
 )
 from app.services.bmi_visualization import build_bmi_scale_v1
@@ -58,81 +55,9 @@ else:
 router = APIRouter(prefix="/api/v1/bmi", tags=["bmi"])
 
 
-# Import canonical normalization from engine (removes duplication).
-# Keep a local fallback for partial checkouts / early-PR staging, but make it testable.
-# TODO(PR-456): Consider making this public API (remove underscore).
-def _fallback_normalize_bool_flag(
-    value: str | bool,
-    yes_values: set[str] | None = None,
-) -> bool:
-    """RU: Fallback на случай, если core недоступен. EN: Fallback if core is unavailable."""
-    if isinstance(value, bool):
-        return value
-    if not isinstance(value, str):
-        return False
-    s = value.strip().lower()
-    if not s:
-        return False
-    allowed = yes_values or {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-    return s in allowed
-
-
-# RU: Тип фиксируем заранее → mypy всегда знает, что возвращается bool.
-# EN: Fix type upfront → mypy always knows return type is bool.
-# Note: Using ... for args to allow optional yes_values parameter
-_normalize_bool_flag: Callable[..., bool] = _fallback_normalize_bool_flag
-
-try:
-    # Импортируем в "временное" имя, потом присваиваем typed-callable
-    from core.bmi.engine import _normalize_bool_flag as _engine_normalize_bool_flag
-
-    _normalize_bool_flag = _engine_normalize_bool_flag
-except ImportError:  # pragma: no cover
-    # Fail-soft: используем fallback
-    pass
-
-
 # Removed _get_lang_from_request() - use core.i18n.normalize_lang() directly
 # This removes duplication and ensures consistent language normalization across the app.
-
-
-def _build_soft_paywall_hook(lang: str) -> SoftPaywallHook | None:
-    """
-    Build text-only soft paywall hook.
-
-    IMPORTANT:
-    - No BMI-dependent logic.
-    - No imports from core/bmi/*.
-    """
-    enabled = _env_bool("SOFT_PAYWALL_ENABLED", default=True)
-    if not enabled:
-        return None
-
-    # Normalize lang defensively (keep it simple; do not introduce logic here)
-    safe_lang = normalize_lang(lang)
-
-    title_key = "soft_paywall.title"
-    body_key = "soft_paywall.body"
-    cta_key = "soft_paywall.cta"
-
-    message = SoftPaywallMessage(
-        lang=safe_lang,
-        title_key=title_key,
-        body_key=body_key,
-        cta_key=cta_key,
-        default_title=t(safe_lang, title_key),
-        default_body=t(safe_lang, body_key),
-        default_cta=t(safe_lang, cta_key),
-    )
-
-    availability = SoftPaywallAvailability(pro_available=True, reason_key=None)
-
-    return SoftPaywallHook(
-        id="bmi.pro_interpretation_v1",
-        message=message,
-        availability=availability,
-        target="pro_paywall",
-    )
+# Removed _normalize_bool_flag and _build_soft_paywall_hook - use shared helpers from _helpers.py
 
 
 async def bmi_calculate_handler(
@@ -239,7 +164,7 @@ async def bmi_calculate_handler(
             resp.visualization = None
 
         # Add soft paywall hook (router layer only, no BMI logic)
-        resp.soft_paywall = _build_soft_paywall_hook(lang=str(req.lang))
+        resp.soft_paywall = _build_soft_paywall_hook(str(req.lang), default_enabled=True)
 
         # Return as dict for legacy compatibility
         # IMPORTANT: use by_alias=True to ensure "from" (not "from_") in JSON

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -7,13 +7,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from app.middleware.api_tiers import require_pro_tier
-from app.routers._helpers import _env_bool
+from app.routers._helpers import _build_soft_paywall_hook, _normalize_bool_flag
 from app.schemas.bmi import (
     BMICalculateProRequest,
     BMICalculateProResponse,
-    SoftPaywallAvailability,
-    SoftPaywallHook,
-    SoftPaywallMessage,
     WaistRiskResultSchema,
 )
 from app.services.bmi_visualization import build_bmi_scale_v1
@@ -71,46 +68,7 @@ def _get_engine_calculator() -> CalculateBmiResult | None:
         return None
 
 
-# Helper functions (same as bmi.py)
-def _normalize_bool_flag(value: str | bool, yes_values: set[str] | None = None) -> bool:
-    """Normalize boolean flag from string or bool."""
-    if isinstance(value, bool):
-        return value
-    if not isinstance(value, str):
-        return False
-    s = value.strip().lower()
-    if not s:
-        return False
-    allowed = yes_values or {"yes", "y", "true", "1", "да", "д", "si", "sí"}
-    return s in allowed
-
-
-def _build_soft_paywall_hook(lang: str) -> SoftPaywallHook | None:
-    """Build text-only soft paywall hook (no BMI logic)."""
-    enabled = _env_bool("SOFT_PAYWALL_ENABLED", default=False)
-    if not enabled:
-        return None
-
-    safe_lang = normalize_lang(lang)
-
-    message = SoftPaywallMessage(
-        lang=safe_lang,
-        title_key="soft_paywall.title",
-        body_key="soft_paywall.body",
-        cta_key="soft_paywall.cta",
-        default_title=t(safe_lang, "soft_paywall.title"),
-        default_body=t(safe_lang, "soft_paywall.body"),
-        default_cta=t(safe_lang, "soft_paywall.cta"),
-    )
-
-    availability = SoftPaywallAvailability(pro_available=True, reason_key=None)
-
-    return SoftPaywallHook(
-        id="bmi.pro_interpretation_v1",
-        message=message,
-        availability=availability,
-        target="pro_paywall",
-    )
+# Helper functions moved to app.routers._helpers (shared across FREE and PRO routers)
 
 
 router = APIRouter(prefix="/api/v1/pro", tags=["pro"])
@@ -348,7 +306,7 @@ async def calculate_bmi_pro(req: BMICalculateProRequest) -> BMICalculateProRespo
 
     # Build soft paywall hook (same logic as FREE endpoint)
     # Note: _build_soft_paywall_hook checks SOFT_PAYWALL_ENABLED internally
-    soft_paywall_hook = _build_soft_paywall_hook(lang)
+    soft_paywall_hook = _build_soft_paywall_hook(lang, default_enabled=False)
 
     # Map to PRO API response (includes whr)
     resp = BMICalculateProResponse(

--- a/tests/test_bmi_endpoint_diff_coverage.py
+++ b/tests/test_bmi_endpoint_diff_coverage.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 
 from app.routers import bmi as bmi_router
+from app.routers._helpers import _normalize_bool_flag
 from app.schemas.bmi import BMICalculateRequest, BMICalculateResponse
 from core.bmi.engine import BMICalculateResult, calculate_bmi_result
 from core.i18n import t
@@ -39,9 +40,7 @@ def test_engine_returns_result_after_implementation() -> None:
     assert result.category == "normal"
 
 
-def test_fallback_normalize_bool_flag() -> None:
-    from app.routers._helpers import _normalize_bool_flag
-
+def test_normalize_bool_flag() -> None:
     assert _normalize_bool_flag(True) is True
     assert _normalize_bool_flag(False) is False
 

--- a/tests/test_bmi_endpoint_diff_coverage.py
+++ b/tests/test_bmi_endpoint_diff_coverage.py
@@ -40,22 +40,24 @@ def test_engine_returns_result_after_implementation() -> None:
 
 
 def test_fallback_normalize_bool_flag() -> None:
-    assert bmi_router._fallback_normalize_bool_flag(True) is True
-    assert bmi_router._fallback_normalize_bool_flag(False) is False
+    from app.routers._helpers import _normalize_bool_flag
+
+    assert _normalize_bool_flag(True) is True
+    assert _normalize_bool_flag(False) is False
 
     # Fail-soft: non-boolean/non-string inputs return False rather than raising.
-    assert bmi_router._fallback_normalize_bool_flag(123) is False  # type: ignore[arg-type]
+    assert _normalize_bool_flag(123) is False  # type: ignore[arg-type]
 
     # Empty/whitespace string → False
-    assert bmi_router._fallback_normalize_bool_flag("   ") is False
+    assert _normalize_bool_flag("   ") is False
 
     # Default allowed values
-    assert bmi_router._fallback_normalize_bool_flag("да") is True
-    assert bmi_router._fallback_normalize_bool_flag("no") is False
+    assert _normalize_bool_flag("да") is True
+    assert _normalize_bool_flag("no") is False
 
     # Custom allowlist
-    assert bmi_router._fallback_normalize_bool_flag("ok", yes_values={"ok"}) is True
-    assert bmi_router._fallback_normalize_bool_flag("yes", yes_values={"ok"}) is False
+    assert _normalize_bool_flag("ok", yes_values={"ok"}) is True
+    assert _normalize_bool_flag("yes", yes_values={"ok"}) is False
 
 
 @pytest.mark.anyio

--- a/tests/test_bmi_pro_endpoint_errors.py
+++ b/tests/test_bmi_pro_endpoint_errors.py
@@ -327,8 +327,8 @@ class TestProEndpointHelperFunctions:
         assert _normalize_bool_flag(True) is True
         assert _normalize_bool_flag(False) is False
         # Test with int (not bool, not str)
-        assert _normalize_bool_flag(0) is False
-        assert _normalize_bool_flag(1) is False
+        assert _normalize_bool_flag(cast("str | bool", 0)) is False
+        assert _normalize_bool_flag(cast("str | bool", 1)) is False
         # Test with None
         assert _normalize_bool_flag(cast("str | bool", None)) is False
         # Test with empty string

--- a/tests/test_bmi_pro_endpoint_errors.py
+++ b/tests/test_bmi_pro_endpoint_errors.py
@@ -41,13 +41,15 @@ class TestProEndpointErrorHandling:
         calc = bmi_pro._get_engine_calculator()
         assert calc is not None
 
-        assert bmi_pro._normalize_bool_flag(True) is True
-        assert bmi_pro._normalize_bool_flag(False) is False
-        assert bmi_pro._normalize_bool_flag("да") is True
-        assert bmi_pro._normalize_bool_flag("nope") is False
+        from app.routers._helpers import _build_soft_paywall_hook, _normalize_bool_flag
+
+        assert _normalize_bool_flag(True) is True
+        assert _normalize_bool_flag(False) is False
+        assert _normalize_bool_flag("да") is True
+        assert _normalize_bool_flag("nope") is False
 
         monkeypatch.setenv("SOFT_PAYWALL_ENABLED", "true")
-        assert bmi_pro._build_soft_paywall_hook("en", default_enabled=False) is not None
+        assert _build_soft_paywall_hook("en", default_enabled=False) is not None
 
         req = BMICalculateProRequest(
             weight_kg=70.0,

--- a/tests/test_bmi_pro_endpoint_errors.py
+++ b/tests/test_bmi_pro_endpoint_errors.py
@@ -47,7 +47,7 @@ class TestProEndpointErrorHandling:
         assert bmi_pro._normalize_bool_flag("nope") is False
 
         monkeypatch.setenv("SOFT_PAYWALL_ENABLED", "true")
-        assert bmi_pro._build_soft_paywall_hook("en") is not None
+        assert bmi_pro._build_soft_paywall_hook("en", default_enabled=False) is not None
 
         req = BMICalculateProRequest(
             weight_kg=70.0,
@@ -309,50 +309,50 @@ class TestProEndpointHelperFunctions:
         assert "detail" in data
 
     def test_env_bool_default_return(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test _env_bool returns default for invalid values (covers line 77)."""
-        from app.routers import bmi_pro
+        """Test _env_bool returns default for invalid values."""
+        from app.routers._helpers import _env_bool
 
         # Set invalid value
         monkeypatch.setenv("TEST_ENV_BOOL", "invalid")
-        result = bmi_pro._env_bool("TEST_ENV_BOOL", default=True)
+        result = _env_bool("TEST_ENV_BOOL", default=True)
         assert result is True  # Should return default for invalid value
 
     def test_normalize_bool_flag_non_str_non_bool(self) -> None:
-        """Test _normalize_bool_flag with non-str, non-bool input (covers lines 82-90)."""
-        from app.routers import bmi_pro
+        """Test _normalize_bool_flag with non-str, non-bool input."""
+        from app.routers._helpers import _normalize_bool_flag
 
-        # Test with bool (covers line 83)
-        assert bmi_pro._normalize_bool_flag(True) is True
-        assert bmi_pro._normalize_bool_flag(False) is False
+        # Test with bool
+        assert _normalize_bool_flag(True) is True
+        assert _normalize_bool_flag(False) is False
         # Test with int (not bool, not str)
-        assert bmi_pro._normalize_bool_flag(0) is False
-        assert bmi_pro._normalize_bool_flag(1) is False
+        assert _normalize_bool_flag(0) is False
+        assert _normalize_bool_flag(1) is False
         # Test with None
-        assert bmi_pro._normalize_bool_flag(cast("str | bool", None)) is False
+        assert _normalize_bool_flag(cast("str | bool", None)) is False
         # Test with empty string
-        assert bmi_pro._normalize_bool_flag("") is False
+        assert _normalize_bool_flag("") is False
         # Test with whitespace-only string
-        assert bmi_pro._normalize_bool_flag("   ") is False
-        # Test with default yes_values (covers lines 89-90: default set)
-        assert bmi_pro._normalize_bool_flag("yes") is True
-        assert bmi_pro._normalize_bool_flag("y") is True
-        assert bmi_pro._normalize_bool_flag("true") is True
-        assert bmi_pro._normalize_bool_flag("1") is True
-        assert bmi_pro._normalize_bool_flag("да") is True
-        assert bmi_pro._normalize_bool_flag("д") is True
-        assert bmi_pro._normalize_bool_flag("si") is True
-        assert bmi_pro._normalize_bool_flag("sí") is True
-        # Test with custom yes_values (covers lines 89-90)
+        assert _normalize_bool_flag("   ") is False
+        # Test with default yes_values
+        assert _normalize_bool_flag("yes") is True
+        assert _normalize_bool_flag("y") is True
+        assert _normalize_bool_flag("true") is True
+        assert _normalize_bool_flag("1") is True
+        assert _normalize_bool_flag("да") is True
+        assert _normalize_bool_flag("д") is True
+        assert _normalize_bool_flag("si") is True
+        assert _normalize_bool_flag("sí") is True
+        # Test with custom yes_values
         custom_yes = {"custom", "yes"}
-        assert bmi_pro._normalize_bool_flag("custom", yes_values=custom_yes) is True
-        assert bmi_pro._normalize_bool_flag("no", yes_values=custom_yes) is False
+        assert _normalize_bool_flag("custom", yes_values=custom_yes) is True
+        assert _normalize_bool_flag("no", yes_values=custom_yes) is False
 
     def test_build_soft_paywall_hook_disabled_returns_none(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test _build_soft_paywall_hook returns None when disabled (covers line 97)."""
-        from app.routers import bmi_pro
+        """Test _build_soft_paywall_hook returns None when disabled."""
+        from app.routers._helpers import _build_soft_paywall_hook
 
         monkeypatch.setenv("SOFT_PAYWALL_ENABLED", "false")
-        result = bmi_pro._build_soft_paywall_hook("en")
+        result = _build_soft_paywall_hook("en", default_enabled=False)
         assert result is None

--- a/tests/test_no_bmi_logic_in_paywall.py
+++ b/tests/test_no_bmi_logic_in_paywall.py
@@ -18,13 +18,10 @@ def test_soft_paywall_builder_does_not_import_core_bmi() -> None:
     This ensures hook builder stays in router/adapter layer only,
     with no BMI logic dependencies.
     """
-    import app.routers.bmi as bmi_router
+    from app.routers._helpers import _build_soft_paywall_hook
 
-    # Get source of the specific function, not the whole module
-    func = getattr(bmi_router, "_build_soft_paywall_hook", None)
-    assert func is not None, "_build_soft_paywall_hook function not found"
-
-    src = inspect.getsource(func)
+    # Get source of the shared helper function
+    src = inspect.getsource(_build_soft_paywall_hook)
     # Check that _build_soft_paywall_hook doesn't import core/bmi
     assert "from core.bmi" not in src
     assert "import core.bmi" not in src

--- a/tests/test_no_bmi_logic_in_paywall.py
+++ b/tests/test_no_bmi_logic_in_paywall.py
@@ -9,6 +9,64 @@ EN: Guard test: soft paywall hook builder must not import core/bmi/*.
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+HELPERS = ROOT / "app" / "routers" / "_helpers.py"
+BMI_ROUTER = ROOT / "app" / "routers" / "bmi.py"
+BMI_PRO_ROUTER = ROOT / "app" / "routers" / "bmi_pro.py"
+
+
+def _read(p: Path) -> str:
+    """Read file content."""
+    return p.read_text(encoding="utf-8")
+
+
+def test_soft_paywall_hook_has_no_core_bmi_imports() -> None:
+    """
+    Guard: soft-paywall hook must remain text-only router helper.
+
+    - No imports from core.bmi / core/bmi/*
+    """
+    # Read the file and extract only the _build_soft_paywall_hook function
+    # (inspect.getsource may include surrounding context)
+    full_src = _read(HELPERS)
+
+    # Find the function definition and extract its body
+    start_idx = full_src.find("def _build_soft_paywall_hook")
+    assert start_idx != -1, "_build_soft_paywall_hook function not found in _helpers.py"
+
+    # Extract from function start to next function or end of file
+    remaining = full_src[start_idx:]
+    # Find the next function definition (if any)
+    next_def = remaining.find("\ndef ", 1)  # Skip the current def
+    if next_def != -1:
+        func_src = remaining[:next_def]
+    else:
+        func_src = remaining
+
+    # Check that _build_soft_paywall_hook doesn't import core/bmi
+    assert "from core.bmi" not in func_src, "Soft paywall hook must not import from core.bmi"
+    assert "import core.bmi" not in func_src, "Soft paywall hook must not import core.bmi"
+
+
+def test_routers_do_not_define_local_soft_paywall_hook() -> None:
+    """
+    Guard: routers must not carry local copies of _build_soft_paywall_hook.
+
+    They must import it from app.routers._helpers so guard covers runtime path.
+    """
+    for router_path in (BMI_ROUTER, BMI_PRO_ROUTER):
+        src = _read(router_path)
+
+        assert "def _build_soft_paywall_hook" not in src, (
+            f"{router_path} defines local _build_soft_paywall_hook — "
+            "must be removed and replaced with shared helper import"
+        )
+        assert (
+            "from app.routers._helpers import _build_soft_paywall_hook" in src
+        ), f"{router_path} must import _build_soft_paywall_hook from app.routers._helpers"
 
 
 def test_soft_paywall_builder_does_not_import_core_bmi() -> None:
@@ -17,6 +75,8 @@ def test_soft_paywall_builder_does_not_import_core_bmi() -> None:
 
     This ensures hook builder stays in router/adapter layer only,
     with no BMI logic dependencies.
+
+    Note: This test validates the shared helper function directly.
     """
     from app.routers._helpers import _build_soft_paywall_hook
 

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -155,6 +155,36 @@ class TestNormalizeBoolFlag:
         assert _helpers._normalize_bool_flag("") is False
         assert _helpers._normalize_bool_flag("   ") is False
 
+    def test_normalize_bool_flag_custom_yes_values_are_case_sensitive_like_engine(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that custom yes_values are case-sensitive like engine (no normalization)."""
+        # Force fallback to test fallback behavior matches engine
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        # Engine uses yes_values as-is, so mixed-case should not match normalized input
+        assert _helpers._normalize_bool_flag("yes", yes_values={"YES"}) is False
+        # Input is normalized to "yes", but set contains "YES" (case-sensitive)
+        assert (
+            _helpers._normalize_bool_flag("YES", yes_values={"YES"}) is False
+        )  # normalized to "yes"
+        # Only exact match (after input normalization) works
+        assert _helpers._normalize_bool_flag("yes", yes_values={"yes"}) is True
+
+    def test_get_engine_normalize_bool_flag_returns_none_on_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _get_engine_normalize_bool_flag returns None on ImportError."""
+
+        # Mock _import_engine_normalize_bool_flag to raise ImportError
+        def _raise() -> object:
+            raise ImportError("Simulated import error")
+
+        monkeypatch.setattr(_helpers, "_import_engine_normalize_bool_flag", _raise)
+
+        result = _helpers._get_engine_normalize_bool_flag()
+        assert result is None
+
 
 class TestBuildSoftPaywallHook:
     """Tests for _build_soft_paywall_hook helper."""

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -104,6 +104,33 @@ class TestNormalizeBoolFlag:
         assert _helpers._normalize_bool_flag("sí") is True
         assert _helpers._normalize_bool_flag("no") is False
 
+    def test_normalize_bool_flag_fallback_bool_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test fallback path handles bool values correctly."""
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        assert _helpers._normalize_bool_flag(True) is True
+        assert _helpers._normalize_bool_flag(False) is False
+
+    def test_normalize_bool_flag_fallback_non_str_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fallback path handles non-str, non-bool values correctly."""
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        from typing import cast
+
+        assert _helpers._normalize_bool_flag(cast("str | bool", 0)) is False
+        assert _helpers._normalize_bool_flag(cast("str | bool", None)) is False
+
+    def test_normalize_bool_flag_fallback_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fallback path handles empty/whitespace strings correctly."""
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        assert _helpers._normalize_bool_flag("") is False
+        assert _helpers._normalize_bool_flag("   ") is False
+
 
 class TestBuildSoftPaywallHook:
     """Tests for _build_soft_paywall_hook helper."""

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for shared router helpers.
+
+RU: Тесты для общих вспомогательных функций роутеров.
+EN: Tests for shared router helper functions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.routers import _helpers
+
+
+class TestEnvBool:
+    """Tests for _env_bool helper."""
+
+    def test_env_bool_default_when_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test _env_bool returns default when env var is not set."""
+        monkeypatch.delenv("X_TEST_BOOL", raising=False)
+        assert _helpers._env_bool("X_TEST_BOOL", default=True) is True
+        assert _helpers._env_bool("X_TEST_BOOL", default=False) is False
+
+    @pytest.mark.parametrize("raw", ["1", "true", "t", "yes", "y", "on", " TRUE "])
+    def test_env_bool_true_values(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """Test _env_bool recognizes truthy values."""
+        monkeypatch.setenv("X_TEST_BOOL", raw)
+        assert _helpers._env_bool("X_TEST_BOOL", default=False) is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "f", "no", "n", "off", " FALSE "])
+    def test_env_bool_false_values(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """Test _env_bool recognizes falsey values."""
+        monkeypatch.setenv("X_TEST_BOOL", raw)
+        assert _helpers._env_bool("X_TEST_BOOL", default=True) is False
+
+    def test_env_bool_garbage_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test _env_bool falls back to default for unrecognized values."""
+        monkeypatch.setenv("X_TEST_BOOL", "maybe")
+        assert _helpers._env_bool("X_TEST_BOOL", default=True) is True
+        assert _helpers._env_bool("X_TEST_BOOL", default=False) is False
+
+
+class TestNormalizeBoolFlag:
+    """Tests for _normalize_bool_flag helper."""
+
+    def test_normalize_bool_flag_engine_path_smoke(self) -> None:
+        """Test _normalize_bool_flag happy path (uses engine implementation)."""
+        assert _helpers._normalize_bool_flag(True) is True
+        assert _helpers._normalize_bool_flag(False) is False
+        assert _helpers._normalize_bool_flag("yes") is True
+        assert _helpers._normalize_bool_flag("no") is False
+
+    def test_normalize_bool_flag_empty_set_preserved(self) -> None:
+        """Test that empty yes_values set() is preserved (not replaced with default)."""
+        # Empty set means no values match (engine uses yes_values as-is)
+        assert _helpers._normalize_bool_flag("yes", yes_values=set()) is False
+        assert _helpers._normalize_bool_flag("y", yes_values=set()) is False
+
+    def test_normalize_bool_flag_custom_yes_values(self) -> None:
+        """Test that custom yes_values work correctly."""
+        # Custom set should work (engine uses yes_values as-is, input is normalized)
+        assert _helpers._normalize_bool_flag("yes", yes_values={"yes", "ok"}) is True
+        assert _helpers._normalize_bool_flag("ok", yes_values={"yes", "ok"}) is True
+        assert _helpers._normalize_bool_flag("no", yes_values={"yes", "ok"}) is False
+
+    def test_normalize_bool_flag_non_str_non_bool(self) -> None:
+        """Test _normalize_bool_flag with non-str, non-bool input."""
+        from typing import cast
+
+        # Test with int (not bool, not str)
+        assert _helpers._normalize_bool_flag(cast("str | bool", 0)) is False
+        assert _helpers._normalize_bool_flag(cast("str | bool", 1)) is False
+        # Test with None
+        assert _helpers._normalize_bool_flag(cast("str | bool", None)) is False
+        # Test with empty string
+        assert _helpers._normalize_bool_flag("") is False
+        # Test with whitespace-only string
+        assert _helpers._normalize_bool_flag("   ") is False
+
+    def test_normalize_bool_flag_default_yes_values(self) -> None:
+        """Test _normalize_bool_flag with default yes_values."""
+        assert _helpers._normalize_bool_flag("yes") is True
+        assert _helpers._normalize_bool_flag("y") is True
+        assert _helpers._normalize_bool_flag("true") is True
+        assert _helpers._normalize_bool_flag("1") is True
+        assert _helpers._normalize_bool_flag("да") is True
+        assert _helpers._normalize_bool_flag("д") is True
+        assert _helpers._normalize_bool_flag("si") is True
+        assert _helpers._normalize_bool_flag("sí") is True
+        assert _helpers._normalize_bool_flag("no") is False
+
+
+class TestBuildSoftPaywallHook:
+    """Tests for _build_soft_paywall_hook helper."""
+
+    @pytest.mark.parametrize(
+        ("default_enabled", "expected"),
+        [(True, True), (False, False)],
+    )
+    def test_soft_paywall_default_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, default_enabled: bool, expected: bool
+    ) -> None:
+        """Test _build_soft_paywall_hook respects default_enabled when env var is not set."""
+        monkeypatch.delenv("SOFT_PAYWALL_ENABLED", raising=False)
+        hook = _helpers._build_soft_paywall_hook("en", default_enabled=default_enabled)
+        assert (hook is not None) is expected
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            ("1", True),
+            ("true", True),
+            ("yes", True),
+            ("on", True),
+            ("0", False),
+            ("false", False),
+            ("no", False),
+            ("off", False),
+        ],
+    )
+    def test_soft_paywall_env_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch, env_value: str, expected: bool
+    ) -> None:
+        """Test _build_soft_paywall_hook env var overrides default_enabled."""
+        monkeypatch.setenv("SOFT_PAYWALL_ENABLED", env_value)
+        hook = _helpers._build_soft_paywall_hook("en", default_enabled=False)
+        assert (hook is not None) is expected
+
+    def test_soft_paywall_shape_when_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test _build_soft_paywall_hook returns correct structure when enabled."""
+        monkeypatch.setenv("SOFT_PAYWALL_ENABLED", "1")
+        hook = _helpers._build_soft_paywall_hook("en", default_enabled=False)
+        assert hook is not None
+        assert hook.id == "bmi.pro_interpretation_v1"
+        assert hook.target == "pro_paywall"
+        assert hook.message.title_key == "soft_paywall.title"
+        assert hook.message.body_key == "soft_paywall.body"
+        assert hook.message.cta_key == "soft_paywall.cta"
+        assert hook.availability.pro_available is True
+
+    def test_soft_paywall_disabled_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test _build_soft_paywall_hook returns None when disabled."""
+        monkeypatch.setenv("SOFT_PAYWALL_ENABLED", "0")
+        hook = _helpers._build_soft_paywall_hook("en", default_enabled=True)
+        assert hook is None

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -51,11 +51,25 @@ class TestNormalizeBoolFlag:
         assert _helpers._normalize_bool_flag("yes") is True
         assert _helpers._normalize_bool_flag("no") is False
 
-    def test_normalize_bool_flag_empty_set_preserved(self) -> None:
+    def test_normalize_bool_flag_empty_set_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that empty yes_values set() is preserved (not replaced with default)."""
-        # Empty set means no values match (engine uses yes_values as-is)
+        # Force fallback path to test fallback behavior
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        # Empty set means no values match (fallback preserves empty set)
         assert _helpers._normalize_bool_flag("yes", yes_values=set()) is False
         assert _helpers._normalize_bool_flag("y", yes_values=set()) is False
+
+    def test_normalize_bool_flag_fallback_accepts_russian_istina(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fallback accepts Russian 'истина' token (aligned with engine defaults)."""
+        # Force fallback without mocking builtins import
+        monkeypatch.setattr(_helpers, "_get_engine_normalize_bool_flag", lambda: None)
+
+        assert _helpers._normalize_bool_flag("истина") is True
+        assert _helpers._normalize_bool_flag(" ИСТИНА ") is True  # with whitespace
+        assert _helpers._normalize_bool_flag("ИСТИНА") is True  # uppercase
 
     def test_normalize_bool_flag_custom_yes_values(self) -> None:
         """Test that custom yes_values work correctly."""

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -8,6 +8,8 @@ EN: Tests for shared router helper functions.
 
 from __future__ import annotations
 
+from typing import NoReturn
+
 import pytest
 
 from app.routers import _helpers
@@ -177,7 +179,7 @@ class TestNormalizeBoolFlag:
         """Test _get_engine_normalize_bool_flag returns None on ImportError."""
 
         # Mock _import_engine_normalize_bool_flag to raise ImportError
-        def _raise() -> object:
+        def _raise() -> NoReturn:
             raise ImportError("Simulated import error")
 
         monkeypatch.setattr(_helpers, "_import_engine_normalize_bool_flag", _raise)

--- a/tests/test_router_helpers.py
+++ b/tests/test_router_helpers.py
@@ -51,6 +51,30 @@ class TestNormalizeBoolFlag:
         assert _helpers._normalize_bool_flag("yes") is True
         assert _helpers._normalize_bool_flag("no") is False
 
+    def test_normalize_bool_flag_delegates_to_engine_when_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _normalize_bool_flag delegates to engine when engine is available."""
+        # Arrange: spy on engine's _normalize_bool_flag to verify delegation
+        import core.bmi.engine as engine
+
+        called = {"count": 0}
+
+        def spy(value: str | bool, yes_values: set[str] | None = None) -> bool:
+            called["count"] += 1
+            # Return True to verify engine path was taken
+            return True
+
+        # Patch engine's function (not builtins.__import__, so this is allowed)
+        monkeypatch.setattr(engine, "_normalize_bool_flag", spy, raising=True)
+
+        # Act: call through helpers (should delegate to engine)
+        result = _helpers._normalize_bool_flag("whatever")
+
+        # Assert: engine function was called and result is from engine
+        assert result is True
+        assert called["count"] == 1
+
     def test_normalize_bool_flag_empty_set_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that empty yes_values set() is preserved (not replaced with default)."""
         # Force fallback path to test fallback behavior


### PR DESCRIPTION
- Add _normalize_bool_flag with core-first + fallback approach
- Add _build_soft_paywall_hook with default_enabled parameter
- Use lazy imports to avoid circular dependencies
- Ensures consistent normalization across FREE and PRO routers

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Вынесены общие вспомогательные функции BMI для нормализации булевых флагов и конструирования soft paywall hook в общий модуль helpers с сохранением границ только для адаптера.

New Features:
- Добавлен общий помощник `_normalize_bool_flag`, который делегирует работу ядру BMI engine с локальным запасным вариантом для разработки и тестирования.
- Добавлен общий помощник `_build_soft_paywall_hook`, который строит текстовый soft paywall hook, управляемый флагом окружения.

Enhancements:
- Централизована логика вспомогательных функций, связанных с BMI, в `app.routers._helpers`, чтобы обеспечить единообразное поведение во FREE и PRO роутерах и избежать циклических зависимостей с помощью ленивых импортов.

Tests:
- Обновлён тест изоляции paywall, чтобы он был нацелен на общий помощник `_build_soft_paywall_hook` и по‑прежнему проверял отсутствие зависимостей от `core.bmi`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared BMI router helpers for boolean flag normalization and soft paywall hook construction into the common helpers module while preserving adapter-only boundaries.

New Features:
- Add a shared _normalize_bool_flag helper that delegates to the core BMI engine with a local fallback for development and testing.
- Add a shared _build_soft_paywall_hook helper that builds a text-only soft paywall hook controlled by an environment flag.

Enhancements:
- Centralize BMI-related helper logic in app.routers._helpers to ensure consistent behavior across FREE and PRO routers and avoid circular dependencies via lazy imports.

Tests:
- Update the paywall isolation test to target the shared _build_soft_paywall_hook helper and continue asserting that it has no core.bmi dependencies.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft paywall messaging added with multi-language text and configurable defaults.

* **Improvements**
  * Centralized paywall and boolean-flag handling with Free default enabled and Pro default disabled; lazy loading ensures behavior when optional components are absent.

* **Tests**
  * New tests enforce isolation of paywall-builder from core calculation logic and validate boolean and paywall behavior across many cases.

* **Documentation**
  * Router helper policy and guidelines added (duplicated block).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->