### PR TITLE
fix(cursor-agents): agent-coordinator uses auto model

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -1,12 +1,12 @@
 ---
 name: agent-coordinator
-model: default
+model: auto
 description: Master coordinator for all PulsePlate project agents. Proactively orchestrates agent collaboration, assigns tasks based on capabilities, synthesizes multi-agent work, provides quality assurance, and generates brainstorming tasks for scientific and creative innovation. Use immediately when any task is created, when coordinating multiple agents, or when synthesizing complex work across domains.
 ---
 
 ## Model Selection Rationale
 
-- **Model:** `auto` (or `default` if Cursor requires it)
+- **Model:** `auto`
 - **Why auto:** Coordinator performs routing and synthesis only, not heavy reasoning. Flexibility benefits from latest model capabilities without manual updates.
 - **Work type:** Task triage → agent assignment → result synthesis → next actions. Process-driven, not model-driven.
 - **Determinism:** Repeatability ensured by canonical process (Audit → Plan → DoD) and links to canonical docs, not fixed model.

--- a/docs/agents/model_rationale_blocks.md
+++ b/docs/agents/model_rationale_blocks.md
@@ -15,7 +15,7 @@
 
 +## Model Selection Rationale
 +
-+- **Model:** `auto` (or `default` if Cursor requires it)
++- **Model:** `auto`
 +- **Why auto:** Coordinator performs routing and synthesis only, not heavy reasoning. Flexibility benefits from latest model capabilities without manual updates.
 +- **Work type:** Task triage → agent assignment → result synthesis → next actions. Process-driven, not model-driven.
 +- **Determinism:** Repeatability ensured by canonical process (Audit → Plan → DoD) and links to canonical docs, not fixed model.


### PR DESCRIPTION
## Problem
`agent-coordinator` не запускался в Cursor: в frontmatter было `model: default`, тогда как остальные агенты и политика (`docs/agents/model_policy.md`) используют `auto`.

## Fix
- `.cursor/agents/agent-coordinator.md`: `model: auto`
- `docs/agents/model_rationale_blocks.md`: убран намёк на `default`, чтобы не повторять ошибку

## Verification
- `make verify`
- `pre-commit run --all-files`

## Summary by Sourcery

Приведение конфигурации и документации agent-coordinator в соответствие с проектным стандартом использования модели `auto` вместо `default`.

Улучшения:
- Обновить определение агента agent-coordinator для использования модели `auto` с целью совместимости с Cursor и другими агентами.
- Уточнить документацию по выбору модели, убрав упоминания `default` и последовательно рекомендуя использовать `auto`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align agent-coordinator configuration and documentation with the project-wide use of the `auto` model instead of `default`.

Enhancements:
- Update the agent-coordinator agent definition to use the `auto` model for compatibility with Cursor and other agents.
- Clarify model selection documentation by removing references to `default` in favor of consistently recommending `auto`.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched agent-coordinator to model: auto so it runs in Cursor and matches the model policy. Cleaned up docs to remove the “default” hint to avoid future mismatches.

<sup>Written for commit a1fe73728e66d12144ae3b58684c43be7331c250. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced agent coordination documentation with expanded guidelines on orchestration, task routing, and quality assurance processes.
  * Updated model configuration specifications for coordinator rationale documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->