### PR TITLE
PR-628: rate-limit LLM + exports (OpenAPI 429 schema fix)

### DIFF
--- a/app/routers/vip_shoplist.py
+++ b/app/routers/vip_shoplist.py
@@ -39,7 +39,7 @@ from app.utils.feature_flags import is_vip_module_enabled
 from core.shoplist_engine.engine import ShoplistEngine
 from fastapi import Request
 
-from app.security.rate_limit import RATE_LIMIT_EXPORTS, limit_if_available
+from app.security.rate_limit import RATE_LIMIT_429_RESPONSES, RATE_LIMIT_EXPORTS, limit_if_available
 from core.shoplist_engine.models import (
     FoodForm,
     FoodRef,
@@ -509,7 +509,7 @@ async def vip_shoplist_weekly(
     "/export",
     responses={
         **COMMON_VIP_SHOPLIST_RESPONSES,
-        429: {"description": "Rate limit exceeded"},
+        **RATE_LIMIT_429_RESPONSES,
     },
     summary="Export VIP shoplist to CSV or PDF",
     description=(

--- a/docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md
+++ b/docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md
@@ -89,16 +89,15 @@ These are gated by `EXPORTS_ENABLED` (see “Feature flags / route registration�
 
 ### What is true today
 
-**Rate limiting is NOT active in runtime.**
+**Rate limiting IS active in runtime (wired), and gracefully degrades if SlowAPI is unavailable.**
 
-- SlowAPI import is optional (present as dependency but not wired):
-  - `legacy_app.py:144-153`
-- All wiring is commented out:
-  - `legacy_app.py:1022-1037`
+- Wiring is executed during FastAPI app creation:
+  - `legacy_app.py:679-688` (imports `wire_rate_limiting` and calls `wire_rate_limiting(app)`).
+- Wiring helper (canonical implementation):
+  - `app/security/rate_limit.py:243-280` (`wire_rate_limiting` attaches limiter, 429 handler, middleware).
 
-**Evidence snippet (commented setup):**
-
-- `legacy_app.py:1022-1037` (middleware + handler + limiter are commented)
+Note: SlowAPI remains an optional dependency (ImportError → no-op stubs), but when installed the limiter
+is enabled by default in runtime and disabled by default in tests unless explicitly enabled (see below).
 
 ---
 
@@ -131,25 +130,26 @@ No explicit Caddy rule for `CF-Connecting-IP` is present; therefore the app must
 
 ### Existing foundation (usable today)
 
-There is already a proxy-aware “client key” helper:
+There is a proxy-aware “client key” helper implemented for SlowAPI:
 
-- `_client_fingerprint()` in `core/fingerprint_security.py:179-226`
+- `app/security/rate_limit.py:173-195` (`rate_limit_client_key`)
+- `app/security/rate_limit.py:139-171` (`extract_client_ip`)
 
 Key properties:
 
-- Trusts `X-Forwarded-For` **only when** the immediate `request.client.host` is in `TRUSTED_PROXIES`.
+- Trusts forwarded headers **only when** the immediate `request.client.host` is in `TRUSTED_PROXIES`.
 - Otherwise falls back to `request.client.host`.
 - Returns a **pseudonymous fingerprint** (hashed), not the raw IP (privacy-friendly).
 
-### Critical gap (must fix for PR-628)
+### Critical gap (historical)
 
-`TRUSTED_PROXIES` matching is currently **exact-string only** (no CIDR). That is fragile for production where:
+Earlier audits flagged that `TRUSTED_PROXIES` matching was **exact-string only** (no CIDR).
+This has since been addressed in the canonical implementation:
 
-- `--forwarded-allow-ips` is configured as a **CIDR network** in production docker-compose,
-- proxy/container IPs are not stable single values,
-- exact-IP allowlists tend to break after redeploy/network changes.
+- `app/security/rate_limit.py:79-136` implements CIDR parsing + membership checks (`parse_trusted_proxies`,
+  `is_trusted_proxy`).
 
-**Requirement for PR-628:** add **CIDR support** for trusted proxies, and in trusted-proxy mode prefer:
+Header precedence (trusted-proxy mode):
 
 1) `CF-Connecting-IP` (when present)
 2) `X-Forwarded-For` (first IP)
@@ -161,9 +161,10 @@ Key properties:
 
 ### Current state
 
-- No existing tests validating real 429 from SlowAPI (only import/coverage tests).
-- Existing `TestClient` fixture exists:
-  - `tests/conftest.py:443-446`
+Deterministic tests exist and are hermetic (no shared limiter state across tests):
+
+- `tests/test_rate_limit_llm_and_exports_api.py` (200 → 429 transitions for insight + representative exports)
+- `tests/test_rate_limit_client_key_api.py` (CIDR + header precedence + handler i18n contract)
 
 ### Required tests (DoD-level)
 

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -9314,6 +9314,13 @@
             "description": "Validation error (invalid enum / DTO)"
           },
           "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponse"
+                }
+              }
+            },
             "description": "Rate limit exceeded"
           },
           "500": {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -7559,7 +7559,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponse"];
+                };
             };
             /** @description Invariant violation (internal) */
             500: {


### PR DESCRIPTION
## Summary
- Refresh PR-628 audit to match current code (runtime wiring, CIDR proxy key, deterministic tests).
- Standardize OpenAPI 429 response schema for VIP shoplist export using canonical `RATE_LIMIT_429_RESPONSES` and regenerate OpenAPI artifacts.

## Why
- PR-628 is the single open P0 CRITICAL item in `docs/roadmap/BACKLOG_LEDGER.md` (cost-abuse/DoS surface for LLM + exports).
- The codebase already wires SlowAPI + decorators; this PR aligns the remaining OpenAPI contract for the VIP export endpoint and updates the audit evidence so the repo’s source-of-truth docs don’t drift.

## Changes
- `docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md`: update “current state” + evidence pointers.
- `app/routers/vip_shoplist.py`: use `RATE_LIMIT_429_RESPONSES` in `responses=...` for `/api/v1/vip/shoplist/export`.
- Regenerated artifacts:
  - `frontend/src/api/openapi.json`
  - `frontend/src/api/schema.ts`

## Test plan
- `pytest -q tests/test_rate_limit_client_key_api.py tests/test_rate_limit_llm_and_exports_api.py`
- `pytest -q tests/test_repo_policy_guards.py`
- `make verify`

## Deferred / Follow-ups
- Ledger follow-up: mark PR-628 as complete/merged only after this PR lands.
- Next P0 from ledger: move insight to VIP tier.

## Summary by Sourcery

Согласовать документацию по аудитам ограничения скорости (rate limiting) и OpenAPI‑контракт экспорта VIP shoplist с текущей реализацией ограничения скорости во время выполнения.

Enhancements:
- Стандартизировать ответ 429 при превышении лимита запросов для экспорта VIP shoplist, используя общую схему `RATE_LIMIT_429_RESPONSES`, и заново сгенерировать артефакты OpenAPI‑клиента, чтобы включить структурированную полезную нагрузку `RateLimitErrorResponse`.

Documentation:
- Обновить аудит ограничения скорости из PR-628, чтобы отразить активную интеграцию SlowAPI, обработку доверенных прокси с учётом CIDR, а также существующие детерминированные тесты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align rate limiting audit documentation and VIP shoplist export OpenAPI contract with the current runtime rate limiting implementation.

Enhancements:
- Standardize the VIP shoplist export 429 rate-limit response to use the shared RATE_LIMIT_429_RESPONSES schema and regenerate OpenAPI client artifacts to include the structured RateLimitErrorResponse payload.

Documentation:
- Update the PR-628 rate limiting audit to reflect the active SlowAPI wiring, CIDR-aware trusted proxy handling, and existing deterministic tests.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the 429 rate-limit response for the VIP shoplist export using the canonical schema and regenerated OpenAPI artifacts to provide a consistent, structured error payload. Also refreshed the PR-628 audit to reflect current runtime wiring, CIDR-aware trusted proxies, and deterministic test coverage.

- **Bug Fixes**
  - Apply RATE_LIMIT_429_RESPONSES to /api/v1/vip/shoplist/export.
  - Regenerate frontend OpenAPI (openapi.json) and types (schema.ts) to include RateLimitErrorResponse content.

<sup>Written for commit 3d7e05b4b07352a127fa5b76bb54e5c07311a7be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting is now active and properly documented on VIP shoplist export endpoints.

* **Bug Fixes**
  * Rate limit error responses now return a structured JSON format for better error handling and consistency.

* **Documentation**
  * Updated documentation to reflect active rate limiting, CIDR support for trusted proxies, and explicit error contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->