### PR TITLE
fix(ios): PR-607 restore UITests bundle executable + CI UI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,7 +770,13 @@ jobs:
           # 1) Try preferred devices (from env or default)
           # 2) Fallback: any iPhone
           # 3) Fallback: any iOS simulator (iPad if no iPhone)
-          pref_devices_str = os.environ.get("PREFERRED_DEVICES", "iPhone 16e,iPhone 16,iPhone 16 Pro,iPhone 15,iPhone 14")
+          # Source of truth: PREFERRED_DEVICES must be provided via workflow env.
+          # This avoids duplicated defaults between YAML and Python.
+          pref_devices_str = os.environ.get("PREFERRED_DEVICES", "")
+          if not pref_devices_str:
+              print("::error::PREFERRED_DEVICES is empty", file=sys.stderr)
+              sys.exit(1)
+
           pref_devices = [name.strip() for name in pref_devices_str.split(",") if name.strip()]
           available_names = [d["name"] for d in available_devices]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,6 +1019,10 @@ jobs:
 
           if [ -z "$SELECTED" ]; then
             echo "::error::No suitable Xcode 16.x found in /Applications."
+            echo "::error::Available Xcode apps:"
+            for app in /Applications/Xcode*.app; do
+              [ -e "$app" ] && echo " - $app"
+            done
             exit 1
           fi
 
@@ -1054,9 +1058,19 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Ensure simctl uses the pinned Xcode
+          echo "=== Xcode pinning verification (select-destination) ==="
+          echo "DEVELOPER_DIR: ${DEVELOPER_DIR:-<empty>}"
+          xcode-select -p
+          xcodebuild -version
+          swift --version
+
+          echo "Preferred devices: ${PREFERRED_DEVICES}"
+
           python3 - << 'PY'
           import json, os, re, subprocess, sys
 
+          # Pin to stable iOS 18.6 to avoid "latest" resolving to iOS 26.x betas.
           out = subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"], text=True)
           data = json.loads(out)
           devices = data.get("devices", {})
@@ -1078,7 +1092,14 @@ jobs:
               runtime_pool = ios18 if ios18 else ios_runtimes
               runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
 
+          major, minor = parse_ios_ver(runtime)
+          if major < 0 or minor < 0:
+              print(f"::error::Cannot parse iOS runtime version from: {runtime}", file=sys.stderr)
+              sys.exit(1)
+
+          os_ver = f"{major}.{minor}"
           available_devices = [d for d in devices.get(runtime, []) if d.get("isAvailable", True)]
+
           if not available_devices:
               print(f"::error::No available devices found for runtime: {runtime}", file=sys.stderr)
               sys.exit(1)
@@ -1087,24 +1108,51 @@ jobs:
           pref_devices = [name.strip() for name in pref_devices_str.split(",") if name.strip()]
           available_names = [d["name"] for d in available_devices]
 
+          device = None
           device_udid = None
+
+          preferred_found = False
           for pref_name in pref_devices:
               if pref_name in available_names:
                   device_obj = next((d for d in available_devices if d["name"] == pref_name), None)
                   if device_obj:
+                      device = pref_name
                       device_udid = device_obj["udid"]
+                      preferred_found = True
                       break
 
           if not device_udid:
               iphones = [d for d in available_devices if d["name"].startswith("iPhone")]
-              iphones.sort(key=lambda d: (d["name"], d["udid"]))
-              device_udid = iphones[0]["udid"] if iphones else available_devices[0]["udid"]
+              if iphones:
+                  iphones.sort(key=lambda d: (d["name"], d["udid"]))
+                  device_obj = iphones[0]
+                  device = device_obj["name"]
+                  device_udid = device_obj["udid"]
+                  if not preferred_found:
+                      print(f"Preferred devices not found, falling back to any iPhone: {device}", file=sys.stderr)
+
+          if not device_udid:
+              available_devices.sort(key=lambda d: (d["name"], d["udid"]))
+              device_obj = available_devices[0]
+              device = device_obj["name"]
+              device_udid = device_obj["udid"]
+              print(f"No iPhone available, falling back to any iOS simulator: {device}", file=sys.stderr)
+
+          if not device_udid:
+              print("::error::No UDID found for selected device (fallback logic failed)", file=sys.stderr)
+              sys.exit(1)
 
           dest = f"platform=iOS Simulator,id={device_udid}"
+
+          print(f"Selected runtime: {runtime} (iOS {os_ver})")
+          print(f"Selected device: {device} (UDID: {device_udid})")
+          print(f"Selected destination: {dest}")
 
           with open(os.environ.get("GITHUB_OUTPUT", "/dev/stdout"), "a", encoding="utf-8") as f:
               print(f"destination={dest}", file=f)
               print(f"udid={device_udid}", file=f)
+              print(f"device_name={device}", file=f)
+              print(f"ios_runtime_id={runtime}", file=f)
           PY
 
       - name: iOS UI smoke (build-for-testing + test-without-building)
@@ -1132,17 +1180,42 @@ jobs:
           export DESTINATION
           export UDID
 
-          # Boot simulator (best-effort) to avoid destination resolution flakes
+          # Boot simulator and enforce bootstatus readiness
           if [ -n "$UDID" ]; then
+            echo "Booting simulator: $UDID"
             xcrun simctl boot "$UDID" || true
-            xcrun simctl bootstatus "$UDID" -b || true
+            export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-180}"
+            echo "Waiting for simulator to be ready (timeout: ${SIM_BOOT_TIMEOUT_SECONDS}s)..."
+            python3 - << 'PY'
+          import os
+          import subprocess
+          import sys
+
+          udid = os.environ.get("UDID", "")
+          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "180"))
+
+          if not udid:
+              print("::error::UDID is empty", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              subprocess.run(["xcrun", "simctl", "bootstatus", udid, "-b"], timeout=timeout_s, check=True)
+          except subprocess.TimeoutExpired:
+              print(f"::error::Simulator not ready after {timeout_s}s (bootstatus timeout)", file=sys.stderr)
+              subprocess.run(["xcrun", "simctl", "list", "devices"], check=False)
+              sys.exit(1)
+          except subprocess.CalledProcessError as e:
+              print("::error::Simulator bootstatus failed", file=sys.stderr)
+              subprocess.run(["xcrun", "simctl", "list", "devices"], check=False)
+              sys.exit(e.returncode)
+          PY
           fi
 
           echo "=== Building for testing (timeout: 10 minutes) ==="
           python3 - << 'PY'
-          import os
           import subprocess
           import sys
+          import os
 
           destination = os.environ.get("DESTINATION", "")
           if not destination:
@@ -1171,9 +1244,9 @@ jobs:
 
           echo "=== Running UI smoke (timeout: 10 minutes) ==="
           python3 - << 'PY'
-          import os
           import subprocess
           import sys
+          import os
 
           destination = os.environ.get("DESTINATION", "")
           if not destination:
@@ -1184,7 +1257,7 @@ jobs:
               "xcodebuild", "test-without-building",
               "-project", "PulsePlate.xcodeproj",
               "-scheme", "PulsePlate",
-              "-only-testing:PulsePlateUITests/PulsePlateUITests/testExample",
+              "-only-testing:PulsePlateUITests/UISmokeTests/testLaunch",
               "-destination", destination,
               "-derivedDataPath", ".derivedData",
               "-clonedSourcePackagesDirPath", ".derivedData/SourcePackages",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -979,6 +979,228 @@ jobs:
               sys.exit(e.returncode)
           PY
 
+  # iOS UI smoke (minimal, separate signal from unit tests)
+  ios-ui-smoke:
+    name: iOS UI smoke (xcodebuild)
+    runs-on: macos-15
+    timeout-minutes: 25
+    if: |
+      needs.changes.outputs.ios == 'true' && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || github.ref == 'refs/heads/main'))
+      )
+    needs: [changes]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Select Xcode (pin 16.x compatible with iOS 18.5/18.6 runtimes)
+        id: select-xcode
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CANDIDATES=(
+            "/Applications/Xcode_16.4.app/Contents/Developer"
+            "/Applications/Xcode_16.4.0.app/Contents/Developer"
+            "/Applications/Xcode_16.3.app/Contents/Developer"
+            "/Applications/Xcode_16.3.0.app/Contents/Developer"
+            "/Applications/Xcode_16.2.app/Contents/Developer"
+            "/Applications/Xcode_16.2.0.app/Contents/Developer"
+          )
+
+          SELECTED=""
+          for d in "${CANDIDATES[@]}"; do
+            if [ -d "$d" ]; then
+              SELECTED="$d"
+              break
+            fi
+          done
+
+          if [ -z "$SELECTED" ]; then
+            echo "::error::No suitable Xcode 16.x found in /Applications."
+            exit 1
+          fi
+
+          echo "DEVELOPER_DIR=$SELECTED" >> "$GITHUB_ENV"
+          echo "developer_dir=$SELECTED" >> "$GITHUB_OUTPUT"
+          sudo xcode-select -s "$SELECTED"
+
+          XCODE_VERSION=$(xcodebuild -version | head -n 1 | sed 's/Xcode //')
+          echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "XCODE_VERSION=$XCODE_VERSION" >> "$GITHUB_ENV"
+
+          xcodebuild -version
+          swift --version
+
+      - name: Cache SwiftPM packages (SourcePackages only, not Build)
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.1.0
+        id: cache-swiftpm
+        with:
+          path: |
+            ios/.derivedData/SourcePackages
+          key: ${{ runner.os }}-xcode-${{ steps.select-xcode.outputs.xcode_version }}-swiftpm-${{ hashFiles('ios/Package.resolved', 'ios/PulsePlate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ steps.select-xcode.outputs.xcode_version }}-swiftpm-
+            ${{ runner.os }}-xcode-${{ steps.select-xcode.outputs.xcode_version }}-
+            ${{ runner.os }}-swiftpm-
+
+      - name: Select iOS simulator destination (stable)
+        working-directory: ios
+        id: select-destination
+        env:
+          DEVELOPER_DIR: ${{ steps.select-xcode.outputs.developer_dir }}
+          PREFERRED_DEVICES: ${{ env.PREFERRED_DEVICES || 'iPhone 16e,iPhone 16,iPhone 16 Pro,iPhone 15,iPhone 14' }}
+        run: |
+          set -euo pipefail
+
+          python3 - << 'PY'
+          import json, os, re, subprocess, sys
+
+          out = subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"], text=True)
+          data = json.loads(out)
+          devices = data.get("devices", {})
+
+          def parse_ios_ver(runtime_id: str) -> tuple[int, int]:
+              m = re.search(r"iOS-(\d+)-(\d+)", runtime_id)
+              return (int(m.group(1)), int(m.group(2))) if m else (-1, -1)
+
+          ios_runtimes = [r for r in devices.keys() if re.search(r"SimRuntime\.iOS-\d+-\d+\b", r)]
+          if not ios_runtimes:
+              print("::error::No iOS Simulator runtimes found", file=sys.stderr)
+              sys.exit(1)
+
+          pinned = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-6\b", r)]
+          if pinned:
+              runtime = pinned[0]
+          else:
+              ios18 = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-\d+\b", r)]
+              runtime_pool = ios18 if ios18 else ios_runtimes
+              runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
+
+          available_devices = [d for d in devices.get(runtime, []) if d.get("isAvailable", True)]
+          if not available_devices:
+              print(f"::error::No available devices found for runtime: {runtime}", file=sys.stderr)
+              sys.exit(1)
+
+          pref_devices_str = os.environ.get("PREFERRED_DEVICES", "iPhone 16e,iPhone 16,iPhone 16 Pro,iPhone 15,iPhone 14")
+          pref_devices = [name.strip() for name in pref_devices_str.split(",") if name.strip()]
+          available_names = [d["name"] for d in available_devices]
+
+          device_udid = None
+          for pref_name in pref_devices:
+              if pref_name in available_names:
+                  device_obj = next((d for d in available_devices if d["name"] == pref_name), None)
+                  if device_obj:
+                      device_udid = device_obj["udid"]
+                      break
+
+          if not device_udid:
+              iphones = [d for d in available_devices if d["name"].startswith("iPhone")]
+              iphones.sort(key=lambda d: (d["name"], d["udid"]))
+              device_udid = iphones[0]["udid"] if iphones else available_devices[0]["udid"]
+
+          dest = f"platform=iOS Simulator,id={device_udid}"
+
+          with open(os.environ.get("GITHUB_OUTPUT", "/dev/stdout"), "a", encoding="utf-8") as f:
+              print(f"destination={dest}", file=f)
+              print(f"udid={device_udid}", file=f)
+          PY
+
+      - name: iOS UI smoke (build-for-testing + test-without-building)
+        working-directory: ios
+        env:
+          DEVELOPER_DIR: ${{ steps.select-xcode.outputs.developer_dir }}
+        run: |
+          set -euo pipefail
+
+          DESTINATION="${{ steps.select-destination.outputs.destination }}"
+          UDID="${{ steps.select-destination.outputs.udid }}"
+
+          if [ -z "$DESTINATION" ]; then
+            echo "::error::IOS_DESTINATION is empty"
+            exit 1
+          fi
+
+          # Anti-nondeterminism guard: OS=latest is forbidden in CI
+          if echo "$DESTINATION" | grep -E -q 'OS=latest|(^|,)latest($|,)'; then
+            echo "::error::CI destination must not contain 'latest'. Use UDID-based destination only."
+            echo "::error::Got destination: $DESTINATION"
+            exit 1
+          fi
+
+          export DESTINATION
+          export UDID
+
+          # Boot simulator (best-effort) to avoid destination resolution flakes
+          if [ -n "$UDID" ]; then
+            xcrun simctl boot "$UDID" || true
+            xcrun simctl bootstatus "$UDID" -b || true
+          fi
+
+          echo "=== Building for testing (timeout: 10 minutes) ==="
+          python3 - << 'PY'
+          import os
+          import subprocess
+          import sys
+
+          destination = os.environ.get("DESTINATION", "")
+          if not destination:
+              print("::error::DESTINATION is empty", file=sys.stderr)
+              sys.exit(1)
+
+          cmd = [
+              "xcodebuild", "build-for-testing",
+              "-project", "PulsePlate.xcodeproj",
+              "-scheme", "PulsePlate",
+              "-destination", destination,
+              "-configuration", "Debug",
+              "-derivedDataPath", ".derivedData",
+              "-clonedSourcePackagesDirPath", ".derivedData/SourcePackages",
+              "-enableCodeCoverage", "NO",
+          ]
+
+          try:
+              subprocess.run(cmd, timeout=600, check=True)
+          except subprocess.TimeoutExpired:
+              print("::error::xcodebuild build-for-testing timed out after 10 minutes", file=sys.stderr)
+              sys.exit(1)
+          except subprocess.CalledProcessError as e:
+              sys.exit(e.returncode)
+          PY
+
+          echo "=== Running UI smoke (timeout: 10 minutes) ==="
+          python3 - << 'PY'
+          import os
+          import subprocess
+          import sys
+
+          destination = os.environ.get("DESTINATION", "")
+          if not destination:
+              print("::error::DESTINATION is empty", file=sys.stderr)
+              sys.exit(1)
+
+          cmd = [
+              "xcodebuild", "test-without-building",
+              "-project", "PulsePlate.xcodeproj",
+              "-scheme", "PulsePlate",
+              "-only-testing:PulsePlateUITests/PulsePlateUITests/testExample",
+              "-destination", destination,
+              "-derivedDataPath", ".derivedData",
+              "-clonedSourcePackagesDirPath", ".derivedData/SourcePackages",
+              "-enableCodeCoverage", "NO",
+              "-parallel-testing-enabled", "NO",
+          ]
+
+          try:
+              subprocess.run(cmd, timeout=600, check=True)
+          except subprocess.TimeoutExpired:
+              print("::error::xcodebuild UI smoke timed out after 10 minutes", file=sys.stderr)
+              sys.exit(1)
+          except subprocess.CalledProcessError as e:
+              sys.exit(e.returncode)
+          PY
+
           # Step 2: Run tests (without building)
           # Timeout: 15 minutes (fail fast instead of consuming full job budget)
           echo "=== Running tests (timeout: 15 minutes) ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1248,7 +1248,7 @@ jobs:
               sys.exit(e.returncode)
           PY
 
-          echo "=== Running UI smoke (timeout: 10 minutes) ==="
+          echo "=== Running UI smoke (timeout: 15 minutes) ==="
           python3 - << 'PY'
           import subprocess
           import sys
@@ -1272,9 +1272,9 @@ jobs:
           ]
 
           try:
-              subprocess.run(cmd, timeout=600, check=True)
+              subprocess.run(cmd, timeout=900, check=True)
           except subprocess.TimeoutExpired:
-              print("::error::xcodebuild UI smoke timed out after 10 minutes", file=sys.stderr)
+              print("::error::xcodebuild UI smoke timed out after 15 minutes", file=sys.stderr)
               sys.exit(1)
           except subprocess.CalledProcessError as e:
               sys.exit(e.returncode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,8 +690,11 @@ jobs:
           echo "Verifying Xcode selection:"
           xcode-select -p
 
-          # Extract Xcode version for cache key
-          XCODE_VERSION=$(xcodebuild -version | head -n 1 | sed 's/Xcode //')
+          # Extract Xcode version for cache key (avoid broken pipe from pipe consumers like head/sed)
+          XCODEBUILD_VERSION="$(xcodebuild -version)"
+          # First line is like: "Xcode 16.4"
+          XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
+          XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
           echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
           echo "XCODE_VERSION=$XCODE_VERSION" >> "$GITHUB_ENV"
 
@@ -1036,7 +1039,11 @@ jobs:
           echo "developer_dir=$SELECTED" >> "$GITHUB_OUTPUT"
           sudo xcode-select -s "$SELECTED"
 
-          XCODE_VERSION=$(xcodebuild -version | head -n 1 | sed 's/Xcode //')
+          # Extract Xcode version for cache key (avoid broken pipe from pipe consumers like head/sed)
+          XCODEBUILD_VERSION="$(xcodebuild -version)"
+          # First line is like: "Xcode 16.4"
+          XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
+          XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
           echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
           echo "XCODE_VERSION=$XCODE_VERSION" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,7 +1179,7 @@ jobs:
           UDID="${{ steps.select-destination.outputs.udid }}"
 
           if [ -z "$DESTINATION" ]; then
-            echo "::error::IOS_DESTINATION is empty"
+            echo "::error::DESTINATION is empty"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,7 +853,7 @@ jobs:
           UDID="${{ steps.select-destination.outputs.udid }}"
 
           if [ -z "$DESTINATION" ]; then
-            echo "::error::IOS_DESTINATION is empty"
+            echo "::error::DESTINATION is empty"
             exit 1
           fi
 
@@ -1188,6 +1188,7 @@ jobs:
 
           # Boot simulator and enforce bootstatus readiness
           if [ -n "$UDID" ]; then
+            echo "=== Booting simulator ==="
             echo "Booting simulator: $UDID"
             xcrun simctl boot "$UDID" || true
             export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-180}"
@@ -1215,6 +1216,14 @@ jobs:
               subprocess.run(["xcrun", "simctl", "list", "devices"], check=False)
               sys.exit(e.returncode)
           PY
+
+            echo "✓ Simulator booted and ready"
+
+            # Warm up system services (best-effort, reduces flaky UI test failures)
+            echo "Warming up system services..."
+            xcrun simctl launch "$UDID" com.apple.springboard || true
+            sleep 2
+            echo "✓ System services ready"
           fi
 
           echo "=== Building for testing (timeout: 10 minutes) ==="

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -133,6 +133,19 @@ If it is not recorded here — it does not exist.
     - `-skip-testing:PulsePlateUITests` removed from CI
     - CI green with UI tests included
 
+- [ ] P1 (postponed): CI iOS workflow dedup (extract shared helpers / composite action)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD
+  - Reason: Avoid drift between `ios-tests` and `ios-ui-smoke` jobs (Xcode pinning, destination selection, boot logic, xcodebuild wrapper). Requested in PR-607 review; deferred to keep remediation PR scope tight.
+  - Links:
+    - .github/workflows/ci.yml
+    - docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+  - DoD:
+    - One shared implementation for destination selection + bootstatus gating + xcodebuild wrapper (script or composite action)
+    - Both iOS jobs reuse the same logic (no duplicated Python snippets)
+    - CI remains deterministic (UDID-only destination, no `OS=latest`)
+
 - [ ] Stabilize AnimationTests.swift (iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: TBD (separate from PR-559)

--- a/ios/PulsePlate.xcodeproj/project.pbxproj
+++ b/ios/PulsePlate.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		B63DC54A60CDD04447BE2DD1 /* __CIAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AAD8EE46580D4F79A394FC /* __CIAnchorTests.swift */; };
 		B6F5B1E4A0C840D5A8C7A9B1 /* PulsePlateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */; };
 		B6F5B1E5A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */; };
+		B6F5B1E7A0C840D5A8C7A9B1 /* UISmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5B1E6A0C840D5A8C7A9B1 /* UISmokeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +39,7 @@
 		B6AAD8EE46580D4F79A394FC /* __CIAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateTests/__CIAnchorTests.swift; sourceTree = SOURCE_ROOT; };
 		B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateUITests/PulsePlateUITests.swift; sourceTree = SOURCE_ROOT; };
 		B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateUITests/PulsePlateUITestsLaunchTests.swift; sourceTree = SOURCE_ROOT; };
+		B6F5B1E6A0C840D5A8C7A9B1 /* UISmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateUITests/UISmokeTests.swift; sourceTree = SOURCE_ROOT; };
 		B65BE4EE2E89AFCA0033BEDF /* PulsePlate.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = PulsePlate.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -104,6 +106,7 @@
 			children = (
 				B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */,
 				B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */,
+				B6F5B1E6A0C840D5A8C7A9B1 /* UISmokeTests.swift */,
 			);
 			path = PulsePlateUITests;
 			sourceTree = "<group>";
@@ -305,6 +308,7 @@
 			files = (
 				B6F5B1E4A0C840D5A8C7A9B1 /* PulsePlateUITests.swift in Sources */,
 				B6F5B1E5A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift in Sources */,
+				B6F5B1E7A0C840D5A8C7A9B1 /* UISmokeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/PulsePlate.xcodeproj/project.pbxproj
+++ b/ios/PulsePlate.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		B6B04C2D2EEF4BC4005E0955 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B6B04C2C2EEF4BC4005E0955 /* Lottie */; };
 		B63DC54A60CDD04447BE2DD1 /* __CIAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AAD8EE46580D4F79A394FC /* __CIAnchorTests.swift */; };
+		B6F5B1E4A0C840D5A8C7A9B1 /* PulsePlateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */; };
+		B6F5B1E5A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +36,8 @@
 		B6169A422E893CF200B218D8 /* PulsePlateTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PulsePlateTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6169A4C2E893CF200B218D8 /* PulsePlateUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PulsePlateUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6AAD8EE46580D4F79A394FC /* __CIAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateTests/__CIAnchorTests.swift; sourceTree = SOURCE_ROOT; };
+		B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateUITests/PulsePlateUITests.swift; sourceTree = SOURCE_ROOT; };
+		B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsePlateUITests/PulsePlateUITestsLaunchTests.swift; sourceTree = SOURCE_ROOT; };
 		B65BE4EE2E89AFCA0033BEDF /* PulsePlate.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = PulsePlate.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -95,11 +99,21 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		B6F5B1E1A0C840D5A8C7A9B1 /* PulsePlateUITests */ = {
+			isa = PBXGroup;
+			children = (
+				B6F5B1E2A0C840D5A8C7A9B1 /* PulsePlateUITests.swift */,
+				B6F5B1E3A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift */,
+			);
+			path = PulsePlateUITests;
+			sourceTree = "<group>";
+		};
 		B6169A2A2E893CF100B218D8 = {
 			isa = PBXGroup;
 			children = (
 				B6169A352E893CF100B218D8 /* PulsePlate */,
 				B6169A892E893CF200B218D8 /* PulsePlateTests */,
+				B6F5B1E1A0C840D5A8C7A9B1 /* PulsePlateUITests */,
 				B6169A342E893CF100B218D8 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -289,6 +303,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B6F5B1E4A0C840D5A8C7A9B1 /* PulsePlateUITests.swift in Sources */,
+				B6F5B1E5A0C840D5A8C7A9B1 /* PulsePlateUITestsLaunchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/PulsePlateUITests/UISmokeTests.swift
+++ b/ios/PulsePlateUITests/UISmokeTests.swift
@@ -1,0 +1,18 @@
+//
+//  UISmokeTests.swift
+//  PulsePlateUITests
+//
+//  Minimal UI smoke test for CI trust.
+//  Минимальный UI smoke тест для доверия к CI.
+//
+
+import XCTest
+
+final class UISmokeTests: XCTestCase {
+  @MainActor
+  func testLaunch() throws {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertTrue(true)
+  }
+}


### PR DESCRIPTION
## Summary
Restore iOS UI test signal by fixing PulsePlateUITests build product so `PulsePlateUITests.xctest` contains an executable (no more Code=4 / exit 65 before tests execute), and add a dedicated CI UI-smoke job.

## Scope / Non-goals
- Scope:
  - `ios/PulsePlate.xcodeproj/project.pbxproj` (ensure UITests target compiles sources)
  - `.github/workflows/ci.yml` (add `ios-ui-smoke` job)
- Non-goals:
  - No product/UI behavior changes
  - No expansion of UI test coverage beyond minimal smoke

## Evidence
- Audit basis: PR-606 `docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md`
- Local: `make ios-test IOS_ONLY_TESTING=\"PulsePlateUITests/PulsePlateUITests/testExample\" IOS_SKIP_TESTING=\"\"` (verifies bundle loads and executes at least one UI test)

## CI
- Adds `ios-ui-smoke` job that runs UI smoke without `-skip-testing:PulsePlateUITests`.

## Test plan
- `pre-commit run --all-files`
- Local UI smoke:
  - `make ios-test IOS_ONLY_TESTING=\"PulsePlateUITests/PulsePlateUITests/testExample\" IOS_SKIP_TESTING=\"\"`

## Summary by Sourcery

Восстановить исполняемость пакета iOS UI-тестов и добавить отдельную задачу iOS UI smoke в CI для запуска минимального end-to-end UI-теста на стабильной конфигурации симулятора.

New Features:
- Ввести задачу GitHub Actions `ios-ui-smoke`, которая собирает iOS‑приложение для тестирования и запускает фокусный UI smoke‑тест через `xcodebuild` на закреплённой версии iOS‑симулятора.

Bug Fixes:
- Обеспечить, чтобы цель `PulsePlateUITests` в проекте Xcode корректно компилировала свои исходники, чтобы сгенерированный пакет `PulsePlateUITests.xctest` содержал исполняемый файл и мог быть загружен с помощью `xcodebuild`.

CI:
- Добавить основанную на macOS задачу workflow `ios-ui-smoke`, которая выбирает совместимую версию инструментария Xcode 16.x, детерминированно выбирает iOS‑симулятор и запускает `build-for-testing`, а затем `test-without-building` для smoke‑кейса `PulsePlateUITests`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the iOS UI test bundle to be executable and add a dedicated iOS UI smoke job in CI to run a minimal end-to-end UI test on a stable simulator destination.

New Features:
- Introduce an `ios-ui-smoke` GitHub Actions job that builds the iOS app for testing and runs a focused UI smoke test via `xcodebuild` on a pinned iOS simulator runtime.

Bug Fixes:
- Ensure the `PulsePlateUITests` target in the Xcode project correctly compiles its sources so the generated `PulsePlateUITests.xctest` bundle contains an executable and can be loaded by `xcodebuild`.

CI:
- Add a macOS-based `ios-ui-smoke` workflow job that selects a compatible Xcode 16.x toolchain, deterministically chooses an iOS simulator, and runs `build-for-testing` followed by `test-without-building` for the `PulsePlateUITests` smoke case.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores iOS UI tests by making PulsePlateUITests.xctest build an executable bundle. Adds a CI UI smoke job to run a minimal UI test for a reliable signal.

- **Bug Fixes**
  - Added UITests sources to the PulsePlateUITests target so the bundle includes an executable and no longer fails with exit 65 before tests run.

- **New Features**
  - Introduced ios-ui-smoke GitHub Actions job that builds-for-testing and runs a minimal UI test on a pinned Xcode 16.x/iOS 18 simulator, with deterministic device selection and SwiftPM caching.

<sup>Written for commit e0843017a07dc5adde19b59f294d2fbdb2e2da5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a minimal iOS UI smoke test to verify the app launches successfully.

* **Chores**
  * Added a deterministic iOS UI smoke CI workflow: pins Xcode, exposes Xcode version for caching, caches SwiftPM, selects and validates a stable simulator destination (UDID-based), enforces preferred-device presence, boots simulators, and runs build/test steps with timeouts and diagnostics.

* **Documentation**
  * Added a backlog item to track shared CI helpers for destination selection and stabilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->