### PR TITLE
fix(db-fallback): use canonical fallback state API in legacy_app

### DIFF
--- a/core/db_fallback.py
+++ b/core/db_fallback.py
@@ -247,5 +247,10 @@ def reset_fallback_state() -> None:
 
 
 def is_fallback_active() -> bool:
-    """Read fallback active marker (public helper)."""
+    """
+    Indicates whether a database fallback is currently active.
+
+    Returns:
+        `True` if a fallback is active, `False` otherwise.
+    """
     return _db_fallback_active

--- a/core/db_fallback.py
+++ b/core/db_fallback.py
@@ -210,7 +210,7 @@ def _attempt_db_fallback(
         fallback_exception = isinstance(db_err, OSError)
 
         if not (explicit_override or fallback_exception):
-            raise db_err  # pragma: no cover
+            raise db_err
 
         logger.warning(
             "Database initialization failed (%s env: %s), attempting fallback SQLite: %s (explicit override: %s, IO error: %s)",
@@ -238,14 +238,14 @@ def set_fallback_active() -> None:
 def clear_fallback_active() -> None:
     """Clear DB fallback active marker (public helper; avoids cross-module writes)."""
     global _db_fallback_active
-    _db_fallback_active = False  # pragma: no cover
+    _db_fallback_active = False
 
 
 def reset_fallback_state() -> None:
     """Reset fallback global state for tests."""
-    clear_fallback_active()  # pragma: no cover
+    clear_fallback_active()
 
 
 def is_fallback_active() -> bool:
     """Read fallback active marker (public helper)."""
-    return _db_fallback_active  # pragma: no cover
+    return _db_fallback_active

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -138,6 +138,19 @@ If it is not recorded here — it does not exist.
     - ✅ OpenAPI unchanged; AGENTS.md + BACKLOG_LEDGER updated
     - ✅ CI green on PR #617 → merge → post-merge sanity
 
+- [ ] PR-619 DB fallback canonical API in legacy_app (open 2026-01-29)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (maintenance)
+  - Target PR: PR #619
+  - Status: 🔄 Open
+  - Reason: Align legacy_app.py with DB fallback policy — no direct read/write of _db_fallback_active outside core/db_fallback.py; use is_fallback_active() and clear_fallback_active().
+  - Links:
+    - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/619
+  - DoD:
+    - No direct _db_fallback_active in legacy_app.py
+    - Guards + tests green; CI green
+  - Next after merge: P0 rate-limiting for LLM endpoints
+
 - [ ] P0 CRITICAL: Rate-limiting for LLM endpoints (prevent $72k/month cost attack)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (CRITICAL security)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -452,7 +452,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # Clear degraded marker if a real database is available
         import core.db_fallback as _fallback_mod
 
-        _fallback_mod._db_fallback_active = False
+        _fallback_mod.clear_fallback_active()
         os.environ.pop("DB_HEALTH_DEGRADED", None)
     except Exception as db_err:
         from core.db_fallback import _attempt_db_fallback
@@ -971,7 +971,7 @@ async def database_health(session: Session = Depends(get_session)) -> Dict[str, 
     try:
         import core.db_fallback as _fallback_mod
 
-        if _fallback_mod._db_fallback_active or os.getenv("DB_HEALTH_DEGRADED") == "1":
+        if _fallback_mod.is_fallback_active() or os.getenv("DB_HEALTH_DEGRADED") == "1":
             raise HTTPException(status_code=503, detail="Database unavailable")
 
         exec_fn = getattr(session, "execute", None)


### PR DESCRIPTION
Align `legacy_app.py` with DB fallback policy in AGENTS.md: no direct read/write of `_db_fallback_active` outside `core/db_fallback.py`.

- Replace direct module state access with canonical helpers (`is_fallback_active()`, `clear_fallback_active()`).
- Remove stale `# pragma: no cover` markers in `core/db_fallback.py` (coverage already ≥97%).
- No runtime behavior change intended; improves correctness and reduces stale-state risks.

**DoD:**
- [x] No direct read/write of `_db_fallback_active` in legacy_app.py
- [x] Guards green
- [x] Tests green (test_repo_policy_guards, test_app_db_fallback_97, test_health_db)
- [ ] CI green

**Deferred / Follow-ups:** None. Next: P0 rate-limiting for LLM endpoints (BACKLOG_LEDGER).

## Summary by Sourcery

Привести обработку резервного режима базы данных (DB fallback) в core utilities и legacy_app в соответствие с каноническим API состояния fallback и выполнить очистку устаревших pragma-директив покрытия.

Исправления ошибок:
- Направить логику проверки состояния базы данных и управления её жизненным циклом в legacy_app через публичные вспомогательные функции DB fallback вместо изменения внутреннего состояния модулей.

Улучшения:
- Удалить устаревшие маркеры `# pragma: no cover` из вспомогательных функций DB fallback, которые теперь покрыты тестами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align DB fallback handling in core utilities and legacy_app with the canonical fallback state API and cleanup of obsolete coverage pragmas.

Bug Fixes:
- Route legacy_app database health and lifespan logic through the public DB fallback helpers instead of mutating internal module state.

Enhancements:
- Remove obsolete `# pragma: no cover` markers from DB fallback helpers now covered by tests.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch legacy_app to the canonical DB fallback helpers and remove stale coverage pragmas. Aligns with the AGENTS.md policy and reduces cross‑module state risk with no behavior changes.

- **Refactors**
  - legacy_app.py: replace direct _db_fallback_active access with clear_fallback_active() and is_fallback_active().
  - core/db_fallback.py: remove outdated "pragma: no cover" markers from public helpers and related paths.

<sup>Written for commit 05397434717e0889444dd9b654f0fd63ea2a4ba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database fallback handling with improved logging when fallback conditions are detected.

* **Documentation**
  * Added backlog entry outlining planned improvements to database fallback standardization across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->