### PR TITLE
chore(pre-commit): update detect-secrets baseline (false positives)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,6 +129,7 @@
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
         "^\\.secrets\\.baseline$",
+        "^ios/PulsePlate\\.xcodeproj/xcshareddata/xcschemes/PulsePlate\\.xcscheme$",
         "^ios/\\.build/",
         "^\\.venv/",
         "^\\.venv-ci/",
@@ -334,29 +335,6 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 9
-      }
-    ],
-    "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme",
-        "hashed_secret": "7208b69960a6f92300545110d222471db91d6f78",
-        "is_verified": false,
-        "line_number": 17
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme",
-        "hashed_secret": "2b7dcb3483951434e96c3488bf0bc173cd9f71f5",
-        "is_verified": false,
-        "line_number": 36
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme",
-        "hashed_secret": "f66064e163cfe3d277a5e4ac707011a12e65f336",
-        "is_verified": false,
-        "line_number": 47
       }
     ],
     "mcp-config.json": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -340,14 +340,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme",
-        "hashed_secret": "d48e77f73bf688e0b573f0502429c1a7d90595c6",
+        "hashed_secret": "7208b69960a6f92300545110d222471db91d6f78",
         "is_verified": false,
         "line_number": 17
       },
       {
         "type": "Hex High Entropy String",
         "filename": "ios/PulsePlate.xcodeproj/xcshareddata/xcschemes/PulsePlate.xcscheme",
-        "hashed_secret": "e208e03b58cbafdac0d0968c4d3fd9d17dc253bc",
+        "hashed_secret": "2b7dcb3483951434e96c3488bf0bc173cd9f71f5",
         "is_verified": false,
         "line_number": 36
       },


### PR DESCRIPTION
## Summary\n- Update  to avoid false positives on Xcode scheme identifier values\n- Exclude Xcode  file from detect-secrets baseline tracking\n\n## Scope\n- Pre-commit / secrets baseline only\n- No runtime impact\n\n## Test plan\n- check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
yamllint (yaml lint).....................................................Passed
detect-secrets (secrets scan)............................................Passed
clean-python-cache.......................................................Passed
check-github-workflows...................................................Passed
black (format)...........................................................Passed
ruff (lint, local).......................................................Passed
ruff (type hints check)..................................................Passed
bandit (security, changed files only)....................................Passed
frontend tests (vitest)..................................................Passed
backend tests (pytest, changed files)....................................Passed
ios syntax check (swift).................................................Passed\n

## Summary by Sourcery

Обновить базовый файл `detect-secrets`, чтобы сократить число ложных срабатываний, и исключить файл схемы Xcode из отслеживания секретов.

Chores:
- Обновить записи базового файла `detect-secrets`, чтобы предотвратить определение идентификаторов схем Xcode как секретов.
- Исключить файл конфигурации схемы Xcode из управления базовым файлом `detect-secrets`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh the detect-secrets baseline to reduce false positives and exclude an Xcode scheme file from secret tracking.

Chores:
- Update detect-secrets baseline entries to avoid flagging Xcode scheme identifiers as secrets.
- Exclude the Xcode scheme configuration file from detect-secrets baseline management.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to refine secret detection patterns and improve scanning efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->