### PR TITLE
fix(security): upgrade OpenSSL in Docker image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,12 +1,12 @@
 ## Trivy vulnerability ignore list
 ##
-## Last reviewed: 2025-12-30
+## Last reviewed: 2026-01-28
 ## Base image: python:3.13.6-slim (Debian 12 bookworm)
-## Next review: 2026-03-30
+## Next review: 2026-04-28
 ## Review process: Re-verify versions when base image updates or quarterly
 ##
 ## IMPORTANT: Container uses python:3.13.6-slim based on Debian bookworm.
-## Actual versions: Python 3.13.6, pip 25.1.1, glibc 2.36-9+deb12u10,
+## Actual versions: Python 3.13.6, pip 25.1.1, glibc 2.36-9+deb12u13,
 ## PAM 1.5.2-6+deb12u1. Many CVEs below reference "trixie" due to historical
 ## confusion - actual base is bookworm. Verify versions before trusting comments.
 ##
@@ -50,6 +50,28 @@ CVE-2025-68972
 ## We accept this risk as documented and will monitor for upstream fixes.
 
 CVE-2025-68973
+
+## CVE-2026-24882 – gpgv (GnuPG) buffer overflow in TPM2 code path
+##
+## Trivy reports this against Debian's `gpgv` package. On Debian-based images, `apt` depends on
+## `gpgv` and removing it can break the base system. Our runtime image does not invoke `apt`/`gpgv`
+## (no package installs at runtime), so we document this as an accepted risk pending upstream fixes.
+##
+## Trivy currently reports no fixed version (as of 2026-01-28). We will revisit when Debian bookworm
+## publishes a patched package or when Trivy metadata is updated with a fixed version.
+
+CVE-2026-24882
+
+## CVE-2026-24883 – gpgv (GnuPG) parse_sig DoS / memory safety issue
+##
+## Trivy reports this against Debian's `gpgv` package. On Debian-based images, `apt` depends on
+## `gpgv` and removing it can break the base system. Our runtime image does not invoke `apt`/`gpgv`
+## (no package installs at runtime), so we document this as an accepted risk pending upstream fixes.
+##
+## Trivy currently reports no fixed version (as of 2026-01-28). We will revisit when Debian bookworm
+## publishes a patched package or when Trivy metadata is updated with a fixed version.
+
+CVE-2026-24883
 
 ## CVE-2023-45853 – MiniZip in zlib through 1.3
 ##

--- a/.trivyignore
+++ b/.trivyignore
@@ -51,27 +51,6 @@ CVE-2025-68972
 
 CVE-2025-68973
 
-## CVE-2026-24882 – gpgv (GnuPG) buffer overflow in TPM2 code path
-##
-## Trivy reports this against Debian's `gpgv` package. On Debian-based images, `apt` depends on
-## `gpgv` and removing it can break the base system. Our runtime image does not invoke `apt`/`gpgv`
-## (no package installs at runtime), so we document this as an accepted risk pending upstream fixes.
-##
-## Trivy currently reports no fixed version (as of 2026-01-28). We will revisit when Debian bookworm
-## publishes a patched package or when Trivy metadata is updated with a fixed version.
-
-CVE-2026-24882
-
-## CVE-2026-24883 – gpgv (GnuPG) parse_sig DoS / memory safety issue
-##
-## Trivy reports this against Debian's `gpgv` package. On Debian-based images, `apt` depends on
-## `gpgv` and removing it can break the base system. Our runtime image does not invoke `apt`/`gpgv`
-## (no package installs at runtime), so we document this as an accepted risk pending upstream fixes.
-##
-## Trivy currently reports no fixed version (as of 2026-01-28). We will revisit when Debian bookworm
-## publishes a patched package or when Trivy metadata is updated with a fixed version.
-
-CVE-2026-24883
 
 ## CVE-2023-45853 – MiniZip in zlib through 1.3
 ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ ENV PYTHONUNBUFFERED=1 \
 # CVE-2025-13151 is NOT fixed in Debian bookworm as of 2026-01 (no patched version available).
 # Tracking: https://security-tracker.debian.org/tracker/CVE-2025-13151
 # Revisit when bookworm publishes a fixed package.
+#
+# Security hardening:
+# Explicitly install openssl/libssl3 to ensure patched versions are pulled from bookworm-security.
+# Do not remove unless Trivy alerts are resolved and base image consistently ships patched OpenSSL.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         libc6 \
+        libssl3 \
+        openssl \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -100,6 +100,19 @@ If it is not recorded here — it does not exist.
 
 ## P1 — Improvements (Optional / polish)
 
+- [ ] Remove Trivy suppressions for gpgv CVEs (CVE-2026-24882 / CVE-2026-24883)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Reason: Trivy reports `gpgv` vulnerabilities with no fixed version available as of 2026-01-28; we suppress to keep Trivy signal actionable and should remove when Debian publishes a patched package / Trivy metadata updates.
+  - Links:
+    - .trivyignore
+    - .github/workflows/trivy.yml
+  - DoD:
+    - Debian bookworm publishes a fixed `gpgv` package (or Trivy publishes fixed-version metadata)
+    - Remove `CVE-2026-24882` and `CVE-2026-24883` from `.trivyignore`
+    - Trivy Code Scanning alerts remain closed on `main`
+
 - [ ] Move insight redaction/import helpers out of legacy_app.py
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -100,17 +100,19 @@ If it is not recorded here — it does not exist.
 
 ## P1 — Improvements (Optional / polish)
 
-- [ ] Remove Trivy suppressions for gpgv CVEs (CVE-2026-24882 / CVE-2026-24883)
+- [ ] Remove Trivy suppression for gpgv CVE (CVE-2026-24883)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: TBD (follow-up after upstream fix)
-  - Reason: Trivy reports `gpgv` vulnerabilities with no fixed version available as of 2026-01-28; we suppress to keep Trivy signal actionable and should remove when Debian publishes a patched package / Trivy metadata updates.
+  - Reason: Trivy reports `gpgv` vulnerability (CVE-2026-24883) with no fixed version available as of 2026-01-28; we suppress via `trivy/ignore-policy.rego` with expiry enforcement to keep Trivy's signal actionable. Should remove when Debian publishes a patched package / Trivy metadata updates.
   - Links:
-    - .trivyignore
-    - .github/workflows/trivy.yml
+    - `trivy/ignore-policy.rego` (rule for CVE-2026-24883)
+    - `docs/security/CVE-2026-24883-gpgv.md`
+    - `.github/workflows/trivy.yml`
   - DoD:
     - Debian bookworm publishes a fixed `gpgv` package (or Trivy publishes fixed-version metadata)
-    - Remove `CVE-2026-24882` and `CVE-2026-24883` from `.trivyignore`
+    - Remove CVE-2026-24883 suppression from `trivy/ignore-policy.rego`
+    - Remove `docs/security/CVE-2026-24883-gpgv.md` (or mark as resolved)
     - Trivy Code Scanning alerts remain closed on `main`
 
 - [ ] Move insight redaction/import helpers out of legacy_app.py

--- a/docs/security/CVE-2026-24883-gpgv.md
+++ b/docs/security/CVE-2026-24883-gpgv.md
@@ -1,0 +1,57 @@
+# CVE-2026-24883 – gpgv (GnuPG) parse_sig DoS / memory safety issue
+
+**Status:** UNPATCHED / awaiting distro fix
+**Suppression expires:** 2026-04-28
+**Last reviewed:** 2026-01-28
+
+## Vulnerability Details
+
+- **CVE ID:** CVE-2026-24883
+- **Package:** gpgv (GnuPG verification tool)
+- **Component:** parse_sig function
+- **Severity:** HIGH
+- **Debian Tracker:** https://security-tracker.debian.org/tracker/CVE-2026-24883
+
+## Risk Assessment
+
+### Why This CVE is Suppressed
+
+1. **No attack surface in runtime:**
+   - Our container does NOT invoke `apt` or `gpgv` at runtime
+   - No package installs occur during application execution
+   - Application does not process untrusted GPG-signed data
+
+2. **Base system dependency:**
+   - On Debian-based images, `apt` depends on `gpgv`
+   - Removing `gpgv` would break the base system
+   - Cannot be removed without breaking container functionality
+
+3. **Upstream status:**
+   - Debian bookworm still vulnerable as of 2026-01-28 (per Debian tracker)
+   - Debian has not shipped a patched `gpgv` package yet
+   - No actionable remediation available in repository
+
+### Exploitation Requirements
+
+Exploitation would require:
+- Direct invocation of `gpgv` with crafted input
+- Access to run `gpgv` on attacker-controlled data
+- Both conditions are NOT met in our deployment model
+
+## Suppression Details
+
+- **Policy file:** `trivy/ignore-policy.rego`
+- **Rule ID:** `CVE-2026-24883` (gpgv package)
+- **Expiry date:** 2026-04-28 (90 days from suppression date)
+- **Enforcement:** CI runs `scripts/ci/check_trivy_ignore_policy_expiry.py` to verify expiry dates
+
+## Removal Condition
+
+Remove this suppression when:
+- Debian bookworm publishes a patched `gpgv` package, OR
+- Trivy metadata includes fixed version information
+
+## Related
+
+- **Ledger item:** `docs/roadmap/BACKLOG_LEDGER.md` (P1 follow-up)
+- **Policy reference:** `AGENTS.md` (Security: Unfixed Distro CVE Policy)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -64,3 +64,15 @@ ignore if {
 	cve_2025_15281_version_match
 	cve_2025_15281_pkgid_match
 }
+
+# CVE-2026-24883 (gpgv) - upstream unfixed in Debian bookworm
+# Review-by: 2026-04-28 (manual removal)
+# Rationale: Unfixed distro CVE; runtime does not invoke apt/gpgv; no attack surface
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-24883
+# Documented in: docs/security/CVE-2026-24883-gpgv.md
+# Removal condition: Remove when Debian bookworm publishes patched gpgv package or Trivy metadata includes fixed version
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-24883"
+	input.PkgName == "gpgv"
+}


### PR DESCRIPTION
## Summary
- Upgrades Debian OpenSSL packages in the production image to pull patched versions (fixes Trivy Code Scanning CVEs for `openssl`/`libssl3`).
- Suppresses `gpgv` CVEs with no fixed version available in Trivy metadata (documented in `.trivyignore`).

## Details
- Trivy Code Scanning alerts on `main` (2026-01-28) were reporting `openssl`/`libssl3` at `3.0.17-1~deb12u2` with fixes available in `3.0.18-1~deb12u2`.
- `gpgv` CVEs `CVE-2026-24882` / `CVE-2026-24883` report no fixed version; we suppress with review date.

## Verification
- `make verify`
- `pre-commit run --all-files`
- `docker build --target=production -t pulseplate:local-security-fix .`

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md` (Remove Trivy suppressions for `gpgv` CVEs once upstream fix is available)

## Summary by Sourcery

Обновить production Docker-образ, чтобы подтягивать пропатченные пакеты OpenSSL и привести конфигурацию security-сканирования и трекинг бэклога в соответствие с актуальным статусом CVE в Trivy.

Исправления ошибок:
- Гарантировать, что в production-образе явно устанавливаются пакеты OpenSSL и libssl3, чтобы применялись обновлённые пакеты безопасности Debian и были устранены CVE по OpenSSL/libssl3, обнаруживаемые Trivy.

Улучшения:
- Добавить пункт в бэклог для отслеживания удаления подавлений (suppressions) в Trivy для нерешённых CVE в gpgv после появления исправлений в апстриме.

Сборка:
- Изменить production Dockerfile, чтобы явно устанавливать libssl3 и openssl и тем самым получать последние пропатченные пакеты Debian.

CI:
- Привести конфигурацию Trivy (через .trivyignore) в соответствие с текущим статусом CVE в gpgv, подавляя CVE без доступной исправленной версии и одновременно снижая «шум» в результатах сканирования кода.

Документация:
- Задокументировать последующую задачу по удалению подавлений Trivy для CVE в gpgv в бэклоге roadmap.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the production Docker image to pull patched OpenSSL packages and align security scanning configuration and backlog tracking with current Trivy CVE status.

Bug Fixes:
- Ensure the production image installs explicit OpenSSL and libssl3 packages so that patched Debian security updates are applied and Trivy-reported OpenSSL/libssl3 CVEs are addressed.

Enhancements:
- Add a backlog item to track removal of Trivy suppressions for unresolved gpgv CVEs once upstream fixes are available.

Build:
- Amend the production Dockerfile to explicitly install libssl3 and openssl to pick up the latest patched Debian packages.

CI:
- Align Trivy configuration (via .trivyignore) with current gpgv CVE status by suppressing CVEs that have no fixed version while keeping code scanning noise low.

Documentation:
- Document the follow-up task for removing Trivy suppressions for gpgv CVEs in the roadmap backlog.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades OpenSSL/libssl3 in the production Docker image to pull patched Debian packages and close Trivy CVEs. Suppresses the unfixed gpgv CVE (CVE-2026-24883) via Trivy policy with a 90-day expiry until Debian publishes a fix.

- **Bug Fixes**
  - Install openssl and libssl3 via apt to ensure patched versions in bookworm.
  - Resolve Trivy alerts for openssl/libssl3.
  - Move gpgv suppression to trivy/ignore-policy.rego with 90-day expiry; limit to CVE-2026-24883, document it, and track removal in the backlog.

<sup>Written for commit 0a2247e9f19220c818aa39d1db77767e4d41e79d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSL/TLS support in the runtime by ensuring security-related packages are installed.

* **Chores**
  * Updated vulnerability tracking and review dates, and noted base-image version details.
  * Added documentation for a specific CVE including rationale and suppression metadata.
  * Added an ignore rule for that CVE and a backlog item to revisit removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->