### PR TITLE
fix(web): align WeekPlanResponse alias with OpenAPI schema

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -478,7 +478,8 @@ export type {
 } from "./premium";
 
 // OpenAPI generated types
-export type WeekPlanResponse = components["schemas"]["WeekPlanResponse"];
+// NOTE: OpenAPI schema name is WeeklyPlanResponse; keep WeekPlanResponse as a local alias.
+export type WeekPlanResponse = components["schemas"]["WeeklyPlanResponse"];
 
 // Endpoints
 


### PR DESCRIPTION
## Summary
- Fix TypeScript alias in `frontend/src/api/client.ts`: `WeekPlanResponse` now points to OpenAPI `WeeklyPlanResponse`.
- Add an explicit note explaining the alias.

## Test plan
- `cd frontend && npm test -- --run src/api/__tests__/client.test.ts`
- `cd frontend && npm run build`

## Scope
- Single-file runtime contract fix (no guard changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API type definition to align with schema naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->