### PR TITLE
docs(roadmap): ledger update after Q2b merges

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -119,19 +119,42 @@ If it is not recorded here — it does not exist.
     - emptyResponse semantics
     - unknown vs transport
 
-- [ ] Stabilize/restore PlateViewTests and UI tests in CI (iOS)
+- [ ] Stabilize/restore PlateViewTests in CI (iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: TBD (separate from PR-559)
-  - Reason: PlateViewTests unstable; UI tests excluded from PR-559 CI to unblock merge. Needs stabilization/rewrite before restoring to CI.
+  - Reason: PlateViewTests were unstable historically; UI tests bundle-load is now fixed, but PlateViewTests stability + CI inclusion remains open.
   - Links:
-    - ios/PulsePlate/Tests/PlateViewTests.swift
-    - .github/workflows/ci.yml (line 633: `-skip-testing:PulsePlateUITests`)
-    - ios/AGENTS.md (Test scope policy)
+    - ios/PulsePlateTests/PlateViewTests.swift
+    - docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/607>
   - DoD:
     - PlateViewTests stabilized (no flaky failures)
-    - UI tests (`PulsePlateUITests`) pass consistently
-    - `-skip-testing:PulsePlateUITests` removed from CI
-    - CI green with UI tests included
+    - PlateViewTests included in CI signal (job or explicit `-only-testing` list)
+    - CI green with PlateViewTests included
+
+- [x] PR-607 merged: iOS UITests bundle load fix + CI UI smoke (merged 2026-01-27)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-607
+  - Status: ✅ Merged
+  - Reason: Restore UI tests build-product correctness (bundle contains executable) and add dedicated `ios-ui-smoke` CI signal.
+  - Links:
+    - docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/607>
+  - DoD: ✅ Completed
+    - `PulsePlateUITests.xctest` contains executable (no Code=4 / exit 65 before tests execute)
+    - CI `ios-ui-smoke` job runs minimal UI smoke
+
+- [x] PR-608 merged: audit post-merge evidence stamp (merged 2026-01-27)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR-608
+  - Status: ✅ Merged
+  - Reason: Record post-merge verification evidence (main SHA + minimal stdout excerpt) for Q2b DoD closure.
+  - Links:
+    - docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/608>
+  - DoD: ✅ Completed
 
 - [ ] P1 (postponed): CI iOS workflow dedup (extract shared helpers / composite action)
   - Owner: @katsiaryna_kavaleuskaya
@@ -145,6 +168,18 @@ If it is not recorded here — it does not exist.
     - One shared implementation for destination selection + bootstatus gating + xcodebuild wrapper (script or composite action)
     - Both iOS jobs reuse the same logic (no duplicated Python snippets)
     - CI remains deterministic (UDID-only destination, no `OS=latest`)
+
+- [ ] Standardize audit verification blocks (require minimal stdout excerpt)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: TBD
+  - Reason: Audit items labeled “Verified” must include minimal observed stdout evidence (1–3 lines) to remain reproducible and reviewable.
+  - Links:
+    - docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md (section F)
+    - AGENTS.md (Verification-audit rule)
+  - DoD:
+    - Add a short, canonical checklist line for audit PRs: include 1–3 raw stdout lines + exit code for each key verification command
+    - No scope creep into runbook-level detail
 
 - [ ] Stabilize AnimationTests.swift (iOS)
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -122,6 +122,7 @@ If it is not recorded here — it does not exist.
 - [ ] Stabilize/restore PlateViewTests in CI (iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: TBD (separate from PR-559)
+  - Priority: P1
   - Reason: PlateViewTests were unstable historically; UI tests bundle-load is now fixed, but PlateViewTests stability + CI inclusion remains open.
   - Links:
     - ios/PulsePlateTests/PlateViewTests.swift
@@ -487,5 +488,5 @@ If it is not recorded here — it does not exist.
 
 ---
 
-**Last updated:** 2026-01-26 (PR-597: Post-merge hygiene for PR-596)
+**Last updated:** 2026-01-27 (PR-597: Post-merge hygiene for PR-596)
 **Maintainer:** @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -488,5 +488,5 @@ If it is not recorded here — it does not exist.
 
 ---
 
-**Last updated:** 2026-01-27 (PR-597: Post-merge hygiene for PR-596)
+**Last updated:** 2026-01-27 (PR-609: Post-merge hygiene for PR-596)
 **Maintainer:** @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
Update `BACKLOG_LEDGER.md` to reflect Q2b completion and capture new follow-ups.

## Changes
- Mark PR-607 (Q2b remediation) as completed.
- Mark PR-608 (post-merge evidence stamp) as completed.
- Narrow the remaining iOS stability item to `PlateViewTests` (UI bundle-load is already fixed).
- Add a P2 item to standardize audit verification blocks (require minimal stdout excerpt).

## Scope / Non-goals
- Docs-only: `docs/roadmap/BACKLOG_LEDGER.md` only.
- No runtime/CI/code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only update to docs/roadmap/BACKLOG_LEDGER.md to close out Q2b. Mark PR-607 and PR-608 as completed, narrow the iOS stability item to PlateViewTests, and add a P2 to standardize audit verification blocks with a minimal stdout excerpt.

<sup>Written for commit e7d01b8e127cf8e1a9aa393322ae0fc802be1b78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Обновить реестр бэклога, чтобы отразить завершение работ по исправлению iOS UI тестов за Q2b и добавить новую задачу по документации для стандартизации доказательств верификации аудита.

Документация:
- Переработать пункт бэклога по стабильности iOS, чтобы он был сосредоточен конкретно на `PlateViewTests` и ссылался на обновлённые расположения тестов и связанный PR по аудиту.
- Зафиксировать `PR-607` и `PR-608` как завершённые элементы по аудиту за Q2b и загрузке бандла iOS UI тестов с указанием причин, ссылок и DoD.
- Добавить новую запись бэклога уровня P2 для стандартизации блоков верификации аудита, требуя минимальных доказательств в `stdout` в документации по аудиту.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the backlog ledger to reflect completion of Q2b iOS UI test remediation work and add a new documentation task for standardizing audit verification evidence.

Documentation:
- Revise the iOS stability backlog item to focus specifically on PlateViewTests and reference the updated test locations and related audit PR.
- Record PR-607 and PR-608 as completed Q2b audit and iOS UI test bundle-load items with their reasons, links, and DoD.
- Add a new P2 backlog entry to standardize audit verification blocks by requiring minimal stdout evidence in audit documentation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated backlog roadmap: adjusted item titles, links, timestamps, and references to reflect recent edits and moved test references.
  * Added two merged work items with updated metadata and links.
  * Added a new backlog item to standardize audit verification blocks (require minimal stdout excerpts).

* **Chores**
  * Expanded Definition of Done to include CI signals for specific tests and minimal stdout evidence for audits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->