### PR TITLE
docs(audit): PR-606 PR-Q2b iOS UITests bundle load failure

### DIFF
--- a/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+++ b/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
@@ -62,17 +62,23 @@ make: *** [ios-test] Error 65
 
 ## B) Inspection commands (for audit completeness)
 
-Run these locally to confirm whether the `.xctest` bundle contains an executable:
+Run these locally to confirm whether the `.xctest` bundle contains an executable.
+Repo default uses `.derivedData` (see `Makefile` iOS `-derivedDataPath`), but you can override with
+`DD=DerivedData ...` if you built via Xcode defaults.
 
 ```bash
+# PulsePlate uses a custom DerivedData path via Makefile:
+# xcodebuild ... -derivedDataPath ../.derivedData
+DD="${DD:-.derivedData}"
+
 # 1) Locate UI test bundle in DerivedData (path varies by build)
-ls -la .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest || true
+ls -la "$DD/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest" || true
 
 # 2) Confirm bundle Info.plist and the expected executable name
-plutil -p .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/Info.plist || true
+plutil -p "$DD/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/Info.plist" || true
 
 # 3) Check if the bundle executable exists (usually same as CFBundleExecutable)
-ls -la .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/* || true
+ls -la "$DD/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/"* || true
 
 # 4) Build settings that commonly explain “no executable in xctest”
 cd ios

--- a/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+++ b/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
@@ -1,0 +1,117 @@
+# PR-Q2b — iOS UITests bundle load failure audit (exit 65)
+
+**Date (ISO 8601):** 2026-01-27Z
+**Revision:** v1
+**Owner:** @katsiaryna_kavaleuskaya
+**Track:** Quality / CI Trust (iOS)
+
+## 0) Scope / Non-goals
+
+### Scope
+
+- Establish reproducible evidence for the iOS UI test runner failure:
+  - `PulsePlateUITests.xctest` fails to load because its executable is missing.
+- Produce a ranked hypothesis list for the minimal `project.pbxproj` fix.
+- Define DoD for the remediation PR that will:
+  - make UI test bundle loadable locally
+  - enable a minimal CI UI-smoke job (separate from unit tests)
+
+### Non-goals
+
+- Product/UX changes are out of scope.
+- New features are out of scope.
+- No “green because skipped”.
+- No remediation changes in this PR (audit-only).
+
+## A) Evidence (observed)
+
+### A1) Repro command (local)
+
+This is the canonical Q2b reproduction after Q2a (`make ios-test` wiring) is merged:
+
+```bash
+make ios-test IOS_ONLY_TESTING="PulsePlateUITests" IOS_SKIP_TESTING=""
+```
+
+> NOTE: Destination is intentionally not pinned to a specific simulator UDID in docs to keep evidence
+> durable across machines/CI runners. The observed failure is independent of the specific simulator.
+
+### A2) Observed output (raw excerpt; first failure)
+
+```text
+PulsePlateUITests-Runner[...] [loading] Cannot find executable for CFBundle .../PulsePlateUITests.xctest> (not loaded)
+NSBundle .../PulsePlateUITests.xctest/ loading failed because of an error Error Domain=NSCocoaErrorDomain Code=4
+"Не удалось загрузить пакет «PulsePlateUITests», так как не найден исполняемый файл."
+
+Testing failed:
+  PulsePlateUITests-Runner (...) encountered an error (Failed to load the test bundle. (Underlying Error: ...))
+
+make: *** [ios-test] Error 65
+```
+
+**Observed exit:** non-zero (`xcodebuild` failed; exit code 65).
+
+### A3) Classification
+
+- ❌ Not a UI regression
+- ❌ Not a test logic failure
+- ✅ Infra / build-product issue:
+  - UI test bundle exists, but the bundle executable is missing
+
+> This failure occurs **before** any UI test code is executed.
+
+## B) Inspection commands (for audit completeness)
+
+Run these locally to confirm whether the `.xctest` bundle contains an executable:
+
+```bash
+# 1) Locate UI test bundle in DerivedData (path varies by build)
+ls -la .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest || true
+
+# 2) Confirm bundle Info.plist and the expected executable name
+plutil -p .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/Info.plist || true
+
+# 3) Check if the bundle executable exists (usually same as CFBundleExecutable)
+ls -la .derivedData/Build/Products/Debug-iphonesimulator/PulsePlateUITests-Runner.app/PlugIns/PulsePlateUITests.xctest/* || true
+
+# 4) Build settings that commonly explain “no executable in xctest”
+cd ios
+xcodebuild -project PulsePlate.xcodeproj -scheme PulsePlate -showBuildSettings \
+  | rg -n "TEST_HOST|BUNDLE_LOADER|WRAPPER_EXTENSION|EXECUTABLE_NAME|PRODUCT_NAME|PRODUCT_BUNDLE_IDENTIFIER"
+```
+
+## C) Ranked hypotheses (most likely first)
+
+1) **UITests target is not producing a binary**
+   - e.g., missing/incorrect `PBXSourcesBuildPhase`, or target marked as “bundle only” with no compile sources.
+2) **UITests bundle is built, but executable is not copied/embedded into the runner**
+   - runner app contains `.xctest/Info.plist` but not the binary referenced by `CFBundleExecutable`.
+3) **Scheme/test action mismatch**
+   - `xcodebuild test` runs a scheme/config that does not build the UITests target product correctly.
+4) **Broken `TEST_HOST` / `BUNDLE_LOADER` configuration**
+   - causes Xcode to generate runner artifacts incorrectly for UI tests.
+5) **File-system-synchronized groups / exceptions misconfiguration**
+   - target membership / exceptions prevent the UITests target from compiling sources into an executable.
+
+## D) Decision
+
+**Decision:** Remediation required in `ios/PulsePlate.xcodeproj/project.pbxproj` (build-product correctness).
+
+- This is a **P0 blocker** for restoring CI trust: UI tests cannot run at all.
+- Fix must be minimal and auditable (no “magic” UI changes).
+
+## E) DoD (for remediation PR-Q2b)
+
+DoD gates (all required):
+
+- **G1:** `PulsePlateUITests.xctest` bundle contains an executable (`CFBundleExecutable` file exists).
+- **G2:** Local UI-only run loads the test bundle (runner starts executing tests):
+  - `make ios-test IOS_ONLY_TESTING="PulsePlateUITests" IOS_SKIP_TESTING=""` no longer fails with Code=4.
+- **G3:** CI has a dedicated `ios-ui-smoke` job (separate from unit tests) that runs minimal UI smoke
+  without `-skip-testing:PulsePlateUITests`.
+- **G4:** UI-smoke job is green for ≥2 consecutive runs (PR checks / reruns).
+
+## Security Notes
+
+- UI tests must not send real credentials or hit real endpoints.
+- Any network must be stubbed/isolated to keep CI deterministic.

--- a/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+++ b/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
@@ -49,7 +49,7 @@ Testing failed:
 make: *** [ios-test] Error 65
 ```
 
-**Observed exit:** non-zero (`xcodebuild` failed; exit code 65).
+**Observed exit:** `xcodebuild` failed (exit code 65); `make` wraps this as exit 2.
 
 ### A3) Classification
 


### PR DESCRIPTION
## Summary
Audit-only PR for Q2b: iOS UITests runner fails to load `PulsePlateUITests.xctest` (exit 65, missing executable).

## Scope / Non-goals
- Scope: add canonical audit document under `docs/audit/`
- Non-goals: no Xcode/CI remediation changes in this PR

## Evidence
- Repro command: `make ios-test IOS_ONLY_TESTING=\"PulsePlateUITests\" IOS_SKIP_TESTING=\"\"`
- Observed symptom: NSCocoaErrorDomain Code=4 (“Cannot find executable for CFBundle … PulsePlateUITests.xctest”) + exit 65.

## Next (separate remediation PR)
- Minimal `project.pbxproj` fix to ensure `.xctest` contains executable
- Add dedicated CI `ios-ui-smoke` job

## Summary by Sourcery

Добавить аудиторский документ, фиксирующий сбой загрузки бандла iOS UI-тестов и определяющий охват, гипотезы и критерии ремедиации.

Документация:
- Задокументировать сбой загрузки бандла iOS UI-тестов, включая шаги воспроизведения, наблюдаемые ошибки, классификацию и команды для инспекции.
- Определить ранжированные гипотезы, обоснование принятых решений и критерии завершения (definition of done) для последующего PR по ремедиации, который будет решать проблему с исполняемым файлом бандла UITest.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an audit document capturing the iOS UI tests bundle load failure and defining scope, hypotheses, and remediation criteria.

Documentation:
- Document the iOS UI test bundle load failure, including reproduction steps, observed errors, classification, and inspection commands.
- Define ranked hypotheses, decision rationale, and definition of done for a follow-up remediation PR addressing the UITest bundle executable issue.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an audit doc for Q2b that captures the iOS UI test bundle load failure (exit 65: missing executable for PulsePlateUITests.xctest), including repro steps, observed logs, ranked hypotheses, and DoD for the follow-up fix. Documentation only; no Xcode or CI changes.

<sup>Written for commit 0dde69e754e692b54e3f48d0c6b39ff9f8de6e68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an audit document for iOS UITests bundle load failures (exit 65), including scope, reproduction steps, observed outputs, inspection steps, ranked hypotheses, remediation guidance, acceptance criteria, and evidence.
  * Includes minimal remediation path and CI security considerations to help teams validate fixes and harden pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->