### PR TITLE
docs(agents): fix nested fenced blocks for markdownlint (MD040)

### DIFF
--- a/.cursor/agents/security-auditor.md
+++ b/.cursor/agents/security-auditor.md
@@ -333,7 +333,7 @@ For each vulnerability:
 
 ### Vulnerability Report
 
-```markdown
+````markdown
 ## Security Audit Report
 
 ### Critical Vulnerabilities (P0)
@@ -397,7 +397,7 @@ For each vulnerability:
 3. **Long-term (architectural):**
    - [ ] Security audit of all tier guards
    - [ ] Add security tests to CI pipeline
-```
+````
 
 ## Proactive Scanning Commands
 


### PR DESCRIPTION
## Summary

Fix MD040 markdownlint error in `security-auditor.md` by using 4-backtick fences for the outer code block that contains nested 3-backtick examples.

## Problem

The Vulnerability Report example section contained nested code blocks (python examples inside a markdown example). Markdownlint was confused by the 3-backtick outer fence being the same length as the nested 3-backtick inner fences, causing a false MD040 "fenced code blocks should have a language specified" error on the closing fence.

## Solution

Changed outer fence from 3 backticks to 4 backticks:
- Opening: ` ```markdown ` → ` ````markdown `
- Closing: ` ``` ` → ` ```` `

This is the canonical approach for nested fenced blocks in Markdown.

## Changes

- `.cursor/agents/security-auditor.md` — 2 lines changed (opening and closing fence)

## DoD

- [x] MD040 error resolved
- [x] Diff = exactly 1 file
- [x] `pre-commit run --all-files` ✅

## Summary by Sourcery

Документация:
- Обновить документацию по агенту аудита безопасности, чтобы использовать внешние блоки кода с четырьмя обратными апострофами вокруг примера Markdown, содержащего вложенные блоки кода, обеспечивая корректное форматирование согласно markdownlint.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the security auditor agent documentation to use four-backtick outer fences around a markdown example that contains nested code blocks, ensuring valid markdownlint formatting.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved markdown formatting in documentation files to enhance readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->