### PR TITLE
ci: gate iOS tests via paths-filter (PR-574)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,30 @@ defaults:
     shell: bash
 
 jobs:
+  changes:
+    name: Determine changed paths (for conditional jobs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+
+      - name: Determine changes
+        id: filter
+        # Keep consistent with other workflows in this repo.
+        uses: dorny/paths-filter@v3.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            ios:
+              - 'ios/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   pr_scope_guard:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -609,8 +633,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 25
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || github.ref == 'refs/heads/main'))
+      needs.changes.outputs.ios == 'true' && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || github.ref == 'refs/heads/main'))
+      )
+    needs: [changes]
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 233
+        "line_number": 257
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-22T07:38:45Z"
+  "generated_at": "2026-01-23T23:41:59Z"
 }

--- a/docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md
+++ b/docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md
@@ -1,0 +1,32 @@
+# PR-574 — CI hardening: iOS path-filter (P1 foundation)
+
+## Scope
+- CI-only change.
+- Touch files:
+  - `.github/workflows/ci.yml`
+  - `docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md`
+- No runtime/product changes (`app/`, `core/`, `ios/` sources unchanged).
+- No new quality gates / thresholds / refactors-for-beauty.
+
+## Problem
+The iOS job (`ios-tests`) runs on PRs even when changes are docs-only or backend-only, creating CI noise
+and exposing the PR pipeline to unrelated iOS flakiness.
+
+## Audit (facts before change)
+- iOS unit tests run as a job inside `.github/workflows/ci.yml` (`ios-tests`, macos-15).
+- The workflow triggers on `pull_request` and `push` to `main` / `feat/**` / `fix/**`.
+- iOS job should still run when:
+  - `ios/**` changes (obvious iOS impact)
+  - CI workflow changes that can affect iOS execution (e.g., `.github/workflows/**`, `.github/actions/**`)
+
+## Proposal
+Add a minimal, job-level path filter:
+- Add a small `changes` job using `dorny/paths-filter`.
+- Gate `ios-tests` behind `needs.changes.outputs.ios == 'true'`.
+
+This avoids altering workflow-level triggers (which would risk skipping non-iOS CI jobs).
+
+## DoD
+- On docs-only PRs (e.g., `docs/**`, `AGENTS.md`, `.cursor/agents/**`), iOS job does **not** run.
+- On PRs touching `ios/**` or CI workflow/actions paths, iOS job **does** run.
+- `pre-commit run --all-files` passes locally.


### PR DESCRIPTION
## Summary
- Gate the `ios-tests` job in `.github/workflows/ci.yml` behind a minimal `dorny/paths-filter` change detector.
- Goal: avoid running macOS iOS tests on docs-only / backend-only PRs (reduce CI noise and flake exposure).

## Scope
- CI-only, no runtime/product changes.
- Files:
  - `.github/workflows/ci.yml`
  - `docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md`

## DoD
- Docs-only PRs: `ios-tests` is skipped.
- `ios/**` changes: `ios-tests` runs.
- CI workflow/action changes: `ios-tests` runs.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Notes
- Pre-commit updated `.secrets.baseline` (detect-secrets); committed as a separate `chore(pre-commit)` commit per repo policy.

## Summary by Sourcery

Ограничить запуск iOS CI тестового job с помощью детектора изменений по путям, чтобы не запускать его при изменениях, не связанных с iOS.

CI:
- Добавить легковесный job `changes`, использующий `dorny/paths-filter` для обнаружения изменений в файлах, связанных с iOS или CI.
- Сделать job `ios-tests` условным, зависящим от обнаруженных изменений путей iOS/CI, при этом сохранить существующие триггеры по событиям/веткам.

Документация:
- Добавить аудит-документ, описывающий обоснование, область применения и поведение нового фильтра путей iOS в CI.

Рутинные задачи:
- Обновить файл baseline для detect-secrets в рамках регулярного обслуживания pre-commit.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate the iOS CI test job behind a path-based change detector to avoid running it on non-iOS-related changes.

CI:
- Introduce a lightweight `changes` job using `dorny/paths-filter` to detect iOS- or CI-related file modifications.
- Make the `ios-tests` job conditional on detected iOS/CI path changes while preserving existing event/branch triggers.

Documentation:
- Add an audit document describing the rationale, scope, and behavior of the new iOS path filter in CI.

Chores:
- Update the detect-secrets baseline file as part of routine pre-commit maintenance.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * CI workflow updated to conditionally run iOS-related jobs based on modified code paths.
  * Baseline metadata updated.

* **Documentation**
  * Added audit documentation for iOS path-filter CI enhancement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->