### PR TITLE
fix(tests/db): eliminate xdist sqlite race conditions (table exists + no-table errors)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -449,7 +449,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 370
       }
     ],
     "tests/disabled_hypothesis/test_life_stage_error_branches_hypothesis.py": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-30T10:33:19Z"
+  "generated_at": "2026-02-01T15:46:00Z"
 }

--- a/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
+++ b/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
@@ -1,0 +1,296 @@
+## Title
+
+PR-617 — SQLite Engine SoT / Nightly Failure Audit (Dual-engine topology & DB URL isolation)
+
+**Date:** 1 февраля 2026 года
+**Owner:** @Katsiarynakavaleuskaya (+ agent)
+
+---
+
+## Reconciliation with original handoff (два “мира”, одна проверка фактами)
+
+В исходном handoff было зафиксировано:
+
+- **Hypothesis A (dual-engine topology)**: падает `tests/test_sqlite_engine_sot.py` из-за mismatch
+  “fixture DB path” vs “app engine path” (на macOS часто выглядит как `/Users/...` vs
+  `/private/var/folders/...`).
+
+В реальном nightly run (GitHub Actions `21559415692`) мы наблюдали:
+
+- **Hypothesis B (order-dependent DB state leak)**: “no such table …” в API тестах + иногда thread-affinity.
+
+Этот audit документирует **оба** и отмечает, что подтверждено артефактами, а что пока остаётся
+гипотезой/не воспроизведено на текущем `main`.
+
+---
+
+## Scope (жёстко ограничено)
+
+- **В рамках этого PR:** DB engine URL Single Source of Truth (SoT) + тестовая изоляция/фикстуры, которые **обязательны** для зелёного nightly.
+- **Вне scope:** любые “рефакторы по пути”, новые фичи, миграции моделей/роутеров, изменения контрактов API.
+
+---
+
+## Invariants (не обсуждаем, просто соблюдаем)
+
+1. **Single Source of Truth для SQLite DB URL в тестах**
+   - `tests/conftest.py::configure_sqlite_database` — SoT, выставляет `DATABASE_URL` для worker’а.
+   - `core.db` обязан использовать этот URL (без “второго” engine/URL).
+
+2. **xdist SQLite requirements**
+   - Только **file-based** SQLite (не `:memory:`) для параллельного прогона.
+   - Пер-worker изоляция (DB path содержит worker id).
+   - `NullPool` + `check_same_thread=False` в тестах/xdist.
+
+3. **No import-time side effects в `core/`**
+   - Нельзя “фиксировать” DB URL на import-time.
+   - Любые env-dependent решения — только внутри функций (у нас это уже реализовано).
+
+---
+
+## Audit Questions (канонические) → Observations/Answers
+
+### Q1) Где создаётся engine? Есть ли import-time `engine = create_engine(...)`?
+
+**Answer:** engine создаётся **лениво** в `core/db.py` через `_get_raw_engine()` и `EngineCompat(_get_raw_engine)`.
+
+**Evidence (code):**
+- `core/db.py`:
+  - `_RAW_ENGINE: Optional[Engine] = None`
+  - `_get_raw_engine()` создаёт engine только при первом доступе и/или когда `DATABASE_URL` изменился
+  - публичный `engine = EngineCompat(_get_raw_engine)` (wrapper, но внутри — lazy)
+
+**Risk:** если какой-либо тест/модуль меняет `DATABASE_URL` и не сбрасывает состояние `core.db`, можно получить “липкий” engine (order-dependent).
+
+---
+
+### Q2) Откуда берётся DB URL в app?
+
+**Answer:** в `core/db.py` DB URL берётся из `get_database_url()` → `_build_engine_url()`:
+
+- Если `DATABASE_URL` выставлен — берём его (env-provided).
+- Иначе — дефолт `sqlite:///cache/app.db` (runtime default).
+
+**Important nuance:** в тестах `DATABASE_URL` выставляется session-scoped fixture’ой, поэтому “дефолт” не должен использоваться в тест-рантайме.
+
+---
+
+### Q3) Как тест фиксирует путь fixture DB? Через какой helper строится expected_path?
+
+**Answer:** guard-тест `tests/test_sqlite_engine_sot.py::test_sqlite_engine_url_is_single_source_of_truth`:
+- Берёт `expected_url = os.environ["DATABASE_URL"]`
+- Берёт `actual_url = str(core.db._RAW_ENGINE.url)` (или fallback на `core.db.engine`)
+- Сравнивает **filesystem path** (`Path(...).resolve()`), игнорируя query params.
+
+**Evidence (code):**
+- `tests/test_sqlite_engine_sot.py` извлекает путь через `url.replace("sqlite:///", "")` и `Path(...).resolve()`.
+
+---
+
+### Q3.1) Статус Hypothesis A (dual-engine topology) на текущем состоянии репо
+
+На текущей ветке фикса (от `main`) guard-тест проходит:
+
+Observed output:
+
+```text
+tests/test_sqlite_engine_sot.py::test_sqlite_engine_url_is_single_source_of_truth PASSED [100%]
+```
+
+**Важно:** у нас нет артефакта, который показывал бы именно тот macOS mismatch (`/Users/...` vs
+`/private/var/folders/...`) на текущем коммите. Поэтому в этом PR мы **не утверждаем**, что
+тот инцидент “исчез” навсегда; мы фиксируем, что **в nightly run `21559415692` падал другой класс проблем**
+и что текущая правка закрывает подтверждённый root cause B.
+
+---
+
+### Q4) Есть ли `get_engine()`/singleton? Как кешируется и когда сбрасывается?
+
+**Answer:** singleton реализован как `_RAW_ENGINE` (module-level cache).
+Сброс — через:
+
+- `core.db.reset_db_for_tests()` (tests-only helper) — обнуляет `_RAW_ENGINE`, `SessionLocal`, async refs.
+- В тест-фикстуре `configure_sqlite_database` есть **жёсткий reset `_RAW_ENGINE`** перед установкой `DATABASE_URL`.
+
+**Risk:** любые тесты, которые вызывают `reset_db_for_tests()` или меняют `DATABASE_URL`, должны быть герметичны (restore env/state), иначе ломают соседние тесты в том же xdist worker.
+
+---
+
+### Q5) Есть ли отдельная логика “for tests” vs “for prod” и где расхождение?
+
+**Answer:** да, частично:
+
+- В тестах SoT = `configure_sqlite_database` → `DATABASE_URL=sqlite:///<repo>/cache/test_db_<worker>.../test_app.sqlite`.
+- В runtime дефолт — `sqlite:///cache/app.db` (если env не задан).
+- Для тестов/xdist `core.db._get_sqlite_poolclass()` применяет `NullPool` и `_sqlite_connect_args()` выставляет `check_same_thread=False`.
+
+**Root issue in nightly оказалась не в dual-engine mismatch**, а в **утечке in-memory DB конфигурации** из одного unit-теста, что превращало весь worker в `sqlite:///:memory:` и приводило к “no such table” в API-тестах.
+
+---
+
+## What actually failed in Nightly (Observed)
+
+### Symptom
+
+Nightly `pytest -n auto` падал на API-тестах с отсутствующими таблицами:
+
+- `sqlite3.OperationalError: no such table: nutrition_events`
+- `sqlite3.OperationalError: no such table: users`
+
+**Evidence (CI log, GitHub Actions run `21559415692`):**
+
+Observed output (3 lines):
+
+```text
+E   sqlite3.OperationalError: no such table: nutrition_events
+FAILED tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state
+FAILED tests/test_users_api.py::test_get_user_not_found - assert 503 == 404
+```
+
+Также в том же прогоне присутствовал симптом thread-affinity:
+
+```text
+sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.
+```
+
+### Why this looks like “dual-engine topology”
+
+С точки зрения поведения это похоже на “app смотрит в другую базу без схемы”.
+Однако guard `tests/test_sqlite_engine_sot.py` по сути проверяет соответствие `DATABASE_URL` ↔ `_RAW_ENGINE.url`, и локально он был зелёный.
+
+Фактическая причина в nightly оказалась **order-dependent leak** внутри одного worker’а.
+
+---
+
+## Root cause (найдено)
+
+### Primary root cause
+
+`tests/test_core_db_coverage.py::TestCoreDB::test_init_db`:
+- делал `db.reset_db_for_tests()`
+- вызывал `db.init_db("sqlite:///:memory:")`
+- **не восстанавливал** `DATABASE_URL`/состояние `core.db` после теста
+
+В xdist это критично, потому что session-scoped фикстуры (`configure_sqlite_database`) уже не перезапускаются в рамках данного worker’а, и остальные тесты в этом worker’е продолжали работать на in-memory DB без требуемых таблиц (или с несогласованным состоянием сессий/engine).
+
+### Secondary impacts
+
+- API тесты (`tests/test_nutrition_log_api.py`, `tests/test_users_api.py`) ожидают, что схема уже создана в file-based DB, которую готовит `configure_sqlite_database`.
+- После утечки in-memory DB: таблицы `nutrition_events`/`users` отсутствовали → 503/OperationalError.
+
+---
+
+## Fix (минимальный, без расширения scope)
+
+Исправление сделано в `tests/test_core_db_coverage.py::TestCoreDB::test_init_db`:
+
+- сохраняем `original_db_url = os.environ.get("DATABASE_URL")`
+- выполняем тестовую in-memory инициализацию, как и раньше
+- в `finally`:
+  - `db.reset_db_for_tests()` (жёсткий сброс engine/sessionmaker)
+  - возвращаем `DATABASE_URL`
+  - вызываем `db.init_db()` чтобы вернуть DB в состояние, ожидаемое API-тестами/фикстурами
+
+**Цель:** гарантировать, что тест, который временно уводит DB в `:memory:`, не ломает остальные тесты в том же worker’е.
+
+---
+
+## Local verification (Observed)
+
+### Regression reproduction subset
+
+Команда:
+
+```bash
+pytest -q \
+  tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
+  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
+  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
+  tests/test_users_api.py::test_get_user_not_found
+```
+
+Observed output:
+
+```text
+....                                                                     [100%]
+```
+
+### Order-dependence check (подозреваемый → жертва и обратно)
+
+Команда (подозреваемый → жертва):
+
+```bash
+pytest -q \
+  tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
+  tests/test_nutrition_log_api.py
+```
+
+Observed output:
+
+```text
+...........                                                              [100%]
+```
+
+Команда (обратно):
+
+```bash
+pytest -q \
+  tests/test_nutrition_log_api.py \
+  tests/test_core_db_coverage.py::TestCoreDB::test_init_db
+```
+
+Observed output:
+
+```text
+...........                                                              [100%]
+```
+
+### Same subset under xdist
+
+Команда:
+
+```bash
+pytest -q -n 2 \
+  tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
+  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
+  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
+  tests/test_users_api.py::test_get_user_not_found
+```
+
+Observed output:
+
+```text
+....                                                                     [100%]
+```
+
+### Fast suite
+
+Команда:
+
+```bash
+make test-fast
+```
+
+Observed output (tail):
+
+```text
+exit_code: 0
+```
+
+---
+
+## DoD mapping (из исходного handoff)
+
+1. ✅ Nightly symptom (“no such table …”) объяснён и локально закрыт минимальным патчем.
+2. ✅ Локально зелёные ключевые репро-тесты + `make test-fast`.
+3. ✅ Import-time engine creation **не обнаружено** (engine lazy); проблема была в утечке состояния из теста.
+4. ✅ Guard на SoT (`tests/test_sqlite_engine_sot.py`) остаётся релевантным; теперь ещё и устранили order-dependent leak.
+5. ⏳ (опционально) После открытия PR обновить этот файл: заменить `PR-TBD` на реальный номер PR и добавить ссылку на CI run.
+
+---
+
+## Notes / Follow-ups (если всплывут)
+
+- Если после фикса nightly всё ещё покажет `sqlite3.ProgrammingError ... thread`:
+  - это обычно признак **какого-то прямого `create_engine("sqlite:///:memory:")` без `check_same_thread=False`** в другом тесте/коде.
+  - тогда отдельным мини-аудитом собрать callsites `create_engine(` (в repo их мало) и герметизировать конкретный тест.

--- a/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
+++ b/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
@@ -366,7 +366,7 @@ exit_code: 0
 2. ✅ Локально зелёные ключевые репро-тесты + `make test-fast`.
 3. ✅ Import-time engine creation **не обнаружено** (engine lazy); проблема была в утечке состояния из теста.
 4. ✅ Guard на SoT (`tests/test_sqlite_engine_sot.py`) остаётся релевантным; теперь ещё и устранили order-dependent leak.
-5. ⏳ (опционально) После открытия PR обновить этот файл: PR-617 (CI: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/617/checks).
+5. ⏳ (опционально) После открытия PR обновить этот файл: PR-617 (CI: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/617/checks>).
 
 ---
 

--- a/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
+++ b/docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
@@ -130,6 +130,87 @@ tests/test_sqlite_engine_sot.py::test_sqlite_engine_url_is_single_source_of_trut
 
 ## What actually failed in Nightly (Observed)
 
+### Evidence 1: Order-dependent DB state leak (GitHub Actions run 21559415692)
+
+**Symptom observed:**
+
+```text
+FAILED tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state
+sqlite3.OperationalError: no such table: nutrition_events
+
+FAILED tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint
+sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread
+```
+
+**Root cause identified:** `tests/test_core_db_coverage.py::TestCoreDB::test_init_db` вызывал `db.init_db("sqlite:///:memory:")` и не восстанавливал `DATABASE_URL` + не сбрасывал `core.db` state в teardown.
+
+**Fix (commit 1):** Добавлен `try/finally` с restore env + `reset_db_for_tests()` + `init_db()` для возврата к file-based DB.
+
+**Local verification (после fix 1):**
+
+```bash
+pytest -q tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
+  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
+  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
+  tests/test_users_api.py::test_get_user_not_found
+# Result: .... [100%] ✅
+
+pytest -q -n 2 tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
+  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
+  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
+  tests/test_users_api.py::test_get_user_not_found
+# Result: .... [100%] ✅
+```
+
+---
+
+### Evidence 2: Fixture ordering race (table already exists)
+
+**Symptom observed (user report + CI):**
+
+```text
+sqlite3.OperationalError: table nutrition_events already exists
+```
+
+Это происходило на setup (до самих тестов) в `core_db.init_db()` → `Base.metadata.create_all(bind=_RAW_ENGINE)`.
+
+**Root cause identified:**
+
+`tests/conftest.py` содержал два `autouse=True, scope="session"` fixtures без явной зависимости:
+
+1. `_init_db_for_api_suite()` — вызывает `core_db.init_db()`
+2. `configure_sqlite_database()` — выставляет per-worker `DATABASE_URL` и снова вызывает `db_module.init_db()` + redundant `Base.metadata.create_all()`
+
+**Проблема:** pytest мог запустить их в любом порядке. Если `_init_db_for_api_suite` запустилась первой:
+- `init_db()` использовал default URL (возможно shared между workers)
+- Затем `configure_sqlite_database` менял URL и снова вызывал `init_db()` + redundant `create_all()`
+- Два xdist workers могли одновременно выполнять `create_all()` на одном файле → race → "table already exists"
+
+**Fix (commit 3):**
+1. Добавлена явная зависимость: `_init_db_for_api_suite(configure_sqlite_database: Any)`
+2. Удалён redundant `Base.metadata.create_all()` из `configure_sqlite_database`
+3. Оставлена verification-only проверка (без создания таблиц)
+
+**Ensures:**
+- per-worker `DATABASE_URL` выставляется **до** любых `init_db()` вызовов
+- `init_db()` запускается ровно один раз на worker
+- Нет DDL race между workers
+
+**Local verification (после fix 2):**
+
+```bash
+pytest -q tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state
+# Result: . [100%] ✅
+
+pytest -q -n 2 tests/test_nutrition_log_api.py
+# Result: .......... [100%] ✅
+
+pytest -q -n 2 tests/test_core_db_coverage.py::TestCoreDB::test_init_db tests/test_nutrition_log_api.py
+# Result: ........... [100%] ✅
+```
+
+---
+
 ### Symptom
 
 Nightly `pytest -n auto` падал на API-тестах с отсутствующими таблицами:
@@ -285,7 +366,7 @@ exit_code: 0
 2. ✅ Локально зелёные ключевые репро-тесты + `make test-fast`.
 3. ✅ Import-time engine creation **не обнаружено** (engine lazy); проблема была в утечке состояния из теста.
 4. ✅ Guard на SoT (`tests/test_sqlite_engine_sot.py`) остаётся релевантным; теперь ещё и устранили order-dependent leak.
-5. ⏳ (опционально) После открытия PR обновить этот файл: заменить `PR-TBD` на реальный номер PR и добавить ссылку на CI run.
+5. ⏳ (опционально) После открытия PR обновить этот файл: PR-617 (CI: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/617/checks).
 
 ---
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -168,6 +168,24 @@ If it is not recorded here — it does not exist.
     - ✅ diff-coverage tests for `_get_sqlite_poolclass` branches
     - ✅ CI green; guards pass
 
+- [x] PR-627 xdist SQLite race conditions (table exists + no-table errors) — merged 2026-02-01
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (infra)
+  - Target PR: PR #627 (`fix/p1-sqlite-engine-sot`)
+  - Status: ✅ Merged
+  - Reason: Fix two independent xdist race conditions: (1) in-memory DB leak from `test_init_db` (no teardown → "no such table" in API tests), (2) fixture ordering race (duplicate `init_db()` + redundant `create_all()` → "table already exists").
+  - Links:
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/627>
+    - docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md
+    - docs/CONTEXT_HANDOFF_2026-01-30.md
+  - DoD:
+    - ✅ Fix 1: `test_init_db` + `try/finally` cleanup (restore env + `reset_db_for_tests()`)
+    - ✅ Fix 2: Explicit fixture dependency + remove redundant `create_all()`
+    - ✅ Tests green under xdist -n 2 (targeted subset + full nutrition_log suite)
+    - ✅ `make test-fast` passes (exit_code 0)
+    - ✅ SoT guard test remains green (no regression)
+    - ✅ CI green; PR merged
+
 - [ ] P0 CRITICAL: Rate-limiting for LLM endpoints (prevent $72k/month cost attack)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (CRITICAL security)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,7 @@ logger = logging.getLogger(__name__)
 # DATABASE INITIALIZATION FOR API TESTS
 # ============================================================================
 @pytest.fixture(autouse=True, scope="session")
-def _init_db_for_api_suite() -> None:
+def _init_db_for_api_suite(configure_sqlite_database: Any) -> None:
     """
     RU: Глобальная инициализация DB для API тестов (legacy expectation: SessionLocal is ready).
     EN: Initialize DB once for API tests; keeps legacy tests stable without import-time side effects.
@@ -161,6 +161,8 @@ def _init_db_for_api_suite() -> None:
 
     CRITICAL: Import core.models here to ensure models are registered with the canonical Base
     before any tests run. This prevents dual-Base issues.
+
+    CRITICAL: Depends on configure_sqlite_database to ensure per-worker DATABASE_URL is set first.
     """
     import core.db as core_db
     import core.models  # noqa: F401  # Ensure models are registered with Base
@@ -273,13 +275,14 @@ def configure_sqlite_database(request: pytest.FixtureRequest) -> Generator[Any, 
 
     db_module.init_db()
 
-    # Belt-and-suspenders: ensure all tables exist (xdist-safe; init_db may have raced)
+    # Verification: ensure all expected tables exist
+    # RU: Проверка, что init_db() создала все таблицы (без повторного create_all).
+    # EN: Verify that init_db() created all tables (without redundant create_all).
     from core.db import Base
     from sqlalchemy import inspect as sa_inspect
 
     engine = getattr(db_module, "_RAW_ENGINE", None) or getattr(db_module, "engine", None)
     if engine is not None:
-        Base.metadata.create_all(bind=engine)
         inspector = sa_inspect(engine)
         expected = set(Base.metadata.tables.keys())
         actual = set(inspector.get_table_names())

--- a/tests/test_core_db_coverage.py
+++ b/tests/test_core_db_coverage.py
@@ -114,15 +114,34 @@ class TestCoreDB:
         from core import db
         from sqlalchemy.schema import MetaData
 
+        # RU: Этот тест временно инициализирует DB в памяти и обязан восстановить
+        # окружение/глобалы, иначе он ломает API-тесты в xdist (order-dependent).
+        # EN: This test temporarily initializes an in-memory DB and must restore
+        # env/module globals, otherwise it breaks API tests under xdist.
+        original_db_url = os.environ.get("DATABASE_URL")
+
         # Ensure init_db goes through the "first init" path
         db.reset_db_for_tests()
 
-        # Patch create_all on MetaData class (Base.metadata is a MetaData instance)
-        # This is the canonical way to mock SQLAlchemy 2.x metadata methods
-        with patch.object(MetaData, "create_all") as mock_create_all:
-            db.init_db("sqlite:///:memory:")
-            # Verify create_all was called once
-            mock_create_all.assert_called_once()
+        try:
+            # Patch create_all on MetaData class (Base.metadata is a MetaData instance)
+            # This is the canonical way to mock SQLAlchemy 2.x metadata methods
+            with patch.object(MetaData, "create_all") as mock_create_all:
+                db.init_db("sqlite:///:memory:")
+                # Verify create_all was called once
+                mock_create_all.assert_called_once()
+        finally:
+            # RU: Сбросить engine/sessionmaker, чтобы не "утекла" in-memory DB конфигурация.
+            # EN: Reset engine/sessionmaker so in-memory DB config cannot leak.
+            db.reset_db_for_tests()
+
+            # RU/EN: Restore env and re-init DB using canonical DATABASE_URL from conftest.
+            if original_db_url is None:
+                os.environ.pop("DATABASE_URL", None)
+            else:
+                os.environ["DATABASE_URL"] = original_db_url
+            # Re-initialize DB for the rest of the suite (session-scoped fixtures won't rerun).
+            db.init_db()
 
     def test_init_db_with_models_import(self):
         """Test init_db imports models correctly."""


### PR DESCRIPTION
# PR-617: Eliminate xdist SQLite race conditions (table exists + no-table errors)

## Summary

Fixes two independent test isolation bugs that caused nightly CI failures under `pytest-xdist`:

1. **In-memory DB leak:** `test_init_db` temporarily initialized `sqlite:///:memory:` but failed to restore `DATABASE_URL` and reset `core.db` module state, causing "no such table" errors in subsequent tests.

2. **Fixture ordering race:** Two session-scoped fixtures could execute in wrong order, causing duplicate `init_db()` calls and DDL race condition between xdist workers → "table already exists" errors.

**Scope:** tests/docs only (no runtime changes)

---

## Two Independent Failures

### Failure 1: In-memory DB leak (order-dependent state)

**Root cause:**  
`tests/test_core_db_coverage.py::TestCoreDB::test_init_db` called `db.init_db("sqlite:///:memory:")` but did not restore original `DATABASE_URL` or reset `core.db` singletons (`_RAW_ENGINE`, `SessionLocal`) in teardown.

**Symptom (CI logs):**
```
sqlite3.OperationalError: no such table: nutrition_events
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread
```

**Fix:**  
Wrap test in `try/finally` to ensure cleanup:
- Save original `DATABASE_URL` before test
- In `finally`: restore env, call `reset_db_for_tests()`, re-init DB with file-based URL

**Commit:** `1a4aaebd` — `test(db): restore DATABASE_URL and reset core.db after init_db coverage test`

---

### Failure 2: Fixture ordering race (DDL conflict)

**Root cause:**  
Two session-scoped `autouse=True` fixtures had no explicit dependency:
- `_init_db_for_api_suite()` — calls `core_db.init_db()`
- `configure_sqlite_database()` — sets per-worker `DATABASE_URL`, calls `db_module.init_db()`, and **redundant** `Base.metadata.create_all()`

pytest could execute them in any order. If `_init_db_for_api_suite` ran first:
1. `init_db()` used default URL (possibly shared between workers)
2. `configure_sqlite_database` changed URL and called `init_db()` again
3. Redundant `create_all()` caused DDL race between xdist workers

**Symptom (CI + local):**
```
sqlite3.OperationalError: table nutrition_events already exists
```

**Fix:**
1. Add explicit dependency: `_init_db_for_api_suite(configure_sqlite_database: Any)`
2. Remove redundant `Base.metadata.create_all()` from `configure_sqlite_database`
3. Keep verification-only check (no table creation)

**Ensures:**
- per-worker `DATABASE_URL` is set **before** any `init_db()` calls
- `init_db()` runs exactly once per worker
- No DDL race between workers

**Commit:** `5bd8c619` — `test(db): fix fixture ordering race in xdist (table already exists)`

---

## Evidence

### CI logs (GitHub Actions run 21559415692)

**Observed failures:**
```
FAILED tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state
sqlite3.OperationalError: no such table: nutrition_events

FAILED tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint
sqlite3.ProgrammingError: SQLite objects created in a thread...
```

### Local verification (after fixes)

**Targeted subset (sequential):**
```bash
pytest -q tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
  tests/test_users_api.py::test_get_user_not_found
# Result: .... [100%] ✅
```

**Under xdist -n 2:**
```bash
pytest -q -n 2 tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
  tests/test_users_api.py::test_get_user_not_found
# Result: .... [100%] ✅
```

**Full nutrition_log suite under xdist:**
```bash
pytest -q -n 2 tests/test_nutrition_log_api.py
# Result: .......... [100%] ✅
```

**SoT guard test (no regression):**
```bash
pytest -q tests/test_sqlite_engine_sot.py -vv
# Result: 1 passed, 1 skipped ✅
```

**Full fast suite:**
```bash
make test-fast
# Result: exit_code 0 ✅
```

---

## Risk

**Low.** Changes are isolated to test infrastructure (`tests/conftest.py` + `tests/test_core_db_coverage.py`).

**No runtime changes:** Only test fixtures and one test's teardown logic modified.

**Root cause elimination:** Fixes ordering bug and redundant DDL, not symptoms.

---

## Testing

### Pre-push checklist

- [x] Targeted subset passes (sequential)
- [x] Targeted subset passes under `pytest-xdist -n 2`
- [x] Full nutrition_log suite passes under xdist
- [x] `test_sqlite_engine_sot.py` passes (SoT guard)
- [x] `make test-fast` passes (full suite)
- [x] Pre-commit hooks pass (formatting, lint, local tests)

### Commands run

```bash
pytest -q tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
  tests/test_users_api.py::test_get_user_not_found

pytest -q -n 2 tests/test_core_db_coverage.py::TestCoreDB::test_init_db \
  tests/test_nutrition_log_api.py::TestNutritionLogAPI::test_meal_log_updates_adherence_state \
  tests/test_simple_coverage_boost.py::TestSimpleCoverageBoost::test_users_endpoint \
  tests/test_users_api.py::test_get_user_not_found

pytest -q -n 2 tests/test_nutrition_log_api.py

pytest -q tests/test_sqlite_engine_sot.py -vv

make test-fast
```

---

## Definition of Done

- [x] **Failure 1 (in-memory leak):** Explained and fixed (`test_init_db` + `finally` cleanup)
- [x] **Failure 2 (fixture race):** Explained and fixed (explicit dependency + remove redundant `create_all`)
- [x] Locally green: targeted tests + xdist + full suite
- [x] `tests/test_sqlite_engine_sot.py` remains green (no SoT guard regression)
- [x] Only tests/docs changed (no runtime changes)
- [x] Audit document created: `docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md`
- [x] `.secrets.baseline` updated by pre-commit (line number shift only, no secrets added)
- [ ] Post-merge: update `docs/roadmap/BACKLOG_LEDGER.md` (mark PR-617 done)
- [ ] Post-merge: (optional) update `tests/AGENTS.md` with DB isolation rule

---

## Security Notes

- No runtime changes; test-only isolation fix
- `.secrets.baseline` updated by pre-commit hook (line number shift from `conftest.py` changes)
- No secrets added or modified

---

## Marketing & GTM

Stabilizes nightly/xdist to reduce flaky CI and unblock feature throughput.

---

## AGENTS.md / BACKLOG_LEDGER.md update

### Proposed AGENTS.md rule (post-merge or separate PR)

**DB Tests / xdist isolation:**

- Session autouse fixtures that initialize DB **must depend on** the fixture that sets `DATABASE_URL` (explicit dependency).
- Do not call `Base.metadata.create_all()` in tests if `init_db()` already owns schema creation.
- Tests that temporarily call `init_db("sqlite:///:memory:")` must restore env + reset db in `finally`.

### BACKLOG_LEDGER.md (post-merge)

Will be updated to mark PR-617 as done.

---

## Related

- **Audit document:** `docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md`
- **GitHub Actions run:** 21559415692 (nightly full tests)
- **Invariants:** `tests/AGENTS.md` (SQLite in tests hard rules)
- **Original handoff:** `docs/CONTEXT_HANDOFF_2026-01-30.md`

---

## Commits

1. `c797cd24` — `docs(audit): PR-617 sqlite db isolation nightly audit`
2. `1a4aaebd` — `test(db): restore DATABASE_URL and reset core.db after init_db coverage test`
3. `5bd8c619` — `test(db): fix fixture ordering race in xdist (table already exists)`
4. `e7b0811a` — `docs(audit): update PR-617 with fixture ordering race findings`

---

## Post-merge checklist

- [ ] `git checkout main && git pull`
- [ ] Re-run targeted subset (sanity check)
- [ ] Delete branch (local + remote)
- [ ] Update `docs/roadmap/BACKLOG_LEDGER.md` (mark PR-617 done)
- [ ] (Optional) Update `tests/AGENTS.md` with DB isolation rule
- [ ] Delete `PR_617_DESCRIPTION.md` (local working file)

---

## Notes

**Key insight:** Two independent bugs, both manifested as "no such table" / "table already exists" in nightly. Both required fixes, both eliminated in this PR via **root cause elimination** (not symptom masking).

**Reconciliation:** Original handoff mentioned "dual-engine topology" hypothesis. Actual nightly failures were order-dependent leak + fixture race. Audit document explicitly reconciles both hypotheses with evidence.

## Summary by Sourcery

Исправление инициализации тестовой базы данных и порядка фикстур для устранения гонок SQLite при использовании pytest-xdist.

Bug Fixes:
- Гарантировать, что тест покрытия инициализации базы данных в памяти восстанавливает `DATABASE_URL` и состояние `core.db`, чтобы последующие тесты использовали корректную файловую базу SQLite.
- Сделать фикстуру инициализации API DB с областью `session` зависимой от фикстуры конфигурации SQLite и убрать избыточное создание схемы, чтобы предотвратить гонки «таблица уже существует» между воркерами xdist.

Documentation:
- Добавить аудит-документ, описывающий предположения о едином источнике правды для движка SQLite, ночные сбои и анализ корневой причины проблем, связанных с xdist.

Tests:
- Ужесточить тесты и фикстуры, связанные с БД, обеспечив безопасность при xdist за счёт корректного teardown и явных зависимостей фикстур для инициализации базы данных.

Chores:
- Обновить baseline секретов, чтобы отразить смещение строк после изменений в тестах и документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix test database initialization and fixture ordering to eliminate SQLite race conditions under pytest-xdist.

Bug Fixes:
- Ensure the in-memory database initialization coverage test restores DATABASE_URL and core.db state so subsequent tests use the correct file-based SQLite database.
- Make the session-scoped API DB init fixture depend on the SQLite configuration fixture and remove redundant schema creation to avoid table-exists race conditions across xdist workers.

Documentation:
- Add an audit document detailing the SQLite engine single-source-of-truth assumptions, the nightly failures, and the root-cause analysis of the xdist-related issues.

Tests:
- Tighten DB-related tests and fixtures to be xdist-safe by enforcing proper teardown and explicit fixture dependencies for database initialization.

Chores:
- Update the secrets baseline to reflect line shifts from test and documentation changes.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky SQLite tests under pytest-xdist by eliminating “table already exists” and “no such table” errors. Test-only changes to fixture ordering and cleanup stabilize nightly CI.

- **Bug Fixes**
  - Stop in-memory DB leak in test_init_db: restore DATABASE_URL, reset core.db state, and re-init file-based DB in a finally block.
  - Enforce fixture order: _init_db_for_api_suite now depends on configure_sqlite_database so per-worker DATABASE_URL is set before any init_db call.
  - Remove redundant Base.metadata.create_all() from configure_sqlite_database; keep a verification-only table check to avoid DDL races.

<sup>Written for commit 3581845c4ec76306f9b2c47a9b00864f7da78ef3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved SQLite test-suite race conditions and cross-test database leakage in parallel runs, improving test reliability.

* **Documentation**
  * Added a comprehensive audit documenting the issue, diagnosis, fixes, verification, and follow-ups.
  * Updated the backlog ledger to reflect the merged infrastructure improvement.

* **Chores**
  * Updated baseline metadata timestamps and references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->