### PR TITLE
PR-631: Full OpenAPI schema без import-time ORM (app.models.*)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,21 +663,10 @@ Source of truth:
 ### SQLAlchemy model import policy (critical)
 
 - **Forbidden**: Import SQLAlchemy models at module level in routers that are included in OpenAPI generation.
-- Routers that import `app.models.*` must be conditionally imported when `PULSEPLATE_OPENAPI=1` to prevent SQLAlchemy "Table already defined" errors.
+- **Forbidden**: Import `app.models.*` (ORM models) at module level in any module that is reachable from OpenAPI generation (`make openapi` → `scripts/generate_openapi.py` → `app.main:app`).
+- **Required wording (canonical)**: OpenAPI generation must be **side-effect free**: no import-time loading of ORM models and no `Base.metadata` registration along the OpenAPI import path.
 - **Allowed**: Import models inside endpoint functions or dependencies (lazy loading).
 - **Rationale**: OpenAPI generation must not trigger SQLAlchemy table creation to ensure deterministic schema generation.
-
-### OpenAPI generation mode
-
-- Generator sets `PULSEPLATE_OPENAPI=1` before importing app.
-- Routers that import SQLAlchemy models (e.g., `premium_week`, `pro`) are skipped in this mode.
-- This ensures schema generation does not load DB layer and prevents double-loading errors.
-
-**Schema-only contract (single source of truth):**
-See `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract` (do not duplicate env/flag lists elsewhere).
-
-**Checklist:**
-- [ ] If you change schema-only OpenAPI behavior (env/flags/router exclusions), update ADR-002 contract section above.
 
 ### Determinism requirement
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,7 +1,6 @@
 """Shared models for the application."""
 
 from app.models.events import JSONEncodedDict, NutritionEvent
-from app.models.nutrition import TargetsIn
 from app.models.plans import DayPlan, WeeklyPlan
 
-__all__ = ["JSONEncodedDict", "NutritionEvent", "TargetsIn", "WeeklyPlan", "DayPlan"]
+__all__ = ["JSONEncodedDict", "NutritionEvent", "WeeklyPlan", "DayPlan"]

--- a/app/routers/nutrition_log.py
+++ b/app/routers/nutrition_log.py
@@ -7,6 +7,7 @@ EN: PRO nutrition logging endpoints that feed the adherence micro-model.
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
@@ -15,13 +16,16 @@ from sqlalchemy.orm import Session
 from starlette.concurrency import run_in_threadpool
 
 from app.middleware.api_tiers import CurrentUser, get_current_user, require_pro_tier
-from app.models import NutritionEvent
 from app.routers.bayes_adherence import get_adherence_service
 from app.schemas.bayes_adherence import AdherenceResponse
 from app.schemas.nutrition_log import DayCloseRequest, MealLogRequest
 from core.bayes.adherence_adapter import DomainEvent
 from core.bayes.adherence_service import AdherenceService
 from core.db import get_session
+
+if TYPE_CHECKING:
+    # Import for type checking only (avoid import-time ORM side effects during OpenAPI generation).
+    from app.models import NutritionEvent
 
 router = APIRouter(
     prefix="/api/v1/pro/nutrition",
@@ -64,13 +68,16 @@ def _is_idempotency_violation(err: IntegrityError) -> bool:
 def _fetch_existing_event(
     session: Session, subject_id: int, day: date, source: str, client_event_id: str
 ) -> NutritionEvent | None:
+    # Lazy import: avoid ORM model import at module import time (OpenAPI generation path).
+    from app.models import NutritionEvent as NutritionEventModel
+
     stmt = (
-        select(NutritionEvent)
+        select(NutritionEventModel)
         .where(
-            NutritionEvent.subject_id == subject_id,
-            NutritionEvent.day == day,
-            NutritionEvent.source == source,
-            NutritionEvent.client_event_id == client_event_id,
+            NutritionEventModel.subject_id == subject_id,
+            NutritionEventModel.day == day,
+            NutritionEventModel.source == source,
+            NutritionEventModel.client_event_id == client_event_id,
         )
         .limit(1)
     )
@@ -164,13 +171,16 @@ async def log_meal(
 
     # Write event to append-only log (idempotent if client_event_id provided)
     event_record: NutritionEvent | None = None
+    # Lazy import: avoid ORM model import at module import time (OpenAPI generation path).
+    from app.models import NutritionEvent as NutritionEventModel
+
     event_payload = {
         "log_type": payload.log_type,
         "adherence_score": payload.adherence_score,
         "applied": False,
     }
     try:
-        event_record = NutritionEvent(
+        event_record = NutritionEventModel(
             subject_id=subject_id,
             day=day,
             source="meal_log",
@@ -230,8 +240,11 @@ async def close_day(
 
     # Write day_closed event to append-only log (idempotent)
     event_record: NutritionEvent | None = None
+    # Lazy import: avoid ORM model import at module import time (OpenAPI generation path).
+    from app.models import NutritionEvent as NutritionEventModel
+
     try:
-        event_record = NutritionEvent(
+        event_record = NutritionEventModel(
             subject_id=subject_id,
             day=day,
             source="day_close",

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -88,7 +88,7 @@ class PremiumWeekPlanRequest(BaseModel):
 class PremiumWeekPlanResponse(BaseModel):
     model_config = ConfigDict(title="PremiumWeekPlanResponse")
 
-    daily_menus: List[Dict]
+    daily_menus: List[Dict[str, Any]]
     weekly_coverage: Dict[str, float]
     shopping_list: Dict[str, float]
     total_cost: float

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -15,10 +15,10 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.middleware.api_tiers import require_pro_tier
-from app.models.nutrition import TargetsIn
+from app.schemas.nutrition_targets import TargetsIn
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
 from core.food_db_new import FoodDB
@@ -67,7 +67,7 @@ def _get_recipe_db() -> RecipeDB:
     return _premium_recipe_db_cache
 
 
-class WeekPlanRequest(BaseModel):
+class PremiumWeekPlanRequest(BaseModel):
     # режим A: передают готовые targets
     targets: Optional[TargetsIn] = None
     # режим B: быстрый профиль (fallback)
@@ -82,8 +82,12 @@ class WeekPlanRequest(BaseModel):
     diet_flags: List[str] = Field(default_factory=list)
     lang: Language = "en"
 
+    model_config = ConfigDict(title="PremiumWeekPlanRequest")
 
-class WeekPlanResponse(BaseModel):
+
+class PremiumWeekPlanResponse(BaseModel):
+    model_config = ConfigDict(title="PremiumWeekPlanResponse")
+
     daily_menus: List[Dict]
     weekly_coverage: Dict[str, float]
     shopping_list: Dict[str, float]
@@ -174,7 +178,7 @@ def estimate_targets_minimal(
 
 @router.post(
     "/plan/week-flexible",
-    response_model=WeekPlanResponse,
+    response_model=PremiumWeekPlanResponse,
     dependencies=[Depends(require_pro_tier)],
     deprecated=True,
     openapi_extra={
@@ -208,7 +212,9 @@ def estimate_targets_minimal(
     - Cost estimation
     """,
 )
-async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JSONResponse]:
+async def generate_week_plan(
+    req: PremiumWeekPlanRequest,
+) -> Union[PremiumWeekPlanResponse, JSONResponse]:
     """
     [DEPRECATED] Generate weekly meal plan with PRO tier features.
 
@@ -267,9 +273,9 @@ async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JS
     # 2) Построить неделю (generation stage) + postprocess (pipeline with ordering guard)
     from core.menu_engine_new import PlateDayTargets
 
-    # Wrap WeekPlanResponse constructor to match postprocess_fn signature
-    def _postprocess_week(week: dict[str, Any]) -> WeekPlanResponse:
-        return WeekPlanResponse(**week)
+    # Wrap PremiumWeekPlanResponse constructor to match postprocess_fn signature
+    def _postprocess_week(week: dict[str, Any]) -> PremiumWeekPlanResponse:
+        return PremiumWeekPlanResponse(**week)
 
     result = run_weekly_pipeline_guarded(
         generation_fn=build_week,
@@ -305,6 +311,6 @@ async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JS
         # IMPORTANT: bypass response_model validation
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=result)
 
-    if not isinstance(result, WeekPlanResponse):
-        raise TypeError(f"Expected WeekPlanResponse, got {type(result).__name__}")
+    if not isinstance(result, PremiumWeekPlanResponse):
+        raise TypeError(f"Expected PremiumWeekPlanResponse, got {type(result).__name__}")
     return result

--- a/app/routers/pro.py
+++ b/app/routers/pro.py
@@ -19,10 +19,10 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.middleware.api_tiers import require_pro_tier
-from app.models.nutrition import TargetsIn
+from app.schemas.nutrition_targets import TargetsIn
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
 from core.food_db_new import FoodDB
@@ -82,13 +82,15 @@ def get_recipe_db() -> RecipeDB:
     return _recipe_db_cache
 
 
-class WeekPlanRequest(BaseModel):
+class ProWeekPlanRequest(BaseModel):
     """Request model for weekly meal plan generation.
 
     Supports two modes:
     - Mode A: Provide ready targets
     - Mode B: Quick profile (fallback)
     """
+
+    model_config = ConfigDict(title="ProWeekPlanRequest")
 
     # Mode A: Provide ready targets
     targets: Optional[TargetsIn] = None
@@ -105,8 +107,10 @@ class WeekPlanRequest(BaseModel):
     lang: Language = "en"
 
 
-class WeekPlanResponse(BaseModel):
+class ProWeekPlanResponse(BaseModel):
     """Response model for weekly meal plan."""
+
+    model_config = ConfigDict(title="ProWeekPlanResponse")
 
     daily_menus: List[Dict]
     weekly_coverage: Dict[str, float]
@@ -240,7 +244,7 @@ def estimate_targets_minimal(
 
 @router.post(
     "/meal/weekly",
-    response_model=WeekPlanResponse,
+    response_model=ProWeekPlanResponse,
     dependencies=[Depends(require_pro_tier)],
     summary="Generate weekly meal plan (PRO tier)",
     description="""
@@ -259,14 +263,14 @@ def estimate_targets_minimal(
     - Cost estimation
     """,
 )
-async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JSONResponse]:
+async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanResponse, JSONResponse]:
     """Generate weekly meal plan with PRO tier features.
 
     Args:
-        req: WeekPlanRequest with targets or user profile
+        req: ProWeekPlanRequest with targets or user profile
 
     Returns:
-        WeekPlanResponse with daily menus, coverage, shopping list, and metrics
+        ProWeekPlanResponse with daily menus, coverage, shopping list, and metrics
 
     Raises:
         HTTPException: 400 if profile data is missing or invalid
@@ -317,9 +321,9 @@ async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JS
     # Build week (generation stage) + postprocess (pipeline with ordering guard)
     from core.menu_engine_new import PlateDayTargets
 
-    # Wrap WeekPlanResponse constructor to match postprocess_fn signature
-    def _postprocess_week(week: Dict[str, Any]) -> WeekPlanResponse:
-        return WeekPlanResponse(**week)
+    # Wrap ProWeekPlanResponse constructor to match postprocess_fn signature
+    def _postprocess_week(week: Dict[str, Any]) -> ProWeekPlanResponse:
+        return ProWeekPlanResponse(**week)
 
     result = run_weekly_pipeline_guarded(
         generation_fn=build_week,
@@ -354,9 +358,9 @@ async def generate_week_plan(req: WeekPlanRequest) -> Union[WeekPlanResponse, JS
         # IMPORTANT: bypass response_model validation
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=result)
 
-    if not isinstance(result, WeekPlanResponse):
+    if not isinstance(result, ProWeekPlanResponse):
         raise TypeError(
-            "Expected WeekPlanResponse from weekly pipeline, "
+            "Expected ProWeekPlanResponse from weekly pipeline, "
             f"got type={type(result).__name__} value={result!r}"
         )
     return result

--- a/app/routers/pro_registration.py
+++ b/app/routers/pro_registration.py
@@ -23,18 +23,6 @@ if TYPE_CHECKING:
 __all__ = ["register_pro_routes"]
 
 
-def _is_openapi_schema_only_mode() -> bool:
-    """Check if OpenAPI schema-only generation mode is active.
-
-    Schema-only mode must never activate in production by accident.
-    We only honor it in generation/test context (PULSEPLATE_OPENAPI=1 AND APP_ENV=test AND ENVIRONMENT=test).
-    """
-    _openapi_flag = (os.getenv("PULSEPLATE_OPENAPI") or "").strip()
-    _app_env = (os.getenv("APP_ENV") or "").strip().lower()
-    _env = (os.getenv("ENVIRONMENT") or "").strip().lower()
-    return (_openapi_flag == "1") and (_app_env == "test") and (_env == "test")
-
-
 def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | None]:
     """
     Register PRO and premium_week routes with the FastAPI application.
@@ -43,29 +31,21 @@ def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | N
     EN: Registers PRO and premium_week routes with the FastAPI application.
 
     This function centralizes PRO route registration logic:
-    - Checks OpenAPI schema-only mode (skips routers that import SQLAlchemy models)
-    - Includes premium_week router
-    - Includes pro router
-    - Applies route-level dependencies (API key)
+    - Includes pro router (canonical /api/v1/pro/* namespace)
+    - Includes premium_week router for backward compatibility (deprecated)
 
     Args:
         app: FastAPI application instance
 
     Returns:
         Tuple of (pro_router, premium_week_router) for backward compatibility.
-        Both may be None if in OpenAPI schema-only mode or feature flags disabled.
+        Both may be None if feature flags are disabled.
 
     Note:
-        This function has no side effects if in OpenAPI schema-only mode.
-        It can be called multiple times safely (idempotent).
+        This function can be called multiple times safely (idempotent).
     """
-    openapi_mode = _is_openapi_schema_only_mode()
-
-    # Return cached values if already registered in the same mode (idempotent)
-    if (
-        getattr(app.state, "_pro_routes_registered", False)
-        and getattr(app.state, "_pro_routes_registered_openapi_mode", None) == openapi_mode
-    ):
+    # Return cached values if already registered (idempotent)
+    if getattr(app.state, "_pro_routes_registered", False):
         cached_pro = getattr(app.state, "_cached_pro_router", None)
         cached_premium = getattr(app.state, "_cached_premium_week_router", None)
         return cached_pro, cached_premium
@@ -73,42 +53,34 @@ def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | N
     pro_router_result: APIRouter | None = None
     premium_week_router_result: APIRouter | None = None
 
-    if not openapi_mode:
-        # Import routers only in non-schema-only mode to avoid import-time ORM hazards.
-        # These routers import app.models at module level, which triggers SQLAlchemy
-        # table creation and causes "Table already defined" errors on repeated imports.
-        from app.routers.pro import router as pro_router_imported
+    from app.routers.pro import router as pro_router_imported
 
-        if pro_router_imported is not None:
-            app.include_router(pro_router_imported)
-            pro_router_result = pro_router_imported
+    if pro_router_imported is not None:
+        app.include_router(pro_router_imported)
+        pro_router_result = pro_router_imported
 
-        # Include premium_week router for backward compatibility (deprecated)
-        # Check FEATURE_PREMIUM_WEEK_ENABLED feature flag
-        from app.utils.feature_flags import is_vip_module_enabled
+    # Include premium_week router for backward compatibility (deprecated)
+    # Check FEATURE_PREMIUM_WEEK_ENABLED feature flag
+    from app.utils.feature_flags import is_vip_module_enabled
 
-        feature_premium_week_enabled = (
-            os.getenv("FEATURE_PREMIUM_WEEK_ENABLED", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        ) or is_vip_module_enabled()  # Also enable if VIP module is enabled
+    feature_premium_week_enabled = (
+        os.getenv("FEATURE_PREMIUM_WEEK_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+    ) or is_vip_module_enabled()  # Also enable if VIP module is enabled
 
-        if feature_premium_week_enabled:
-            from app.routers.premium_week import router as premium_week_router_imported
+    if feature_premium_week_enabled:
+        from app.routers.premium_week import router as premium_week_router_imported
 
-            # premium_week endpoints enforce tier access internally via app.middleware.api_tiers
-            # (e.g., require_pro_tier). Do not add the global API_KEY guard here, otherwise
-            # PRO/VIP test keys (test_pro_key/test_vip_key) are rejected when API_KEY is set.
-            # NOTE: This router is deprecated. Use /api/v1/pro/* endpoints instead.
-            if premium_week_router_imported is not None:
-                app.include_router(premium_week_router_imported)
-                premium_week_router_result = premium_week_router_imported
+        # premium_week endpoints enforce tier access internally via app.middleware.api_tiers
+        # (e.g., require_pro_tier). Do not add the global API_KEY guard here, otherwise
+        # PRO/VIP test keys (test_pro_key/test_vip_key) are rejected when API_KEY is set.
+        # NOTE: This router is deprecated. Use /api/v1/pro/* endpoints instead.
+        if premium_week_router_imported is not None:
+            app.include_router(premium_week_router_imported)
+            premium_week_router_result = premium_week_router_imported
 
     # Cache routers for idempotent return.
-    # Avoid "locking in" schema-only results in case the same app instance is reused.
-    if not openapi_mode:
-        app.state._pro_routes_registered = True
-        app.state._pro_routes_registered_openapi_mode = openapi_mode
-        app.state._cached_pro_router = pro_router_result
-        app.state._cached_premium_week_router = premium_week_router_result
+    app.state._pro_routes_registered = True
+    app.state._cached_pro_router = pro_router_result
+    app.state._cached_premium_week_router = premium_week_router_result
 
     return pro_router_result, premium_week_router_result

--- a/app/schemas/nutrition_targets.py
+++ b/app/schemas/nutrition_targets.py
@@ -1,0 +1,64 @@
+"""Nutrition target schemas (Pydantic).
+
+RU: Pydantic-схемы для nutrition targets (без ORM / SQLAlchemy).
+EN: Pydantic schemas for nutrition targets (no ORM / SQLAlchemy).
+
+IMPORTANT:
+- This module must stay import-safe (no SQLAlchemy, no Base/metadata side-effects).
+- Routers may import these schemas at module import time (OpenAPI generation path).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TargetsIn(BaseModel):
+    """Nutrition targets input model.
+
+    RU: Входная схема таргетов питания (используется в PRO/Premium эндпоинтах).
+    EN: Input schema for nutrition targets (used by PRO/Premium endpoints).
+    """
+
+    kcal: int = Field(..., gt=500, lt=6000)
+    macros: Dict[str, float]
+    micro: Dict[str, float]
+    water_ml: int = Field(0, ge=0)
+    activity_week: Optional[Dict[str, int]] = None
+
+    @field_validator("macros")
+    @classmethod
+    def _validate_macros(cls, v: Dict[str, float]) -> Dict[str, float]:
+        """Validate macros are finite numbers >= 0.
+
+        RU: Проверяем, что macros содержат конечные числа >= 0.
+        EN: Ensure macros contain finite numbers >= 0.
+        """
+
+        for key, val in v.items():
+            if not isinstance(val, (int, float)) or isinstance(val, bool):
+                raise ValueError(f"macros[{key}] must be a finite number >= 0")
+
+            if not math.isfinite(val) or val < 0:
+                raise ValueError(f"macros[{key}] must be a finite number >= 0")
+        return v
+
+    @field_validator("micro")
+    @classmethod
+    def _validate_micro(cls, v: Dict[str, float]) -> Dict[str, float]:
+        """Validate micros are finite numbers >= 0.
+
+        RU: Проверяем, что micro содержат конечные числа >= 0.
+        EN: Ensure micro contains finite numbers >= 0.
+        """
+
+        for key, val in v.items():
+            if not isinstance(val, (int, float)) or isinstance(val, bool):
+                raise ValueError(f"micro[{key}] must be a finite number >= 0")
+
+            if not math.isfinite(val) or val < 0:
+                raise ValueError(f"micro[{key}] must be a finite number >= 0")
+        return v

--- a/app/schemas/nutrition_targets.py
+++ b/app/schemas/nutrition_targets.py
@@ -11,24 +11,25 @@ IMPORTANT:
 from __future__ import annotations
 
 import math
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
 
-def _validate_numeric_dict(v: Dict[str, float], field_name: str) -> Dict[str, float]:
-    """Shared numeric-dict validator.
-
-    RU: Общая проверка словаря чисел >= 0 и finite.
-    EN: Shared validator for numeric dict values (finite, >= 0).
+def _validate_numeric_dict(v: Dict[str, Any], field_name: str) -> Dict[str, Any]:
+    """RU: Проверка словаря чисел (finite, >=0), bool запрещён.
+    EN: Validate numeric dict values (finite, >=0), bool is forbidden.
     """
 
     for key, val in v.items():
-        # bool is subclass of int -> exclude explicitly
-        if not isinstance(val, (int, float)) or isinstance(val, bool):
+        # bool is a subclass of int -> must reject explicitly (before Pydantic coercion).
+        if isinstance(val, bool):
             raise ValueError(f"{field_name}[{key}] must be a finite number >= 0")
-        val_f = float(val)
-        if not math.isfinite(val_f) or val_f < 0:
+        try:
+            num = float(val)
+        except (TypeError, ValueError):
+            raise ValueError(f"{field_name}[{key}] must be a finite number >= 0") from None
+        if not math.isfinite(num) or num < 0:
             raise ValueError(f"{field_name}[{key}] must be a finite number >= 0")
     return v
 
@@ -46,12 +47,12 @@ class TargetsIn(BaseModel):
     water_ml: int = Field(0, ge=0)
     activity_week: Optional[Dict[str, int]] = None
 
-    @field_validator("macros")
+    @field_validator("macros", mode="before")
     @classmethod
-    def _validate_macros(cls, v: Dict[str, float]) -> Dict[str, float]:
+    def _validate_macros(cls, v: Dict[str, Any]) -> Dict[str, Any]:
         return _validate_numeric_dict(v, "macros")
 
-    @field_validator("micro")
+    @field_validator("micro", mode="before")
     @classmethod
-    def _validate_micro(cls, v: Dict[str, float]) -> Dict[str, float]:
+    def _validate_micro(cls, v: Dict[str, Any]) -> Dict[str, Any]:
         return _validate_numeric_dict(v, "micro")

--- a/app/schemas/nutrition_targets.py
+++ b/app/schemas/nutrition_targets.py
@@ -16,6 +16,23 @@ from typing import Dict, Optional
 from pydantic import BaseModel, Field, field_validator
 
 
+def _validate_numeric_dict(v: Dict[str, float], field_name: str) -> Dict[str, float]:
+    """Shared numeric-dict validator.
+
+    RU: Общая проверка словаря чисел >= 0 и finite.
+    EN: Shared validator for numeric dict values (finite, >= 0).
+    """
+
+    for key, val in v.items():
+        # bool is subclass of int -> exclude explicitly
+        if not isinstance(val, (int, float)) or isinstance(val, bool):
+            raise ValueError(f"{field_name}[{key}] must be a finite number >= 0")
+        val_f = float(val)
+        if not math.isfinite(val_f) or val_f < 0:
+            raise ValueError(f"{field_name}[{key}] must be a finite number >= 0")
+    return v
+
+
 class TargetsIn(BaseModel):
     """Nutrition targets input model.
 
@@ -32,33 +49,9 @@ class TargetsIn(BaseModel):
     @field_validator("macros")
     @classmethod
     def _validate_macros(cls, v: Dict[str, float]) -> Dict[str, float]:
-        """Validate macros are finite numbers >= 0.
-
-        RU: Проверяем, что macros содержат конечные числа >= 0.
-        EN: Ensure macros contain finite numbers >= 0.
-        """
-
-        for key, val in v.items():
-            if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise ValueError(f"macros[{key}] must be a finite number >= 0")
-
-            if not math.isfinite(val) or val < 0:
-                raise ValueError(f"macros[{key}] must be a finite number >= 0")
-        return v
+        return _validate_numeric_dict(v, "macros")
 
     @field_validator("micro")
     @classmethod
     def _validate_micro(cls, v: Dict[str, float]) -> Dict[str, float]:
-        """Validate micros are finite numbers >= 0.
-
-        RU: Проверяем, что micro содержат конечные числа >= 0.
-        EN: Ensure micro contains finite numbers >= 0.
-        """
-
-        for key, val in v.items():
-            if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise ValueError(f"micro[{key}] must be a finite number >= 0")
-
-            if not math.isfinite(val) or val < 0:
-                raise ValueError(f"micro[{key}] must be a finite number >= 0")
-        return v
+        return _validate_numeric_dict(v, "micro")

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -369,6 +369,37 @@ If it is not recorded here — it does not exist.
     - OpenAPI generation works with routers enabled
     - Determinism test stays green
 
+- [ ] P1: Unify `TargetsIn` schemas (legacy_app ↔ `app.schemas.nutrition_targets`)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (drift prevention)
+  - Target PR: TBD (follow-up after PR-631)
+  - Status: 📋 Ready to start
+  - Reason: There are currently two `TargetsIn` schemas (`legacy_app.TargetsIn` and `app.schemas.nutrition_targets.TargetsIn`). This is a potential source of drift over time, even though PR-631 intentionally kept them separate to stay scope-minimal (remediation only).
+  - Links:
+    - PR #631 (remediation): full OpenAPI without import-time `app.models.*` along OpenAPI path
+  - Evidence:
+    - `app/schemas/nutrition_targets.py` (import-safe schema)
+    - `legacy_app.py` (`TargetsIn` used in legacy endpoints)
+  - DoD:
+    - One canonical schema (single source of truth) with a thin wrapper/alias where needed
+    - Parity tests that prevent schema drift (fields + validation behavior for structured targets payloads)
+    - No contract break for legacy endpoints (explicitly verified in tests)
+
+- [ ] P1: Extract import-safe ORM model helper for OpenAPI path (dedupe lazy-import pattern)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (maintainability / import hygiene)
+  - Target PR: TBD (follow-up after PR-631)
+  - Status: 📋 Ready to start
+  - Reason: `app.routers.nutrition_log` uses repeated lazy-import of `NutritionEvent` model to avoid import-time ORM side effects. A tiny helper (import-safe) would reduce duplication and make future additions safer.
+  - Links:
+    - PR #631 (remediation): moved ORM model import from module-level to lazy-import inside handlers
+  - Evidence:
+    - `app/routers/nutrition_log.py` (repeated lazy imports of `NutritionEvent`)
+  - DoD:
+    - Add a single helper (import-safe) for model retrieval used by `nutrition_log` (and any similar routers)
+    - Unit test that validates helper is import-safe (no import-time `app.models.*` in OpenAPI path)
+    - No runtime behavior change (pure refactor)
+
 - [ ] Constrain compat shim: `sys.modules["app_module"]` mapping in `app/__init__.py`
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (maintainability)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -378,8 +378,9 @@ If it is not recorded here — it does not exist.
   - Links:
     - PR #631 (remediation): full OpenAPI without import-time `app.models.*` along OpenAPI path
   - Evidence:
-    - `app/schemas/nutrition_targets.py` (import-safe schema)
-    - `legacy_app.py` (`TargetsIn` used in legacy endpoints)
+    - `app/schemas/nutrition_targets.py:L1-L58` (import-safe schema + `TargetsIn` validators)
+    - `legacy_app.py:L2879-L2919` (`legacy_app.TargetsIn` definition)
+    - `legacy_app.py:L2939-L2954` (`TargetsIn.model_validate(...)` use in legacy request validator)
   - DoD:
     - One canonical schema (single source of truth) with a thin wrapper/alias where needed
     - Parity tests that prevent schema drift (fields + validation behavior for structured targets payloads)
@@ -394,7 +395,9 @@ If it is not recorded here — it does not exist.
   - Links:
     - PR #631 (remediation): moved ORM model import from module-level to lazy-import inside handlers
   - Evidence:
-    - `app/routers/nutrition_log.py` (repeated lazy imports of `NutritionEvent`)
+    - `app/routers/nutrition_log.py:L68-L84` (lazy-import inside `_fetch_existing_event`)
+    - `app/routers/nutrition_log.py:L172-L176` (lazy-import inside `log_meal`)
+    - `app/routers/nutrition_log.py:L241-L245` (lazy-import inside `close_day`)
   - DoD:
     - Add a single helper (import-safe) for model retrieval used by `nutrition_log` (and any similar routers)
     - Unit test that validates helper is import-safe (no import-time `app.models.*` in OpenAPI path)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -253,6 +253,9 @@ If it is not recorded here — it does not exist.
     - `pytest -q tests/test_nutrition_log_api.py` passes in CI runner
     - No "no such table: users" or "no such table: nutrition_events" in setup/teardown
     - Fail-fast guard: if schema missing after init_db(), tests fail with clear message (no silent warn+continue)
+  - Notes (3 February 2026, America/New_York):
+    - Fix: close leaked TestClients (context-managed `tests/conftest.py::client` + close in `tests/test_nutrition_log_api.py` teardown) to ensure lifespan runs deterministically under xdist.
+    - Verification (local): `pytest -q tests/test_nutrition_log_api.py -n 2 --dist=loadgroup` passed; CI link: TBD (after run completes).
 
 - [x] P1: Verify and secure WebSocket endpoint (if exists) — RESOLVED
   - Owner: @katsiaryna_kavaleuskaya

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -87,6 +87,367 @@
         "title": "AdherenceResponse",
         "type": "object"
       },
+      "BMICalculateProRequest": {
+        "additionalProperties": false,
+        "description": "PRO tier BMI calculation request (extends FREE with hip_cm for WHR).\n\nRU: Запрос расчета BMI для PRO уровня (расширяет FREE с hip_cm для WHR).\nEN: PRO tier BMI calculation request (extends FREE with hip_cm for WHR).",
+        "properties": {
+          "age": {
+            "description": "Age in years. Range: 1-120.",
+            "examples": [
+              25,
+              30,
+              45,
+              65
+            ],
+            "maximum": 120.0,
+            "minimum": 1.0,
+            "title": "Age",
+            "type": "integer"
+          },
+          "athlete": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "default": false,
+            "description": "Athlete status. Accepts: 'yes'/'no' (string) or True/False (bool). Will be normalized to bool by schema.",
+            "examples": [
+              "no",
+              "yes",
+              false,
+              true
+            ],
+            "title": "Athlete"
+          },
+          "gender": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Gender: 'male' or 'female'. Normalized by schema validator. Guaranteed to be str after validation.",
+            "examples": [
+              "male",
+              "female",
+              "муж",
+              "жен",
+              null
+            ],
+            "title": "Gender"
+          },
+          "height_cm": {
+            "description": "Height in centimeters. Must be positive.",
+            "examples": [
+              170.0,
+              175.5,
+              180.0
+            ],
+            "exclusiveMinimum": 0.0,
+            "title": "Height Cm",
+            "type": "number"
+          },
+          "hip_cm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Hip circumference in centimeters (optional, PRO tier only). If provided along with waist_cm, enables WHR (Waist-to-Hip Ratio) calculation.",
+            "examples": [
+              95.0,
+              100.5,
+              null
+            ],
+            "title": "Hip Cm"
+          },
+          "lang": {
+            "default": "en",
+            "description": "Language for localized responses: 'ru', 'en', or 'es'.",
+            "enum": [
+              "ru",
+              "en",
+              "es"
+            ],
+            "examples": [
+              "en",
+              "ru",
+              "es"
+            ],
+            "title": "Lang",
+            "type": "string"
+          },
+          "pregnant": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "default": false,
+            "description": "Pregnancy status. Accepts: 'yes'/'no' (string) or True/False (bool). Will be normalized to bool by engine.",
+            "examples": [
+              "no",
+              "yes",
+              false,
+              true
+            ],
+            "title": "Pregnant"
+          },
+          "waist_cm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Waist circumference in centimeters (optional). If provided, enables WHtR and waist risk assessment.",
+            "examples": [
+              80.0,
+              90.5,
+              null
+            ],
+            "title": "Waist Cm"
+          },
+          "weight_kg": {
+            "description": "Weight in kilograms. Must be positive.",
+            "examples": [
+              65.5,
+              70.0,
+              80.3
+            ],
+            "exclusiveMinimum": 0.0,
+            "title": "Weight Kg",
+            "type": "number"
+          }
+        },
+        "required": [
+          "weight_kg",
+          "height_cm",
+          "age"
+        ],
+        "title": "BMICalculateProRequest",
+        "type": "object"
+      },
+      "BMICalculateProResponse": {
+        "additionalProperties": false,
+        "description": "PRO tier BMI calculation response (extends FREE with whr).\n\nRU: Ответ расчета BMI для PRO уровня (расширяет FREE с whr).\nEN: PRO tier BMI calculation response (extends FREE with whr).",
+        "properties": {
+          "age_band": {
+            "description": "Age band for UI differentiation: 'too_young' (<12), 'child' (12-14), 'teen' (15-18), 'adult' (19-59), 'elderly' (>=60).",
+            "enum": [
+              "too_young",
+              "child",
+              "teen",
+              "adult",
+              "elderly"
+            ],
+            "examples": [
+              "adult",
+              "teen",
+              "elderly"
+            ],
+            "title": "Age Band",
+            "type": "string"
+          },
+          "bmi": {
+            "description": "Calculated BMI value (weight_kg / (height_m ** 2)).",
+            "examples": [
+              22.5,
+              25.3,
+              18.7
+            ],
+            "title": "Bmi",
+            "type": "number"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "BMI category (localized). None for users in 'pregnant', 'too_young', 'child' or 'teen' age bands - not an error, medical disclaimer. BMI categories are not provided during pregnancy or for users in 'too_young', 'child' and 'teen' age bands.",
+            "examples": [
+              "normal",
+              "overweight",
+              null
+            ],
+            "title": "Category"
+          },
+          "group": {
+            "description": "User group determined by auto_group(): 'general', 'athlete', 'elderly', 'child', 'teen', 'too_young', 'pregnant'.",
+            "examples": [
+              "general",
+              "athlete",
+              "elderly"
+            ],
+            "title": "Group",
+            "type": "string"
+          },
+          "group_display": {
+            "description": "Localized display name for the group.",
+            "examples": [
+              "General",
+              "Athlete",
+              "Elderly"
+            ],
+            "title": "Group Display",
+            "type": "string"
+          },
+          "interpretation": {
+            "description": "Localized interpretation text for the BMI value in the context of the group.",
+            "examples": [
+              "Your BMI is within the normal range for your age group."
+            ],
+            "title": "Interpretation",
+            "type": "string"
+          },
+          "interpretation_v1": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BMIInterpretationV1Schema"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional structured interpretation (v1). i18n keys only. Currently may be None while wiring is in progress. Planned behavior: None only for too_young; pregnancy returns structured interpretation (goal=medical_review, target=prenatal_guidelines), and pregnant+athlete includes additional athlete disclaimers.",
+            "examples": [
+              {
+                "disclaimers": [
+                  "bmi.interpretation.disclaimer.general"
+                ],
+                "goal_direction": "maintain",
+                "priority_notes": [],
+                "risk_flags": [],
+                "target_range": {
+                  "max": 25.0,
+                  "min": 18.5
+                }
+              },
+              null
+            ]
+          },
+          "notes": {
+            "description": "Aggregated notes (currently only from waist_risk.notes). Empty list if no notes.",
+            "examples": [
+              [],
+              [
+                "Increased waist-related risk"
+              ]
+            ],
+            "items": {
+              "type": "string"
+            },
+            "title": "Notes",
+            "type": "array"
+          },
+          "soft_paywall": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SoftPaywallHook"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional soft paywall hook for PRO tier upsell (wellness positioning only)."
+          },
+          "visualization": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BMIScaleV1Spec"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional BMI scale visualization spec (v1). Frontend should render this if available."
+          },
+          "waist_risk": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WaistRiskResultSchema"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Waist risk assessment result. Present only if waist_cm was provided and risk was calculated.",
+            "examples": [
+              {
+                "notes": [
+                  "Increased waist-related risk"
+                ],
+                "risk_level": "moderate",
+                "wht_ratio": 0.52
+              },
+              null
+            ]
+          },
+          "whr": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Waist-to-Hip Ratio (WHR, PRO tier only). Calculated only if both waist_cm and hip_cm were provided and >0.",
+            "examples": [
+              0.8,
+              0.95,
+              null
+            ],
+            "title": "Whr"
+          },
+          "wht_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Waist-to-Height Ratio (WHtR). Calculated only if waist_cm was provided.",
+            "examples": [
+              0.47,
+              0.52,
+              null
+            ],
+            "title": "Wht Ratio"
+          }
+        },
+        "required": [
+          "bmi",
+          "group",
+          "group_display",
+          "interpretation",
+          "age_band"
+        ],
+        "title": "BMICalculateProResponse",
+        "type": "object"
+      },
       "BMICalculateRequest": {
         "additionalProperties": false,
         "description": "RU: Запрос для расчета BMI через единый engine.\nEN: Request for BMI calculation via unified engine.\n\nFREE tier endpoint (no API key required).",
@@ -521,6 +882,143 @@
           "value"
         ],
         "title": "BMIMarkerSpec",
+        "type": "object"
+      },
+      "BMIProRequest": {
+        "properties": {
+          "age": {
+            "maximum": 100.0,
+            "minimum": 10.0,
+            "title": "Age",
+            "type": "integer"
+          },
+          "bodyfat_percent": {
+            "anyOf": [
+              {
+                "maximum": 60.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bodyfat Percent"
+          },
+          "height_cm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Height Cm",
+            "type": "number"
+          },
+          "hip_cm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hip Cm"
+          },
+          "lang": {
+            "default": "en",
+            "enum": [
+              "ru",
+              "en",
+              "es"
+            ],
+            "title": "Lang",
+            "type": "string"
+          },
+          "sex": {
+            "enum": [
+              "female",
+              "male"
+            ],
+            "title": "Sex",
+            "type": "string"
+          },
+          "waist_cm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Waist Cm",
+            "type": "number"
+          },
+          "weight_kg": {
+            "exclusiveMinimum": 0.0,
+            "title": "Weight Kg",
+            "type": "number"
+          }
+        },
+        "required": [
+          "height_cm",
+          "weight_kg",
+          "sex",
+          "age",
+          "waist_cm"
+        ],
+        "title": "BMIProRequest",
+        "type": "object"
+      },
+      "BMIProResponse": {
+        "properties": {
+          "bmi": {
+            "title": "Bmi",
+            "type": "number"
+          },
+          "ffmi": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ffmi"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Notes",
+            "type": "array"
+          },
+          "risk_level": {
+            "enum": [
+              "low",
+              "moderate",
+              "high"
+            ],
+            "title": "Risk Level",
+            "type": "string"
+          },
+          "whr": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whr"
+          },
+          "whtr": {
+            "title": "Whtr",
+            "type": "number"
+          }
+        },
+        "required": [
+          "bmi",
+          "whtr",
+          "whr",
+          "ffmi",
+          "risk_level",
+          "notes"
+        ],
+        "title": "BMIProResponse",
         "type": "object"
       },
       "BMIRangeSpec": {
@@ -1118,6 +1616,105 @@
         "title": "BodyFatRequest",
         "type": "object"
       },
+      "BusinessAnalysisRequest": {
+        "description": "Request model for business analysis.",
+        "properties": {
+          "code": {
+            "description": "Code to analyze (max 100KB)",
+            "title": "Code",
+            "type": "string"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "test_name": {
+            "default": "business_analysis",
+            "title": "Test Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "BusinessAnalysisRequest",
+        "type": "object"
+      },
+      "BusinessAnalysisResponse": {
+        "description": "Response model for business analysis.",
+        "properties": {
+          "business_category": {
+            "title": "Business Category",
+            "type": "string"
+          },
+          "cost_impact": {
+            "title": "Cost Impact",
+            "type": "string"
+          },
+          "customer_impact": {
+            "title": "Customer Impact",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "error_type": {
+            "title": "Error Type",
+            "type": "string"
+          },
+          "optimization_potential": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Optimization Potential"
+          },
+          "revenue_impact": {
+            "title": "Revenue Impact",
+            "type": "string"
+          },
+          "success": {
+            "title": "Success",
+            "type": "boolean"
+          },
+          "test_name": {
+            "title": "Test Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "test_name",
+          "success",
+          "business_category",
+          "error_type",
+          "error_message",
+          "revenue_impact",
+          "cost_impact",
+          "customer_impact",
+          "optimization_potential"
+        ],
+        "title": "BusinessAnalysisResponse",
+        "type": "object"
+      },
       "CatalogInfoDTO": {
         "description": "RU: Каталожная информация для enrichment слоя (adapter-only).\nEN: Catalog enrichment info (adapter-only).\n\nThis is attached to shoplist lines when region_id/store_id are provided.\nMissing catalog is not an error (fail-soft).",
         "properties": {
@@ -1443,6 +2040,80 @@
         "title": "CurrencyDTO",
         "type": "string"
       },
+      "DailyGoals": {
+        "description": "Daily nutrition goals.",
+        "properties": {
+          "carbs": {
+            "description": "Target carbohydrate servings",
+            "minimum": 0.0,
+            "title": "Carbs",
+            "type": "number"
+          },
+          "fats": {
+            "description": "Target fat servings",
+            "minimum": 0.0,
+            "title": "Fats",
+            "type": "number"
+          },
+          "protein": {
+            "description": "Target protein servings",
+            "minimum": 0.0,
+            "title": "Protein",
+            "type": "number"
+          },
+          "vegetables": {
+            "description": "Target vegetable servings",
+            "minimum": 0.0,
+            "title": "Vegetables",
+            "type": "number"
+          }
+        },
+        "required": [
+          "vegetables",
+          "protein",
+          "carbs",
+          "fats"
+        ],
+        "title": "DailyGoals",
+        "type": "object"
+      },
+      "DailyNutritionResponse": {
+        "description": "Daily nutrition data for Plate view.",
+        "properties": {
+          "daily_goals": {
+            "$ref": "#/components/schemas/DailyGoals",
+            "description": "Daily nutrition goals"
+          },
+          "date": {
+            "description": "Date in ISO 8601 format (YYYY-MM-DD)",
+            "title": "Date",
+            "type": "string"
+          },
+          "segments": {
+            "description": "Nutrition segments for plate visualization",
+            "items": {
+              "$ref": "#/components/schemas/NutritionSegmentData"
+            },
+            "title": "Segments",
+            "type": "array"
+          },
+          "total_progress": {
+            "description": "Overall daily progress (0.0-1.0)",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Total Progress",
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "segments",
+          "total_progress",
+          "daily_goals"
+        ],
+        "title": "DailyNutritionResponse",
+        "type": "object"
+      },
       "DayCloseRequest": {
         "description": "Close a day with an adherence score.\n\nRU: Закрыть день с оценкой выполнения.\nEN: Close day with adherence score.",
         "properties": {
@@ -1758,6 +2429,190 @@
         "title": "InsightResponse",
         "type": "object"
       },
+      "LegacyWeekPlanRequest": {
+        "additionalProperties": false,
+        "description": "Extended request for week plan with optional pre-calculated targets.\n\nSupports two modes:\n- Mode A: With targets (pre-calculated nutrition goals)\n- Mode B: Calculate targets from user profile (sex, age, etc.)",
+        "properties": {
+          "activity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "sedentary",
+                  "light",
+                  "moderate",
+                  "active",
+                  "very_active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activity"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "maximum": 120.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "bodyfat": {
+            "anyOf": [
+              {
+                "maximum": 60.0,
+                "minimum": 3.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bodyfat"
+          },
+          "deficit_pct": {
+            "anyOf": [
+              {
+                "maximum": 25.0,
+                "minimum": 5.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deficit Pct"
+          },
+          "diet_flags": {
+            "anyOf": [
+              {
+                "items": {
+                  "enum": [
+                    "VEG",
+                    "GF",
+                    "DAIRY_FREE",
+                    "LOW_COST",
+                    "HIGH_PROTEIN",
+                    "LOW_CARB",
+                    "MEDITERRANEAN",
+                    "VEGAN",
+                    "KETO",
+                    "PALEO"
+                  ],
+                  "type": "string"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diet Flags"
+          },
+          "goal": {
+            "default": "maintain",
+            "enum": [
+              "loss",
+              "maintain",
+              "gain"
+            ],
+            "title": "Goal",
+            "type": "string"
+          },
+          "height_cm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height Cm"
+          },
+          "lang": {
+            "default": "en",
+            "title": "Lang",
+            "type": "string"
+          },
+          "life_stage": {
+            "default": "adult",
+            "enum": [
+              "child",
+              "teen",
+              "adult",
+              "pregnant",
+              "lactating",
+              "elderly"
+            ],
+            "title": "Life Stage",
+            "type": "string"
+          },
+          "sex": {
+            "anyOf": [
+              {
+                "enum": [
+                  "female",
+                  "male"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sex"
+          },
+          "surplus_pct": {
+            "anyOf": [
+              {
+                "maximum": 20.0,
+                "minimum": 5.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surplus Pct"
+          },
+          "targets": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Targets"
+          },
+          "weight_kg": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight Kg"
+          }
+        },
+        "title": "LegacyWeekPlanRequest",
+        "type": "object"
+      },
       "MealLogRequest": {
         "description": "Log a meal-related event.\n\nRU: Логировать событие приёма пищи.\nEN: Log a meal event.",
         "properties": {
@@ -1936,6 +2791,55 @@
           "adherence_score"
         ],
         "title": "NutrientGapsResponse",
+        "type": "object"
+      },
+      "NutritionSegmentData": {
+        "description": "Single nutrition segment (e.g., Vegetables, Protein, Carbs, Fats).",
+        "properties": {
+          "color": {
+            "description": "Color identifier (e.g., 'green', 'red')",
+            "title": "Color",
+            "type": "string"
+          },
+          "current_value": {
+            "description": "Current servings consumed",
+            "minimum": 0.0,
+            "title": "Current Value",
+            "type": "number"
+          },
+          "icon": {
+            "description": "SF Symbol icon name (e.g., 'leaf.fill')",
+            "title": "Icon",
+            "type": "string"
+          },
+          "name": {
+            "description": "Segment name (e.g., 'Vegetables')",
+            "title": "Name",
+            "type": "string"
+          },
+          "percentage": {
+            "description": "Percentage of plate (0-100)",
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Percentage",
+            "type": "number"
+          },
+          "target_value": {
+            "description": "Target servings for the day",
+            "minimum": 0.0,
+            "title": "Target Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "current_value",
+          "target_value",
+          "percentage",
+          "color",
+          "icon"
+        ],
+        "title": "NutritionSegmentData",
         "type": "object"
       },
       "PackageRuleDTO": {
@@ -2278,6 +3182,340 @@
           "meals"
         ],
         "title": "PlateResponse",
+        "type": "object"
+      },
+      "PremiumWeekPlanRequest": {
+        "properties": {
+          "activity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "sedentary",
+                  "light",
+                  "moderate",
+                  "active",
+                  "very_active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "moderate",
+            "title": "Activity"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 90.0,
+                "exclusiveMinimum": 10.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "diet_flags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Diet Flags",
+            "type": "array"
+          },
+          "goal": {
+            "anyOf": [
+              {
+                "enum": [
+                  "loss",
+                  "maintain",
+                  "gain"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "maintain",
+            "title": "Goal"
+          },
+          "height_cm": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 220.0,
+                "exclusiveMinimum": 100.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height Cm"
+          },
+          "lang": {
+            "default": "en",
+            "enum": [
+              "ru",
+              "en",
+              "es"
+            ],
+            "title": "Lang",
+            "type": "string"
+          },
+          "sex": {
+            "anyOf": [
+              {
+                "enum": [
+                  "female",
+                  "male"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sex"
+          },
+          "targets": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TargetsIn"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "weight_kg": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 300.0,
+                "exclusiveMinimum": 30.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight Kg"
+          }
+        },
+        "title": "PremiumWeekPlanRequest",
+        "type": "object"
+      },
+      "PremiumWeekPlanResponse": {
+        "properties": {
+          "adherence_score": {
+            "title": "Adherence Score",
+            "type": "number"
+          },
+          "daily_menus": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Daily Menus",
+            "type": "array"
+          },
+          "shopping_list": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Shopping List",
+            "type": "object"
+          },
+          "total_cost": {
+            "title": "Total Cost",
+            "type": "number"
+          },
+          "weekly_coverage": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Weekly Coverage",
+            "type": "object"
+          }
+        },
+        "required": [
+          "daily_menus",
+          "weekly_coverage",
+          "shopping_list",
+          "total_cost",
+          "adherence_score"
+        ],
+        "title": "PremiumWeekPlanResponse",
+        "type": "object"
+      },
+      "ProWeekPlanRequest": {
+        "description": "Request model for weekly meal plan generation.\n\nSupports two modes:\n- Mode A: Provide ready targets\n- Mode B: Quick profile (fallback)",
+        "properties": {
+          "activity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "sedentary",
+                  "light",
+                  "moderate",
+                  "active",
+                  "very_active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "moderate",
+            "title": "Activity"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 90.0,
+                "exclusiveMinimum": 10.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "diet_flags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Diet Flags",
+            "type": "array"
+          },
+          "goal": {
+            "anyOf": [
+              {
+                "enum": [
+                  "loss",
+                  "maintain",
+                  "gain"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "maintain",
+            "title": "Goal"
+          },
+          "height_cm": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 220.0,
+                "exclusiveMinimum": 100.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height Cm"
+          },
+          "lang": {
+            "default": "en",
+            "enum": [
+              "ru",
+              "en",
+              "es"
+            ],
+            "title": "Lang",
+            "type": "string"
+          },
+          "sex": {
+            "anyOf": [
+              {
+                "enum": [
+                  "female",
+                  "male"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sex"
+          },
+          "targets": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TargetsIn"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "weight_kg": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 300.0,
+                "exclusiveMinimum": 30.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight Kg"
+          }
+        },
+        "title": "ProWeekPlanRequest",
+        "type": "object"
+      },
+      "ProWeekPlanResponse": {
+        "description": "Response model for weekly meal plan.",
+        "properties": {
+          "adherence_score": {
+            "title": "Adherence Score",
+            "type": "number"
+          },
+          "daily_menus": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Daily Menus",
+            "type": "array"
+          },
+          "shopping_list": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Shopping List",
+            "type": "object"
+          },
+          "total_cost": {
+            "title": "Total Cost",
+            "type": "number"
+          },
+          "weekly_coverage": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Weekly Coverage",
+            "type": "object"
+          }
+        },
+        "required": [
+          "daily_menus",
+          "weekly_coverage",
+          "shopping_list",
+          "total_cost",
+          "adherence_score"
+        ],
+        "title": "ProWeekPlanResponse",
         "type": "object"
       },
       "QuantityDTO-Input": {
@@ -3639,6 +4877,58 @@
         "title": "SoftPaywallMessage",
         "type": "object"
       },
+      "TargetsIn": {
+        "description": "Nutrition targets input model.\n\nRU: Входная схема таргетов питания (используется в PRO/Premium эндпоинтах).\nEN: Input schema for nutrition targets (used by PRO/Premium endpoints).",
+        "properties": {
+          "activity_week": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activity Week"
+          },
+          "kcal": {
+            "exclusiveMaximum": 6000.0,
+            "exclusiveMinimum": 500.0,
+            "title": "Kcal",
+            "type": "integer"
+          },
+          "macros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Macros",
+            "type": "object"
+          },
+          "micro": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Micro",
+            "type": "object"
+          },
+          "water_ml": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Water Ml",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "kcal",
+          "macros",
+          "micro"
+        ],
+        "title": "TargetsIn",
+        "type": "object"
+      },
       "TestResponse": {
         "description": "Standard test response model.",
         "properties": {
@@ -4096,190 +5386,6 @@
         "title": "WaistRiskResultSchema",
         "type": "object"
       },
-      "WeekPlanRequest": {
-        "additionalProperties": false,
-        "description": "Extended request for week plan with optional pre-calculated targets.\n\nSupports two modes:\n- Mode A: With targets (pre-calculated nutrition goals)\n- Mode B: Calculate targets from user profile (sex, age, etc.)",
-        "properties": {
-          "activity": {
-            "anyOf": [
-              {
-                "enum": [
-                  "sedentary",
-                  "light",
-                  "moderate",
-                  "active",
-                  "very_active"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Activity"
-          },
-          "age": {
-            "anyOf": [
-              {
-                "maximum": 120.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Age"
-          },
-          "bodyfat": {
-            "anyOf": [
-              {
-                "maximum": 60.0,
-                "minimum": 3.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bodyfat"
-          },
-          "deficit_pct": {
-            "anyOf": [
-              {
-                "maximum": 25.0,
-                "minimum": 5.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deficit Pct"
-          },
-          "diet_flags": {
-            "anyOf": [
-              {
-                "items": {
-                  "enum": [
-                    "VEG",
-                    "GF",
-                    "DAIRY_FREE",
-                    "LOW_COST",
-                    "HIGH_PROTEIN",
-                    "LOW_CARB",
-                    "MEDITERRANEAN",
-                    "VEGAN",
-                    "KETO",
-                    "PALEO"
-                  ],
-                  "type": "string"
-                },
-                "type": "array",
-                "uniqueItems": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diet Flags"
-          },
-          "goal": {
-            "default": "maintain",
-            "enum": [
-              "loss",
-              "maintain",
-              "gain"
-            ],
-            "title": "Goal",
-            "type": "string"
-          },
-          "height_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Height Cm"
-          },
-          "lang": {
-            "default": "en",
-            "title": "Lang",
-            "type": "string"
-          },
-          "life_stage": {
-            "default": "adult",
-            "enum": [
-              "child",
-              "teen",
-              "adult",
-              "pregnant",
-              "lactating",
-              "elderly"
-            ],
-            "title": "Life Stage",
-            "type": "string"
-          },
-          "sex": {
-            "anyOf": [
-              {
-                "enum": [
-                  "female",
-                  "male"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sex"
-          },
-          "surplus_pct": {
-            "anyOf": [
-              {
-                "maximum": 20.0,
-                "minimum": 5.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Surplus Pct"
-          },
-          "targets": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Targets"
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weight Kg"
-          }
-        },
-        "title": "WeekPlanRequest",
-        "type": "object"
-      },
       "WeeklyMenuResponse": {
         "description": "RU: Ответ с недельным меню.\nEN: Response with weekly menu.",
         "properties": {
@@ -4371,17 +5477,12 @@
       "name": "PulsePlate API Support",
       "url": "https://github.com/Katsiarynakavaleuskaya/PulsePlate"
     },
-    "description": "\n## PulsePlate - Nutrition & Meal Planning API\n\n**Mobile-first API** for iOS and web applications with tiered subscription access.\n\n### Subscription Tiers\n\n- **FREE**: BMI calculations, food/recipe search, user management\n- **PRO**: Advanced meal planning, WHO-based nutrition targets, macro tracking\n- **VIP**: Micronutrient goals, AI recipe synthesis, auto-repair, shopping lists\n\n### Authentication\n\nPremium endpoints require API key in `X-API-Key` header:\n- PRO tier: Use API key with PRO access level\n- VIP tier: Use API key with VIP access level\n\n### Test API Keys (Development Only)\n\n- PRO: `YOUR_PRO_TEST_KEY`\n- VIP: `YOUR_VIP_TEST_KEY`\n\n**Note**: Replace with actual test keys from your environment variables or Config.plist.\n**Production**: Test keys are disabled in production environments.\n\n### Documentation\n\n- Mobile API Migration Guide: `docs/MOBILE_API_MIGRATION_GUIDE.md`\n- iOS Integration: `docs/IOS_API_INTEGRATION.md`\n\n\n⚠️ **Schema-only mode**: Premium/pro routers excluded due to import-time ORM dependencies. Full schema will be restored in PR-509 after eliminating import-time ORM deps.",
+    "description": "\n## PulsePlate - Nutrition & Meal Planning API\n\n**Mobile-first API** for iOS and web applications with tiered subscription access.\n\n### Subscription Tiers\n\n- **FREE**: BMI calculations, food/recipe search, user management\n- **PRO**: Advanced meal planning, WHO-based nutrition targets, macro tracking\n- **VIP**: Micronutrient goals, AI recipe synthesis, auto-repair, shopping lists\n\n### Authentication\n\nPremium endpoints require API key in `X-API-Key` header:\n- PRO tier: Use API key with PRO access level\n- VIP tier: Use API key with VIP access level\n\n### Test API Keys (Development Only)\n\n- PRO: `YOUR_PRO_TEST_KEY`\n- VIP: `YOUR_VIP_TEST_KEY`\n\n**Note**: Replace with actual test keys from your environment variables or Config.plist.\n**Production**: Test keys are disabled in production environments.\n\n### Documentation\n\n- Mobile API Migration Guide: `docs/MOBILE_API_MIGRATION_GUIDE.md`\n- iOS Integration: `docs/IOS_API_INTEGRATION.md`\n",
     "license": {
       "name": "MIT"
     },
     "title": "PulsePlate",
-    "version": "0.1.0",
-    "x-excluded-routers": [
-      "premium_week",
-      "pro"
-    ],
-    "x-openapi-mode": "schema-only"
+    "version": "0.1.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -4943,6 +6044,56 @@
         ]
       }
     },
+    "/api/v1/bmi/pro": {
+      "post": {
+        "deprecated": true,
+        "description": "Legacy BMI Pro endpoint (deprecated).\n\nThis endpoint is maintained for backward compatibility only.\nNew clients should use the canonical endpoint: POST /api/v1/pro/bmi\n\nArgs:\n    req: BMI Pro request payload\n    _: Pro tier guard (required, ensures tier check before proxying)\n\nReturns:\n    BMI Pro response with analysis results",
+        "operationId": "bmi_pro_legacy_alias_api_v1_bmi_pro_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BMIProRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BMIProResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Bmi Pro Legacy Alias",
+        "tags": [
+          "bmi"
+        ],
+        "x-alias-of": "/api/v1/pro/bmi",
+        "x-migration-path": "Migrate to POST /api/v1/pro/bmi (same contract)"
+      }
+    },
     "/api/v1/bodyfat": {
       "post": {
         "operationId": "calc_bodyfat_api_v1_bodyfat_post",
@@ -4981,6 +6132,81 @@
           }
         },
         "summary": "Calc Bodyfat"
+      }
+    },
+    "/api/v1/business/analyze": {
+      "post": {
+        "description": "Analyze code from a business perspective.\n\nProvides business insights on monetization strategies, cost optimization,\ncustomer acquisition, revenue growth, and customer retention.",
+        "operationId": "analyze_business_code_api_v1_business_analyze_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BusinessAnalysisRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BusinessAnalysisResponse"
+                  },
+                  "title": "Response Analyze Business Code Api V1 Business Analyze Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Analyze Business Code",
+        "tags": [
+          "business"
+        ]
+      }
+    },
+    "/api/v1/business/status": {
+      "get": {
+        "description": "Check if the business module is enabled.",
+        "operationId": "business_status_api_v1_business_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Business Status Api V1 Business Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Business Status",
+        "tags": [
+          "business"
+        ]
       }
     },
     "/api/v1/catalog/regions": {
@@ -5905,7 +7131,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/WeekPlanRequest"
+                "$ref": "#/components/schemas/LegacyWeekPlanRequest"
               }
             }
           },
@@ -5939,6 +7165,56 @@
           }
         ],
         "summary": "Api Weekly Menu"
+      }
+    },
+    "/api/v1/premium/plan/week-flexible": {
+      "post": {
+        "deprecated": true,
+        "description": "⚠️ **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.\n\n    Please use `/api/v1/pro/meal/weekly` instead.\n\n    Migration guide:\n    - Update your API client to use `/api/v1/pro/meal/weekly`\n    - Request/response format remains the same\n    - API key validation remains the same (PRO tier required)\n\n    Original description:\n    Generate weekly meal plan with PRO tier features.\n\n    RU: Генерация недельного плана питания с функциями PRO уровня.\n    EN: Generate weekly meal plan with PRO tier features.\n\n    Requires: PRO tier API key in X-API-Key header\n\n    Features:\n    - WHO-based nutrition targets\n    - Macro and micronutrient planning\n    - Dietary restrictions support\n    - Weekly shopping list\n    - Cost estimation",
+        "operationId": "generate_week_plan_api_v1_premium_plan_week_flexible_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PremiumWeekPlanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PremiumWeekPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "[DEPRECATED] Generate weekly meal plan",
+        "tags": [
+          "premium"
+        ],
+        "x-alias-of": "/api/v1/pro/meal/weekly",
+        "x-migration-path": "Migrate to /api/v1/pro/meal/weekly (same contract)"
       }
     },
     "/api/v1/premium/plate": {
@@ -6037,6 +7313,101 @@
         "x-migration-path": "Migrate to /api/v1/pro/nutrition/targets (same contract)"
       }
     },
+    "/api/v1/pro/bmi": {
+      "post": {
+        "deprecated": true,
+        "description": "DEPRECATED: This endpoint uses legacy BMI calculation logic outside canonical engine.\n    Use `/api/v1/pro/bmi/calculate` instead (canonical engine-based endpoint with WHR support).\n\n    RU: Устаревший endpoint. Используйте /api/v1/pro/bmi/calculate.\n    EN: Deprecated endpoint. Use /api/v1/pro/bmi/calculate instead.",
+        "operationId": "bmi_pro_api_v1_pro_bmi_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BMIProRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BMIProResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "[DEPRECATED] Legacy PRO BMI endpoint",
+        "tags": [
+          "pro"
+        ]
+      }
+    },
+    "/api/v1/pro/bmi/calculate": {
+      "post": {
+        "description": "PRO tier BMI calculation endpoint with WHR (Waist-to-Hip Ratio) support.\n\n    RU: Расчет BMI с поддержкой WHR для PRO уровня.\n    EN: PRO tier BMI calculation with WHR support.\n\n    Requires: PRO tier API key in X-API-Key header\n\n    Features:\n    - All FREE tier features (BMI, category, WHtR, waist risk)\n    - WHR calculation (requires hip_cm)\n    - PRO tier soft paywall hooks",
+        "operationId": "calculate_bmi_pro_api_v1_pro_bmi_calculate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BMICalculateProRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BMICalculateProResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Calculate BMI with WHR (PRO tier)",
+        "tags": [
+          "pro"
+        ]
+      }
+    },
     "/api/v1/pro/meal/shopping-list": {
       "post": {
         "description": "Generate shopping list from weekly meal plan.\n\n**Input:**\n- `weekly_plan_id`: Optional ID of saved weekly plan (from DB)\n- `plan_data`: Optional inline weekly plan JSON\n- `preferences`: Shopping list generation preferences\n\n**Output:**\n- Categories with grouped items\n- Total item count\n- Generation metadata\n\n**Algorithm:**\n1. Validate input (XOR: weekly_plan_id OR plan_data)\n2. Extract ingredients from plan_data\n3. Normalize keys and aggregate quantities\n4. Group by categories\n5. Return structured DTO with warnings",
@@ -6082,6 +7453,211 @@
         "tags": [
           "pro",
           "shopping-list"
+        ]
+      }
+    },
+    "/api/v1/pro/meal/weekly": {
+      "post": {
+        "description": "Generate weekly meal plan with PRO tier features.\n\n    RU: Генерация недельного плана питания с функциями PRO уровня.\n    EN: Generate weekly meal plan with PRO tier features.\n\n    Requires: PRO tier API key in X-API-Key header\n\n    Features:\n    - WHO-based nutrition targets\n    - Macro and micronutrient planning\n    - Dietary restrictions support\n    - Weekly shopping list\n    - Cost estimation",
+        "operationId": "generate_week_plan_api_v1_pro_meal_weekly_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProWeekPlanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProWeekPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Generate weekly meal plan (PRO tier)",
+        "tags": [
+          "pro"
+        ]
+      }
+    },
+    "/api/v1/pro/nutrition/daily": {
+      "get": {
+        "description": "Get daily nutrition tracking data for Plate view based on WHO targets.\n\n    RU: Получить данные по питанию за день для визуализации тарелки на основе таргетов ВОЗ.\n    EN: Get daily nutrition tracking data for Plate view based on WHO targets.\n\n    Requires: PRO tier API key in X-API-Key header\n\n    Features:\n    - WHO/USDA-based personalized targets\n    - Plate segment visualization\n    - Overall progress tracking\n\n    Query Parameters:\n    - date: Date in YYYY-MM-DD format (required)\n    - sex: Biological sex (required)\n    - age: Age in years (required)\n    - height_cm: Height in centimeters (required)\n    - weight_kg: Weight in kilograms (required)\n    - activity: Activity level (optional, default: moderate)\n    - goal: Nutrition goal (optional, default: maintain)\n    - lang: Language for localized segment names (optional, default: en)\n\n    Note: Current consumption values (current_value) are 0.0 until meal logging is implemented.",
+        "operationId": "get_daily_nutrition_api_v1_pro_nutrition_daily_get",
+        "parameters": [
+          {
+            "description": "Date in ISO 8601 format (YYYY-MM-DD)",
+            "in": "query",
+            "name": "date",
+            "required": true,
+            "schema": {
+              "description": "Date in ISO 8601 format (YYYY-MM-DD)",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "title": "Date",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Biological sex",
+            "in": "query",
+            "name": "sex",
+            "required": true,
+            "schema": {
+              "description": "Biological sex",
+              "enum": [
+                "female",
+                "male"
+              ],
+              "title": "Sex",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Age in years (10-100 inclusive)",
+            "in": "query",
+            "name": "age",
+            "required": true,
+            "schema": {
+              "description": "Age in years (10-100 inclusive)",
+              "maximum": 100,
+              "minimum": 10,
+              "title": "Age",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Height in centimeters",
+            "in": "query",
+            "name": "height_cm",
+            "required": true,
+            "schema": {
+              "description": "Height in centimeters",
+              "exclusiveMaximum": 250,
+              "exclusiveMinimum": 100,
+              "title": "Height Cm",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Weight in kilograms",
+            "in": "query",
+            "name": "weight_kg",
+            "required": true,
+            "schema": {
+              "description": "Weight in kilograms",
+              "exclusiveMaximum": 300,
+              "exclusiveMinimum": 30,
+              "title": "Weight Kg",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Activity level",
+            "in": "query",
+            "name": "activity",
+            "required": false,
+            "schema": {
+              "default": "moderate",
+              "description": "Activity level",
+              "enum": [
+                "sedentary",
+                "light",
+                "moderate",
+                "active",
+                "very_active"
+              ],
+              "title": "Activity",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Nutrition goal",
+            "in": "query",
+            "name": "goal",
+            "required": false,
+            "schema": {
+              "default": "maintain",
+              "description": "Nutrition goal",
+              "enum": [
+                "loss",
+                "maintain",
+                "gain"
+              ],
+              "title": "Goal",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Language for localized content",
+            "in": "query",
+            "name": "lang",
+            "required": false,
+            "schema": {
+              "default": "en",
+              "description": "Language for localized content",
+              "enum": [
+                "ru",
+                "en",
+                "es"
+              ],
+              "title": "Lang",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyNutritionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get daily nutrition data (PRO tier)",
+        "tags": [
+          "pro"
         ]
       }
     },

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -337,6 +337,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/bmi/pro": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bmi Pro Legacy Alias
+         * @deprecated
+         * @description Legacy BMI Pro endpoint (deprecated).
+         *
+         *     This endpoint is maintained for backward compatibility only.
+         *     New clients should use the canonical endpoint: POST /api/v1/pro/bmi
+         *
+         *     Args:
+         *         req: BMI Pro request payload
+         *         _: Pro tier guard (required, ensures tier check before proxying)
+         *
+         *     Returns:
+         *         BMI Pro response with analysis results
+         */
+        post: operations["bmi_pro_legacy_alias_api_v1_bmi_pro_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/bodyfat": {
         parameters: {
             query?: never;
@@ -348,6 +379,49 @@ export interface paths {
         put?: never;
         /** Calc Bodyfat */
         post: operations["calc_bodyfat_api_v1_bodyfat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/business/analyze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Analyze Business Code
+         * @description Analyze code from a business perspective.
+         *
+         *     Provides business insights on monetization strategies, cost optimization,
+         *     customer acquisition, revenue growth, and customer retention.
+         */
+        post: operations["analyze_business_code_api_v1_business_analyze_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/business/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Business Status
+         * @description Check if the business module is enabled.
+         */
+        get: operations["business_status_api_v1_business_status_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -725,6 +799,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/premium/plan/week-flexible": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * [DEPRECATED] Generate weekly meal plan
+         * @deprecated
+         * @description ⚠️ **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.
+         *
+         *         Please use `/api/v1/pro/meal/weekly` instead.
+         *
+         *         Migration guide:
+         *         - Update your API client to use `/api/v1/pro/meal/weekly`
+         *         - Request/response format remains the same
+         *         - API key validation remains the same (PRO tier required)
+         *
+         *         Original description:
+         *         Generate weekly meal plan with PRO tier features.
+         *
+         *         RU: Генерация недельного плана питания с функциями PRO уровня.
+         *         EN: Generate weekly meal plan with PRO tier features.
+         *
+         *         Requires: PRO tier API key in X-API-Key header
+         *
+         *         Features:
+         *         - WHO-based nutrition targets
+         *         - Macro and micronutrient planning
+         *         - Dietary restrictions support
+         *         - Weekly shopping list
+         *         - Cost estimation
+         */
+        post: operations["generate_week_plan_api_v1_premium_plan_week_flexible_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/premium/plate": {
         parameters: {
             query?: never;
@@ -770,6 +887,61 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/bmi": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * [DEPRECATED] Legacy PRO BMI endpoint
+         * @deprecated
+         * @description DEPRECATED: This endpoint uses legacy BMI calculation logic outside canonical engine.
+         *         Use `/api/v1/pro/bmi/calculate` instead (canonical engine-based endpoint with WHR support).
+         *
+         *         RU: Устаревший endpoint. Используйте /api/v1/pro/bmi/calculate.
+         *         EN: Deprecated endpoint. Use /api/v1/pro/bmi/calculate instead.
+         */
+        post: operations["bmi_pro_api_v1_pro_bmi_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/bmi/calculate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Calculate BMI with WHR (PRO tier)
+         * @description PRO tier BMI calculation endpoint with WHR (Waist-to-Hip Ratio) support.
+         *
+         *         RU: Расчет BMI с поддержкой WHR для PRO уровня.
+         *         EN: PRO tier BMI calculation with WHR support.
+         *
+         *         Requires: PRO tier API key in X-API-Key header
+         *
+         *         Features:
+         *         - All FREE tier features (BMI, category, WHtR, waist risk)
+         *         - WHR calculation (requires hip_cm)
+         *         - PRO tier soft paywall hooks
+         */
+        post: operations["calculate_bmi_pro_api_v1_pro_bmi_calculate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/meal/shopping-list": {
         parameters: {
             query?: never;
@@ -801,6 +973,80 @@ export interface paths {
          *     5. Return structured DTO with warnings
          */
         post: operations["generate_shopping_list_api_v1_pro_meal_shopping_list_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/meal/weekly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate weekly meal plan (PRO tier)
+         * @description Generate weekly meal plan with PRO tier features.
+         *
+         *         RU: Генерация недельного плана питания с функциями PRO уровня.
+         *         EN: Generate weekly meal plan with PRO tier features.
+         *
+         *         Requires: PRO tier API key in X-API-Key header
+         *
+         *         Features:
+         *         - WHO-based nutrition targets
+         *         - Macro and micronutrient planning
+         *         - Dietary restrictions support
+         *         - Weekly shopping list
+         *         - Cost estimation
+         */
+        post: operations["generate_week_plan_api_v1_pro_meal_weekly_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/nutrition/daily": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get daily nutrition data (PRO tier)
+         * @description Get daily nutrition tracking data for Plate view based on WHO targets.
+         *
+         *         RU: Получить данные по питанию за день для визуализации тарелки на основе таргетов ВОЗ.
+         *         EN: Get daily nutrition tracking data for Plate view based on WHO targets.
+         *
+         *         Requires: PRO tier API key in X-API-Key header
+         *
+         *         Features:
+         *         - WHO/USDA-based personalized targets
+         *         - Plate segment visualization
+         *         - Overall progress tracking
+         *
+         *         Query Parameters:
+         *         - date: Date in YYYY-MM-DD format (required)
+         *         - sex: Biological sex (required)
+         *         - age: Age in years (required)
+         *         - height_cm: Height in centimeters (required)
+         *         - weight_kg: Weight in kilograms (required)
+         *         - activity: Activity level (optional, default: moderate)
+         *         - goal: Nutrition goal (optional, default: maintain)
+         *         - lang: Language for localized segment names (optional, default: en)
+         *
+         *         Note: Current consumption values (current_value) are 0.0 until meal logging is implemented.
+         */
+        get: operations["get_daily_nutrition_api_v1_pro_nutrition_daily_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1990,6 +2236,210 @@ export interface components {
             user_id: number;
         };
         /**
+         * BMICalculateProRequest
+         * @description PRO tier BMI calculation request (extends FREE with hip_cm for WHR).
+         *
+         *     RU: Запрос расчета BMI для PRO уровня (расширяет FREE с hip_cm для WHR).
+         *     EN: PRO tier BMI calculation request (extends FREE with hip_cm for WHR).
+         */
+        BMICalculateProRequest: {
+            /**
+             * Age
+             * @description Age in years. Range: 1-120.
+             * @example 25
+             * @example 30
+             * @example 45
+             * @example 65
+             */
+            age: number;
+            /**
+             * Athlete
+             * @description Athlete status. Accepts: 'yes'/'no' (string) or True/False (bool). Will be normalized to bool by schema.
+             * @default false
+             * @example no
+             * @example yes
+             * @example false
+             * @example true
+             */
+            athlete: string | boolean;
+            /**
+             * Gender
+             * @description Gender: 'male' or 'female'. Normalized by schema validator. Guaranteed to be str after validation.
+             * @example male
+             * @example female
+             * @example муж
+             * @example жен
+             * @example null
+             */
+            gender?: string | null;
+            /**
+             * Height Cm
+             * @description Height in centimeters. Must be positive.
+             * @example 170
+             * @example 175.5
+             * @example 180
+             */
+            height_cm: number;
+            /**
+             * Hip Cm
+             * @description Hip circumference in centimeters (optional, PRO tier only). If provided along with waist_cm, enables WHR (Waist-to-Hip Ratio) calculation.
+             * @example 95
+             * @example 100.5
+             * @example null
+             */
+            hip_cm?: number | null;
+            /**
+             * Lang
+             * @description Language for localized responses: 'ru', 'en', or 'es'.
+             * @default en
+             * @example en
+             * @example ru
+             * @example es
+             * @enum {string}
+             */
+            lang: "ru" | "en" | "es";
+            /**
+             * Pregnant
+             * @description Pregnancy status. Accepts: 'yes'/'no' (string) or True/False (bool). Will be normalized to bool by engine.
+             * @default false
+             * @example no
+             * @example yes
+             * @example false
+             * @example true
+             */
+            pregnant: string | boolean;
+            /**
+             * Waist Cm
+             * @description Waist circumference in centimeters (optional). If provided, enables WHtR and waist risk assessment.
+             * @example 80
+             * @example 90.5
+             * @example null
+             */
+            waist_cm?: number | null;
+            /**
+             * Weight Kg
+             * @description Weight in kilograms. Must be positive.
+             * @example 65.5
+             * @example 70
+             * @example 80.3
+             */
+            weight_kg: number;
+        };
+        /**
+         * BMICalculateProResponse
+         * @description PRO tier BMI calculation response (extends FREE with whr).
+         *
+         *     RU: Ответ расчета BMI для PRO уровня (расширяет FREE с whr).
+         *     EN: PRO tier BMI calculation response (extends FREE with whr).
+         */
+        BMICalculateProResponse: {
+            /**
+             * Age Band
+             * @description Age band for UI differentiation: 'too_young' (<12), 'child' (12-14), 'teen' (15-18), 'adult' (19-59), 'elderly' (>=60).
+             * @example adult
+             * @example teen
+             * @example elderly
+             * @enum {string}
+             */
+            age_band: "too_young" | "child" | "teen" | "adult" | "elderly";
+            /**
+             * Bmi
+             * @description Calculated BMI value (weight_kg / (height_m ** 2)).
+             * @example 22.5
+             * @example 25.3
+             * @example 18.7
+             */
+            bmi: number;
+            /**
+             * Category
+             * @description BMI category (localized). None for users in 'pregnant', 'too_young', 'child' or 'teen' age bands - not an error, medical disclaimer. BMI categories are not provided during pregnancy or for users in 'too_young', 'child' and 'teen' age bands.
+             * @example normal
+             * @example overweight
+             * @example null
+             */
+            category?: string | null;
+            /**
+             * Group
+             * @description User group determined by auto_group(): 'general', 'athlete', 'elderly', 'child', 'teen', 'too_young', 'pregnant'.
+             * @example general
+             * @example athlete
+             * @example elderly
+             */
+            group: string;
+            /**
+             * Group Display
+             * @description Localized display name for the group.
+             * @example General
+             * @example Athlete
+             * @example Elderly
+             */
+            group_display: string;
+            /**
+             * Interpretation
+             * @description Localized interpretation text for the BMI value in the context of the group.
+             * @example Your BMI is within the normal range for your age group.
+             */
+            interpretation: string;
+            /**
+             * @description Optional structured interpretation (v1). i18n keys only. Currently may be None while wiring is in progress. Planned behavior: None only for too_young; pregnancy returns structured interpretation (goal=medical_review, target=prenatal_guidelines), and pregnant+athlete includes additional athlete disclaimers.
+             * @example {
+             *       "disclaimers": [
+             *         "bmi.interpretation.disclaimer.general"
+             *       ],
+             *       "goal_direction": "maintain",
+             *       "priority_notes": [],
+             *       "risk_flags": [],
+             *       "target_range": {
+             *         "max": 25,
+             *         "min": 18.5
+             *       }
+             *     }
+             * @example null
+             */
+            interpretation_v1?: components["schemas"]["BMIInterpretationV1Schema"] | null;
+            /**
+             * Notes
+             * @description Aggregated notes (currently only from waist_risk.notes). Empty list if no notes.
+             * @example []
+             * @example [
+             *       "Increased waist-related risk"
+             *     ]
+             */
+            notes?: string[];
+            /** @description Optional soft paywall hook for PRO tier upsell (wellness positioning only). */
+            soft_paywall?: components["schemas"]["SoftPaywallHook"] | null;
+            /** @description Optional BMI scale visualization spec (v1). Frontend should render this if available. */
+            visualization?: components["schemas"]["BMIScaleV1Spec"] | null;
+            /**
+             * @description Waist risk assessment result. Present only if waist_cm was provided and risk was calculated.
+             * @example {
+             *       "notes": [
+             *         "Increased waist-related risk"
+             *       ],
+             *       "risk_level": "moderate",
+             *       "wht_ratio": 0.52
+             *     }
+             * @example null
+             */
+            waist_risk?: components["schemas"]["WaistRiskResultSchema"] | null;
+            /**
+             * Whr
+             * @description Waist-to-Hip Ratio (WHR, PRO tier only). Calculated only if both waist_cm and hip_cm were provided and >0.
+             * @example 0.8
+             * @example 0.95
+             * @example null
+             */
+            whr?: number | null;
+            /**
+             * Wht Ratio
+             * @description Waist-to-Height Ratio (WHtR). Calculated only if waist_cm was provided.
+             * @example 0.47
+             * @example 0.52
+             * @example null
+             */
+            wht_ratio?: number | null;
+        };
+        /**
          * BMICalculateRequest
          * @description RU: Запрос для расчета BMI через единый engine.
          *     EN: Request for BMI calculation via unified engine.
@@ -2242,6 +2692,50 @@ export interface components {
              * @example 18.5
              */
             value: number;
+        };
+        /** BMIProRequest */
+        BMIProRequest: {
+            /** Age */
+            age: number;
+            /** Bodyfat Percent */
+            bodyfat_percent?: number | null;
+            /** Height Cm */
+            height_cm: number;
+            /** Hip Cm */
+            hip_cm?: number | null;
+            /**
+             * Lang
+             * @default en
+             * @enum {string}
+             */
+            lang: "ru" | "en" | "es";
+            /**
+             * Sex
+             * @enum {string}
+             */
+            sex: "female" | "male";
+            /** Waist Cm */
+            waist_cm: number;
+            /** Weight Kg */
+            weight_kg: number;
+        };
+        /** BMIProResponse */
+        BMIProResponse: {
+            /** Bmi */
+            bmi: number;
+            /** Ffmi */
+            ffmi: number | null;
+            /** Notes */
+            notes: string[];
+            /**
+             * Risk Level
+             * @enum {string}
+             */
+            risk_level: "low" | "moderate" | "high";
+            /** Whr */
+            whr: number | null;
+            /** Whtr */
+            whtr: number;
         };
         /**
          * BMIRangeSpec
@@ -2556,6 +3050,48 @@ export interface components {
             weight_kg?: number | null;
         };
         /**
+         * BusinessAnalysisRequest
+         * @description Request model for business analysis.
+         */
+        BusinessAnalysisRequest: {
+            /**
+             * Code
+             * @description Code to analyze (max 100KB)
+             */
+            code: string;
+            /** Locale */
+            locale?: string | null;
+            /**
+             * Test Name
+             * @default business_analysis
+             */
+            test_name: string;
+        };
+        /**
+         * BusinessAnalysisResponse
+         * @description Response model for business analysis.
+         */
+        BusinessAnalysisResponse: {
+            /** Business Category */
+            business_category: string;
+            /** Cost Impact */
+            cost_impact: string;
+            /** Customer Impact */
+            customer_impact: string;
+            /** Error Message */
+            error_message: string | null;
+            /** Error Type */
+            error_type: string;
+            /** Optimization Potential */
+            optimization_potential: string | null;
+            /** Revenue Impact */
+            revenue_impact: string;
+            /** Success */
+            success: boolean;
+            /** Test Name */
+            test_name: string;
+        };
+        /**
          * CatalogInfoDTO
          * @description RU: Каталожная информация для enrichment слоя (adapter-only).
          *     EN: Catalog enrichment info (adapter-only).
@@ -2730,6 +3266,55 @@ export interface components {
          * @enum {string}
          */
         CurrencyDTO: "EUR" | "USD" | "GBP" | "CAD" | "MXN" | "AUD" | "JPY" | "BYN" | "RUB";
+        /**
+         * DailyGoals
+         * @description Daily nutrition goals.
+         */
+        DailyGoals: {
+            /**
+             * Carbs
+             * @description Target carbohydrate servings
+             */
+            carbs: number;
+            /**
+             * Fats
+             * @description Target fat servings
+             */
+            fats: number;
+            /**
+             * Protein
+             * @description Target protein servings
+             */
+            protein: number;
+            /**
+             * Vegetables
+             * @description Target vegetable servings
+             */
+            vegetables: number;
+        };
+        /**
+         * DailyNutritionResponse
+         * @description Daily nutrition data for Plate view.
+         */
+        DailyNutritionResponse: {
+            /** @description Daily nutrition goals */
+            daily_goals: components["schemas"]["DailyGoals"];
+            /**
+             * Date
+             * @description Date in ISO 8601 format (YYYY-MM-DD)
+             */
+            date: string;
+            /**
+             * Segments
+             * @description Nutrition segments for plate visualization
+             */
+            segments: components["schemas"]["NutritionSegmentData"][];
+            /**
+             * Total Progress
+             * @description Overall daily progress (0.0-1.0)
+             */
+            total_progress: number;
+        };
         /**
          * DayCloseRequest
          * @description Close a day with an adherence score.
@@ -2935,6 +3520,55 @@ export interface components {
             provider: string;
         };
         /**
+         * LegacyWeekPlanRequest
+         * @description Extended request for week plan with optional pre-calculated targets.
+         *
+         *     Supports two modes:
+         *     - Mode A: With targets (pre-calculated nutrition goals)
+         *     - Mode B: Calculate targets from user profile (sex, age, etc.)
+         */
+        LegacyWeekPlanRequest: {
+            /** Activity */
+            activity?: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
+            /** Age */
+            age?: number | null;
+            /** Bodyfat */
+            bodyfat?: number | null;
+            /** Deficit Pct */
+            deficit_pct?: number | null;
+            /** Diet Flags */
+            diet_flags?: ("VEG" | "GF" | "DAIRY_FREE" | "LOW_COST" | "HIGH_PROTEIN" | "LOW_CARB" | "MEDITERRANEAN" | "VEGAN" | "KETO" | "PALEO")[] | null;
+            /**
+             * Goal
+             * @default maintain
+             * @enum {string}
+             */
+            goal: "loss" | "maintain" | "gain";
+            /** Height Cm */
+            height_cm?: number | null;
+            /**
+             * Lang
+             * @default en
+             */
+            lang: string;
+            /**
+             * Life Stage
+             * @default adult
+             * @enum {string}
+             */
+            life_stage: "child" | "teen" | "adult" | "pregnant" | "lactating" | "elderly";
+            /** Sex */
+            sex?: ("female" | "male") | null;
+            /** Surplus Pct */
+            surplus_pct?: number | null;
+            /** Targets */
+            targets?: {
+                [key: string]: unknown;
+            } | null;
+            /** Weight Kg */
+            weight_kg?: number | null;
+        };
+        /**
          * MealLogRequest
          * @description Log a meal-related event.
          *
@@ -3026,6 +3660,42 @@ export interface components {
                     [key: string]: unknown;
                 };
             };
+        };
+        /**
+         * NutritionSegmentData
+         * @description Single nutrition segment (e.g., Vegetables, Protein, Carbs, Fats).
+         */
+        NutritionSegmentData: {
+            /**
+             * Color
+             * @description Color identifier (e.g., 'green', 'red')
+             */
+            color: string;
+            /**
+             * Current Value
+             * @description Current servings consumed
+             */
+            current_value: number;
+            /**
+             * Icon
+             * @description SF Symbol icon name (e.g., 'leaf.fill')
+             */
+            icon: string;
+            /**
+             * Name
+             * @description Segment name (e.g., 'Vegetables')
+             */
+            name: string;
+            /**
+             * Percentage
+             * @description Percentage of plate (0-100)
+             */
+            percentage: number;
+            /**
+             * Target Value
+             * @description Target servings for the day
+             */
+            target_value: number;
         };
         /**
          * PackageRuleDTO
@@ -3179,6 +3849,114 @@ export interface components {
             meals_per_day: number;
             /** Portions */
             portions: {
+                [key: string]: number;
+            };
+        };
+        /** PremiumWeekPlanRequest */
+        PremiumWeekPlanRequest: {
+            /**
+             * Activity
+             * @default moderate
+             */
+            activity: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
+            /** Age */
+            age?: number | null;
+            /** Diet Flags */
+            diet_flags?: string[];
+            /**
+             * Goal
+             * @default maintain
+             */
+            goal: ("loss" | "maintain" | "gain") | null;
+            /** Height Cm */
+            height_cm?: number | null;
+            /**
+             * Lang
+             * @default en
+             * @enum {string}
+             */
+            lang: "ru" | "en" | "es";
+            /** Sex */
+            sex?: ("female" | "male") | null;
+            targets?: components["schemas"]["TargetsIn"] | null;
+            /** Weight Kg */
+            weight_kg?: number | null;
+        };
+        /** PremiumWeekPlanResponse */
+        PremiumWeekPlanResponse: {
+            /** Adherence Score */
+            adherence_score: number;
+            /** Daily Menus */
+            daily_menus: {
+                [key: string]: unknown;
+            }[];
+            /** Shopping List */
+            shopping_list: {
+                [key: string]: number;
+            };
+            /** Total Cost */
+            total_cost: number;
+            /** Weekly Coverage */
+            weekly_coverage: {
+                [key: string]: number;
+            };
+        };
+        /**
+         * ProWeekPlanRequest
+         * @description Request model for weekly meal plan generation.
+         *
+         *     Supports two modes:
+         *     - Mode A: Provide ready targets
+         *     - Mode B: Quick profile (fallback)
+         */
+        ProWeekPlanRequest: {
+            /**
+             * Activity
+             * @default moderate
+             */
+            activity: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
+            /** Age */
+            age?: number | null;
+            /** Diet Flags */
+            diet_flags?: string[];
+            /**
+             * Goal
+             * @default maintain
+             */
+            goal: ("loss" | "maintain" | "gain") | null;
+            /** Height Cm */
+            height_cm?: number | null;
+            /**
+             * Lang
+             * @default en
+             * @enum {string}
+             */
+            lang: "ru" | "en" | "es";
+            /** Sex */
+            sex?: ("female" | "male") | null;
+            targets?: components["schemas"]["TargetsIn"] | null;
+            /** Weight Kg */
+            weight_kg?: number | null;
+        };
+        /**
+         * ProWeekPlanResponse
+         * @description Response model for weekly meal plan.
+         */
+        ProWeekPlanResponse: {
+            /** Adherence Score */
+            adherence_score: number;
+            /** Daily Menus */
+            daily_menus: {
+                [key: string]: unknown;
+            }[];
+            /** Shopping List */
+            shopping_list: {
+                [key: string]: number;
+            };
+            /** Total Cost */
+            total_cost: number;
+            /** Weekly Coverage */
+            weekly_coverage: {
                 [key: string]: number;
             };
         };
@@ -3941,6 +4719,34 @@ export interface components {
             title_key: string;
         };
         /**
+         * TargetsIn
+         * @description Nutrition targets input model.
+         *
+         *     RU: Входная схема таргетов питания (используется в PRO/Premium эндпоинтах).
+         *     EN: Input schema for nutrition targets (used by PRO/Premium endpoints).
+         */
+        TargetsIn: {
+            /** Activity Week */
+            activity_week?: {
+                [key: string]: number;
+            } | null;
+            /** Kcal */
+            kcal: number;
+            /** Macros */
+            macros: {
+                [key: string]: number;
+            };
+            /** Micro */
+            micro: {
+                [key: string]: number;
+            };
+            /**
+             * Water Ml
+             * @default 0
+             */
+            water_ml: number;
+        };
+        /**
          * TestResponse
          * @description Standard test response model.
          */
@@ -4112,55 +4918,6 @@ export interface components {
              * @description Response status
              */
             status: string;
-        };
-        /**
-         * WeekPlanRequest
-         * @description Extended request for week plan with optional pre-calculated targets.
-         *
-         *     Supports two modes:
-         *     - Mode A: With targets (pre-calculated nutrition goals)
-         *     - Mode B: Calculate targets from user profile (sex, age, etc.)
-         */
-        WeekPlanRequest: {
-            /** Activity */
-            activity?: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
-            /** Age */
-            age?: number | null;
-            /** Bodyfat */
-            bodyfat?: number | null;
-            /** Deficit Pct */
-            deficit_pct?: number | null;
-            /** Diet Flags */
-            diet_flags?: ("VEG" | "GF" | "DAIRY_FREE" | "LOW_COST" | "HIGH_PROTEIN" | "LOW_CARB" | "MEDITERRANEAN" | "VEGAN" | "KETO" | "PALEO")[] | null;
-            /**
-             * Goal
-             * @default maintain
-             * @enum {string}
-             */
-            goal: "loss" | "maintain" | "gain";
-            /** Height Cm */
-            height_cm?: number | null;
-            /**
-             * Lang
-             * @default en
-             */
-            lang: string;
-            /**
-             * Life Stage
-             * @default adult
-             * @enum {string}
-             */
-            life_stage: "child" | "teen" | "adult" | "pregnant" | "lactating" | "elderly";
-            /** Sex */
-            sex?: ("female" | "male") | null;
-            /** Surplus Pct */
-            surplus_pct?: number | null;
-            /** Targets */
-            targets?: {
-                [key: string]: unknown;
-            } | null;
-            /** Weight Kg */
-            weight_kg?: number | null;
         };
         /**
          * WHOTargetsRequest
@@ -4608,6 +5365,39 @@ export interface operations {
             };
         };
     };
+    bmi_pro_legacy_alias_api_v1_bmi_pro_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BMIProRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BMIProResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     calc_bodyfat_api_v1_bodyfat_post: {
         parameters: {
             query?: never;
@@ -4639,6 +5429,61 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_business_code_api_v1_business_analyze_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BusinessAnalysisRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BusinessAnalysisResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    business_status_api_v1_business_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };
@@ -5279,7 +6124,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["WeekPlanRequest"];
+                "application/json": components["schemas"]["LegacyWeekPlanRequest"];
             };
         };
         responses: {
@@ -5290,6 +6135,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WeeklyMenuResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_week_plan_api_v1_premium_plan_week_flexible_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PremiumWeekPlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PremiumWeekPlanResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5371,6 +6249,72 @@ export interface operations {
             };
         };
     };
+    bmi_pro_api_v1_pro_bmi_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BMIProRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BMIProResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    calculate_bmi_pro_api_v1_pro_bmi_calculate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BMICalculateProRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BMICalculateProResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     generate_shopping_list_api_v1_pro_meal_shopping_list_post: {
         parameters: {
             query?: never;
@@ -5391,6 +6335,85 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ShoppingListDTO"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_week_plan_api_v1_pro_meal_weekly_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProWeekPlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProWeekPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_daily_nutrition_api_v1_pro_nutrition_daily_get: {
+        parameters: {
+            query: {
+                /** @description Activity level */
+                activity?: "sedentary" | "light" | "moderate" | "active" | "very_active";
+                /** @description Age in years (10-100 inclusive) */
+                age: number;
+                /** @description Date in ISO 8601 format (YYYY-MM-DD) */
+                date: string;
+                /** @description Nutrition goal */
+                goal?: "loss" | "maintain" | "gain";
+                /** @description Height in centimeters */
+                height_cm: number;
+                /** @description Language for localized content */
+                lang?: "ru" | "en" | "es";
+                /** @description Biological sex */
+                sex: "female" | "male";
+                /** @description Weight in kilograms */
+                weight_kg: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyNutritionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -32,6 +32,7 @@ from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     StrictFloat,
     ValidationError,
@@ -2881,6 +2882,8 @@ class TargetsIn(BaseModel):
     Similar to app.routers.premium_week.TargetsIn but used in main app endpoints.
     """
 
+    model_config = ConfigDict(title="LegacyTargetsIn")
+
     kcal: int = Field(..., gt=500, lt=6000)
     macros: Dict[str, float]
     micro: Dict[str, float]
@@ -2916,13 +2919,15 @@ class TargetsIn(BaseModel):
         return v
 
 
-class WeekPlanRequest(WHOTargetsRequest):
+class LegacyWeekPlanRequest(WHOTargetsRequest):
     """Extended request for week plan with optional pre-calculated targets.
 
     Supports two modes:
     - Mode A: With targets (pre-calculated nutrition goals)
     - Mode B: Calculate targets from user profile (sex, age, etc.)
     """
+
+    model_config = ConfigDict(title="LegacyWeekPlanRequest")
 
     # Make base fields optional when targets are provided
     sex: Optional[Sex] = None  # type: ignore[assignment]
@@ -2932,7 +2937,7 @@ class WeekPlanRequest(WHOTargetsRequest):
     activity: Optional[Activity] = None  # type: ignore[assignment]
 
     @model_validator(mode="after")
-    def _validate_request_mode(self) -> "WeekPlanRequest":
+    def _validate_request_mode(self) -> "LegacyWeekPlanRequest":
         """Ensure either targets or profile data is provided.
 
         - If ``targets`` contains a structured payload with ``macros`` / ``micro``,
@@ -4267,7 +4272,7 @@ async def api_who_targets(payload: Dict[str, Any] = Body(...)) -> WHOTargetsResp
     response_model=WeeklyMenuResponse,
     deprecated=True,
 )
-async def api_weekly_menu(req: WeekPlanRequest) -> WeeklyMenuResponse:
+async def api_weekly_menu(req: LegacyWeekPlanRequest) -> WeeklyMenuResponse:
     """
     RU: Генерирует недельный план питания (через core.menu_engine.make_weekly_menu).
     EN: Generate a weekly meal plan using core.menu_engine.make_weekly_menu.

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -92,52 +92,32 @@ def normalize_openapi_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 
 def main() -> int:
-    # Make OpenAPI generation deterministic across dev/CI
-    # Enable schema-only mode to avoid SQLAlchemy model double-loading
-    # This prevents "Table already defined" errors and ensures deterministic schema
-    os.environ["PULSEPLATE_OPENAPI"] = "1"
-
-    # Hard pin environment and feature flags for schema-only mode
-    # IMPORTANT: This is schema-only mode (temporary). Premium/pro routers are disabled
-    # because they import SQLAlchemy models at module level, causing double-load errors.
-    # Follow-up PR-509: eliminate import-time ORM dependencies to enable full schema.
-    # CI uses APP_ENV=test/ENVIRONMENT=test, so we align here
+    # Make OpenAPI generation deterministic across dev/CI.
+    #
+    # IMPORTANT (PR-631): This is FULL schema mode.
+    # OpenAPI generation must not rely on schema-only router skips or import-time ORM hacks.
+    #
+    # CI uses APP_ENV=test/ENVIRONMENT=test, so we align here.
     os.environ["APP_ENV"] = "test"
     os.environ["ENVIRONMENT"] = "test"
     os.environ["ENABLE_TEST_ROUTES"] = "1"
-    # Disable routers that import SQLAlchemy models at module level (temporary)
-    # These will be re-enabled in PR-509 after moving models to lazy imports or app/schemas
-    os.environ["FEATURE_PREMIUM_WEEK_ENABLED"] = "false"
-    os.environ["FEATURE_BMI_PRO_ENABLED"] = "false"
-    os.environ["BUSINESS_MODULE_ENABLED"] = "false"
+    # Enable feature-flagged routers during schema generation to produce a full schema.
+    # RU: Включаем фичи для полной схемы (только для генерации OpenAPI).
+    # EN: Enable features for full OpenAPI schema generation (generator-only).
+    os.environ["FEATURE_PREMIUM_WEEK_ENABLED"] = "true"
+    os.environ["FEATURE_BMI_PRO_ENABLED"] = "true"
+    os.environ["BUSINESS_MODULE_ENABLED"] = "true"
 
     repo_root = Path(__file__).resolve().parent.parent
     out_path = repo_root / "frontend" / "src" / "api" / "openapi.json"
 
     # IMPORTANT: canonical entrypoint (applies register_metrics bootstrap)
-    # PULSEPLATE_OPENAPI=1 must be set BEFORE importing app to prevent SQLAlchemy double-loading
     from app.main import (
         app,
     )  # noqa: WPS433, ANN401 (intentional runtime import, dynamic typing needed)
 
     schema = app.openapi()
     schema = normalize_openapi_schema(schema)
-
-    # Add explicit marker for schema-only mode (transparency for reviewers/consumers)
-    if "info" not in schema:
-        schema["info"] = {}
-    schema["info"]["x-openapi-mode"] = "schema-only"
-    schema["info"]["x-excluded-routers"] = ["premium_week", "pro"]
-    if "description" in schema["info"]:
-        schema["info"]["description"] += (
-            "\n\n⚠️ **Schema-only mode**: Premium/pro routers excluded due to import-time ORM dependencies. "
-            "Full schema will be restored in PR-509 after eliminating import-time ORM deps."
-        )
-    else:
-        schema["info"]["description"] = (
-            "⚠️ **Schema-only mode**: Premium/pro routers excluded due to import-time ORM dependencies. "
-            "Full schema will be restored in PR-509 after eliminating import-time ORM deps."
-        )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,9 +441,14 @@ def app(app_module: ModuleType) -> FastAPI:
 
 
 @pytest.fixture
-def client(app: FastAPI) -> TestClient:
-    """Return a TestClient for the FastAPI app."""
-    return TestClient(app)
+def client(app: FastAPI) -> Generator[TestClient, None, None]:
+    """Return a TestClient for the FastAPI app (always closed).
+
+    Using TestClient as a context manager ensures lifespan startup/shutdown runs
+    deterministically and prevents leaking background threads across tests.
+    """
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 # --- VIP shoplist test fixtures ---
@@ -501,21 +506,23 @@ def client_with_vip_access(app_module: ModuleType) -> Generator[TestClient, None
     # NOTE: We do NOT override require_vip_module_enabled - it should check the feature flag
     # Tests can use monkeypatch.setattr("app.routers.vip_shoplist.is_vip_module_enabled", ...)
 
-    route = _find_route_by_endpoint_name(app_instance, "vip_shoplist_generate")
-    assert route is not None, "Route for endpoint 'vip_shoplist_generate' not found"
+    route_level_deps: list[Callable] = []
+    try:
+        route = _find_route_by_endpoint_name(app_instance, "vip_shoplist_generate")
+        assert route is not None, "Route for endpoint 'vip_shoplist_generate' not found"
 
-    # Route has API-key dependency applied at route level (via app.include_router);
-    # override it here to avoid requiring headers/env in tests.
-    route_level_deps = list(_iter_route_dependencies(route))
-    for dep_fn in route_level_deps:
-        app_instance.dependency_overrides[dep_fn] = mock_api_key
+        # Route has API-key dependency applied at route level (via app.include_router);
+        # override it here to avoid requiring headers/env in tests.
+        route_level_deps = list(_iter_route_dependencies(route))
+        for dep_fn in route_level_deps:
+            app_instance.dependency_overrides[dep_fn] = mock_api_key
 
-    client = TestClient(app_instance)
-    yield client
-
-    app_instance.dependency_overrides.pop(vip_router.require_vip_tier, None)
-    for dep_fn in route_level_deps:
-        app_instance.dependency_overrides.pop(dep_fn, None)
+        with TestClient(app_instance) as client:
+            yield client
+    finally:
+        app_instance.dependency_overrides.pop(vip_router.require_vip_tier, None)
+        for dep_fn in route_level_deps:
+            app_instance.dependency_overrides.pop(dep_fn, None)
 
 
 @pytest.fixture

--- a/tests/test_diff_coverage_pr339.py
+++ b/tests/test_diff_coverage_pr339.py
@@ -230,12 +230,12 @@ class TestPRORouterDiffCoverage:
         self, monkeypatch, kwargs: Dict[str, Any], expected_field: str
     ):
         """Cover all missing profile field branches in PRO router."""
-        from app.routers.pro import WeekPlanRequest, generate_week_plan
+        from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.pro.get_recipe_db", lambda: MagicMock())
 
-        req = WeekPlanRequest(**kwargs)
+        req = ProWeekPlanRequest(**kwargs)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)
@@ -246,7 +246,7 @@ class TestPRORouterDiffCoverage:
     @pytest.mark.asyncio
     async def test_generate_week_plan_hard_guard_not_dict(self, monkeypatch):
         """Cover hard guard: targets is not a dict → 400."""
-        from app.routers.pro import WeekPlanRequest, generate_week_plan
+        from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
         # Mock dependencies
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
@@ -256,7 +256,7 @@ class TestPRORouterDiffCoverage:
             lambda *args, **kwargs: "not_a_dict",  # Type guard should catch this
         )
 
-        req = WeekPlanRequest(sex="female", age=25, height_cm=165, weight_kg=60)
+        req = ProWeekPlanRequest(sex="female", age=25, height_cm=165, weight_kg=60)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)
@@ -267,7 +267,7 @@ class TestPRORouterDiffCoverage:
     @pytest.mark.asyncio
     async def test_generate_week_plan_hard_guard_incomplete(self, monkeypatch):
         """Cover hard guard: targets dict incomplete → 400."""
-        from app.routers.pro import WeekPlanRequest, generate_week_plan
+        from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
         # Mock dependencies
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
@@ -277,7 +277,7 @@ class TestPRORouterDiffCoverage:
             lambda *args, **kwargs: {"kcal": 2000, "macros": {}, "micro": {}},  # Missing keys
         )
 
-        req = WeekPlanRequest(sex="male", age=30, height_cm=175, weight_kg=70)
+        req = ProWeekPlanRequest(sex="male", age=30, height_cm=175, weight_kg=70)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)
@@ -288,7 +288,7 @@ class TestPRORouterDiffCoverage:
     @pytest.mark.asyncio
     async def test_generate_week_plan_with_valid_targets(self, monkeypatch):
         """Cover happy path: valid targets dict from request."""
-        from app.routers.pro import WeekPlanRequest, generate_week_plan
+        from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.pro.get_recipe_db", lambda: MagicMock())
@@ -303,7 +303,7 @@ class TestPRORouterDiffCoverage:
             },
         )
 
-        req = WeekPlanRequest(
+        req = ProWeekPlanRequest(
             targets={
                 "kcal": 2000,
                 "macros": {
@@ -493,7 +493,7 @@ class TestPremiumWeekDiffCoverage:
     async def test_deprecation_event_both_states(self, monkeypatch):
         """Cover deprecation logging Event transitions (not set → set)."""
         from app.routers.premium_week import (
-            WeekPlanRequest,
+            PremiumWeekPlanRequest,
             _deprecation_logged,
             generate_week_plan,
         )
@@ -515,7 +515,7 @@ class TestPremiumWeekDiffCoverage:
         # Clear event to cover "not set" → "set" transition
         _deprecation_logged.clear()
 
-        req = WeekPlanRequest(
+        req = PremiumWeekPlanRequest(
             targets={
                 "kcal": 2000,
                 "macros": {"protein_g": 100, "fat_g": 70, "carbs_g": 250, "fiber_g": 30},
@@ -535,7 +535,7 @@ class TestPremiumWeekDiffCoverage:
     @pytest.mark.asyncio
     async def test_hard_guard_malformed_targets(self, monkeypatch):
         """Cover hard guard for malformed targets after derivation."""
-        from app.routers.premium_week import WeekPlanRequest, generate_week_plan
+        from app.routers.premium_week import PremiumWeekPlanRequest, generate_week_plan
 
         # Mock dependencies
         monkeypatch.setattr("app.routers.premium_week._get_food_db", lambda: MagicMock())
@@ -545,7 +545,7 @@ class TestPremiumWeekDiffCoverage:
             lambda *args, **kwargs: {"kcal": 2000},  # Incomplete
         )
 
-        req = WeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
+        req = PremiumWeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)
@@ -556,7 +556,7 @@ class TestPremiumWeekDiffCoverage:
     @pytest.mark.asyncio
     async def test_premium_hard_guard_targets_not_dict(self, monkeypatch):
         """Cover hard guard where derived targets are not a dict."""
-        from app.routers.premium_week import WeekPlanRequest, generate_week_plan
+        from app.routers.premium_week import PremiumWeekPlanRequest, generate_week_plan
 
         monkeypatch.setattr("app.routers.premium_week._get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.premium_week._get_recipe_db", lambda: MagicMock())
@@ -565,7 +565,7 @@ class TestPremiumWeekDiffCoverage:
             lambda *args, **kwargs: "not_a_dict",
         )
 
-        req = WeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
+        req = PremiumWeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)
@@ -607,7 +607,7 @@ class TestPremiumWeekDiffCoverage:
         self, monkeypatch, kwargs: Dict[str, Any], expected_field: str
     ):
         """Cover missing profile field branches in premium router."""
-        from app.routers.premium_week import WeekPlanRequest, generate_week_plan
+        from app.routers.premium_week import PremiumWeekPlanRequest, generate_week_plan
 
         monkeypatch.setattr("app.routers.premium_week._get_food_db", lambda: MagicMock())
         monkeypatch.setattr(
@@ -615,7 +615,7 @@ class TestPremiumWeekDiffCoverage:
             lambda: MagicMock(),
         )
 
-        req = WeekPlanRequest(**kwargs)
+        req = PremiumWeekPlanRequest(**kwargs)
 
         with pytest.raises(HTTPException) as exc_info:
             await generate_week_plan(req)

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -520,7 +520,7 @@ async def test_week_plan_missing_required_fields_raises_422(
     model_construct.
     """
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
-    req = legacy_app.WeekPlanRequest.model_construct(
+    req = legacy_app.LegacyWeekPlanRequest.model_construct(
         sex=None,
         age=None,
         height_cm=None,

--- a/tests/test_nutrition_log_api.py
+++ b/tests/test_nutrition_log_api.py
@@ -6,6 +6,8 @@ EN: Tests for nutrition log endpoints.
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import OperationalError
 
@@ -35,34 +37,39 @@ class TestNutritionLogAPI:
             Base.metadata.create_all(bind=raw_engine)
 
     def teardown_method(self) -> None:
-        fastapi_app.dependency_overrides.clear()
-
-        # Clean up analyzer state for this test subject to avoid cross-test interference
-        import core.db as core_db
-
-        # API tests expect DB initialized; if a test called reset_db_for_tests() or otherwise
-        # invalidated the SessionLocal binding, re-init and rebuild the session factory.
-        if core_db.SessionLocal is None:
-            core_db.init_db()
-
-        session_factory = core_db.get_session_factory()
-        session = session_factory()
-        if getattr(session, "bind", None) is None:
-            session.close()
-            core_db.init_db()
-            session = core_db.get_session_factory()()
         try:
-            session.query(AnalyzerStateModel).filter(
-                AnalyzerStateModel.user_id == self.user_id
-            ).delete(synchronize_session=False)
-            session.commit()
-        except OperationalError as exc:
-            if "no such table" in str(exc).lower():
-                session.rollback()
-            else:
-                raise
+            fastapi_app.dependency_overrides.clear()
+
+            # Clean up analyzer state for this test subject to avoid cross-test interference
+            import core.db as core_db
+
+            # API tests expect DB initialized; if a test called reset_db_for_tests() or otherwise
+            # invalidated the SessionLocal binding, re-init and rebuild the session factory.
+            if core_db.SessionLocal is None:
+                core_db.init_db()
+
+            session_factory = core_db.get_session_factory()
+            session = session_factory()
+            if getattr(session, "bind", None) is None:
+                session.close()
+                core_db.init_db()
+                session = core_db.get_session_factory()()
+            try:
+                session.query(AnalyzerStateModel).filter(
+                    AnalyzerStateModel.user_id == self.user_id
+                ).delete(synchronize_session=False)
+                session.commit()
+            except OperationalError as exc:
+                if "no such table" in str(exc).lower():
+                    session.rollback()
+                else:
+                    raise
+            finally:
+                session.close()
         finally:
-            session.close()
+            # Ensure TestClient shutdown runs (prevents leaked background threads in xdist)
+            with suppress(Exception):
+                self.client.close()
 
     def test_meal_log_updates_adherence_state(self) -> None:
         response = self.client.post(

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -1,6 +1,7 @@
 """Test that OpenAPI generation is deterministic across multiple runs."""
 
 import hashlib
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -39,6 +40,19 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    # Sanity-check: generator must produce FULL schema (no schema-only markers) and include
+    # key endpoints that were previously excluded behind schema-only mode.
+    schema = json.loads(openapi_path.read_text(encoding="utf-8"))
+    info = schema.get("info") or {}
+    assert info.get("x-openapi-mode") != "schema-only"
+    paths = schema.get("paths") or {}
+    assert "/api/v1/pro/meal/weekly" in paths
+    assert "/api/v1/pro/nutrition/daily" in paths
+    assert "/api/v1/pro/nutrition/meal-log" in paths
+    assert "/api/v1/premium/plan/week-flexible" in paths
+    assert "/api/v1/pro/bmi/calculate" in paths
+    assert "/api/v1/business/analyze" in paths
+
     h1: tuple[str, str] = (_sha256(openapi_path), _sha256(schema_path))
 
     subprocess.check_call(
@@ -70,10 +84,8 @@ def test_register_pro_routes_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> N
 
     from app.routers.pro_registration import register_pro_routes
 
-    # Ensure we are NOT in schema-only mode so openapi_mode resolves to False
-    monkeypatch.delenv("PULSEPLATE_OPENAPI", raising=False)
-    monkeypatch.setenv("APP_ENV", "test")
-    monkeypatch.setenv("ENVIRONMENT", "test")
+    # Ensure feature flags do not accidentally alter the cached early-return path.
+    monkeypatch.setenv("FEATURE_PREMIUM_WEEK_ENABLED", "true")
 
     app = FastAPI()
 
@@ -81,7 +93,6 @@ def test_register_pro_routes_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> N
     sentinel_pro = APIRouter()
     sentinel_week = APIRouter()
     app.state._pro_routes_registered = True
-    app.state._pro_routes_registered_openapi_mode = False
     app.state._cached_pro_router = sentinel_pro
     app.state._cached_premium_week_router = sentinel_week
 

--- a/tests/test_premium_week_router.py
+++ b/tests/test_premium_week_router.py
@@ -257,7 +257,7 @@ class TestPremiumWeekRouter:
             )
 
     def test_week_plan_request_model(self) -> None:
-        """Test WeekPlanRequest model."""
+        """Test PremiumWeekPlanRequest model."""
         request = PremiumWeekPlanRequest(
             sex="female",
             age=25,

--- a/tests/test_premium_week_router.py
+++ b/tests/test_premium_week_router.py
@@ -10,7 +10,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.routers.premium_week import TargetsIn, WeekPlanRequest, WeekPlanResponse, router
+from app.routers.premium_week import (
+    PremiumWeekPlanRequest,
+    PremiumWeekPlanResponse,
+    TargetsIn,
+    router,
+)
 
 
 class TestPremiumWeekRouter:
@@ -253,7 +258,7 @@ class TestPremiumWeekRouter:
 
     def test_week_plan_request_model(self) -> None:
         """Test WeekPlanRequest model."""
-        request = WeekPlanRequest(
+        request = PremiumWeekPlanRequest(
             sex="female",
             age=25,
             height_cm=165,
@@ -275,7 +280,7 @@ class TestPremiumWeekRouter:
 
     def test_week_plan_response_model(self) -> None:
         """Test WeekPlanResponse model."""
-        response = WeekPlanResponse(
+        response = PremiumWeekPlanResponse(
             daily_menus=[{"day": "Monday", "meals": []}],
             weekly_coverage={"protein": 0.95, "carbs": 0.90},
             shopping_list={"chicken": 1.0},

--- a/tests/test_premium_week_router_isolated.py
+++ b/tests/test_premium_week_router_isolated.py
@@ -40,7 +40,7 @@ def test_premium_week_pipeline_type_mismatch_raises_typeerror(
 
     client = TestClient(app)
     try:
-        with pytest.raises(TypeError, match=r"Expected WeekPlanResponse"):
+        with pytest.raises(TypeError, match=r"Expected PremiumWeekPlanResponse"):
             _ = client.post("/api/v1/premium/plan/week-flexible", json={})
     finally:
         client.close()

--- a/tests/test_pro_registration_router.py
+++ b/tests/test_pro_registration_router.py
@@ -1,0 +1,118 @@
+"""Targeted branch coverage for PRO route registration.
+
+RU: Точечные тесты ветвления для `register_pro_routes()` (Codecov partials).
+EN: Targeted branch tests for `register_pro_routes()` (Codecov partials).
+
+Goal:
+- Cover feature-flag and VIP-flag branches deterministically without importing real routers.
+- Avoid sys.modules mutation directly (use monkeypatch.setitem per repo policy).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+
+def _install_dummy_router_module(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, router_obj: APIRouter | None
+) -> None:
+    """Install a dummy module with a `router` attribute into sys.modules.
+
+    This allows `from app.routers.<x> import router` imports inside the function under test
+    to resolve without importing the real modules (and their side-effects).
+    """
+
+    dummy_mod = types.ModuleType(module_name)
+    dummy_mod.router = router_obj  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, dummy_mod)
+
+
+def test_register_pro_routes_idempotent_second_call_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second call should hit cached/idempotent branch (no new routes)."""
+
+    import app.utils.feature_flags as feature_flags
+    from app.routers.pro_registration import register_pro_routes
+
+    app = FastAPI()
+
+    pro_router = APIRouter()
+    _install_dummy_router_module(monkeypatch, "app.routers.pro", pro_router)
+
+    # Ensure premium_week branch is NOT taken for this test.
+    monkeypatch.delenv("FEATURE_PREMIUM_WEEK_ENABLED", raising=False)
+    monkeypatch.setattr(feature_flags, "is_vip_module_enabled", lambda: False)
+
+    pro1, week1 = register_pro_routes(app)
+    routes_after_first = len(app.router.routes)
+
+    pro2, week2 = register_pro_routes(app)
+    routes_after_second = len(app.router.routes)
+
+    assert routes_after_second == routes_after_first
+    assert pro2 is pro1
+    assert week2 is week1
+
+
+def test_register_pro_routes_includes_premium_week_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FEATURE_PREMIUM_WEEK_ENABLED=true includes premium_week router."""
+
+    import app.utils.feature_flags as feature_flags
+    from app.routers.pro_registration import register_pro_routes
+
+    app = FastAPI()
+
+    pro_router = APIRouter()
+    week_router = APIRouter()
+    _install_dummy_router_module(monkeypatch, "app.routers.pro", pro_router)
+    _install_dummy_router_module(monkeypatch, "app.routers.premium_week", week_router)
+
+    monkeypatch.setenv("FEATURE_PREMIUM_WEEK_ENABLED", "true")
+    monkeypatch.setattr(feature_flags, "is_vip_module_enabled", lambda: False)
+
+    pro_res, week_res = register_pro_routes(app)
+    assert pro_res is pro_router
+    assert week_res is week_router
+
+
+def test_register_pro_routes_includes_premium_week_by_vip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VIP module enabled includes premium_week router when env flag is not set."""
+
+    import app.utils.feature_flags as feature_flags
+    from app.routers.pro_registration import register_pro_routes
+
+    app = FastAPI()
+
+    pro_router = APIRouter()
+    week_router = APIRouter()
+    _install_dummy_router_module(monkeypatch, "app.routers.pro", pro_router)
+    _install_dummy_router_module(monkeypatch, "app.routers.premium_week", week_router)
+
+    monkeypatch.delenv("FEATURE_PREMIUM_WEEK_ENABLED", raising=False)
+    monkeypatch.setattr(feature_flags, "is_vip_module_enabled", lambda: True)
+
+    pro_res, week_res = register_pro_routes(app)
+    assert pro_res is pro_router
+    assert week_res is week_router
+
+
+def test_register_pro_routes_handles_none_routers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cover `is not None` branches when imported routers are None."""
+
+    import app.utils.feature_flags as feature_flags
+    from app.routers.pro_registration import register_pro_routes
+
+    app = FastAPI()
+
+    _install_dummy_router_module(monkeypatch, "app.routers.pro", None)
+    _install_dummy_router_module(monkeypatch, "app.routers.premium_week", None)
+
+    monkeypatch.setenv("FEATURE_PREMIUM_WEEK_ENABLED", "true")
+    monkeypatch.setattr(feature_flags, "is_vip_module_enabled", lambda: False)
+
+    pro_res, week_res = register_pro_routes(app)
+    assert pro_res is None
+    assert week_res is None

--- a/tests/test_pro_registration_router_coverage.py
+++ b/tests/test_pro_registration_router_coverage.py
@@ -27,7 +27,7 @@ def _install_dummy_router_module(
     """
 
     dummy_mod = types.ModuleType(module_name)
-    dummy_mod.router = router_obj  # type: ignore[attr-defined]
+    setattr(dummy_mod, "router", router_obj)
     monkeypatch.setitem(sys.modules, module_name, dummy_mod)
 
 

--- a/tests/test_pro_router.py
+++ b/tests/test_pro_router.py
@@ -134,7 +134,7 @@ class TestProRouterIsolated:
 
         monkeypatch.setattr(self.pro_mod, "run_weekly_pipeline_guarded", _fake_pipeline)
 
-        with pytest.raises(TypeError, match=r"Expected WeekPlanResponse"):
+        with pytest.raises(TypeError, match=r"Expected ProWeekPlanResponse"):
             _ = self.client.post("/api/v1/pro/meal/weekly", json={})
 
     def test_weekly_meal_plan_missing_profile_field_400(

--- a/tests/test_weekly_plan_postprocess_error_envelope_diff_coverage.py
+++ b/tests/test_weekly_plan_postprocess_error_envelope_diff_coverage.py
@@ -51,12 +51,12 @@ def test_pro_weekly_returns_error_envelope_on_postprocess_failure(
         raising=True,
     )
 
-    # Force postprocess (WeekPlanResponse(**week)) to fail.
+    # Force postprocess (ProWeekPlanResponse(**week)) to fail.
     class BoomWeekPlanResponse:
         def __init__(self, **_kwargs: Any) -> None:
             raise ValueError("postprocess failed")
 
-    monkeypatch.setattr(pro_router, "WeekPlanResponse", BoomWeekPlanResponse, raising=True)
+    monkeypatch.setattr(pro_router, "ProWeekPlanResponse", BoomWeekPlanResponse, raising=True)
 
     resp = client.post(
         "/api/v1/pro/meal/weekly",
@@ -96,7 +96,9 @@ def test_premium_weekly_returns_error_envelope_on_postprocess_failure(
         def __init__(self, **_kwargs: Any) -> None:
             raise ValueError("postprocess failed")
 
-    monkeypatch.setattr(premium_router, "WeekPlanResponse", BoomWeekPlanResponse, raising=True)
+    monkeypatch.setattr(
+        premium_router, "PremiumWeekPlanResponse", BoomWeekPlanResponse, raising=True
+    )
 
     resp = client.post(
         "/api/v1/premium/plan/week-flexible",


### PR DESCRIPTION
## Summary

- Устраняет **import-time загрузку ORM-моделей и `Base.metadata` (`app.models.*`) по пути генерации OpenAPI**.
- Включает **full OpenAPI schema** (все роутеры), без schema-only пропусков/хаков.

## Root cause

OpenAPI генерация импортировала `app.main:app`, а на этом пути отдельные модули тянули ORM **на уровне импорта**, что приводило к metadata/model-registration сайд-эффектам и недетерминизму.

## Решение

- Удалены ORM-импорты на уровне модулей в OpenAPI-достижимых местах.
- Применён паттерн:
  - типы только под `TYPE_CHECKING`
  - ORM-модели импортятся **lazy внутри функций/хендлеров**
- Вынесены import-safe Pydantic схемы в `app/schemas/*` (без SQLAlchemy зависимостей).

## Проверки (локально)

- `make verify` ✅
- `pre-commit run --all-files` ✅
- `make openapi-check` ✅

## Не входит в scope

- runtime-логика ORM/БД не меняется
- продуктовые изменения API — только полнота OpenAPI схемы

## Следующий шаг

- Guard enforcement будет отдельным P1 PR (scope-minimal), чтобы закрепить инвариант.

## Reviewer checklist

- [ ] В OpenAPI-достижимых модулях нет `app.models.*` импортов на уровне файла
- [ ] OpenAPI генерируется в full режиме без schema-only пропусков
- [ ] OpenAPI детерминизм сохранён (`make openapi-check`)
- [ ] CI зелёный

## Summary by Sourcery

Включена полная генерация схемы OpenAPI без режима «только схема», при этом импорт роутеров остаётся безопасным для ORM, а публичные API‑контракты обновлены соответствующим образом.

Новые возможности:
- Экспорт дополнительных PRO, премиальных, BMI, бизнес-аналитики и нутриционных эндпоинтов в сгенерированной OpenAPI-схеме и фронтенд-клиенте на TypeScript, включая устаревшие легаси-алиасы и их канонические замены.
- Введены отдельные схемы запросов/ответов для PRO‑расчёта BMI, сервиса BMI PRO, ежедневных данных по питанию и PRO/премиального еженедельного планирования питания.

Улучшения:
- Рефакторинг моделей и ответов PRO и премиального еженедельного планирования для использования отдельных, явно названных Pydantic‑схем и выравнивания легаси‑моделей под `legacy_app` для ясности и единообразия имен в OpenAPI.
- Документирована и закреплена более строгая политика, запрещающая загрузку ORM‑моделей во время импорта по пути генерации OpenAPI, а также добавлены безопасные для импорта Pydantic‑схемы целей по питанию в `app/schemas`.
- Упрощена регистрация PRO‑роутов так, чтобы она была идемпотентной без опоры на флаги режима «только схема», и включены роутеры под feature‑флагами во время генерации OpenAPI для получения полной схемы.
- Скорректированы тесты детерминизма OpenAPI и тесты покрытия по диффу, чтобы проверять наличие и поведение новых эндпоинтов и переименованных моделей.

Тесты:
- Расширены и обновлены тесты для роутеров PRO и премиального еженедельного плана, легаси‑еженедельного меню и детерминизма OpenAPI, чтобы покрыть новые схемы, именование и оболочки ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable full OpenAPI schema generation without schema-only mode while keeping router imports ORM-safe and updating exposed API contracts accordingly.

New Features:
- Expose additional PRO, premium, BMI, business analysis, and nutrition endpoints in the generated OpenAPI and frontend TypeScript client, including deprecated legacy aliases and canonical replacements.
- Introduce dedicated request/response schemas for PRO BMI calculation, BMI PRO service, daily nutrition data, and PRO/premium weekly meal planning.

Enhancements:
- Refactor PRO and premium weekly planning models and responses to use distinct, explicitly named Pydantic schemas and align legacy models under legacy_app for clarity and OpenAPI naming.
- Document and enforce a stricter policy forbidding import-time ORM model loading along the OpenAPI generation path, and add import-safe Pydantic nutrition target schemas under app/schemas.
- Simplify PRO route registration to be idempotent without relying on schema-only mode flags and enable feature-flagged routers during OpenAPI generation for a complete schema.
- Adjust OpenAPI determinism tests and diff-coverage tests to assert presence and behavior of the newly exposed endpoints and renamed models.

Tests:
- Extend and update tests for PRO and premium weekly plan routers, legacy weekly menu, and OpenAPI determinism to cover the new schemas, naming, and error envelopes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * PRO weekly meal planning with extended profile information
  * Premium flexible weekly meal scheduling
  * Daily nutrition tracking and analysis endpoints
  * Enhanced BMI calculations with additional measurements
  * Business analytics endpoints for nutrition insights
<!-- end of auto-generated comment: release notes by coderabbit.ai -->