### PR TITLE
feat(ios): thin HTTP adapter for BMI (transport layer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,59 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - Shared schemas: `app/schemas/` are the source of truth; coordinate breaking changes with clients.
 - Auth and tiers: API key + user sessions; VIP/Pro tier routing enforced in middleware.
 
+## Thin HTTP Adapter Policy (Hard Rule)
+
+**Invariant:** Clients (iOS/Web) must be **thin adapters only** — zero business logic, only transport/contract/UX.
+
+**Forbidden on clients:**
+
+- ❌ Any BMI/waist/risk calculation formulas (thresholds, categories, interpretations)
+- ❌ Any business logic that duplicates backend domain rules
+- ❌ Any "smart" inference or computation from API responses (only display as-is)
+- ❌ Manual DTO types that duplicate backend schemas (use OpenAPI-generated types)
+
+**Allowed on clients:**
+
+- ✅ HTTP transport layer (baseURL, headers, JSON encode/decode, timeouts, retries)
+- ✅ Error envelope mapping (422/400/5xx → UI-friendly messages)
+- ✅ i18n localization of backend-provided keys
+- ✅ UI formatting (rounding numbers for display, date formatting, not recalculation)
+- ✅ Conditional rendering based on API response fields (UI logic, not computation)
+- ✅ OpenAPI-generated types (`openapi-typescript` for Web, aligned DTOs for iOS)
+
+**Contract-first principle:**
+
+- Any DTO changes → update OpenAPI/contract docs first, then regenerate client types
+- Clients must follow canonical error envelope format (no "guessing" error structure)
+- Backend `app/schemas/` is the source of truth; clients are consumers only
+
+**Enforcement:**
+
+- iOS: `ThinClientGuardsTests` (scans for BMI thresholds/computation patterns)
+- Web: TypeScript types from OpenAPI (prevents manual DTO drift)
+- Code review: grep for forbidden patterns (BMI math, threshold literals, category inference)
+
+**DTO contract rules:**
+
+- SoftPaywall availability MUST include `reason_key` if present; never drop fields silently.
+- Legacy DTOs may remain temporarily, but must be tracked in BACKLOG_LEDGER with migration PR.
+- All DTO fields must match backend schema exactly (no "convenient" omissions).
+
+**No dual-path networking (hard rule):**
+
+- ❌ **Forbidden:** Any new network calls using direct `URLSession` or custom HTTP clients
+- ✅ **Required:** All new network calls MUST use `APIClient`/`HTTPClient` (iOS) or thin fetch wrapper (Web)
+- **Rationale:** Prevents code duplication, ensures consistent error handling, enforces thin client policy
+- **Enforcement:** Code review + grep for `URLSession.shared.data(for:)` or custom HTTP clients
+- **Migration:** Existing services (ShoppingListService, WeeklyPlanService) must migrate to `APIClient` — tracked in `BACKLOG_LEDGER.md` (P1 item)
+
+**See:**
+
+- `ios/AGENTS.md` — iOS Thin Client Policy (detailed)
+- `frontend/AGENTS.md` — Frontend conventions
+- `docs/BMI_CANONICAL_HANDOFF.md` — One BMI Engine invariant
+- `docs/CONTEXT_HANDOFF_2026-01-21.md` — Thin HTTP adapter PR plan
+
 ## Verification (preferred approach)
 
 - Run quiet first; re-run narrowed failures with verbose logs only when debugging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -996,6 +996,7 @@ git grep -nE "spec_from_file_location|exec_module|sys\.modules\[" -- scripts || 
 - Prefer `trivy/ignore-policy.rego` (scoped by package + version + context fields where possible).
 - `.trivyignore` is for legacy/minimal ignores; do not rely on it for expiry monitoring.
 - CI uses `TRIVY_IGNORE_POLICY_PATH` to point to active policy file(s); expiry enforcement runs `scripts/ci/check_trivy_ignore_policy_expiry.py`.
+- **Runner version drift policy:** If base image/version varies across CI runners (e.g., `deb12u10` vs `deb12u13`), add **allowlist of observed versions** in suppression rules, not wildcards. Example: use helper rules matching `u10` and `u13` explicitly, not `deb12u*` pattern. Rationale: Prevents accidental suppression of future versions (u14/u15) that may have fixes available.
 
 **Security PR scoping:**
 

--- a/docs/CONTEXT_HANDOFF_2026-01-21.md
+++ b/docs/CONTEXT_HANDOFF_2026-01-21.md
@@ -1,0 +1,157 @@
+# 🧾 PulsePlate — CONTEXT HANDOFF (после merge PR-560 + PR-561)
+
+**Дата фиксации:** 2026-01-21
+**Ветка/статус:** `main` актуален, PR-560 и PR-561 **смерджены**
+**Правило процесса:** всегда **Audit (Qoder) → Implementation (Cursor) → DoD/CI**
+
+---
+
+## 0) Канонические принципы (не обсуждаем, соблюдаем)
+
+1. **Thin clients only** (iOS/Web): **0** BMI/нутри-логики на клиенте. Только контракт, UX, локализация, ретраи, ошибки.
+2. **Backend first / determinism first**: downstream меняем только когда upstream стабилен.
+3. **Документация как контракт**: изменения в процессах/политиках → обновлять **AGENTS.md** и при необходимости **RUNBOOK_AGENT.md**.
+4. **Security suppressions**: отдельные PR, 1 CVE per PR, с `docs/security/CVE-*.md`, expiry + monitor.
+
+---
+
+## 1) Что закрыто и смёржено (факты)
+
+### PR-560 — CI iOS stability (merged)
+
+**Что вошло:**
+
+* Исправления iOS CI стабилизации (bootstatus timeout **60s → 180s**, параметризовано env `SIM_BOOT_TIMEOUT_SECONDS`)
+* `docs/roadmap/BACKLOG_LEDGER.md`: статус и DoD чекбоксы выровнены под "awaiting merge / in progress" до мержа
+* `ios/AGENTS.md`: приведён к **split build/test flow** (`build-for-testing` → `test-without-building`), убрана/правится дублирующая секция (если осталась — чистить отдельным коммитом, но PR уже merged)
+* Swift 6 actor isolation ошибки устранены (ошибки типа "Main actor-isolated…")
+
+**Заметка:** часть "debug procedures" лучше держать в `RUNBOOK_AGENT.md`, а в `AGENTS.md` — только инварианты/правила.
+
+### PR-561 — Trivy suppression (CVE-2025-15281 glibc) (merged)
+
+**Что вошло:**
+
+* `trivy/ignore-policy.rego`: исправлен Rego parse error (helper rules вместо inline `or`)
+* Suppression с **узким allowlist**:
+  * пакеты: `libc6`, `libc-bin`
+  * версии: **deb12u10** и **deb12u13** (runner drift)
+  * PkgID: все 4 комбинации (libc6/libc-bin × u10/u13)
+* Expiry policy checker проходит: **ровно 1** строка `Suppression expires:` в файле, остальное через `Review-by:`
+* `docs/security/CVE-2025-15281-glibc.md`: severity уточнена до **Minor (per Debian Security Tracker)** + monitor/expiry
+
+---
+
+## 2) Канонические документы/карта (куда смотреть)
+
+**Обязательные "канон" доки проекта:**
+
+* `docs/BMI_CANONICAL_HANDOFF.md` (One BMI Engine, anti-dup guards, child ≠ teen, downstream freeze правила)
+* `docs/audit/ROOT_CAUSE_ANALYSIS_BMI_UNDEFINED.md`, `docs/audit/DECISION_LOG_BMI_UNDEFINED.md`
+* `docs/audit/BACKEND_P0_REMEDIATION_PLAN.md`, `docs/audit/BACKEND_P0_GUARD_POLICY_PROPOSAL.md`
+* `docs/roadmap/BACKLOG_LEDGER.md` (postponed items обязаны фиксироваться)
+* `docs/security/*` (CVE suppressions с expiry/monitor)
+* `AGENTS.md` + `ios/AGENTS.md` + `frontend/AGENTS.md` + `RUNBOOK_AGENT.md`
+
+---
+
+# Следующий PR (старт нового окна): Thin HTTP Adapter для iOS + Web
+
+## Цель
+
+Сделать **единую тонкую транспортную прослойку** (HTTP adapter) для клиентов:
+
+* **iOS (Swift)**: `APIClient`/`BMIService`/`HTTPClient` без бизнес-логики
+* **Web (TS)**: такой же thin adapter (fetch/httpx-like wrapper), типы из OpenAPI
+* Клиенты должны уметь: baseURL, headers, JSON encode/decode, error envelope, timeouts/retry (минимально), telemetry hooks (опционально), i18n ошибок.
+
+## Принципиально: что НЕ делаем в этом PR
+
+* Никаких формул BMI/waist/рисков на клиенте
+* Никаких "интерпретаций"/категорий на клиенте
+* Никаких "схем расчётов" в UI — только отображение ответа API
+
+---
+
+## План PR: Audit → Implementation
+
+## A) AUDIT (в начале нового окна, до кода)
+
+**Нужно собрать фактами:**
+
+1. **Канонические endpoints** (что клиент зовёт реально):
+   * Public BMI calculate (точный путь + request/response модель)
+   * (если уже есть) soft paywall hook контракт и поля (но UI не делаем)
+
+2. **Error envelope**: как backend отдаёт ошибки (422/400/5xx) и формат payload
+
+3. **Auth**: публичные запросы без ключа vs Pro/VIP (какие headers)
+
+4. **i18n**: какие ключи приходят с backend и что локализуем на клиенте
+
+**Выход аудита:**
+
+* `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT.md`:
+  * endpoints table
+  * request/response samples (curl + JSON)
+  * error payload examples
+  * contract invariants (no client logic)
+
+## B) IMPLEMENTATION (Cursor)
+
+### iOS
+
+* `ios/PulsePlate/Networking/HTTPClient.swift` (URLSession wrapper)
+* `ios/PulsePlate/Networking/APIClient.swift` (baseURL from Info.plist, headers, JSON)
+* `ios/PulsePlate/Services/BMIService.swift` (only calls endpoint, returns DTO)
+* `ios/PulsePlate/Models/*DTO.swift` (request/response DTOs strictly aligned)
+
+**Тесты:**
+
+* URLProtocol stub tests (у вас уже есть паттерн `FailingURLProtocol`)
+* decode/encode snapshot-like tests (no UI)
+
+### Web (Vite/TS)
+
+* `frontend/src/api/http.ts` (thin fetch wrapper)
+* `frontend/src/api/bmi.ts` (function `calculateBMI(req): Promise<BMIResponseDTO>`)
+* типы: либо `openapi-typescript`, либо ручной DTO (лучше автоген)
+* error mapping: 422 validation errors → UI-friendly message keys
+
+---
+
+## DoD для PR (жёстко)
+
+* [ ] iOS: unit tests green (encoding/decoding + request building + error mapping)
+* [ ] Web: unit tests/tsc build green (минимум)
+* [ ] No business logic on client (grep policy / review checklist)
+* [ ] Документация обновлена:
+  * `ios/AGENTS.md`: правила для thin adapter (где нельзя логика)
+  * `frontend/AGENTS.md`: правила для thin adapter (где нельзя логика)
+  * `AGENTS.md`: общий принцип thin clients (если ещё не закреплён)
+  * если добавим debug steps — в `RUNBOOK_AGENT.md`, не в AGENTS
+
+---
+
+## Что нужно обновить в AGENTS.md (обязательно)
+
+Добавить/уточнить правила:
+
+1. **Client logic ban:** никакой BMI/waist/рисковой логики в iOS/Web — только отображение данных API.
+2. **Contract-first:** любые изменения DTO → сначала обновить OpenAPI/contract docs, потом код.
+3. **Error envelope canonical mapping:** клиент не "угадывает", а следует контракту.
+
+---
+
+## Ссылки на связанные документы
+
+* `docs/BMI_CANONICAL_HANDOFF.md` — One BMI Engine invariant
+* `ios/AGENTS.md` — iOS Thin Client Policy (уже есть)
+* `frontend/AGENTS.md` — Frontend conventions
+* `docs/contracts/soft_paywall.md` — Soft paywall hook contract
+* `docs/roadmap/BACKLOG_LEDGER.md` — Postponed items
+
+---
+
+**Last updated:** 2026-01-21
+**Maintainer:** @katsiaryna_kavaleuskaya

--- a/docs/PR_XXX_COMMIT_STRUCTURE.md
+++ b/docs/PR_XXX_COMMIT_STRUCTURE.md
@@ -1,0 +1,274 @@
+# PR-XXX Commit Structure (Atomic Commits)
+
+**PR:** PR-XXX (Thin HTTP Adapter iOS)
+**Date:** 2026-01-22
+
+---
+
+## Commit 1: Networking transport (core)
+
+**Message:**
+```
+feat(ios): add thin HTTPClient + APIClient error mapping
+
+- HTTPClient: low-level HTTP client with error envelope mapping
+  - Distinguishes 422 (detail[]) vs 400/500 (detail: str)
+  - Uses ValidationErrorResponse for 422 decoding
+  - Uses SimpleErrorResponse for 400/500 decoding
+- APIClient: request builder (URL, headers, JSON encoding)
+  - Builds URL from baseURL + path
+  - Sets Content-Type: application/json
+  - Supports custom headers
+  - JSON encodes with snake_case conversion
+- APIError: unified error model (422 vs 400/500)
+- ErrorsDTO: error response DTOs (ValidationErrorResponse, SimpleErrorResponse)
+
+Transport layer only (no business logic).
+```
+
+**Files:**
+- `ios/PulsePlate/Networking/HTTPClient.swift` (new)
+- `ios/PulsePlate/Networking/APIClient.swift` (new)
+- `ios/PulsePlate/Networking/APIError.swift` (new)
+- `ios/PulsePlate/Networking/ErrorsDTO.swift` (new)
+
+---
+
+## Commit 2: BMI thin adapter + DTO contract
+
+**Message:**
+```
+feat(ios): wire BMIService to thin adapter + canonical DTOs
+
+- BMIService: thin wrapper over APIClient
+  - Calls canonical endpoint /api/v1/bmi/calculate
+  - Returns BMICalculateResponseDTO as-is (no computation)
+  - Forbidden: BMI math, thresholds, category inference
+- DTOs aligned to backend schema (app/schemas/bmi.py):
+  - BMICalculateRequestDTO (request)
+  - BMICalculateResponseDTO (response with nullable category)
+  - WaistRiskDTO (wht_ratio, risk_level, notes[])
+  - BMIScaleV1DTO (visualization ranges)
+  - BMIInterpretationV1DTO (goalDirection, targetRange, priorityNotes)
+  - SoftPaywallHookDTO (with reasonKey)
+
+Contract frozen per audit document.
+```
+
+**Files:**
+- `ios/PulsePlate/Services/BMIService.swift` (new BMIService class, lines 1-46)
+- `ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift` (new)
+- `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift` (new)
+- `ios/PulsePlate/Models/BMI/WaistRiskDTO.swift` (new)
+- `ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift` (new)
+- `ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift` (new)
+- `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift` (new)
+
+---
+
+## Commit 3: Tests (contract boundary)
+
+**Message:**
+```
+test(ios): add thin adapter contract tests (422/400/500, snake_case, path)
+
+- HTTPClientTests: error mapping tests
+  - 422 validation error decoding (detail[])
+  - 400/500 API error decoding (detail: str)
+  - Successful 200 decoding
+  - Anti-flake: tearDown() resets StubURLProtocol.handler
+- APIClientTests: request building tests
+  - URL construction (baseURL + path)
+  - Content-Type header
+  - Custom headers
+  - snake_case JSON encoding
+- BMIServiceThinAdapterTests: thinness verification
+  - Canonical path /api/v1/bmi/calculate
+  - DTO passthrough (no modification)
+  - Nullable category decoding
+  - visualization.ranges[].key, from, to decoding
+
+10 tests passing. Contract boundary verified.
+```
+
+**Files:**
+- `ios/PulsePlateTests/Networking/HTTPClientTests.swift` (new)
+- `ios/PulsePlateTests/Networking/APIClientTests.swift` (new)
+- `ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift` (new)
+
+---
+
+## Commit 4: Compatibility shims (temporary)
+
+**Message:**
+```
+fix(ios): resolve naming conflicts and keep legacy BMI UI compiling
+
+- NutritionData.swift: rename APIError → NutritionAPIError
+  - Avoids conflict with Networking/APIError
+- BMIService.swift: add legacy compatibility shims (lines 48-159)
+  - LegacyBMIServicing protocol (uses BMIRequest/BMIResponse)
+  - DefaultBMIService class (legacy implementation)
+  - BMIServiceError enum (legacy error type)
+- BMICalculatorViewModel.swift: use LegacyBMIServicing
+  - Migration deferred to separate PR (tracked in BACKLOG_LEDGER.md)
+- MockBMIService.swift: update to LegacyBMIServicing
+
+Temporary shims to unblock compilation without breaking UI.
+UI migration tracked in BACKLOG_LEDGER.md (P1 item).
+See: docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md
+```
+
+**Files:**
+- `ios/PulsePlate/Models/NutritionData.swift` (rename APIError → NutritionAPIError)
+- `ios/PulsePlate/Services/BMIService.swift` (add legacy shims, lines 48-159)
+- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift` (use LegacyBMIServicing)
+- `ios/PulsePlateTests/Mocks/MockBMIService.swift` (update to LegacyBMIServicing)
+
+---
+
+## Commit 5: Docs/Process updates
+
+**Message:**
+```
+docs(process): enforce thin client policy and track UI DTO migration
+
+- AGENTS.md: add "Thin HTTP Adapter Policy (Hard Rule)"
+  - Forbidden patterns (BMI math, thresholds, business logic)
+  - Allowed patterns (transport, error mapping, i18n lookup)
+  - Contract-first principle
+  - Enforcement mechanisms (guard tests, code review)
+- BACKLOG_LEDGER.md: track UI migration (P1 item)
+  - Technical debt details (legacy shims, code duplication)
+  - DoD for UI migration
+  - Links to relevant files
+- docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md: contract freeze
+- docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md: technical debt analysis
+```
+
+**Files:**
+- `AGENTS.md` (add thin client policy section)
+- `docs/roadmap/BACKLOG_LEDGER.md` (add UI migration item)
+- `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md` (if not already committed)
+- `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md` (if not already committed)
+- `docs/CONTEXT_HANDOFF_2026-01-21.md` (if not already committed)
+
+---
+
+## Alternative: Single Commit (If Already Too Late)
+
+If commits are already mixed, use single commit with comprehensive message:
+
+**Message:**
+```
+feat(ios): implement thin HTTP adapter for BMI service
+
+Transport layer:
+- HTTPClient: error mapping (422 vs 400/500)
+- APIClient: request builder (URL, headers, JSON encoding)
+- BMIService: thin wrapper (canonical path, DTO passthrough)
+- DTOs aligned to backend schema (app/schemas/bmi.py)
+
+Tests:
+- 10 tests passing (HTTPClient, APIClient, BMIService)
+- Contract boundary verified (422/400/500, snake_case, canonical path)
+- Anti-flake: tearDown() resets StubURLProtocol.handler
+
+Compatibility shims (temporary):
+- LegacyBMIServicing/DefaultBMIService for existing UI
+- UI migration tracked in BACKLOG_LEDGER.md (P1 item)
+
+Documentation:
+- AGENTS.md: thin client policy
+- BACKLOG_LEDGER.md: UI migration tracking
+- Technical debt report: docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md
+
+See: docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md
+```
+
+---
+
+## Git Commands (If Starting Fresh)
+
+```bash
+# Commit 1: Networking transport
+git add ios/PulsePlate/Networking/HTTPClient.swift
+git add ios/PulsePlate/Networking/APIClient.swift
+git add ios/PulsePlate/Networking/APIError.swift
+git add ios/PulsePlate/Networking/ErrorsDTO.swift
+git commit -m "feat(ios): add thin HTTPClient + APIClient error mapping
+
+- HTTPClient: low-level HTTP client with error envelope mapping
+- APIClient: request builder (URL, headers, JSON encoding)
+- APIError: unified error model (422 vs 400/500)
+- ErrorsDTO: error response DTOs
+
+Transport layer only (no business logic)."
+
+# Commit 2: BMI thin adapter + DTOs
+git add ios/PulsePlate/Services/BMIService.swift
+git add ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift
+git add ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift
+git add ios/PulsePlate/Models/BMI/WaistRiskDTO.swift
+git add ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift
+git add ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift
+git add ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift
+git commit -m "feat(ios): wire BMIService to thin adapter + canonical DTOs
+
+- BMIService: thin wrapper over APIClient
+- DTOs aligned to backend schema (app/schemas/bmi.py)
+- Contract frozen per audit document."
+
+# Commit 3: Tests
+git add ios/PulsePlateTests/Networking/HTTPClientTests.swift
+git add ios/PulsePlateTests/Networking/APIClientTests.swift
+git add ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift
+git commit -m "test(ios): add thin adapter contract tests (422/400/500, snake_case, path)
+
+10 tests passing. Contract boundary verified."
+
+# Commit 4: Compatibility shims
+git add ios/PulsePlate/Models/NutritionData.swift
+git add ios/PulsePlate/Services/BMIService.swift  # (legacy shims only)
+git add ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift
+git add ios/PulsePlateTests/Mocks/MockBMIService.swift
+git commit -m "fix(ios): resolve naming conflicts and keep legacy BMI UI compiling
+
+Temporary shims to unblock compilation without breaking UI.
+UI migration tracked in BACKLOG_LEDGER.md (P1 item)."
+
+# Commit 5: Docs
+git add AGENTS.md
+git add docs/roadmap/BACKLOG_LEDGER.md
+git add docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md
+git add docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md
+git add docs/CONTEXT_HANDOFF_2026-01-21.md
+git commit -m "docs(process): enforce thin client policy and track UI DTO migration
+
+- AGENTS.md: thin client policy
+- BACKLOG_LEDGER.md: UI migration tracking
+- Technical debt report"
+```
+
+---
+
+## Verification After Commits
+
+```bash
+# Verify all tests still pass
+cd ios && xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate \
+  -destination 'platform=iOS Simulator,id=8B9BF341-A44D-4BB0-A898-EC8CFEE56B79' \
+  -only-testing:PulsePlateTests/HTTPClientTests \
+  -only-testing:PulsePlateTests/APIClientTests \
+  -only-testing:PulsePlateTests/BMIServiceThinAdapterTests test
+
+# Verify no BMI math in client code
+grep -r "18\.5\|24\.9\|25\|30\|80\|88\|94\|102" ios/PulsePlate/Networking/ ios/PulsePlate/Services/BMIService.swift | grep -v "test\|TODO\|comment" || echo "OK: No BMI thresholds in transport layer"
+
+# Verify DTOs match backend schema (manual review)
+# Compare ios/PulsePlate/Models/BMI/*.swift with app/schemas/bmi.py
+```
+
+---
+
+**Last updated:** 2026-01-22

--- a/docs/PR_XXX_DESCRIPTION_FINAL.md
+++ b/docs/PR_XXX_DESCRIPTION_FINAL.md
@@ -1,0 +1,225 @@
+# PR-XXX: Thin HTTP Adapter for iOS (Transport Layer)
+
+## Summary
+
+Implements thin HTTP transport layer for iOS client, aligned with backend contracts. Adds `HTTPClient`/`APIClient` for error mapping and `BMIService` as thin wrapper. DTOs match backend OpenAPI schemas exactly.
+
+**Scope:** Transport layer only (no UI migration in this PR).
+
+**DoD Evidence:** See `docs/PR_XXX_DOD_CHECKLIST.md`
+**Review Checklist:** See `docs/PR_XXX_REVIEW_CHECKLIST.md`
+
+---
+
+## Contract Freeze
+
+**Effective date:** 2026-01-22
+
+**Frozen contracts:**
+- **Canonical endpoint:** `/api/v1/bmi/calculate`
+- **Error formats:**
+  - `422`: `{"detail": [{"type": "...", "loc": [...], "msg": "...", "input": ...}]}` (plain English)
+  - `400/500/501`: `{"detail": "localized text"}` (via backend `t(lang, key)`)
+- **Request/Response schemas:** `app/schemas/bmi.py` (backend source of truth)
+- **i18n approach:** Mixed model (text fields vs i18n keys — see audit doc)
+
+**Enforcement:**
+- Client implementation matches frozen contracts exactly
+- Any deviation requires explicit backend PR to change contract first
+- See: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+
+---
+
+## Changes
+
+### Core Transport Layer
+
+**Files:**
+- `ios/PulsePlate/Networking/HTTPClient.swift` — low-level HTTP client with error mapping
+- `ios/PulsePlate/Networking/APIClient.swift` — request builder (URL, headers, JSON encoding)
+- `ios/PulsePlate/Networking/APIError.swift` — unified error model (422 vs 400/500)
+- `ios/PulsePlate/Networking/ErrorsDTO.swift` — error response DTOs
+
+**Responsibilities:**
+- Transport only (no business logic)
+- Error envelope mapping (422 `detail[]` vs 400/500 `detail: str`)
+- JSON encode/decode with `snake_case` conversion
+
+### BMI Thin Adapter
+
+**Files:**
+- `ios/PulsePlate/Services/BMIService.swift` — thin wrapper over `APIClient` (lines 1-46)
+- `ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift` — request DTO
+- `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift` — response DTO
+- `ios/PulsePlate/Models/BMI/WaistRiskDTO.swift` — waist risk DTO
+- `ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift` — visualization DTO
+- `ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift` — interpretation DTO
+- `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift` — soft paywall DTO
+
+**Responsibilities:**
+- Call canonical endpoint only
+- Return DTOs as-is (no computation, no interpretation)
+- Forbidden: BMI math, thresholds, category inference
+
+### Tests
+
+**Files:**
+- `ios/PulsePlateTests/Networking/HTTPClientTests.swift` — error mapping tests (422 vs 400/500)
+- `ios/PulsePlateTests/Networking/APIClientTests.swift` — request building tests (URL, headers, snake_case)
+- `ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift` — thinness verification tests
+
+**Coverage:**
+- ✅ 10 tests passing
+- ✅ Contract boundary verified (422/400/500, snake_case, canonical path)
+- ✅ Anti-flake: `StubURLProtocol.handler` reset in `tearDown()`
+
+### Compatibility Shims (Temporary)
+
+**Why:** To unblock compilation and tests without breaking existing UI code.
+
+**Files:**
+- `ios/PulsePlate/Models/NutritionData.swift` — renamed `APIError` → `NutritionAPIError` (naming conflict)
+- `ios/PulsePlate/Services/BMIService.swift` (lines 48-159) — legacy compatibility shims:
+  - `LegacyBMIServicing` protocol (uses `BMIRequest`/`BMIResponse`)
+  - `DefaultBMIService` class (legacy implementation with direct `URLSession`)
+  - `BMIServiceError` enum (legacy error type)
+- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift` — still uses legacy types (migration deferred)
+- `ios/PulsePlateTests/Mocks/MockBMIService.swift` — updated to `LegacyBMIServicing` for test compatibility
+
+**Trade-off:** Code duplication (legacy vs new) accepted to keep PR scope focused (transport layer only). UI migration tracked in `BACKLOG_LEDGER.md` (P1 item).
+
+**See:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md` for detailed analysis.
+
+---
+
+## DoD Evidence
+
+### Tests
+
+```bash
+cd ios && xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate \
+  -destination 'platform=iOS Simulator,id=8B9BF341-A44D-4BB0-A898-EC8CFEE56B79' \
+  -only-testing:PulsePlateTests/HTTPClientTests \
+  -only-testing:PulsePlateTests/APIClientTests \
+  -only-testing:PulsePlateTests/BMIServiceThinAdapterTests test
+```
+
+**Result:** ✅ 10 tests passing
+
+- `HTTPClientTests` (4 tests): 422 vs 400/500 error mapping
+- `APIClientTests` (3 tests): URL building, headers, snake_case encoding
+- `BMIServiceThinAdapterTests` (3 tests): canonical path, DTO passthrough, nullable `category`
+
+### Contract Verification
+
+- ✅ `HTTPClient` distinguishes 422 (`detail[]`) vs 400/500 (`detail: str`)
+- ✅ `APIClient` builds URL from `baseURL + path`, sets `Content-Type`, supports custom headers
+- ✅ `BMIService` calls canonical path `/api/v1/bmi/calculate`, only passthrough DTO
+- ✅ DTO contract: `category: String?` (nullable), `soft_paywall: nil|object`, `visualization.ranges.from/to` verified
+
+### Documentation
+
+- ✅ `AGENTS.md` updated (thin client policy, contract-first, legacy DTO migration tracking, "No dual-path networking" rule)
+- ✅ `BACKLOG_LEDGER.md` updated (UI migration tracked as P1 item)
+- ✅ Audit document: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+- ✅ Technical debt report: `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
+
+**Full DoD checklist:** `docs/PR_XXX_DOD_CHECKLIST.md`
+
+---
+
+## Deferred / Follow-ups
+
+**Tracked in:** `docs/roadmap/BACKLOG_LEDGER.md`
+
+### P1 — UI Migration (Post PR-XXX) 🔴
+
+**Item:** "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO; delete legacy BMIRequest/BMIResponse (iOS)"
+
+**Scope:**
+- Migrate `BMICalculatorViewModel` to use `BMIServicing` + DTOs
+- Update `BMICalculatorScreen` to use new DTOs
+- Delete legacy types: `BMIRequest`, `BMIResponse`
+- Delete legacy shims: `LegacyBMIServicing`, `DefaultBMIService`, `BMIServiceError`
+- Update `MockBMIService` to `BMIServicing`
+- Single HTTP client path (no duplication)
+
+**DoD:** See `BACKLOG_LEDGER.md` (P1 item: "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO")
+
+**Technical debt created in this PR:** See `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
+
+### P1 — Other Services Migration (Post PR-XXX)
+
+**Item:** "Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter (iOS)"
+
+**Scope:**
+- Migrate `ShoppingListService` to use `APIClient` (no direct `URLSession`)
+- Migrate `WeeklyPlanService` to use `APIClient` (no direct `URLSession`)
+- Replace custom error enums with `APIError` from Networking layer
+- All services follow same thin adapter pattern
+
+**DoD:** See `BACKLOG_LEDGER.md` (P1 item: "Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter")
+
+**Rationale:** Enforces "No dual-path networking" rule (see `AGENTS.md`)
+
+### P0 — Web Thin Adapter (Post PR-XXX)
+
+**Item:** "PR-XXX Thin HTTP Adapter (iOS + Web)" — Web part
+
+**Scope:**
+- Implement thin fetch wrapper (TypeScript)
+- Generate types from OpenAPI (`openapi-typescript`)
+- Error envelope mapping (422 vs 400/500)
+- BMI API client (transport only)
+
+**DoD:** See `BACKLOG_LEDGER.md` (P0 item: "PR-XXX Thin HTTP Adapter (iOS + Web)")
+
+---
+
+## Breaking Changes
+
+**None** — this PR adds new transport layer without breaking existing UI code. Legacy compatibility shims ensure backward compatibility until UI migration.
+
+---
+
+## Testing
+
+### Unit Tests
+
+- ✅ `HTTPClientTests` — error mapping (422 vs 400/500)
+- ✅ `APIClientTests` — request building (URL, headers, snake_case)
+- ✅ `BMIServiceThinAdapterTests` — thinness verification (canonical path, DTO passthrough)
+
+**Full test results:** See `docs/PR_XXX_DOD_CHECKLIST.md` (section: "Tests")
+
+### Manual Testing
+
+- ✅ Project compiles
+- ✅ Existing UI code still works (via legacy shims)
+- ✅ New `BMIService` can be used independently (for future UI migration)
+
+---
+
+## References
+
+- **DoD Checklist:** `docs/PR_XXX_DOD_CHECKLIST.md`
+- **Review Checklist:** `docs/PR_XXX_REVIEW_CHECKLIST.md`
+- **Audit document:** `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+- **Technical debt report:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
+- **Context handoff:** `docs/CONTEXT_HANDOFF_2026-01-21.md`
+- **Backlog ledger:** `docs/roadmap/BACKLOG_LEDGER.md`
+- **Thin client policy:** `AGENTS.md` (section: "Thin HTTP Adapter Policy (Hard Rule)")
+
+---
+
+**Related PRs:**
+- PR-560: CI iOS stability (merged 2026-01-21)
+- PR-561: Trivy suppression (merged 2026-01-21)
+
+---
+
+**Reviewer notes:**
+- Focus on transport layer correctness (error mapping, URL building, snake_case)
+- Verify no BMI math in client code (grep for thresholds)
+- Check DTO alignment with backend schema (`app/schemas/bmi.py`)
+- Legacy shims are temporary (documented in technical debt report)

--- a/docs/PR_XXX_DESCRIPTION_TEMPLATE.md
+++ b/docs/PR_XXX_DESCRIPTION_TEMPLATE.md
@@ -1,0 +1,185 @@
+# PR-XXX: Thin HTTP Adapter for iOS (Transport Layer)
+
+## Summary
+
+Implements thin HTTP transport layer for iOS client, aligned with backend contracts. Adds `HTTPClient`/`APIClient` for error mapping and `BMIService` as thin wrapper. DTOs match backend OpenAPI schemas exactly.
+
+**Scope:** Transport layer only (no UI migration in this PR).
+
+---
+
+## Contract Freeze
+
+**Effective date:** 2026-01-22
+
+**Frozen contracts:**
+- **Canonical endpoint:** `/api/v1/bmi/calculate`
+- **Error formats:**
+  - `422`: `{"detail": [{"type": "...", "loc": [...], "msg": "...", "input": ...}]}` (plain English)
+  - `400/500/501`: `{"detail": "localized text"}` (via backend `t(lang, key)`)
+- **Request/Response schemas:** `app/schemas/bmi.py` (backend source of truth)
+- **i18n approach:** Mixed model (text fields vs i18n keys — see audit doc)
+
+**Enforcement:**
+- Client implementation matches frozen contracts exactly
+- Any deviation requires explicit backend PR to change contract first
+- See: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+
+---
+
+## Changes
+
+### Core Transport Layer
+
+**Files:**
+- `ios/PulsePlate/Networking/HTTPClient.swift` — low-level HTTP client with error mapping
+- `ios/PulsePlate/Networking/APIClient.swift` — request builder (URL, headers, JSON encoding)
+- `ios/PulsePlate/Networking/APIError.swift` — unified error model (422 vs 400/500)
+- `ios/PulsePlate/Networking/ErrorsDTO.swift` — error response DTOs
+
+**Responsibilities:**
+- Transport only (no business logic)
+- Error envelope mapping (422 `detail[]` vs 400/500 `detail: str`)
+- JSON encode/decode with `snake_case` conversion
+
+### BMI Thin Adapter
+
+**Files:**
+- `ios/PulsePlate/Services/BMIService.swift` — thin wrapper over `APIClient`
+- `ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift` — request DTO
+- `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift` — response DTO
+- `ios/PulsePlate/Models/BMI/WaistRiskDTO.swift` — waist risk DTO
+- `ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift` — visualization DTO
+- `ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift` — interpretation DTO
+- `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift` — soft paywall DTO
+
+**Responsibilities:**
+- Call canonical endpoint only
+- Return DTOs as-is (no computation, no interpretation)
+- Forbidden: BMI math, thresholds, category inference
+
+### Tests
+
+**Files:**
+- `ios/PulsePlateTests/Networking/HTTPClientTests.swift` — error mapping tests (422 vs 400/500)
+- `ios/PulsePlateTests/Networking/APIClientTests.swift` — request building tests (URL, headers, snake_case)
+- `ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift` — thinness verification tests
+
+**Coverage:**
+- ✅ 10 tests passing
+- ✅ Contract boundary verified (422/400/500, snake_case, canonical path)
+- ✅ Anti-flake: `StubURLProtocol.handler` reset in `tearDown()`
+
+### Compatibility Shims (Temporary)
+
+**Why:** To unblock compilation and tests without breaking existing UI code.
+
+**Files:**
+- `ios/PulsePlate/Models/NutritionData.swift` — renamed `APIError` → `NutritionAPIError` (naming conflict)
+- `ios/PulsePlate/Services/BMIService.swift` (lines 48-159) — legacy compatibility shims:
+  - `LegacyBMIServicing` protocol (uses `BMIRequest`/`BMIResponse`)
+  - `DefaultBMIService` class (legacy implementation with direct `URLSession`)
+  - `BMIServiceError` enum (legacy error type)
+- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift` — still uses legacy types (migration deferred)
+- `ios/PulsePlateTests/Mocks/MockBMIService.swift` — updated to `LegacyBMIServicing` for test compatibility
+
+**Trade-off:** Code duplication (legacy vs new) accepted to keep PR scope focused (transport layer only). UI migration tracked in `BACKLOG_LEDGER.md` (P1 item).
+
+**See:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md` for detailed analysis.
+
+---
+
+## DoD Evidence
+
+### Tests
+
+```bash
+cd ios && xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate \
+  -destination 'platform=iOS Simulator,id=8B9BF341-A44D-4BB0-A898-EC8CFEE56B79' \
+  -only-testing:PulsePlateTests/HTTPClientTests \
+  -only-testing:PulsePlateTests/APIClientTests \
+  -only-testing:PulsePlateTests/BMIServiceThinAdapterTests test
+```
+
+**Result:** ✅ 10 tests passing
+
+- `HTTPClientTests` (4 tests): 422 vs 400/500 error mapping
+- `APIClientTests` (3 tests): URL building, headers, snake_case encoding
+- `BMIServiceThinAdapterTests` (3 tests): canonical path, DTO passthrough, nullable `category`
+
+### Contract Verification
+
+- ✅ `HTTPClient` distinguishes 422 (`detail[]`) vs 400/500 (`detail: str`)
+- ✅ `APIClient` builds URL from `baseURL + path`, sets `Content-Type`, supports custom headers
+- ✅ `BMIService` calls canonical path `/api/v1/bmi/calculate`, only passthrough DTO
+- ✅ DTO contract: `category: String?` (nullable), `soft_paywall: nil|object`, `visualization.ranges.from/to` verified
+
+### Documentation
+
+- ✅ `AGENTS.md` updated (thin client policy, contract-first, legacy DTO migration tracking)
+- ✅ `BACKLOG_LEDGER.md` updated (UI migration tracked as P1 item)
+- ✅ Audit document: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+- ✅ Technical debt report: `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
+
+---
+
+## Deferred / Follow-ups
+
+**Tracked in:** `docs/roadmap/BACKLOG_LEDGER.md`
+
+### P1 — UI Migration (Post PR-XXX)
+
+- [ ] Migrate `BMICalculatorViewModel + Screen` to `BMICalculate*DTO`
+- [ ] Delete legacy types: `BMIRequest`, `BMIResponse`
+- [ ] Delete legacy shims: `LegacyBMIServicing`, `DefaultBMIService`, `BMIServiceError`
+- [ ] Update `MockBMIService` to `BMIServicing`
+- [ ] Single HTTP client path (no duplication)
+
+**DoD:** See `BACKLOG_LEDGER.md` (P1 item: "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO")
+
+### P1 — Web Thin Adapter (Post PR-XXX)
+
+- [ ] Implement thin fetch wrapper (TypeScript)
+- [ ] Generate types from OpenAPI (`openapi-typescript`)
+- [ ] Error envelope mapping (422 vs 400/500)
+- [ ] BMI API client (transport only)
+
+**DoD:** See `BACKLOG_LEDGER.md` (P0 item: "PR-XXX Thin HTTP Adapter (iOS + Web)")
+
+---
+
+## Breaking Changes
+
+**None** — this PR adds new transport layer without breaking existing UI code. Legacy compatibility shims ensure backward compatibility until UI migration.
+
+---
+
+## Testing
+
+### Unit Tests
+
+- ✅ `HTTPClientTests` — error mapping (422 vs 400/500)
+- ✅ `APIClientTests` — request building (URL, headers, snake_case)
+- ✅ `BMIServiceThinAdapterTests` — thinness verification (canonical path, DTO passthrough)
+
+### Manual Testing
+
+- ✅ Project compiles
+- ✅ Existing UI code still works (via legacy shims)
+- ✅ New `BMIService` can be used independently (for future UI migration)
+
+---
+
+## References
+
+- **Audit document:** `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
+- **Technical debt report:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
+- **Context handoff:** `docs/CONTEXT_HANDOFF_2026-01-21.md`
+- **Backlog ledger:** `docs/roadmap/BACKLOG_LEDGER.md`
+- **Thin client policy:** `AGENTS.md` (section: "Thin HTTP Adapter Policy (Hard Rule)")
+
+---
+
+**Related PRs:**
+- PR-560: CI iOS stability (merged 2026-01-21)
+- PR-561: Trivy suppression (merged 2026-01-21)

--- a/docs/PR_XXX_DOD_CHECKLIST.md
+++ b/docs/PR_XXX_DOD_CHECKLIST.md
@@ -1,0 +1,246 @@
+# PR-XXX DoD Checklist (Thin HTTP Adapter iOS)
+
+**PR:** PR-XXX
+**Date:** 2026-01-22
+**Status:** ✅ All checks passing
+
+---
+
+## ✅ Must-have (Transport Layer)
+
+### HTTPClient
+
+- [x] Distinguishes 422 (`detail[]`) vs 400/500 (`detail: str`)
+  - **Evidence:** `HTTPClientTests.test_422_decodesValidationErrorResponse()` passes
+  - **Evidence:** `HTTPClientTests.test_400_decodesSimpleErrorResponse()` passes
+  - **Evidence:** `HTTPClientTests.test_500_decodesSimpleErrorResponse()` passes
+
+- [x] Uses `ValidationErrorResponse` for 422 decoding
+  - **Evidence:** `HTTPClient.swift` line 70-76: `decodeValidationError(from:)`
+
+- [x] Uses `SimpleErrorResponse` for 400/500 decoding
+  - **Evidence:** `HTTPClient.swift` line 80-91: `decodeAPIError(from:statusCode:)`
+
+- [x] Throws `APIError.validation()` for 422
+  - **Evidence:** `HTTPClient.swift` line 52: `throw try decodeValidationError(from: data)`
+
+- [x] Throws `APIError.api(statusCode, message)` for 400/500
+  - **Evidence:** `HTTPClient.swift` line 52: `throw try decodeAPIError(from: data, statusCode: httpResponse.statusCode)`
+
+- [x] Handles decoding failures gracefully
+  - **Evidence:** `HTTPClient.swift` line 66-68: `catch { throw APIError.decodingFailed(...) }`
+
+- [x] No business logic (BMI math, thresholds, categories)
+  - **Evidence:** `grep -r "18\.5\|24\.9\|25\|30" ios/PulsePlate/Networking/` → no matches
+
+### APIClient
+
+- [x] Builds URL from `baseURL + path` correctly
+  - **Evidence:** `APIClientTests.test_post_buildsCorrectURLAndHeadersAndBody()` passes
+  - **Evidence:** `APIClient.swift` line 45: `baseURL.appendingPathComponent(path)`
+
+- [x] Sets `Content-Type: application/json` header
+  - **Evidence:** `APIClientTests.test_post_buildsCorrectURLAndHeadersAndBody()` passes
+  - **Evidence:** `APIClient.swift` line 47: `request.setValue("application/json", forHTTPHeaderField: "Content-Type")`
+
+- [x] Supports custom headers (passed through)
+  - **Evidence:** `APIClientTests.test_post_withCustomHeaders_appendsHeaders()` passes
+  - **Evidence:** `APIClient.swift` line 49-51: `headers.forEach { ... }`
+
+- [x] JSON encodes request body with `snake_case` conversion
+  - **Evidence:** `APIClientTests.test_post_buildsCorrectURLAndHeadersAndBody()` verifies `json?["weight_kg"]`
+  - **Evidence:** `BMICalculateRequestDTO.swift` uses `CodingKeys` for snake_case mapping
+
+- [x] Uses `HTTPClientProtocol` for dependency injection
+  - **Evidence:** `APIClient.swift` line 36: `private let httpClient: HTTPClientProtocol`
+
+- [x] No business logic
+  - **Evidence:** `grep -r "18\.5\|24\.9\|25\|30" ios/PulsePlate/Networking/APIClient.swift` → no matches
+
+### BMIService
+
+- [x] Calls canonical endpoint `/api/v1/bmi/calculate` only
+  - **Evidence:** `BMIServiceThinAdapterTests.test_calculate_callsCanonicalEndpoint()` passes
+  - **Evidence:** `BMIService.swift` line 30: `path: "/api/v1/bmi/calculate"`
+
+- [x] Uses `APIClientProtocol` (dependency injection)
+  - **Evidence:** `BMIService.swift` line 21: `private let apiClient: APIClientProtocol`
+
+- [x] Returns `BMICalculateResponseDTO` as-is (no modification)
+  - **Evidence:** `BMIServiceThinAdapterTests.test_calculate_returnsBMICalculateResponseDTO()` passes
+
+- [x] No BMI math, thresholds, category inference
+  - **Evidence:** `grep -r "18\.5\|24\.9\|25\|30" ios/PulsePlate/Services/BMIService.swift` → no matches (only in legacy shims, lines 48-159)
+
+- [x] No i18n logic (backend provides localized text)
+  - **Evidence:** `BMIService.swift` lines 1-46: no i18n code
+
+- [x] No soft paywall logic (backend provides hook structure)
+  - **Evidence:** `BMIService.swift` lines 1-46: no paywall code
+
+---
+
+## ✅ Contract Enforcement
+
+### DTO Contract
+
+- [x] `category: String?` is nullable
+  - **Evidence:** `BMICalculateResponseDTO.swift` line 8: `public let category: String?`
+  - **Evidence:** `BMIServiceThinAdapterTests.test_calculate_nullableCategory_decodesCorrectly()` passes
+
+- [x] `soft_paywall: nil|object` (never `{enabled: false}`)
+  - **Evidence:** `BMICalculateResponseDTO.swift` line 18: `public let softPaywall: SoftPaywallHookDTO?`
+  - **Evidence:** Audit doc confirms backend returns `null` when disabled
+
+- [x] `visualization.ranges[].from/to` are optional
+  - **Evidence:** `BMIScaleV1DTO.swift`: `BMIRangeDTO` has `from: Double?`, `to: Double?`
+  - **Evidence:** `BMIServiceThinAdapterTests.test_calculate_returnsBMICalculateResponseDTO()` verifies `from`/`to` decoding
+
+- [x] `SoftPaywallAvailabilityDTO` includes `reasonKey: String?`
+  - **Evidence:** `SoftPaywallHookDTO.swift` line 48: `public let reasonKey: String?`
+
+- [x] `BMIInterpretationV1DTO` includes all fields
+  - **Evidence:** `BMIInterpretationV1DTO.swift`: includes `goalDirection`, `targetRange`, `priorityNotes`
+
+### Error Contract
+
+- [x] 422: `{"detail": [{"type": "...", "loc": [...], "msg": "...", "input": ...}]}`
+  - **Evidence:** `ErrorsDTO.swift`: `ValidationErrorResponse` matches format
+  - **Evidence:** `HTTPClientTests.test_422_decodesValidationErrorResponse()` passes
+
+- [x] 400/500: `{"detail": "localized text"}`
+  - **Evidence:** `ErrorsDTO.swift`: `SimpleErrorResponse` matches format
+  - **Evidence:** `HTTPClientTests.test_400_decodesSimpleErrorResponse()` passes
+
+### Tests
+
+- [x] 10 tests passing
+  - **Evidence:** `xcodebuild test` output shows 10 tests passed:
+    - `HTTPClientTests` (4 tests)
+    - `APIClientTests` (3 tests)
+    - `BMIServiceThinAdapterTests` (3 tests)
+
+- [x] Anti-flake: `tearDown()` resets `StubURLProtocol.handler`
+  - **Evidence:** `HTTPClientTests.swift` line 30-32: `override func tearDown() { StubURLProtocol.handler = nil }`
+
+- [x] Contract boundary verified
+  - **Evidence:** Tests verify 422 vs 400/500, snake_case, canonical path
+
+---
+
+## ✅ Documentation
+
+### AGENTS.md
+
+- [x] "Thin HTTP Adapter Policy (Hard Rule)" section added
+  - **Evidence:** `AGENTS.md` lines 320-361: section exists
+
+- [x] Forbidden patterns listed
+  - **Evidence:** `AGENTS.md` lines 321-326: forbidden patterns listed
+
+- [x] Allowed patterns listed
+  - **Evidence:** `AGENTS.md` lines 328-335: allowed patterns listed
+
+- [x] Contract-first principle documented
+  - **Evidence:** `AGENTS.md` lines 337-341: contract-first principle
+
+- [x] Enforcement mechanisms listed
+  - **Evidence:** `AGENTS.md` lines 343-347: enforcement mechanisms
+
+### BACKLOG_LEDGER.md
+
+- [x] UI migration item added (P1)
+  - **Evidence:** `BACKLOG_LEDGER.md` lines 149-178: P1 item exists
+
+- [x] Technical debt details included
+  - **Evidence:** `BACKLOG_LEDGER.md` lines 152-160: technical debt details
+
+- [x] DoD for UI migration specified
+  - **Evidence:** `BACKLOG_LEDGER.md` lines 161-178: DoD specified
+
+- [x] Links to relevant files
+  - **Evidence:** `BACKLOG_LEDGER.md` lines 153-159: links included
+
+### Audit Document
+
+- [x] `PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md` exists
+  - **Evidence:** File exists in `docs/audit/`
+
+- [x] Contract freeze declaration included
+  - **Evidence:** Audit doc has "Contract Freeze Declaration" section
+
+- [x] All TODOs replaced with facts from code
+  - **Evidence:** Audit doc verified against `app/schemas/bmi.py`
+
+### Technical Debt Report
+
+- [x] `PR_XXX_TECHNICAL_DEBT_REPORT.md` exists
+  - **Evidence:** File exists in `docs/audit/`
+
+- [x] Technical debt items listed with rationale
+  - **Evidence:** Report includes detailed analysis
+
+- [x] Follow-up plan specified
+  - **Evidence:** Report includes "Follow-Up Plan" section
+
+- [x] Risk assessment included
+  - **Evidence:** Report includes "Impact Assessment" table
+
+---
+
+## ✅ Compatibility Shims (Temporary)
+
+- [x] Legacy shims documented
+  - **Evidence:** `BMIService.swift` lines 48-52: comments explain temporary nature
+  - **Evidence:** `BMICalculatorViewModel.swift` lines 6-19: TODO comments reference BACKLOG_LEDGER.md
+
+- [x] Naming conflicts resolved
+  - **Evidence:** `NutritionData.swift`: `APIError` renamed to `NutritionAPIError`
+
+- [x] UI still compiles
+  - **Evidence:** `xcodebuild build` succeeds
+
+- [x] Tests still pass
+  - **Evidence:** `xcodebuild test` shows 10 tests passing
+
+---
+
+## ✅ Final Verification
+
+- [x] All tests passing (10 tests)
+  - **Command:** `xcodebuild test -only-testing:PulsePlateTests/HTTPClientTests -only-testing:PulsePlateTests/APIClientTests -only-testing:PulsePlateTests/BMIServiceThinAdapterTests`
+  - **Result:** ✅ 10 tests passed
+
+- [x] No BMI math in client code
+  - **Command:** `grep -r "18\.5\|24\.9\|25\|30" ios/PulsePlate/Networking/ ios/PulsePlate/Services/BMIService.swift | grep -v "test\|TODO\|comment"`
+  - **Result:** ✅ No matches (except in legacy shims, which are temporary)
+
+- [x] DTOs match backend schema
+  - **Method:** Manual review of `ios/PulsePlate/Models/BMI/*.swift` vs `app/schemas/bmi.py`
+  - **Result:** ✅ DTOs aligned
+
+- [x] Contract freeze documented
+  - **Evidence:** Audit doc has "Contract Freeze Declaration" section
+
+- [x] Technical debt tracked
+  - **Evidence:** `BACKLOG_LEDGER.md` updated, technical debt report created
+
+---
+
+## Summary
+
+**Status:** ✅ **All DoD checks passing**
+
+- ✅ Transport layer implemented (HTTPClient, APIClient, BMIService)
+- ✅ 10 tests passing (contract boundary verified)
+- ✅ DTOs aligned to backend schema
+- ✅ Documentation updated (AGENTS.md, BACKLOG_LEDGER.md)
+- ✅ Technical debt tracked and documented
+- ✅ Compatibility shims added (temporary, documented)
+
+**Ready for:** PR review and merge
+
+---
+
+**Last updated:** 2026-01-22
+**Verified by:** @katsiaryna_kavaleuskaya

--- a/docs/PR_XXX_OPENING_CHECKLIST.md
+++ b/docs/PR_XXX_OPENING_CHECKLIST.md
@@ -1,0 +1,156 @@
+# PR-XXX Opening Checklist
+
+**Date:** 2026-01-22
+**Status:** ✅ Ready to open
+
+---
+
+## Pre-PR Checks
+
+- [x] All tests passing (10 tests)
+- [x] No BMI math in transport layer (grep verified)
+- [x] DTOs aligned with backend schema (`app/schemas/bmi.py`)
+- [x] Contract freeze documented
+- [x] Technical debt tracked in BACKLOG_LEDGER.md
+- [x] Legacy shims documented and isolated
+- [x] Documentation updated (AGENTS.md, BACKLOG_LEDGER.md)
+- [x] PR description ready (`docs/PR_XXX_DESCRIPTION_FINAL.md`)
+
+---
+
+## PR Opening Steps
+
+### 1. Create PR Branch
+
+```bash
+# If not already on feature branch
+git checkout -b feat/ios-thin-http-adapter
+
+# Commit all changes (or use atomic commits from PR_XXX_COMMIT_STRUCTURE.md)
+git add .
+git commit -m "feat(ios): implement thin HTTP adapter for BMI service
+
+Transport layer:
+- HTTPClient: error mapping (422 vs 400/500)
+- APIClient: request builder (URL, headers, JSON encoding)
+- BMIService: thin wrapper (canonical path, DTO passthrough)
+- DTOs aligned to backend schema (app/schemas/bmi.py)
+
+Tests:
+- 10 tests passing (HTTPClient, APIClient, BMIService)
+- Contract boundary verified (422/400/500, snake_case, canonical path)
+- Anti-flake: tearDown() resets StubURLProtocol.handler
+
+Compatibility shims (temporary):
+- LegacyBMIServicing/DefaultBMIService for existing UI
+- UI migration tracked in BACKLOG_LEDGER.md (P1 item)
+
+Documentation:
+- AGENTS.md: thin client policy + no dual-path networking rule
+- BACKLOG_LEDGER.md: UI migration tracking
+- Technical debt report: docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md
+
+See: docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md"
+
+# Push branch
+git push -u origin feat/ios-thin-http-adapter
+```
+
+### 2. Create PR on GitHub
+
+**Title:**
+```
+feat(ios): thin HTTP adapter for BMI (transport layer)
+```
+
+**Description:**
+- Copy entire content from `docs/PR_XXX_DESCRIPTION_FINAL.md`
+- Ensure all links are correct (relative paths work in GitHub)
+
+**Labels:**
+- `enhancement`
+- `ios`
+- `networking`
+- `backend-integration`
+
+**Reviewers:**
+- CodeRabbit (if configured)
+- Human reviewer (if needed)
+
+**Assignees:**
+- @katsiaryna_kavaleuskaya
+
+---
+
+## Post-PR Actions
+
+### 1. Monitor CI
+
+- [ ] Wait for CI to pass
+- [ ] Check test results (10 tests should pass)
+- [ ] Verify no linter errors
+
+### 2. Address Review Comments
+
+**Common CodeRabbit comments (prepared responses):**
+
+**Q: "Why is there code duplication (DefaultBMIService vs BMIService)?"**
+
+**A:** This is temporary technical debt to unblock compilation without breaking existing UI code. Legacy shims are isolated (lines 48-159 in BMIService.swift) and will be removed in follow-up PR. See:
+- `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md` (detailed analysis)
+- `docs/roadmap/BACKLOG_LEDGER.md` (P1 item: "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO")
+
+**Q: "Why are there two error types (BMIServiceError vs APIError)?"**
+
+**A:** `BMIServiceError` is legacy error type for backward compatibility with existing UI code. It will be removed when UI migrates to new DTOs. New code should use `APIError` from `Networking/APIError.swift`. See technical debt report for details.
+
+**Q: "Why does BMICalculatorViewModel still use legacy types?"**
+
+**A:** UI migration is deferred to separate PR to keep this PR focused on transport layer only. ViewModel migration is tracked in BACKLOG_LEDGER.md (P1 item). This PR adds new transport layer without breaking existing UI.
+
+**Q: "Shouldn't ShoppingListService/WeeklyPlanService also use APIClient?"**
+
+**A:** Yes, that's tracked in BACKLOG_LEDGER.md (P1 item: "Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter"). This PR establishes the pattern; other services will migrate in follow-up PRs. See AGENTS.md "No dual-path networking" rule.
+
+### 3. After Merge
+
+- [ ] Update BACKLOG_LEDGER.md: mark PR-XXX as merged
+- [ ] Create follow-up PR for UI migration (P1)
+- [ ] Create follow-up PR for Web thin adapter (P0)
+
+---
+
+## Quick Self-Review (2 minutes)
+
+**Run these commands before opening PR:**
+
+```bash
+# 1. Verify no BMI math in transport layer
+grep -r "18\.5\|24\.9\|25\|30" ios/PulsePlate/Networking/ ios/PulsePlate/Services/BMIService.swift | grep -v "test\|TODO\|comment\|legacy" || echo "✅ OK"
+
+# 2. Verify tests pass
+cd ios && xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate \
+  -destination 'platform=iOS Simulator,id=8B9BF341-A44D-4BB0-A898-EC8CFEE56B79' \
+  -only-testing:PulsePlateTests/HTTPClientTests \
+  -only-testing:PulsePlateTests/APIClientTests \
+  -only-testing:PulsePlateTests/BMIServiceThinAdapterTests test 2>&1 | grep -E "(passed|failed)" | tail -5
+
+# 3. Verify documentation exists
+ls -la docs/PR_XXX_*.md docs/audit/PR_XXX_*.md || echo "⚠️ Missing docs"
+```
+
+---
+
+## Success Criteria
+
+**PR is ready to merge when:**
+
+- ✅ CI green (all tests passing)
+- ✅ Code review approved (no blocking comments)
+- ✅ Documentation complete (DoD checklist, review checklist, technical debt report)
+- ✅ Follow-ups tracked (BACKLOG_LEDGER.md updated)
+
+---
+
+**Last updated:** 2026-01-22
+**Status:** ✅ Ready to open

--- a/docs/PR_XXX_REVIEW_CHECKLIST.md
+++ b/docs/PR_XXX_REVIEW_CHECKLIST.md
@@ -1,0 +1,220 @@
+# PR-XXX Review Checklist (Thin HTTP Adapter iOS)
+
+**Reviewer:** @katsiaryna_kavaleuskaya (or assigned reviewer)
+**PR:** PR-XXX
+**Date:** 2026-01-22
+
+---
+
+## ✅ Pre-Review Checks
+
+- [ ] PR description includes "Contract Freeze" section
+- [ ] PR description includes "Compatibility Shims (Temporary)" section
+- [ ] PR description links to technical debt report
+- [ ] All commits are atomic (one logical change per commit)
+- [ ] Commit messages follow convention (`feat:`, `test:`, `fix:`, `docs:`)
+
+---
+
+## 🔍 Code Review — Transport Layer
+
+### HTTPClient.swift
+
+- [ ] Distinguishes 422 (`detail[]`) vs 400/500 (`detail: str`)
+- [ ] Uses `ValidationErrorResponse` for 422 decoding
+- [ ] Uses `SimpleErrorResponse` for 400/500 decoding
+- [ ] Throws `APIError.validation()` for 422
+- [ ] Throws `APIError.api(statusCode, message)` for 400/500
+- [ ] Handles decoding failures gracefully (`APIError.decodingFailed`)
+- [ ] No business logic (BMI math, thresholds, categories)
+
+### APIClient.swift
+
+- [ ] Builds URL from `baseURL + path` correctly
+- [ ] Sets `Content-Type: application/json` header
+- [ ] Supports custom headers (passed through)
+- [ ] JSON encodes request body with `snake_case` conversion
+- [ ] Uses `HTTPClientProtocol` for dependency injection
+- [ ] No business logic
+
+### APIError.swift
+
+- [ ] Enum cases: `.validation()`, `.api()`, `.decodingFailed()`, `.invalidResponse()`, `.unhandledStatusCode()`
+- [ ] Conforms to `LocalizedError` (for UI display)
+- [ ] Conforms to `Equatable`, `Sendable` (for testing/concurrency)
+
+### ErrorsDTO.swift
+
+- [ ] `ValidationErrorResponse` matches backend 422 format exactly
+- [ ] `SimpleErrorResponse` matches backend 400/500 format exactly
+- [ ] `ValidationErrorItem` includes all fields: `type`, `loc`, `msg`, `input`
+
+---
+
+## 🔍 Code Review — BMI Thin Adapter
+
+### BMIService.swift
+
+- [ ] Calls canonical endpoint `/api/v1/bmi/calculate` only
+- [ ] Uses `APIClientProtocol` (dependency injection)
+- [ ] Returns `BMICalculateResponseDTO` as-is (no modification)
+- [ ] No BMI math, thresholds, category inference
+- [ ] No i18n logic (backend provides localized text)
+- [ ] No soft paywall logic (backend provides hook structure)
+
+### DTOs (BMICalculateRequestDTO, BMICalculateResponseDTO, etc.)
+
+- [ ] Field names match backend schema exactly (`snake_case` → `camelCase` via `CodingKeys`)
+- [ ] Types match backend schema (nullable fields, enums, arrays)
+- [ ] `category: String?` is nullable (valid for child/teen/pregnant/too_young)
+- [ ] `soft_paywall: nil|object` (never `{enabled: false}`)
+- [ ] `visualization.ranges[].from/to` are optional (for future extensions)
+- [ ] `SoftPaywallAvailabilityDTO` includes `reasonKey: String?`
+- [ ] `BMIInterpretationV1DTO` includes all fields (`goalDirection`, `targetRange`, `priorityNotes`)
+
+---
+
+## 🔍 Code Review — Tests
+
+### HTTPClientTests.swift
+
+- [ ] Tests 422 error decoding (`detail[]` → `APIError.validation()`)
+- [ ] Tests 400/500 error decoding (`detail: str` → `APIError.api()`)
+- [ ] Tests successful 200 decoding
+- [ ] Uses `StubURLProtocol` for mocking
+- [ ] **Anti-flake:** `tearDown()` resets `StubURLProtocol.handler = nil`
+- [ ] No business logic in tests
+
+### APIClientTests.swift
+
+- [ ] Tests URL building (`baseURL + path`)
+- [ ] Tests `Content-Type` header
+- [ ] Tests custom headers (passed through)
+- [ ] Tests `snake_case` conversion in JSON body
+- [ ] Uses `CapturingHTTPClient` mock
+- [ ] `DummyResponse` can decode from `{}` (has `ok: Bool?` field)
+
+### BMIServiceThinAdapterTests.swift
+
+- [ ] Tests canonical path `/api/v1/bmi/calculate`
+- [ ] Tests DTO passthrough (no modification)
+- [ ] Tests nullable `category` decoding
+- [ ] Tests `visualization.ranges[].key`, `from`, `to` decoding
+- [ ] Uses `FakeAPIClient` mock
+- [ ] No business logic in tests
+
+---
+
+## 🔍 Code Review — Compatibility Shims
+
+### NutritionData.swift
+
+- [ ] `APIError` renamed to `NutritionAPIError` (naming conflict resolved)
+- [ ] Comment explains why (to avoid conflict with `Networking/APIError`)
+
+### BMIService.swift (Legacy Shims)
+
+- [ ] `LegacyBMIServicing` protocol clearly marked as temporary
+- [ ] `DefaultBMIService` clearly marked as temporary
+- [ ] `BMIServiceError` clearly marked as temporary
+- [ ] TODO comments reference `BACKLOG_LEDGER.md`
+- [ ] Legacy shims isolated to lines 48-159 (not mixed with new code)
+
+### BMICalculatorViewModel.swift
+
+- [ ] Still uses legacy types (expected — migration deferred)
+- [ ] TODO comments reference `BACKLOG_LEDGER.md`
+- [ ] No breaking changes to public API
+
+### MockBMIService.swift
+
+- [ ] Updated to `LegacyBMIServicing` (for test compatibility)
+- [ ] Comment explains why (temporary until UI migration)
+
+---
+
+## 🔍 Code Review — Documentation
+
+### AGENTS.md
+
+- [ ] "Thin HTTP Adapter Policy (Hard Rule)" section added
+- [ ] Forbidden patterns listed (BMI math, thresholds, business logic)
+- [ ] Allowed patterns listed (transport, error mapping, i18n lookup)
+- [ ] Contract-first principle documented
+- [ ] Enforcement mechanisms listed (guard tests, code review)
+
+### BACKLOG_LEDGER.md
+
+- [ ] UI migration item added (P1)
+- [ ] Technical debt details included (legacy shims, code duplication)
+- [ ] DoD for UI migration specified
+- [ ] Links to relevant files
+
+### Audit Document
+
+- [ ] `PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md` exists
+- [ ] Contract freeze declaration included
+- [ ] All TODOs replaced with facts from code
+
+### Technical Debt Report
+
+- [ ] `PR_XXX_TECHNICAL_DEBT_REPORT.md` exists
+- [ ] Technical debt items listed with rationale
+- [ ] Follow-up plan specified
+- [ ] Risk assessment included
+
+---
+
+## ⚠️ Red Flags (Blockers)
+
+- [ ] **BMI math in client code** (any thresholds, categories, calculations) → **BLOCK**
+- [ ] **Business logic in transport layer** (interpretation, i18n keys computed) → **BLOCK**
+- [ ] **DTO fields don't match backend schema** (missing fields, wrong types) → **BLOCK**
+- [ ] **Tests don't verify contract** (no 422/400/500 tests, no snake_case tests) → **BLOCK**
+- [ ] **No tearDown() in HTTPClientTests** (potential test flakiness) → **BLOCK**
+- [ ] **Legacy shims not documented** (no comments, no BACKLOG_LEDGER entry) → **BLOCK**
+
+---
+
+## ✅ Green Flags (Good Practices)
+
+- [ ] ✅ Dependency injection via protocols (`HTTPClientProtocol`, `APIClientProtocol`)
+- [ ] ✅ Tests use mocks (no real network calls)
+- [ ] ✅ Anti-flake measures (`tearDown()` resets static state)
+- [ ] ✅ Contract verification in tests (422 vs 400/500, snake_case, canonical path)
+- [ ] ✅ Documentation updated (`AGENTS.md`, `BACKLOG_LEDGER.md`)
+- [ ] ✅ Technical debt explicitly tracked and documented
+
+---
+
+## 📋 Review Questions (For Reviewer)
+
+1. **Scope:** Is PR scope clear? (Transport layer only, UI migration deferred)
+2. **Contract:** Are DTOs aligned with backend schema? (Check against `app/schemas/bmi.py`)
+3. **Tests:** Do tests verify contract boundary? (422 vs 400/500, snake_case, canonical path)
+4. **Technical debt:** Is technical debt acceptable? (Code duplication vs scope discipline)
+5. **Documentation:** Are follow-ups tracked? (BACKLOG_LEDGER.md updated)
+
+---
+
+## 🎯 Approval Criteria
+
+**Must-have:**
+- ✅ All tests passing (10 tests)
+- ✅ No BMI math in client code (grep verification)
+- ✅ DTOs match backend schema (manual review)
+- ✅ Contract freeze documented
+- ✅ Technical debt tracked in BACKLOG_LEDGER.md
+
+**Nice-to-have:**
+- ✅ Commits are atomic
+- ✅ PR description is comprehensive
+- ✅ Documentation is clear
+
+---
+
+**Reviewer notes:**
+
+---
+
+**Status:** ⏳ Pending review

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -19,17 +19,36 @@ If it is not recorded here — it does not exist.
 ---
 
 ## P0 — Next (Must happen)
-- [ ] PR-560 Web Thin Client (BMI)
+- [x] PR-560 CI iOS stability (merged 2026-01-21)
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: PR-560
-  - Reason: separated scope; iOS PR-559 must merge first
+  - Status: ✅ Merged
   - Links:
-    - docs/audit/IOS_WEB_THIN_CLIENT_AUDIT.md
+    - docs/CONTEXT_HANDOFF_2026-01-21.md
+
+- [x] PR-561 Trivy suppression (CVE-2025-15281 glibc) (merged 2026-01-21)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: PR-561
+  - Status: ✅ Merged
+  - Links:
+    - docs/security/CVE-2025-15281-glibc.md
+    - trivy/ignore-policy.rego
+
+- [ ] PR-XXX Thin HTTP Adapter (iOS + Web)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: PR-XXX (TBD)
+  - Reason: unified thin transport layer for iOS and Web clients (no business logic)
+  - Links:
+    - docs/CONTEXT_HANDOFF_2026-01-21.md
+    - docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md
   - DoD:
-    - Web calls POST `/api/v1/bmi/calculate` only
-    - No BMI math / thresholds / inference in web client
-    - Contract-driven UI only
-    - Add web anti-duplication guard (equivalent to iOS guard concept)
+    - iOS: HTTPClient/APIClient/BMIService implemented (transport only)
+    - Web: thin fetch wrapper + BMI API client (transport only)
+    - No BMI/waist/risk logic on clients (grep policy / guard tests)
+    - Unit tests green (iOS + Web)
+    - DTOs aligned with backend OpenAPI schemas
+    - Error envelope mapping implemented
+    - AGENTS.md updated (thin client policy)
     - CI green
 
 ---
@@ -110,6 +129,60 @@ If it is not recorded here — it does not exist.
     - Guard remains strict but avoids comment-only hits
     - CI remains deterministic
 
+- [ ] Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter (iOS)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: TBD (post PR-XXX)
+  - Reason: ShoppingListService and WeeklyPlanService currently use URLSession directly with custom error enums, not aligned with thin HTTP adapter policy established in PR-XXX. BMIService was refactored to use APIClient/HTTPClient; other services should follow same pattern for consistency.
+  - Links:
+    - ios/PulsePlate/Services/ShoppingListService.swift
+    - ios/PulsePlate/Services/WeeklyPlanService.swift
+    - ios/PulsePlate/Networking/APIClient.swift (reference implementation)
+    - docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md
+  - DoD:
+    - ShoppingListService uses APIClient (no direct URLSession)
+    - WeeklyPlanService uses APIClient (no direct URLSession)
+    - Custom error enums replaced with APIError from Networking layer
+    - All services follow same thin adapter pattern
+    - Tests updated to use HTTPClientProtocol stubs
+    - No breaking changes to public APIs
+
+- [ ] Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO; delete legacy BMIRequest/BMIResponse (iOS)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: TBD (post PR-XXX)
+  - **Status:** 🔴 **Technical debt created in PR-XXX** — legacy compatibility shims added to unblock tests/compilation
+  - Reason: UI layer (BMICalculatorViewModel, BMICalculatorScreen) still uses legacy BMIRequest/BMIResponse types. New thin adapter uses BMICalculateRequestDTO/BMICalculateResponseDTO. Migration deferred to separate PR to keep PR-XXX scope focused on transport layer only.
+  - **Technical debt details (created in PR-XXX):**
+    - `LegacyBMIServicing` protocol (lines 53-55 in BMIService.swift) — uses BMIRequest/BMIResponse instead of DTOs
+    - `DefaultBMIService` class (lines 91-159 in BMIService.swift) — legacy implementation with direct URLSession, duplicates HTTP logic from HTTPClient/APIClient
+    - `BMIServiceError` enum (lines 59-87 in BMIService.swift) — legacy error type, duplicates APIError functionality from Networking/APIError.swift
+    - `BMICalculatorViewModel` (lines 6-35) — still uses LegacyBMIServicing, BMIRequest, BMIResponse, BMIServiceError
+    - `MockBMIService` — updated to LegacyBMIServicing for test compatibility (should be BMIServicing after migration)
+  - **Why deferred:** To avoid breaking existing UI code in transport-layer PR. UI migration is separate scope. Tests needed to compile/run, so legacy shims were added as temporary compatibility layer.
+  - **Risk:** Code duplication (DefaultBMIService vs BMIService), two error types (BMIServiceError vs APIError), maintenance burden, potential confusion about which service to use.
+  - Links:
+    - ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift
+    - ios/PulsePlate/Screens/BMICalculatorScreen.swift
+    - ios/PulsePlate/Models/BMI/BMIRequest.swift (legacy, to be deleted)
+    - ios/PulsePlate/Models/BMI/BMIResponse.swift (legacy, to be deleted)
+    - ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift (new)
+    - ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift (new)
+    - ios/PulsePlate/Services/BMIService.swift (lines 48-159: legacy compatibility shims)
+    - ios/PulsePlate/Networking/APIError.swift (canonical error type)
+  - DoD:
+    - BMICalculatorViewModel uses BMICalculateRequestDTO/BMICalculateResponseDTO
+    - BMICalculatorViewModel uses APIError (not BMIServiceError)
+    - BMICalculatorScreen uses new DTO types
+    - Legacy BMIRequest.swift deleted
+    - Legacy BMIResponse.swift deleted
+    - LegacyBMIServicing protocol removed
+    - DefaultBMIService class removed (replaced by BMIService)
+    - BMIServiceError enum removed (replaced by APIError from Networking/)
+    - MockBMIService updated to BMIServicing (not LegacyBMIServicing)
+    - Error handling updated to use APIError (not BMIServiceError)
+    - No breaking changes to public ViewModel API
+    - Tests updated
+    - No code duplication (single HTTP client path)
+
 ---
 
 ## P2 — Future (Low priority / research)
@@ -117,5 +190,5 @@ If it is not recorded here — it does not exist.
 
 ---
 
-**Last updated:** 2026-01-21
+**Last updated:** 2026-01-21 (after PR-560 + PR-561 merge)
 **Maintainer:** @katsiaryna_kavaleuskaya

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -1,0 +1,59 @@
+# CVE-2025-15281: glibc vulnerability in Debian bookworm (CI runner)
+
+**Status:** UNFIXED in Debian bookworm at time of suppression (see Monitor link)
+**Severity:** UNKNOWN (as reported by Trivy at time of suppression)
+**Suppression Expires:** 2026-03-01
+**Monitor:** <https://security-tracker.debian.org/tracker/CVE-2025-15281>
+
+---
+
+## Summary
+
+Trivy reports `CVE-2025-15281` against the system `glibc` packages used by our CI environment.
+This is a **system library vulnerability**, not application code.
+
+At time of suppression, there is **no actionable remediation in this repo** because the affected
+packages are part of the GitHub-hosted runner base image (Debian bookworm, `deb12u13`), not a
+dependency we directly control.
+
+This document captures the rationale for a temporary suppression and how to monitor for removal.
+
+---
+
+## What Is Suppressed
+
+Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.rego`:
+
+- `CVE-2025-15281`
+- Packages: `libc6`, `libc-bin`
+- Installed version: `2.36-9+deb12u13`
+
+---
+
+## Rationale
+
+- **Upstream/Distro:** Unfixed at time of suppression (see Debian tracker).
+- **Control surface:** The vulnerable packages are in the CI runner base image; we cannot patch them
+  from this repository.
+- **Scope-limited:** Suppression applies only to the specific packages + installed version observed.
+
+---
+
+## Monitoring And Removal Plan
+
+1. Monitor Debian Security Tracker weekly:
+   <https://security-tracker.debian.org/tracker/CVE-2025-15281>
+2. When Debian bookworm shows a fixed version and the runner image updates:
+   - Remove the `CVE-2025-15281` rules from `trivy/ignore-policy.rego`.
+   - Re-run Trivy to confirm the finding is resolved without suppression.
+
+---
+
+## References
+
+- [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2025-15281)
+
+---
+
+**Last updated:** 2026-01-21
+**Review cadence:** Weekly (e.g., Fridays) as part of Security triage routine

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -26,7 +26,7 @@ Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.r
 
 - `CVE-2025-15281`
 - Packages: `libc6`, `libc-bin`
-- Installed version: `2.36-9+deb12u13`
+- Observed versions: `2.36-9+deb12u10`, `2.36-9+deb12u13` (GitHub runner base image variants)
 
 ---
 

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -1,7 +1,7 @@
 # CVE-2025-15281: glibc vulnerability in Debian bookworm (CI runner)
 
 **Status:** UNFIXED in Debian bookworm at time of suppression (see Monitor link)
-**Severity:** UNKNOWN (as reported by Trivy at time of suppression)
+**Severity:** Minor (per Debian Security Tracker)
 **Suppression Expires:** 2026-03-01
 **Monitor:** <https://security-tracker.debian.org/tracker/CVE-2025-15281>
 

--- a/ios/PulsePlate.xcodeproj/project.pbxproj
+++ b/ios/PulsePlate.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-		objectVersion = 77;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift
+++ b/ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Request DTO for canonical BMI calculation endpoint.
+///
+/// Backend: POST /api/v1/bmi/calculate
+///
+/// Contract notes:
+/// - All numeric values must be positive where applicable
+/// - `category` is NOT part of request (response-only)
+/// - `lang` defaults to "en" on backend if omitted
+///
+/// Forbidden:
+/// - No computed properties
+/// - No validation logic
+/// - No default value inference
+public struct BMICalculateRequestDTO: Encodable, Equatable, Sendable {
+
+    /// Weight in kilograms (gt=0)
+    public let weightKg: Double
+
+    /// Height in centimeters (gt=0)
+    public let heightCm: Double
+
+    /// Age in years (1...120)
+    public let age: Int
+
+    /// Gender (normalized on backend)
+    /// Allowed values: "male", "female" (case-insensitive)
+    /// Optional by contract.
+    public let gender: String?
+
+    /// Pregnancy flag (normalized on backend)
+    /// Accepts bool or string on backend; client sends Bool.
+    public let pregnant: Bool?
+
+    /// Athlete flag (normalized on backend)
+    /// Accepts bool or string on backend; client sends Bool.
+    public let athlete: Bool?
+
+    /// Waist circumference in centimeters (gt=0 if provided)
+    public let waistCm: Double?
+
+    /// Language code for localization (default handled by backend)
+    /// Examples: "en", "ru", "es"
+    public let lang: String?
+
+    public init(
+        weightKg: Double,
+        heightCm: Double,
+        age: Int,
+        gender: String? = nil,
+        pregnant: Bool? = nil,
+        athlete: Bool? = nil,
+        waistCm: Double? = nil,
+        lang: String? = nil
+    ) {
+        self.weightKg = weightKg
+        self.heightCm = heightCm
+        self.age = age
+        self.gender = gender
+        self.pregnant = pregnant
+        self.athlete = athlete
+        self.waistCm = waistCm
+        self.lang = lang
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case weightKg = "weight_kg"
+        case heightCm = "height_cm"
+        case age
+        case gender
+        case pregnant
+        case athlete
+        case waistCm = "waist_cm"
+        case lang
+    }
+}

--- a/ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift
+++ b/ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Response DTO for canonical BMI calculation.
+///
+/// Backend: POST /api/v1/bmi/calculate
+///
+/// Contract:
+/// - `category` may be nil (child / teen / pregnant / too_young)
+/// - `groupDisplay` and `interpretation` are localized TEXT
+/// - i18n KEYS appear only in visualization / interpretation_v1 / soft_paywall
+/// - No client-side logic allowed
+public struct BMICalculateResponseDTO: Decodable, Sendable {
+
+    public let bmi: Double
+    public let category: String?
+    public let group: String
+    public let groupDisplay: String
+    public let interpretation: String
+
+    public let whtRatio: Double?
+    public let waistRisk: WaistRiskDTO?
+    public let notes: [String]
+    public let ageBand: String
+
+    public let visualization: BMIScaleV1DTO?
+    public let interpretationV1: BMIInterpretationV1DTO?
+    public let softPaywall: SoftPaywallHookDTO?
+
+    enum CodingKeys: String, CodingKey {
+        case bmi
+        case category
+        case group
+        case groupDisplay = "group_display"
+        case interpretation
+        case whtRatio = "wht_ratio"
+        case waistRisk = "waist_risk"
+        case notes
+        case ageBand = "age_band"
+        case visualization
+        case interpretationV1 = "interpretation_v1"
+        case softPaywall = "soft_paywall"
+    }
+}

--- a/ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift
+++ b/ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Interpretation v1 (i18n-key based).
+///
+/// Backend schema: `app/schemas/bmi.py::BMIInterpretationV1Schema` (lines 365-404)
+/// All fields are i18n keys (client must perform lookup).
+public struct BMIInterpretationV1DTO: Decodable, Sendable {
+
+    public let goalDirection: String
+    public let targetRange: TargetRangeDTO?
+    public let riskFlags: [String]
+    public let priorityNotes: [String]
+    public let disclaimers: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case goalDirection = "goal_direction"
+        case targetRange = "target_range"
+        case riskFlags = "risk_flags"
+        case priorityNotes = "priority_notes"
+        case disclaimers
+    }
+}
+
+/// Target range: numeric or literal string.
+///
+/// Backend: `NumericRangeSchema | Literal["age_appropriate_growth", "prenatal_guidelines"] | None`
+public enum TargetRangeDTO: Decodable, Sendable {
+    case numeric(NumericRangeDTO)
+    case literal(String)
+
+    public struct NumericRangeDTO: Decodable, Sendable {
+        public let min: Double
+        public let max: Double
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let numeric = try? container.decode(NumericRangeDTO.self) {
+            self = .numeric(numeric)
+            return
+        }
+        if let literal = try? container.decode(String.self) {
+            self = .literal(literal)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "TargetRangeDTO must be NumericRangeDTO or String"
+        )
+    }
+}

--- a/ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift
+++ b/ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// BMI scale visualization (v1).
+/// Client relies ONLY on ranges[].key for i18n lookup.
+public struct BMIScaleV1DTO: Decodable, Sendable {
+
+    public let ranges: [BMIRangeDTO]
+
+    enum CodingKeys: String, CodingKey {
+        case ranges
+    }
+}
+
+public struct BMIRangeDTO: Decodable, Sendable {
+
+    /// i18n key, e.g. "bmi.normal"
+    public let key: String
+    public let from: Double?
+    public let to: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case from
+        case to
+    }
+}

--- a/ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift
+++ b/ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Soft paywall hook DTO.
+///
+/// Contract: `null` when disabled, full object when enabled (never `{enabled: false}`).
+public struct SoftPaywallHookDTO: Decodable, Sendable {
+
+    public let id: String
+    public let kind: String
+    public let position: String
+    public let priority: Int
+    public let message: SoftPaywallMessageDTO
+    public let availability: SoftPaywallAvailabilityDTO
+    public let target: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case position
+        case priority
+        case message
+        case availability
+        case target
+    }
+}
+
+public struct SoftPaywallMessageDTO: Decodable, Sendable {
+
+    /// i18n keys
+    public let titleKey: String?
+    public let bodyKey: String?
+    public let ctaKey: String?
+
+    /// localized fallback text
+    public let defaultTitle: String?
+    public let defaultBody: String?
+    public let defaultCta: String?
+
+    enum CodingKeys: String, CodingKey {
+        case titleKey = "title_key"
+        case bodyKey = "body_key"
+        case ctaKey = "cta_key"
+        case defaultTitle = "default_title"
+        case defaultBody = "default_body"
+        case defaultCta = "default_cta"
+    }
+}
+
+public struct SoftPaywallAvailabilityDTO: Decodable, Sendable {
+
+    public let proAvailable: Bool
+    public let reasonKey: String?
+
+    enum CodingKeys: String, CodingKey {
+        case proAvailable = "pro_available"
+        case reasonKey = "reason_key"
+    }
+}

--- a/ios/PulsePlate/Models/BMI/WaistRiskDTO.swift
+++ b/ios/PulsePlate/Models/BMI/WaistRiskDTO.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Waist-to-height risk result.
+///
+/// Backend schema: `app/schemas/bmi.py::WaistRiskResultSchema` (lines 87-107)
+/// Source of truth: audit-док section 1.1 Response Schema
+public struct WaistRiskDTO: Decodable, Sendable {
+
+    public let whtRatio: Double?
+    public let riskLevel: String
+    public let notes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case whtRatio = "wht_ratio"
+        case riskLevel = "risk_level"
+        case notes
+    }
+}

--- a/ios/PulsePlate/Models/NutritionData.swift
+++ b/ios/PulsePlate/Models/NutritionData.swift
@@ -51,7 +51,7 @@ class NutritionService: ObservableObject {
 
       let baseURL = AppConfig.baseURL()
       guard let url = URL(string: "\(baseURL.absoluteString)/api/nutrition/\(dateString)") else {
-        throw APIError.invalidURL
+        throw NutritionAPIError.invalidURL
       }
 
       var request = URLRequest(url: url)
@@ -60,7 +60,7 @@ class NutritionService: ObservableObject {
       let (data, response) = try await URLSession.shared.data(for: request)
 
       guard let httpResponse = response as? HTTPURLResponse else {
-        throw APIError.invalidResponse
+        throw NutritionAPIError.invalidResponse
       }
 
       // Fallback to mock data if endpoint not implemented (404) or not ready (501)
@@ -73,7 +73,7 @@ class NutritionService: ObservableObject {
       }
 
       guard httpResponse.statusCode == 200 else {
-        throw APIError.serverError(statusCode: httpResponse.statusCode)
+        throw NutritionAPIError.serverError(statusCode: httpResponse.statusCode)
       }
 
       let nutritionData = try JSONDecoder().decode(NutritionData.self, from: data)
@@ -118,7 +118,8 @@ class NutritionService: ObservableObject {
 }
 
 // MARK: - API Errors
-enum APIError: Error, LocalizedError {
+// Note: Legacy APIError renamed to NutritionAPIError to avoid conflict with Networking/APIError
+enum NutritionAPIError: Error, LocalizedError {
   case invalidURL
   case invalidResponse
   case noData

--- a/ios/PulsePlate/Networking/APIClient.swift
+++ b/ios/PulsePlate/Networking/APIClient.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Protocol for API client (enables testing via dependency injection).
+public protocol APIClientProtocol: Sendable {
+    func post<Response: Decodable, Body: Encodable>(
+        path: String,
+        body: Body,
+        headers: [String: String]
+    ) async throws -> Response
+}
+
+extension APIClientProtocol {
+    /// Convenience method with default empty headers.
+    public func post<Response: Decodable, Body: Encodable>(
+        path: String,
+        body: Body
+    ) async throws -> Response {
+        try await post(path: path, body: body, headers: [:])
+    }
+}
+
+/// Base API client for PulsePlate backend.
+///
+/// Responsibilities:
+/// - Build URLRequest with baseURL
+/// - Set headers (Content-Type, X-API-Key if provided)
+/// - JSON encode request body
+/// - Delegate sending & error handling to HTTPClient
+///
+/// Forbidden:
+/// - No business logic
+/// - No endpoint-specific behavior
+public final class APIClient: APIClientProtocol, Sendable {
+
+    private let baseURL: URL
+    private let httpClient: HTTPClientProtocol
+    private let encoder: JSONEncoder
+
+    public init(
+        baseURL: URL,
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        encoder: JSONEncoder = JSONEncoder()
+    ) {
+        self.baseURL = baseURL
+        self.httpClient = httpClient
+        self.encoder = encoder
+    }
+
+    public func post<Response: Decodable, Body: Encodable>(
+        path: String,
+        body: Body,
+        headers: [String: String] = [:]
+    ) async throws -> Response {
+
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        headers.forEach { key, value in
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        do {
+            request.httpBody = try encoder.encode(body)
+        } catch {
+            throw APIError.decodingFailed("Failed to encode request body: \(error.localizedDescription)")
+        }
+
+        return try await httpClient.send(request, responseType: Response.self)
+    }
+}

--- a/ios/PulsePlate/Networking/APIError.swift
+++ b/ios/PulsePlate/Networking/APIError.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Unified API error model for thin HTTP adapter.
+///
+/// Distinguishes between validation errors (422) and API errors (400/500/501)
+/// as per audit contract: 422 = detail array (plain English), 400/500 = detail string (localized).
+public enum APIError: Error, Equatable, Sendable {
+    /// Validation errors (422): FastAPI RequestValidationError format
+    case validation(ValidationErrorResponse)
+
+    /// API errors (400/401/403/500/501): localized detail string
+    case api(statusCode: Int, message: String)
+
+    /// JSON decoding failed
+    case decodingFailed(String)
+
+    /// Invalid HTTP response (not HTTPURLResponse)
+    case invalidResponse
+
+    /// Unhandled status code
+    case unhandledStatusCode(Int)
+}
+
+extension APIError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .validation(let response):
+            return response.detail.map(\.msg).joined(separator: "\n")
+        case .api(let statusCode, let message):
+            return "Server error \(statusCode): \(message)"
+        case .decodingFailed(let message):
+            return "Decoding failed: \(message)"
+        case .invalidResponse:
+            return "Invalid HTTP response"
+        case .unhandledStatusCode(let code):
+            return "Unhandled status code: \(code)"
+        }
+    }
+}

--- a/ios/PulsePlate/Networking/ErrorsDTO.swift
+++ b/ios/PulsePlate/Networking/ErrorsDTO.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// FastAPI validation error response (422).
+///
+/// Format: `{"detail": [{"type": "...", "loc": [...], "msg": "...", "input": ...}]}`
+/// Note: `msg` is plain English (not i18n keys) per audit contract.
+public struct ValidationErrorResponse: Decodable, Equatable, Sendable {
+    public let detail: [ValidationErrorItem]
+}
+
+public struct ValidationErrorItem: Decodable, Equatable, Sendable {
+    public let loc: [String]
+    public let msg: String
+    public let type: String
+    // Note: `input` field may be present but we don't decode it (not needed for client)
+}
+
+/// Simple error response (400/500/501).
+///
+/// Format: `{"detail": "localized error message"}`
+/// Note: `detail` is localized text via backend `t(lang, key)` per audit contract.
+public struct SimpleErrorResponse: Decodable, Equatable, Sendable {
+    public let detail: String
+}

--- a/ios/PulsePlate/Networking/HTTPClient.swift
+++ b/ios/PulsePlate/Networking/HTTPClient.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Protocol for HTTP client (enables testing via URLProtocol stubs).
+public protocol HTTPClientProtocol: Sendable {
+    func send<T: Decodable>(
+        _ request: URLRequest,
+        responseType: T.Type
+    ) async throws -> T
+}
+
+/// Thin HTTP client: URLSession wrapper with JSON encode/decode and error mapping.
+///
+/// Responsibilities (strictly transport-only):
+/// - Build URLRequest
+/// - JSON encode/decode
+/// - Distinguish 422 (validation) vs 400/500 (API errors) per audit contract
+///
+/// Forbidden:
+/// - No BMI/waist/risk logic
+/// - No business rule interpretation
+/// - No i18n localization (error messages are passed through as-is)
+public final class HTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    public init(
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.session = session
+        self.decoder = decoder
+    }
+
+    public func send<T: Decodable>(
+        _ request: URLRequest,
+        responseType: T.Type
+    ) async throws -> T {
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 200...299:
+            return try decode(data, as: T.self)
+
+        case 422:
+            throw try decodeValidationError(from: data)
+
+        case 400, 401, 403, 500, 501:
+            throw try decodeAPIError(from: data, statusCode: httpResponse.statusCode)
+
+        default:
+            throw APIError.unhandledStatusCode(httpResponse.statusCode)
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func decode<T: Decodable>(_ data: Data, as type: T.Type) throws -> T {
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            let message = error.localizedDescription
+            throw APIError.decodingFailed(message)
+        }
+    }
+
+    private func decodeValidationError(from data: Data) throws -> APIError {
+        do {
+            let error = try decoder.decode(ValidationErrorResponse.self, from: data)
+            return .validation(error)
+        } catch {
+            // If validation error response itself fails to decode, treat as decoding error
+            throw APIError.decodingFailed("Failed to decode validation error: \(error.localizedDescription)")
+        }
+    }
+
+    private func decodeAPIError(from data: Data, statusCode: Int) throws -> APIError {
+        do {
+            let error = try decoder.decode(SimpleErrorResponse.self, from: data)
+            return .api(statusCode: statusCode, message: error.detail)
+        } catch {
+            // If simple error response fails to decode, try to extract detail as plain string
+            // This handles edge cases where backend might return non-JSON error
+            if let errorString = String(data: data, encoding: .utf8) {
+                return .api(statusCode: statusCode, message: errorString)
+            }
+            throw APIError.decodingFailed("Failed to decode API error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/ios/PulsePlate/Services/BMIService.swift
+++ b/ios/PulsePlate/Services/BMIService.swift
@@ -1,9 +1,61 @@
 import Foundation
 
+/// Protocol for BMI service (enables testing via dependency injection).
 public protocol BMIServicing: Sendable {
+    func calculateBMI(request: BMICalculateRequestDTO) async throws -> BMICalculateResponseDTO
+}
+
+/// BMI service — thin wrapper over APIClient.
+///
+/// Responsibilities:
+/// - Call canonical BMI calculate endpoint
+/// - Return response DTO as-is
+///
+/// Forbidden:
+/// - No BMI/waist/risk logic
+/// - No interpretation
+/// - No i18n
+/// - No soft paywall logic
+public final class BMIService: BMIServicing, Sendable {
+
+    private let apiClient: APIClientProtocol
+
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    public func calculateBMI(
+        request: BMICalculateRequestDTO
+    ) async throws -> BMICalculateResponseDTO {
+        try await apiClient.post(
+            path: "/api/v1/bmi/calculate",
+            body: request
+        )
+    }
+}
+
+// MARK: - Convenience Initializer
+
+extension BMIService {
+    /// Convenience initializer using AppConfig.baseURL().
+    public convenience init(baseURL: URL? = nil) {
+        let url = baseURL ?? AppConfig.baseURL()
+        let client = APIClient(baseURL: url)
+        self.init(apiClient: client)
+    }
+}
+
+// MARK: - Legacy Compatibility (temporary, until UI migration)
+
+/// Legacy BMI service using old types (BMIRequest/BMIResponse).
+/// This is a compatibility shim for existing UI code.
+/// TODO: Remove after UI migration to BMICalculate*DTO (tracked in BACKLOG_LEDGER.md)
+public protocol LegacyBMIServicing: Sendable {
     func calculateBMI(request: BMIRequest) async throws -> BMIResponse
 }
 
+/// Legacy error type for backward compatibility with UI.
+/// TODO: Migrate UI to APIError (tracked in BACKLOG_LEDGER.md)
 public enum BMIServiceError: Error, LocalizedError, Sendable, Equatable {
     case http(Int, String?)
     case encoding(String)
@@ -34,7 +86,9 @@ public enum BMIServiceError: Error, LocalizedError, Sendable, Equatable {
     }
 }
 
-public final class DefaultBMIService: BMIServicing, @unchecked Sendable {
+/// Legacy BMI service implementation (temporary compatibility shim).
+/// TODO: Remove after UI migration (tracked in BACKLOG_LEDGER.md)
+public final class DefaultBMIService: LegacyBMIServicing, @unchecked Sendable {
     private let baseURL: URL
     private let session: URLSession
 
@@ -80,7 +134,14 @@ public final class DefaultBMIService: BMIServicing, @unchecked Sendable {
 
         if http.statusCode == 422 {
             if let parsed = try? JSONDecoder().decode(ValidationErrorResponse.self, from: data) {
-                throw BMIServiceError.validation(parsed.detail)
+                throw BMIServiceError.validation(parsed.detail.map { err in
+                    BMIServiceError.ValidationError(
+                        type: err.type,
+                        loc: err.loc,
+                        msg: err.msg,
+                        input: nil // Legacy doesn't decode input
+                    )
+                })
             }
         }
 
@@ -90,8 +151,6 @@ public final class DefaultBMIService: BMIServicing, @unchecked Sendable {
         }
 
         do {
-            // BMIResponse declares explicit CodingKeys for snake_case fields (e.g., group_display).
-            // Using .convertFromSnakeCase here could prevent those keys from matching.
             return try JSONDecoder().decode(BMIResponse.self, from: data)
         } catch {
             throw BMIServiceError.decoding(error.localizedDescription)
@@ -99,9 +158,7 @@ public final class DefaultBMIService: BMIServicing, @unchecked Sendable {
     }
 }
 
-private struct ValidationErrorResponse: Codable {
-    let detail: [BMIServiceError.ValidationError]
-}
+// Note: ValidationErrorResponse is imported from Networking/ErrorsDTO.swift
 
 /// Minimal AnyCodable for validation payloads.
 /// (Keeps tests deterministic; not intended for general use.)

--- a/ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift
+++ b/ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift
@@ -3,16 +3,20 @@ import Combine
 
 @MainActor
 final class BMICalculatorViewModel: ObservableObject {
+    // TODO: Migrate to BMICalculateResponseDTO (tracked in BACKLOG_LEDGER.md)
     @Published var result: BMIResponse?
     @Published var isLoading = false
+    // TODO: Migrate to APIError (tracked in BACKLOG_LEDGER.md)
     @Published var error: BMIServiceError?
 
-    private let service: BMIServicing
+    private let service: LegacyBMIServicing
 
-    init(service: BMIServicing = DefaultBMIService()) {
+    // TODO: Update to use BMIService() after UI migration (tracked in BACKLOG_LEDGER.md)
+    init(service: LegacyBMIServicing = DefaultBMIService()) {
         self.service = service
     }
 
+    // TODO: Migrate to BMICalculateRequestDTO (tracked in BACKLOG_LEDGER.md)
     func calculateBMI(request: BMIRequest) async {
         isLoading = true
         error = nil

--- a/ios/PulsePlateTests/Mocks/MockBMIService.swift
+++ b/ios/PulsePlateTests/Mocks/MockBMIService.swift
@@ -1,7 +1,9 @@
 import Foundation
 @testable import PulsePlate
 
-final class MockBMIService: BMIServicing {
+/// Mock BMI service for testing (uses legacy types for backward compatibility with existing tests).
+/// TODO: Update to use BMICalculate*DTO after UI migration (tracked in BACKLOG_LEDGER.md)
+final class MockBMIService: LegacyBMIServicing {
     var result: Result<BMIResponse, Error> = .failure(BMIServiceError.transport("not set"))
 
     func calculateBMI(request: BMIRequest) async throws -> BMIResponse {

--- a/ios/PulsePlateTests/Networking/APIClientTests.swift
+++ b/ios/PulsePlateTests/Networking/APIClientTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import PulsePlate
+
+final class APIClientTests: XCTestCase {
+
+    fileprivate final class CapturingHTTPClient: HTTPClientProtocol {
+        var lastRequest: URLRequest?
+
+        func send<T: Decodable>(
+            _ request: URLRequest,
+            responseType: T.Type
+        ) async throws -> T {
+            lastRequest = request
+            // Return dummy by decoding empty JSON object
+            // For empty structs, we need at least one field or use a workaround
+            // This is a test helper - in real tests we'd use proper response types
+            let data = "{}".data(using: .utf8)!
+            // Note: Empty struct {} can decode if T has no required fields
+            // If decoding fails, the test will catch it
+            return try JSONDecoder().decode(T.self, from: data)
+        }
+    }
+
+    func test_post_buildsCorrectURLAndHeadersAndBody() async throws {
+        let http = CapturingHTTPClient()
+        let api = APIClient(
+            baseURL: URL(string: "https://example.com")!,
+            httpClient: http
+        )
+
+        let req = BMICalculateRequestDTO(
+            weightKg: 70.0,
+            heightCm: 175.0,
+            age: 30,
+            gender: "male",
+            lang: "en"
+        )
+
+        // Use a simple response type that can decode from {}
+        struct DummyResponse: Decodable {
+            let ok: Bool?
+        }
+        let _: DummyResponse = try await api.post(
+            path: "/api/v1/bmi/calculate",
+            body: req,
+            headers: [:]
+        ) as DummyResponse
+
+        guard let request = http.lastRequest else {
+            XCTFail("Request not captured")
+            return
+        }
+
+        XCTAssertEqual(request.url?.absoluteString, "https://example.com/api/v1/bmi/calculate")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertNotNil(request.httpBody)
+
+        // JSON keys must be snake_case
+        let json = try JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        XCTAssertNotNil(json?["weight_kg"])
+        XCTAssertNotNil(json?["height_cm"])
+        XCTAssertEqual(json?["age"] as? Int, 30)
+        XCTAssertEqual(json?["gender"] as? String, "male")
+        XCTAssertEqual(json?["lang"] as? String, "en")
+    }
+
+    func test_post_withCustomHeaders_appendsHeaders() async throws {
+        let http = CapturingHTTPClient()
+        let api = APIClient(
+            baseURL: URL(string: "https://example.com")!,
+            httpClient: http
+        )
+
+        let req = BMICalculateRequestDTO(weightKg: 70.0, heightCm: 175.0, age: 30)
+
+        // Use a simple response type that can decode from {}
+        struct DummyResponse: Decodable {
+            let ok: Bool?
+        }
+        let _: DummyResponse = try await api.post(
+            path: "/api/v1/bmi/calculate",
+            body: req,
+            headers: ["X-API-Key": "test-key"]
+        ) as DummyResponse
+
+        guard let request = http.lastRequest else {
+            XCTFail("Request not captured")
+            return
+        }
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-API-Key"), "test-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func test_post_encodeFailure_throwsDecodingFailed() async throws {
+        // Use a type that can't be encoded
+        struct Unencodable: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue("test", .init(codingPath: [], debugDescription: "test"))
+            }
+        }
+
+        let api = APIClient(baseURL: URL(string: "https://example.com")!)
+
+        do {
+            struct DummyResponse: Decodable {
+                let ok: Bool?
+            }
+            let _: DummyResponse = try await api.post(
+                path: "/api/v1/bmi/calculate",
+                body: Unencodable(),
+                headers: [:]
+            ) as DummyResponse
+            XCTFail("Expected to throw")
+        } catch let error as APIError {
+            guard case .decodingFailed = error else {
+                XCTFail("Expected .decodingFailed, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/ios/PulsePlateTests/Networking/HTTPClientTests.swift
+++ b/ios/PulsePlateTests/Networking/HTTPClientTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import PulsePlate
+
+final class HTTPClientTests: XCTestCase {
+
+    fileprivate final class StubURLProtocol: URLProtocol {
+        static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            guard let handler = Self.handler else {
+                XCTFail("StubURLProtocol.handler not set")
+                return
+            }
+            do {
+                let (response, data) = try handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+
+        override func stopLoading() {}
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        StubURLProtocol.handler = nil
+    }
+
+    private func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    func test_422_decodesValidationErrorResponse() async throws {
+        let session = makeSession()
+        let client = HTTPClient(session: session)
+
+        StubURLProtocol.handler = { request in
+            let body = """
+            {
+              "detail": [
+                { "type": "value_error", "loc": ["body","weight_kg"], "msg": "Value must be positive", "input": -1 }
+              ]
+            }
+            """.data(using: .utf8)!
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        var request = URLRequest(url: URL(string: "https://example.com/api/v1/bmi/calculate")!)
+        request.httpMethod = "POST"
+
+        do {
+            struct Dummy: Decodable {}
+            _ = try await client.send(request, responseType: Dummy.self)
+            XCTFail("Expected to throw")
+        } catch let error as APIError {
+            guard case .validation(let detail) = error else {
+                XCTFail("Expected .validation, got \(error)")
+                return
+            }
+            XCTAssertEqual(detail.detail.count, 1)
+            XCTAssertEqual(detail.detail.first?.msg, "Value must be positive")
+            XCTAssertEqual(detail.detail.first?.loc, ["body", "weight_kg"])
+        }
+    }
+
+    func test_400_decodesSimpleErrorResponse() async throws {
+        let session = makeSession()
+        let client = HTTPClient(session: session)
+
+        StubURLProtocol.handler = { request in
+            let body = """
+            { "detail": "Invalid parameters" }
+            """.data(using: .utf8)!
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        var request = URLRequest(url: URL(string: "https://example.com/api/v1/bmi/calculate")!)
+        request.httpMethod = "POST"
+
+        do {
+            struct Dummy: Decodable {}
+            _ = try await client.send(request, responseType: Dummy.self)
+            XCTFail("Expected to throw")
+        } catch let error as APIError {
+            guard case .api(let statusCode, let message) = error else {
+                XCTFail("Expected .api, got \(error)")
+                return
+            }
+            XCTAssertEqual(statusCode, 400)
+            XCTAssertEqual(message, "Invalid parameters")
+        }
+    }
+
+    func test_500_decodesSimpleErrorResponse() async throws {
+        let session = makeSession()
+        let client = HTTPClient(session: session)
+
+        StubURLProtocol.handler = { request in
+            let body = """
+            { "detail": "BMI calculation failed" }
+            """.data(using: .utf8)!
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        var request = URLRequest(url: URL(string: "https://example.com/api/v1/bmi/calculate")!)
+        request.httpMethod = "POST"
+
+        do {
+            struct Dummy: Decodable {}
+            _ = try await client.send(request, responseType: Dummy.self)
+            XCTFail("Expected to throw")
+        } catch let error as APIError {
+            guard case .api(let statusCode, let message) = error else {
+                XCTFail("Expected .api, got \(error)")
+                return
+            }
+            XCTAssertEqual(statusCode, 500)
+            XCTAssertEqual(message, "BMI calculation failed")
+        }
+    }
+
+    func test_200_decodesResponse() async throws {
+        let session = makeSession()
+        let client = HTTPClient(session: session)
+
+        StubURLProtocol.handler = { request in
+            let body = """
+            { "bmi": 22.5 }
+            """.data(using: .utf8)!
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        struct Response: Decodable {
+            let bmi: Double
+        }
+
+        var request = URLRequest(url: URL(string: "https://example.com/api/v1/bmi/calculate")!)
+        request.httpMethod = "POST"
+
+        let result = try await client.send(request, responseType: Response.self)
+        XCTAssertEqual(result.bmi, 22.5)
+    }
+
+    // Note: test_invalidResponse is skipped because URLSession.data(for:) always returns
+    // HTTPURLResponse for HTTP/HTTPS requests. The guard clause in HTTPClient is defensive
+    // programming but difficult to test without mocking URLSession internals.
+    // The guard is verified by code review and integration tests.
+}

--- a/ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift
+++ b/ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import PulsePlate
+
+/// Tests for BMIService "thinness" — verifies no business logic, only transport.
+final class BMIServiceThinAdapterTests: XCTestCase {
+
+    fileprivate final class FakeAPIClient: APIClientProtocol {
+        var lastPath: String?
+        var lastBody: BMICalculateRequestDTO?
+
+        func post<Response: Decodable, Body: Encodable>(
+            path: String,
+            body: Body,
+            headers: [String: String]
+        ) async throws -> Response {
+            lastPath = path
+            if let bmiBody = body as? BMICalculateRequestDTO {
+                lastBody = bmiBody
+            }
+
+            // Return minimal valid response matching BMICalculateResponseDTO
+            let json = """
+            {
+              "bmi": 22.5,
+              "category": "normal",
+              "group": "general",
+              "group_display": "General",
+              "interpretation": "Your BMI is within the normal range.",
+              "wht_ratio": null,
+              "waist_risk": null,
+              "notes": [],
+              "age_band": "adult",
+              "visualization": null,
+              "interpretation_v1": null,
+              "soft_paywall": null
+            }
+            """.data(using: .utf8)!
+
+            return try JSONDecoder().decode(Response.self, from: json)
+        }
+    }
+
+    func test_calculate_callsCanonicalEndpoint() async throws {
+        let api = FakeAPIClient()
+        let service = BMIService(apiClient: api)
+
+        let req = BMICalculateRequestDTO(weightKg: 70.0, heightCm: 175.0, age: 30)
+
+        let response = try await service.calculateBMI(request: req)
+
+        XCTAssertEqual(api.lastPath, "/api/v1/bmi/calculate")
+        XCTAssertNotNil(api.lastBody)
+        XCTAssertEqual(api.lastBody?.weightKg, 70.0)
+        XCTAssertEqual(api.lastBody?.heightCm, 175.0)
+        XCTAssertEqual(api.lastBody?.age, 30)
+        XCTAssertEqual(response.bmi, 22.5)
+        XCTAssertEqual(response.group, "general")
+        XCTAssertEqual(response.category, "normal")
+    }
+
+    func test_calculate_returnsBMICalculateResponseDTO() async throws {
+        // Integration-style test: verify DTO structure matches contract
+        let json = """
+        {
+          "bmi": 24.69,
+          "category": "normal",
+          "group": "general",
+          "group_display": "General",
+          "interpretation": "Your BMI is within the normal range.",
+          "wht_ratio": 0.51,
+          "waist_risk": {
+            "wht_ratio": 0.51,
+            "risk_level": "low",
+            "notes": []
+          },
+          "notes": [],
+          "age_band": "adult",
+          "visualization": {
+            "ranges": [
+              {"key": "bmi.underweight", "from": 0, "to": 18.5},
+              {"key": "bmi.normal", "from": 18.5, "to": 25}
+            ]
+          },
+          "interpretation_v1": null,
+          "soft_paywall": null
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(BMICalculateResponseDTO.self, from: json)
+
+        XCTAssertEqual(response.bmi, 24.69)
+        XCTAssertEqual(response.category, "normal")
+        XCTAssertEqual(response.group, "general")
+        XCTAssertEqual(response.groupDisplay, "General")
+        XCTAssertEqual(response.interpretation, "Your BMI is within the normal range.")
+        XCTAssertEqual(response.whtRatio, 0.51)
+        XCTAssertNotNil(response.waistRisk)
+        XCTAssertEqual(response.waistRisk?.riskLevel, "low")
+        XCTAssertEqual(response.ageBand, "adult")
+        XCTAssertNotNil(response.visualization)
+        XCTAssertEqual(response.visualization?.ranges.count, 2)
+        XCTAssertEqual(response.visualization?.ranges.first?.key, "bmi.underweight")
+        XCTAssertEqual(response.visualization?.ranges.first?.from, 0)
+        XCTAssertEqual(response.visualization?.ranges.first?.to, 18.5)
+    }
+
+    func test_calculate_nullableCategory_decodesCorrectly() async throws {
+        // Test that category can be nil (child/teen/pregnant)
+        let json = """
+        {
+          "bmi": 18.0,
+          "category": null,
+          "group": "child",
+          "group_display": "Child",
+          "interpretation": "BMI categories are not provided for children.",
+          "wht_ratio": null,
+          "waist_risk": null,
+          "notes": [],
+          "age_band": "child",
+          "visualization": null,
+          "interpretation_v1": null,
+          "soft_paywall": null
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(BMICalculateResponseDTO.self, from: json)
+
+        XCTAssertNil(response.category)
+        XCTAssertEqual(response.group, "child")
+    }
+}

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -9,7 +9,7 @@ default ignore := false
 # - Limit to the installed versions reported at time of suppression
 #
 # Suppression expires: 2026-03-01 (manual removal)
-# Documented in: docs/security/CVE-2026-0915-glibc.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -20,6 +20,26 @@ ignore if {
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
+	input.PkgName == "libc-bin"
+	input.InstalledVersion == "2.36-9+deb12u13"
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+}
+
+# CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image
+# Review-by: 2026-03-01 (manual removal)
+# Rationale: Upstream unfixed; GitHub runner base image (deb12u13); no actionable remediation in repo
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
+# Documented in: docs/security/CVE-2025-15281-glibc.md
+
+ignore if {
+	input.VulnerabilityID == "CVE-2025-15281"
+	input.PkgName == "libc6"
+	input.InstalledVersion == "2.36-9+deb12u13"
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2025-15281"
 	input.PkgName == "libc-bin"
 	input.InstalledVersion == "2.36-9+deb12u13"
 	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -27,13 +27,30 @@ ignore if {
 
 # CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image
 # Review-by: 2026-03-01 (manual removal)
-# Rationale: Upstream unfixed; GitHub runner base image (deb12u13); no actionable remediation in repo
+# Rationale: Upstream unfixed; GitHub runner base image (deb12u10/deb12u13); no actionable remediation in repo
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
 # Documented in: docs/security/CVE-2025-15281-glibc.md
 
-# Helper rule: check if PkgID matches allowed glibc packages
+# Helper rule: check if InstalledVersion matches observed runner versions
+cve_2025_15281_version_match if {
+	input.InstalledVersion == "2.36-9+deb12u10"
+}
+
+cve_2025_15281_version_match if {
+	input.InstalledVersion == "2.36-9+deb12u13"
+}
+
+# Helper rule: check if PkgID matches allowed glibc packages (both u10 and u13)
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc6@2.36-9+deb12u10")
+}
+
 cve_2025_15281_pkgid_match if {
 	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u10")
 }
 
 cve_2025_15281_pkgid_match if {
@@ -44,6 +61,6 @@ ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
 	allowed_packages := {"libc6", "libc-bin"}
 	allowed_packages[input.PkgName]
-	input.InstalledVersion == "2.36-9+deb12u13"
+	cve_2025_15281_version_match
 	cve_2025_15281_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -31,10 +31,19 @@ ignore if {
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
 # Documented in: docs/security/CVE-2025-15281-glibc.md
 
+# Helper rule: check if PkgID matches allowed glibc packages
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
+}
+
+cve_2025_15281_pkgid_match if {
+	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
 	allowed_packages := {"libc6", "libc-bin"}
 	allowed_packages[input.PkgName]
 	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc6@2.36-9+deb12u13") or startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+	cve_2025_15281_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -33,14 +33,8 @@ ignore if {
 
 ignore if {
 	input.VulnerabilityID == "CVE-2025-15281"
-	input.PkgName == "libc6"
+	allowed_packages := {"libc6", "libc-bin"}
+	allowed_packages[input.PkgName]
 	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc6@2.36-9+deb12u13")
-}
-
-ignore if {
-	input.VulnerabilityID == "CVE-2025-15281"
-	input.PkgName == "libc-bin"
-	input.InstalledVersion == "2.36-9+deb12u13"
-	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+	startswith(input.PkgID, "libc6@2.36-9+deb12u13") or startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
 }


### PR DESCRIPTION
# PR-XXX: Thin HTTP Adapter for iOS (Transport Layer)

## Summary

Implements thin HTTP transport layer for iOS client, aligned with backend contracts. Adds `HTTPClient`/`APIClient` for error mapping and `BMIService` as thin wrapper. DTOs match backend OpenAPI schemas exactly.

**Scope:** Transport layer only (no UI migration in this PR).

**DoD Evidence:** See `docs/PR_XXX_DOD_CHECKLIST.md`
**Review Checklist:** See `docs/PR_XXX_REVIEW_CHECKLIST.md`

---

## Contract Freeze

**Effective date:** 2026-01-22

**Frozen contracts:**
- **Canonical endpoint:** `/api/v1/bmi/calculate`
- **Error formats:**
  - `422`: `{"detail": [{"type": "...", "loc": [...], "msg": "...", "input": ...}]}` (plain English)
  - `400/500/501`: `{"detail": "localized text"}` (via backend `t(lang, key)`)
- **Request/Response schemas:** `app/schemas/bmi.py` (backend source of truth)
- **i18n approach:** Mixed model (text fields vs i18n keys — see audit doc)

**Enforcement:**
- Client implementation matches frozen contracts exactly
- Any deviation requires explicit backend PR to change contract first
- See: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`

---

## Changes

### Core Transport Layer

**Files:**
- `ios/PulsePlate/Networking/HTTPClient.swift` — low-level HTTP client with error mapping
- `ios/PulsePlate/Networking/APIClient.swift` — request builder (URL, headers, JSON encoding)
- `ios/PulsePlate/Networking/APIError.swift` — unified error model (422 vs 400/500)
- `ios/PulsePlate/Networking/ErrorsDTO.swift` — error response DTOs

**Responsibilities:**
- Transport only (no business logic)
- Error envelope mapping (422 `detail[]` vs 400/500 `detail: str`)
- JSON encode/decode with `snake_case` conversion

### BMI Thin Adapter

**Files:**
- `ios/PulsePlate/Services/BMIService.swift` — thin wrapper over `APIClient` (lines 1-46)
- `ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift` — request DTO
- `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift` — response DTO
- `ios/PulsePlate/Models/BMI/WaistRiskDTO.swift` — waist risk DTO
- `ios/PulsePlate/Models/BMI/BMIScaleV1DTO.swift` — visualization DTO
- `ios/PulsePlate/Models/BMI/BMIInterpretationV1DTO.swift` — interpretation DTO
- `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift` — soft paywall DTO

**Responsibilities:**
- Call canonical endpoint only
- Return DTOs as-is (no computation, no interpretation)
- Forbidden: BMI math, thresholds, category inference

### Tests

**Files:**
- `ios/PulsePlateTests/Networking/HTTPClientTests.swift` — error mapping tests (422 vs 400/500)
- `ios/PulsePlateTests/Networking/APIClientTests.swift` — request building tests (URL, headers, snake_case)
- `ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift` — thinness verification tests

**Coverage:**
- ✅ 10 tests passing
- ✅ Contract boundary verified (422/400/500, snake_case, canonical path)
- ✅ Anti-flake: `StubURLProtocol.handler` reset in `tearDown()`

### Compatibility Shims (Temporary)

**Why:** To unblock compilation and tests without breaking existing UI code.

**Files:**
- `ios/PulsePlate/Models/NutritionData.swift` — renamed `APIError` → `NutritionAPIError` (naming conflict)
- `ios/PulsePlate/Services/BMIService.swift` (lines 48-159) — legacy compatibility shims:
  - `LegacyBMIServicing` protocol (uses `BMIRequest`/`BMIResponse`)
  - `DefaultBMIService` class (legacy implementation with direct `URLSession`)
  - `BMIServiceError` enum (legacy error type)
- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift` — still uses legacy types (migration deferred)
- `ios/PulsePlateTests/Mocks/MockBMIService.swift` — updated to `LegacyBMIServicing` for test compatibility

**Trade-off:** Code duplication (legacy vs new) accepted to keep PR scope focused (transport layer only). UI migration tracked in `BACKLOG_LEDGER.md` (P1 item).

**See:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md` for detailed analysis.

---

## DoD Evidence

### Tests

```bash
cd ios && xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate \
  -destination 'platform=iOS Simulator,id=8B9BF341-A44D-4BB0-A898-EC8CFEE56B79' \
  -only-testing:PulsePlateTests/HTTPClientTests \
  -only-testing:PulsePlateTests/APIClientTests \
  -only-testing:PulsePlateTests/BMIServiceThinAdapterTests test
```

**Result:** ✅ 10 tests passing

- `HTTPClientTests` (4 tests): 422 vs 400/500 error mapping
- `APIClientTests` (3 tests): URL building, headers, snake_case encoding
- `BMIServiceThinAdapterTests` (3 tests): canonical path, DTO passthrough, nullable `category`

### Contract Verification

- ✅ `HTTPClient` distinguishes 422 (`detail[]`) vs 400/500 (`detail: str`)
- ✅ `APIClient` builds URL from `baseURL + path`, sets `Content-Type`, supports custom headers
- ✅ `BMIService` calls canonical path `/api/v1/bmi/calculate`, only passthrough DTO
- ✅ DTO contract: `category: String?` (nullable), `soft_paywall: nil|object`, `visualization.ranges.from/to` verified

### Documentation

- ✅ `AGENTS.md` updated (thin client policy, contract-first, legacy DTO migration tracking, "No dual-path networking" rule)
- ✅ `BACKLOG_LEDGER.md` updated (UI migration tracked as P1 item)
- ✅ Audit document: `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
- ✅ Technical debt report: `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`

**Full DoD checklist:** `docs/PR_XXX_DOD_CHECKLIST.md`

---

## Deferred / Follow-ups

**Tracked in:** `docs/roadmap/BACKLOG_LEDGER.md`

### P1 — UI Migration (Post PR-XXX) 🔴

**Item:** "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO; delete legacy BMIRequest/BMIResponse (iOS)"

**Scope:**
- Migrate `BMICalculatorViewModel` to use `BMIServicing` + DTOs
- Update `BMICalculatorScreen` to use new DTOs
- Delete legacy types: `BMIRequest`, `BMIResponse`
- Delete legacy shims: `LegacyBMIServicing`, `DefaultBMIService`, `BMIServiceError`
- Update `MockBMIService` to `BMIServicing`
- Single HTTP client path (no duplication)

**DoD:** See `BACKLOG_LEDGER.md` (P1 item: "Migrate BMICalculatorViewModel + Screen to BMICalculate*DTO")

**Technical debt created in this PR:** See `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`

### P1 — Other Services Migration (Post PR-XXX)

**Item:** "Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter (iOS)"

**Scope:**
- Migrate `ShoppingListService` to use `APIClient` (no direct `URLSession`)
- Migrate `WeeklyPlanService` to use `APIClient` (no direct `URLSession`)
- Replace custom error enums with `APIError` from Networking layer
- All services follow same thin adapter pattern

**DoD:** See `BACKLOG_LEDGER.md` (P1 item: "Unify ShoppingListService / WeeklyPlanService under thin HTTP adapter")

**Rationale:** Enforces "No dual-path networking" rule (see `AGENTS.md`)

### P0 — Web Thin Adapter (Post PR-XXX)

**Item:** "PR-XXX Thin HTTP Adapter (iOS + Web)" — Web part

**Scope:**
- Implement thin fetch wrapper (TypeScript)
- Generate types from OpenAPI (`openapi-typescript`)
- Error envelope mapping (422 vs 400/500)
- BMI API client (transport only)

**DoD:** See `BACKLOG_LEDGER.md` (P0 item: "PR-XXX Thin HTTP Adapter (iOS + Web)")

---

## Breaking Changes

**None** — this PR adds new transport layer without breaking existing UI code. Legacy compatibility shims ensure backward compatibility until UI migration.

---

## Testing

### Unit Tests

- ✅ `HTTPClientTests` — error mapping (422 vs 400/500)
- ✅ `APIClientTests` — request building (URL, headers, snake_case)
- ✅ `BMIServiceThinAdapterTests` — thinness verification (canonical path, DTO passthrough)

**Full test results:** See `docs/PR_XXX_DOD_CHECKLIST.md` (section: "Tests")

### Manual Testing

- ✅ Project compiles
- ✅ Existing UI code still works (via legacy shims)
- ✅ New `BMIService` can be used independently (for future UI migration)

---

## References

- **DoD Checklist:** `docs/PR_XXX_DOD_CHECKLIST.md`
- **Review Checklist:** `docs/PR_XXX_REVIEW_CHECKLIST.md`
- **Audit document:** `docs/audit/PR_XXX_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md`
- **Technical debt report:** `docs/audit/PR_XXX_TECHNICAL_DEBT_REPORT.md`
- **Context handoff:** `docs/CONTEXT_HANDOFF_2026-01-21.md`
- **Backlog ledger:** `docs/roadmap/BACKLOG_LEDGER.md`
- **Thin client policy:** `AGENTS.md` (section: "Thin HTTP Adapter Policy (Hard Rule)")

---

**Related PRs:**
- PR-560: CI iOS stability (merged 2026-01-21)
- PR-561: Trivy suppression (merged 2026-01-21)

---

**Reviewer notes:**
- Focus on transport layer correctness (error mapping, URL building, snake_case)
- Verify no BMI math in client code (grep for thresholds)
- Check DTO alignment with backend schema (`app/schemas/bmi.py`)
- Legacy shims are temporary (documented in technical debt report)

## Summary by Sourcery

Ввести тонкий слой HTTP-транспорта для iOS-функциональности BMI, согласовать клиентские DTO и обработку ошибок с контрактами бэкенда и формализовать политики thin‑client и подавления (suppression) по безопасности, сохранив работоспособность существующего UI-кода через временные шимы.

New Features:
- Добавить абстракции `HTTPClient` и `APIClient` на iOS для JSON‑транспорта и стандартизированного отображения ошибок.
- Ввести `BMIService` и связанные с BMI DTO запросов/ответов как тонкий адаптер над каноничным эндпоинтом `/api/v1/bmi/calculate`.
- Добавить DTO для soft paywall, визуализаций и интерпретаций, отражающие (зеркалящие) схемы BMI на бэкенде.

Bug Fixes:
- Разрешить конфликт именования `APIError` в `NutritionData`, переименовав локальный тип ошибки в `NutritionAPIError`.
- Добавить точные, привязанные к версии правила игнора Trivy для уязвимости glibc CVE-2025-15281, чтобы убрать шум в CI‑сканировании.

Enhancements:
- Определить унифицированную модель `APIError` и DTO ошибок для разделения ошибок валидации и общих ошибок API на iOS.
- Задокументировать и внедрить политику тонкого HTTP‑адаптера и правило запрета dual‑path‑сети (no dual-path networking) на клиентах.
- Добавить детализированные документы по DoD, ревью, открытию PR и передаче контекста, чтобы стандартизировать, как PR-ы по thin‑adapter реализуются и рассматриваются.
- Отслеживать и описывать технический долг и последующую работу по миграции легаси‑UI BMI и других сервисов на новый адаптер.

Documentation:
- Обновить `AGENTS.md`, добавив политику тонкого HTTP‑адаптера и рекомендации по дрейфу версий в правилах подавления Trivy.
- Расширить `BACKLOG_LEDGER` и новые PR‑специфичные документы для фиксации миграции BMI UI, миграций других сервисов и последующих задач по web‑thin‑adapter.
- Добавить документацию по безопасности для CVE-2025-15281 и несколько документов формата PR-XXX (процесс/чек-листы) для будущих сопровождающих.

Tests:
- Добавить модульные тесты для `HTTPClient`, `APIClient` и `BMIServiceThinAdapter` для проверки отображения ошибок, построения запросов и контрактов DTO.
- Ввести тестовый стенд на основе заглушенного `URLProtocol`, чтобы избежать нестабильности сети в тестах HTTP‑слоя.

Chores:
- Обновить элементы бэклога с учётом влитых PR по CI и Trivy и добавить новые пункты по унификации iOS‑сервисов под тонким адаптером.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a thin HTTP transport layer for the iOS BMI feature, align client DTOs and error handling with backend contracts, and formalize thin-client and security suppression policies while keeping existing UI code working via temporary shims.

New Features:
- Add HTTPClient and APIClient abstractions on iOS for JSON transport and standardized error mapping.
- Introduce BMIService and BMI-related request/response DTOs as a thin adapter over the canonical /api/v1/bmi/calculate endpoint.
- Add soft paywall, visualization, and interpretation DTOs that mirror backend BMI schemas.

Bug Fixes:
- Resolve APIError naming conflict in NutritionData by renaming the local error type to NutritionAPIError.
- Add precise, version-pinned Trivy ignore rules for glibc CVE-2025-15281 to fix CI scanning noise.

Enhancements:
- Define a unified APIError model and error DTOs to distinguish validation errors from general API errors on iOS.
- Document and enforce a thin HTTP adapter policy and a no dual-path networking rule for clients.
- Add detailed DoD, review, opening, and context handoff documents to standardize how thin-adapter PRs are implemented and reviewed.
- Track and describe technical debt and follow-up work for migrating legacy BMI UI and other services onto the new adapter.

Documentation:
- Update AGENTS.md with a thin HTTP adapter policy and guidance on Trivy suppression version drift.
- Extend BACKLOG_LEDGER and new PR-specific docs to record BMI UI migration, other service migrations, and web thin-adapter follow-ups.
- Add security documentation for CVE-2025-15281 and multiple PR-XXX process/checklist documents for future maintainers.

Tests:
- Add HTTPClient, APIClient, and BMIServiceThinAdapter unit tests to validate error mapping, request construction, and DTO contracts.
- Introduce a stubbed URLProtocol-based test harness to avoid network flakiness in HTTP-layer tests.

Chores:
- Update backlog entries to reflect merged CI and Trivy PRs and to add new items for unifying iOS services under the thin adapter.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented thin HTTP adapter for iOS/Web with streamlined request/response handling and improved error mapping
  * Enhanced BMI calculation service with extended data support including visualization and health interpretations

* **Documentation**
  * Updated API governance policies and enforcement mechanisms
  * Added comprehensive process documentation and implementation checklists

* **Security**
  * Added suppression policy for CVE-2025-15281 (glibc) with explicit version pinning

* **Tests**
  * Added comprehensive test coverage for networking and service layers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->