### PR TITLE
fix(ios): PR-604 make ios-test support UI-only targeting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,6 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		if [ -n "$$SKIP_ITEMS" ]; then \
 			IFS=','; for t in $$SKIP_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && SKIP_FLAGS="$$SKIP_FLAGS -skip-testing:$$t"; done; unset IFS; \
 		fi; \
-		echo "xcodebuild test $$SKIP_FLAGS $$ONLY_FLAGS -destination \"$$DESTINATION\""; \
 		cd ios && xcodebuild test \
 			-project PulsePlate.xcodeproj \
 			-scheme PulsePlate \

--- a/Makefile
+++ b/Makefile
@@ -319,11 +319,11 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 	@echo "$(YELLOW)🧪 Запуск iOS unit tests...$(NC)"
 	@SIM_NAME="$(or $(IOS_SIM_NAME),iPhone 16e)"; \
 		SIM_OS="$(or $(IOS_SIM_OS),latest)"; \
-		DESTINATION="$(IOS_DESTINATION)"; \
+		DESTINATION="$${IOS_DESTINATION:-$(IOS_DESTINATION)}"; \
 		if [ -z "$$DESTINATION" ]; then DESTINATION="platform=iOS Simulator,name=$$SIM_NAME,OS=$$SIM_OS"; fi; \
 		echo "Using destination: $$DESTINATION"; \
-		ONLY_ITEMS="$$IOS_ONLY_TESTING"; \
-		SKIP_ITEMS="$$IOS_SKIP_TESTING"; \
+		ONLY_ITEMS="$${IOS_ONLY_TESTING:-$(IOS_ONLY_TESTING)}"; \
+		SKIP_ITEMS="$${IOS_SKIP_TESTING:-$(IOS_SKIP_TESTING)}"; \
 		ONLY_FLAGS=""; \
 		SKIP_FLAGS=""; \
 		if [ -n "$$ONLY_ITEMS" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,9 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		echo "Using destination: $$DESTINATION"; \
 		ONLY_ITEMS="$${IOS_ONLY_TESTING:-$(IOS_ONLY_TESTING)}"; \
 		SKIP_ITEMS="$${IOS_SKIP_TESTING:-$(IOS_SKIP_TESTING)}"; \
+		SKIP_PROVIDED=""; \
+		if [ -n "$${IOS_SKIP_TESTING+x}" ]; then SKIP_PROVIDED="1"; fi; \
+		if [ "$(origin IOS_SKIP_TESTING)" != "undefined" ]; then SKIP_PROVIDED="1"; fi; \
 		ONLY_FLAGS=""; \
 		SKIP_FLAGS=""; \
 		if [ -n "$$ONLY_ITEMS" ]; then \
@@ -331,12 +334,13 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		else \
 			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests"; \
 		fi; \
-		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_ITEMS" ]; then \
+		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_PROVIDED" ]; then \
 			SKIP_FLAGS="-skip-testing:PulsePlateUITests"; \
 		fi; \
 		if [ -n "$$SKIP_ITEMS" ]; then \
 			IFS=','; for t in $$SKIP_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && SKIP_FLAGS="$$SKIP_FLAGS -skip-testing:$$t"; done; unset IFS; \
 		fi; \
+		echo "xcodebuild test $$SKIP_FLAGS $$ONLY_FLAGS -destination \"$$DESTINATION\""; \
 		cd ios && xcodebuild test \
 			-project PulsePlate.xcodeproj \
 			-scheme PulsePlate \

--- a/Makefile
+++ b/Makefile
@@ -309,23 +309,40 @@ openapi-check: openapi ## Verify OpenAPI + generated FE types are committed (fai
 
 ## Run iOS unit tests (xcodebuild test)
 ## Usage: make ios-test [IOS_SIM_NAME="iPhone 16e"] [IOS_SIM_OS=latest]
+## Optional:
+## - IOS_ONLY_TESTING="Target[/Class[/test]],..." (comma-separated)
+## - IOS_SKIP_TESTING="Target[/Class[/test]],..." (comma-separated)
+## - IOS_DESTINATION="platform=iOS Simulator,id=<UDID>" (overrides name/OS destination)
 ## Default: iPhone 16e (local development). CI uses UDID-only destination (see ios/AGENTS.md).
 ## NOTE: Uses -project (workspace scheme has test action issue).
 ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 	@echo "$(YELLOW)🧪 Запуск iOS unit tests...$(NC)"
 	@SIM_NAME="$(or $(IOS_SIM_NAME),iPhone 16e)"; \
 		SIM_OS="$(or $(IOS_SIM_OS),latest)"; \
-		echo "Using simulator: $$SIM_NAME, OS: $$SIM_OS"; \
+		DESTINATION="$(IOS_DESTINATION)"; \
+		if [ -z "$$DESTINATION" ]; then DESTINATION="platform=iOS Simulator,name=$$SIM_NAME,OS=$$SIM_OS"; fi; \
+		echo "Using destination: $$DESTINATION"; \
+		ONLY_ITEMS="$$IOS_ONLY_TESTING"; \
+		SKIP_ITEMS="$$IOS_SKIP_TESTING"; \
+		ONLY_FLAGS=""; \
+		SKIP_FLAGS=""; \
+		if [ -n "$$ONLY_ITEMS" ]; then \
+			IFS=','; for t in $$ONLY_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && ONLY_FLAGS="$$ONLY_FLAGS -only-testing:$$t"; done; unset IFS; \
+		else \
+			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests"; \
+		fi; \
+		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_ITEMS" ]; then \
+			SKIP_FLAGS="-skip-testing:PulsePlateUITests"; \
+		fi; \
+		if [ -n "$$SKIP_ITEMS" ]; then \
+			IFS=','; for t in $$SKIP_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && SKIP_FLAGS="$$SKIP_FLAGS -skip-testing:$$t"; done; unset IFS; \
+		fi; \
 		cd ios && xcodebuild test \
 			-project PulsePlate.xcodeproj \
 			-scheme PulsePlate \
-			-skip-testing:PulsePlateUITests \
-			-only-testing:PulsePlateTests/ThinClientGuardsTests \
-			-only-testing:PulsePlateTests/BMIServiceTests \
-			-only-testing:PulsePlateTests/BMIResponseDecodingTests \
-			-only-testing:PulsePlateTests/BMIRequestEncodingTests \
-			-only-testing:PulsePlateTests/LocaleParsingTests \
-			-destination "platform=iOS Simulator,name=$$SIM_NAME,OS=$$SIM_OS" \
+			$$SKIP_FLAGS \
+			$$ONLY_FLAGS \
+			-destination "$$DESTINATION" \
 			-configuration Debug \
 			-derivedDataPath ../.derivedData \
 			-enableCodeCoverage NO \

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -200,6 +200,13 @@
 - This runs all unit tests including guard tests
 - Catches issues before CI
 
+**Local iOS test targeting (Makefile):**
+
+- `make ios-test IOS_ONLY_TESTING="PulsePlateTests/PlateViewTests"`
+- `make ios-test IOS_ONLY_TESTING="PulsePlateUITests"`
+- `make ios-test IOS_ONLY_TESTING="PulsePlateUITests" IOS_SKIP_TESTING=""` (override default skip behavior)
+- Optional deterministic destination: `IOS_DESTINATION="platform=iOS Simulator,id=<UDID>"`
+
 **Local vs CI differences:**
 
 - **Local:** Default `iPhone 16e` (can be overridden via `IOS_SIM_NAME`/`IOS_SIM_OS`)


### PR DESCRIPTION
## Summary
- Unblock PR-Q2 by allowing `make ios-test` to target UI/unit suites via variables:
  - `IOS_ONLY_TESTING` (comma-separated)
  - `IOS_SKIP_TESTING` (comma-separated)
  - `IOS_DESTINATION` (optional deterministic destination)

## Scope / Non-goals
- Scope: Makefile (+ short local usage note in `ios/AGENTS.md`)
- Non-goals: no CI workflow changes; no fixes for UI test bundle loading (handled in Q2b).

## Evidence / Test plan
- PlateViewTests targeting:
  - `make ios-test IOS_DESTINATION=\"platform=iOS Simulator,id=<UDID>\" IOS_ONLY_TESTING=\"PulsePlateTests/PlateViewTests\"`
- UI tests targeting (expected to fail until Q2b, but command wiring works):
  - `make ios-test IOS_DESTINATION=\"platform=iOS Simulator,id=<UDID>\" IOS_ONLY_TESTING=\"PulsePlateUITests\" IOS_SKIP_TESTING=\"\"`
- `pre-commit run --all-files`

## Links
- Audit: PR-603 `docs/audit/PR_Q2_IOS_UI_TESTS_RESTORE_AUDIT.md`

## Summary by Sourcery

Позволить тестам iOS в Makefile запускать конкретные наборы UI- и модульных тестов с помощью настраиваемых переменных и задокументировать локальное использование.

Новые возможности:
- Добавлена поддержка в Makefile для указания списков включения и исключения iOS-тестов, а также явных назначений симуляторов при запуске `ios-test`.

Улучшения:
- Сохранено текущее поведение по умолчанию: запуск подмножества модульных тестов и пропуск UI-тестов, когда целевые переменные не заданы.
- Задокументированы локальные шаблоны таргетирования iOS-тестов и переопределения назначений в `ios/AGENTS.md`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow iOS Makefile tests to target specific UI and unit test suites via configurable variables and document local usage.

New Features:
- Add Makefile support for specifying iOS test inclusion and exclusion lists and explicit simulator destinations when running ios-test.

Enhancements:
- Preserve existing default unit test subset and UI test skipping behavior when no targeting variables are provided.
- Document local iOS test targeting patterns and destination overrides in ios/AGENTS.md.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled UI-only and targeted iOS test runs via make ios-test. Supports Linear PR-Q2 by adding variables to control test suites and destination.

- **New Features**
  - Added IOS_ONLY_TESTING, IOS_SKIP_TESTING, and IOS_DESTINATION to map to xcodebuild -only-testing/-skip-testing and destination; accepts make vars or env vars.
  - Default runs a small unit test subset and skips PulsePlateUITests; setting variables overrides defaults (empty IOS_SKIP_TESTING removes the skip).
  - Flags built from comma-separated items; destination is logged; usage examples added to ios/AGENTS.md.

<sup>Written for commit 57c806da3c12a99cff9970cf7757d20ced15b98e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled configurable iOS test selection and destination overrides via new environment variables (IOS_ONLY_TESTING, IOS_SKIP_TESTING, IOS_DESTINATION); applies computed destination to test runs and disables parallel testing.
* **Documentation**
  * Added a local iOS test targeting guide describing the new environment options and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->