### PR TITLE
docs(audit): PR-598 iOS BMI thin-client dedup (verification)

### DIFF
--- a/docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md
+++ b/docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md
@@ -1,0 +1,87 @@
+# PR-598 — iOS BMI thin-client dedup (verification audit)
+
+Status: 🟢 Verified (already remediated in PR-596)
+Owner: @katsiaryna_kavaleuskaya
+Date: 26 января 2026 года
+
+## 0) Goal
+
+Verify that iOS BMI feature no longer contains legacy BMI shims/types and uses:
+
+- **Canonical DTOs**: `BMICalculateRequestDTO` / `BMICalculateResponseDTO`
+- **One HTTP path**: `BMIService` → `APIClient` → `HTTPClient` (no direct URLSession outside transport)
+- **Canonical errors**: `APIError` (incl. `transport` vs `unknown`)
+
+## 1) Scope / Non-goals
+
+### In-scope
+
+- iOS BMI transport + DTO boundary + error mapping in the BMI feature surface.
+
+### Out-of-scope
+
+- Any backend BMI math / categorization.
+- Any UI redesign or UX improvements (only contract/transport correctness).
+
+## 2) Canonical invariants (policy anchors)
+
+- **Thin HTTP Adapter**: iOS client must be transport/contract/UX only; no domain logic.
+- **No dual-path networking**: no direct `URLSession` usage outside `Networking/*`.
+- **APIError semantics**:
+  - Network/transport failures → `APIError.transport` (never `statusCode: 0`)
+  - Unexpected non-`APIError` failures → `APIError.unknown` (not transport)
+
+## 3) Evidence commands (copy/paste)
+
+```bash
+# Legacy shims/types MUST be absent
+rg -n "LegacyBMIServicing|DefaultBMIService|BMIServiceError\\b|\\bBMIRequest\\b|\\bBMIResponse\\b" ios/
+
+# Canonical BMI DTO usage
+rg -n "BMICalculateRequestDTO|BMICalculateResponseDTO" ios/PulsePlate ios/PulsePlateTests
+
+# Endpoint path and transport seam
+rg -n "/api/v1/bmi/calculate" ios/PulsePlate
+rg -n "APIClient\\(|HTTPClient\\(|URLSession\\.shared|URLSession\\(" ios/PulsePlate
+```
+
+## 4) Findings (AS-IS, verified)
+
+### 4.1 Canonical DTOs used by UI/service
+
+- `ios/PulsePlate/Screens/BMICalculatorScreen.swift:103-114` builds `BMICalculateRequestDTO`.
+- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift:6-32` stores `BMICalculateResponseDTO?` and `APIError?`.
+- `ios/PulsePlate/Models/BMI/BMICalculateRequestDTO.swift` documents canonical request contract (snake_case keys).
+
+### 4.2 Single HTTP path (thin adapter)
+
+- `ios/PulsePlate/Services/BMIService.swift:27-34` calls **canonical** endpoint:
+  - `POST /api/v1/bmi/calculate`
+  - via `apiClient.post(path:..., body: request)`
+
+### 4.3 Legacy shims/types removed
+
+Verified: no matches for `LegacyBMIServicing`, `DefaultBMIService`, `BMIServiceError`, `BMIRequest`, `BMIResponse` in `ios/`.
+
+### 4.4 Error mapping semantics present
+
+- `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift:27-32`:
+  - `APIError` is preserved as-is
+  - non-`APIError` failures map to `APIError.unknown(...)`
+
+## 5) AS-IS → TO-BE table
+
+| Area | AS-IS | TO-BE | Status |
+|------|-------|-------|--------|
+| DTO boundary | `BMICalculateRequestDTO/ResponseDTO` | same | ✅ |
+| Transport seam | `BMIService → APIClient → HTTPClient` | same | ✅ |
+| Legacy BMI shims/types | absent | absent | ✅ |
+| Error semantics | `APIError.transport` vs `APIError.unknown` | same | ✅ |
+
+## 6) Decision
+
+**No remediation PR needed** for “BMI thin-client dedup”: the intended end state is already present (landed via PR-596).
+
+## 7) Links
+
+- PR-596 (remediation): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/596`

--- a/docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md
+++ b/docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md
@@ -45,6 +45,28 @@ rg -n "/api/v1/bmi/calculate" ios/PulsePlate
 rg -n "APIClient\\(|HTTPClient\\(|URLSession\\.shared|URLSession\\(" ios/PulsePlate
 ```
 
+### 3.1 Observed output (key checks)
+
+**Legacy shims/types grep (expected: 0 matches):**
+
+```text
+No matches found
+```
+
+**Canonical DTO grep (sample):**
+
+```text
+ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift:6
+ios/PulsePlate/Services/BMIService.swift:5
+ios/PulsePlate/Screens/BMICalculatorScreen.swift:103
+```
+
+**Endpoint grep (sample):**
+
+```text
+ios/PulsePlate/Services/BMIService.swift:31:            path: "/api/v1/bmi/calculate",
+```
+
 ## 4) Findings (AS-IS, verified)
 
 ### 4.1 Canonical DTOs used by UI/service
@@ -85,3 +107,5 @@ Verified: no matches for `LegacyBMIServicing`, `DefaultBMIService`, `BMIServiceE
 ## 7) Links
 
 - PR-596 (remediation): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/596`
+- PR-596 merge commit: `e0eea0bb0ae987876ade13518222c65d8c21ec8e`
+- PR-597 (post-merge hygiene): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/597`


### PR DESCRIPTION
## Summary
- Audit-only verification that iOS BMI is already on canonical BMICalculate*DTO and routes via BMIService → APIClient.
- Confirms legacy BMI shims/types are absent and error mapping uses `APIError.unknown` vs `APIError.transport` semantics.

## Test plan
- [ ] N/A (docs-only)

## Links
- PR-596: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/596

## Summary by Sourcery

Документация:
- Задокументировать процесс проверки, охват, доказательства и решение по аудиту дедупликации тонкого клиента iOS BMI, подтверждающему ранее выполненное исправление.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the verification process, scope, evidence, and decision for the iOS BMI thin-client deduplication audit confirming prior remediation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added verification audit documentation for iOS BMI thin-client functionality, confirming implementation completeness with findings and remediation decisions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->