### PR TITLE
feat(guards): PR-586 Web thin-client guards (expected-red)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,8 +383,14 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 **Enforcement:**
 
 - iOS: `ThinClientGuardsTests` (scans for BMI thresholds/computation patterns)
+- Web: `thin-client-guards.test.ts` (scans for BMI thresholds + direct fetch violations)
 - Web: TypeScript types from OpenAPI (prevents manual DTO drift)
 - Code review: grep for forbidden patterns (BMI math, threshold literals, category inference)
+
+**Guard PRs:**
+
+- PR-586: Web guards introduced (expected-red — violations detected)
+- PR-587: Web remediation (fixes 4 direct fetch violations)
 
 **DTO contract rules:**
 
@@ -403,7 +409,8 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 **See:**
 
 - `ios/AGENTS.md` — iOS Thin Client Policy (detailed)
-- `frontend/AGENTS.md` — Frontend conventions
+- `frontend/AGENTS.md` — Frontend Thin Client Policy (detailed)
+- `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md` — Web adapter audit
 - `docs/BMI_CANONICAL_HANDOFF.md` — One BMI Engine invariant
 - `docs/CONTEXT_HANDOFF_2026-01-21.md` — Thin HTTP adapter PR plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,10 +387,14 @@ Backend spans `app/` + `core/` (unified API + domain logic).
 - Web: TypeScript types from OpenAPI (prevents manual DTO drift)
 - Code review: grep for forbidden patterns (BMI math, threshold literals, category inference)
 
-**Guard PRs:**
+**Guard PRs and expected-red workflow:**
 
-- PR-586: Web guards introduced (expected-red — violations detected)
-- PR-587: Web remediation (fixes 4 direct fetch violations)
+Some guard PRs are intentionally **expected-red** to expose real policy violations.
+Remediation must happen in a follow-up remediation PR.
+
+Source of truth:
+- Audit docs: `docs/audit/*`
+- Canonical backlog: `docs/roadmap/BACKLOG_LEDGER.md`
 
 **DTO contract rules:**
 

--- a/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+++ b/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
@@ -16,7 +16,7 @@
 - This is the "policy enforcement" pattern: guards first → remediation in PR-587
 - **Do not fix violations in this PR** — PR-587 handles remediation
 
-**Remediation:** PR-587 (migration of 4 files to `api()`)
+**Decision:** PR-586 = policy+guards (expected-red), PR-587 = remediation (green)
 
 ---
 
@@ -25,388 +25,132 @@
 ### Q0.1 Why is Web Thin Adapter needed now?
 
 **Answer:**
-
-- ✅ iOS Thin HTTP Adapter merged (PR-563)
+- ✅ iOS Thin HTTP Adapter in review (PR-563)
 - ✅ Recorded in BACKLOG_LEDGER as P0
 - ✅ Client parity required (iOS + Web must follow same thin-client policy)
 
 **Links:**
+- PR-563: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/563
+- Ledger item: `docs/roadmap/BACKLOG_LEDGER.md` (P0: Web Thin HTTP Adapter)
 
-- PR-563: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/563>
-- PR-585: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/585>
-- Ledger item: `docs/roadmap/BACKLOG_LEDGER.md` (P0: Thin HTTP Adapter Web)
+### Q0.2 Split decision
 
-### Q0.2 Is this P0 and cannot be split?
+**Answer:** ✅ Intentional split for policy enforcement pattern:
+- **PR-586:** Guards + policy documentation (expected-red)
+- **PR-587:** Remediation of 4 violations (expected-green)
 
-**Answer:** ✅ Yes, P0. Single transport layer change, splitting would create inconsistent client states.
+**Rationale:** Guards must fail before remediation to prove they work.
 
 ### Q0.3 Is this transport-only by fact?
 
-**Answer:** ✅ Yes. Current frontend already follows thin pattern:
-
+**Answer:** ✅ Yes. Current frontend already follows thin pattern for most code:
 - HTTP via `api()` function in `frontend/src/api/client.ts`
 - DTOs from OpenAPI schema (`frontend/src/api/schema.ts`)
 - No BMI calculations or threshold logic found
 
----
-
-## 1. Scope — What is ALLOWED
-
-### 1.1 HTTP Layer
-
-#### Q1.1 Where does HTTP happen now?
-
-**Inventory:**
-
-| File | Method | Used by |
-|------|--------|---------|
-| `frontend/src/api/client.ts` | `api<T>()` | All API calls |
-| `frontend/src/api/bmi.ts` | `calculateBMI()` | BMI page |
-| `frontend/src/api/premium/bmr.ts` | `getBmr()` | PRO features |
-| `frontend/src/api/premium/plate.ts` | `getPlate()` | PRO features |
-| `frontend/src/api/premium/targets.ts` | `getTargets()` | PRO features |
-| `frontend/src/api/premium/weekly-plan.ts` | `getWeeklyPlan()` | PRO features |
-
-**Status:** ✅ Single HTTP client (`api()` in `client.ts`)
-
-#### Q1.2 Is there a single entry point for HTTP?
-
-**Answer:** ✅ Yes
-
-- Main client: `frontend/src/api/client.ts` exports `api()` and `fetchJson()`
-- All endpoints use `api()` internally
-- Factory pattern: `createPremiumEndpoint()` for PRO endpoints
-
-#### Q1.3 Clear separation of transport/DTO/consumer?
-
-| Layer | Location | Status |
-|-------|----------|--------|
-| Transport | `frontend/src/api/client.ts` | ✅ Isolated |
-| DTO | `frontend/src/api/schema.ts` | ✅ OpenAPI generated |
-| Consumer | `frontend/src/pages/*/`, hooks | ✅ Uses typed APIs |
-
-**Status:** ✅ Clean separation exists
-
-#### Q1.4 Single error envelope (backend-compatible)?
-
-**Answer:** ✅ Yes
-
-```typescript
-// client.ts handles:
-// - 401/403 → UnauthorizedError + redirect
-// - Other errors → Error with HTTP status + body
-```
-
-Error mapping:
-
-- 401/403 → `UnauthorizedError` → clear API key + redirect
-- 422 → Validation error (passed through)
-- 5xx → Server error (passed through)
+**Exception:** 4 files use direct `fetch()` — violations detected by guards.
 
 ---
 
-### 1.2 DTO / Contracts
+## 1. Guard Tests Implementation
 
-#### Q1.5 All types generated from OpenAPI?
+### Q1.1 Guard tests exist?
 
-**Answer:** ✅ Yes
+**Answer:** ✅ Implemented
 
-```typescript
-// bmi.ts
-import type { components } from './schema';
-type BMICalculateRequest = components['schemas']['BMICalculateRequest'];
-type BMICalculateResponse = components['schemas']['BMICalculateResponse'];
+**Location:** `frontend/src/api/__tests__/thin-client-guards.test.ts`
 
-// premium/types.ts
-export type PlateRequest = components["schemas"]["PlateRequest"];
-export type TargetsRequest = components["schemas"]["WHOTargetsRequest"];
-```
+**Features:**
+- Block comment handling (`/* ... */` state tracking)
+- Shared file scanning helper (`collectSourceFiles()`)
+- Exact path check for allowed fetch file (`api/client.ts`)
+- Consistent comment skip in both tests
 
-**Exception:** Some hand-written types in `premium/types.ts`:
+### Q1.2 What do guards check?
 
-- `BmrRequest` (not using OpenAPI schema)
-- `BmrApiResponse` (not using OpenAPI schema)
+| Guard | Status | Description |
+|-------|--------|-------------|
+| BMI thresholds | ✅ PASS | No 18.5/24.9/25/30 literals |
+| BMI comparisons | ✅ PASS | No `if (bmi < ...)` |
+| Category/risk assignments | ✅ PASS | No hardcoded categories |
+| Local BMI functions | ✅ PASS | No `computeBMI()` etc. |
+| Direct fetch | 🔴 FAIL | 4 violations detected |
 
-**Action needed:** [ ] Verify if OpenAPI has BMR schemas; migrate if available
+### Q1.3 frontend/AGENTS.md updated?
 
-#### Q1.6 Schema version binding?
-
-**Answer:**
-
-- `frontend/src/api/schema.ts` — generated from `frontend/src/api/openapi.json`
-- Generation via `make openapi` (documented in AGENTS.md)
-- No explicit commit hash binding
-
-**Action needed:** [ ] Consider adding schema generation timestamp/hash
-
-#### Q1.7 Web DTO == iOS DTO == Backend schema?
-
-**Answer:** ✅ Semantically aligned
-
-- Web uses OpenAPI-generated types
-- iOS uses aligned DTOs (PR-563)
-- Both derive from backend Pydantic schemas
+**Answer:** ✅ Done — Thin HTTP Adapter Policy documented
 
 ---
 
-## 2. Anti-Scope — What is FORBIDDEN
+## 2. Detected Violations (4 direct fetch)
 
-### 2.1 Business Logic
+| File | Line | Endpoint | Issue |
+|------|------|----------|-------|
+| `features/plan/WeeklyPlanViewer.tsx` | 39 | signed URL download | direct `fetch(url)` |
+| `features/shoplist/ShoplistPreview.tsx` | 109 | `/api/v1/shoplist/export.{csv\|pdf}` | direct `fetch()` |
+| `lib/shareFile.ts` | 108 | file download URL | direct `fetch(url)` |
+| `lib/sharedLinks.ts` | 21 | `/api/v1/export/sign` | direct `fetch()` |
 
-#### Q2.1 BMI logic in web code?
-
-**Grep results:**
-
-```bash
-rg "(18\.5|24\.9|25\.0|30\.0|if.*bmi|bmi\s*[<>=]|category.*=|risk.*=)" frontend/src --type ts --type tsx
-```
-
-**Findings:**
-
-- ❌ No BMI threshold literals in code
-- ❌ No BMI comparisons
-- ❌ No category assignments
-- ✅ Only in `schema.ts` (OpenAPI comments, not code)
-
-**Status:** ✅ PASS — No BMI business logic
-
-#### Q2.2 Helper functions that aggregate/interpret?
-
-**Answer:** ✅ None found
-
-The UI only displays `response.interpretation` as-is:
-
-```typescript
-// BMICalculatePage.tsx
-{response.interpretation && (
-  <p className="text-sm text-muted">{response.interpretation}</p>
-)}
-```
-
-#### Q2.3 Backend data used only for display?
-
-**Answer:** ✅ Yes — no reinterpretation detected
+**Remediation:** PR-587 (tracked in BACKLOG_LEDGER)
 
 ---
 
-### 2.2 Duplicate HTTP Logic
+## 3. DoD PR-586
 
-#### Q2.4 Direct fetch outside thin adapter?
-
-**Answer:** ❌ **VIOLATIONS FOUND** by guard tests
-
-```
-features/plan/WeeklyPlanViewer.tsx:39      - direct fetch()
-features/shoplist/ShoplistPreview.tsx:109  - direct fetch()
-lib/shareFile.ts:108                       - direct fetch()
-lib/sharedLinks.ts:21                      - direct fetch()
-```
-
-**Remediation (PR-587):**
-- [ ] Migrate `WeeklyPlanViewer.tsx` to use `api()`
-- [ ] Migrate `ShoplistPreview.tsx` to use `api()`
-- [ ] Migrate `shareFile.ts` to use `api()`
-- [ ] Migrate `sharedLinks.ts` to use `api()`
-
-**Note:** Migrations tracked in PR-587, not this PR (guards-first pattern)
-
-#### Q2.5 Can `rg fetch\(` return only one module?
-
-**Answer:** ❌ No — 4 files have direct fetch outside `client.ts`
-
-**Status:** ❌ FAIL — requires migration
+- [x] Guard tests created (`thin-client-guards.test.ts`)
+- [x] Block comment handling (A)
+- [x] Shared file scanning helper (B)
+- [x] Stricter client.ts skip (C)
+- [x] Consistent comment skip (D)
+- [x] `frontend/AGENTS.md` updated with thin-client policy
+- [x] `AGENTS.md` updated with guard references
+- [x] `BACKLOG_LEDGER.md` updated (PR-586 + PR-587 split)
+- [x] Audit doc created
+- [x] CI expected RED (4 violations — this is correct)
 
 ---
 
-## 3. Thin-Client Policy (Invariants)
-
-#### Q3.1 Web = renderer of contracts, not interpreter?
-
-**Answer:** ✅ Yes — frontend renders backend-provided values
-
-#### Q3.2 Guard mechanisms exist?
-
-| Guard | Status | Location |
-|-------|--------|----------|
-| ESLint rule | ❌ Not implemented | — |
-| Grep-based test | ✅ **Implemented** | `frontend/src/api/__tests__/thin-client-guards.test.ts` |
-| CI job | ⚠️ Runs via pre-commit | Pre-commit hook runs tests |
-
-**Status:** ✅ Guard tests implemented (expected-red due to 4 direct fetch violations)
-
-#### Q3.3 Forbidden patterns documented?
-
-**Answer:** ✅ Documented in both `AGENTS.md` and `frontend/AGENTS.md`
-
-**Status:** ✅ `frontend/AGENTS.md` updated with thin-client policy (hard rule)
-
----
-
-## 4. Error Handling
-
-#### Q4.1 Single error mapping exists?
-
-**Answer:** ✅ Yes — in `client.ts`:
-
-- 401/403 → UnauthorizedError + redirect
-- Other errors → pass through with status/body
-
-#### Q4.2 No error masking or normalization?
-
-**Answer:** ✅ Correct — errors passed through as-is
-
----
-
-## 5. i18n / UX
-
-#### Q5.1 Web shows only backend-provided texts?
-
-**Answer:** ✅ Yes
-
-- `interpretation` field displayed as-is
-- `soft_paywall_hook` uses i18n keys from backend
-
-#### Q5.2 No local fallback texts or interpretations?
-
-**Answer:** ✅ Correct — no local interpretation logic
-
----
-
-## 6. Tests
-
-#### Q6.1 Unit tests for HTTP adapter?
-
-**Location:** `frontend/src/api/__tests__/`
-
-| Test File | Coverage |
-|-----------|----------|
-| `client.test.ts` | ✅ HTTP client behavior |
-| `api-auth-callback.test.ts` | ✅ Auth error handling |
-| `api-serialization.test.ts` | ✅ JSON serialization |
-
-**Status:** ✅ Adequate coverage
-
-#### Q6.2 Tests that forbid BMI logic?
-
-**Answer:** ✅ **Implemented** — `thin-client-guards.test.ts`
-
-| Test | Status |
-|------|--------|
-| BMI thresholds/logic scan | ✅ PASS (no violations) |
-| Direct fetch scan | 🔴 FAIL (4 violations — expected) |
-
-**Status:** Guard tests work correctly — PR-587 will fix violations
-
-#### Q6.3 Tests don't "know" business meaning?
-
-**Answer:** ✅ Tests use mock responses, don't validate BMI values
-
----
-
-## 7. CI / Tooling
-
-#### Q7.1 CI step that fails on thin-policy violation?
-
-**Answer:** ✅ Vitest runs guard tests → CI fails on violations
-
-- Pre-commit hook runs `thin-client-guards.test.ts`
-- PR-586 is expected-red (guards detect violations)
-- PR-587 will make guards green
-
-#### Q7.2 Documented in frontend/AGENTS.md?
-
-**Answer:** ✅ Updated — `frontend/AGENTS.md` contains thin-client policy (hard rule)
-
----
-
-## 8. Security
-
-#### Q8.1 No hardcoded URLs or tokens?
-
-**Answer:** ✅ Correct
-
-- API base from env: `VITE_API_BASE`
-- API key from storage: `getStoredApiKey()`
-
-#### Q8.2 401/403 handled centrally?
-
-**Answer:** ✅ Yes — in `client.ts` with redirect to `/enter-key`
-
----
-
-## 9. Migration / Compatibility
-
-#### Q9.1 PR-586 breaks existing UI?
-
-**Answer:** ✅ No — current code already follows thin pattern
-
-#### Q9.2 Legacy cleanup plan?
-
-**Items for ledger:**
-
-- [ ] Hand-written DTOs in `premium/types.ts` (BmrRequest, BmrApiResponse)
-- [ ] Mock files cleanup (duplicate files: `server 2.ts`, `browser 2.ts`)
-
----
-
-## 10. DoD — Acceptance Criteria
-
-### Self-Check Checklist
-
-- [x] No BMI logic, thresholds, or interpretations in web code
-- [x] Single HTTP path (`api()` in `client.ts`)
-- [x] DTOs from OpenAPI (mostly — see exceptions)
-- [x] Errors not masked
-- [x] Guard tests exist ✅ Created
-- [x] `frontend/AGENTS.md` updated ✅ Done
-- [ ] **Direct fetch violations fixed** (4 files need migration)
-
----
-
-## Summary
-
-| Area | Status | Action |
-|------|--------|--------|
-| HTTP Layer | ❌ **4 Violations** | Migrate files to use `api()` |
-| DTOs | ⚠️ Mostly compliant | (P2) Migrate BmrRequest/Response |
-| Business Logic | ✅ None found | None |
-| Error Handling | ✅ Compliant | None |
-| Guards | ✅ Implemented | Guard tests created |
-| Documentation | ✅ Updated | frontend/AGENTS.md done |
-
-### Conclusion
-
-**Current state:** Frontend mostly follows thin-client pattern, but has **4 direct fetch() violations**.
-
-**PR-586 scope (expanded after audit):**
-
-1. ✅ Add guard tests for forbidden patterns
-2. ✅ Update `frontend/AGENTS.md` with thin-client policy
-3. **Migrate 4 files** to use `api()` instead of direct `fetch()`:
-   - `features/plan/WeeklyPlanViewer.tsx:39`
-   - `features/shoplist/ShoplistPreview.tsx:109`
-   - `lib/shareFile.ts:108`
-   - `lib/sharedLinks.ts:21`
-4. (P2) Migrate hand-written DTOs to OpenAPI
-
-**This is a "hardening + migration" PR** — guard tests exposed real violations.
-
----
-
-## Files to Change in PR-586
+## 4. Files Changed in PR-586
 
 | File | Change |
 |------|--------|
-| `frontend/src/api/__tests__/thin-client-guards.test.ts` | ✅ NEW — guard tests |
-| `frontend/AGENTS.md` | ✅ UPDATE — thin-client policy |
-| `frontend/src/features/plan/WeeklyPlanViewer.tsx` | MIGRATE — use `api()` |
-| `frontend/src/features/shoplist/ShoplistPreview.tsx` | MIGRATE — use `api()` |
-| `frontend/src/lib/shareFile.ts` | MIGRATE — use `api()` |
-| `frontend/src/lib/sharedLinks.ts` | MIGRATE — use `api()` |
-| `docs/roadmap/BACKLOG_LEDGER.md` | UPDATE — after migration done |
+| `frontend/src/api/__tests__/thin-client-guards.test.ts` | NEW — guard tests |
+| `frontend/AGENTS.md` | UPDATE — thin-client policy |
+| `AGENTS.md` | UPDATE — guard references |
+| `docs/roadmap/BACKLOG_LEDGER.md` | UPDATE — PR-586/PR-587 split |
+| `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md` | NEW — this doc |
+
+---
+
+## 5. PR-587 Audit Questions (for remediation)
+
+### Scope
+1. Какие **точно файлы** устраняем? → 4 файла (см. таблицу выше)
+2. Какие **endpoint paths** затронуты?
+   - Weekly plan viewer: signed URL (blob download)
+   - Shoplist export: `/api/v1/shoplist/export.{csv|pdf}` (blob)
+   - shareFile: generic URL (blob download)
+   - sharedLinks: `/api/v1/export/sign` (JSON)
+
+### Anti-scope
+3. Не добавляем "wrapper вокруг fetch" в feature-слое? → Нет, используем `api()` или `fetchBlob()`
+4. Не создаём новый `client.ts`-дубликат? → Нет
+
+### Implementation sanity
+5. Есть ли готовые API функции? → Нужен `fetchBlob()` для blob downloads
+6. Сохраняем ли 401/403 через `api()`? → Да, `fetchBlob()` наследует auth handling
+
+### Verification
+7. `npm test` зелёный + guard test зелёный? → DoD PR-587
+8. `rg -n "\bfetch\s*\(" frontend/src` → только `client.ts`
+9. Новые hand-written DTO? → Нет
+
+### DoD PR-587
+10. Guards PASS
+11. Нет direct fetch вне client.ts
+12. PR body: ссылка на PR-586 как policy anchor
 
 ---
 
 **Last updated:** 2026-01-25
-**Status:** Audit complete. Guard tests created. **4 fetch migrations required.**
-**Next step:** Migrate direct fetch() calls to api()
+**Next step:** Merge PR-586 (expected-red), then PR-587 remediation

--- a/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+++ b/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
@@ -1,0 +1,406 @@
+# PR-586 — Web Thin HTTP Adapter Audit (Policy Enforcement)
+
+**Date:** 2026-01-25
+**Target branch:** `main`
+**Source branch:** `audit/pr-586-web-thin-http-adapter`
+**Author:** @katsiaryna_kavaleuskaya
+**Status:** 🔴 **Expected RED** (guard tests expose violations)
+
+---
+
+## ⚠️ Expected CI Behavior
+
+**This PR is intentionally expected-red.**
+
+- Guard tests (`thin-client-guards.test.ts`) detect **4 direct fetch() violations**
+- This is the "policy enforcement" pattern: guards first → remediation in PR-587
+- **Do not fix violations in this PR** — PR-587 handles remediation
+
+**Remediation:** PR-587 (migration of 4 files to `api()`)
+
+---
+
+## 0. Meta / Gatekeeping
+
+### Q0.1 Why is Web Thin Adapter needed now?
+
+**Answer:**
+
+- ✅ iOS Thin HTTP Adapter merged (PR-563)
+- ✅ Recorded in BACKLOG_LEDGER as P0
+- ✅ Client parity required (iOS + Web must follow same thin-client policy)
+
+**Links:**
+
+- PR-563: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/563>
+- PR-585: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/585>
+- Ledger item: `docs/roadmap/BACKLOG_LEDGER.md` (P0: Thin HTTP Adapter Web)
+
+### Q0.2 Is this P0 and cannot be split?
+
+**Answer:** ✅ Yes, P0. Single transport layer change, splitting would create inconsistent client states.
+
+### Q0.3 Is this transport-only by fact?
+
+**Answer:** ✅ Yes. Current frontend already follows thin pattern:
+
+- HTTP via `api()` function in `frontend/src/api/client.ts`
+- DTOs from OpenAPI schema (`frontend/src/api/schema.ts`)
+- No BMI calculations or threshold logic found
+
+---
+
+## 1. Scope — What is ALLOWED
+
+### 1.1 HTTP Layer
+
+#### Q1.1 Where does HTTP happen now?
+
+**Inventory:**
+
+| File | Method | Used by |
+|------|--------|---------|
+| `frontend/src/api/client.ts` | `api<T>()` | All API calls |
+| `frontend/src/api/bmi.ts` | `calculateBMI()` | BMI page |
+| `frontend/src/api/premium/bmr.ts` | `getBmr()` | PRO features |
+| `frontend/src/api/premium/plate.ts` | `getPlate()` | PRO features |
+| `frontend/src/api/premium/targets.ts` | `getTargets()` | PRO features |
+| `frontend/src/api/premium/weekly-plan.ts` | `getWeeklyPlan()` | PRO features |
+
+**Status:** ✅ Single HTTP client (`api()` in `client.ts`)
+
+#### Q1.2 Is there a single entry point for HTTP?
+
+**Answer:** ✅ Yes
+
+- Main client: `frontend/src/api/client.ts` exports `api()` and `fetchJson()`
+- All endpoints use `api()` internally
+- Factory pattern: `createPremiumEndpoint()` for PRO endpoints
+
+#### Q1.3 Clear separation of transport/DTO/consumer?
+
+| Layer | Location | Status |
+|-------|----------|--------|
+| Transport | `frontend/src/api/client.ts` | ✅ Isolated |
+| DTO | `frontend/src/api/schema.ts` | ✅ OpenAPI generated |
+| Consumer | `frontend/src/pages/*/`, hooks | ✅ Uses typed APIs |
+
+**Status:** ✅ Clean separation exists
+
+#### Q1.4 Single error envelope (backend-compatible)?
+
+**Answer:** ✅ Yes
+
+```typescript
+// client.ts handles:
+// - 401/403 → UnauthorizedError + redirect
+// - Other errors → Error with HTTP status + body
+```
+
+Error mapping:
+
+- 401/403 → `UnauthorizedError` → clear API key + redirect
+- 422 → Validation error (passed through)
+- 5xx → Server error (passed through)
+
+---
+
+### 1.2 DTO / Contracts
+
+#### Q1.5 All types generated from OpenAPI?
+
+**Answer:** ✅ Yes
+
+```typescript
+// bmi.ts
+import type { components } from './schema';
+type BMICalculateRequest = components['schemas']['BMICalculateRequest'];
+type BMICalculateResponse = components['schemas']['BMICalculateResponse'];
+
+// premium/types.ts
+export type PlateRequest = components["schemas"]["PlateRequest"];
+export type TargetsRequest = components["schemas"]["WHOTargetsRequest"];
+```
+
+**Exception:** Some hand-written types in `premium/types.ts`:
+
+- `BmrRequest` (not using OpenAPI schema)
+- `BmrApiResponse` (not using OpenAPI schema)
+
+**Action needed:** [ ] Verify if OpenAPI has BMR schemas; migrate if available
+
+#### Q1.6 Schema version binding?
+
+**Answer:**
+
+- `frontend/src/api/schema.ts` — generated from `frontend/src/api/openapi.json`
+- Generation via `make openapi` (documented in AGENTS.md)
+- No explicit commit hash binding
+
+**Action needed:** [ ] Consider adding schema generation timestamp/hash
+
+#### Q1.7 Web DTO == iOS DTO == Backend schema?
+
+**Answer:** ✅ Semantically aligned
+
+- Web uses OpenAPI-generated types
+- iOS uses aligned DTOs (PR-563)
+- Both derive from backend Pydantic schemas
+
+---
+
+## 2. Anti-Scope — What is FORBIDDEN
+
+### 2.1 Business Logic
+
+#### Q2.1 BMI logic in web code?
+
+**Grep results:**
+
+```bash
+rg "(18\.5|24\.9|25\.0|30\.0|if.*bmi|bmi\s*[<>=]|category.*=|risk.*=)" frontend/src --type ts --type tsx
+```
+
+**Findings:**
+
+- ❌ No BMI threshold literals in code
+- ❌ No BMI comparisons
+- ❌ No category assignments
+- ✅ Only in `schema.ts` (OpenAPI comments, not code)
+
+**Status:** ✅ PASS — No BMI business logic
+
+#### Q2.2 Helper functions that aggregate/interpret?
+
+**Answer:** ✅ None found
+
+The UI only displays `response.interpretation` as-is:
+
+```typescript
+// BMICalculatePage.tsx
+{response.interpretation && (
+  <p className="text-sm text-muted">{response.interpretation}</p>
+)}
+```
+
+#### Q2.3 Backend data used only for display?
+
+**Answer:** ✅ Yes — no reinterpretation detected
+
+---
+
+### 2.2 Duplicate HTTP Logic
+
+#### Q2.4 Direct fetch outside thin adapter?
+
+**Answer:** ❌ **VIOLATIONS FOUND** by guard tests
+
+```
+features/plan/WeeklyPlanViewer.tsx:39      - direct fetch()
+features/shoplist/ShoplistPreview.tsx:109  - direct fetch()
+lib/shareFile.ts:108                       - direct fetch()
+lib/sharedLinks.ts:21                      - direct fetch()
+```
+
+**Action needed:**
+- [ ] Migrate `WeeklyPlanViewer.tsx` to use `api()` or dedicated endpoint
+- [ ] Migrate `ShoplistPreview.tsx` to use `api()`
+- [ ] Migrate `shareFile.ts` to use `api()`
+- [ ] Migrate `sharedLinks.ts` to use `api()`
+
+#### Q2.5 Can `rg fetch\(` return only one module?
+
+**Answer:** ❌ No — 4 files have direct fetch outside `client.ts`
+
+**Status:** ❌ FAIL — requires migration
+
+---
+
+## 3. Thin-Client Policy (Invariants)
+
+#### Q3.1 Web = renderer of contracts, not interpreter?
+
+**Answer:** ✅ Yes — frontend renders backend-provided values
+
+#### Q3.2 Guard mechanisms exist?
+
+| Guard | Status | Location |
+|-------|--------|----------|
+| ESLint rule | ❌ Not implemented | — |
+| Grep-based test | ❌ Not implemented | — |
+| CI job | ❌ Not implemented | — |
+
+**Action needed:**
+
+- [ ] Add guard test similar to iOS `ThinClientGuardsTests`
+- [ ] Add to CI pipeline
+
+#### Q3.3 Forbidden patterns documented?
+
+**Answer:** ⚠️ Partially — in `AGENTS.md` but not in `frontend/AGENTS.md`
+
+**Action needed:** [ ] Update `frontend/AGENTS.md` with thin-client policy
+
+---
+
+## 4. Error Handling
+
+#### Q4.1 Single error mapping exists?
+
+**Answer:** ✅ Yes — in `client.ts`:
+
+- 401/403 → UnauthorizedError + redirect
+- Other errors → pass through with status/body
+
+#### Q4.2 No error masking or normalization?
+
+**Answer:** ✅ Correct — errors passed through as-is
+
+---
+
+## 5. i18n / UX
+
+#### Q5.1 Web shows only backend-provided texts?
+
+**Answer:** ✅ Yes
+
+- `interpretation` field displayed as-is
+- `soft_paywall_hook` uses i18n keys from backend
+
+#### Q5.2 No local fallback texts or interpretations?
+
+**Answer:** ✅ Correct — no local interpretation logic
+
+---
+
+## 6. Tests
+
+#### Q6.1 Unit tests for HTTP adapter?
+
+**Location:** `frontend/src/api/__tests__/`
+
+| Test File | Coverage |
+|-----------|----------|
+| `client.test.ts` | ✅ HTTP client behavior |
+| `api-auth-callback.test.ts` | ✅ Auth error handling |
+| `api-serialization.test.ts` | ✅ JSON serialization |
+
+**Status:** ✅ Adequate coverage
+
+#### Q6.2 Tests that forbid BMI logic?
+
+**Answer:** ❌ Not implemented
+
+**Action needed:** [ ] Add guard tests (like iOS ThinClientGuardsTests)
+
+#### Q6.3 Tests don't "know" business meaning?
+
+**Answer:** ✅ Tests use mock responses, don't validate BMI values
+
+---
+
+## 7. CI / Tooling
+
+#### Q7.1 CI step that fails on thin-policy violation?
+
+**Answer:** ❌ Not implemented
+
+**Action needed:** [ ] Add CI grep/lint step for forbidden patterns
+
+#### Q7.2 Documented in frontend/AGENTS.md?
+
+**Answer:** ⚠️ Partial — needs update
+
+---
+
+## 8. Security
+
+#### Q8.1 No hardcoded URLs or tokens?
+
+**Answer:** ✅ Correct
+
+- API base from env: `VITE_API_BASE`
+- API key from storage: `getStoredApiKey()`
+
+#### Q8.2 401/403 handled centrally?
+
+**Answer:** ✅ Yes — in `client.ts` with redirect to `/enter-key`
+
+---
+
+## 9. Migration / Compatibility
+
+#### Q9.1 PR-586 breaks existing UI?
+
+**Answer:** ✅ No — current code already follows thin pattern
+
+#### Q9.2 Legacy cleanup plan?
+
+**Items for ledger:**
+
+- [ ] Hand-written DTOs in `premium/types.ts` (BmrRequest, BmrApiResponse)
+- [ ] Mock files cleanup (duplicate files: `server 2.ts`, `browser 2.ts`)
+
+---
+
+## 10. DoD — Acceptance Criteria
+
+### Self-Check Checklist
+
+- [x] No BMI logic, thresholds, or interpretations in web code
+- [x] Single HTTP path (`api()` in `client.ts`)
+- [x] DTOs from OpenAPI (mostly — see exceptions)
+- [x] Errors not masked
+- [x] Guard tests exist ✅ Created
+- [x] `frontend/AGENTS.md` updated ✅ Done
+- [ ] **Direct fetch violations fixed** (4 files need migration)
+
+---
+
+## Summary
+
+| Area | Status | Action |
+|------|--------|--------|
+| HTTP Layer | ❌ **4 Violations** | Migrate files to use `api()` |
+| DTOs | ⚠️ Mostly compliant | (P2) Migrate BmrRequest/Response |
+| Business Logic | ✅ None found | None |
+| Error Handling | ✅ Compliant | None |
+| Guards | ✅ Implemented | Guard tests created |
+| Documentation | ✅ Updated | frontend/AGENTS.md done |
+
+### Conclusion
+
+**Current state:** Frontend mostly follows thin-client pattern, but has **4 direct fetch() violations**.
+
+**PR-586 scope (expanded after audit):**
+
+1. ✅ Add guard tests for forbidden patterns
+2. ✅ Update `frontend/AGENTS.md` with thin-client policy
+3. **Migrate 4 files** to use `api()` instead of direct `fetch()`:
+   - `features/plan/WeeklyPlanViewer.tsx:39`
+   - `features/shoplist/ShoplistPreview.tsx:109`
+   - `lib/shareFile.ts:108`
+   - `lib/sharedLinks.ts:21`
+4. (P2) Migrate hand-written DTOs to OpenAPI
+
+**This is a "hardening + migration" PR** — guard tests exposed real violations.
+
+---
+
+## Files to Change in PR-586
+
+| File | Change |
+|------|--------|
+| `frontend/src/api/__tests__/thin-client-guards.test.ts` | ✅ NEW — guard tests |
+| `frontend/AGENTS.md` | ✅ UPDATE — thin-client policy |
+| `frontend/src/features/plan/WeeklyPlanViewer.tsx` | MIGRATE — use `api()` |
+| `frontend/src/features/shoplist/ShoplistPreview.tsx` | MIGRATE — use `api()` |
+| `frontend/src/lib/shareFile.ts` | MIGRATE — use `api()` |
+| `frontend/src/lib/sharedLinks.ts` | MIGRATE — use `api()` |
+| `docs/roadmap/BACKLOG_LEDGER.md` | UPDATE — after migration done |
+
+---
+
+**Last updated:** 2026-01-25
+**Status:** Audit complete. Guard tests created. **4 fetch migrations required.**
+**Next step:** Migrate direct fetch() calls to api()

--- a/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+++ b/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
@@ -202,11 +202,13 @@ lib/shareFile.ts:108                       - direct fetch()
 lib/sharedLinks.ts:21                      - direct fetch()
 ```
 
-**Action needed:**
-- [ ] Migrate `WeeklyPlanViewer.tsx` to use `api()` or dedicated endpoint
+**Remediation (PR-587):**
+- [ ] Migrate `WeeklyPlanViewer.tsx` to use `api()`
 - [ ] Migrate `ShoplistPreview.tsx` to use `api()`
 - [ ] Migrate `shareFile.ts` to use `api()`
 - [ ] Migrate `sharedLinks.ts` to use `api()`
+
+**Note:** Migrations tracked in PR-587, not this PR (guards-first pattern)
 
 #### Q2.5 Can `rg fetch\(` return only one module?
 
@@ -227,19 +229,16 @@ lib/sharedLinks.ts:21                      - direct fetch()
 | Guard | Status | Location |
 |-------|--------|----------|
 | ESLint rule | ❌ Not implemented | — |
-| Grep-based test | ❌ Not implemented | — |
-| CI job | ❌ Not implemented | — |
+| Grep-based test | ✅ **Implemented** | `frontend/src/api/__tests__/thin-client-guards.test.ts` |
+| CI job | ⚠️ Runs via pre-commit | Pre-commit hook runs tests |
 
-**Action needed:**
-
-- [ ] Add guard test similar to iOS `ThinClientGuardsTests`
-- [ ] Add to CI pipeline
+**Status:** ✅ Guard tests implemented (expected-red due to 4 direct fetch violations)
 
 #### Q3.3 Forbidden patterns documented?
 
-**Answer:** ⚠️ Partially — in `AGENTS.md` but not in `frontend/AGENTS.md`
+**Answer:** ✅ Documented in both `AGENTS.md` and `frontend/AGENTS.md`
 
-**Action needed:** [ ] Update `frontend/AGENTS.md` with thin-client policy
+**Status:** ✅ `frontend/AGENTS.md` updated with thin-client policy (hard rule)
 
 ---
 
@@ -289,9 +288,14 @@ lib/sharedLinks.ts:21                      - direct fetch()
 
 #### Q6.2 Tests that forbid BMI logic?
 
-**Answer:** ❌ Not implemented
+**Answer:** ✅ **Implemented** — `thin-client-guards.test.ts`
 
-**Action needed:** [ ] Add guard tests (like iOS ThinClientGuardsTests)
+| Test | Status |
+|------|--------|
+| BMI thresholds/logic scan | ✅ PASS (no violations) |
+| Direct fetch scan | 🔴 FAIL (4 violations — expected) |
+
+**Status:** Guard tests work correctly — PR-587 will fix violations
 
 #### Q6.3 Tests don't "know" business meaning?
 
@@ -303,13 +307,15 @@ lib/sharedLinks.ts:21                      - direct fetch()
 
 #### Q7.1 CI step that fails on thin-policy violation?
 
-**Answer:** ❌ Not implemented
+**Answer:** ✅ Vitest runs guard tests → CI fails on violations
 
-**Action needed:** [ ] Add CI grep/lint step for forbidden patterns
+- Pre-commit hook runs `thin-client-guards.test.ts`
+- PR-586 is expected-red (guards detect violations)
+- PR-587 will make guards green
 
 #### Q7.2 Documented in frontend/AGENTS.md?
 
-**Answer:** ⚠️ Partial — needs update
+**Answer:** ✅ Updated — `frontend/AGENTS.md` contains thin-client policy (hard rule)
 
 ---
 

--- a/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+++ b/docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
@@ -12,11 +12,15 @@
 
 **This PR is intentionally expected-red.**
 
-- Guard tests (`thin-client-guards.test.ts`) detect **4 direct fetch() violations**
-- This is the "policy enforcement" pattern: guards first → remediation in PR-587
-- **Do not fix violations in this PR** — PR-587 handles remediation
+**Expected red reason:** Direct fetch guard only (4 violations detected by `thin-client-guards.test.ts`).
 
-**Decision:** PR-586 = policy+guards (expected-red), PR-587 = remediation (green)
+- Guard tests (`thin-client-guards.test.ts`) detect **4 direct fetch() violations**
+- This is the "policy enforcement" pattern: guards first → remediation follows
+- **Do not fix violations in this PR** — remediation is a separate PR
+
+All other checks (linting, markdownlint, BMI logic guard) must be **green**.
+
+**Decision:** This PR = policy+guards (expected-red), remediation PR = fixes violations (green)
 
 ---
 
@@ -30,14 +34,14 @@
 - ✅ Client parity required (iOS + Web must follow same thin-client policy)
 
 **Links:**
-- PR-563: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/563
+- PR-563: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/563>
 - Ledger item: `docs/roadmap/BACKLOG_LEDGER.md` (P0: Web Thin HTTP Adapter)
 
 ### Q0.2 Split decision
 
 **Answer:** ✅ Intentional split for policy enforcement pattern:
-- **PR-586:** Guards + policy documentation (expected-red)
-- **PR-587:** Remediation of 4 violations (expected-green)
+- **This PR:** Guards + policy documentation (expected-red)
+- **Remediation PR:** Fixes 4 violations (expected-green)
 
 **Rationale:** Guards must fail before remediation to prove they work.
 
@@ -91,7 +95,7 @@
 | `lib/shareFile.ts` | 108 | file download URL | direct `fetch(url)` |
 | `lib/sharedLinks.ts` | 21 | `/api/v1/export/sign` | direct `fetch()` |
 
-**Remediation:** PR-587 (tracked in BACKLOG_LEDGER)
+**Remediation:** Separate PR (tracked in `docs/roadmap/BACKLOG_LEDGER.md`)
 
 ---
 
@@ -104,7 +108,7 @@
 - [x] Consistent comment skip (D)
 - [x] `frontend/AGENTS.md` updated with thin-client policy
 - [x] `AGENTS.md` updated with guard references
-- [x] `BACKLOG_LEDGER.md` updated (PR-586 + PR-587 split)
+- [x] `BACKLOG_LEDGER.md` updated (guards + remediation split)
 - [x] Audit doc created
 - [x] CI expected RED (4 violations — this is correct)
 
@@ -122,7 +126,7 @@
 
 ---
 
-## 5. PR-587 Audit Questions (for remediation)
+## 5. Remediation Audit Questions (for follow-up PR)
 
 ### Scope
 1. Какие **точно файлы** устраняем? → 4 файла (см. таблицу выше)
@@ -141,16 +145,16 @@
 6. Сохраняем ли 401/403 через `api()`? → Да, `fetchBlob()` наследует auth handling
 
 ### Verification
-7. `npm test` зелёный + guard test зелёный? → DoD PR-587
+7. `npm test` зелёный + guard test зелёный? → DoD remediation PR
 8. `rg -n "\bfetch\s*\(" frontend/src` → только `client.ts`
 9. Новые hand-written DTO? → Нет
 
-### DoD PR-587
+### DoD Remediation PR
 10. Guards PASS
 11. Нет direct fetch вне client.ts
-12. PR body: ссылка на PR-586 как policy anchor
+12. PR body: ссылка на guards PR как policy anchor
 
 ---
 
 **Last updated:** 2026-01-25
-**Next step:** Merge PR-586 (expected-red), then PR-587 remediation
+**Next step:** Merge this PR (expected-red), then remediation PR

--- a/docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md
+++ b/docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md
@@ -1,0 +1,218 @@
+# PR-587 — Web Thin HTTP Adapter Remediation Audit
+
+**Date:** 2026-01-25
+**Target branch:** `main`
+**Source branch:** `fix/pr-587-web-thin-remediation` (TBD)
+**Author:** @katsiaryna_kavaleuskaya
+**Status:** 🟡 **Audit-first** (code not started)
+**Policy anchor:** PR-586 (guards, expected-red)
+
+---
+
+## A. Scope (факты)
+
+### Q1. Какие **точно 4 файла** сейчас нарушают policy (path + line)?
+
+| File | Line | Violation |
+|------|------|-----------|
+| `frontend/src/lib/sharedLinks.ts` | 21 | `await fetch("/api/v1/export/sign", {...})` |
+| `frontend/src/lib/shareFile.ts` | 108 | `await fetch(url)` |
+| `frontend/src/features/shoplist/ShoplistPreview.tsx` | 109 | `await fetch(\`/api/v1/shoplist/export.${kind}\`)` |
+| `frontend/src/features/plan/WeeklyPlanViewer.tsx` | 39 | `await fetch(url)` |
+
+### Q2. Какие **HTTP сценарии** покрывает каждый файл?
+
+| File | User Action |
+|------|-------------|
+| `sharedLinks.ts` | Запрос подписанной ссылки для безопасного экспорта файла |
+| `shareFile.ts` | Скачивание blob с подписанного URL для native share |
+| `ShoplistPreview.tsx` | Скачивание списка покупок как CSV/PDF |
+| `WeeklyPlanViewer.tsx` | Скачивание PDF недельного плана с подписанного URL |
+
+### Q3. Какие **backend endpoints** и методы реально вызываются?
+
+| File | URL | URL Type | Method | Response |
+|------|-----|----------|--------|----------|
+| `sharedLinks.ts` | `/api/v1/export/sign` | **API path** | POST | JSON `{url, ttl, exp}` |
+| `shareFile.ts` | `https://...` (signed URL) | **External** | GET | blob → arrayBuffer |
+| `ShoplistPreview.tsx` | `/api/v1/shoplist/export.{csv\|pdf}` | **API path** | GET | blob |
+| `WeeklyPlanViewer.tsx` | `https://...` (signed URL) | **External** | GET | blob |
+
+### Q4. Есть ли уже **готовая обёртка** в `src/api/*` для каждого вызова?
+
+| File | Existing Wrapper | Notes |
+|------|-----------------|-------|
+| `sharedLinks.ts` | ✅ `api()` | Can use `api<{url: string, ttl?: number, exp?: number}>()` |
+| `shareFile.ts` | ❌ None | Needs new `fetchBlob()` for binary |
+| `ShoplistPreview.tsx` | ❌ None | Needs new `fetchBlob()` for binary |
+| `WeeklyPlanViewer.tsx` | ❌ None | Needs new `fetchBlob()` for binary |
+
+---
+
+## B. Anti-scope (жёсткие запреты)
+
+### Q5. Мы **не** создаём "локальные http helpers" в `features/*` или `lib/*`?
+
+**Answer:** ✅ Верно. Все новые http функции только в `src/api/client.ts`.
+
+### Q6. Мы **не** добавляем новые hand-written DTO / не правим OpenAPI в этом PR?
+
+**Answer:** ✅ Верно. Используем существующие типы из `schema.ts` + inline types где нужно.
+
+### Q7. Мы **не** меняем UI поведение/тексты/flow, кроме транспорта?
+
+**Answer:** ✅ Верно. Только замена `fetch()` → `api()` / `fetchBlob()`.
+
+---
+
+## C. Transport design (как будет после)
+
+### Q8. Для каждого из 4 кейсов: какая **целевая API-функция** будет использована?
+
+| File | Target Function | URL Type | Notes |
+|------|-----------------|----------|-------|
+| `sharedLinks.ts` | `api<SignedLinkResponse>()` | API path | Existing, POST JSON |
+| `shareFile.ts` | `fetchBlob()` | External | **NEW**, no auth headers |
+| `ShoplistPreview.tsx` | `fetchBlob()` | API path | **NEW**, with auth headers |
+| `WeeklyPlanViewer.tsx` | `fetchBlob()` | External | **NEW**, no auth headers |
+
+### Q9. Будут ли какие-то вызовы требовать **blob/arrayBuffer**?
+
+**Answer:** Да, 3 из 4 кейсов требуют blob:
+- `shareFile.ts`: uses `arrayBuffer()` → need blob → arrayBuffer conversion
+- `ShoplistPreview.tsx`: uses `blob()` → direct return
+- `WeeklyPlanViewer.tsx`: uses `blob()` → direct return
+
+**Solution:** `fetchBlob()` returns `Blob`, caller can call `.arrayBuffer()` if needed.
+
+### Q10. Как будет обрабатываться **401/403**?
+
+**URL Classification Rule (Critical):**
+
+| URL Pattern | Classification | Behavior |
+|-------------|----------------|----------|
+| `/api/...` | **API path** | Prepend `VITE_API_BASE`, attach auth headers, apply `onAuthError` (401/403 → clear key + redirect) |
+| `http://...` or `https://...` | **External signed URL** | **NO** auth headers, **NO** api-base prepend, **NO** key clearing / redirect |
+| Other | **Error** | Throw immediately (prevent silent wrong requests) |
+
+**Security rationale:**
+- Signed URLs already contain auth token in query string
+- Sending API key to external domain = credential leak risk
+- External 401/403 should not trigger local auth state changes
+
+**New function signature:**
+
+```typescript
+// In src/api/client.ts
+export async function fetchBlob(
+  url: string,
+  init?: RequestInit
+): Promise<Blob>
+```
+
+**Internal logic:**
+- `classifyUrl(url)` → `'api' | 'absolute'`
+- API path: prepend base, add auth headers, handle 401/403
+- External: pass-through fetch, no auth modification
+
+---
+
+## D. Tests & Verification (DoD PR-587)
+
+### Q11. `thin-client-guards.test.ts` должен стать **PASS**?
+
+**Answer:** ✅ Да, это главный критерий.
+
+### Q12. `rg -n "\\bfetch\\s*\\(" frontend/src` возвращает **только** `src/api/client.ts`?
+
+**Answer:** ✅ Да (и test files, которые excluded).
+
+### Q13. Добавим ли мы regression test на каждый из 4 кейсов?
+
+**Answer:**
+- ✅ Unit test for `fetchBlob()` in `client.test.ts`
+- 🔄 Existing tests in `shareFile.test.ts` need mock updates (fetch → fetchBlob)
+- ⏭️ Component tests optional (transport layer tested)
+
+### Q14. Как мы проверим, что export/download всё ещё работает?
+
+**Local verification steps:**
+1. `npm test` — all tests pass
+2. `npm run dev` — start dev server
+3. Test shopping list export (CSV/PDF download)
+4. Test weekly plan PDF download
+5. Test native share on mobile (if possible)
+
+---
+
+## E. Links
+
+### Q15. Ссылка на policy anchor
+
+- Guards PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/586>
+
+### Q16. Ссылка на ledger item (P0)
+
+- `docs/roadmap/BACKLOG_LEDGER.md` — "PR-587 Web Thin HTTP Adapter — Remediation"
+
+### Q17. Ссылка на конкретные строки нарушений
+
+- Guards PR audit: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md` (Section 2)
+
+---
+
+## F. Implementation Plan
+
+1. **Add `fetchBlob()` to `client.ts`**
+   - Add `classifyUrl()` helper
+   - Implement auth handling for API paths only
+   - Return `Blob` instead of JSON
+
+2. **Migrate `sharedLinks.ts`**
+   - Replace `fetch()` with `api()`
+   - Import `api, getApiBase` from `../api/client`
+
+3. **Migrate `shareFile.ts`**
+   - Replace `fetch()` with `fetchBlob()`
+   - Keep `.arrayBuffer()` call on result
+
+4. **Migrate `ShoplistPreview.tsx`**
+   - Replace `fetch()` with `fetchBlob()`
+
+5. **Migrate `WeeklyPlanViewer.tsx`**
+   - Replace `fetch()` with `fetchBlob()`
+
+6. **Update tests**
+   - Update `shareFile.test.ts` mocks
+
+7. **Verify**
+   - `npm test` — all pass
+   - Guard tests PASS
+   - Manual verification of exports
+
+---
+
+## G. DoD Checklist
+
+### Transport layer
+- [ ] `fetchBlob()` added to `client.ts`
+- [ ] `fetchBlob()` must **NOT** send API key to external URLs (security)
+- [ ] `fetchBlob()` must **NOT** clear stored key / redirect on 401/403 for external URLs
+- [ ] URL classification: `/api/...` vs `http(s)://...` handled correctly
+
+### Migrations
+- [ ] `sharedLinks.ts` migrated to `api()` (JSON, internal)
+- [ ] `shareFile.ts` migrated to `fetchBlob()` (blob, external signed URL)
+- [ ] `ShoplistPreview.tsx` migrated to `fetchBlob()` (blob, API path)
+- [ ] `WeeklyPlanViewer.tsx` migrated to `fetchBlob()` (blob, external signed URL)
+
+### Tests & Verification
+- [ ] `shareFile.test.ts` mocks updated
+- [ ] `thin-client-guards.test.ts` PASS
+- [ ] `rg -n "\\bfetch\\s*\\(" frontend/src` → only `src/api/client.ts`
+- [ ] CI green
+
+---
+
+**Last updated:** 2026-01-25
+**Maintainer:** @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -53,19 +53,31 @@ If it is not recorded here — it does not exist.
     - ✅ Merge conflict safety guards added (3 levels)
     - ⏳ CI green (awaiting CI run)
 
-- [ ] PR-564 Thin HTTP Adapter (Web)
+- [ ] PR-586 Web Thin HTTP Adapter — Guards (expected-red)
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: PR-564 (TBD, after PR-563 merge)
-  - Reason: unified thin transport layer for Web client (no business logic)
+  - Target PR: PR-586 (after PR-563 merge)
+  - Reason: Policy enforcement — guard tests to detect thin-client violations
   - Links:
-    - docs/CONTEXT_HANDOFF_2026-01-21.md
-    - docs/audit/PR_562_THIN_CLIENT_HTTP_ADAPTER_AUDIT_TEMPLATE.md (originally for PR-562, applies to PR-563)
+    - docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/586>
   - DoD:
-    - Web: thin fetch wrapper + BMI API client (transport only)
-    - No BMI/waist/risk logic on clients (grep policy / guard tests)
-    - Unit tests green (Web)
-    - DTOs aligned with backend OpenAPI schemas (openapi-typescript)
-    - Error envelope mapping implemented (422 vs 400/500)
+    - ✅ Guard tests created (`frontend/src/api/__tests__/thin-client-guards.test.ts`)
+    - ✅ `frontend/AGENTS.md` updated with thin-client policy
+    - 🔴 CI expected RED (guards expose 4 direct fetch violations)
+    - Remediation tracked in PR-587
+
+- [ ] PR-587 Web Thin HTTP Adapter — Remediation (fix-green)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: PR-587 (after PR-586)
+  - Reason: Fix 4 direct fetch() violations detected by guards
+  - Links:
+    - docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md (violations list)
+  - DoD:
+    - Migrate `features/plan/WeeklyPlanViewer.tsx:39` to use `api()`
+    - Migrate `features/shoplist/ShoplistPreview.tsx:109` to use `api()`
+    - Migrate `lib/shareFile.ts:108` to use `api()`
+    - Migrate `lib/sharedLinks.ts:21` to use `api()`
+    - Guard tests pass (all 4 violations fixed)
     - CI green
 
 ---

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,6 +17,49 @@
 - OpenAPI types are generated from `src/api/openapi.json` into `src/api/schema.ts`.
 - Keep UI changes in sync with backend schema updates.
 
+## Thin HTTP Adapter Policy (Hard Rule)
+
+**Invariant:** Web client must be a **thin adapter only** — zero business logic, only transport/contract/UX.
+
+### Forbidden on Web client
+
+- ❌ Any BMI/waist/risk calculation formulas (thresholds, categories, interpretations)
+- ❌ Any business logic that duplicates backend domain rules
+- ❌ Any "smart" inference or computation from API responses (only display as-is)
+- ❌ Hand-written DTOs not aligned with OpenAPI schemas
+- ❌ Direct `fetch()` calls outside `src/api/client.ts`
+
+### Allowed on Web client
+
+- ✅ HTTP transport layer (`api()` function in `src/api/client.ts`)
+- ✅ Error envelope mapping (401/403 → redirect, pass through others)
+- ✅ i18n localization of backend-provided keys
+- ✅ UI formatting (number display, date formatting — not recalculation)
+- ✅ Conditional rendering based on API response fields (UI logic, not computation)
+- ✅ OpenAPI-generated types from `src/api/schema.ts`
+
+### Forbidden patterns (grep targets)
+
+```
+18.5, 24.9, 25.0, 30.0        # BMI thresholds
+if (bmi < ...), bmi > ...     # BMI comparisons
+category =, risk =            # Category/risk assignments
+calculateBMI, computeBMI      # Local BMI functions
+```
+
+### Enforcement
+
+- Guard tests: `src/api/__tests__/thin-client-guards.test.ts`
+- CI: Grep for forbidden patterns in `frontend/src/`
+- Code review: Check for BMI logic before merge
+
+**Links:**
+- Root policy: `AGENTS.md` (Thin HTTP Adapter Policy)
+- iOS equivalent: `ios/AGENTS.md` (iOS Thin Client Policy)
+- Audit: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
+
+---
+
 ## Contracts & Types policy (OpenAPI)
 
 **Canonical source:** See root `AGENTS.md` section "OpenAPI generation (determinism requirement)" for full policy.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -40,7 +40,7 @@
 
 ### Forbidden patterns (grep targets)
 
-```
+```text
 18.5, 24.9, 25.0, 30.0        # BMI thresholds
 if (bmi < ...), bmi > ...     # BMI comparisons
 category =, risk =            # Category/risk assignments

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -13,12 +13,13 @@
  * - BMI comparisons (if bmi <, bmi >, etc.)
  * - Category/risk assignments
  * - Local BMI calculation functions
+ * - Direct fetch() calls outside client.ts
  *
  * @see docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
  * @see frontend/AGENTS.md (Thin HTTP Adapter Policy)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -88,10 +89,23 @@ const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp; description: st
   },
 ];
 
+// Canonical path for the allowed fetch file
+const ALLOWED_FETCH_FILE = path.join('api', 'client.ts');
+
+/**
+ * Source file with content for scanning
+ */
+interface SourceFile {
+  path: string;
+  relativePath: string;
+  content: string;
+  lines: string[];
+}
+
 /**
  * Recursively get all TypeScript/TSX files in a directory
  */
-function getSourceFiles(dir: string): string[] {
+function getSourceFilePaths(dir: string): string[] {
   const files: string[] = [];
 
   if (!fs.existsSync(dir)) {
@@ -109,7 +123,7 @@ function getSourceFiles(dir: string): string[] {
     }
 
     if (entry.isDirectory()) {
-      files.push(...getSourceFiles(fullPath));
+      files.push(...getSourceFilePaths(fullPath));
     } else if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
       files.push(fullPath);
     }
@@ -119,41 +133,96 @@ function getSourceFiles(dir: string): string[] {
 }
 
 /**
- * Scan a file for forbidden patterns
+ * Load source files with content (shared helper to avoid duplicate FS reads)
+ * FIX B: Shared helper for file collection
  */
-function scanFile(
-  filePath: string
-): Array<{ pattern: string; line: number; content: string }> {
-  const violations: Array<{ pattern: string; line: number; content: string }> = [];
-  const content = fs.readFileSync(filePath, 'utf-8');
-  const lines = content.split('\n');
+function collectSourceFiles(srcDir: string, scanDirs: string[]): SourceFile[] {
+  const sourceFiles: SourceFile[] = [];
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const lineNum = i + 1;
+  for (const subDir of scanDirs) {
+    const dirPath = path.join(srcDir, subDir);
+    const filePaths = getSourceFilePaths(dirPath);
 
-    // Skip comments
-    const trimmed = line.trim();
-    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
-      continue;
-    }
-
-    for (const { name, pattern } of FORBIDDEN_PATTERNS) {
-      if (pattern.test(line)) {
-        violations.push({
-          pattern: name,
-          line: lineNum,
-          content: line.trim().substring(0, 100),
-        });
-      }
+    for (const filePath of filePaths) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      sourceFiles.push({
+        path: filePath,
+        relativePath: path.relative(srcDir, filePath),
+        content,
+        lines: content.split('\n'),
+      });
     }
   }
 
-  return violations;
+  return sourceFiles;
+}
+
+/**
+ * Check if a line is inside a comment (handles block comments)
+ * FIX A: Proper block comment handling
+ */
+function isLineInComment(
+  line: string,
+  inBlockComment: boolean
+): { skip: boolean; newBlockCommentState: boolean } {
+  const trimmed = line.trim();
+
+  // If we're in a block comment, check if it ends on this line
+  if (inBlockComment) {
+    if (trimmed.includes('*/')) {
+      // Block comment ends on this line - check if there's code after
+      const afterClose = trimmed.substring(trimmed.indexOf('*/') + 2).trim();
+      // If there's no code after the close, skip this line
+      // Otherwise, we need to process the code after
+      if (!afterClose) {
+        return { skip: true, newBlockCommentState: false };
+      }
+      // There's code after - don't skip, but block comment is closed
+      return { skip: false, newBlockCommentState: false };
+    }
+    // Still in block comment
+    return { skip: true, newBlockCommentState: true };
+  }
+
+  // Not in block comment - check for new block comment start
+  if (trimmed.startsWith('/*')) {
+    // Check if block comment closes on same line
+    if (trimmed.includes('*/')) {
+      // Single-line block comment - skip this line
+      return { skip: true, newBlockCommentState: false };
+    }
+    // Block comment starts but doesn't close
+    return { skip: true, newBlockCommentState: true };
+  }
+
+  // Single-line comment or JSDoc continuation
+  if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+    return { skip: true, newBlockCommentState: false };
+  }
+
+  // Not a comment
+  return { skip: false, newBlockCommentState: false };
+}
+
+/**
+ * Check if file is the canonical client.ts (allowed to use fetch)
+ * FIX C: Stricter client.ts skip condition using exact path
+ */
+function isAllowedFetchFile(relativePath: string): boolean {
+  // Normalize path separators for cross-platform compatibility
+  const normalized = relativePath.replace(/\\/g, '/');
+  return normalized === 'api/client.ts' || normalized.endsWith('/api/client.ts');
 }
 
 describe('ThinClientGuards', () => {
   const srcDir = path.resolve(__dirname, '../..');
+
+  // FIX B: Collect files once, share between tests
+  let sourceFiles: SourceFile[];
+
+  beforeAll(() => {
+    sourceFiles = collectSourceFiles(srcDir, SCAN_DIRS);
+  });
 
   it('should not contain BMI thresholds or business logic in frontend code', () => {
     const allViolations: Array<{
@@ -163,17 +232,30 @@ describe('ThinClientGuards', () => {
       content: string;
     }> = [];
 
-    for (const subDir of SCAN_DIRS) {
-      const dirPath = path.join(srcDir, subDir);
-      const files = getSourceFiles(dirPath);
+    for (const file of sourceFiles) {
+      let inBlockComment = false;
 
-      for (const file of files) {
-        const violations = scanFile(file);
-        for (const v of violations) {
-          allViolations.push({
-            file: path.relative(srcDir, file),
-            ...v,
-          });
+      for (let i = 0; i < file.lines.length; i++) {
+        const line = file.lines[i];
+        const lineNum = i + 1;
+
+        // FIX A/D: Consistent comment handling with block comment support
+        const commentCheck = isLineInComment(line, inBlockComment);
+        inBlockComment = commentCheck.newBlockCommentState;
+
+        if (commentCheck.skip) {
+          continue;
+        }
+
+        for (const { name, pattern } of FORBIDDEN_PATTERNS) {
+          if (pattern.test(line)) {
+            allViolations.push({
+              file: file.relativePath,
+              pattern: name,
+              line: lineNum,
+              content: line.trim().substring(0, 100),
+            });
+          }
         }
       }
     }
@@ -200,35 +282,31 @@ describe('ThinClientGuards', () => {
     const violations: Array<{ file: string; line: number; content: string }> = [];
     const fetchPattern = /\bfetch\s*\(/;
 
-    for (const subDir of SCAN_DIRS) {
-      const dirPath = path.join(srcDir, subDir);
-      const files = getSourceFiles(dirPath);
+    for (const file of sourceFiles) {
+      // FIX C: Use exact path check for client.ts
+      if (isAllowedFetchFile(file.relativePath)) {
+        continue;
+      }
 
-      for (const file of files) {
-        // Skip the client.ts file (it's allowed to use fetch)
-        if (file.includes('client.ts')) {
+      let inBlockComment = false;
+
+      for (let i = 0; i < file.lines.length; i++) {
+        const line = file.lines[i];
+
+        // FIX A/D: Consistent comment handling with block comment support
+        const commentCheck = isLineInComment(line, inBlockComment);
+        inBlockComment = commentCheck.newBlockCommentState;
+
+        if (commentCheck.skip) {
           continue;
         }
 
-        const content = fs.readFileSync(file, 'utf-8');
-        const lines = content.split('\n');
-
-        for (let i = 0; i < lines.length; i++) {
-          const line = lines[i];
-          const trimmed = line.trim();
-
-          // Skip comments
-          if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
-            continue;
-          }
-
-          if (fetchPattern.test(line)) {
-            violations.push({
-              file: path.relative(srcDir, file),
-              line: i + 1,
-              content: trimmed.substring(0, 100),
-            });
-          }
+        if (fetchPattern.test(line)) {
+          violations.push({
+            file: file.relativePath,
+            line: i + 1,
+            content: line.trim().substring(0, 100),
+          });
         }
       }
     }

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Thin Client Guards Tests
+ *
+ * RU: Защитные тесты против появления BMI логики во frontend коде.
+ * EN: Guard tests to prevent BMI logic from appearing in frontend code.
+ *
+ * These tests scan the frontend source code to detect violations of the
+ * thin-client policy. The frontend should be a pure renderer of backend
+ * contracts, with zero business logic.
+ *
+ * Forbidden patterns:
+ * - BMI thresholds (18.5, 24.9, 25.0, 30.0)
+ * - BMI comparisons (if bmi <, bmi >, etc.)
+ * - Category/risk assignments
+ * - Local BMI calculation functions
+ *
+ * @see docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+ * @see frontend/AGENTS.md (Thin HTTP Adapter Policy)
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Directories to scan (relative to frontend/src)
+const SCAN_DIRS = ['api', 'pages', 'components', 'features', 'hooks', 'lib'];
+
+// Directories/files to exclude from scanning
+const EXCLUDE_PATTERNS = [
+  '__tests__',
+  '.test.',
+  '.spec.',
+  'mock',
+  'fixture',
+  'schema.ts', // OpenAPI generated - contains threshold examples in comments
+  'openapi.json', // OpenAPI spec
+];
+
+// Forbidden patterns that indicate BMI logic violations
+const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp; description: string }> = [
+  {
+    name: 'bmi-threshold-18.5',
+    pattern: /(?<!['"`/])\b18\.5\b(?!['"`])/,
+    description: 'BMI threshold 18.5 (underweight boundary)',
+  },
+  {
+    name: 'bmi-threshold-24.9',
+    pattern: /(?<!['"`/])\b24\.9\b(?!['"`])/,
+    description: 'BMI threshold 24.9 (normal upper boundary)',
+  },
+  {
+    name: 'bmi-threshold-25',
+    pattern: /(?<!['"`/])\b25\.0?\b(?!['"`])(?!\d)/,
+    description: 'BMI threshold 25 (overweight boundary)',
+  },
+  {
+    name: 'bmi-threshold-30',
+    pattern: /(?<!['"`/])\b30\.0?\b(?!['"`])(?!\d)/,
+    description: 'BMI threshold 30 (obesity boundary)',
+  },
+  {
+    name: 'bmi-comparison',
+    pattern: /\bbmi\s*[<>=!]+\s*\d/i,
+    description: 'BMI value comparison (business logic)',
+  },
+  {
+    name: 'category-assignment',
+    pattern: /\bcategory\s*=\s*['"`]?(underweight|normal|overweight|obese)/i,
+    description: 'BMI category assignment (business logic)',
+  },
+  {
+    name: 'risk-assignment',
+    pattern: /\brisk\s*=\s*['"`]?(low|moderate|high|extreme)/i,
+    description: 'Risk level assignment (business logic)',
+  },
+  {
+    name: 'local-bmi-calc',
+    // Exclude API function calls (calculateBMI from api/bmi.ts is allowed)
+    // Match only: function declarations with BMI math, or non-API calculateBMI usage
+    pattern: /\b(computeBMI|getBMICategory|calcBMI)\s*\(/i,
+    description: 'Local BMI calculation function (should use backend)',
+  },
+  {
+    name: 'bmi-formula',
+    // Match BMI formula: weight / (height * height) or similar
+    pattern: /weight\s*\/\s*\(?\s*height\s*\*\s*height/i,
+    description: 'BMI formula implementation (should use backend)',
+  },
+];
+
+/**
+ * Recursively get all TypeScript/TSX files in a directory
+ */
+function getSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    // Skip excluded patterns
+    if (EXCLUDE_PATTERNS.some((pattern) => fullPath.includes(pattern))) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      files.push(...getSourceFiles(fullPath));
+    } else if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Scan a file for forbidden patterns
+ */
+function scanFile(
+  filePath: string
+): Array<{ pattern: string; line: number; content: string }> {
+  const violations: Array<{ pattern: string; line: number; content: string }> = [];
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+
+    // Skip comments
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+      continue;
+    }
+
+    for (const { name, pattern } of FORBIDDEN_PATTERNS) {
+      if (pattern.test(line)) {
+        violations.push({
+          pattern: name,
+          line: lineNum,
+          content: line.trim().substring(0, 100),
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+describe('ThinClientGuards', () => {
+  const srcDir = path.resolve(__dirname, '../..');
+
+  it('should not contain BMI thresholds or business logic in frontend code', () => {
+    const allViolations: Array<{
+      file: string;
+      pattern: string;
+      line: number;
+      content: string;
+    }> = [];
+
+    for (const subDir of SCAN_DIRS) {
+      const dirPath = path.join(srcDir, subDir);
+      const files = getSourceFiles(dirPath);
+
+      for (const file of files) {
+        const violations = scanFile(file);
+        for (const v of violations) {
+          allViolations.push({
+            file: path.relative(srcDir, file),
+            ...v,
+          });
+        }
+      }
+    }
+
+    if (allViolations.length > 0) {
+      const report = allViolations
+        .map((v) => `  ${v.file}:${v.line} [${v.pattern}]\n    ${v.content}`)
+        .join('\n');
+
+      expect.fail(
+        `Thin Client Policy Violation!\n\n` +
+          `Found ${allViolations.length} violation(s) in frontend code:\n\n` +
+          `${report}\n\n` +
+          `The frontend must be a thin HTTP adapter with zero BMI logic.\n` +
+          `All calculations and interpretations must come from the backend.\n\n` +
+          `See: frontend/AGENTS.md (Thin HTTP Adapter Policy)`
+      );
+    }
+
+    expect(allViolations).toHaveLength(0);
+  });
+
+  it('should use api() function for all HTTP calls (no direct fetch)', () => {
+    const violations: Array<{ file: string; line: number; content: string }> = [];
+    const fetchPattern = /\bfetch\s*\(/;
+
+    for (const subDir of SCAN_DIRS) {
+      const dirPath = path.join(srcDir, subDir);
+      const files = getSourceFiles(dirPath);
+
+      for (const file of files) {
+        // Skip the client.ts file (it's allowed to use fetch)
+        if (file.includes('client.ts')) {
+          continue;
+        }
+
+        const content = fs.readFileSync(file, 'utf-8');
+        const lines = content.split('\n');
+
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          const trimmed = line.trim();
+
+          // Skip comments
+          if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+            continue;
+          }
+
+          if (fetchPattern.test(line)) {
+            violations.push({
+              file: path.relative(srcDir, file),
+              line: i + 1,
+              content: trimmed.substring(0, 100),
+            });
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const report = violations
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.content}`)
+        .join('\n');
+
+      expect.fail(
+        `Direct fetch() usage detected!\n\n` +
+          `Found ${violations.length} violation(s):\n\n` +
+          `${report}\n\n` +
+          `All HTTP calls must go through api() from src/api/client.ts.\n` +
+          `Direct fetch() calls violate the thin client policy.`
+      );
+    }
+
+    expect(violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## ⚠️ Expected CI: FAIL

**This is a Policy Enforcement PR** — guard tests intentionally detect violations.

Guard tests expose **4 direct fetch() violations** in frontend code.
**Do not fix here** — remediation in PR-587.

---

## Scope

- Add guard tests: `frontend/src/api/__tests__/thin-client-guards.test.ts`
- Update `frontend/AGENTS.md` with thin-client policy (hard rule)
- Update root `AGENTS.md` with guard references
- Add audit doc: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
- Update `BACKLOG_LEDGER.md` (split: PR-586 guards + PR-587 remediation)

---

## Detected Violations (by guard tests)

| File | Line | Issue |
|------|------|-------|
| `features/plan/WeeklyPlanViewer.tsx` | 39 | direct fetch() |
| `features/shoplist/ShoplistPreview.tsx` | 109 | direct fetch() |
| `lib/shareFile.ts` | 108 | direct fetch() |
| `lib/sharedLinks.ts` | 21 | direct fetch() |

---

## Why expected-red?

1. Guards must detect violations before remediation
2. Visible proof that guards work (moment of truth)
3. Process: contract/guard → remediation (PR-587)

---

## --no-verify rationale

Pre-commit hook runs tests and fails on guard violations.
This is expected behavior for guards-first approach.
See AGENTS.md: "--no-verify is allowed ONLY for expected-red PR".

---

## Links

- Audit: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
- Remediation: PR-587 (after this PR)
- Ledger: `docs/roadmap/BACKLOG_LEDGER.md`

---

## Deferred / Follow-ups

- **PR-587:** Migrate 4 files to use `api()` (remediation)

## Summary by Sourcery

Внедрить применение политики «тонкого клиента» для веб-фронтенда и добавить guard-тесты, которые намеренно падают при существующем прямом использовании `fetch()` и нарушениях логики BMI.

Документация:
- Задокументировать жёсткую политику веб Thin HTTP Adapter и запрещённые паттерны BMI/бизнес-логики в `frontend/AGENTS.md` и корневом `AGENTS.md`.
- Добавить подробный аудит-отчёт для PR-586, охватывающий текущее соответствие веб тонкого клиента, обнаруженные нарушения и план последующей ремедиации.
- Обновить `BACKLOG_LEDGER` отдельными записями для применения guard-проверок (PR-586) и ремедиации (PR-587), включая DoD и ссылки.

Тесты:
- Добавить тесты `ThinClientGuards`, которые сканируют исходный код фронтенда на предмет бизнес-логики, связанной с BMI, и обеспечивают использование общего HTTP-клиента `api()` вместо прямых вызовов `fetch()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce thin-client policy enforcement for the web frontend and add guard tests that intentionally fail on existing direct fetch() usage and BMI logic violations.

Documentation:
- Document the web Thin HTTP Adapter hard policy and forbidden BMI/business-logic patterns in frontend/AGENTS.md and root AGENTS.md.
- Add a detailed audit report for PR-586 covering current web thin-client compliance, detected violations, and follow-up remediation plan.
- Update BACKLOG_LEDGER with separate entries for guard enforcement (PR-586) and remediation (PR-587), including DoD and links.

Tests:
- Add ThinClientGuards tests that scan frontend source code for BMI-related business logic and enforce use of the shared api() HTTP client instead of direct fetch() calls.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Web thin-client guards to block BMI logic and direct fetch usage. CI is expected to fail because guards expose existing violations; fixes will land in PR-587.

- **New Features**
  - Added thin-client-guards.test.ts to scan for BMI logic and direct fetch; handles block comments and only allows fetch in api/client.ts; fails CI on violations.
  - Updated frontend/AGENTS.md and root AGENTS.md with the thin-client policy; added audits for PR-586 and PR-587; refreshed BACKLOG_LEDGER.md.

- **Migration**
  - Do not fix here; remediation is in PR-587. Guards currently flag direct fetch in: features/plan/WeeklyPlanViewer.tsx:39, features/shoplist/ShoplistPreview.tsx:109, lib/shareFile.ts:108, lib/sharedLinks.ts:21.
  - CI is expected red; pre-commit will fail on guards. --no-verify is allowed for this expected-red policy PR.

<sup>Written for commit 63cd8d2c360327f7e8e513b4219645f0a479caaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Web Thin HTTP Adapter audit and expanded the Frontend Thin Client policy with Web-specific guard guidance, DTO contract rules, and updated references.

* **Tests**
  * Introduced guard tests that detect direct frontend fetch usage and prevent embedding certain business logic in UI code.

* **Chores**
  * Updated backlog/roadmap entries to track guard enforcement, remediation PRs, and migration targets for adopting the thin-client API pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->