### PR TITLE
fix(security): suppress glibc CVE-2025-15281 (Trivy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -996,6 +996,7 @@ git grep -nE "spec_from_file_location|exec_module|sys\.modules\[" -- scripts || 
 - Prefer `trivy/ignore-policy.rego` (scoped by package + version + context fields where possible).
 - `.trivyignore` is for legacy/minimal ignores; do not rely on it for expiry monitoring.
 - CI uses `TRIVY_IGNORE_POLICY_PATH` to point to active policy file(s); expiry enforcement runs `scripts/ci/check_trivy_ignore_policy_expiry.py`.
+- **Runner version drift policy:** If base image/version varies across CI runners (e.g., `deb12u10` vs `deb12u13`), add **allowlist of observed versions** in suppression rules, not wildcards. Example: use helper rules matching `u10` and `u13` explicitly, not `deb12u*` pattern. Rationale: Prevents accidental suppression of future versions (u14/u15) that may have fixes available.
 
 **Security PR scoping:**
 

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -1,0 +1,59 @@
+# CVE-2025-15281: glibc vulnerability in Debian bookworm (CI runner)
+
+**Status:** UNFIXED in Debian bookworm at time of suppression (see Monitor link)
+**Severity:** UNKNOWN (as reported by Trivy at time of suppression)
+**Suppression Expires:** 2026-03-01
+**Monitor:** <https://security-tracker.debian.org/tracker/CVE-2025-15281>
+
+---
+
+## Summary
+
+Trivy reports `CVE-2025-15281` against the system `glibc` packages used by our CI environment.
+This is a **system library vulnerability**, not application code.
+
+At time of suppression, there is **no actionable remediation in this repo** because the affected
+packages are part of the GitHub-hosted runner base image (Debian bookworm, `deb12u13`), not a
+dependency we directly control.
+
+This document captures the rationale for a temporary suppression and how to monitor for removal.
+
+---
+
+## What Is Suppressed
+
+Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.rego`:
+
+- `CVE-2025-15281`
+- Packages: `libc6`, `libc-bin`
+- Installed version: `2.36-9+deb12u13`
+
+---
+
+## Rationale
+
+- **Upstream/Distro:** Unfixed at time of suppression (see Debian tracker).
+- **Control surface:** The vulnerable packages are in the CI runner base image; we cannot patch them
+  from this repository.
+- **Scope-limited:** Suppression applies only to the specific packages + installed version observed.
+
+---
+
+## Monitoring And Removal Plan
+
+1. Monitor Debian Security Tracker weekly:
+   <https://security-tracker.debian.org/tracker/CVE-2025-15281>
+2. When Debian bookworm shows a fixed version and the runner image updates:
+   - Remove the `CVE-2025-15281` rules from `trivy/ignore-policy.rego`.
+   - Re-run Trivy to confirm the finding is resolved without suppression.
+
+---
+
+## References
+
+- [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2025-15281)
+
+---
+
+**Last updated:** 2026-01-21
+**Review cadence:** Weekly (e.g., Fridays) as part of Security triage routine

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -26,7 +26,7 @@ Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.r
 
 - `CVE-2025-15281`
 - Packages: `libc6`, `libc-bin`
-- Installed version: `2.36-9+deb12u13`
+- Observed versions: `2.36-9+deb12u10`, `2.36-9+deb12u13` (GitHub runner base image variants)
 
 ---
 

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -1,7 +1,7 @@
 # CVE-2025-15281: glibc vulnerability in Debian bookworm (CI runner)
 
 **Status:** UNFIXED in Debian bookworm at time of suppression (see Monitor link)
-**Severity:** UNKNOWN (as reported by Trivy at time of suppression)
+**Severity:** Minor (per Debian Security Tracker)
 **Suppression Expires:** 2026-03-01
 **Monitor:** <https://security-tracker.debian.org/tracker/CVE-2025-15281>
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -9,7 +9,7 @@ default ignore := false
 # - Limit to the installed versions reported at time of suppression
 #
 # Suppression expires: 2026-03-01 (manual removal)
-# Documented in: docs/security/CVE-2026-0915-glibc.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -20,6 +20,26 @@ ignore if {
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
+	input.PkgName == "libc-bin"
+	input.InstalledVersion == "2.36-9+deb12u13"
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+}
+
+# CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image
+# Review-by: 2026-03-01 (manual removal)
+# Rationale: Upstream unfixed; GitHub runner base image (deb12u13); no actionable remediation in repo
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
+# Documented in: docs/security/CVE-2025-15281-glibc.md
+
+ignore if {
+	input.VulnerabilityID == "CVE-2025-15281"
+	input.PkgName == "libc6"
+	input.InstalledVersion == "2.36-9+deb12u13"
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2025-15281"
 	input.PkgName == "libc-bin"
 	input.InstalledVersion == "2.36-9+deb12u13"
 	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -27,13 +27,30 @@ ignore if {
 
 # CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image
 # Review-by: 2026-03-01 (manual removal)
-# Rationale: Upstream unfixed; GitHub runner base image (deb12u13); no actionable remediation in repo
+# Rationale: Upstream unfixed; GitHub runner base image (deb12u10/deb12u13); no actionable remediation in repo
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
 # Documented in: docs/security/CVE-2025-15281-glibc.md
 
-# Helper rule: check if PkgID matches allowed glibc packages
+# Helper rule: check if InstalledVersion matches observed runner versions
+cve_2025_15281_version_match if {
+	input.InstalledVersion == "2.36-9+deb12u10"
+}
+
+cve_2025_15281_version_match if {
+	input.InstalledVersion == "2.36-9+deb12u13"
+}
+
+# Helper rule: check if PkgID matches allowed glibc packages (both u10 and u13)
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc6@2.36-9+deb12u10")
+}
+
 cve_2025_15281_pkgid_match if {
 	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u10")
 }
 
 cve_2025_15281_pkgid_match if {
@@ -44,6 +61,6 @@ ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
 	allowed_packages := {"libc6", "libc-bin"}
 	allowed_packages[input.PkgName]
-	input.InstalledVersion == "2.36-9+deb12u13"
+	cve_2025_15281_version_match
 	cve_2025_15281_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -31,10 +31,19 @@ ignore if {
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
 # Documented in: docs/security/CVE-2025-15281-glibc.md
 
+# Helper rule: check if PkgID matches allowed glibc packages
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
 	allowed_packages := {"libc6", "libc-bin"}
 	allowed_packages[input.PkgName]
 	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc6@2.36-9+deb12u13") or startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+	cve_2025_15281_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -33,14 +33,8 @@ ignore if {
 
 ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
-	input.PkgName == "libc6"
+	allowed_packages := {"libc6", "libc-bin"}
+	allowed_packages[input.PkgName]
 	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
-}
-
-ignore if {
-	input.VulnerabilityID == "CVE-2025-15281"
-	input.PkgName == "libc-bin"
-	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13") or startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
 }


### PR DESCRIPTION
Dedicated security-only PR per repo policy.

- Adds narrow Trivy ignore-policy rules for CVE-2025-15281 in glibc (libc6/libc-bin 2.36-9+deb12u13).
- Adds documentation: docs/security/CVE-2025-15281-glibc.md (rationale + monitoring plan).

Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
Review-by: 2026-03-01

## Summary by Sourcery

Добавить временное, привязанное к версии подавление Trivy для уязвимости glibc CVE-2025-15281 в базовом образе CI‑runner'а и задокументировать обоснование и план мониторинга.

Исправления ошибок:
- Подавить шумные находки Trivy для glibc CVE-2025-15281, которые нельзя устранить в рамках данного репозитория.

Улучшения:
- Расширить существующую политику игнорирования Trivy узко сфокусированными, зависящими от версии правилами для glibc CVE-2025-15281.
- Уточнить документацию по безопасности, добавив отдельную заметку для CVE-2025-15281 и сославшись на неё из существующей политики игнорирования.

Документация:
- Добавить заметку по безопасности, описывающую CVE-2025-15281 в glibc, включая обоснование, область подавления и план мониторинга/удаления.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a temporary, version-pinned Trivy suppression for glibc CVE-2025-15281 in the CI runner base image and document the rationale and monitoring plan.

Bug Fixes:
- Suppress noisy Trivy findings for glibc CVE-2025-15281 that cannot be remediated within this repository.

Enhancements:
- Extend the existing Trivy ignore policy with narrowly scoped, version-specific rules for glibc CVE-2025-15281.
- Clarify security documentation by adding a dedicated note for CVE-2025-15281 and referencing it from the existing ignore policy.

Documentation:
- Add a security note documenting CVE-2025-15281 in glibc, including rationale, scope of suppression, and monitoring/removal plan.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for suppressing CVE-2025-15281, including status, severity, rationale, suppression expiry, monitoring cadence, and references.

* **Chores**
  * Updated security-scan suppressions to narrowly ignore the CI runner's system-library vulnerability and documented monitoring/removal procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->