### PR TITLE
docs(audit): post-merge verification for PR-Q2b

### DIFF
--- a/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+++ b/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
@@ -119,13 +119,25 @@ DoD gates (all required):
 
 ## F) Post-merge verification (main)
 
-Observed on `main` after remediation was merged:
+Observed on `main` at commit:
+
+- **Commit:** `179eb94c9b18e9889d7f0a735df472408bff0228` (main)
+
+Environment:
+- Xcode: local `/Applications/Xcode.app`
+- Simulator destination: `platform=iOS Simulator,name=iPhone 16e,OS=latest`
 
 ```bash
 make ios-test IOS_ONLY_TESTING="PulsePlateUITests/UISmokeTests/testLaunch" IOS_SKIP_TESTING=""
 ```
 
-Observed result:
+Observed results:
+
+```text
+Test Suite 'UISmokeTests' passed at 2026-01-27 10:54:51.234.
+** TEST SUCCEEDED **
+exit=0
+```
 
 - Exit: `0`
 - `Cannot find executable … PulsePlateUITests.xctest`: **absent**

--- a/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+++ b/docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
@@ -117,6 +117,19 @@ DoD gates (all required):
   without `-skip-testing:PulsePlateUITests`.
 - **G4:** UI-smoke job is green for ≥2 consecutive runs (PR checks / reruns).
 
+## F) Post-merge verification (main)
+
+Observed on `main` after remediation was merged:
+
+```bash
+make ios-test IOS_ONLY_TESTING="PulsePlateUITests/UISmokeTests/testLaunch" IOS_SKIP_TESTING=""
+```
+
+Observed result:
+
+- Exit: `0`
+- `Cannot find executable … PulsePlateUITests.xctest`: **absent**
+
 ## Security Notes
 
 - UI tests must not send real credentials or hit real endpoints.


### PR DESCRIPTION
## Summary
Record post-merge evidence that PR-Q2b remediation is effective on `main`.

## Evidence
- `make ios-test IOS_ONLY_TESTING=\"PulsePlateUITests/UISmokeTests/testLaunch\" IOS_SKIP_TESTING=\"\"` → exit 0
- No `Cannot find executable … PulsePlateUITests.xctest`

## Scope / Non-goals
- Docs-only change to `docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md`
- No runtime/CI changes

## Summary by Sourcery

Документация:
- Добавлен раздел проверки после слияния, фиксирующий успешное выполнение смоук-теста интерфейса PulsePlate в ветке `main` без ошибок загрузки бандла.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add post-merge verification section recording successful execution of the PulsePlate UI smoke test on main without bundle load errors.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-merge verification note to the Q2b iOS UI tests audit, confirming the remediation works on main. The documented ios-test command exits 0 and the prior “Cannot find executable … PulsePlateUITests.xctest” error is absent.

<sup>Written for commit 14cbd13984f391813c5de4556b3a80b0c82cd93e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a post-merge verification section capturing observed commit, environment, verification command and test results to aid reproducible checks.
  * Expanded security guidance to require network stubbing/isolation in CI to keep tests deterministic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->