### PR TITLE
chore(security): post-merge fixups for PR-613 review actionables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ ENV PYTHONUNBUFFERED=1 \
 # Revisit when bookworm publishes a fixed package.
 #
 # Security hardening:
-# Explicitly install openssl/libssl3 to ensure patched versions are pulled from bookworm-security.
-# Do not remove unless Trivy alerts are resolved and base image consistently ships patched OpenSSL.
+# Explicitly install openssl/libssl3 to pull the latest available versions from bookworm-security.
+# Do not remove unless Trivy alerts are resolved and the base image consistently ships updated OpenSSL.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/docs/security/CVE-2026-24883-gpgv.md
+++ b/docs/security/CVE-2026-24883-gpgv.md
@@ -10,7 +10,7 @@
 - **Package:** gpgv (GnuPG verification tool)
 - **Component:** parse_sig function
 - **Severity:** HIGH
-- **Debian Tracker:** https://security-tracker.debian.org/tracker/CVE-2026-24883
+- **Debian Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-24883>
 
 ## Risk Assessment
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -72,7 +72,19 @@ ignore if {
 # Documented in: docs/security/CVE-2026-24883-gpgv.md
 # Removal condition: Remove when Debian bookworm publishes patched gpgv package or Trivy metadata includes fixed version
 
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_24883_version_match if {
+	input.InstalledVersion == "2.2.40-1.1"
+}
+
+# Helper rule: check if PkgID matches observed gpgv package
+cve_2026_24883_pkgid_match if {
+	startswith(input.PkgID, "gpgv@2.2.40-1.1")
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2026-24883"
 	input.PkgName == "gpgv"
+	cve_2026_24883_version_match
+	cve_2026_24883_pkgid_match
 }


### PR DESCRIPTION
## Summary

Post-merge follow-up PR addressing CodeRabbit review feedback on PR-613 (already merged).

## Changes

1. **Dockerfile comment** — Softened wording (removed "ensure patched" guarantee, changed to "pull the latest available versions")
2. **Security doc MD034 fix** — Fixed bare URL in markdown (angle brackets)
3. **Narrowing ignore rule** — Restricted gpgv suppression to specific observed version (2.2.40-1.1) to prevent suppressing future patched versions

## Scope

- ✅ Comment wording only (no behavior change)
- ✅ Markdownlint compliance
- ✅ Rule narrowing (matches glibc pattern)
- ❌ No new suppressions
- ❌ No CVE docs for OpenSSL
- ❌ No refactor/unrelated changes

## Verification

- Expiry checker passes locally
- Rule matches observed gpgv version from production image

## Related

- PR-613 (merged): Initial security fixes
- Follows AGENTS.md "Security: Unfixed Distro CVE Policy"

## Summary by Sourcery

Уточнить правило игнорирования CVE для `gpgv` до конкретной наблюдаемой уязвимой версии и обновить связанную документацию по безопасности и комментарии для ясности и соответствия требованиям линтинга.

Исправления ошибок:
- Ограничить правило игнорирования CVE-2026-24883 для `gpgv` конкретной установленной версией и идентификатором пакета, чтобы избежать подавления будущих исправленных версий.

Улучшения:
- Уточнить комментарий о безопасности в Dockerfile относительно поведения установки OpenSSL, не подразумевая гарантированно исправленные версии.

Документация:
- Исправить “голый” URL в markdown-документе по безопасности CVE для `gpgv` в соответствии с правилами линтинга markdown.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the gpgv CVE ignore rule to the specific observed vulnerable version and update related security documentation and comments for clarity and lint compliance.

Bug Fixes:
- Restrict the CVE-2026-24883 gpgv ignore rule to a specific installed version and package ID to avoid suppressing future patched versions.

Enhancements:
- Clarify Dockerfile security comment about OpenSSL installation behavior without implying guaranteed patched versions.

Documentation:
- Fix markdown bare URL in the gpgv CVE security document to comply with markdown linting rules.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Post-merge follow-up to PR-613 that clarifies security notes and tightens the gpgv CVE ignore. Softened the Dockerfile OpenSSL comment, fixed a bare URL in the gpgv CVE doc, and restricted CVE-2026-24883 suppression to gpgv 2.2.40-1.1 (version + PkgID) to avoid suppressing future patched versions; no runtime changes.

<sup>Written for commit 59430c57e663f7aa6abaefbbfe1939b56b42e5a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security hardening documentation.
  * Improved formatting of security references.

* **Security**
  * Tightened vulnerability suppression rules to apply only to specific package versions, enhancing precision of security controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->