### PR TITLE
security: bump pip to >=26.0 in Docker build (CVE-2026-1703)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 # Multi-stage Dockerfile for PulsePlate
 # Optimized for production with minimal image size and security
 
+# Centralize pip upgrade range (SoT) to avoid drift across stages.
+ARG PIP_VERSION_RANGE="pip>=26.0,<27.0"
+
 # Stage 1: Build stage
 FROM python:3.13.6-slim-bookworm AS builder
 
 # Set build arguments
+ARG PIP_VERSION_RANGE
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
@@ -17,13 +21,13 @@ RUN apt-get update && apt-get install -y \
 # Create virtual environment
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_NO_PYTHON_VERSION_WARNING=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_PYTHON_VERSION_WARNING=1
 
 # SECURITY (CVE-2026-1703):
 # Ensure pip is upgraded in the venv before installing dependencies.
 # Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
-RUN /opt/venv/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.0,<27.0"
+RUN /opt/venv/bin/python -m pip install --no-cache-dir --upgrade "${PIP_VERSION_RANGE}"
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt requirements-dev.txt ./
@@ -42,6 +46,9 @@ PY
 # NOTE: Keep system package manager tools here so the development stage can install tools via apt.
 FROM python:3.13.6-slim-bookworm AS runtime-base
 
+# Re-declare build arg in this stage.
+ARG PIP_VERSION_RANGE
+
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -52,7 +59,7 @@ ENV PYTHONUNBUFFERED=1 \
 # The base image may ship with an affected pip (e.g., 25.2) in system site-packages.
 # Upgrade it so scanners do not detect pip 25.2 at /usr/local/lib/... in the runtime image.
 # Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
-RUN python -m pip install --no-cache-dir --upgrade "pip>=26.0,<27.0"
+RUN python -m pip install --no-cache-dir --upgrade "${PIP_VERSION_RANGE}"
 
 # Install runtime dependencies only (curl removed - using Python for healthcheck)
 # NOTE: libtasn1-6 comes transitively via libgnutls30 (required for TLS/HTTPS).

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG PIP_VERSION_RANGE="pip>=26.0,<27.0"
 FROM python:3.13.6-slim-bookworm AS builder
 
 # Set build arguments
-ARG PIP_VERSION_RANGE
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
@@ -24,8 +23,13 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_PYTHON_VERSION_WARNING=1
 
+# Centralize pip version range (SoT) for CVE fixes.
+ARG PIP_VERSION_RANGE
+
 # SECURITY (CVE-2026-1703):
 # Ensure pip is upgraded in the venv before installing dependencies.
+# We must upgrade pip inside the image (system + venv) because scanners flag installed pip dist-info.
+# requirements.in cannot affect pip shipped in the base image.
 # Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
 RUN /opt/venv/bin/python -m pip install --no-cache-dir --upgrade "${PIP_VERSION_RANGE}"
 
@@ -58,6 +62,8 @@ ENV PYTHONUNBUFFERED=1 \
 # SECURITY (CVE-2026-1703):
 # The base image may ship with an affected pip (e.g., 25.2) in system site-packages.
 # Upgrade it so scanners do not detect pip 25.2 at /usr/local/lib/... in the runtime image.
+# We must upgrade pip inside the image (system + venv) because scanners flag installed pip dist-info.
+# requirements.in cannot affect pip shipped in the base image.
 # Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
 RUN python -m pip install --no-cache-dir --upgrade "${PIP_VERSION_RANGE}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PIP_NO_PYTHON_VERSION_WARNING=1
 
+# SECURITY (CVE-2026-1703):
+# Ensure pip is upgraded in the venv before installing dependencies.
+# Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
+RUN /opt/venv/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.0,<27.0"
+
 # Copy requirements and install Python dependencies
 COPY requirements.txt requirements-dev.txt ./
 RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt && \
@@ -42,6 +47,12 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/venv/bin:$PATH" \
     PYTHONPATH="/app"
+
+# SECURITY (CVE-2026-1703):
+# The base image may ship with an affected pip (e.g., 25.2) in system site-packages.
+# Upgrade it so scanners do not detect pip 25.2 at /usr/local/lib/... in the runtime image.
+# Policy: do not pin exact pip in Dockerfile; use a safe version range instead.
+RUN python -m pip install --no-cache-dir --upgrade "pip>=26.0,<27.0"
 
 # Install runtime dependencies only (curl removed - using Python for healthcheck)
 # NOTE: libtasn1-6 comes transitively via libgnutls30 (required for TLS/HTTPS).

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -458,6 +458,20 @@ If it is not recorded here — it does not exist.
     - Remove `docs/security/CVE-2026-24883-gpgv.md` (or mark as resolved)
     - Trivy Code Scanning alerts remain closed on `main`
 
+- [ ] Resolve pip CVE-2026-1703 (pip 25.2 → 26.0+) in Docker image (GitHub alerts #533/#534)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-636
+  - Status: 🟡 In progress
+  - Reason: Code Scanning alerts #533/#534 report CVE-2026-1703 for `pip 25.2` detected in two locations inside the built image (`/usr/local/lib/...` and `/opt/venv/lib/...`). Fix is to ensure Docker build upgrades pip to ≥26.0 (without exact pin in Dockerfile per policy).
+  - Links:
+    - GitHub alerts #533 / #534
+    - `Dockerfile` (builder venv + runtime-base system pip)
+    - `.github/workflows/trivy.yml` (builds `production` target and scans the image)
+  - DoD:
+    - Production image contains `pip>=26.0,<27.0` in both `/usr/local/lib/.../pip-*.dist-info` and `/opt/venv/lib/.../pip-*.dist-info`
+    - Alerts #533/#534 are closed on `main` after the next scan
+
 - [x] Resolve CVE-2026-24882 Trivy alert (accepted risk) (merged 2026-01-28)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1


### PR DESCRIPTION
## Summary
- Fix Code Scanning alerts #533/#534 (CVE-2026-1703) by ensuring `pip>=26.0,<27.0` is installed in both:
  - system site-packages (`/usr/local/lib/python3.13/site-packages/`)
  - application venv (`/opt/venv/lib/python3.13/site-packages/`)

## Why
- The base image shipped `pip 25.2`, which is flagged for CVE-2026-1703 (wheel extraction path traversal).
- Alerts appear twice because scanners see two pip installations (system + venv).

## Changes
- `Dockerfile`:
  - upgrade pip in builder venv before dependency install
  - upgrade pip in runtime-base system Python
  - uses a version *range* (no exact pin) to comply with repo Dockerfile policy
- `docs/roadmap/BACKLOG_LEDGER.md`:
  - add tracked item for CVE-2026-1703 remediation (PR-636)

## Verification (local)
- `docker build --target=production -t pulseplate:pr636-pip-cve .`
- `docker run --rm pulseplate:pr636-pip-cve python -c "import pip; print(pip.__version__)"` → `26.0`
- `docker run --rm pulseplate:pr636-pip-cve sh -lc "ls -d /usr/local/lib/python3.13/site-packages/pip-*.dist-info; ls -d /opt/venv/lib/python3.13/site-packages/pip-*.dist-info"`
  - shows `pip-26.0.dist-info` in both locations

## Deferred / Follow-ups
- None (alerts should close after next scan on `main`).

## Summary by Sourcery

Обновить pip до безопасной версии в Docker-образах для устранения CVE-2026-1703 и зафиксировать задачу по ремедиации в реестре бэклога по безопасности.

Исправления ошибок:
- Снизить риск CVE-2026-1703, гарантируя, что при сборке Docker устанавливается pip версии `>=26.0,<27.0` как в виртуальном окружении сборщика, так и в системном Python среды выполнения.

Сборка:
- Обновить Dockerfile, чтобы повышать версию pip в виртуальном окружении приложения и базовом образе среды выполнения, используя безопасный диапазон версий вместо уязвимой версии в базовом образе.

Документация:
- Добавить запись в `BACKLOG_LEDGER`, отслеживающую ремедиацию уязвимости pip CVE-2026-1703 в Docker-образе и связанных оповещений сканирования кода.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade pip to a secure version in Docker images to address CVE-2026-1703 and record the remediation work item in the security backlog ledger.

Bug Fixes:
- Mitigate CVE-2026-1703 by ensuring the Docker build installs pip>=26.0,<27.0 in both the builder virtualenv and the runtime system Python.

Build:
- Update the Dockerfile to upgrade pip in the application virtualenv and runtime base image using a safe version range instead of the vulnerable base image version.

Documentation:
- Add a BACKLOG_LEDGER entry tracking remediation of pip CVE-2026-1703 in the Docker image and associated code scanning alerts.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CVE-2026-1703 by upgrading pip to >=26.0 in the Docker build so no vulnerable 25.2 remains. This clears GitHub code scanning alerts #533/#534.

- **Dependencies**
  - Upgrade pip in the builder venv and runtime system Python using a centralized ARG: "pip>=26.0,<27.0" (no exact pin).
  - Run the upgrade before installing requirements to cover both site-packages locations.
  - Add a BACKLOG_LEDGER entry to track this remediation (PR-636).

<sup>Written for commit 82963e78ec60faf9b21fdee80ea53b57db580e16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a backlog/roadmap item tracking a high-priority security upgrade with acceptance criteria.

- Chores
  - Standardized the packaging tool version range across container build and runtime stages to close a CVE and ensure consistent, more reliable images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->