### PR TITLE
PR-633: Unify TargetsIn schema (legacy ↔ canonical)

### DIFF
--- a/docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md
+++ b/docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md
@@ -1,0 +1,124 @@
+# PR-633 — Unify `TargetsIn` schemas (legacy_app ↔ `app.schemas.nutrition_targets`)
+
+**Date:** 3 февраля 2026 года
+**Type:** Follow-up (P1, drift prevention)
+**Scope owner:** @katsiaryna_kavaleuskaya
+
+---
+
+## Summary
+
+This PR eliminates schema drift by making `TargetsIn` a **single source of truth** and ensuring
+legacy endpoints validate structured `targets` payloads via the canonical schema.
+
+---
+
+## Ledger scope (source of truth)
+
+Backlog item (P1, next by order for PR-633) defines strict DoD:
+
+- One canonical schema (single source of truth) + thin wrapper/alias where needed
+- Parity tests (fields + validation behavior)
+- No contract break for legacy endpoints (explicitly verified in tests)
+
+**Evidence (ledger):**
+
+```375:390:docs/roadmap/BACKLOG_LEDGER.md
+- [ ] P1: Unify `TargetsIn` schemas (legacy_app ↔ `app.schemas.nutrition_targets`)
+  ...
+  - Evidence:
+    - `app/schemas/nutrition_targets.py:L1-L58` (import-safe schema + `TargetsIn` validators)
+    - `legacy_app.py:L2879-L2919` (`legacy_app.TargetsIn` definition)
+    - `legacy_app.py:L2939-L2954` (`TargetsIn.model_validate(...)` use in legacy request validator)
+  - DoD:
+    - One canonical schema (single source of truth) with a thin wrapper/alias where needed
+    - Parity tests that prevent schema drift (fields + validation behavior for structured targets payloads)
+    - No contract break for legacy endpoints (explicitly verified in tests)
+```
+
+---
+
+## Locked scope
+
+### In scope
+
+- Canonical `TargetsIn` remains in `app/schemas/nutrition_targets.py` (import-safe).
+- `legacy_app.TargetsIn` becomes a thin alias/wrapper to canonical schema (no local validators).
+- Add parity tests to prevent drift in fields + validation behavior.
+- Add explicit test that legacy endpoint contract is not broken by this unification.
+
+### Anti-scope (explicitly forbidden)
+
+- OpenAPI remediation / feature flags / unrelated routers
+- New endpoints
+- Any new business logic in `legacy_app.py` (legacy must remain thin proxy / delegation only)
+
+---
+
+## Architecture decision
+
+### Source of truth (SoT)
+
+**SoT:** `app.schemas.nutrition_targets.TargetsIn`
+
+**Reason:** module is explicitly designed to be import-safe for OpenAPI path.
+
+**Evidence:**
+
+```1:9:app/schemas/nutrition_targets.py
+IMPORTANT:
+- This module must stay import-safe (no SQLAlchemy, no Base/metadata side-effects).
+- Routers may import these schemas at module import time (OpenAPI generation path).
+```
+
+### Legacy policy
+
+Legacy must not define its own validation path for `TargetsIn` to avoid drift. Legacy uses canonical
+schema by alias/wrapper.
+
+---
+
+## Contract decision (F17)
+
+✅ Numeric strings (e.g. `"150.0"`) are considered **valid** numeric inputs for `macros`/`micro`.
+
+**Reason:** reduces client breakage and avoids avoidable 422 errors caused by UI serialization
+while preserving strict validation (bool forbidden; finite; `>= 0`).
+
+This decision is enforced by parity tests.
+
+---
+
+## Test plan (DoD evidence)
+
+- Parity tests validate:
+  - same fields
+  - same validation behavior (`"150.0"` valid; `True` invalid; `NaN/Inf` invalid; negative invalid)
+- Legacy endpoint test verifies:
+  - structured `targets` payload validation remains strict
+  - no contract break (request still accepted/rejected deterministically)
+
+---
+
+## Verification gates (canonical)
+
+Before merge:
+
+- `pre-commit run --all-files`
+- `make verify`
+- `make openapi-check` (expected: **no diff**)
+
+---
+
+## Security Notes
+
+- Accepting numeric strings does not expand attack surface: values are still strictly normalized and
+  validated (no bool, must be finite, must be `>= 0`).
+- Removing duplicate validation paths reduces ambiguity and “bypass via drift” risk.
+
+---
+
+## Marketing & GTM Notes
+
+This PR is user-invisible but improves reliability: fewer unexpected 422 errors from serialization
+differences → fewer “app feels broken” moments → better onboarding retention.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import math
 import os
 import secrets
 import sys
@@ -36,7 +35,6 @@ from pydantic import (
     Field,
     StrictFloat,
     ValidationError,
-    field_validator,
     model_validator,
 )
 from sqlalchemy import text
@@ -72,6 +70,7 @@ from app.schemas.premium_contracts import (
     WHOTargetsRequest,
     WHOTargetsResponse,
 )
+from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
 from app.services import recipe_store
 from app.services.food_store import get_food
 
@@ -109,6 +108,9 @@ from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
     _calculate_all_tdee_wrapper,
 )
+
+# PR-633: thin alias to canonical import-safe schema (no local validation).
+TargetsIn = CanonicalTargetsIn
 
 # Rate limiting imports (PR-628)
 # RU: Импорты для rate-limiting (медленные imports только если slowapi доступен).
@@ -2874,49 +2876,9 @@ def _ensure_priority_micros(values: Dict[str, float]) -> Dict[str, float]:
 
 
 # WHO-Based Nutrition Models
-
-
-class TargetsIn(BaseModel):
-    """Validated nutrition targets with strict non-negative checks.
-
-    Similar to app.routers.premium_week.TargetsIn but used in main app endpoints.
-    """
-
-    model_config = ConfigDict(title="LegacyTargetsIn")
-
-    kcal: int = Field(..., gt=500, lt=6000)
-    macros: Dict[str, float]
-    micro: Dict[str, float]
-    water_ml: int = Field(0, ge=0)
-    activity_week: Optional[Dict[str, int]] = None
-
-    @field_validator("macros")
-    @classmethod
-    def _validate_macros(cls, v: Dict[str, float]) -> Dict[str, float]:
-        # Ensure all values are finite numbers >= 0
-        for key, val in v.items():
-            # Check if value is a numeric type (int or float)
-            if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise ValueError(f"macros[{key}] must be a finite number >= 0")
-
-            # Check if value is finite (not NaN or Infinity) and non-negative
-            if not math.isfinite(val) or val < 0:
-                raise ValueError(f"macros[{key}] must be a finite number >= 0")
-        return v
-
-    @field_validator("micro")
-    @classmethod
-    def _validate_micro(cls, v: Dict[str, float]) -> Dict[str, float]:
-        # Ensure all values are finite numbers >= 0
-        for key, val in v.items():
-            # Check if value is a numeric type (int or float)
-            if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise ValueError(f"micro[{key}] must be a finite number >= 0")
-
-            # Check if value is finite (not NaN or Infinity) and non-negative
-            if not math.isfinite(val) or val < 0:
-                raise ValueError(f"micro[{key}] must be a finite number >= 0")
-        return v
+#
+# NOTE (PR-633): `TargetsIn` is canonical in `app.schemas.nutrition_targets` (import-safe).
+# Legacy endpoints must not define a second validation path to avoid drift.
 
 
 class LegacyWeekPlanRequest(WHOTargetsRequest):

--- a/tests/test_targets_in_parity.py
+++ b/tests/test_targets_in_parity.py
@@ -1,0 +1,90 @@
+import math
+
+import pytest
+from pydantic import ValidationError
+
+import legacy_app
+from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
+
+
+def test_legacy_targets_in_is_canonical_alias() -> None:
+    """RU: Legacy TargetsIn должен быть alias на canonical (без drift).
+    EN: Legacy TargetsIn must be an alias to canonical (no drift).
+    """
+
+    assert legacy_app.TargetsIn is CanonicalTargetsIn
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": "150.0", "fat_g": "65.0", "carbs_g": "250.0"},
+            "micro": {"vitamin_c_mg": "90.0"},
+            "water_ml": 2000,
+        },
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": 150.0},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+    ],
+)
+def test_targets_in_accepts_numeric_strings(payload: dict[str, object]) -> None:
+    """RU: Числовые строки (например, '150.0') валидны.
+    EN: Numeric strings (e.g. '150.0') are valid.
+    """
+
+    out_canonical = CanonicalTargetsIn.model_validate(payload)
+    out_legacy = legacy_app.TargetsIn.model_validate(payload)
+
+    assert out_canonical.model_dump() == out_legacy.model_dump()
+    assert out_canonical.kcal == 2000
+    assert out_canonical.macros["protein_g"] == 150.0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # bool must be rejected explicitly (bool is subclass of int)
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": True},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+        # NaN must be rejected
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": math.nan},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+        # Infinity must be rejected
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": math.inf},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+        # negative must be rejected
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": -1.0},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+    ],
+)
+def test_targets_in_rejects_invalid_values(payload: dict[str, object]) -> None:
+    """RU: Невалидные значения должны падать детерминированно.
+    EN: Invalid values must fail deterministically.
+    """
+
+    with pytest.raises(ValidationError):
+        CanonicalTargetsIn.model_validate(payload)
+
+    with pytest.raises(ValidationError):
+        legacy_app.TargetsIn.model_validate(payload)

--- a/tests/test_targets_in_parity.py
+++ b/tests/test_targets_in_parity.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 import legacy_app
@@ -91,6 +92,20 @@ def test_targets_in_accepts_numeric_strings(payload: dict[str, object]) -> None:
             "micro": {"vitamin_c_mg": 90.0},
             "water_ml": 2000,
         },
+        # micro invalid (negative)
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": 150.0},
+            "micro": {"vitamin_c_mg": -1.0},
+            "water_ml": 2000,
+        },
+        # water_ml invalid (negative)
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": 150.0},
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": -1,
+        },
     ],
 )
 def test_targets_in_rejects_invalid_values(payload: dict[str, object]) -> None:
@@ -106,7 +121,7 @@ def test_targets_in_rejects_invalid_values(payload: dict[str, object]) -> None:
 
 
 def test_legacy_week_endpoint_accepts_numeric_string_targets(
-    client, api_key: str, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, vip_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """RU: Legacy endpoint не должен ломаться при targets с числовыми строками.
     EN: Legacy endpoint must not break when targets contains numeric strings.
@@ -115,6 +130,8 @@ def test_legacy_week_endpoint_accepts_numeric_string_targets(
     import app as app_module
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    # Legacy API-key guard compares against env API_KEY; align it to the VIP test key.
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
     monkeypatch.setattr(app_module, "make_weekly_menu", _weekly_menu_stub)
 
     payload = {
@@ -130,25 +147,31 @@ def test_legacy_week_endpoint_accepts_numeric_string_targets(
             "water_ml": 2000,
         },
     }
-    r = client.post("/api/v1/premium/plan/week", json=payload, headers={"X-API-Key": api_key})
+    r = client.post("/api/v1/premium/plan/week", json=payload, headers=vip_headers)
     assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert isinstance(data, dict)
+    for key in ("weekly_coverage", "shopping_list", "total_cost"):
+        assert key in data
+    assert isinstance(data["weekly_coverage"], dict)
+    assert isinstance(data["shopping_list"], dict)
+    assert isinstance(data["total_cost"], (int, float))
 
 
 @pytest.mark.parametrize(
-    "bad_macros",
+    "bad_targets",
     [
-        {"protein_g": True},
-        # JSON payload cannot carry NaN/Inf floats; send strings to hit the same validator branch.
-        {"protein_g": "nan"},
-        {"protein_g": "inf"},
-        {"protein_g": -1.0},
+        {"macros": {"protein_g": True}},
+        {"micro": {"vitamin_c_mg": -1.0}},
+        {"water_ml": -1},
     ],
 )
 def test_legacy_week_endpoint_rejects_invalid_targets_values(
-    client,
-    api_key: str,
+    client: TestClient,
+    vip_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
-    bad_macros: dict[str, object],
+    bad_targets: dict[str, object],
 ) -> None:
     """RU: Legacy endpoint отклоняет невалидные значения в structured targets (contract no-break).
     EN: Legacy endpoint rejects invalid values in structured targets (contract no-break).
@@ -157,20 +180,24 @@ def test_legacy_week_endpoint_rejects_invalid_targets_values(
     import app as app_module
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
     monkeypatch.setattr(app_module, "make_weekly_menu", _weekly_menu_stub)
 
-    payload = {
+    targets: dict[str, object] = {
+        "kcal": 2000,
+        "macros": {"protein_g": 150.0},
+        "micro": {"vitamin_c_mg": 90.0},
+        "water_ml": 2000,
+    }
+    targets.update(bad_targets)
+
+    payload: dict[str, object] = {
         "sex": "male",
         "age": 30,
         "height_cm": 175,
         "weight_kg": 70,
         "activity": "moderate",
-        "targets": {
-            "kcal": 2000,
-            "macros": bad_macros,
-            "micro": {"vitamin_c_mg": 90.0},
-            "water_ml": 2000,
-        },
+        "targets": targets,
     }
-    r = client.post("/api/v1/premium/plan/week", json=payload, headers={"X-API-Key": api_key})
+    r = client.post("/api/v1/premium/plan/week", json=payload, headers=vip_headers)
     assert r.status_code == 422, r.text

--- a/tests/test_targets_in_parity.py
+++ b/tests/test_targets_in_parity.py
@@ -7,6 +7,21 @@ import legacy_app
 from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
 
 
+def _weekly_menu_stub(*args: object, **kwargs: object) -> object:
+    """RU: Заглушка weekly menu для e2e-ish legacy endpoint tests.
+    EN: Weekly menu stub for e2e-ish legacy endpoint tests.
+    """
+
+    class _WeekMenu:
+        weekly_coverage = {"protein": 0.9}
+        shopping_list = {"chicken": 1.0}
+        total_cost = 10.0
+        adherence_score = 0.5
+        daily_menus: list[object] = []
+
+    return _WeekMenu()
+
+
 def test_legacy_targets_in_is_canonical_alias() -> None:
     """RU: Legacy TargetsIn должен быть alias на canonical (без drift).
     EN: Legacy TargetsIn must be an alias to canonical (no drift).
@@ -88,3 +103,74 @@ def test_targets_in_rejects_invalid_values(payload: dict[str, object]) -> None:
 
     with pytest.raises(ValidationError):
         legacy_app.TargetsIn.model_validate(payload)
+
+
+def test_legacy_week_endpoint_accepts_numeric_string_targets(
+    client, api_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RU: Legacy endpoint не должен ломаться при targets с числовыми строками.
+    EN: Legacy endpoint must not break when targets contains numeric strings.
+    """
+
+    import app as app_module
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setattr(app_module, "make_weekly_menu", _weekly_menu_stub)
+
+    payload = {
+        "sex": "male",
+        "age": 30,
+        "height_cm": 175,
+        "weight_kg": 70,
+        "activity": "moderate",
+        "targets": {
+            "kcal": 2000,
+            "macros": {"protein_g": "150.0"},
+            "micro": {"vitamin_c_mg": "90.0"},
+            "water_ml": 2000,
+        },
+    }
+    r = client.post("/api/v1/premium/plan/week", json=payload, headers={"X-API-Key": api_key})
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.parametrize(
+    "bad_macros",
+    [
+        {"protein_g": True},
+        # JSON payload cannot carry NaN/Inf floats; send strings to hit the same validator branch.
+        {"protein_g": "nan"},
+        {"protein_g": "inf"},
+        {"protein_g": -1.0},
+    ],
+)
+def test_legacy_week_endpoint_rejects_invalid_targets_values(
+    client,
+    api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_macros: dict[str, object],
+) -> None:
+    """RU: Legacy endpoint отклоняет невалидные значения в structured targets (contract no-break).
+    EN: Legacy endpoint rejects invalid values in structured targets (contract no-break).
+    """
+
+    import app as app_module
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setattr(app_module, "make_weekly_menu", _weekly_menu_stub)
+
+    payload = {
+        "sex": "male",
+        "age": 30,
+        "height_cm": 175,
+        "weight_kg": 70,
+        "activity": "moderate",
+        "targets": {
+            "kcal": 2000,
+            "macros": bad_macros,
+            "micro": {"vitamin_c_mg": 90.0},
+            "water_ml": 2000,
+        },
+    }
+    r = client.post("/api/v1/premium/plan/week", json=payload, headers={"X-API-Key": api_key})
+    assert r.status_code == 422, r.text


### PR DESCRIPTION
## Audit
- Audit doc: `docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md`
- Backlog item: P1 — Unify `TargetsIn` schemas (legacy_app ↔ app.schemas.nutrition_targets)
- SoT (locked): `app/schemas/nutrition_targets.py::TargetsIn`
- Decision locked: numeric strings (e.g. \"150.0\") are VALID

## Scope (locked)
- Make `legacy_app.TargetsIn` a thin alias to canonical schema (no local validators)
- Add parity tests for validation behavior + legacy endpoint contract no-break

## Anti-scope (explicit)
- No changes to `app/schemas/nutrition_targets.py`
- No router/OpenAPI/business logic changes
- No new endpoints/schemas

## Changes
- `legacy_app.py`: remove local `TargetsIn` class; alias to canonical `TargetsIn`
- `tests/test_targets_in_parity.py`: parity matrix + legacy endpoint contract tests

## Verification (required)
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `make openapi-check` ✅ (NO DIFF)

## Summary by Sourcery

Унифицировать устаревшую схему `TargetsIn` с канонической `nutrition_targets.TargetsIn` и зафиксировать совпадающее поведение валидации для устаревших эндпоинтов.

Bug Fixes:
- Гарантировать, что устаревший эндпоинт премиум-недели корректно принимает структурированные payload'ы целей с числовыми строковыми значениями и отклоняет некорректные значения в соответствии с канонической схемой.

Enhancements:
- Сделать `legacy_app.TargetsIn` тонкой алиасной обёрткой над `app.schemas.nutrition_targets.TargetsIn`, чтобы убрать дублирующие пути валидации и предотвратить расхождения.

Documentation:
- Добавить аудиторский документ, описывающий унификацию схемы `TargetsIn`, принятые решения и шаги по проверке.

Tests:
- Добавить тесты на паритет, гарантирующие, что `legacy_app.TargetsIn` остаётся алиасом канонической схемы и что обе используют идентичное поведение валидации, включая контрактные тесты устаревших эндпоинтов для структурированных целей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the legacy TargetsIn schema with the canonical nutrition_targets.TargetsIn and lock in matching validation behavior for legacy endpoints.

Bug Fixes:
- Ensure the legacy premium week endpoint correctly accepts structured targets payloads with numeric string values and rejects invalid values in line with the canonical schema.

Enhancements:
- Make legacy_app.TargetsIn a thin alias of app.schemas.nutrition_targets.TargetsIn to remove duplicate validation paths and prevent drift.

Documentation:
- Add an audit document describing the TargetsIn schema unification, decisions, and verification steps.

Tests:
- Add parity tests to guarantee legacy_app.TargetsIn remains an alias of the canonical schema and that both share identical validation behavior, including legacy endpoint contract tests for structured targets.

</details>

Исправления ошибок (Bug Fixes):
- Гарантировать, что устаревший premium week эндпоинт корректно принимает структурированные payload'ы целей с числовыми строковыми значениями и отклоняет некорректные значения в полном соответствии с канонической схемой.

Улучшения (Enhancements):
- Сделать `legacy_app.TargetsIn` тонким алиасом канонической схемы `app.schemas.nutrition_targets.TargetsIn`, чтобы устранить дублирование путей валидации и риск расхождений.

Документация (Documentation):
- Добавить аудиторский документ, описывающий унификацию схемы `TargetsIn`: охват, принятые решения и шаги верификации.

Тесты (Tests):
- Добавить тесты на паритет, чтобы гарантировать, что устаревший `TargetsIn` остаётся алиасом канонической схемы и что обе имеют идентичное поведение валидации, включая контрактные тесты устаревшего эндпоинта для структурированных целей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать устаревшую схему `TargetsIn` с канонической `nutrition_targets.TargetsIn` и зафиксировать совпадающее поведение валидации для устаревших эндпоинтов.

Bug Fixes:
- Гарантировать, что устаревший эндпоинт премиум-недели корректно принимает структурированные payload'ы целей с числовыми строковыми значениями и отклоняет некорректные значения в соответствии с канонической схемой.

Enhancements:
- Сделать `legacy_app.TargetsIn` тонкой алиасной обёрткой над `app.schemas.nutrition_targets.TargetsIn`, чтобы убрать дублирующие пути валидации и предотвратить расхождения.

Documentation:
- Добавить аудиторский документ, описывающий унификацию схемы `TargetsIn`, принятые решения и шаги по проверке.

Tests:
- Добавить тесты на паритет, гарантирующие, что `legacy_app.TargetsIn` остаётся алиасом канонической схемы и что обе используют идентичное поведение валидации, включая контрактные тесты устаревших эндпоинтов для структурированных целей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the legacy TargetsIn schema with the canonical nutrition_targets.TargetsIn and lock in matching validation behavior for legacy endpoints.

Bug Fixes:
- Ensure the legacy premium week endpoint correctly accepts structured targets payloads with numeric string values and rejects invalid values in line with the canonical schema.

Enhancements:
- Make legacy_app.TargetsIn a thin alias of app.schemas.nutrition_targets.TargetsIn to remove duplicate validation paths and prevent drift.

Documentation:
- Add an audit document describing the TargetsIn schema unification, decisions, and verification steps.

Tests:
- Add parity tests to guarantee legacy_app.TargetsIn remains an alias of the canonical schema and that both share identical validation behavior, including legacy endpoint contract tests for structured targets.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies TargetsIn by aliasing legacy_app.TargetsIn to app.schemas.nutrition_targets.TargetsIn to eliminate drift and keep legacy endpoints stable. Meets P1 requirements: single source of truth, parity tests, and no contract changes; numeric strings like "150.0" are valid; OpenAPI unchanged.

- **Refactors**
  - Replaced legacy TargetsIn with a thin alias to the canonical import-safe schema; removed duplicate validators.
  - Added parity and legacy endpoint tests to lock validation behavior (numeric strings accepted; bool/NaN/Inf/negative rejected).
  - Added audit doc; verification and OpenAPI checks pass with no diffs.

<sup>Written for commit 227c787839c8d1023dfe688b2505b5c11d173518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive audit documenting consolidation of nutrition targets schemas and acceptance criteria.

* **Improvements**
  * Nutrition targets are unified under a single canonical schema across endpoints, providing consistent validation and accepting numeric strings as valid inputs.

* **Tests**
  * Added parity tests ensuring legacy and canonical targets behave identically, validating numeric-string handling, rejecting invalid values, and confirming legacy endpoint compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->