### PR TITLE
ci: harden iOS path-filter (SHA pin + permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     name: Determine changed paths (for conditional jobs)
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
@@ -39,8 +42,8 @@ jobs:
 
       - name: Determine changes
         id: filter
-        # Keep consistent with other workflows in this repo.
-        uses: dorny/paths-filter@v3.0.2
+        # SHA pin for security (v3.0.2)
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 260
+        "line_number": 257
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-25T08:58:24Z"
+  "generated_at": "2026-01-25T08:46:24Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 260
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-25T08:46:24Z"
+  "generated_at": "2026-01-25T08:58:24Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1222,6 +1222,13 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 
 **Rationale:** Guard tests and architectural invariants are only enforced if tests actually run in CI. Syntax checks do not execute test code.
 
+**iOS CI job gating (paths-filter):**
+
+- `ios-tests` job is gated via `changes` job using `dorny/paths-filter`.
+- iOS tests run **only** when PR touches: `ios/**`, `.github/workflows/**`, or `.github/actions/**`.
+- Docs-only PRs (e.g., `docs/**/*.md`, `README*.md`, `AGENTS.md`, `.github/*.md`) **do not** run macOS iOS jobs.
+- **Rationale:** Reduces CI noise, prevents flaky iOS tests on unrelated PRs, speeds up docs-only PR cycle.
+
 **iOS CI destination policy (canonical):**
 
 - **CI destination MUST be UDID-only:** `platform=iOS Simulator,id=<UDID>`


### PR DESCRIPTION
## Summary

Follow-up to #574 addressing CodeRabbit/Cubic feedback:

1. **SHA pin** `dorny/paths-filter` for security (was `v3.0.2`)
2. **Permissions** added to `changes` job (`contents: read`, `pull-requests: read`)
3. **docs(agents)** document iOS CI job gating policy

## Changes

- `.github/workflows/ci.yml` — SHA pin + permissions
- `AGENTS.md` — iOS CI job gating documentation
- `.secrets.baseline` — line number updates (pre-commit hook)

## DoD

- [x] SHA pinned (de90cc6fb38fc0963ad72b210f1f284cd68cea36)
- [x] Permissions explicit
- [x] docs(agents) added
- [x] `pre-commit run --all-files` ✅

## Summary by Sourcery

Усилить условия запуска задач CI, связанных с iOS, и задокументировать политику iOS CI.

CI:
- Зафиксировать версию GitHub Action `dorny/paths-filter` на конкретном коммите (commit SHA) и предоставить минимальные права на чтение задаче `changes` в основном CI‑воркфлоу.

Документация:
- Задокументировать политику условий запуска iOS‑задач в CI, включая случаи, когда iOS‑тесты запускаются на основе фильтров путей, а также обоснование пропуска этих тестов в PR, содержащих только изменения в документации.

Рутинные задачи:
- Обновить файл с базовой линией секретов (secrets baseline), чтобы отразить актуальные номера строк после внесённых изменений в конфигурацию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen iOS-related CI job gating and document the iOS CI policy.

CI:
- Pin the dorny/paths-filter GitHub Action to a specific commit SHA and grant minimal read permissions to the changes job in the main CI workflow.

Documentation:
- Document the iOS CI job gating policy, including when iOS tests run based on path filters and the rationale for skipping them on docs-only PRs.

Chores:
- Update the secrets baseline file to reflect current line numbers after configuration changes.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the iOS path filter in CI by pinning the action and scoping permissions. Also documents the iOS CI job gating policy to reduce noisy macOS runs on docs-only PRs.

- **Dependencies**
  - Pin dorny/paths-filter to a specific commit in .github/workflows/ci.yml.

- **Refactors**
  - Add explicit permissions (contents: read, pull-requests: read) to the changes job.
  - Document iOS CI job gating in AGENTS.md (iOS tests run only on ios/** or workflow/action changes).

<sup>Written for commit b1b7a07d069064349f4b456f308c311a87143766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing iOS CI job gating conditions and test execution parameters.

* **Chores**
  * Improved CI/workflow infrastructure with enhanced security measures and explicit permission controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->