### PR TITLE
fix(security): handle Trivy alert CVE-2026-24882 for gpgv (scoped + expiring)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ ENV PYTHONUNBUFFERED=1 \
 # Revisit when bookworm publishes a fixed package.
 #
 # Security hardening:
-# Explicitly install openssl/libssl3 to ensure patched versions are pulled from bookworm-security.
-# Do not remove unless Trivy alerts are resolved and base image consistently ships patched OpenSSL.
+# Explicitly install openssl/libssl3 to pull the latest available versions from bookworm-security.
+# Do not remove unless Trivy alerts are resolved and the base image consistently ships updated OpenSSL.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -115,6 +115,24 @@ If it is not recorded here — it does not exist.
     - Remove `docs/security/CVE-2026-24883-gpgv.md` (or mark as resolved)
     - Trivy Code Scanning alerts remain closed on `main`
 
+- [ ] Resolve CVE-2026-24882 Trivy alert (accepted risk)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Reason: GitHub alert #515 reports CVE-2026-24882 (gpgv tpm2daemon buffer overflow) for installed version 2.2.40-1.1. Debian tracker confirms bookworm is vulnerable (no fixed version available). Suppressed as accepted risk (no attack surface: runtime does not invoke gpgv/tpm2daemon, no TPM2-backed keys used).
+  - Links:
+    - `trivy/ignore-policy.rego` (rule for CVE-2026-24882)
+    - `docs/security/CVE-2026-24882-gpgv.md`
+    - GitHub alert #515
+    - `.github/workflows/trivy.yml`
+  - DoD:
+    - Debian bookworm publishes a fixed `gpgv` package (≥ 2.5.17 or backported fix), OR
+    - Trivy metadata includes fixed version information, OR
+    - GitHub alert #515 is automatically resolved by upstream fix
+    - Remove CVE-2026-24882 suppression from `trivy/ignore-policy.rego`
+    - Remove `docs/security/CVE-2026-24882-gpgv.md` (or mark as resolved)
+    - Trivy Code Scanning alert #515 remains closed on `main`
+
 - [ ] Move insight redaction/import helpers out of legacy_app.py
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/docs/security/CVE-2026-24882-gpgv.md
+++ b/docs/security/CVE-2026-24882-gpgv.md
@@ -1,0 +1,78 @@
+# CVE-2026-24882 – gpgv (GnuPG) tpm2daemon buffer overflow
+
+**Status:** ACCEPTED RISK / awaiting distro fix
+**Suppression expires:** 2026-04-28
+**Last reviewed:** 2026-01-28
+**GitHub Alert:** #515
+
+## Vulnerability Details
+
+- **CVE ID:** CVE-2026-24882
+- **Package:** gpgv (GnuPG verification tool)
+- **Component:** tpm2daemon (TPM2 code path)
+- **Severity:** HIGH
+- **Debian Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-24882>
+- **Source Package:** gnupg2
+
+## Evidence
+
+### Observed Version in Production Image
+
+```bash
+$ docker run --rm pulseplate:production dpkg-query -W -f='${Package}@${Version}\n' gpgv
+gpgv@2.2.40-1.1
+```
+
+### Debian Tracker Status
+
+- **Bookworm (Debian 12):** `2.2.40-1.1+deb12u2` — **vulnerable** (confirmed 2026-01-28)
+- **Fixed Version:** None available in bookworm as of 2026-01-28
+- **Upstream:** Fixed in GnuPG 2.5.17+ (not available in bookworm)
+
+## Risk Assessment
+
+### Why This CVE is Suppressed (Accepted Risk)
+
+1. **No attack surface in runtime:**
+   - Our container does NOT invoke `apt`, `gpgv`, or `tpm2daemon` at runtime
+   - No package installs occur during application execution
+   - Application does not use TPM2-backed keys or process untrusted GPG data via tpm2daemon
+
+2. **Base system dependency:**
+   - On Debian-based images, `apt` depends on `gpgv`
+   - Removing `gpgv` would break the base system
+   - Cannot be removed without breaking container functionality
+
+3. **Vulnerability scope:**
+   - CVE-2026-24882 affects `tpm2daemon` component (TPM2-backed RSA/ECC keys)
+   - Our application does not use TPM2 hardware or TPM2-backed keys
+   - The vulnerable code path is not executed in our deployment model
+
+### Exploitation Requirements
+
+Exploitation would require:
+- Direct invocation of `gpgv` with TPM2-backed keys
+- Access to `tpm2daemon` with crafted PKDECRYPT command
+- Both conditions are NOT met in our deployment model
+
+## Suppression Details
+
+- **Policy file:** `trivy/ignore-policy.rego`
+- **Rule ID:** `CVE-2026-24882` (gpgv package, version-scoped)
+- **Expiry date:** 2026-04-28 (90 days from suppression date)
+- **Enforcement:** CI runs `scripts/ci/check_trivy_ignore_policy_expiry.py` to verify expiry dates
+- **Version scope:** `2.2.40-1.1` (prevents suppressing future patched versions)
+
+## Removal Condition
+
+Remove this suppression when:
+- Debian bookworm publishes a patched `gpgv` package (≥ 2.5.17 or backported fix), OR
+- Trivy metadata includes fixed version information, OR
+- GitHub alert #515 is automatically resolved by upstream fix
+
+## Related
+
+- **GitHub Alert:** #515 (Trivy Code Scanning)
+- **Ledger item:** `docs/roadmap/BACKLOG_LEDGER.md` (P1 follow-up)
+- **Policy reference:** `AGENTS.md` (Security: Unfixed Distro CVE Policy)
+- **Related CVE:** CVE-2026-24883 (same package, different component)

--- a/docs/security/CVE-2026-24883-gpgv.md
+++ b/docs/security/CVE-2026-24883-gpgv.md
@@ -10,7 +10,7 @@
 - **Package:** gpgv (GnuPG verification tool)
 - **Component:** parse_sig function
 - **Severity:** HIGH
-- **Debian Tracker:** https://security-tracker.debian.org/tracker/CVE-2026-24883
+- **Debian Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-24883>
 
 ## Risk Assessment
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -88,3 +88,27 @@ ignore if {
 	cve_2026_24883_version_match
 	cve_2026_24883_pkgid_match
 }
+
+# CVE-2026-24882 (gpgv) - upstream unfixed in Debian bookworm (tpm2daemon buffer overflow)
+# Review-by: 2026-04-28 (manual removal)
+# Rationale: Unfixed distro CVE; runtime does not invoke apt/gpgv/tpm2daemon; no attack surface
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-24882
+# Documented in: docs/security/CVE-2026-24882-gpgv.md
+# Removal condition: Remove when Debian bookworm publishes patched gpgv package or Trivy metadata includes fixed version
+
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_24882_version_match if {
+	input.InstalledVersion == "2.2.40-1.1"
+}
+
+# Helper rule: check if PkgID matches observed gpgv package
+cve_2026_24882_pkgid_match if {
+	startswith(input.PkgID, "gpgv@2.2.40-1.1")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-24882"
+	input.PkgName == "gpgv"
+	cve_2026_24882_version_match
+	cve_2026_24882_pkgid_match
+}

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -72,7 +72,19 @@ ignore if {
 # Documented in: docs/security/CVE-2026-24883-gpgv.md
 # Removal condition: Remove when Debian bookworm publishes patched gpgv package or Trivy metadata includes fixed version
 
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_24883_version_match if {
+	input.InstalledVersion == "2.2.40-1.1"
+}
+
+# Helper rule: check if PkgID matches observed gpgv package
+cve_2026_24883_pkgid_match if {
+	startswith(input.PkgID, "gpgv@2.2.40-1.1")
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2026-24883"
 	input.PkgName == "gpgv"
+	cve_2026_24883_version_match
+	cve_2026_24883_pkgid_match
 }


### PR DESCRIPTION
## Summary

Addresses GitHub alert #515: CVE-2026-24882 (gpgv tpm2daemon buffer overflow) reported by Trivy Code Scanning.

## Evidence

- **Observed installed version:** `gpgv@2.2.40-1.1` (from production Docker image)
- **Debian tracker status:** Vulnerable for bookworm (2.2.40-1.1+deb12u2) — no fixed version available as of 2026-01-28
- **Upstream fix:** Available in GnuPG 2.5.17+ (not backported to bookworm)
- **Expiry:** 2026-04-28 (90 days)

## Risk Assessment

**Accepted risk** (not false-positive):
- Runtime does NOT invoke `gpgv`, `tpm2daemon`, or process TPM2-backed keys
- No attack surface in our deployment model
- `gpgv` is a base system dependency (cannot be removed without breaking container)

## Changes

1. **Version-scoped suppression rule** in `trivy/ignore-policy.rego`:
   - Matches `InstalledVersion == "2.2.40-1.1"` and `PkgID` (prevents suppressing future patched versions)
   - Expiry: 2026-04-28 (90 days)

2. **Security documentation** in `docs/security/CVE-2026-24882-gpgv.md`:
   - Evidence (dpkg-query output, Debian tracker links)
   - Risk assessment (accepted risk rationale)
   - Removal conditions

3. **Ledger update** in `BACKLOG_LEDGER.md`:
   - Follow-up item for alert #515 resolution

## DoD

- [x] Alert #515 will close on `main` after merge
- [x] Suppression in `trivy/ignore-policy.rego` with expiry ≤ 90 days
- [x] Rule version-scoped (`InstalledVersion`/`PkgID`)
- [x] `docs/security/CVE-2026-24882-gpgv.md` created
- [x] `scripts/ci/check_trivy_ignore_policy_expiry.py` passes

## Related

- **GitHub Alert:** #515
- **Related CVE:** CVE-2026-24883 (same package, different component)
- **Policy:** AGENTS.md "Security: Unfixed Distro CVE Policy"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability documentation for CVE-2026-24882 and CVE-2026-24883 affecting gpgv components, including risk assessment and suppression rationale.

* **Chores**
  * Updated security scanning policy to acknowledge two CVE alerts as accepted risks.
  * Updated backlog tracking with new security item.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->