### PR TITLE
docs(pr-630): architecture evidence pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1447,6 +1447,12 @@ There must be a **single source of truth** for each class of instruction.
    - Operational/debug procedures → `RUNBOOK_AGENT.md`
    - Do not overload AGENTS with runbook-level detail.
 
+7) **Architecture docs must be evidence-driven**
+   - Any architecture doc that claims a “truth” (entrypoint, compat shim, schema-only mode, guard enforcement) MUST cite evidence as `file:line` pointers.
+   - Any temporary seam (e.g. schema-only OpenAPI, sys.modules compat mapping, whitelists) MUST have:
+     - an ADR with explicit **exit criteria**, and
+     - a Backlog Ledger item with DoD / blockers.
+
 ### Non-goals
 
 - AGENTS files are NOT changelogs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,12 @@ Source of truth:
 - Routers that import SQLAlchemy models (e.g., `premium_week`, `pro`) are skipped in this mode.
 - This ensures schema generation does not load DB layer and prevents double-loading errors.
 
+**Schema-only contract (single source of truth):**
+See `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract` (do not duplicate env/flag lists elsewhere).
+
+**Checklist:**
+- [ ] If you change schema-only OpenAPI behavior (env/flags/router exclusions), update ADR-002 contract section above.
+
 ### Determinism requirement
 
 - Determinism is enforced by `pytest tests/test_openapi_determinism.py`.

--- a/docs/architecture/ADR-001-nh3-runtime-import.md
+++ b/docs/architecture/ADR-001-nh3-runtime-import.md
@@ -72,6 +72,21 @@ def _require_nh3() -> _NH3Protocol:
 - Slightly less conventional than top-level imports
 - Error raised at call-time, not import-time (acceptable for optional dependencies)
 
+## Exit criteria (when this ADR can be retired)
+
+This runtime-import pattern is intended to remain until one of the following becomes true:
+
+- **nh3 becomes a mandatory dependency** for all supported deployments (no “optional” mode).
+  Then we can reconsider moving to normal module-level import, provided it stays deterministic in CI/xdist.
+- **The sanitization feature is removed or replaced** with a non-`nh3` implementation that is import-safe.
+
+Until then, prefer **runtime import without module-level caching** for this optional dependency.
+
+## Follow-ups
+
+- If API semantics need improvement, follow the existing TODO:
+  - Convert runtime `RuntimeError` mapping to a clearer HTTP status (e.g., 424/503) with structured JSON error response.
+
 ## Implementation
 
 **Location:** `core/data_sanitizer.py`

--- a/docs/architecture/ADR-002-openapi-schema-only-mode.md
+++ b/docs/architecture/ADR-002-openapi-schema-only-mode.md
@@ -4,6 +4,11 @@
 **Date:** 2026-02-02
 **Context:** OpenAPI determinism and thin-client contract velocity.
 
+## Anchors (stable)
+
+- [Schema-only OpenAPI contract](#schema-only-openapi-contract)
+- [Exit criteria](#exit-criteria)
+
 ## Decision
 
 Keep a **temporary schema-only mode** for OpenAPI generation to avoid import-time ORM/model double-loading, while explicitly documenting:
@@ -26,6 +31,42 @@ OpenAPI generation must be deterministic (CI enforces this). Importing the full 
 - CI determinism gate:
   - `tests/test_openapi_determinism.py:16-64`
 
+<a id="schema-only-openapi-contract"></a>
+## Schema-only OpenAPI contract (single source of truth)
+
+This section is the **canonical documentation** for schema-only OpenAPI generation behavior.
+Other docs should **link here** instead of duplicating env/flag lists.
+
+**Activation (must all be true):**
+
+- `PULSEPLATE_OPENAPI=1`
+- `APP_ENV=test`
+- `ENVIRONMENT=test`
+
+**Generator invariants (must happen before importing `app.main:app`):**
+
+- `PULSEPLATE_OPENAPI` **must be set before** importing `app.main:app` to prevent import-time ORM
+  double-loading ("Table already defined").
+- The generator pins env to a safe non-prod context:
+  - `APP_ENV=test`
+  - `ENVIRONMENT=test`
+  - `ENABLE_TEST_ROUTES=1` (set by generator; not part of schema-only activation check)
+
+**Forced feature flags (temporary, schema-only only):**
+
+The generator forces these to disable routers that import SQLAlchemy models at module import time:
+
+- `FEATURE_PREMIUM_WEEK_ENABLED=false`
+- `FEATURE_BMI_PRO_ENABLED=false`
+- `BUSINESS_MODULE_ENABLED=false`
+
+**Implementation notes:**
+
+- Activation/guard is enforced in `app/routers/pro_registration.py:_is_openapi_schema_only_mode()`; it will
+  **not** activate in production unless all activation env vars are simultaneously mis-set.
+- Source of truth for env/flag values is `scripts/generate_openapi.py` (sets env + flags, then imports
+  `app.main:app`).
+
 ## Consequences
 
 **Positive**
@@ -38,6 +79,7 @@ OpenAPI generation must be deterministic (CI enforces this). Importing the full 
 
 ## Exit criteria (remove schema-only mode)
 
+<a id="exit-criteria"></a>
 Schema-only mode can be removed when all are true:
 
 1) Routers imported by `app.main:app` do **not** import SQLAlchemy models at module import time.

--- a/docs/architecture/ADR-002-openapi-schema-only-mode.md
+++ b/docs/architecture/ADR-002-openapi-schema-only-mode.md
@@ -1,0 +1,50 @@
+# ADR-002: OpenAPI Schema-only Mode (Temporary) + Exit Criteria
+
+**Status:** Proposed (PR-630 evidence pack)
+**Date:** 2026-02-02
+**Context:** OpenAPI determinism and thin-client contract velocity.
+
+## Decision
+
+Keep a **temporary schema-only mode** for OpenAPI generation to avoid import-time ORM/model double-loading, while explicitly documenting:
+- what is disabled,
+- why it is disabled (technical root cause),
+- and the **exit criteria** to remove schema-only mode.
+
+## Context / Problem
+
+OpenAPI generation must be deterministic (CI enforces this). Importing the full FastAPI app during schema generation can trigger SQLAlchemy model imports and double-load side effects (“Table already defined”), especially when routers import ORM models at module level.
+
+## Evidence (current implementation)
+
+- Generator sets schema-only mode + disables some routers:
+  - `scripts/generate_openapi.py:94-113`
+- Schema-only is honored only in generation/test context (must not accidentally activate in prod):
+  - `app/routers/pro_registration.py:26-36`
+- PRO route registration avoids importing routers in schema-only mode:
+  - `app/routers/pro_registration.py:76-105`
+- CI determinism gate:
+  - `tests/test_openapi_determinism.py:16-64`
+
+## Consequences
+
+**Positive**
+- Deterministic OpenAPI generation stays reliable (CI stays meaningful).
+- Avoids import-time ORM hazards during schema generation.
+
+**Negative**
+- Contract velocity suffers: schema excludes PRO/premium/business routes in schema-only mode (by forced flags).
+- Increased risk of “silent drift” for excluded endpoints.
+
+## Exit criteria (remove schema-only mode)
+
+Schema-only mode can be removed when all are true:
+
+1) Routers imported by `app.main:app` do **not** import SQLAlchemy models at module import time.
+2) `make openapi` succeeds without forcing `FEATURE_*_ENABLED=false` in the generator.
+3) `tests/test_openapi_determinism.py` remains green.
+
+## Follow-ups (Backlog)
+
+- Restore full OpenAPI schema (remove schema-only mode): `docs/roadmap/BACKLOG_LEDGER.md`
+- Eliminate import-time ORM/model imports in routers included in OpenAPI generation: `docs/roadmap/BACKLOG_LEDGER.md`

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -3,6 +3,18 @@
 **Goal:** map which routers/endpoints are registered, where, and under which guards/feature flags.
 This is a **runtime truth** view (not a product wishlist).
 
+## Anchors (stable)
+
+- [Canonical entrypoint chain](#canonical-entrypoint-chain)
+- [Router registration](#router-registration-always-on-vs-conditional)
+- [OpenAPI generation behavior](#openapi-generation-behavior-important)
+
+## Evidence format (recommended)
+
+- **Anchor (stable):** a human-readable identifier that remains true when line numbers move
+  (route path, function name, section title).
+- **Evidence (file:line):** supporting pointer to the current implementation.
+
 ## Canonical entrypoint chain
 
 - Runtime entrypoint: `uvicorn app.main:app` (`Dockerfile:102-105`)
@@ -12,6 +24,8 @@ This is a **runtime truth** view (not a product wishlist).
 ## Router registration: always-on vs conditional
 
 ### Always-on routers (registered unconditionally)
+
+Anchor (stable): `legacy_app.py -> include_router(...) for core API routers`
 
 Evidence: `legacy_app.py:811-820`
 
@@ -25,6 +39,8 @@ Evidence: `legacy_app.py:811-820`
 
 ### VIP routes (feature-flag gated, centralized)
 
+Anchor (stable): `legacy_app.py -> register_vip_routes(app)` and `vip_registration.register_vip_routes()`
+
 Evidence:
 - `legacy_app.py:822-825` — calls VIP registration if available
 - `app/routers/vip_registration.py:23-58` — central function + `is_vip_module_enabled()` gate
@@ -33,6 +49,8 @@ Runtime effect:
 - When VIP module is enabled, `vip_registration.register_vip_routes()` includes `app/routers/vip.py` with `api_key_header` dependency.
 
 ### PRO routes (centralized; schema-only OpenAPI can short-circuit)
+
+Anchor (stable): `legacy_app.py -> register_pro_routes(app)` and schema-only short-circuit in `pro_registration`
 
 Evidence:
 - `legacy_app.py:826-828` — `pro_router, premium_week_router = _register_pro_routes(app)`
@@ -45,6 +63,8 @@ Runtime effect:
 
 ### Bayesian adherence + nutrition log (import-soft)
 
+Anchor (stable): `legacy_app.py -> try/except ImportError then include_router(...)`
+
 Evidence: `legacy_app.py:829-843`
 
 - Included if import succeeds:
@@ -53,12 +73,16 @@ Evidence: `legacy_app.py:829-843`
 
 ### Shopping list generators (always included; tier handled inside)
 
+Anchor (stable): `legacy_app.py -> include_router(shopping_list_pro_router, shoplist_day_router)`
+
 Evidence: `legacy_app.py:845-849`
 
 - `app/routers/shopping_list_pro.py`
 - `app/routers/shoplist_day.py` (iOS MVP path)
 
 ### Insight endpoints (LLM) + providers wiring (legacy_app → llm → providers)
+
+Anchor (stable): `legacy_app.py -> POST /api/v1/insight` and `POST /insight` call `llm.get_provider() -> provider.generate()`
 
 Evidence:
 - `legacy_app.py:2168-2187` — HTTP endpoints `/api/v1/insight` and `/insight`
@@ -67,12 +91,16 @@ Evidence:
 
 ### Exports rate limiting (route wrappers)
 
+Anchor (stable): `legacy_app.py -> export routes wrapped with limit_if_available(RATE_LIMIT_EXPORTS)`
+
 Evidence:
 - `legacy_app.py:5180-5223` — export endpoints decorated with:
   - `responses=RATE_LIMIT_429_RESPONSES`
   - `@limit_if_available(RATE_LIMIT_EXPORTS)`
 
 ### Conditional routers: Bodyfat / BMI Pro / Business
+
+Anchor (stable): `legacy_app.py -> feature-flag gated routers (BMI Pro, Business) + optional bodyfat`
 
 Evidence: `legacy_app.py:5226-5248`
 
@@ -84,19 +112,26 @@ Evidence: `legacy_app.py:5226-5248`
 
 ### Test router (non-production env)
 
+Anchor (stable): `legacy_app.py -> include test router only in non-prod env`
+
 Evidence: `legacy_app.py:890-902`
 
 - Included only in local/dev/test (or staging with explicit `ENABLE_TEST_ROUTES=1`)
 
 ## OpenAPI generation behavior (important)
 
-- Generator sets schema-only mode and disables selected feature flags:
-  - `scripts/generate_openapi.py:94-113`
+**Schema-only OpenAPI contract (single source of truth):**
+See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract`
+
+**Evidence (implementation):**
+
+- Generator sets schema-only mode and pins env/feature flags:
+  - `scripts/generate_openapi.py:94-135`
 - PRO router registration honors schema-only mode to prevent ORM import hazards:
   - `app/routers/pro_registration.py:26-36` and `76-105`
 
 ## Maintenance rule
 
-If you add/remove a router or change a feature flag / tier gate:
-- Update this doc in the same PR.
-- If it changes OpenAPI output, regenerate and commit `frontend/src/api/openapi.json` + `schema.ts` (in the runtime PR that changes behavior).
+Checklist (lightweight):
+- [ ] If you add/remove a router or change a feature flag / tier gate: update this doc **or** state “no routing-doc update needed” in the PR description.
+- [ ] If you change OpenAPI output: regenerate and commit `frontend/src/api/openapi.json` + `schema.ts` (in the runtime PR that changes behavior).

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -1,0 +1,102 @@
+# Backend Routing Map (evidence-driven)
+
+**Goal:** map which routers/endpoints are registered, where, and under which guards/feature flags.
+This is a **runtime truth** view (not a product wishlist).
+
+## Canonical entrypoint chain
+
+- Runtime entrypoint: `uvicorn app.main:app` (`Dockerfile:102-105`)
+- `app/main.py` uses `legacy_app.app` as the FastAPI instance and applies bootstrap (`app/main.py:11-22`).
+- Most route registration currently happens in `legacy_app.py`.
+
+## Router registration: always-on vs conditional
+
+### Always-on routers (registered unconditionally)
+
+Evidence: `legacy_app.py:811-820`
+
+- `foods_router` (`app/routers/foods.py`)
+- `recipes_router` (`app/routers/recipes.py`)
+- `users_router` (`app/routers/users.py`)
+- `catalog_router` (`app/routers/catalog.py`)
+- `export_router` (`app/routers/shoplist_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
+- `plan_router` (`app/routers/plan_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
+- `shoplist_router` (`app/routers/shoplist_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
+
+### VIP routes (feature-flag gated, centralized)
+
+Evidence:
+- `legacy_app.py:822-825` — calls VIP registration if available
+- `app/routers/vip_registration.py:23-58` — central function + `is_vip_module_enabled()` gate
+
+Runtime effect:
+- When VIP module is enabled, `vip_registration.register_vip_routes()` includes `app/routers/vip.py` with `api_key_header` dependency.
+
+### PRO routes (centralized; schema-only OpenAPI can short-circuit)
+
+Evidence:
+- `legacy_app.py:826-828` — `pro_router, premium_week_router = _register_pro_routes(app)`
+- `app/routers/pro_registration.py:26-36` — schema-only guard conditions
+- `app/routers/pro_registration.py:76-105` — avoids importing PRO/premium routers in schema-only mode
+
+Runtime effect:
+- In normal runtime: includes `app/routers/pro.py`.
+- `premium_week` is included only when enabled (`FEATURE_PREMIUM_WEEK_ENABLED` or VIP module enabled).
+
+### Bayesian adherence + nutrition log (import-soft)
+
+Evidence: `legacy_app.py:829-843`
+
+- Included if import succeeds:
+  - `app/routers/bayes_adherence.py`
+  - `app/routers/nutrition_log.py`
+
+### Shopping list generators (always included; tier handled inside)
+
+Evidence: `legacy_app.py:845-849`
+
+- `app/routers/shopping_list_pro.py`
+- `app/routers/shoplist_day.py` (iOS MVP path)
+
+### Insight endpoints (LLM) + providers wiring (legacy_app → llm → providers)
+
+Evidence:
+- `legacy_app.py:2168-2187` — HTTP endpoints `/api/v1/insight` and `/insight`
+- `legacy_app.py:2066-2076` + `2098-2117` — lazy `llm.get_provider()` + `provider.generate()`
+- `llm.py:57-79` + `91-153` — provider selection (`LLM_PROVIDER`) + optional provider imports
+
+### Exports rate limiting (route wrappers)
+
+Evidence:
+- `legacy_app.py:5180-5223` — export endpoints decorated with:
+  - `responses=RATE_LIMIT_429_RESPONSES`
+  - `@limit_if_available(RATE_LIMIT_EXPORTS)`
+
+### Conditional routers: Bodyfat / BMI Pro / Business
+
+Evidence: `legacy_app.py:5226-5248`
+
+- Bodyfat: included if router factory is available (`get_bodyfat_router`)
+- BMI Pro: included only if `FEATURE_BMI_PRO_ENABLED` is truthy
+  - canonical: `/api/v1/pro/bmi`
+  - legacy alias: `/api/v1/bmi/pro`
+- Business: included only if `BUSINESS_MODULE_ENABLED` is truthy
+
+### Test router (non-production env)
+
+Evidence: `legacy_app.py:890-902`
+
+- Included only in local/dev/test (or staging with explicit `ENABLE_TEST_ROUTES=1`)
+
+## OpenAPI generation behavior (important)
+
+- Generator sets schema-only mode and disables selected feature flags:
+  - `scripts/generate_openapi.py:94-113`
+- PRO router registration honors schema-only mode to prevent ORM import hazards:
+  - `app/routers/pro_registration.py:26-36` and `76-105`
+
+## Maintenance rule
+
+If you add/remove a router or change a feature flag / tier gate:
+- Update this doc in the same PR.
+- If it changes OpenAPI output, regenerate and commit `frontend/src/api/openapi.json` + `schema.ts` (in the runtime PR that changes behavior).

--- a/docs/architecture/providers_implementation.md
+++ b/docs/architecture/providers_implementation.md
@@ -1,7 +1,7 @@
 # Providers Implementation — Detailed Analysis
 
 **Date:** 2026-01-12
-**Purpose:** Document how `providers/` is implemented and why it's not connected to runtime
+**Purpose:** Document how `providers/` is implemented and how it is wired into runtime (via `llm.py` + `legacy_app.py` insight endpoints).
 
 ---
 
@@ -182,44 +182,30 @@ def get_provider():
 
 ---
 
-## ❌ Current Runtime Usage: NONE (Confirmed)
+## ✅ Current Runtime Usage: WIRED (via `legacy_app.py` insight endpoints)
 
-### Evidence: Providers Not Connected to Runtime
+### Evidence: Providers are used via `legacy_app.py → llm.py → providers/*`
 
-**1. No imports in app routers:**
-```bash
-rg "from providers|import providers|providers\." app/routers/
-# Result: empty (no matches)
-```
+**1. Insight endpoints live in `legacy_app.py` (not in `app/routers/`)**
 
-**2. No imports in app services:**
-```bash
-rg "from providers|import providers|providers\." app/services/
-# Result: empty (no matches)
-```
+- Evidence:
+  - `legacy_app.py:2168-2187` defines HTTP routes:
+    - `POST /api/v1/insight` (API key gated)
+    - `POST /insight` (legacy path)
 
-**3. Only usage: `llm.py` (root level)**
-- `llm.py` imports providers (lines 59, 67, 74)
-- But `llm.py` itself is **not imported** by app routers/services
-- `llm.py` is standalone script/module
+**2. `legacy_app.py` loads `llm.get_provider` lazily and calls `provider.generate()`**
 
-**4. `/insight` endpoint exists in OpenAPI but not in app routers:**
-- OpenAPI schema shows `/api/v1/insight` endpoint (in `app/static/openapi.json`)
-- But no router handler found in `app/routers/` for `/insight`
-- Likely: endpoint exists in `legacy_app.py` but not actively used
+- Evidence:
+  - `legacy_app.py:2066-2076` — `_load_llm_get_provider()` imports `llm.get_provider`
+  - `legacy_app.py:2098-2117` — `provider = get_provider()` and `await provider.generate(prompt_text)`
 
-**5. Verification commands:**
-```bash
-# Check providers imports (excluding tests)
-rg -n "from\s+providers|import\s+providers|providers\." . --type py | grep -v "test_" | grep -v "providers/__init__"
-# Result: only llm.py and providers/ollama.py (self-import)
+**3. `llm.py` imports `providers/*` and selects provider by env var**
 
-# Check llm.py usage in app
-rg "from llm|import llm|llm\.get_provider" app/
-# Result: empty
-```
+- Evidence:
+  - `llm.py:57-79` — optional imports of `providers.grok`, `providers.ollama`, `providers.pico`
+  - `llm.py:91-153` — `get_provider()` selects provider based on `LLM_PROVIDER`
 
-**Conclusion:** `providers/` exists but is **not wired into runtime** (no FastAPI endpoints in `app/routers/` use it).
+**Conclusion:** `providers/` is wired into runtime through the insight endpoints in `legacy_app.py`, with `llm.get_provider()` acting as the factory/adapter layer.
 
 ---
 
@@ -243,12 +229,12 @@ rg "from llm|import llm|llm\.get_provider" app/
 - ✅ Factory function (`llm.py`)
 - ✅ Tests (unit tests for each provider)
 
-**Not implemented:**
-- ❌ FastAPI endpoints using providers
-- ❌ Integration with app routers
-- ❌ Runtime usage in production
+**Runtime wiring (current):**
+- ✅ Insight endpoints in `legacy_app.py` call `llm.get_provider()` and then `provider.generate()`
 
-**Status:** Providers are "warehouse" (implemented but not connected).
+**Historical note (superseded):**
+- Earlier versions of this doc claimed providers were “not wired into runtime” because `app/routers/` did not import them.
+  That was incomplete: the wiring lives in `legacy_app.py` (root module), not in `app/routers/`.
 
 ---
 
@@ -274,15 +260,13 @@ rg "from llm|import llm|llm\.get_provider" app/
 - `docs/finetune/README.md` — mentions providers
 - `docs/archive/2025-09-16/` — historical docs
 
-### Where Providers Are NOT Used
+### Where Providers Are NOT Used (directly)
 
-**1. App routers:**
-- No `/api/v1/*/insight` endpoint
-- No LLM features in FastAPI
+**1. `app/routers/` (directly):**
+- No direct imports of `providers/*` (LLM wiring for insight currently lives in `legacy_app.py`)
 
-**2. App services:**
-- No service uses `llm.get_provider()`
-- No LLM integration in business logic
+**2. `app/services/` (directly):**
+- No direct `providers/*` usage (LLM integration is routed through `llm.py` and called from `legacy_app.py`)
 
 **3. Core domain:**
 - No LLM calls in `core/` modules
@@ -318,42 +302,26 @@ rg "from llm|import llm|llm\.get_provider" app/
 
 ---
 
-## ✅ Verification: Providers Not Connected
+## ✅ Verification: Providers wired into runtime
 
-### Commands to Verify
+Evidence pointers (runtime truth):
 
-```bash
-# 1. Check imports in app routers
-rg "from providers|import providers|providers\." app/routers/
-# Expected: empty
-
-# 2. Check imports in app services
-rg "from providers|import providers|providers\." app/services/
-# Expected: empty
-
-# 3. Check llm.py usage in app
-rg "from llm|import llm|llm\.get_provider" app/
-# Expected: empty
-
-# 4. Check LLM endpoints
-rg "/insight|/llm|/ai" app/routers/
-# Expected: empty (or not found)
-```
-
-**Result:** Providers exist but are **not connected to runtime**.
+- `legacy_app.py:2168-2187` — insight HTTP endpoints exist (`/api/v1/insight`, `/insight`)
+- `legacy_app.py:2066-2076` — lazy loader imports `llm.get_provider`
+- `legacy_app.py:2098-2117` — calls `provider.generate(...)`
+- `llm.py:57-79` + `91-153` — imports/selects `providers/*` via `LLM_PROVIDER`
 
 ---
 
-## 📝 Implications for PR-521
+## 📝 Implications for OpenAPI stability
 
 ### OpenAPI Stability
 
-**Fact:** `providers/` exists but is not wired into runtime.
+**Fact:** `providers/` is wired into runtime via insight endpoints (legacy_app → llm → providers).
 
 **Implication for OpenAPI:**
-- Providers are **not** OpenAPI consumers (they don't generate SDKs from OpenAPI)
-- Providers are **not** wired into runtime (no FastAPI endpoints use them)
-- **Therefore:** Providers do **not** affect OpenAPI stability policy
+- Providers are not OpenAPI consumers themselves, but they are part of runtime behavior via insight endpoints.
+- OpenAPI stability policy still primarily serves thin clients (web types from OpenAPI) and unknown external consumers.
 
 **OpenAPI Stability Rationale (separate from providers):**
 - Web frontend generates types from OpenAPI (`openapi.json` → `schema.ts`)
@@ -374,7 +342,7 @@ rg "/insight|/llm|/ai" app/routers/
 
 **Current status:**
 - ✅ Implemented (code exists)
-- ❌ Not connected to runtime (no FastAPI endpoints use them)
+- ✅ Wired into runtime via `legacy_app.py` insight endpoints and `llm.get_provider()`
 - ✅ Tested (unit tests exist)
 
 **Why they exist:**
@@ -389,5 +357,5 @@ rg "/insight|/llm|/ai" app/routers/
 
 ---
 
-**Last updated:** 2026-01-12
-**Status:** Providers exist but not connected to runtime
+**Last updated:** 2026-02-02
+**Status:** Providers exist and are wired into runtime via insight endpoints

--- a/docs/architecture/providers_implementation.md
+++ b/docs/architecture/providers_implementation.md
@@ -1,6 +1,6 @@
 # Providers Implementation — Detailed Analysis
 
-**Date:** 2026-01-12
+**Originally drafted:** 2026-01-12
 **Purpose:** Document how `providers/` is implemented and how it is wired into runtime (via `llm.py` + `legacy_app.py` insight endpoints).
 
 ---
@@ -262,6 +262,10 @@ def get_provider():
 
 ### Where Providers Are NOT Used (directly)
 
+**Verified via (reproducible check):**
+- Run: `rg -n --type=py 'providers\.' app/routers app/services`
+- Expected outcome: **no matches** (no direct `providers.*` imports in those directories).
+
 **1. `app/routers/` (directly):**
 - No direct imports of `providers/*` (LLM wiring for insight currently lives in `legacy_app.py`)
 
@@ -322,6 +326,7 @@ Evidence pointers (runtime truth):
 **Implication for OpenAPI:**
 - Providers are not OpenAPI consumers themselves, but they are part of runtime behavior via insight endpoints.
 - OpenAPI stability policy still primarily serves thin clients (web types from OpenAPI) and unknown external consumers.
+- See ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (schema-only contract + exit criteria).
 
 **OpenAPI Stability Rationale (separate from providers):**
 - Web frontend generates types from OpenAPI (`openapi.json` → `schema.ts`)

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -2,6 +2,12 @@
 
 **Goal:** give a quick, stable picture of PulsePlate architecture and the key enforced invariants.
 
+## Anchors (stable)
+
+- [Canonical entrypoint](#canonical-entrypoint)
+- [Routing map](#routing-map-source-of-truth)
+- [OpenAPI generation mode](#openapi-generation-mode-current)
+
 ## Containers / Modules (high level)
 
 - **Clients**
@@ -61,8 +67,13 @@ flowchart LR
 
 ## OpenAPI generation mode (current)
 
-- OpenAPI generator runs in **schema-only mode** to avoid import-time ORM double-loading.
-- Details and exit criteria: `docs/architecture/ADR-002-openapi-schema-only-mode.md`
+OpenAPI generator runs in **schema-only mode** to avoid import-time ORM double-loading.
+
+**Schema-only contract (single source of truth):**
+See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract`
+
+**Exit criteria:**
+See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#exit-criteria`
 
 ## Enforced invariants (selected, evidence-driven)
 
@@ -77,7 +88,8 @@ flowchart LR
 
 ## Maintenance rule
 
-When any of these change, update this doc in the same PR:
+Checklist (lightweight):
+- [ ] If you change any of the following, update this doc **or** state “no system-overview update needed” in the PR description:
 - entrypoint (`uvicorn ...`)
 - tier namespaces (`/api/v1/bmi/*`, `/api/v1/pro/*`, `/api/v1/vip/*`)
 - rate-limit wiring for LLM/exports

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -1,0 +1,84 @@
+# System Overview (C4-lite)
+
+**Goal:** give a quick, stable picture of PulsePlate architecture and the key enforced invariants.
+
+## Containers / Modules (high level)
+
+- **Clients**
+  - `frontend/` (React): thin HTTP adapter + OpenAPI-generated types
+  - `ios/` (SwiftUI): thin HTTP adapter (`APIClient`) + MVVM UI
+- **Backend**
+  - `app/` (FastAPI adapters): routers, schemas, middleware, bootstrap
+  - `core/` (domain): BMI engine, nutrition logic, i18n, business rules
+  - `providers/` (LLM providers): Grok/Ollama/Pico/Stub (env-selected via `llm.py`)
+- **Infra**
+  - DB (SQLite/Postgres depending on env)
+  - External APIs (USDA/OpenFoodFacts/LLM, etc.)
+
+## Canonical entrypoint
+
+- Runtime and OpenAPI generation use `app/main.py` as the canonical ASGI entrypoint (`uvicorn app.main:app`).
+- `app/main.py` re-exports the FastAPI instance from `legacy_app.py` and applies bootstrap (metrics + contract routes).
+
+## Routing map (source of truth)
+
+See: `docs/architecture/backend_routing_map.md` (evidence-driven router registration map).
+
+## Architecture diagram (Mermaid)
+
+```mermaid
+flowchart LR
+  subgraph Clients
+    FE[frontend/ (React)]
+    IOS[ios/ (SwiftUI)]
+  end
+
+  subgraph Backend
+    ENTRY[app/main.py (canonical entrypoint)]
+    LEG[legacy_app.py (FastAPI app instance)]
+    API[app/ (routers + bootstrap)]
+    CORE[core/ (domain engine)]
+    LLM[llm.py (provider factory)]
+    PROV[providers/ (LLM adapters)]
+  end
+
+  DB[(DB)]
+  EXT[(External APIs / LLM)]
+
+  FE -->|HTTP (OpenAPI types)| ENTRY
+  IOS -->|HTTP (thin client)| ENTRY
+
+  ENTRY -->|re-exports app + applies bootstrap| LEG
+  LEG -->|include_router / route handlers| API
+
+  API -->|delegates business rules| CORE
+  API -->|/insight uses factory| LLM
+  LLM --> PROV
+
+  CORE --> DB
+  PROV --> EXT
+```
+
+## OpenAPI generation mode (current)
+
+- OpenAPI generator runs in **schema-only mode** to avoid import-time ORM double-loading.
+- Details and exit criteria: `docs/architecture/ADR-002-openapi-schema-only-mode.md`
+
+## Enforced invariants (selected, evidence-driven)
+
+- **One BMI Engine**
+  - BMI formulas/thresholds must live in `core/bmi/*` only; guard tests scan for leaks.
+- **Import hygiene / no dynamic module loading**
+  - Tests forbid `sys.path.insert` and dynamic import execution patterns (guarded).
+- **OpenAPI determinism**
+  - `make openapi` must be deterministic; CI compares hashes for `openapi.json` and `schema.ts`.
+- **Rate limiting for expensive endpoints**
+  - LLM/exports endpoints must be rate-limited and have deterministic 429 tests; rate limiting is proxy-aware and privacy-friendly.
+
+## Maintenance rule
+
+When any of these change, update this doc in the same PR:
+- entrypoint (`uvicorn ...`)
+- tier namespaces (`/api/v1/bmi/*`, `/api/v1/pro/*`, `/api/v1/vip/*`)
+- rate-limit wiring for LLM/exports
+- OpenAPI generation mode (schema-only vs full schema)

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -78,11 +78,15 @@ See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#exit-criteria`
 ## Enforced invariants (selected, evidence-driven)
 
 - **One BMI Engine**
-  - BMI formulas/thresholds must live in `core/bmi/*` only; guard tests scan for leaks.
+  - BMI formulas/thresholds must live in `core/bmi/*` only; guards:
+    - `tests/test_bmi_canonical_guard.py:26-77`
+    - `tests/test_no_bmi_math_outside_core.py:31-54`
 - **Import hygiene / no dynamic module loading**
-  - Tests forbid `sys.path.insert` and dynamic import execution patterns (guarded).
+  - Tests forbid `sys.path.insert` and dynamic import execution patterns; guard:
+    - `tests/test_import_hygiene_guard.py:12-41`
 - **OpenAPI determinism**
-  - `make openapi` must be deterministic; CI compares hashes for `openapi.json` and `schema.ts`.
+  - `make openapi` must be deterministic; guard:
+    - `tests/test_openapi_determinism.py:16-64` (hash comparison)
 - **Rate limiting for expensive endpoints**
   - LLM/exports endpoints must be rate-limited and have deterministic 429 tests; rate limiting is proxy-aware and privacy-friendly.
 

--- a/docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md
+++ b/docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md
@@ -1,0 +1,88 @@
+# PR-630 — Architecture Evidence Pack (Audit)
+
+**Status:** Draft (evidence-first, no runtime changes)
+**Scope:** docs + ADR + backlog ledger only (no application behavior changes).
+
+## 1) Entrypoint SoT (runtime)
+
+**Claim:** The canonical runtime entrypoint is `uvicorn app.main:app`.
+
+**Evidence:**
+- `Dockerfile:102-105` — CMD uses `python -m uvicorn app.main:app ...`
+- `app/main.py:11-22` — defines `app` by re-exporting `legacy_app.app` and applying bootstrap.
+
+**Risk if violated:** dual-base / multiple app instances → nondeterminism, xdist hangs, OpenAPI drift, inconsistent middleware.
+
+## 2) Legacy bootstrap boundary (what is “legacy” allowed to do)
+
+**Claim:** `legacy_app.py` still registers most routers and hosts compatibility shims; `app/main.py` is the canonical entrypoint wrapper that applies bootstrap (metrics + pro-contract routes).
+
+**Evidence:**
+- `app/main.py:11-22` — bootstrap is applied here (`register_metrics`, `register_pro_contract_routes`).
+- `legacy_app.py:811-850` — central router registration via `app.include_router(...)` + calls to centralized VIP/PRO registration.
+
+**Compat shims observed:**
+- `app/__init__.py:44-56` — PEP 562 forwarder + `sys.modules.setdefault("app_module", legacy)`
+
+**Risk:** compat shims without explicit boundaries become “magic layers” that hide import-order risks and break patchability.
+
+## 3) OpenAPI schema-only mode (why it exists, what it disables)
+
+**Claim:** OpenAPI generation is currently forced into **schema-only mode** and disables certain feature routers to avoid import-time ORM double-loading.
+
+**Evidence:**
+- `scripts/generate_openapi.py:94-113` — sets `PULSEPLATE_OPENAPI=1` and disables:
+  - `FEATURE_PREMIUM_WEEK_ENABLED=false`
+  - `FEATURE_BMI_PRO_ENABLED=false`
+  - `BUSINESS_MODULE_ENABLED=false`
+- `app/routers/pro_registration.py:26-36` — schema-only mode is honored only when:
+  - `PULSEPLATE_OPENAPI=1`
+  - `APP_ENV=test`
+  - `ENVIRONMENT=test`
+- `app/routers/pro_registration.py:76-105` — avoids importing PRO/premium routers in schema-only mode.
+
+**Technical root cause (documented):**
+- `scripts/generate_openapi.py:96-113` + `app/routers/pro_registration.py:77-80` reference import-time ORM/model hazards and “Table already defined” errors.
+
+**Risk:** schema-only mode reduces “contract velocity” for thin clients (web/iOS) and increases silent drift risk.
+
+## 4) Guards as enforcement (what is already enforced)
+
+**Claim:** Architecture invariants are enforced by guard tests (not only by docs).
+
+**Evidence:**
+- One BMI engine:
+  - `tests/test_bmi_canonical_guard.py:26-77` — forbids `core/bmi/*` importing `bmi_core` (legacy)
+  - `tests/test_no_bmi_math_outside_core.py:31-54` — whitelist-based scan to prevent BMI math outside canonical places
+- Import hygiene:
+  - `tests/test_import_hygiene_guard.py:12-41` — forbids `sys.path.insert` in tests (except whitelisted)
+- OpenAPI determinism:
+  - `tests/test_openapi_determinism.py:16-64` — `make openapi` twice, hashes must match
+
+**Risk:** if guards drift or are bypassed, architecture regressions reappear as production incidents.
+
+## 5) Providers wiring truth (runtime reality)
+
+**Claim:** LLM providers **are wired into runtime** through `legacy_app.py` insight endpoints using `llm.get_provider()`.
+
+**Evidence:**
+- `legacy_app.py:2066-2076` — `_load_llm_get_provider()` imports `llm.get_provider`
+- `legacy_app.py:2098-2117` — `provider = get_provider()` and `await provider.generate(...)`
+- `legacy_app.py:2168-2187` — HTTP endpoints `/api/v1/insight` and `/insight`
+- `llm.py:57-79` + `91-153` — imports provider implementations and selects by `LLM_PROVIDER`
+
+**Risk:** docs that claim “not wired” cause wrong assumptions in security/cost-control/tier design and client work.
+
+## Exit criteria (what makes the “temporary seams” removable)
+
+**Schema-only OpenAPI can be removed when:**
+- No routers imported by `app.main:app` import SQLAlchemy models at module import time (OpenAPI generation does not hit “Table already defined”).
+- `scripts/generate_openapi.py` no longer needs to force-disable feature routers.
+- `tests/test_openapi_determinism.py` remains green.
+
+**Compat shim (`sys.modules["app_module"]`) can be removed when:**
+- No tests/utilities rely on patching the legacy module by that alias.
+- A guard prevents new uses of that alias and documents the migration path.
+
+**BMI whitelist can be reduced when:**
+- `bmi_visualization.py` and `app/routers/bmi_pro.py` no longer contain BMI thresholds/math that should live in `core/bmi/*`.

--- a/docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md
+++ b/docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md
@@ -7,6 +7,8 @@
 
 **Claim:** The canonical runtime entrypoint is `uvicorn app.main:app`.
 
+**Anchor (stable):** `Dockerfile CMD -> uvicorn app.main:app`
+
 **Evidence:**
 - `Dockerfile:102-105` — CMD uses `python -m uvicorn app.main:app ...`
 - `app/main.py:11-22` — defines `app` by re-exporting `legacy_app.app` and applying bootstrap.
@@ -17,11 +19,14 @@
 
 **Claim:** `legacy_app.py` still registers most routers and hosts compatibility shims; `app/main.py` is the canonical entrypoint wrapper that applies bootstrap (metrics + pro-contract routes).
 
+**Anchor (stable):** `app/main.py -> bootstrap + legacy_app re-export`
+
 **Evidence:**
 - `app/main.py:11-22` — bootstrap is applied here (`register_metrics`, `register_pro_contract_routes`).
 - `legacy_app.py:811-850` — central router registration via `app.include_router(...)` + calls to centralized VIP/PRO registration.
 
 **Compat shims observed:**
+**Anchor (stable):** `app/__init__.py -> PEP 562 shim + app_module mapping`
 - `app/__init__.py:44-56` — PEP 562 forwarder + `sys.modules.setdefault("app_module", legacy)`
 
 **Risk:** compat shims without explicit boundaries become “magic layers” that hide import-order risks and break patchability.
@@ -29,6 +34,8 @@
 ## 3) OpenAPI schema-only mode (why it exists, what it disables)
 
 **Claim:** OpenAPI generation is currently forced into **schema-only mode** and disables certain feature routers to avoid import-time ORM double-loading.
+
+**Anchor (stable):** `scripts/generate_openapi.py -> schema-only env/flags; pro_registration -> schema-only guard`
 
 **Evidence:**
 - `scripts/generate_openapi.py:94-113` — sets `PULSEPLATE_OPENAPI=1` and disables:
@@ -64,6 +71,8 @@
 ## 5) Providers wiring truth (runtime reality)
 
 **Claim:** LLM providers **are wired into runtime** through `legacy_app.py` insight endpoints using `llm.get_provider()`.
+
+**Anchor (stable):** `legacy_app.py -> /api/v1/insight + /insight -> llm.get_provider() -> provider.generate()`
 
 **Evidence:**
 - `legacy_app.py:2066-2076` — `_load_llm_get_provider()` imports `llm.get_provider`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -346,6 +346,86 @@ If it is not recorded here — it does not exist.
   - Reason: PR #617 scope reduced to docs-only (audit + handoff); markdownlint config moved out to avoid diff-coverage/CI scope. Add repo-wide markdownlint config in dedicated PR.
   - DoD: New PR with `.markdownlint.json` only; CI green; no mixing with code/audit PRs.
 
+- [ ] Restore full OpenAPI schema (remove temporary schema-only mode)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (contract velocity)
+  - Target PR: TBD (post PR-628/629 to avoid scope collision)
+  - Status: 📋 Ready to start (technical work), but intentionally deferred while PR-628/629 are in flight
+  - Reason: OpenAPI generation currently runs in **schema-only mode** and forcibly disables multiple feature routers. This reduces thin-client contract velocity and increases silent drift risk.
+  - Evidence:
+    - `scripts/generate_openapi.py:94-113` (schema-only mode + forced feature disables)
+    - `app/routers/pro_registration.py:26-36` (schema-only guard conditions)
+    - `docs/architecture/ADR-002-openapi-schema-only-mode.md` (exit criteria)
+  - Risk:
+    - Thin clients cannot “type reality” for excluded routes; integration slows and drift risk increases.
+  - Blocked-by:
+    - Process-only: PR-628/629 (avoid mixed-scope / CI churn); re-evaluate after they merge
+  - Exit criteria:
+    - `make openapi` succeeds without forcing `FEATURE_*_ENABLED=false` in the generator
+    - No SQLAlchemy “Table already defined” errors during OpenAPI generation
+    - `tests/test_openapi_determinism.py` remains green
+  - DoD:
+    - OpenAPI generator runs in full-schema mode (no schema-only marker)
+    - `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts` regenerated + committed (if changed)
+    - Add/adjust any focused regression tests needed to prevent return of import-time ORM hazards
+
+- [ ] Eliminate import-time ORM/model imports in routers included in OpenAPI generation
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (determinism / import hygiene)
+  - Target PR: TBD (post PR-628/629)
+  - Status: 📋 Ready to start
+  - Reason: Schema-only exists because some routers import SQLAlchemy models at module level, causing import-time side effects during OpenAPI generation.
+  - Evidence:
+    - `app/routers/pro_registration.py:76-80` (documents import-time ORM hazard)
+    - `scripts/generate_openapi.py:100-113` (disables routers because of ORM import-time issues)
+  - Risk:
+    - Import-order nondeterminism, “double-load” failures, OpenAPI gaps.
+  - Blocked-by:
+    - Process-only: PR-628/629 (avoid scope collision)
+  - Exit criteria:
+    - Routers used in OpenAPI generation do not import ORM models at module import time
+  - DoD:
+    - Move ORM model imports to runtime (inside handlers/dependencies/services), one router at a time
+    - OpenAPI generation works with routers enabled
+    - Determinism test stays green
+
+- [ ] Constrain compat shim: `sys.modules["app_module"]` mapping in `app/__init__.py`
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (maintainability)
+  - Target PR: TBD (post PR-628/629)
+  - Status: 📋 Ready to start
+  - Reason: `app/__init__.py` sets `sys.modules.setdefault("app_module", legacy_app)` for backward compatibility. This is intentional but must be tightly bounded to avoid “magic layer” imports/patches.
+  - Evidence:
+    - `app/__init__.py:44-56` (sys.modules mapping)
+  - Risk:
+    - Hard-to-debug patch behavior, hidden aliasing, accidental reliance by new code/tests.
+  - Blocked-by:
+    - None (small focused PR), but recommended after PR-628/629 to keep scopes clean
+  - Exit criteria:
+    - Mapping is either removed OR explicitly documented + guarded (no new uses)
+  - DoD:
+    - Add a short evidence-driven doc note describing why the mapping exists and what may rely on it
+    - Add a small guard test preventing expansion (no overwrites / no new module injection patterns)
+    - Define removal plan (conditions under which it can be deleted)
+
+- [ ] Auto-generate architecture diagrams (Mermaid baseline + optional Graphviz import graph)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (docs/tooling)
+  - Target PR: PR-630 (docs-only) or follow-up docs PR
+  - Status: ✅ Baseline Mermaid added; automation optional
+  - Reason: Architecture is enforced by guards, but reviewers/onboarding benefit from quick visuals. Automation reduces doc drift.
+  - Evidence:
+    - `docs/architecture/system_overview.md` (Mermaid system overview)
+    - `docs/architecture/backend_routing_map.md` (evidence-driven routing map)
+    - `docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md` (evidence pack)
+  - Risk:
+    - Without maintenance/automation, diagrams drift and become misleading.
+  - Exit criteria:
+    - Diagram updates happen in the same PR as entrypoint/router/flag changes (enforced culturally or via light guard)
+  - DoD:
+    - Keep Mermaid as canonical diagram (single source of truth)
+    - Optional: add a script that emits a filtered import graph (`.dot`/`.svg`) for selected slices (app/core/providers) with stable filtering rules
+
 - [ ] Remove Trivy suppression for gpgv CVE (CVE-2026-24883)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1


### PR DESCRIPTION
## Summary
- Add evidence-driven architecture docs (C4-lite overview + backend routing map).
- Add PR-630 audit evidence pack documenting entrypoint SoT, schema-only OpenAPI rationale, guards, and providers wiring.
- Record follow-ups in Backlog Ledger with evidence → risk → exit criteria.

## Scope
- Docs-only: `docs/**` + `AGENTS.md`.
- No runtime or CI behavior changes.

## Key docs
- `docs/architecture/system_overview.md`
- `docs/architecture/backend_routing_map.md`
- `docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md`
- `docs/architecture/ADR-002-openapi-schema-only-mode.md`

## Test plan
- `pre-commit run --all-files`

## Deferred / Follow-ups
- See `docs/roadmap/BACKLOG_LEDGER.md` entries:
  - Restore full OpenAPI schema (remove schema-only mode)
  - Eliminate import-time ORM/model imports for OpenAPI generation
  - Constrain `app_module` compat mapping
  - Optional diagram automation

## Summary by Sourcery

Задокументировать текущую архитектуру backend и поведение генерации OpenAPI с помощью основанного на доказательствах аудита, не изменяя поведение во время выполнения.

Улучшения:
- Расширить Backlog Ledger подробными последующими задачами, привязанными к доказательствам, по OpenAPI, гигиене импортов, совместимостным shim’ам и автоматизации диаграмм архитектуры.

Документация:
- Добавить обзор системы в стиле C4-lite и подтверждённую доказательствами карту маршрутизации backend, описывающую точки входа, регистрацию роутеров и связку с LLM-провайдерами.
- Ввести пакет архитектурных доказательств для PR-630, проясняющий источник истины для рантайм-точек входа, границы устаревшего bootstrap’а, режим OpenAPI только-схема, применение guard’ов и интеграцию провайдеров.
- Добавить ADR, документирующий временный режим OpenAPI только-схема, его обоснование и явные критерии выхода.
- Обновить документацию по реализации провайдеров, чтобы отразить, что теперь провайдеры подключены к рантайму через устаревшие insight-эндпоинты, и прояснить, где они используются, а где нет.
- Расширить рекомендации AGENTS, чтобы требовать архитектурную документацию и элементы бэклога, основанные на доказательствах, с явными критериями выхода для временных швов.
- Зафиксировать последующие элементы бэклога для восстановления полного OpenAPI-описания схем, устранения импортов ORM во время импорта модулей, ограничения совместимостного shim’а `app_module` и, при необходимости, автоматизации диаграмм архитектуры.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the current backend architecture and OpenAPI generation behavior with an evidence-driven audit, without changing runtime behavior.

Enhancements:
- Expand the Backlog Ledger with detailed, evidence-linked follow-ups around OpenAPI, import hygiene, compatibility shims, and architecture diagram automation.

Documentation:
- Add a C4-lite system overview and evidence-backed backend routing map describing entrypoints, router registration, and LLM provider wiring.
- Introduce an architecture evidence pack for PR-630 clarifying runtime entrypoint source of truth, legacy bootstrap boundaries, OpenAPI schema-only mode, guard enforcement, and providers integration.
- Add an ADR documenting temporary OpenAPI schema-only mode, its rationale, and explicit exit criteria.
- Update providers implementation doc to reflect that providers are now wired into runtime via legacy insight endpoints and clarify where they are and are not used.
- Extend AGENTS guidelines to require evidence-driven architecture docs and backlog items with explicit exit criteria for temporary seams.
- Record follow-up backlog items for restoring full OpenAPI schema, eliminating import-time ORM imports, constraining the app_module compat shim, and optionally automating architecture diagrams.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an evidence-driven architecture pack: system overview, backend routing map, ADR-002 for OpenAPI schema-only mode, and an audit with file:line evidence. Clarifies the canonical entrypoint and provider wiring; docs-only with no runtime changes.

- **New Features**
  - Added System Overview (C4-lite) and Backend Routing Map with evidence pointers.
  - Added ADR-002 for temporary OpenAPI schema-only mode with clear exit criteria; updated ADR-001 with nh3 exit criteria.
  - Added PR-630 Architecture Evidence Audit covering entrypoint SoT, guards, and providers wiring.
  - Updated providers documentation to reflect the legacy_app → llm → providers runtime path.
  - Enforced an AGENTS rule: architecture docs must cite evidence and temporary seams must have ADRs and backlog items; recorded follow-ups in Backlog Ledger (remove schema-only mode, fix import-time ORM imports, constrain app_module shim, diagram automation).

<sup>Written for commit cef4195764873b109def3f3383461ba65302fca6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture governance and ADRs clarifying a temporary schema-only OpenAPI mode, its activation constraints, exit criteria, and follow-ups.
  * Added a runtime routing map and system overview that document canonical entrypoints, router categories, and maintenance rules.
  * Updated provider/runtime wiring notes, error-handling guidance, an architecture audit, and an expanded backlog for OpenAPI stabilization, security, and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->