### PR TITLE
docs(agents): require English-first backlog entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1273,8 +1273,9 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
    - Reason for deferral
    - Links to relevant audit/docs
    - DoD (acceptance criteria)
-3. Every PR description MUST include a "Deferred / Follow-ups" section with links to ledger items (and GitHub issues if present).
-4. Closing a ledger item requires:
+3. Backlog entries must be English-first; non-English text MUST include an English summary on the same line.
+4. Every PR description MUST include a "Deferred / Follow-ups" section with links to ledger items (and GitHub issues if present).
+5. Closing a ledger item requires:
    - PR merged OR explicit "won't do" decision recorded (with reason).
 
 **Agent enforcement:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1274,6 +1274,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
    - Links to relevant audit/docs
    - DoD (acceptance criteria)
 3. Backlog entries must be English-first; non-English text MUST include an English summary on the same line.
+   Automated review bots may block PRs that violate English-first ledger entries.
 4. Every PR description MUST include a "Deferred / Follow-ups" section with links to ledger items (and GitHub issues if present).
 5. Closing a ledger item requires:
    - PR merged OR explicit "won't do" decision recorded (with reason).


### PR DESCRIPTION
## Scope
- Docs-only (`AGENTS.md` only).

## Change
- Add a micro-rule under **Backlog Ledger Policy**: backlog entries must be English-first; if non-English text is used, include an English summary on the same line.

## Test plan
- N/A (docs-only)

## Deferred / Follow-ups
- None.

## Summary by Sourcery

Документация:
- Уточнить документацию по бэклог-реестру, чтобы обязать вести записи в бэклоге в первую очередь на английском языке и требовать английское резюме (краткое описание) вместе с любым текстом на другом языке.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify backlog ledger documentation to mandate English-first backlog entries and require an English summary alongside any non-English text.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a rule to the Backlog Ledger Policy: backlog entries must be English-first, and any non-English text must include an English summary on the same line. Docs-only update to AGENTS.md; automated review bots may block PRs that violate English-first ledger entries.

<sup>Written for commit eae3f2c09283a77d8bf2366c60a0cb57006ec92e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Backlog guidelines now require English-first entries; non-English content must include an inline English summary.
  * Note added that automated review checks may block PRs that don't meet the English-first requirement.
  * Backlog-related items renumbered to reflect the new English-first priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->