### PR TITLE
fix(web): post-merge hardening for thin-client guards

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -759,7 +759,7 @@
         "filename": "tests/test_bayesian_diff_gaps.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 289
       }
     ],
     "tests/test_business_router_coverage.py": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-25T10:37:21Z"
+  "generated_at": "2026-01-25T20:56:21Z"
 }

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -62,16 +62,19 @@ If it is not recorded here — it does not exist.
     - 🔴 CI expected RED (guards expose 4 direct fetch violations)
     - Remediation tracked in PR-587
 
-- [ ] PR-587 Web Thin HTTP Adapter — Remediation (fix-green)
+- [x] PR-587 Web Thin HTTP Adapter — Remediation (fix-green)
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: PR-587 (after PR-586)
+  - Target PR: PR-590 (superseded PR-587/589)
+  - Status: ✅ Superseded by PR-590 (merged)
   - Reason: Fix 4 direct fetch() violations detected by guards
   - Links:
     - docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md (violations list)
-  - DoD:
-    - Migrate `features/plan/WeeklyPlanViewer.tsx:39` to use `api()`
-    - Migrate `features/shoplist/ShoplistPreview.tsx:109` to use `api()`
-    - Migrate `lib/shareFile.ts:108` to use `api()`
+    - docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/590>
+  - DoD: ✅ Completed
+    - Migrate `features/plan/WeeklyPlanViewer.tsx:39` to use `fetchBlob()`
+    - Migrate `features/shoplist/ShoplistPreview.tsx:109` to use `fetchBlob()`
+    - Migrate `lib/shareFile.ts:108` to use `fetchBlob()`
     - Migrate `lib/sharedLinks.ts:21` to use `api()`
     - Guard tests pass (all 4 violations fixed)
     - CI green
@@ -276,6 +279,9 @@ If it is not recorded here — it does not exist.
   - Finding Type: improvement (Sourcery PR-592)
   - Location: `frontend/src/api/__tests__/thin-client-guards.test.ts`
   - Reason: FORBIDDEN_PATTERNS/SCAN_DIRS/EXCLUDE_PATTERNS should be shared between guards and AGENTS.md to prevent policy drift
+  - Links:
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/592> (source PR)
+    - Sourcery comment on PR-592
   - DoD:
     - Config extracted to shared module
     - Guards import config
@@ -289,6 +295,9 @@ If it is not recorded here — it does not exist.
   - Finding Type: improvement (Sourcery PR-592)
   - Location: `frontend/src/api/__tests__/thin-client-guards.test.ts`
   - Reason: Current `isLineInComment` may not handle inline `/* ... */` on same line correctly
+  - Links:
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/592> (source PR)
+    - Sourcery comment on PR-592
   - DoD:
     - Stricter inline comment parsing
     - Test cases for edge cases

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -30,13 +30,6 @@
 
 ### Quick checks
 
-```bash
-# All fetch() calls must be in client.ts only
-rg "fetch\(" frontend/src -g'*.ts' -g'*.tsx' | grep -v client.ts | grep -v __tests__
-
-# Run guard tests
-npm test -- --run src/api/__tests__/thin-client-guards.test.ts
-```
 
 **Links:**
 - Root policy: `AGENTS.md` (Thin HTTP Adapter Policy)

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -19,43 +19,27 @@
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 
-**Invariant:** Web client must be a **thin adapter only** — zero business logic, only transport/contract/UX.
+**Invariant:** See root `AGENTS.md` → "Thin HTTP Adapter Policy (Hard Rule)" for full policy.
 
-### Forbidden on Web client
+### Web-specific enforcement
 
-- ❌ Any BMI/waist/risk calculation formulas (thresholds, categories, interpretations)
-- ❌ Any business logic that duplicates backend domain rules
-- ❌ Any "smart" inference or computation from API responses (only display as-is)
-- ❌ Hand-written DTOs not aligned with OpenAPI schemas
 - ❌ Direct `fetch()` calls outside `src/api/client.ts`
-
-### Allowed on Web client
-
-- ✅ HTTP transport layer (`api()` function in `src/api/client.ts`)
-- ✅ Error envelope mapping (401/403 → redirect, pass through others)
-- ✅ i18n localization of backend-provided keys
-- ✅ UI formatting (number display, date formatting — not recalculation)
-- ✅ Conditional rendering based on API response fields (UI logic, not computation)
+- ✅ Use `api()` / `fetchBlob()` from `src/api/client.ts`
 - ✅ OpenAPI-generated types from `src/api/schema.ts`
+- ✅ Guards: `src/api/__tests__/thin-client-guards.test.ts` must stay green
 
-### Forbidden patterns (grep targets)
+### Quick checks
 
-```text
-18.5, 24.9, 25.0, 30.0        # BMI thresholds
-if (bmi < ...), bmi > ...     # BMI comparisons
-category =, risk =            # Category/risk assignments
-calculateBMI, computeBMI      # Local BMI functions
+```bash
+# All fetch() calls must be in client.ts only
+rg "fetch\(" frontend/src -g'*.ts' -g'*.tsx' | grep -v client.ts | grep -v __tests__
+
+# Run guard tests
+npm test -- --run src/api/__tests__/thin-client-guards.test.ts
 ```
-
-### Enforcement
-
-- Guard tests: `src/api/__tests__/thin-client-guards.test.ts`
-- CI: Grep for forbidden patterns in `frontend/src/`
-- Code review: Check for BMI logic before merge
 
 **Links:**
 - Root policy: `AGENTS.md` (Thin HTTP Adapter Policy)
-- iOS equivalent: `ios/AGENTS.md` (iOS Thin Client Policy)
 - Audit: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
 
 ---

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -28,8 +28,18 @@
 - ✅ OpenAPI-generated types from `src/api/schema.ts`
 - ✅ Guards: `src/api/__tests__/thin-client-guards.test.ts` must stay green
 
-### Quick checks
+### Canonical local checks
 
+```bash
+# Run guard tests (thin-client policy enforcement)
+npm test -- --run src/api/__tests__/thin-client-guards.test.ts
+
+# Run all frontend tests
+npm test
+
+# Build (catches TS errors)
+npm run build
+```
 
 **Links:**
 - Root policy: `AGENTS.md` (Thin HTTP Adapter Policy)

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -95,9 +95,6 @@ const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp; description: st
   },
 ];
 
-// Canonical path for the allowed fetch file
-const ALLOWED_FETCH_FILE = path.join('api', 'client.ts');
-
 /**
  * Source file with content for scanning
  */

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { isLineInComment, stripInlineComments } from '../thinClientGuardUtils';
 
 // Directories to scan (relative to frontend/src)
 const SCAN_DIRS = ['api', 'pages', 'components', 'features', 'hooks', 'lib'];
@@ -162,75 +163,8 @@ function collectSourceFiles(srcDir: string, scanDirs: string[]): SourceFile[] {
   return sourceFiles;
 }
 
-/**
- * Check if a line is inside a comment (handles block comments)
- * FIX A: Proper block comment handling
- */
-function isLineInComment(
-  line: string,
-  inBlockComment: boolean
-): { skip: boolean; newBlockCommentState: boolean } {
-  const trimmed = line.trim();
-
-  // If we're in a block comment, check if it ends on this line
-  if (inBlockComment) {
-    if (trimmed.includes('*/')) {
-      // Block comment ends on this line - check if there's code after
-      const afterClose = trimmed.substring(trimmed.indexOf('*/') + 2).trim();
-      // If there's no code after the close, skip this line
-      // Otherwise, we need to process the code after
-      if (!afterClose) {
-        return { skip: true, newBlockCommentState: false };
-      }
-      // There's code after - don't skip, but block comment is closed
-      return { skip: false, newBlockCommentState: false };
-    }
-    // Still in block comment
-    return { skip: true, newBlockCommentState: true };
-  }
-
-  // Not in block comment - check for new block comment start
-  if (trimmed.startsWith('/*')) {
-    // Check if block comment closes on same line
-    if (trimmed.includes('*/')) {
-      // Single-line block comment - skip this line
-      return { skip: true, newBlockCommentState: false };
-    }
-    // Block comment starts but doesn't close
-    return { skip: true, newBlockCommentState: true };
-  }
-
-  // Single-line comment
-  if (trimmed.startsWith('//')) {
-    return { skip: true, newBlockCommentState: false };
-  }
-
-  // JSDoc/block comment continuation: only skip `*` lines when INSIDE a block comment
-  // Cubic fix: `* height` in multiline expression should NOT be skipped
-  // Note: we're NOT in block comment here (handled above), so `*` is code, not comment
-
-  // Not a comment
-  return { skip: false, newBlockCommentState: false };
-}
-
-/**
- * Strip inline comments from a line for pattern matching
- * CodeRabbit fix: avoid false positives from comments after code
- */
-function stripInlineComments(line: string): string {
-  const lineCommentIdx = line.indexOf('//');
-  const blockCommentIdx = line.indexOf('/*');
-  let cutPoint = line.length;
-
-  if (lineCommentIdx !== -1) {
-    cutPoint = Math.min(cutPoint, lineCommentIdx);
-  }
-  if (blockCommentIdx !== -1) {
-    cutPoint = Math.min(cutPoint, blockCommentIdx);
-  }
-
-  return line.slice(0, cutPoint);
-}
+// Helper functions (isLineInComment, stripInlineComments) are imported from thinClientGuardUtils.ts
+// See thinClientGuardUtils.test.ts for unit tests on these helpers
 
 /**
  * Check if file is the canonical client.ts (allowed to use fetch)

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -51,12 +51,17 @@ const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp; description: st
   },
   {
     name: 'bmi-threshold-25',
-    pattern: /(?<!['"`/])\b25\.0?\b(?!['"`])(?!\d)/,
+    // Match 25, 25.0, 25.00 but NOT 0.25 or percentage: 25
+    // Cubic fix: dot optional, but avoid false positives
+    // Lookbehind excludes: quotes, slash, dot, colon+space (age: 30)
+    pattern: /(?<!['"`/.])(?<!:\s)\b25(\.0{1,2})?\b(?!['"`])(?!\d)/,
     description: 'BMI threshold 25 (overweight boundary)',
   },
   {
     name: 'bmi-threshold-30',
-    pattern: /(?<!['"`/])\b30\.0?\b(?!['"`])(?!\d)/,
+    // Match 30, 30.0, 30.00 but NOT age: 30
+    // Cubic fix: dot optional, but avoid false positives
+    pattern: /(?<!['"`/.])(?<!:\s)\b30(\.0{1,2})?\b(?!['"`])(?!\d)/,
     description: 'BMI threshold 30 (obesity boundary)',
   },
   {
@@ -195,13 +200,36 @@ function isLineInComment(
     return { skip: true, newBlockCommentState: true };
   }
 
-  // Single-line comment or JSDoc continuation
-  if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+  // Single-line comment
+  if (trimmed.startsWith('//')) {
     return { skip: true, newBlockCommentState: false };
   }
 
+  // JSDoc/block comment continuation: only skip `*` lines when INSIDE a block comment
+  // Cubic fix: `* height` in multiline expression should NOT be skipped
+  // Note: we're NOT in block comment here (handled above), so `*` is code, not comment
+
   // Not a comment
   return { skip: false, newBlockCommentState: false };
+}
+
+/**
+ * Strip inline comments from a line for pattern matching
+ * CodeRabbit fix: avoid false positives from comments after code
+ */
+function stripInlineComments(line: string): string {
+  const lineCommentIdx = line.indexOf('//');
+  const blockCommentIdx = line.indexOf('/*');
+  let cutPoint = line.length;
+
+  if (lineCommentIdx !== -1) {
+    cutPoint = Math.min(cutPoint, lineCommentIdx);
+  }
+  if (blockCommentIdx !== -1) {
+    cutPoint = Math.min(cutPoint, blockCommentIdx);
+  }
+
+  return line.slice(0, cutPoint);
 }
 
 /**
@@ -247,8 +275,14 @@ describe('ThinClientGuards', () => {
           continue;
         }
 
+        // CodeRabbit fix: strip inline comments before pattern matching
+        const candidate = stripInlineComments(line);
+        if (!candidate.trim()) {
+          continue;
+        }
+
         for (const { name, pattern } of FORBIDDEN_PATTERNS) {
-          if (pattern.test(line)) {
+          if (pattern.test(candidate)) {
             allViolations.push({
               file: file.relativePath,
               pattern: name,
@@ -301,7 +335,13 @@ describe('ThinClientGuards', () => {
           continue;
         }
 
-        if (fetchPattern.test(line)) {
+        // CodeRabbit fix: strip inline comments before pattern matching
+        const candidate = stripInlineComments(line);
+        if (!candidate.trim()) {
+          continue;
+        }
+
+        if (fetchPattern.test(candidate)) {
           violations.push({
             file: file.relativePath,
             line: i + 1,

--- a/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
+++ b/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
@@ -157,6 +157,13 @@ describe('isLineInComment()', () => {
       expect(res.skip).toBe(false);
       expect(res.newBlockCommentState).toBe(false);
     });
+
+    it('does not skip line with code between block comments (regression)', () => {
+      const line = '/* closed */ code /* unclosed';
+      const res = isLineInComment(line, false);
+      expect(res.skip).toBe(false);
+      expect(res.newBlockCommentState).toBe(true);
+    });
   });
 
   describe('inside block comment (inBlockComment=true)', () => {

--- a/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
+++ b/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
@@ -79,6 +79,26 @@ describe('stripInlineComments()', () => {
       expect(stripped).toContain('const bmi = 30');
     });
 
+    it('removes /* ... */ but keeps code after */ (prevents guard blind spot)', () => {
+      const line = 'const a = 1; /* bmi >= 25 */ const b = 25;';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const b = 25;');
+      expect(stripped).not.toContain('bmi >= 25');
+    });
+
+    it('keeps URL strings and keeps code after */', () => {
+      const line = 'const url = "http://x"; /* c */ const b = 25;';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('"http://x"');
+      expect(stripped).toContain('const b = 25;');
+    });
+
+    it('unterminated /* removes rest of line', () => {
+      const line = 'const a = 1; /* unterminated bmi >= 25';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toBe('const a = 1; ');
+    });
+
     it('cuts at // outside strings after string ends', () => {
       const line = 'const url = "http://example.com"; // real comment with 25';
       const stripped = stripInlineComments(line);

--- a/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
+++ b/frontend/src/api/__tests__/thinClientGuardUtils.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit Tests for Thin Client Guard Utilities
+ *
+ * RU: Регрессионные тесты для вспомогательных функций guard-тестов.
+ * EN: Regression tests for guard helper functions.
+ *
+ * These tests ensure the guard utilities correctly handle:
+ * - Inline comment stripping
+ * - Block/line comment detection
+ * - Edge cases that caused false positives/negatives
+ *
+ * @see thinClientGuardUtils.ts
+ * @see thin-client-guards.test.ts (main guard tests)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isLineInComment, stripInlineComments } from '../thinClientGuardUtils';
+
+describe('stripInlineComments()', () => {
+  describe('basic comment stripping', () => {
+    it('strips // inline comments', () => {
+      const line = 'const x = 1; // bmi >= 25';
+      expect(stripInlineComments(line)).toBe('const x = 1; ');
+    });
+
+    it('strips /* inline block comments', () => {
+      const line = 'const y = 2; /* bmi >= 30 */';
+      expect(stripInlineComments(line)).toBe('const y = 2; ');
+    });
+
+    it('returns empty for pure // comment line', () => {
+      const line = '// bmi >= 25';
+      expect(stripInlineComments(line).trim()).toBe('');
+    });
+
+    it('returns empty for pure /* comment line', () => {
+      const line = '/* bmi >= 30 */';
+      expect(stripInlineComments(line).trim()).toBe('');
+    });
+
+    it('preserves code before comment', () => {
+      const line = 'const threshold = value; // threshold 25';
+      const result = stripInlineComments(line);
+      expect(result).toBe('const threshold = value; ');
+      // Ensure the guard pattern would NOT match after stripping
+      expect(result).not.toContain('25');
+    });
+
+    it('handles line with no comments', () => {
+      const line = 'const bmi = response.bmi;';
+      expect(stripInlineComments(line)).toBe('const bmi = response.bmi;');
+    });
+  });
+
+  describe('quote-aware (prevents false negatives)', () => {
+    it('does NOT cut at // inside double-quoted string (URL)', () => {
+      // This was the bug: "http://..." would be cut at "//" causing false negatives
+      const line = 'const url = "http://example.com"; const bmi = 25;';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const bmi = 25');
+      expect(stripped).toBe(line); // No cutting should occur
+    });
+
+    it('does NOT cut at // inside single-quoted string', () => {
+      const line = "const url = 'http://example.com'; const bmi = 25;";
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const bmi = 25');
+    });
+
+    it('does NOT cut at // inside backtick string', () => {
+      const line = 'const url = `http://example.com`; const bmi = 25;';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const bmi = 25');
+    });
+
+    it('does NOT cut at /* inside string literal', () => {
+      const line = "const s = 'a/*b'; const bmi = 30;";
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const bmi = 30');
+    });
+
+    it('cuts at // outside strings after string ends', () => {
+      const line = 'const url = "http://example.com"; // real comment with 25';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toBe('const url = "http://example.com"; ');
+      expect(stripped).not.toContain('25');
+    });
+
+    it('handles escaped quotes inside strings', () => {
+      const line = 'const s = "say \\"hi\\""; const bmi = 25;';
+      const stripped = stripInlineComments(line);
+      expect(stripped).toContain('const bmi = 25');
+    });
+
+    it('handles mixed quote types correctly', () => {
+      const line = `const s = "it's a test"; // comment`;
+      const stripped = stripInlineComments(line);
+      expect(stripped).toBe(`const s = "it's a test"; `);
+    });
+  });
+});
+
+describe('isLineInComment()', () => {
+  describe('outside block comment (inBlockComment=false)', () => {
+    it('does not skip "*" lines outside block comment (math expression)', () => {
+      // This was the Cubic bug: `* height` was incorrectly skipped
+      const res = isLineInComment('  * height', false);
+      expect(res.skip).toBe(false);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+
+    it('does not skip multiplication expressions', () => {
+      const res = isLineInComment('width * height', false);
+      expect(res.skip).toBe(false);
+    });
+
+    it('skips // comment lines', () => {
+      const res = isLineInComment('  // comment', false);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+
+    it('starts block comment on /* and sets state', () => {
+      const res = isLineInComment('/* start of comment', false);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(true);
+    });
+
+    it('handles single-line block comment /* ... */', () => {
+      const res = isLineInComment('/* single line */', false);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+
+    it('does not skip regular code', () => {
+      const res = isLineInComment('const x = 5;', false);
+      expect(res.skip).toBe(false);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+  });
+
+  describe('inside block comment (inBlockComment=true)', () => {
+    it('skips "*" lines inside block comment (JSDoc continuation)', () => {
+      const res = isLineInComment('  * @param docs', true);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(true);
+    });
+
+    it('skips regular text inside block comment', () => {
+      const res = isLineInComment('still in comment', true);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(true);
+    });
+
+    it('ends block comment on */ and clears state', () => {
+      const res = isLineInComment('end of comment */', true);
+      expect(res.skip).toBe(true);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+
+    it('handles code after block comment close', () => {
+      const res = isLineInComment('*/ const x = 5;', true);
+      // There's code after - don't skip so we can scan it
+      expect(res.skip).toBe(false);
+      expect(res.newBlockCommentState).toBe(false);
+    });
+  });
+
+  describe('block comment lifecycle', () => {
+    it('tracks state through multi-line block comment (no code after close)', () => {
+      // Simulate scanning through a block comment that closes cleanly
+      const lines = ['/* start', ' * middle', ' * still in', ' */'];
+
+      let state = false;
+      const results: boolean[] = [];
+
+      for (const line of lines) {
+        const res = isLineInComment(line, state);
+        results.push(res.skip);
+        state = res.newBlockCommentState;
+      }
+
+      // All lines should be skipped, final state should be false
+      expect(results).toEqual([true, true, true, true]);
+      expect(state).toBe(false);
+    });
+
+    it('does not skip line with code after block comment close', () => {
+      // When there's code after */, we don't skip so we can scan that code
+      const lines = ['/* start', '*/ const x = 25;'];
+
+      let state = false;
+      const results: boolean[] = [];
+
+      for (const line of lines) {
+        const res = isLineInComment(line, state);
+        results.push(res.skip);
+        state = res.newBlockCommentState;
+      }
+
+      // First line skipped (starts comment), second NOT skipped (has code after)
+      expect(results).toEqual([true, false]);
+      expect(state).toBe(false);
+    });
+  });
+});
+
+describe('FORBIDDEN_PATTERNS regex (threshold correctness)', () => {
+  // These patterns are copied from thin-client-guards.test.ts to verify correctness
+  const bmi25Pattern = /(?<!['"`/.])(?<!:\s)\b25(\.0{1,2})?\b(?!['"`])(?!\d)/;
+  const bmi30Pattern = /(?<!['"`/.])(?<!:\s)\b30(\.0{1,2})?\b(?!['"`])(?!\d)/;
+
+  describe('bmi-threshold-25', () => {
+    it('matches "bmi >= 25"', () => {
+      expect(bmi25Pattern.test('if (bmi >= 25)')).toBe(true);
+    });
+
+    it('matches "bmi >= 25.0"', () => {
+      expect(bmi25Pattern.test('if (bmi >= 25.0)')).toBe(true);
+    });
+
+    it('matches "bmi >= 25.00"', () => {
+      expect(bmi25Pattern.test('if (bmi >= 25.00)')).toBe(true);
+    });
+
+    it('does NOT match "250" (different number)', () => {
+      expect(bmi25Pattern.test('if (count >= 250)')).toBe(false);
+    });
+
+    it('does NOT match "0.25" (decimal coefficient)', () => {
+      expect(bmi25Pattern.test('const ratio = 0.25')).toBe(false);
+    });
+
+    it('does NOT match "percentage: 25" (key-value context)', () => {
+      expect(bmi25Pattern.test('percentage: 25')).toBe(false);
+    });
+
+    it('does NOT match quoted "25"', () => {
+      expect(bmi25Pattern.test('const s = "25"')).toBe(false);
+    });
+  });
+
+  describe('bmi-threshold-30', () => {
+    it('matches "bmi >= 30"', () => {
+      expect(bmi30Pattern.test('if (bmi >= 30)')).toBe(true);
+    });
+
+    it('matches "bmi >= 30.0"', () => {
+      expect(bmi30Pattern.test('if (bmi >= 30.0)')).toBe(true);
+    });
+
+    it('matches "bmi >= 30.00"', () => {
+      expect(bmi30Pattern.test('if (bmi >= 30.00)')).toBe(true);
+    });
+
+    it('does NOT match "300" (different number)', () => {
+      expect(bmi30Pattern.test('if (count >= 300)')).toBe(false);
+    });
+
+    it('does NOT match "age: 30" (key-value context)', () => {
+      expect(bmi30Pattern.test('age: 30')).toBe(false);
+    });
+
+    it('does NOT match quoted "30"', () => {
+      expect(bmi30Pattern.test('const s = "30"')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/api/thinClientGuardUtils.ts
+++ b/frontend/src/api/thinClientGuardUtils.ts
@@ -120,49 +120,85 @@ export function isLineInComment(
   line: string,
   inBlockComment: boolean
 ): CommentState {
-  const trimmed = line.trim();
+  // We use a small quote-aware scanner to decide whether the line contains any code outside
+  // comments, and to update block-comment state.
+  //
+  // Key bug fixed: don't mix lastIndexOf('/*') state detection with indexOf('/*') skip decision.
+  // Lines like `/* closed */ code /* unclosed` MUST NOT be skipped (code exists), but must set
+  // newBlockCommentState=true (unclosed block at end).
+  let inBlock = inBlockComment;
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  let escaped = false;
 
-  // If we're in a block comment, check if it ends on this line
-  if (inBlockComment) {
-    if (trimmed.includes('*/')) {
-      // Block comment ends on this line - check if there's code after
-      const afterClose = trimmed.substring(trimmed.indexOf('*/') + 2).trim();
-      // If there's no code after the close, skip this line
-      // Otherwise, we need to process the code after
-      if (!afterClose) {
-        return { skip: true, newBlockCommentState: false };
+  let hasCodeOutsideComments = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = i + 1 < line.length ? line[i + 1] : '';
+
+    // Inside block comment: scan until close.
+    if (inBlock) {
+      if (ch === '*' && next === '/') {
+        inBlock = false;
+        i += 1; // skip '/'
       }
-      // There's code after - don't skip, but block comment is closed
-      return { skip: false, newBlockCommentState: false };
+      continue;
     }
-    // Still in block comment - skip any line including JSDoc "*" continuations
-    return { skip: true, newBlockCommentState: true };
-  }
 
-  // Not in block comment - check for new block comment start
-  // Check for block comment start anywhere in the line
-  const blockStartIdx = trimmed.lastIndexOf('/*');
-  if (blockStartIdx !== -1) {
-    // Check if block comment closes on same line
-    const closeIdx = trimmed.indexOf('*/', blockStartIdx + 2);
-    if (closeIdx !== -1) {
-      // Block comment closes after the last open - no ongoing block
-      return { skip: trimmed.indexOf('/*') === 0, newBlockCommentState: false };
+    // Inside string literal (quote-aware)
+    if (inSingle || inDouble || inBacktick) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (inSingle && ch === "'") {
+        inSingle = false;
+      } else if (inDouble && ch === '"') {
+        inDouble = false;
+      } else if (inBacktick && ch === '`') {
+        inBacktick = false;
+      }
+      continue;
     }
-    // Block comment starts but doesn't close on this line
-    return { skip: trimmed.indexOf('/*') === 0, newBlockCommentState: true };
+
+    // Not in block comment & not in string: detect comment starts
+    if (ch === '/' && next === '/') {
+      break; // rest of line is a comment
+    }
+    if (ch === '/' && next === '*') {
+      inBlock = true;
+      i += 1; // skip '*'
+      continue;
+    }
+
+    // Enter string literal (counts as code)
+    if (ch === "'") {
+      inSingle = true;
+      hasCodeOutsideComments = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      hasCodeOutsideComments = true;
+      continue;
+    }
+    if (ch === '`') {
+      inBacktick = true;
+      hasCodeOutsideComments = true;
+      continue;
+    }
+
+    // Any non-whitespace char outside comments => this line has code.
+    if (ch.trim() !== '') {
+      hasCodeOutsideComments = true;
+    }
   }
 
-  // Single-line comment
-  if (trimmed.startsWith('//')) {
-    return { skip: true, newBlockCommentState: false };
-  }
-
-  // IMPORTANT: Do NOT treat "*" as comment outside block comment.
-  // This prevents skipping valid multiline math like:
-  // width
-  //   * height
-
-  // Not a comment
-  return { skip: false, newBlockCommentState: false };
+  return { skip: !hasCodeOutsideComments, newBlockCommentState: inBlock };
 }

--- a/frontend/src/api/thinClientGuardUtils.ts
+++ b/frontend/src/api/thinClientGuardUtils.ts
@@ -35,18 +35,33 @@ export function stripInlineComments(line: string): string {
   let inDouble = false;
   let inBacktick = false;
   let escaped = false;
+  let inBlockComment = false;
+
+  const out: string[] = [];
 
   for (let i = 0; i < line.length; i += 1) {
     const ch = line[i];
     const next = i + 1 < line.length ? line[i + 1] : '';
 
+    // If we're inside a block comment, skip content until we find the close.
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1; // skip '/'
+      }
+      continue;
+    }
+
     if (escaped) {
+      // Keep escaped character in output and clear escape state.
+      out.push(ch);
       escaped = false;
       continue;
     }
 
     if (ch === '\\') {
       // escape only matters inside strings
+      out.push(ch);
       if (inSingle || inDouble || inBacktick) {
         escaped = true;
       }
@@ -56,29 +71,36 @@ export function stripInlineComments(line: string): string {
     // Toggle quote states (only when not inside another quote type)
     if (!inDouble && !inBacktick && ch === "'") {
       inSingle = !inSingle;
+      out.push(ch);
       continue;
     }
     if (!inSingle && !inBacktick && ch === '"') {
       inDouble = !inDouble;
+      out.push(ch);
       continue;
     }
     if (!inSingle && !inDouble && ch === '`') {
       inBacktick = !inBacktick;
+      out.push(ch);
       continue;
     }
 
     // Detect comment starts only when NOT in any string literal
     if (!inSingle && !inDouble && !inBacktick) {
       if (ch === '/' && next === '/') {
-        return line.slice(0, i);
+        break; // rest of the line is a comment
       }
       if (ch === '/' && next === '*') {
-        return line.slice(0, i);
+        inBlockComment = true;
+        i += 1; // skip '*'
+        continue;
       }
     }
+
+    out.push(ch);
   }
 
-  return line;
+  return out.join('');
 }
 
 /**
@@ -119,15 +141,16 @@ export function isLineInComment(
 
   // Not in block comment - check for new block comment start
   // Check for block comment start anywhere in the line
-  const blockStartIdx = trimmed.indexOf('/*');
+  const blockStartIdx = trimmed.lastIndexOf('/*');
   if (blockStartIdx !== -1) {
     // Check if block comment closes on same line
-    if (trimmed.includes('*/')) {
-      // Single-line block comment - don't skip if there's code before it
-      return { skip: blockStartIdx === 0, newBlockCommentState: false };
+    const closeIdx = trimmed.indexOf('*/', blockStartIdx + 2);
+    if (closeIdx !== -1) {
+      // Block comment closes after the last open - no ongoing block
+      return { skip: trimmed.indexOf('/*') === 0, newBlockCommentState: false };
     }
-    // Block comment starts but doesn't close - set state, skip only if at start
-    return { skip: blockStartIdx === 0, newBlockCommentState: true };
+    // Block comment starts but doesn't close on this line
+    return { skip: trimmed.indexOf('/*') === 0, newBlockCommentState: true };
   }
 
   // Single-line comment

--- a/frontend/src/api/thinClientGuardUtils.ts
+++ b/frontend/src/api/thinClientGuardUtils.ts
@@ -1,0 +1,143 @@
+/**
+ * Thin Client Guard Utilities
+ *
+ * RU: Вспомогательные функции для guard-тестов тонкого клиента.
+ * EN: Helper functions for thin client guard tests.
+ *
+ * These utilities are extracted for testability - they handle
+ * comment detection and inline comment stripping for pattern matching.
+ *
+ * @see thin-client-guards.test.ts (main guard tests)
+ * @see docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md
+ */
+
+export type CommentState = {
+  skip: boolean;
+  newBlockCommentState: boolean;
+};
+
+/**
+ * Strip inline comments from a line for pattern matching (quote-aware).
+ *
+ * RU: Обрезает inline-комментарии (//, /*) только если они НЕ внутри строковых литералов.
+ * EN: Strips inline comments only when outside of string literals.
+ *
+ * Goal: reduce false positives from trailing comments WITHOUT creating false negatives.
+ * This is a minimal scanner, not a full JS parser - we intentionally don't handle:
+ * - Template literal interpolation ${...}
+ * - Regex literals /pattern/
+ * - Complex escape sequences beyond basic \\
+ *
+ * The trade-off is acceptable for guard tests that scan for obvious BMI logic violations.
+ */
+export function stripInlineComments(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = i + 1 < line.length ? line[i + 1] : '';
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      // escape only matters inside strings
+      if (inSingle || inDouble || inBacktick) {
+        escaped = true;
+      }
+      continue;
+    }
+
+    // Toggle quote states (only when not inside another quote type)
+    if (!inDouble && !inBacktick && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && !inBacktick && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && ch === '`') {
+      inBacktick = !inBacktick;
+      continue;
+    }
+
+    // Detect comment starts only when NOT in any string literal
+    if (!inSingle && !inDouble && !inBacktick) {
+      if (ch === '/' && next === '/') {
+        return line.slice(0, i);
+      }
+      if (ch === '/' && next === '*') {
+        return line.slice(0, i);
+      }
+    }
+  }
+
+  return line;
+}
+
+/**
+ * Check if a line is inside a comment (handles block comments).
+ *
+ * RU: Определяет, пропускать ли строку как комментарий.
+ * EN: Returns whether to skip a line due to comment context.
+ *
+ * Rules:
+ * - If we're inside a block comment, skip until we see "*&#47;" (closing ends the state).
+ * - A line starting a block comment "/*" is skipped (single-line or multi-line start).
+ * - A line starting with "//" is skipped.
+ * - A line starting with "*" is considered JSDoc continuation ONLY when inside block comment.
+ *   This prevents skipping valid multiline math like `width * height`.
+ */
+export function isLineInComment(
+  line: string,
+  inBlockComment: boolean
+): CommentState {
+  const trimmed = line.trim();
+
+  // If we're in a block comment, check if it ends on this line
+  if (inBlockComment) {
+    if (trimmed.includes('*/')) {
+      // Block comment ends on this line - check if there's code after
+      const afterClose = trimmed.substring(trimmed.indexOf('*/') + 2).trim();
+      // If there's no code after the close, skip this line
+      // Otherwise, we need to process the code after
+      if (!afterClose) {
+        return { skip: true, newBlockCommentState: false };
+      }
+      // There's code after - don't skip, but block comment is closed
+      return { skip: false, newBlockCommentState: false };
+    }
+    // Still in block comment - skip any line including JSDoc "*" continuations
+    return { skip: true, newBlockCommentState: true };
+  }
+
+  // Not in block comment - check for new block comment start
+  if (trimmed.startsWith('/*')) {
+    // Check if block comment closes on same line
+    if (trimmed.includes('*/')) {
+      // Single-line block comment - skip this line
+      return { skip: true, newBlockCommentState: false };
+    }
+    // Block comment starts but doesn't close
+    return { skip: true, newBlockCommentState: true };
+  }
+
+  // Single-line comment
+  if (trimmed.startsWith('//')) {
+    return { skip: true, newBlockCommentState: false };
+  }
+
+  // IMPORTANT: Do NOT treat "*" as comment outside block comment.
+  // This prevents skipping valid multiline math like:
+  // width
+  //   * height
+
+  // Not a comment
+  return { skip: false, newBlockCommentState: false };
+}

--- a/frontend/src/api/thinClientGuardUtils.ts
+++ b/frontend/src/api/thinClientGuardUtils.ts
@@ -118,14 +118,16 @@ export function isLineInComment(
   }
 
   // Not in block comment - check for new block comment start
-  if (trimmed.startsWith('/*')) {
+  // Check for block comment start anywhere in the line
+  const blockStartIdx = trimmed.indexOf('/*');
+  if (blockStartIdx !== -1) {
     // Check if block comment closes on same line
     if (trimmed.includes('*/')) {
-      // Single-line block comment - skip this line
-      return { skip: true, newBlockCommentState: false };
+      // Single-line block comment - don't skip if there's code before it
+      return { skip: blockStartIdx === 0, newBlockCommentState: false };
     }
-    // Block comment starts but doesn't close
-    return { skip: true, newBlockCommentState: true };
+    // Block comment starts but doesn't close - set state, skip only if at start
+    return { skip: blockStartIdx === 0, newBlockCommentState: true };
   }
 
   // Single-line comment


### PR DESCRIPTION
## Summary

Hotfix after PR-592 merge addressing Cubic/CodeRabbit actionables.

## Changes

### Guards (`thin-client-guards.test.ts`)

- **A1: Regex 25/30** — catches without decimals + excludes false positives (0.25, age: 30)
- **A2: Comment handling** — `*` lines not skipped outside block comments
- **A3: Inline comments** — `stripInlineComments()` to avoid false positives

### Docs

- **frontend/AGENTS.md** — scoped, references root policy
- **BACKLOG_LEDGER.md** — PR-587 superseded by PR-590, Links added

## Test Plan

- [x] Guards tests pass (2/2)
- [x] All frontend tests pass (533)
- [x] pre-commit hooks pass

## Related

- Fixes post-merge findings from PR-592

## Summary by Sourcery

Усилены тесты guard-механизмов тонкого клиента и приведены документация и записи в бэклоге в соответствие с обновлённой политикой веб‑тонкого HTTP‑адаптера и недавними работами по ремедиации.

Bug Fixes:
- Ужесточены шаблоны регулярных выражений для пороговых значений ИМТ, чтобы корректно сопоставлять варианты 25/30 и избегать ложных срабатываний, таких как десятичные значения и нецелевые использования, не связанные с ИМТ.
- Изменено определение комментариев так, чтобы ведущий символ `*` считался кодом, если он не находится внутри блочного комментария, и чтобы предотвратить пропуск валидных строк кода.
- Стриппинг (удаление) сегментов встроенных и блочных комментариев из строк перед применением проверок на запрещённые шаблоны и шаблоны выборок, чтобы избежать ложных срабатываний на строки, состоящие только из комментариев.

Documentation:
- Ограничен охват политики web AGENTS, чтобы она ссылалась на корневую политику тонкого HTTP‑адаптера и документировала веб‑специфичное применение правил и быстрые guard‑проверки.
- Обновлён BACKLOG_LEDGER: веб‑ремедиация тонкого HTTP‑адаптера помечена как завершённая через PR-590, включая обновлённые ссылки и элементы «definition of done».

Tests:
- Расширена логика тестов guard‑механизмов тонкого клиента: добавлена предобработка строк путём удаления встроенных комментариев перед сопоставлением с шаблонами, чтобы гарантировать синхронизацию поведения guard‑проверок с документированной политикой.

Chores:
- Обновлены внутренние ссылки и ссылки на предыдущие PR и находки Sourcery в бэклоге, чтобы лучше отслеживать задачи по улучшению guard‑механизмов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden thin-client guard tests and align documentation and backlog records with the updated web thin HTTP adapter policy and recent remediation work.

Bug Fixes:
- Tighten BMI threshold regex patterns to correctly match 25/30 variants while avoiding false positives such as decimals and non-BMI usages.
- Adjust comment detection to treat leading `*` as code when not inside a block comment and prevent skipping valid code lines.
- Strip inline and block comment segments from lines before applying forbidden and fetch pattern checks to avoid comment-only false positives.

Documentation:
- Scope the web AGENTS policy to reference the root thin HTTP adapter policy and document web-specific enforcement and quick guard checks.
- Update BACKLOG_LEDGER to mark the web thin HTTP adapter remediation as completed via PR-590, including updated links and definition of done items.

Tests:
- Extend thin-client guard test logic to preprocess lines by removing inline comments before pattern matching and ensure guard behavior stays in sync with documented policy.

Chores:
- Refresh internal references and links to prior PRs and Sourcery findings in the backlog to better track guard-related improvement items.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens web thin-client guards to reduce false positives and keep policy checks accurate. Updates web docs to point to the root policy and cleans backlog references.

- **Bug Fixes**
  - Regex for BMI thresholds (25/30) now matches integers and decimals, and ignores 0.25, age: 30, and percentage 25.
  - Comment handling fixed: only skip “*” lines inside block comments; quote-aware inline comment stripping; helpers extracted to a shared module with unit tests.
  - Docs: AGENTS.md now references the root policy and adds quick checks; BACKLOG_LEDGER marks PR-587 as superseded by PR-590 with links.

<sup>Written for commit 3762c50f43026b53e5ce13c055b41b121b9c95ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

