### PR TITLE
P0: Enforce VIP tier for LLM Insight and close legacy /insight endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -556,15 +556,6 @@
         "line_number": 24
       }
     ],
-    "tests/test_admin_endpoints_97.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_admin_endpoints_97.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 120
-      }
-    ],
     "tests/test_aliases_coverage_96.py": [
       {
         "type": "Secret Keyword",
@@ -1430,7 +1421,7 @@
         "filename": "tests/test_targeted_coverage_boost.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 22
       }
     ],
     "tests/test_targeted_coverage_improvement.py": [
@@ -1645,5 +1636,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-03T19:25:39Z"
+  "generated_at": "2026-02-03T19:59:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -562,7 +562,7 @@
         "filename": "tests/test_admin_endpoints_97.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 120
       }
     ],
     "tests/test_aliases_coverage_96.py": [
@@ -572,15 +572,6 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 20
-      }
-    ],
-    "tests/test_api.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_api.py",
-        "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
-        "is_verified": false,
-        "line_number": 375
       }
     ],
     "tests/test_api_endpoint.py": [
@@ -732,7 +723,7 @@
         "filename": "tests/test_app_missing_lines_extra.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 15
       }
     ],
     "tests/test_app_real_coverage_97.py": [
@@ -1654,5 +1645,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-03T18:45:19Z"
+  "generated_at": "2026-02-03T19:25:39Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -556,15 +556,6 @@
         "line_number": 24
       }
     ],
-    "tests/test_admin_endpoints_97.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_admin_endpoints_97.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 120
-      }
-    ],
     "tests/test_aliases_coverage_96.py": [
       {
         "type": "Secret Keyword",
@@ -1430,7 +1421,7 @@
         "filename": "tests/test_targeted_coverage_boost.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 22
       }
     ],
     "tests/test_targeted_coverage_improvement.py": [
@@ -1645,5 +1636,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-03T19:25:39Z"
+  "generated_at": "2026-02-03T20:10:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -680,14 +680,14 @@
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "e2a41f90b2e59f1b35df9f6f500188988639f8de",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 104
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "ca6bef61e666e4c8985e5ea22e682f23a06040ba",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 106
       }
     ],
     "tests/test_app_exact_coverage_96.py": [
@@ -705,7 +705,7 @@
         "filename": "tests/test_app_extended_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 27
       }
     ],
     "tests/test_app_extra_coverage.py": [
@@ -903,7 +903,7 @@
         "filename": "tests/test_coverage_improvement.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 23
       }
     ],
     "tests/test_critical_blocks_targets_gaps.py": [
@@ -1439,7 +1439,7 @@
         "filename": "tests/test_targeted_coverage_boost.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 23
       }
     ],
     "tests/test_targeted_coverage_improvement.py": [
@@ -1654,5 +1654,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-01T15:46:00Z"
+  "generated_at": "2026-02-03T18:45:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -556,6 +556,15 @@
         "line_number": 24
       }
     ],
+    "tests/test_admin_endpoints_97.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_admin_endpoints_97.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
     "tests/test_aliases_coverage_96.py": [
       {
         "type": "Secret Keyword",
@@ -1421,7 +1430,7 @@
         "filename": "tests/test_targeted_coverage_boost.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 23
       }
     ],
     "tests/test_targeted_coverage_improvement.py": [
@@ -1636,5 +1645,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-03T19:59:13Z"
+  "generated_at": "2026-02-03T19:25:39Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -843,15 +843,6 @@
         "line_number": 18
       }
     ],
-    "tests/test_coverage_97_ultimate_final.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_coverage_97_ultimate_final.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 18
-      }
-    ],
     "tests/test_coverage_boost.py": [
       {
         "type": "Secret Keyword",
@@ -1636,5 +1627,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-03T20:10:26Z"
+  "generated_at": "2026-02-03T21:00:41Z"
 }

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,6 +1,12 @@
 # Sourcery AI Configuration for PulsePlate
 # https://docs.sourcery.ai/
 
+# Sourcery should not analyze generated / non-code artifacts.
+# In particular, `.secrets.baseline` contains hashed_secret fingerprints that can be
+# misclassified as "Generic API Key" by security scanners.
+ignore:
+  - .secrets.baseline
+
 # GitHub integration
 github:
   request_review: always

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -6,6 +6,7 @@
 # misclassified as "Generic API Key" by security scanners.
 ignore:
   - .secrets.baseline
+  - ./.secrets.baseline
 
 # GitHub integration
 github:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,6 +604,7 @@ Source of truth:
 - **Guard-consistency tests assert status codes only** (not error payload shape); payload-shape belongs to dedicated contract tests.
 - **FREE tier tests use empty headers** (`{}`), not a "FREE key" — FREE = no key required.
 - **Tests must not mutate `os.environ` directly** — use `monkeypatch.setenv` (prefer an `autouse` fixture for class-level suites).
+- **Never call `response.json()` without asserting `Content-Type` starts with `application/json`** — prevents cryptic errors when endpoint returns HTML or plain text on error.
 - **Type hints required for all new or modified functions** (including tests).
 - OK: `def test_x(vip_headers: dict[str, str]) -> None:` or `def test_x(pro_headers: dict[str, str]) -> None:`
 - Not OK: `def test_x(vip_headers):` (missing types)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,7 +604,6 @@ Source of truth:
 - **Guard-consistency tests assert status codes only** (not error payload shape); payload-shape belongs to dedicated contract tests.
 - **FREE tier tests use empty headers** (`{}`), not a "FREE key" — FREE = no key required.
 - **Tests must not mutate `os.environ` directly** — use `monkeypatch.setenv` (prefer an `autouse` fixture for class-level suites).
-- **Never call `response.json()` without asserting `Content-Type` starts with `application/json`** — prevents cryptic errors when endpoint returns HTML or plain text on error.
 - **Type hints required for all new or modified functions** (including tests).
 - OK: `def test_x(vip_headers: dict[str, str]) -> None:` or `def test_x(pro_headers: dict[str, str]) -> None:`
 - Not OK: `def test_x(vip_headers):` (missing types)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Or individually:
   2. Check `git status` for modified files (e.g., `.secrets.baseline`, whitespace fixes, formatting)
   3. **Commit hook modifications as a separate commit:** `chore(pre-commit): apply hook fixes`
   4. **Important:** If `detect-secrets` updated `.secrets.baseline`, this must be committed (it's a legitimate baseline update, not a secret leak)
+- **Sourcery + baseline note:** `.secrets.baseline` is a **generated** `detect-secrets` artifact and may contain hashed fingerprints that some scanners misclassify as “Generic API Key”.
+  - Sourcery is configured to **ignore only** `.secrets.baseline` (see `.sourcery.yaml`) to avoid false-positive PR blocks; this does **not** replace `detect-secrets` enforcement.
 - CI runs `pre-commit run --all-files` and will fail if hooks would modify files that aren't committed.
 - This is not optional: uncommitted hook modifications guarantee CI failure.
 - **One-time setup:** Run `pre-commit install` locally once to enable automatic hook execution on `git commit` (reduces CI noise).

--- a/docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md
+++ b/docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md
@@ -15,43 +15,43 @@
 - **Cost abuse** (LLM calls at scale; ledger notes “\$72k/month cost attack” risk).
 - **DoS risk** (PDF/CSV endpoints can be heavy; repeated calls can exhaust CPU/memory).
 
-**Goal (PR-628):** Enable a correct, proxy-aware rate limiter in runtime and apply limits to LLM + export surfaces, with deterministic tests and OpenAPI documentation.
+**Goal (PR-628):** Enable a correct, proxy-aware rate limiter at runtime and apply limits to LLM + export surfaces, with deterministic tests and OpenAPI documentation.
 
 ---
 
 ## 1) Surface Area (candidates to rate-limit)
 
-Format: **METHOD + PATH + file:line**
+Format: **METHOD + PATH + evidence anchor**
 
 ### A) LLM / Insight
 
 | Method | Path                | Evidence                   |
 | ------ | ------------------- | -------------------------- |
-| POST   | `/api/v1/insight`   | `legacy_app.py:2037-2042`  |
-| POST   | `/insight` (legacy) | `legacy_app.py:2085-2089`  |
+| POST   | `/api/v1/insight`   | `legacy_app.py` → route wrapper `insight_v1_route` |
+| POST   | `/insight` (legacy) | `legacy_app.py` → route wrapper `insight_route` |
 
 ### B) Export / PDF / CSV (real routers)
 
-- GET `/api/v1/plan/week/export.csv` — `app/routers/plan_export.py:347` (router prefix at `:42`)
-- GET `/api/v1/plan/week/export.pdf` — `app/routers/plan_export.py:444` (router prefix at `:42`)
-- POST `/api/v1/export/sign` — `app/routers/plan_export.py:561` (router prefix at `:43`)
-- GET `/api/v1/shoplist` — `app/routers/shoplist_export.py:230` (router prefix at `:25`)
-- GET `/api/v1/shoplist/export.csv` — `app/routers/shoplist_export.py:237`
-- GET `/api/v1/shoplist/export.pdf` — `app/routers/shoplist_export.py:258`
+- GET `/api/v1/plan/week/export.csv` — `app/routers/plan_export.py` → `plan_router.get("/week/export.csv")`
+- GET `/api/v1/plan/week/export.pdf` — `app/routers/plan_export.py` → `plan_router.get("/week/export.pdf")`
+- POST `/api/v1/export/sign` — `app/routers/plan_export.py` → `export_router.post("/sign")`
+- GET `/api/v1/shoplist` — `app/routers/shoplist_export.py` → `router.get("")`
+- GET `/api/v1/shoplist/export.csv` — `app/routers/shoplist_export.py` → `router.get("/export.csv")`
+- GET `/api/v1/shoplist/export.pdf` — `app/routers/shoplist_export.py` → `router.get("/export.pdf")`
 
 ### C) Export / PDF / CSV (VIP)
 
-- POST `/api/v1/vip/shoplist/export` — `app/routers/vip_shoplist.py:505` (VIP prefix: `app/routers/vip.py:127` + include: `:130`)
+- POST `/api/v1/vip/shoplist/export` — `app/routers/vip_shoplist.py` → `router.post("/export")`
 
 ### D) Export / PDF / CSV (test/demo endpoints in legacy_app.py)
 
 These are gated by `EXPORTS_ENABLED` (see “Feature flags / route registration” below), but **still represent surface area** when enabled.
 
-- GET `/api/v1/premium/exports/day/{plan_id}.csv` — `legacy_app.py:4695-4697`
-- POST `/api/v1/export/pdf` (generic) — `legacy_app.py:4778-4781`
-- GET `/api/v1/premium/exports/week/{plan_id}.csv` — `legacy_app.py:4830-4833`
-- GET `/api/v1/premium/exports/day/{plan_id}.pdf` — `legacy_app.py:4941-4943`
-- GET `/api/v1/premium/exports/week/{plan_id}.pdf` — `legacy_app.py:5026-5029`
+- GET `/api/v1/premium/exports/day/{plan_id}.csv` — `legacy_app.py` → exports block (gated by `EXPORTS_ENABLED`)
+- POST `/api/v1/export/pdf` (generic) — `legacy_app.py` → exports block (gated by `EXPORTS_ENABLED`)
+- GET `/api/v1/premium/exports/week/{plan_id}.csv` — `legacy_app.py` → exports block (gated by `EXPORTS_ENABLED`)
+- GET `/api/v1/premium/exports/day/{plan_id}.pdf` — `legacy_app.py` → exports block (gated by `EXPORTS_ENABLED`)
+- GET `/api/v1/premium/exports/week/{plan_id}.pdf` — `legacy_app.py` → exports block (gated by `EXPORTS_ENABLED`)
 
 ---
 
@@ -60,44 +60,43 @@ These are gated by `EXPORTS_ENABLED` (see “Feature flags / route registration�
 ### A) Insight gating flag
 
 - `FEATURE_INSIGHT` gates both insight paths:
-  - `legacy_app.py:2047-2049` (`/api/v1/insight`)
-  - `legacy_app.py:2095-2098` (`/insight`)
+  - `legacy_app.py` → `insight_v1()` and `insight()` (feature-flag gate)
 
 ### B) VIP module gating flag
 
 - `VIP_MODULE_ENABLED` parsed via `app/utils/feature_flags.py:24-26`
 - Registration is centralized:
-  - `app/routers/vip_registration.py:42-57` (includes `app/routers/vip.py` router)
+  - `app/routers/vip_registration.py` (includes `app/routers/vip.py` router)
 
 ### C) Legacy “exports enabled” gating
 
 `legacy_app.py` defines:
 
 - `EXPORTS_ENABLED` computed from `FEATURE_EXPORTS` and test/debug heuristics:
-  - `legacy_app.py:4676-4693`
+  - `legacy_app.py` → `EXPORTS_ENABLED = ...` and `if EXPORTS_ENABLED:` exports block
 - When enabled, legacy “test/demo” export endpoints are defined (see surface table above).
 
 ### D) Signed export token gating (plan_export)
 
 - `PRIVATE_EXPORTS_ENABLED` (env) parsed in `settings.py:10-14`
 - Token guard logic:
-  - `app/routers/plan_export.py:332-345`
+  - `app/routers/plan_export.py` → `_require_valid_token(request)`
 
 ---
 
-## 3) Current State (rate limiting in runtime)
+## 3) Current State (rate limiting at runtime)
 
 ### What is true today
 
-**Rate limiting IS active in runtime (wired), and gracefully degrades if SlowAPI is unavailable.**
+**Rate limiting IS active at runtime (wired), and gracefully degrades if SlowAPI is unavailable.**
 
 - Wiring is executed during FastAPI app creation:
-  - `legacy_app.py:679-688` (imports `wire_rate_limiting` and calls `wire_rate_limiting(app)`).
+  - `legacy_app.py` → app initialization block (calls `wire_rate_limiting(app)`).
 - Wiring helper (canonical implementation):
-  - `app/security/rate_limit.py:243-280` (`wire_rate_limiting` attaches limiter, 429 handler, middleware).
+  - `app/security/rate_limit.py` → `wire_rate_limiting(app)` (attaches limiter, 429 handler, middleware).
 
 Note: SlowAPI remains an optional dependency (ImportError → no-op stubs), but when installed the limiter
-is enabled by default in runtime and disabled by default in tests unless explicitly enabled (see below).
+is enabled by default at runtime and disabled by default in tests unless explicitly enabled (see below).
 
 ---
 
@@ -132,8 +131,8 @@ No explicit Caddy rule for `CF-Connecting-IP` is present; therefore the app must
 
 There is a proxy-aware “client key” helper implemented for SlowAPI:
 
-- `app/security/rate_limit.py:173-195` (`rate_limit_client_key`)
-- `app/security/rate_limit.py:139-171` (`extract_client_ip`)
+- `app/security/rate_limit.py` → `rate_limit_client_key(request)`
+- `app/security/rate_limit.py` → `extract_client_ip(request, trusted_entries)`
 
 Key properties:
 
@@ -146,7 +145,7 @@ Key properties:
 Earlier audits flagged that `TRUSTED_PROXIES` matching was **exact-string only** (no CIDR).
 This has since been addressed in the canonical implementation:
 
-- `app/security/rate_limit.py:79-136` implements CIDR parsing + membership checks (`parse_trusted_proxies`,
+- `app/security/rate_limit.py` implements CIDR parsing + membership checks (`parse_trusted_proxies`,
   `is_trusted_proxy`).
 
 Header precedence (trusted-proxy mode):
@@ -220,7 +219,7 @@ and should return a stable JSON payload (minimum acceptable):
 
 ## 8) Definition of Done (PR-628)
 
-- SlowAPI is active in runtime (Limiter + middleware + 429 handler).
+- SlowAPI is active at runtime (Limiter + middleware + 429 handler).
 - Proxy-aware key function works behind Cloudflare/Caddy/Uvicorn and does not collapse all users under one IP.
 - Limits applied to:
   - `/api/v1/insight` and `/insight`
@@ -252,8 +251,8 @@ and should return a stable JSON payload (minimum acceptable):
 
 - Ledger: `docs/roadmap/BACKLOG_LEDGER.md` (P0 CRITICAL: Rate-limiting for LLM endpoints)
 - LLM endpoints: `legacy_app.py` (`/api/v1/insight`, `/insight`)
-- SlowAPI wiring (commented): `legacy_app.py:1022-1037`
-- Client fingerprint helper: `core/fingerprint_security.py:_client_fingerprint`
+- SlowAPI wiring: `legacy_app.py` → app initialization block (calls `wire_rate_limiting(app)`)
+- Client fingerprint helper: `core/fingerprint_security.py:compute_fingerprint`
 - Proxy infra:
   - `deploy/Caddyfile`, `deploy/Caddyfile.production`
   - `deploy/docker-compose.staging.yaml`, `deploy/docker-compose.production.yaml`

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -4,7 +4,7 @@
 **Branch:** `fix/p0-vip-guard-insight`
 **Ledger item (source of truth):** `docs/roadmap/BACKLOG_LEDGER.md` → “P0 CRITICAL: Move LLM insight to VIP tier”
 
-### Goal
+# Goal
 
 - Make all LLM-backed “insight” endpoints **VIP-only** to prevent FREE/PRO access to expensive LLM calls.
 - Ensure there is **no public unguarded** insight path.

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -1,0 +1,100 @@
+## PR (P0): Move LLM insight to VIP tier — Audit (evidence-first)
+
+**Date:** 3 February 2026  
+**Branch:** `fix/p0-vip-guard-insight`  
+**Ledger item (source of truth):** `docs/roadmap/BACKLOG_LEDGER.md` → “P0 CRITICAL: Move LLM insight to VIP tier”
+
+### Goal
+
+- Make all LLM-backed “insight” endpoints **VIP-only** to prevent FREE/PRO access to expensive LLM calls.
+- Ensure there is **no public unguarded** insight path.
+- Keep scope tight: adapter/guard only + tests + OpenAPI regen.
+
+---
+
+## 1) Which handlers exist (evidence)
+
+### `/api/v1/insight`
+
+- **Defined in:** `legacy_app.py` (route wrapper around `insight_v1`)
+- **Evidence:** `legacy_app.py:2171-2179`
+- **Current guard:** `Depends(_get_api_key_dynamic)` (API key check, **not** tier-aware)
+
+### `/insight` (legacy)
+
+- **Defined in:** `legacy_app.py` (route wrapper around `insight`)
+- **Evidence:** `legacy_app.py:2182-2190`
+- **Current guard:** **none** (public path), only feature-flag gate inside handler (`FEATURE_INSIGHT`)
+
+---
+
+## 2) Client usage (thin clients)
+
+### Frontend (React)
+
+- No direct usage found in `frontend/src/**` (only in generated OpenAPI artifacts).
+- Evidence: search for `/insight` and `/api/v1/insight` matches only:
+  - `frontend/src/api/openapi.json`
+  - `frontend/src/api/schema.ts`
+
+### iOS (Swift)
+
+- No usage found in `ios/**` (no string matches for `insight` endpoints).
+
+Implication: we can safely **hide legacy `/insight` from OpenAPI** (and keep/guard it for backward
+compat only), without breaking known clients.
+
+---
+
+## 3) Current auth/tier logic (evidence)
+
+- VIP tier dependency exists and is canonical:
+  - `app/middleware/api_tiers.py:205+` (`require_vip_tier`)
+- Test fixtures for tiered access exist:
+  - `tests/conftest.py:539-566` (`pro_headers`, `vip_headers`)
+
+---
+
+## 4) Decision (scope)
+
+### `/api/v1/insight`
+
+- Replace `_get_api_key_dynamic` gate with `require_vip_tier()` to enforce VIP-only.
+
+### `/insight`
+
+- Keep endpoint as legacy compatibility shim **but VIP-guard it** and set `include_in_schema=False`
+  so it is not emitted into public OpenAPI (thin-client policy: deprecated/legacy paths hidden).
+
+---
+
+## 5) Test strategy (deterministic)
+
+Add/adjust tests to cover:
+
+- **FREE** (no headers) → `403`
+- **PRO** (`pro_headers`) → `403`
+- **VIP** (`vip_headers`) → `200` (with provider stubbed to avoid external calls)
+
+Also update existing insight safety tests (`tests/test_insight_error_hygiene.py`) to call the endpoints
+with `vip_headers`, so the tests continue to validate “no error detail leakage” under the new guard.
+
+---
+
+## 6) OpenAPI contract
+
+- `/api/v1/insight` remains public but becomes VIP-guarded via `require_vip_tier` dependency.
+- `/insight` becomes `include_in_schema=False` (hidden; legacy only).
+- Regenerate artifacts via `make openapi` and commit:
+  - `frontend/src/api/openapi.json`
+  - `frontend/src/api/schema.ts`
+
+---
+
+## 7) DoD
+
+- FREE/PRO cannot call insight: `403`
+- VIP can call insight: `200`
+- No public unguarded `/insight` (either removed or VIP-guarded + hidden)
+- Targeted pytest suite green + `make verify` green
+

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -4,7 +4,7 @@
 **Branch:** `fix/p0-vip-guard-insight`
 **Ledger item (source of truth):** `docs/roadmap/BACKLOG_LEDGER.md` → “P0 CRITICAL: Move LLM insight to VIP tier”
 
-### Goal
+## Goal
 
 - Make all LLM-backed “insight” endpoints **VIP-only** to prevent FREE/PRO access to expensive LLM calls.
 - Ensure there is **no public unguarded** insight path.

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -1,4 +1,4 @@
-## PR (P0): Move LLM insight to VIP tier — Audit (evidence-first)
+# PR (P0): Move LLM insight to VIP tier — Audit (evidence-first)
 
 **Date:** 3 February 2026
 **Branch:** `fix/p0-vip-guard-insight`
@@ -17,14 +17,14 @@
 ### `/api/v1/insight`
 
 - **Defined in:** `legacy_app.py` (route wrapper around `insight_v1`)
-- **Evidence:** `legacy_app.py:2171-2179`
-- **Current guard:** `Depends(_get_api_key_dynamic)` (API key check, **not** tier-aware)
+- **Evidence anchor:** `@app.post("/api/v1/insight")` decorator and its `dependencies=[Depends(require_vip_tier)]`
+- **Current guard:** `Depends(require_vip_tier)` (**tier-aware** VIP-only)
 
 ### `/insight` (legacy)
 
 - **Defined in:** `legacy_app.py` (route wrapper around `insight`)
-- **Evidence:** `legacy_app.py:2182-2190`
-- **Current guard:** **none** (public path), only feature-flag gate inside handler (`FEATURE_INSIGHT`)
+- **Evidence anchor:** `@app.post("/insight")` decorator and its `dependencies=[Depends(require_vip_tier)]`
+- **Current guard:** `Depends(require_vip_tier)` (VIP-only), plus feature-flag gate inside handler (`FEATURE_INSIGHT`)
 
 ---
 
@@ -57,11 +57,11 @@ compat only), without breaking known clients.
 
 ## 4) Decision (scope)
 
-### `/api/v1/insight`
+### Decision: `/api/v1/insight`
 
 - Replace `_get_api_key_dynamic` gate with `require_vip_tier()` to enforce VIP-only.
 
-### `/insight`
+### Decision: `/insight`
 
 - Keep endpoint as legacy compatibility shim **but VIP-guard it** and set `include_in_schema=False`
   so it is not emitted into public OpenAPI (thin-client policy: deprecated/legacy paths hidden).
@@ -85,6 +85,8 @@ with `vip_headers`, so the tests continue to validate “no error detail leakage
 
 - `/api/v1/insight` remains public but becomes VIP-guarded via `require_vip_tier` dependency.
 - `/insight` becomes `include_in_schema=False` (hidden; legacy only).
+- Exception (policy note): `/api/v1/insight` remains the canonical path but is VIP-guarded; no `/api/v1/vip/insight`
+  is introduced in this P0 PR.
 - Regenerate artifacts via `make openapi` and commit:
   - `frontend/src/api/openapi.json`
   - `frontend/src/api/schema.ts`

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -4,7 +4,7 @@
 **Branch:** `fix/p0-vip-guard-insight`
 **Ledger item (source of truth):** `docs/roadmap/BACKLOG_LEDGER.md` → “P0 CRITICAL: Move LLM insight to VIP tier”
 
-## Goal
+### Goal
 
 - Make all LLM-backed “insight” endpoints **VIP-only** to prevent FREE/PRO access to expensive LLM calls.
 - Ensure there is **no public unguarded** insight path.

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -1,7 +1,7 @@
 ## PR (P0): Move LLM insight to VIP tier — Audit (evidence-first)
 
-**Date:** 3 February 2026  
-**Branch:** `fix/p0-vip-guard-insight`  
+**Date:** 3 February 2026
+**Branch:** `fix/p0-vip-guard-insight`
 **Ledger item (source of truth):** `docs/roadmap/BACKLOG_LEDGER.md` → “P0 CRITICAL: Move LLM insight to VIP tier”
 
 ### Goal
@@ -97,4 +97,3 @@ with `vip_headers`, so the tests continue to validate “no error detail leakage
 - VIP can call insight: `200`
 - No public unguarded `/insight` (either removed or VIP-guarded + hidden)
 - Targeted pytest suite green + `make verify` green
-

--- a/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
+++ b/docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md
@@ -49,9 +49,9 @@ compat only), without breaking known clients.
 ## 3) Current auth/tier logic (evidence)
 
 - VIP tier dependency exists and is canonical:
-  - `app/middleware/api_tiers.py:205+` (`require_vip_tier`)
+  - `app/middleware/api_tiers.py` → function `require_vip_tier()`
 - Test fixtures for tiered access exist:
-  - `tests/conftest.py:539-566` (`pro_headers`, `vip_headers`)
+  - `tests/conftest.py` → fixtures `pro_headers`, `vip_headers`
 
 ---
 

--- a/docs/process/PRECOMMIT_BASELINE_POLICY.md
+++ b/docs/process/PRECOMMIT_BASELINE_POLICY.md
@@ -1,0 +1,13 @@
+# Pre-commit baseline policy: detect-secrets
+
+## Why `.secrets.baseline` can change unexpectedly
+
+The `detect-secrets` pre-commit hook may update `.secrets.baseline` to keep line numbers in sync
+after code changes. In some cases, this update can occur during a non-hook-focused commit.
+
+## Policy (canonical)
+
+- Prefer committing `.secrets.baseline` updates in a **separate commit**:
+  `chore(pre-commit): update .secrets.baseline`
+- If a baseline update accidentally lands inside a feature/fix commit, add an explicit follow-up note
+  in the PR history and ensure future PRs stage + commit the baseline **first**.

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -9706,54 +9706,6 @@
         "summary": "Database Health"
       }
     },
-    "/insight": {
-      "post": {
-        "operationId": "insight_route_insight_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InsightRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InsightResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RateLimitErrorResponse"
-                }
-              }
-            },
-            "description": "Rate limit exceeded"
-          }
-        },
-        "summary": "Insight Route"
-      }
-    },
     "/plan": {
       "post": {
         "description": "RU: Legacy endpoint /plan (contract must remain stable in PR-457=A).\nEN: Legacy /plan endpoint (contract must remain stable in PR-457=A).\n\nPR-457=A: Delegates to canonical BMI engine but preserves legacy response contract.",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2071,23 +2071,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/insight": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Insight Route */
-        post: operations["insight_route_insight_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/plan": {
         parameters: {
             query?: never;
@@ -7885,48 +7868,6 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
-                };
-            };
-        };
-    };
-    insight_route_insight_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InsightRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InsightResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Rate limit exceeded */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RateLimitErrorResponse"];
                 };
             };
         };

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -104,6 +104,7 @@ from app.scheduler_helpers import (
 )
 from app.utils.helpers import _resolve_app_callable, _short_git_sha
 from app.utils.feature_flags import _is_truthy
+from app.middleware.api_tiers import require_vip_tier
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
     _calculate_all_tdee_wrapper,
@@ -2170,7 +2171,7 @@ async def insight(req: InsightRequest) -> InsightResponse:
 
 @app.post(
     "/api/v1/insight",
-    dependencies=[Depends(_get_api_key_dynamic)],
+    dependencies=[Depends(require_vip_tier)],
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
 )
@@ -2182,6 +2183,9 @@ async def insight_v1_route(request: Request, req: InsightRequest) -> InsightResp
 # Backward-compatible simple insight endpoint (no API key)
 @app.post(
     "/insight",
+    include_in_schema=False,
+    deprecated=True,
+    dependencies=[Depends(require_vip_tier)],
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
 )

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -74,7 +74,7 @@ from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
 from app.services import recipe_store
 from app.services.food_store import get_food
 
-# Legacy BMI helpers removed from request-path (PR-457=A)
+# tegacy BMI helpers removed from request-path (PR-457=A)
 # /plan now delegates to canonical BMI engine via compat layer
 from decimal import Decimal
 

--- a/tests/edges/test_app_branches.py
+++ b/tests/edges/test_app_branches.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 from starlette.types import ASGIApp
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 
 def test_api_key_strict_production_requires_config(monkeypatch):
@@ -43,7 +44,7 @@ def test_insight_feature_disabled_and_import_error(monkeypatch):
     # RU: FEATURE_INSIGHT выключен → 503 (legacy path)
     # EN: FEATURE_INSIGHT disabled → 503 (legacy path)
     monkeypatch.delenv("FEATURE_INSIGHT", raising=False)
-    r = client.post("/insight", json={"text": "hello"})
+    r = client.post("/insight", json={"text": "hello"}, headers={"X-API-Key": TEST_KEY_VIP})
     assert r.status_code == 503
 
     # RU: Включаем флаг и ломаем импорт llm → 503 (v1 path)
@@ -54,10 +55,10 @@ def test_insight_feature_disabled_and_import_error(monkeypatch):
     r2 = client.post(
         "/api/v1/insight",
         json={"text": "hello"},
-        headers={"X-API-Key": "test_key"},
+        headers={"X-API-Key": TEST_KEY_VIP},
     )
-    # Accept both 503 (service unavailable) and 403 (auth check before service check)
-    assert r2.status_code in [403, 503]
+    # Feature enabled but llm import broken → 503
+    assert r2.status_code == 503
 
 
 def test_admin_status_scheduler_error_paths(monkeypatch, api_key):

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -29,7 +29,9 @@ def client(app: FastAPI):
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
 
-    def test_force_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_force_update_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест /api/v1/admin/force-update (блок 1566-1595)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -44,10 +46,13 @@ class TestAdminEndpoints:
 
         if response.status_code == 500:
             # Проверим что получили правильную ошибку
+            assert response.headers.get("content-type", "").startswith("application/json")
             data = response.json()
             assert "detail" in data
 
-    def test_check_updates_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_check_updates_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест /api/v1/admin/check-updates (блок 1607-1624)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -56,10 +61,11 @@ class TestAdminEndpoints:
         assert response.status_code in [200, 500, 503]
 
         if response.status_code == 200:
+            assert response.headers.get("content-type", "").startswith("application/json")
             data = response.json()
             assert "message" in data
 
-    def test_rollback_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/rollback (блок 1640-1662)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -71,7 +77,9 @@ class TestAdminEndpoints:
 
         assert response.status_code in [200, 400, 422, 500, 503]
 
-    def test_admin_endpoints_integration(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_admin_endpoints_integration(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test admin endpoints with real behavior"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -99,8 +107,12 @@ class TestAdminEndpoints:
 class TestRemainingBlocks:
     """Тесты для покрытия оставшихся мелких блоков"""
 
-    def test_insight_endpoints(self, client, vip_headers: dict[str, str]) -> None:
+    def test_insight_endpoints(
+        self, client: TestClient, vip_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест insight endpoints"""
+        monkeypatch.setenv("API_KEY", "test_key")
+
         # Basic insight
         response = client.post(
             "/insight",
@@ -117,45 +129,37 @@ class TestRemainingBlocks:
         assert response.status_code in [200, 422, 500, 503]
 
         # API v1 insight
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/insight",
-                headers=vip_headers,
-                json={
-                    "weight_kg": 70,
-                    "height_m": 1.75,
-                    "age": 30,
-                    "gender": "male",
-                    "pregnant": "no",
-                    "athlete": "no",
-                },
-            )
-            assert response.status_code in [200, 422, 500, 503]
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        response = client.post(
+            "/api/v1/insight",
+            headers=vip_headers,
+            json={
+                "weight_kg": 70,
+                "height_m": 1.75,
+                "age": 30,
+                "gender": "male",
+                "pregnant": "no",
+                "athlete": "no",
+            },
+        )
+        assert response.status_code in [200, 422, 500, 503]
 
-    def test_api_v1_bmi(self, client):
+    def test_api_v1_bmi(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест API v1 BMI endpoint"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/bmi",
-                headers={"X-API-Key": "test_key"},
-                json={
-                    "weight_kg": 70,
-                    "height_m": 1.75,
-                    "age": 30,
-                    "gender": "male",
-                    "pregnant": "no",
-                    "athlete": "no",
-                },
-            )
-            assert response.status_code in [200, 422, 500]
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        response = client.post(
+            "/api/v1/bmi",
+            headers={"X-API-Key": "test_key"},
+            json={
+                "weight_kg": 70,
+                "height_m": 1.75,
+                "age": 30,
+                "gender": "male",
+                "pregnant": "no",
+                "athlete": "no",
+            },
+        )
+        assert response.status_code in [200, 422, 500]
 
     def test_edge_cases_comprehensive(self, client):
         """Комплексные edge cases для добивания покрытия"""

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -29,9 +29,7 @@ def client(app: FastAPI):
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
 
-    def test_force_update_endpoint(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_force_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/force-update (блок 1566-1595)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -49,9 +47,7 @@ class TestAdminEndpoints:
             data = response.json()
             assert "detail" in data
 
-    def test_check_updates_endpoint(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_check_updates_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/check-updates (блок 1607-1624)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -63,7 +59,7 @@ class TestAdminEndpoints:
             data = response.json()
             assert "message" in data
 
-    def test_rollback_endpoint(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/rollback (блок 1640-1662)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -75,9 +71,7 @@ class TestAdminEndpoints:
 
         assert response.status_code in [200, 400, 422, 500, 503]
 
-    def test_admin_endpoints_integration(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_admin_endpoints_integration(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test admin endpoints with real behavior"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -105,12 +99,8 @@ class TestAdminEndpoints:
 class TestRemainingBlocks:
     """Тесты для покрытия оставшихся мелких блоков"""
 
-    def test_insight_endpoints(
-        self, client: TestClient, vip_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_insight_endpoints(self, client, vip_headers: dict[str, str]) -> None:
         """Тест insight endpoints"""
-        monkeypatch.setenv("API_KEY", "test_key")
-
         # Basic insight
         response = client.post(
             "/insight",
@@ -127,37 +117,45 @@ class TestRemainingBlocks:
         assert response.status_code in [200, 422, 500, 503]
 
         # API v1 insight
-        response = client.post(
-            "/api/v1/insight",
-            headers=vip_headers,
-            json={
-                "weight_kg": 70,
-                "height_m": 1.75,
-                "age": 30,
-                "gender": "male",
-                "pregnant": "no",
-                "athlete": "no",
-            },
-        )
-        assert response.status_code in [200, 422, 500, 503]
+        os.environ["API_KEY"] = "test_key"
+        try:
+            response = client.post(
+                "/api/v1/insight",
+                headers=vip_headers,
+                json={
+                    "weight_kg": 70,
+                    "height_m": 1.75,
+                    "age": 30,
+                    "gender": "male",
+                    "pregnant": "no",
+                    "athlete": "no",
+                },
+            )
+            assert response.status_code in [200, 422, 500, 503]
+        finally:
+            if "API_KEY" in os.environ:
+                del os.environ["API_KEY"]
 
-    def test_api_v1_bmi(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_api_v1_bmi(self, client):
         """Тест API v1 BMI endpoint"""
-        monkeypatch.setenv("API_KEY", "test_key")
-
-        response = client.post(
-            "/api/v1/bmi",
-            headers={"X-API-Key": "test_key"},
-            json={
-                "weight_kg": 70,
-                "height_m": 1.75,
-                "age": 30,
-                "gender": "male",
-                "pregnant": "no",
-                "athlete": "no",
-            },
-        )
-        assert response.status_code in [200, 422, 500]
+        os.environ["API_KEY"] = "test_key"
+        try:
+            response = client.post(
+                "/api/v1/bmi",
+                headers={"X-API-Key": "test_key"},
+                json={
+                    "weight_kg": 70,
+                    "height_m": 1.75,
+                    "age": 30,
+                    "gender": "male",
+                    "pregnant": "no",
+                    "athlete": "no",
+                },
+            )
+            assert response.status_code in [200, 422, 500]
+        finally:
+            if "API_KEY" in os.environ:
+                del os.environ["API_KEY"]
 
     def test_edge_cases_comprehensive(self, client):
         """Комплексные edge cases для добивания покрытия"""

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -115,7 +115,7 @@ class TestAdminEndpoints:
 class TestRemainingBlocks:
     """Тесты для покрытия оставшихся мелких блоков"""
 
-    def test_insight_endpoints(self, client):
+    def test_insight_endpoints(self, client, vip_headers: dict[str, str]) -> None:
         """Тест insight endpoints"""
         # Basic insight
         response = client.post(
@@ -128,15 +128,16 @@ class TestRemainingBlocks:
                 "pregnant": "no",
                 "athlete": "no",
             },
+            headers=vip_headers,
         )
-        assert response.status_code in [200, 422, 500]
+        assert response.status_code in [200, 422, 500, 503]
 
         # API v1 insight
         os.environ["API_KEY"] = "test_key"
         try:
             response = client.post(
                 "/api/v1/insight",
-                headers={"X-API-Key": "test_key"},
+                headers=vip_headers,
                 json={
                     "weight_kg": 70,
                     "height_m": 1.75,

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -29,87 +29,71 @@ def client(app: FastAPI):
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
 
-    def test_force_update_endpoint(self, client):
+    def test_force_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/force-update (блок 1566-1595)"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/admin/force-update",
-                headers={"X-API-Key": "test_key"},
-                json={"source": "usda"},
-            )
+        monkeypatch.setenv("API_KEY", "test_key")
 
-            # Endpoint может работать или падать в зависимости от реализации
-            assert response.status_code in [200, 400, 500, 503]
+        response = client.post(
+            "/api/v1/admin/force-update",
+            headers={"X-API-Key": "test_key"},
+            json={"source": "usda"},
+        )
 
-            if response.status_code == 500:
-                # Проверим что получили правильную ошибку
-                data = response.json()
-                assert "detail" in data
+        # Endpoint может работать или падать в зависимости от реализации
+        assert response.status_code in [200, 400, 500, 503]
 
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        if response.status_code == 500:
+            # Проверим что получили правильную ошибку
+            data = response.json()
+            assert "detail" in data
 
-    def test_check_updates_endpoint(self, client):
+    def test_check_updates_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/check-updates (блок 1607-1624)"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.get("/api/v1/admin/check-updates", headers={"X-API-Key": "test_key"})
+        monkeypatch.setenv("API_KEY", "test_key")
 
-            assert response.status_code in [200, 500, 503]
+        response = client.get("/api/v1/admin/check-updates", headers={"X-API-Key": "test_key"})
 
-            if response.status_code == 200:
-                data = response.json()
-                assert "message" in data
+        assert response.status_code in [200, 500, 503]
 
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        if response.status_code == 200:
+            data = response.json()
+            assert "message" in data
 
-    def test_rollback_endpoint(self, client):
+    def test_rollback_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/rollback (блок 1640-1662)"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/admin/rollback",
-                headers={"X-API-Key": "test_key"},
-                json={"source": "usda", "target_version": "1.0.0"},
-            )
+        monkeypatch.setenv("API_KEY", "test_key")
 
-            assert response.status_code in [200, 400, 422, 500, 503]
+        response = client.post(
+            "/api/v1/admin/rollback",
+            headers={"X-API-Key": "test_key"},
+            json={"source": "usda", "target_version": "1.0.0"},
+        )
 
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        assert response.status_code in [200, 400, 422, 500, 503]
 
-    def test_admin_endpoints_integration(self, client):
+    def test_admin_endpoints_integration(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test admin endpoints with real behavior"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            # Test force-update (real request, no invasive sys.modules patching)
-            response = client.post(
-                "/api/v1/admin/force-update",
-                headers={"X-API-Key": "test_key"},
-                json={"source": "usda"},
-            )
-            assert response.status_code in [200, 400, 404, 422, 500, 503]
+        monkeypatch.setenv("API_KEY", "test_key")
 
-            # Test check-updates
-            response = client.get("/api/v1/admin/check-updates", headers={"X-API-Key": "test_key"})
-            assert response.status_code in [200, 404, 500, 503]
+        # Test force-update (real request, no invasive sys.modules patching)
+        response = client.post(
+            "/api/v1/admin/force-update",
+            headers={"X-API-Key": "test_key"},
+            json={"source": "usda"},
+        )
+        assert response.status_code in [200, 400, 404, 422, 500, 503]
 
-            # Test rollback
-            response = client.post(
-                "/api/v1/admin/rollback",
-                headers={"X-API-Key": "test_key"},
-                json={"source": "usda", "target_version": "1.0.0"},
-            )
-            assert response.status_code in [200, 400, 404, 422, 500, 503]
+        # Test check-updates
+        response = client.get("/api/v1/admin/check-updates", headers={"X-API-Key": "test_key"})
+        assert response.status_code in [200, 404, 500, 503]
 
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        # Test rollback
+        response = client.post(
+            "/api/v1/admin/rollback",
+            headers={"X-API-Key": "test_key"},
+            json={"source": "usda", "target_version": "1.0.0"},
+        )
+        assert response.status_code in [200, 400, 404, 422, 500, 503]
 
 
 class TestRemainingBlocks:

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -29,7 +29,9 @@ def client(app: FastAPI):
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
 
-    def test_force_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_force_update_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест /api/v1/admin/force-update (блок 1566-1595)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -47,7 +49,9 @@ class TestAdminEndpoints:
             data = response.json()
             assert "detail" in data
 
-    def test_check_updates_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_check_updates_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест /api/v1/admin/check-updates (блок 1607-1624)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -59,7 +63,7 @@ class TestAdminEndpoints:
             data = response.json()
             assert "message" in data
 
-    def test_rollback_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест /api/v1/admin/rollback (блок 1640-1662)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -71,7 +75,9 @@ class TestAdminEndpoints:
 
         assert response.status_code in [200, 400, 422, 500, 503]
 
-    def test_admin_endpoints_integration(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_admin_endpoints_integration(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test admin endpoints with real behavior"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -99,8 +105,12 @@ class TestAdminEndpoints:
 class TestRemainingBlocks:
     """Тесты для покрытия оставшихся мелких блоков"""
 
-    def test_insight_endpoints(self, client, vip_headers: dict[str, str]) -> None:
+    def test_insight_endpoints(
+        self, client: TestClient, vip_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Тест insight endpoints"""
+        monkeypatch.setenv("API_KEY", "test_key")
+
         # Basic insight
         response = client.post(
             "/insight",
@@ -117,45 +127,37 @@ class TestRemainingBlocks:
         assert response.status_code in [200, 422, 500, 503]
 
         # API v1 insight
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/insight",
-                headers=vip_headers,
-                json={
-                    "weight_kg": 70,
-                    "height_m": 1.75,
-                    "age": 30,
-                    "gender": "male",
-                    "pregnant": "no",
-                    "athlete": "no",
-                },
-            )
-            assert response.status_code in [200, 422, 500, 503]
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        response = client.post(
+            "/api/v1/insight",
+            headers=vip_headers,
+            json={
+                "weight_kg": 70,
+                "height_m": 1.75,
+                "age": 30,
+                "gender": "male",
+                "pregnant": "no",
+                "athlete": "no",
+            },
+        )
+        assert response.status_code in [200, 422, 500, 503]
 
-    def test_api_v1_bmi(self, client):
+    def test_api_v1_bmi(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест API v1 BMI endpoint"""
-        os.environ["API_KEY"] = "test_key"
-        try:
-            response = client.post(
-                "/api/v1/bmi",
-                headers={"X-API-Key": "test_key"},
-                json={
-                    "weight_kg": 70,
-                    "height_m": 1.75,
-                    "age": 30,
-                    "gender": "male",
-                    "pregnant": "no",
-                    "athlete": "no",
-                },
-            )
-            assert response.status_code in [200, 422, 500]
-        finally:
-            if "API_KEY" in os.environ:
-                del os.environ["API_KEY"]
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        response = client.post(
+            "/api/v1/bmi",
+            headers={"X-API-Key": "test_key"},
+            json={
+                "weight_kg": 70,
+                "height_m": 1.75,
+                "age": 30,
+                "gender": "male",
+                "pregnant": "no",
+                "athlete": "no",
+            },
+        )
+        assert response.status_code in [200, 422, 500]
 
     def test_edge_cases_comprehensive(self, client):
         """Комплексные edge cases для добивания покрытия"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -248,7 +248,10 @@ def test_insight_import_failure(client: TestClient, monkeypatch: pytest.MonkeyPa
 
 @patch("llm.get_provider")
 def test_api_insight_provider_generate_failure(
-    mock_get_provider: Mock, client: TestClient, vip_headers: dict[str, str]
+    mock_get_provider: Mock,
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test coverage for provider.generate exception in insight endpoint."""
     from unittest.mock import MagicMock
@@ -258,11 +261,8 @@ def test_api_insight_provider_generate_failure(
     mock_provider.generate.side_effect = Exception("Generate failed")
     mock_get_provider.return_value = mock_provider
 
-    # Устанавливаем переменные окружения для теста
-    import os
-
-    original_feature = os.environ.get("FEATURE_INSIGHT")
-    os.environ["FEATURE_INSIGHT"] = "true"
+    # Deterministic env setup with auto-cleanup
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
 
     response = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
     assert response.status_code == 503
@@ -271,37 +271,25 @@ def test_api_insight_provider_generate_failure(
     # Privacy/safety: never leak raw exception details to the client.
     assert "Generate failed" not in data.get("detail", "")
 
-    # Восстанавливаем переменные окружения
-    if original_feature is not None:
-        os.environ["FEATURE_INSIGHT"] = original_feature
-    else:
-        del os.environ["FEATURE_INSIGHT"]
-
 
 @patch("llm.get_provider")
 def test_api_insight_provider_none(
-    mock_get_provider: Mock, client: TestClient, vip_headers: dict[str, str]
+    mock_get_provider: Mock,
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test coverage for provider is None in insight endpoint."""
     mock_get_provider.return_value = None
 
-    # Устанавливаем переменные окружения для теста
-    import os
-
-    original_feature = os.environ.get("FEATURE_INSIGHT")
-    os.environ["FEATURE_INSIGHT"] = "true"
+    # Deterministic env setup with auto-cleanup
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
 
     response = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
     assert response.status_code == 503
     assert response.headers["content-type"].startswith("application/json")
     data = response.json()
     assert "No LLM provider configured" in data["detail"]
-
-    # Восстанавливаем переменные окружения
-    if original_feature is not None:
-        os.environ["FEATURE_INSIGHT"] = original_feature
-    else:
-        del os.environ["FEATURE_INSIGHT"]
 
 
 def test_metrics(client):
@@ -371,19 +359,14 @@ def test_compute_wht_ratio_round_exception(client) -> None:
 # These tests are obsolete as they tested API key validation on BMI endpoint
 
 
-def test_v1_insight_invalid_api_key(client):
-    os.environ["API_KEY"] = "valid_key"
-    try:
-        r = client.post(
-            "/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "wrong_key"}
-        )
-        assert r.status_code == 403
-        data = r.json()
-        # VIP tier gate: wrong key → VIP access denied (tier-aware error message).
-        assert "VIP" in data["detail"]
-    finally:
-        if "API_KEY" in os.environ:
-            del os.environ["API_KEY"]
+def test_v1_insight_invalid_api_key(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_KEY", "valid_key")
+
+    r = client.post("/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "wrong_key"})
+    assert r.status_code == 403
+    data = r.json()
+    # VIP tier gate: wrong key → VIP access denied (tier-aware error message).
+    assert "VIP" in data["detail"]
 
 
 def test_slowapi_import_failure(client):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -360,13 +360,12 @@ def test_compute_wht_ratio_round_exception(client) -> None:
 
 
 def test_v1_insight_invalid_api_key(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier guard test: FREE headers (no key) → 403. Status-only assertion."""
     monkeypatch.setenv("API_KEY", "valid_key")
 
-    r = client.post("/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "wrong_key"})
+    # FREE headers (empty) → VIP tier gate denies access.
+    r = client.post("/api/v1/insight", json={"text": "test"}, headers={})
     assert r.status_code == 403
-    data = r.json()
-    # VIP tier gate: wrong key → VIP access denied (tier-aware error message).
-    assert "VIP" in data["detail"]
 
 
 def test_slowapi_import_failure(client):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -360,12 +360,13 @@ def test_compute_wht_ratio_round_exception(client) -> None:
 
 
 def test_v1_insight_invalid_api_key(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tier guard test: FREE headers (no key) → 403. Status-only assertion."""
     monkeypatch.setenv("API_KEY", "valid_key")
 
-    # FREE headers (empty) → VIP tier gate denies access.
-    r = client.post("/api/v1/insight", json={"text": "test"}, headers={})
+    r = client.post("/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "wrong_key"})
     assert r.status_code == 403
+    data = r.json()
+    # VIP tier gate: wrong key → VIP access denied (tier-aware error message).
+    assert "VIP" in data["detail"]
 
 
 def test_slowapi_import_failure(client):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -247,7 +247,9 @@ def test_insight_import_failure(client: TestClient, monkeypatch: pytest.MonkeyPa
 
 
 @patch("llm.get_provider")
-def test_api_insight_provider_generate_failure(mock_get_provider: Mock, client: TestClient) -> None:
+def test_api_insight_provider_generate_failure(
+    mock_get_provider: Mock, client: TestClient, vip_headers: dict[str, str]
+) -> None:
     """Test coverage for provider.generate exception in insight endpoint."""
     from unittest.mock import MagicMock
 
@@ -262,9 +264,7 @@ def test_api_insight_provider_generate_failure(mock_get_provider: Mock, client: 
     original_feature = os.environ.get("FEATURE_INSIGHT")
     os.environ["FEATURE_INSIGHT"] = "true"
 
-    response = client.post(
-        "/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "test_key"}
-    )
+    response = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
     assert response.status_code == 503
     assert response.headers["content-type"].startswith("application/json")
     data = response.json()
@@ -279,7 +279,9 @@ def test_api_insight_provider_generate_failure(mock_get_provider: Mock, client: 
 
 
 @patch("llm.get_provider")
-def test_api_insight_provider_none(mock_get_provider: Mock, client: TestClient) -> None:
+def test_api_insight_provider_none(
+    mock_get_provider: Mock, client: TestClient, vip_headers: dict[str, str]
+) -> None:
     """Test coverage for provider is None in insight endpoint."""
     mock_get_provider.return_value = None
 
@@ -289,9 +291,7 @@ def test_api_insight_provider_none(mock_get_provider: Mock, client: TestClient) 
     original_feature = os.environ.get("FEATURE_INSIGHT")
     os.environ["FEATURE_INSIGHT"] = "true"
 
-    response = client.post(
-        "/api/v1/insight", json={"text": "test"}, headers={"X-API-Key": "test_key"}
-    )
+    response = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
     assert response.status_code == 503
     assert response.headers["content-type"].startswith("application/json")
     data = response.json()
@@ -379,7 +379,8 @@ def test_v1_insight_invalid_api_key(client):
         )
         assert r.status_code == 403
         data = r.json()
-        assert "Invalid API Key" in data["detail"]
+        # VIP tier gate: wrong key → VIP access denied (tier-aware error message).
+        assert "VIP" in data["detail"]
     finally:
         if "API_KEY" in os.environ:
             del os.environ["API_KEY"]

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -49,7 +49,7 @@ def test_export_csv_no_key_auth_only(client: TestClient) -> None:
 
 
 def test_export_pdf_no_reportlab_with_key(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch, api_key_headers
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, pro_headers: dict[str, str]
 ) -> None:
     """Checks graceful degradation (503) when reportlab is missing on protected PDF export endpoint.
 
@@ -72,9 +72,7 @@ def test_export_pdf_no_reportlab_with_key(
     assert app_module.app is not None, "app must be initialized"
     reloaded_client = TestClient(cast(FastAPI, app_module.app))
     # Test GET endpoint (POST endpoint doesn't exist at this path)
-    response = reloaded_client.get(
-        "/api/v1/premium/exports/day/plan123.pdf", headers=api_key_headers
-    )
+    response = reloaded_client.get("/api/v1/premium/exports/day/plan123.pdf", headers=pro_headers)
     # Expect 503 Service Unavailable when reportlab is missing, or 403 if API key is invalid
     assert response.status_code in [503, 403]
     if response.status_code == 503:
@@ -85,27 +83,19 @@ def test_export_pdf_no_reportlab_with_key(
         )
 
 
-# Fixture for API key headers
-@pytest.fixture
-def api_key_headers() -> dict[str, str]:
-    from app.middleware.api_tiers import TEST_KEY_VIP
-
-    return {"X-API-Key": TEST_KEY_VIP}
-
-
 def test_rag_context_fallback(
-    client: TestClient, api_key_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    client: TestClient, vip_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Проверяет fallback-ветку RAG (core.rag) — ImportError не должен ломать insight endpoint."""
     disable_optional_modules(monkeypatch, "core.rag.simple_rag")
     payload = {"text": "What is BMI?"}
-    response = client.post("/api/v1/insight", json=payload, headers=api_key_headers)
+    response = client.post("/api/v1/insight", json=payload, headers=vip_headers)
     # VIP tier gate runs before handler; FEATURE_INSIGHT may still be disabled (503).
     assert response.status_code in [200, 503]
 
 
 def test_premium_nutrient_gaps_fallback(
-    client: TestClient, api_key_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Проверяет fallback-ветку premium nutrient gaps (analyze_nutrient_gaps ImportError)."""
     disable_optional_modules(monkeypatch, "core.menu_engine")
@@ -118,19 +108,19 @@ def test_premium_nutrient_gaps_fallback(
         # Expected when optional modules are missing - app.py should handle this gracefully
         pass
     payload = {"weight_kg": 70, "height_cm": 170, "age": 30, "sex": "male", "activity": "sedentary"}
-    response = client.post("/api/v1/premium/gaps", json=payload, headers=api_key_headers)
+    response = client.post("/api/v1/premium/gaps", json=payload, headers=pro_headers)
     # If API key is invalid, expect 403, else 503/500
     assert response.status_code in (503, 500, 403)
 
 
-def test_bmi_endpoint_invalid_payload(client: TestClient, api_key_headers: dict[str, str]) -> None:
+def test_bmi_endpoint_invalid_payload(client: TestClient, pro_headers: dict[str, str]) -> None:
     """Проверяет 422 Unprocessable Entity для невалидного запроса к /api/v1/bmi."""
-    response = client.post("/api/v1/bmi", json={"weight_kg": None}, headers=api_key_headers)
+    response = client.post("/api/v1/bmi", json={"weight_kg": None}, headers=pro_headers)
     # If API key is invalid, expect 403, else 422
     assert response.status_code in [422, 403]
 
 
-def test_bmi_endpoint_value_error(client: TestClient, api_key_headers: dict[str, str]) -> None:
+def test_bmi_endpoint_value_error(client: TestClient, pro_headers: dict[str, str]) -> None:
     """Проверяет 400 Bad Request при ValueError в /api/v1/bmi (например, строка вместо числа)."""
     bad_payload = {
         "weight_kg": "not_a_number",
@@ -139,36 +129,36 @@ def test_bmi_endpoint_value_error(client: TestClient, api_key_headers: dict[str,
         "sex": "male",
         "activity": "sedentary",
     }
-    response = client.post("/api/v1/bmi", json=bad_payload, headers=api_key_headers)
+    response = client.post("/api/v1/bmi", json=bad_payload, headers=pro_headers)
     # If API key is invalid, expect 403, else 400/422
     assert response.status_code in (400, 422, 403)
 
 
 def test_premium_bmr_403_if_feature_flag(
-    client: TestClient, api_key_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Проверяет 503 Service Unavailable если FEATURE_PREMIUM_NUTRITION=0."""
     monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "0")
     payload = {"weight_kg": 70, "height_cm": 170, "age": 30, "sex": "male", "activity": "sedentary"}
-    response = client.post("/api/v1/premium/bmr", json=payload, headers=api_key_headers)
+    response = client.post("/api/v1/premium/bmr", json=payload, headers=pro_headers)
     # If API key is invalid, expect 403, else 503
     assert response.status_code in [503, 403]
 
 
 def test_export_pdf_error(
-    client: TestClient, api_key_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Проверяет 500 Internal Server Error при ошибке экспорта PDF."""
     # Test PDF export endpoint - it may not exist or return 404/403
     response = client.post(
-        "/api/v1/premium/exports/day/pdf", json={"meals": [], "totals": {}}, headers=api_key_headers
+        "/api/v1/premium/exports/day/pdf", json={"meals": [], "totals": {}}, headers=pro_headers
     )
     # Endpoint does not exist, expect 404, or 403 if forbidden
     assert response.status_code in [404, 403]
 
 
 def test_weekly_menu_generation_error(
-    client: TestClient, api_key_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Проверяет 500 Internal Server Error при ошибке генерации недельного меню."""
 
@@ -179,7 +169,7 @@ def test_weekly_menu_generation_error(
 
     monkeypatch.setattr(app_module, "make_weekly_menu", raise_menu)
     payload = {"weight_kg": 70, "height_cm": 170, "age": 30, "sex": "male", "activity": "sedentary"}
-    response = client.post("/api/v1/premium/plan/week", json=payload, headers=api_key_headers)
+    response = client.post("/api/v1/premium/plan/week", json=payload, headers=pro_headers)
     # Endpoint requires API key, may return 403 if key is invalid, or 500 if error
     assert response.status_code in [500, 403]
 
@@ -263,8 +253,8 @@ def test_vip_module_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
         raise RuntimeError("app_module.app is not a FastAPI instance after reload.")
 
 
-def test_invalid_method(client: TestClient, api_key_headers: dict[str, str]) -> None:
-    response = client.put("/api/v1/health", headers=api_key_headers)
+def test_invalid_method(client: TestClient, pro_headers: dict[str, str]) -> None:
+    response = client.put("/api/v1/health", headers=pro_headers)
     assert response.status_code in (405, 404)
 
 

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -77,7 +77,6 @@ def test_export_pdf_no_reportlab_with_key(
     assert response.status_code in [503, 403]
     if response.status_code == 503:
         # Verify error message indicates PDF export is not available
-        assert response.headers.get("content-type", "").startswith("application/json")
         assert (
             "PDF export" in response.json().get("detail", "").lower()
             or "not available" in response.json().get("detail", "").lower()

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -88,7 +88,9 @@ def test_export_pdf_no_reportlab_with_key(
 # Fixture for API key headers
 @pytest.fixture
 def api_key_headers() -> dict[str, str]:
-    return {"X-API-Key": "test"}
+    from app.middleware.api_tiers import TEST_KEY_VIP
+
+    return {"X-API-Key": TEST_KEY_VIP}
 
 
 def test_rag_context_fallback(
@@ -98,8 +100,8 @@ def test_rag_context_fallback(
     disable_optional_modules(monkeypatch, "core.rag.simple_rag")
     payload = {"text": "What is BMI?"}
     response = client.post("/api/v1/insight", json=payload, headers=api_key_headers)
-    # If API key is invalid, expect 403, else 200
-    assert response.status_code in [200, 403]
+    # VIP tier gate runs before handler; FEATURE_INSIGHT may still be disabled (503).
+    assert response.status_code in [200, 503]
 
 
 def test_premium_nutrient_gaps_fallback(

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -77,6 +77,7 @@ def test_export_pdf_no_reportlab_with_key(
     assert response.status_code in [503, 403]
     if response.status_code == 503:
         # Verify error message indicates PDF export is not available
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert (
             "PDF export" in response.json().get("detail", "").lower()
             or "not available" in response.json().get("detail", "").lower()

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -28,12 +28,14 @@ class TestAppCoverage:
         # Groups endpoint should return 404 as it's not implemented
         assert response.status_code == 404
 
-    def test_insight_endpoint_coverage(self, client: TestClient) -> None:
+    def test_insight_endpoint_coverage(
+        self, client: TestClient, vip_headers: dict[str, str]
+    ) -> None:
         """Test insight endpoint for coverage."""
         response = client.post(
             "/api/v1/insight",
             json={"text": "test insight"},
-            headers={"X-API-Key": "test_key"},
+            headers=vip_headers,
         )
         # With test_environment fixture, should return 200 or 503 (if LLM unavailable)
         assert response.status_code in [200, 503]

--- a/tests/test_app_endpoints_coverage.py
+++ b/tests/test_app_endpoints_coverage.py
@@ -85,15 +85,16 @@ class TestAppEndpointsCoverage:
         )
         assert response.status_code in [200, 422]
 
-    def test_app_insight_endpoint_coverage(self, client):
+    def test_app_insight_endpoint_coverage(self, client, vip_headers: dict[str, str]) -> None:
         """Тест покрытия app.py insight endpoint"""
         # Тестируем insight endpoint
         response = client.post(
             "/api/v1/insight",
             json={"weight_kg": 70, "height_cm": 170, "group": "general"},
-            headers={"X-API-Key": "test_key"},
+            headers=vip_headers,
         )
-        assert response.status_code in [200, 404, 422]
+        # Coverage test: endpoint may return 422 for payload validation, or 200/503 depending on LLM availability.
+        assert response.status_code in [200, 422, 503]
 
     def test_app_vip_endpoints_coverage(
         self,

--- a/tests/test_app_error_handling_combined.py
+++ b/tests/test_app_error_handling_combined.py
@@ -11,7 +11,8 @@ import pytest
 from unittest.mock import patch
 import httpx
 from fastapi.testclient import TestClient
-from typing import NoReturn
+from typing import NoReturn, cast
+from starlette.types import ASGIApp
 
 import app
 
@@ -123,47 +124,51 @@ class TestAppExceptionHandlersCoverage:
         response = client.delete("/health")
         assert response.status_code == 405
 
-    def test_runtime_error_handler(self, client: TestClient) -> None:
+    def test_runtime_error_handler(self, client: TestClient, vip_headers: dict[str, str]) -> None:
         """Test runtime error handler coverage: BMI endpoint is now public, test on another."""
 
         # BMI endpoint no longer uses get_api_key, use insight endpoint
-        def _fail_api_key(_: str = "") -> NoReturn:
+        def _fail_vip_guard() -> NoReturn:
             raise RuntimeError("boom")
 
         if app.app is None:
             pytest.skip("app.app is None - cannot run integration test")
 
+        from app.middleware.api_tiers import require_vip_tier
+
         with patch.dict(
-            app.app.dependency_overrides, {app.get_api_key: _fail_api_key}, clear=False
+            app.app.dependency_overrides, {require_vip_tier: _fail_vip_guard}, clear=False
         ):
-            response = client.post(
-                "/api/v1/insight",
-                json={"text": "test"},
-                headers={"X-API-Key": "test_key"},
+            # Use a client that does not re-raise server exceptions so we can assert on HTTP status codes.
+            local_client = TestClient(cast(ASGIApp, app.app), raise_server_exceptions=False)
+            response = local_client.post(
+                "/api/v1/insight", json={"text": "test"}, headers=vip_headers
             )
         # Runtime error can result in either 500 (internal error) or 503 (service unavailable)
         assert response.status_code in [500, 503]
 
-    def test_connection_error_handler(self, client: TestClient) -> None:
+    def test_connection_error_handler(
+        self, client: TestClient, vip_headers: dict[str, str]
+    ) -> None:
         """Test connection error handler coverage"""
         # Test with insight endpoint that makes external LLM calls
         with patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("Connection failed")):
             response = client.post(
                 "/api/v1/insight",
                 json={"text": "test"},
-                headers={"X-API-Key": "test_key"},
+                headers=vip_headers,
             )
             # Should handle connection error gracefully
             assert response.status_code in [500, 503, 502]
 
-    def test_timeout_error_handler(self, client: TestClient) -> None:
+    def test_timeout_error_handler(self, client: TestClient, vip_headers: dict[str, str]) -> None:
         """Test timeout error handler coverage"""
         # Test with insight endpoint that makes external LLM calls
         with patch("httpx.AsyncClient.post", side_effect=httpx.ReadTimeout("Request timeout")):
             response = client.post(
                 "/api/v1/insight",
                 json={"text": "test"},
-                headers={"X-API-Key": "test_key"},
+                headers=vip_headers,
             )
             # Should handle timeout error gracefully - expect 503 Service Unavailable
             assert response.status_code == 503

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -15,6 +15,7 @@ from starlette.types import ASGIApp
 
 # Import the canonical FastAPI app (registers metrics, etc.)
 from app.main import app
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 
 @pytest.mark.slow
@@ -286,11 +287,12 @@ class TestInsightEndpoints:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(cast(ASGIApp, app))
+        self.vip_headers = {"X-API-Key": TEST_KEY_VIP}
 
     def test_insight_endpoint_disabled_explicitly(self) -> None:
         """Test insight endpoint when explicitly disabled."""
         with patch.dict(os.environ, {"FEATURE_INSIGHT": "false"}):
-            response = self.client.post("/insight", json={"text": "test"})
+            response = self.client.post("/insight", json={"text": "test"}, headers=self.vip_headers)
             assert response.status_code == 503
             assert response.headers["content-type"].startswith("application/json")
             assert "disabled" in response.json()["detail"]
@@ -301,7 +303,7 @@ class TestInsightEndpoints:
             patch.dict(os.environ, {"FEATURE_INSIGHT": "true"}),
             patch("llm.get_provider", return_value=None),
         ):
-            response = self.client.post("/insight", json={"text": "test"})
+            response = self.client.post("/insight", json={"text": "test"}, headers=self.vip_headers)
             assert response.status_code == 503
             assert response.headers["content-type"].startswith("application/json")
             assert "No LLM provider configured" in response.json()["detail"]
@@ -315,7 +317,7 @@ class TestInsightEndpoints:
             patch.dict(os.environ, {"FEATURE_INSIGHT": "true"}),
             patch("llm.get_provider", return_value=mock_provider),
         ):
-            response = self.client.post("/insight", json={"text": "test"})
+            response = self.client.post("/insight", json={"text": "test"}, headers=self.vip_headers)
             assert response.status_code == 503
             # Privacy/safety: do not leak provider exception details.
             assert response.headers["content-type"].startswith("application/json")
@@ -333,7 +335,9 @@ class TestInsightEndpoints:
             patch.dict(os.environ, {"FEATURE_INSIGHT": "true"}),
             patch("llm.get_provider", return_value=mock_provider),
         ):
-            response = self.client.post("/insight", json={"text": "test query"})
+            response = self.client.post(
+                "/insight", json={"text": "test query"}, headers=self.vip_headers
+            )
             assert response.status_code == 200
             assert response.headers["content-type"].startswith("application/json")
             data = response.json()
@@ -352,9 +356,8 @@ class TestInsightEndpoints:
             patch.dict(os.environ, {"API_KEY": "test_key", "FEATURE_INSIGHT": "true"}),
             patch("llm.get_provider", return_value=mock_provider),
         ):
-            headers = {"X-API-Key": "test_key"}
             response = self.client.post(
-                "/api/v1/insight", json={"text": "test query"}, headers=headers
+                "/api/v1/insight", json={"text": "test query"}, headers=self.vip_headers
             )
             assert response.status_code == 200
             assert response.headers["content-type"].startswith("application/json")
@@ -371,10 +374,10 @@ class TestInsightEndpoints:
 
         try:
             with patch.dict(os.environ, {"API_KEY": "test_key"}):
-                headers = {"X-API-Key": "test_key"}
                 response = self.client.post(
-                    "/api/v1/insight", json={"text": "test query"}, headers=headers
+                    "/api/v1/insight", json={"text": "test query"}, headers=self.vip_headers
                 )
+                # VIP guard passes; default FEATURE_INSIGHT may still be disabled → 503.
                 assert response.status_code == 503
                 assert "FEATURE_INSIGHT is disabled" in response.json()["detail"]
         finally:

--- a/tests/test_app_faker_realistic.py
+++ b/tests/test_app_faker_realistic.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import main  # Import at module level so import errors surface during collection
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 fake = Faker()
 
@@ -123,8 +124,10 @@ class TestAppRealisticData:
             "lang": fake.random_element(["en", "ru", "es"]),
         }
 
-        response = self.client.post("/insight", json=insight_data)
-        assert response.status_code in [200, 400, 422]
+        response = self.client.post(
+            "/insight", json=insight_data, headers={"X-API-Key": TEST_KEY_VIP}
+        )
+        assert response.status_code in [200, 400, 422, 503]
 
     def test_health_endpoints(self):
         """Test health check endpoints"""

--- a/tests/test_app_missing_lines_extra.py
+++ b/tests/test_app_missing_lines_extra.py
@@ -90,7 +90,9 @@ class TestAppMissingLinesExtra:
             patch.dict(os.environ, {"FEATURE_INSIGHT": "maybe"}, clear=False),
             patch("llm.get_provider", return_value=_Stub()),
         ):
-            r = self.client.post("/insight", json={"text": "x"})
+            r = self.client.post(
+                "/insight", json={"text": "x"}, headers={"X-API-Key": "test_vip_key"}
+            )
             assert r.status_code == 503
             assert "disabled" in r.json().get("detail", "").lower()
 

--- a/tests/test_app_missing_lines_extra.py
+++ b/tests/test_app_missing_lines_extra.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 import app as app_mod
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 
 class TestAppMissingLinesExtra:
@@ -91,7 +92,7 @@ class TestAppMissingLinesExtra:
             patch("llm.get_provider", return_value=_Stub()),
         ):
             r = self.client.post(
-                "/insight", json={"text": "x"}, headers={"X-API-Key": "test_vip_key"}
+                "/insight", json={"text": "x"}, headers={"X-API-Key": TEST_KEY_VIP}
             )
             assert r.status_code == 503
             assert "disabled" in r.json().get("detail", "").lower()

--- a/tests/test_app_missing_lines_realistic.py
+++ b/tests/test_app_missing_lines_realistic.py
@@ -11,6 +11,7 @@ import sys
 import os
 
 from app import app
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 fake = Faker()
 
@@ -43,7 +44,9 @@ class TestAppMissingLinesTargeted:
         with patch.dict("os.environ", {"FEATURE_INSIGHT": "0"}):
             test_data = {"text": fake.text(max_nb_chars=100), "lang": "en"}
 
-            response = self.client.post("/insight", json=test_data)
+            response = self.client.post(
+                "/insight", json=test_data, headers={"X-API-Key": TEST_KEY_VIP}
+            )
             # Should return 503 when feature is disabled
             assert response.status_code in [503, 400, 422]
 
@@ -140,7 +143,11 @@ class TestAppMissingLinesTargeted:
             return self.client.get("/health")
 
         def make_insight_request():
-            return self.client.post("/insight", json={"text": fake.sentence(), "lang": "en"})
+            return self.client.post(
+                "/insight",
+                json={"text": fake.sentence(), "lang": "en"},
+                headers={"X-API-Key": TEST_KEY_VIP},
+            )
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             futures = []
@@ -184,7 +191,7 @@ class TestAppLargePayloadsAndLimits:
 
         test_data = {"text": long_text, "lang": "en"}
 
-        response = self.client.post("/insight", json=test_data)
+        response = self.client.post("/insight", json=test_data, headers={"X-API-Key": TEST_KEY_VIP})
         assert response.status_code in [200, 400, 413, 422, 503]
 
     def test_plan_endpoint_with_complex_data(self) -> None:
@@ -230,7 +237,9 @@ class TestAppErrorHandlingPaths:
         # Test with various environment combinations
         with patch.dict("os.environ", {"FEATURE_INSIGHT": "0", "VIP_MODULE_ENABLED": "false"}):
             # Test insight when disabled
-            response = self.client.post("/insight", json={"text": "test", "lang": "en"})
+            response = self.client.post(
+                "/insight", json={"text": "test", "lang": "en"}, headers={"X-API-Key": TEST_KEY_VIP}
+            )
             assert response.status_code in [503, 400, 422]
 
     def test_authentication_error_paths(self) -> None:

--- a/tests/test_app_router_inclusion_coverage.py
+++ b/tests/test_app_router_inclusion_coverage.py
@@ -48,15 +48,17 @@ class TestAppRouterInclusionCoverage:
         response = client.get("/api/v1/bodyfat")
         assert response.status_code in [200, 405]
 
-    def test_app_router_inclusion_insight_coverage(self, client):
+    def test_app_router_inclusion_insight_coverage(
+        self, client, vip_headers: dict[str, str]
+    ) -> None:
         """Тест покрытия app.py insight router inclusion (строка 2151)"""
         # Тестируем insight router inclusion
         response = client.post(
             "/api/v1/insight",
             json={"weight_kg": 70, "height_cm": 170, "group": "general"},
-            headers={"X-API-Key": "test_key"},
+            headers=vip_headers,
         )
-        assert response.status_code in [200, 404, 422]
+        assert response.status_code in [200, 422, 503]
 
         # Проверяем, что insight router работает
         response = client.get("/api/v1/insight")

--- a/tests/test_coverage_97_final_push.py
+++ b/tests/test_coverage_97_final_push.py
@@ -162,7 +162,9 @@ class TestCoverage97FinalPush:
         )
         assert response.status_code in [200, 422]
 
-    def test_app_coverage_missing_lines_1008_1012(self, test_environment):
+    def test_app_coverage_missing_lines_1008_1012(
+        self, test_environment, vip_headers: dict[str, str]
+    ) -> None:
         """Тест покрытия app.py строк 1008-1012"""
         import app
 
@@ -172,14 +174,14 @@ class TestCoverage97FinalPush:
         response = client.post(
             "/api/v1/insight",
             json={"bmi": 22.5, "age": 30, "sex": "male"},
-            headers={"X-API-Key": "test_key"},
+            headers=vip_headers,
         )
         assert response.status_code in [200, 422]
 
         response = client.post(
             "/api/v1/insight",
             json={"bmi": 25.0, "age": 25, "sex": "female"},
-            headers={"X-API-Key": "test_key"},
+            headers=vip_headers,
         )
         assert response.status_code in [200, 422]
 

--- a/tests/test_coverage_97_ultimate_boost.py
+++ b/tests/test_coverage_97_ultimate_boost.py
@@ -429,7 +429,7 @@ class TestCoverage97UltimateBoost:
         self,
         test_environment,
         vip_headers: dict[str, str],
-    ) -> None:
+    ):
         """Тест покрытия app.py строк 1325-1326, 1328-1329 - VIP endpoints с различными данными"""
         import app
 
@@ -491,7 +491,7 @@ class TestCoverage97UltimateBoost:
         self,
         test_environment,
         vip_headers: dict[str, str],
-    ) -> None:
+    ):
         """Тест покрытия app.py строк 1342-1365 - VIP recipes endpoint с различными данными"""
         import app
 

--- a/tests/test_coverage_97_ultimate_boost.py
+++ b/tests/test_coverage_97_ultimate_boost.py
@@ -253,7 +253,9 @@ class TestCoverage97UltimateBoost:
             )
             assert response.status_code in [200, 422]
 
-    def test_app_coverage_ultimate_boost_missing_lines_1008_1012(self, test_environment):
+    def test_app_coverage_ultimate_boost_missing_lines_1008_1012(
+        self, test_environment, vip_headers: dict[str, str]
+    ) -> None:
         """Тест покрытия app.py строк 1008-1012 - insight endpoint с различными данными"""
         import app
 
@@ -272,7 +274,7 @@ class TestCoverage97UltimateBoost:
             response = client.post(
                 "/api/v1/insight",
                 json=scenario,
-                headers={"X-API-Key": "test_key"},
+                headers=vip_headers,
             )
             assert response.status_code in [200, 422]
 

--- a/tests/test_coverage_97_ultimate_boost.py
+++ b/tests/test_coverage_97_ultimate_boost.py
@@ -2,7 +2,7 @@
 Ультимативные тесты для достижения 97% покрытия - финальный буст
 """
 
-from typing import cast
+from typing import Generator, cast
 
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
@@ -254,7 +254,7 @@ class TestCoverage97UltimateBoost:
             assert response.status_code in [200, 422]
 
     def test_app_coverage_ultimate_boost_missing_lines_1008_1012(
-        self, test_environment, vip_headers: dict[str, str]
+        self, test_environment: Generator[None, None, None], vip_headers: dict[str, str]
     ) -> None:
         """Тест покрытия app.py строк 1008-1012 - insight endpoint с различными данными"""
         import app
@@ -427,9 +427,9 @@ class TestCoverage97UltimateBoost:
 
     def test_app_coverage_ultimate_boost_missing_lines_1325_1326_1328_1329(
         self,
-        test_environment,
+        test_environment: Generator[None, None, None],
         vip_headers: dict[str, str],
-    ):
+    ) -> None:
         """Тест покрытия app.py строк 1325-1326, 1328-1329 - VIP endpoints с различными данными"""
         import app
 
@@ -489,9 +489,9 @@ class TestCoverage97UltimateBoost:
 
     def test_app_coverage_ultimate_boost_missing_lines_1342_1365(
         self,
-        test_environment,
+        test_environment: Generator[None, None, None],
         vip_headers: dict[str, str],
-    ):
+    ) -> None:
         """Тест покрытия app.py строк 1342-1365 - VIP recipes endpoint с различными данными"""
         import app
 

--- a/tests/test_coverage_97_ultimate_boost.py
+++ b/tests/test_coverage_97_ultimate_boost.py
@@ -429,7 +429,7 @@ class TestCoverage97UltimateBoost:
         self,
         test_environment,
         vip_headers: dict[str, str],
-    ):
+    ) -> None:
         """Тест покрытия app.py строк 1325-1326, 1328-1329 - VIP endpoints с различными данными"""
         import app
 
@@ -491,7 +491,7 @@ class TestCoverage97UltimateBoost:
         self,
         test_environment,
         vip_headers: dict[str, str],
-    ):
+    ) -> None:
         """Тест покрытия app.py строк 1342-1365 - VIP recipes endpoint с различными данными"""
         import app
 

--- a/tests/test_coverage_97_ultimate_final.py
+++ b/tests/test_coverage_97_ultimate_final.py
@@ -79,7 +79,9 @@ class TestCoverage97UltimateFinal:
         """Test insight endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"text": "test insight", "lang": "en"}
-        response = client.post("/insight", json=payload)
+        from app.middleware.api_tiers import TEST_KEY_VIP
+
+        response = client.post("/insight", json=payload, headers={"X-API-Key": TEST_KEY_VIP})
         assert response.status_code in [200, 422, 503]
 
     def test_app_premium_bmr_with_lang(self):

--- a/tests/test_coverage_97_ultimate_final.py
+++ b/tests/test_coverage_97_ultimate_final.py
@@ -22,13 +22,19 @@ class TestCoverage97UltimateFinal:
         os.environ.pop("API_KEY", None)
 
     def test_app_openapi_schema(self) -> None:
-        """Test OpenAPI schema generation."""
+        """Test OpenAPI schema generation and verify /insight is hidden."""
         client = TestClient(cast(ASGIApp, app.app))
         response = client.get("/openapi.json")
         assert response.status_code in [200, 500, 503]
+        assert response.headers.get("content-type", "").startswith("application/json")
         schema = response.json()
         assert "openapi" in schema
         assert "info" in schema
+
+        # Verify legacy /insight is hidden from OpenAPI, canonical /api/v1/insight is visible
+        paths = schema.get("paths", {})
+        assert "/insight" not in paths
+        assert "/api/v1/insight" in paths
 
     def test_app_docs_endpoint(self) -> None:
         """Test docs endpoint."""

--- a/tests/test_coverage_97_ultimate_final.py
+++ b/tests/test_coverage_97_ultimate_final.py
@@ -21,7 +21,7 @@ class TestCoverage97UltimateFinal:
         """Clean up test environment."""
         os.environ.pop("API_KEY", None)
 
-    def test_app_openapi_schema(self):
+    def test_app_openapi_schema(self) -> None:
         """Test OpenAPI schema generation."""
         client = TestClient(cast(ASGIApp, app.app))
         response = client.get("/openapi.json")
@@ -30,19 +30,19 @@ class TestCoverage97UltimateFinal:
         assert "openapi" in schema
         assert "info" in schema
 
-    def test_app_docs_endpoint(self):
+    def test_app_docs_endpoint(self) -> None:
         """Test docs endpoint."""
         client = TestClient(cast(ASGIApp, app.app))
         response = client.get("/docs")
         assert response.status_code in [200, 500, 503]
 
-    def test_app_redoc_endpoint(self):
+    def test_app_redoc_endpoint(self) -> None:
         """Test redoc endpoint."""
         client = TestClient(cast(ASGIApp, app.app))
         response = client.get("/redoc")
         assert response.status_code in [200, 500, 503]
 
-    def test_app_bmi_with_all_params(self):
+    def test_app_bmi_with_all_params(self) -> None:
         """Test BMI endpoint with all parameters."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -59,7 +59,7 @@ class TestCoverage97UltimateFinal:
         response = client.post("/bmi", json=payload)
         assert response.status_code in [200, 422]
 
-    def test_app_bodyfat_with_all_params(self):
+    def test_app_bodyfat_with_all_params(self) -> None:
         """Test bodyfat endpoint with all parameters."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -82,7 +82,7 @@ class TestCoverage97UltimateFinal:
         response = client.post("/insight", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 503]
 
-    def test_app_premium_bmr_with_lang(self):
+    def test_app_premium_bmr_with_lang(self) -> None:
         """Test premium BMR endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -98,7 +98,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403]
 
-    def test_app_premium_tdee_with_lang(self):
+    def test_app_premium_tdee_with_lang(self) -> None:
         """Test premium TDEE endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -114,7 +114,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_premium_plate_with_lang(self):
+    def test_app_premium_plate_with_lang(self) -> None:
         """Test premium plate endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -131,7 +131,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403]
 
-    def test_app_premium_gaps_with_lang(self):
+    def test_app_premium_gaps_with_lang(self) -> None:
         """Test premium gaps endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -151,14 +151,14 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 500, 503]
 
-    def test_app_vip_echo_with_lang(self):
+    def test_app_vip_echo_with_lang(self) -> None:
         """Test VIP echo endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"test": "data", "lang": "en"}
         response = client.post("/api/v1/vip/echo", json=payload, headers={"X-API-Key": "test_key"})
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_weekly_menu_with_lang(self):
+    def test_app_vip_weekly_menu_with_lang(self) -> None:
         """Test VIP weekly menu endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -177,7 +177,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_recipes_with_lang(self):
+    def test_app_vip_recipes_with_lang(self) -> None:
         """Test VIP recipes endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -190,7 +190,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_shoplist_with_lang(self):
+    def test_app_vip_shoplist_with_lang(self) -> None:
         """Test VIP shoplist endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -204,7 +204,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_auto_repair_with_lang(self):
+    def test_app_vip_auto_repair_with_lang(self) -> None:
         """Test VIP auto repair endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -216,7 +216,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_region_catalog_with_lang(self):
+    def test_app_vip_region_catalog_with_lang(self) -> None:
         """Test VIP region catalog endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"region": "US", "category": "fruits", "lang": "en"}
@@ -225,7 +225,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_product_search_with_lang(self):
+    def test_app_vip_product_search_with_lang(self) -> None:
         """Test VIP product search endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"query": "apple", "region": "US", "lang": "en"}
@@ -234,7 +234,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_nutrition_analysis_with_lang(self):
+    def test_app_vip_nutrition_analysis_with_lang(self) -> None:
         """Test VIP nutrition analysis endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"food_items": ["apple", "banana"], "quantities": [1, 2], "lang": "en"}
@@ -243,7 +243,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_user_profile_with_lang(self):
+    def test_app_vip_user_profile_with_lang(self) -> None:
         """Test VIP user profile endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
@@ -260,7 +260,7 @@ class TestCoverage97UltimateFinal:
         )
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_micronutrient_targets_with_lang(self):
+    def test_app_vip_micronutrient_targets_with_lang(self) -> None:
         """Test VIP micronutrient targets endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {

--- a/tests/test_coverage_97_ultimate_final.py
+++ b/tests/test_coverage_97_ultimate_final.py
@@ -1,9 +1,7 @@
 """Ultimate final coverage tests to reach 97% coverage."""
 
-import os
 from typing import cast
 
-import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
@@ -12,14 +10,6 @@ import app
 
 class TestCoverage97UltimateFinal:
     """Ultimate final tests for coverage to reach 97%."""
-
-    def setup_method(self):
-        """Set up test environment."""
-        os.environ["API_KEY"] = "test_key"
-
-    def teardown_method(self):
-        """Clean up test environment."""
-        os.environ.pop("API_KEY", None)
 
     def test_app_openapi_schema(self) -> None:
         """Test OpenAPI schema generation and verify /insight is hidden."""
@@ -49,7 +39,7 @@ class TestCoverage97UltimateFinal:
         assert response.status_code in [200, 500, 503]
 
     def test_app_bmi_with_all_params(self) -> None:
-        """Test BMI endpoint with all parameters."""
+        """Test BMI endpoint with all parameters (FREE tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "weight_kg": 70.0,
@@ -66,7 +56,7 @@ class TestCoverage97UltimateFinal:
         assert response.status_code in [200, 422]
 
     def test_app_bodyfat_with_all_params(self) -> None:
-        """Test bodyfat endpoint with all parameters."""
+        """Test bodyfat endpoint with all parameters (FREE tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "weight_kg": 70.0,
@@ -82,14 +72,14 @@ class TestCoverage97UltimateFinal:
         assert response.status_code in [200, 422, 404]
 
     def test_app_insight_with_lang(self, vip_headers: dict[str, str]) -> None:
-        """Test insight endpoint with language parameter."""
+        """Test insight endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"text": "test insight", "lang": "en"}
         response = client.post("/insight", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 503]
 
-    def test_app_premium_bmr_with_lang(self) -> None:
-        """Test premium BMR endpoint with language parameter."""
+    def test_app_premium_bmr_with_lang(self, pro_headers: dict[str, str]) -> None:
+        """Test premium BMR endpoint with language parameter (PRO tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "weight_kg": 70.0,
@@ -99,13 +89,11 @@ class TestCoverage97UltimateFinal:
             "activity": "light",
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/premium/bmr", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/premium/bmr", json=payload, headers=pro_headers)
         assert response.status_code in [200, 422, 403]
 
-    def test_app_premium_tdee_with_lang(self) -> None:
-        """Test premium TDEE endpoint with language parameter."""
+    def test_app_premium_tdee_with_lang(self, pro_headers: dict[str, str]) -> None:
+        """Test premium TDEE endpoint with language parameter (PRO tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "weight_kg": 70.0,
@@ -115,13 +103,11 @@ class TestCoverage97UltimateFinal:
             "activity": "light",
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/premium/tdee", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/premium/tdee", json=payload, headers=pro_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_premium_plate_with_lang(self) -> None:
-        """Test premium plate endpoint with language parameter."""
+    def test_app_premium_plate_with_lang(self, pro_headers: dict[str, str]) -> None:
+        """Test premium plate endpoint with language parameter (PRO tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "sex": "male",
@@ -132,13 +118,11 @@ class TestCoverage97UltimateFinal:
             "goal": "maintain",
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/premium/plate", json=payload, headers=pro_headers)
         assert response.status_code in [200, 422, 403]
 
-    def test_app_premium_gaps_with_lang(self) -> None:
-        """Test premium gaps endpoint with language parameter."""
+    def test_app_premium_gaps_with_lang(self, pro_headers: dict[str, str]) -> None:
+        """Test premium gaps endpoint with language parameter (PRO tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "consumed_nutrients": {"protein_g": 80, "carbs_g": 200},
@@ -152,20 +136,18 @@ class TestCoverage97UltimateFinal:
                 "lang": "en",
             },
         }
-        response = client.post(
-            "/api/v1/premium/gaps", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/premium/gaps", json=payload, headers=pro_headers)
         assert response.status_code in [200, 422, 403, 500, 503]
 
-    def test_app_vip_echo_with_lang(self) -> None:
-        """Test VIP echo endpoint with language parameter."""
+    def test_app_vip_echo_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP echo endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"test": "data", "lang": "en"}
-        response = client.post("/api/v1/vip/echo", json=payload, headers={"X-API-Key": "test_key"})
+        response = client.post("/api/v1/vip/echo", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_weekly_menu_with_lang(self) -> None:
-        """Test VIP weekly menu endpoint with language parameter."""
+    def test_app_vip_weekly_menu_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP weekly menu endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "user_profile": {
@@ -178,26 +160,22 @@ class TestCoverage97UltimateFinal:
                 "lang": "en",
             }
         }
-        response = client.post(
-            "/api/v1/vip/weekly-menu", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/weekly-menu", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_recipes_with_lang(self) -> None:
-        """Test VIP recipes endpoint with language parameter."""
+    def test_app_vip_recipes_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP recipes endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "ingredients": ["chicken", "rice", "vegetables"],
             "dietary_preferences": ["low_carb"],
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/vip/recipes", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/recipes", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_shoplist_with_lang(self) -> None:
-        """Test VIP shoplist endpoint with language parameter."""
+    def test_app_vip_shoplist_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP shoplist endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "menu_plan": {
@@ -205,52 +183,42 @@ class TestCoverage97UltimateFinal:
             },
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/vip/shoplist", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/shoplist", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_auto_repair_with_lang(self) -> None:
-        """Test VIP auto repair endpoint with language parameter."""
+    def test_app_vip_auto_repair_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP auto repair endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "menu_plan": {"days": [{"meals": [{"name": "Breakfast", "kcal": 300}]}]},
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/vip/auto-repair", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/auto-repair", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_region_catalog_with_lang(self) -> None:
-        """Test VIP region catalog endpoint with language parameter."""
+    def test_app_vip_region_catalog_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP region catalog endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"region": "US", "category": "fruits", "lang": "en"}
-        response = client.post(
-            "/api/v1/vip/region-catalog", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/region-catalog", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_product_search_with_lang(self) -> None:
-        """Test VIP product search endpoint with language parameter."""
+    def test_app_vip_product_search_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP product search endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"query": "apple", "region": "US", "lang": "en"}
-        response = client.post(
-            "/api/v1/vip/product-search", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/product-search", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_nutrition_analysis_with_lang(self) -> None:
-        """Test VIP nutrition analysis endpoint with language parameter."""
+    def test_app_vip_nutrition_analysis_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP nutrition analysis endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"food_items": ["apple", "banana"], "quantities": [1, 2], "lang": "en"}
-        response = client.post(
-            "/api/v1/vip/nutrition-analysis", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/nutrition-analysis", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_user_profile_with_lang(self) -> None:
-        """Test VIP user profile endpoint with language parameter."""
+    def test_app_vip_user_profile_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP user profile endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "sex": "male",
@@ -261,13 +229,11 @@ class TestCoverage97UltimateFinal:
             "goal": "maintain",
             "lang": "en",
         }
-        response = client.post(
-            "/api/v1/vip/user-profile", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        response = client.post("/api/v1/vip/user-profile", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 403, 404]
 
-    def test_app_vip_micronutrient_targets_with_lang(self) -> None:
-        """Test VIP micronutrient targets endpoint with language parameter."""
+    def test_app_vip_micronutrient_targets_with_lang(self, vip_headers: dict[str, str]) -> None:
+        """Test VIP micronutrient targets endpoint with language parameter (VIP tier)."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {
             "user_profile": {
@@ -281,6 +247,6 @@ class TestCoverage97UltimateFinal:
             "lang": "en",
         }
         response = client.post(
-            "/api/v1/vip/micronutrient-targets", json=payload, headers={"X-API-Key": "test_key"}
+            "/api/v1/vip/micronutrient-targets", json=payload, headers=vip_headers
         )
         assert response.status_code in [200, 422, 403, 404]

--- a/tests/test_coverage_97_ultimate_final.py
+++ b/tests/test_coverage_97_ultimate_final.py
@@ -75,13 +75,11 @@ class TestCoverage97UltimateFinal:
         response = client.post("/bodyfat", json=payload)
         assert response.status_code in [200, 422, 404]
 
-    def test_app_insight_with_lang(self):
+    def test_app_insight_with_lang(self, vip_headers: dict[str, str]) -> None:
         """Test insight endpoint with language parameter."""
         client = TestClient(cast(ASGIApp, app.app))
         payload = {"text": "test insight", "lang": "en"}
-        from app.middleware.api_tiers import TEST_KEY_VIP
-
-        response = client.post("/insight", json=payload, headers={"X-API-Key": TEST_KEY_VIP})
+        response = client.post("/insight", json=payload, headers=vip_headers)
         assert response.status_code in [200, 422, 503]
 
     def test_app_premium_bmr_with_lang(self):

--- a/tests/test_coverage_final_push.py
+++ b/tests/test_coverage_final_push.py
@@ -189,6 +189,7 @@ class TestFinalCoveragePush:
             response = client.post("/bmi", json=payload)
             assert response.status_code in [200, 422]  # Success or validation error
             if response.status_code == 200:
+                assert response.headers.get("content-type", "").startswith("application/json")
                 data = response.json()
                 assert "bmi" in data
 

--- a/tests/test_coverage_final_push.py
+++ b/tests/test_coverage_final_push.py
@@ -156,32 +156,22 @@ class TestFinalCoveragePush:
             # Basic health check
             response = client.get("/api/v1/health")
             assert response.status_code == 200
+            assert response.headers.get("content-type", "").startswith("application/json")
             data = response.json()
             assert "status" in data
 
             # Health check with query params
             response = client.get("/api/v1/health?details=true")
             assert response.status_code == 200
-            # Basic health check
-            response = client.get("/api/v1/health")
-            assert response.status_code == 200
-            data = response.json()
-            assert "status" in data
+            assert response.headers.get("content-type", "").startswith("application/json")
 
-            # Health check with query params
-            response = client.get("/api/v1/health?details=true")
-            assert response.status_code == 200
-
-    def test_export_functionality(self) -> None:
+    def test_export_functionality(self, vip_headers: dict[str, str]) -> None:
         """Test insight endpoint functionality."""
         import app
 
         with TestClient(cast(ASGIApp, app.app)) as client:
             payload = {"weight_kg": 70, "height_cm": 170, "age_years": 30, "gender": "male"}
-
-            from app.middleware.api_tiers import TEST_KEY_VIP
-
-            response = client.post("/insight", json=payload, headers={"X-API-Key": TEST_KEY_VIP})
+            response = client.post("/insight", json=payload, headers=vip_headers)
             assert response.status_code in [
                 200,
                 422,

--- a/tests/test_coverage_final_push.py
+++ b/tests/test_coverage_final_push.py
@@ -189,7 +189,6 @@ class TestFinalCoveragePush:
             response = client.post("/bmi", json=payload)
             assert response.status_code in [200, 422]  # Success or validation error
             if response.status_code == 200:
-                assert response.headers.get("content-type", "").startswith("application/json")
                 data = response.json()
                 assert "bmi" in data
 

--- a/tests/test_coverage_final_push.py
+++ b/tests/test_coverage_final_push.py
@@ -149,17 +149,19 @@ class TestFinalCoveragePush:
         import app
 
         with TestClient(cast(ASGIApp, app.app)) as client:
-            # Test with missing required fields
-            payload = {}
+            # Test with missing required fields - should error
+            response = client.post("/plan", json={})
+            assert response.status_code in [422, 503]
 
-            response = client.post("/plan", json=payload)
-            assert response.status_code in [422, 503]  # Validation error or service unavailable
+            # Basic health check
+            response = client.get("/api/v1/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert "status" in data
 
-    def test_health_endpoint_comprehensive(self) -> None:
-        """Test health endpoint with different scenarios."""
-        import app
-
-        with TestClient(cast(ASGIApp, app.app)) as client:
+            # Health check with query params
+            response = client.get("/api/v1/health?details=true")
+            assert response.status_code == 200
             # Basic health check
             response = client.get("/api/v1/health")
             assert response.status_code == 200
@@ -177,7 +179,9 @@ class TestFinalCoveragePush:
         with TestClient(cast(ASGIApp, app.app)) as client:
             payload = {"weight_kg": 70, "height_cm": 170, "age_years": 30, "gender": "male"}
 
-            response = client.post("/insight", json=payload)
+            from app.middleware.api_tiers import TEST_KEY_VIP
+
+            response = client.post("/insight", json=payload, headers={"X-API-Key": TEST_KEY_VIP})
             assert response.status_code in [
                 200,
                 422,

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 # Import the FastAPI app from app.py file
 from app import app
+from app.middleware.api_tiers import TEST_KEY_VIP
 import legacy_app
 
 
@@ -22,6 +23,7 @@ class TestCoverageImprovement:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
+        self.vip_headers = {"X-API-Key": TEST_KEY_VIP}
 
     def teardown_method(self) -> None:
         """Clean up test environment."""
@@ -91,7 +93,7 @@ class TestCoverageImprovement:
         """Test uncovered paths in insight endpoints."""
         # Test /insight endpoint with feature disabled via env var
         with patch.dict(os.environ, {"FEATURE_INSIGHT": "0"}):
-            response = self.client.post("/insight", json={"text": "test"})
+            response = self.client.post("/insight", json={"text": "test"}, headers=self.vip_headers)
             assert response.status_code == 503
 
         # Test /insight endpoint with feature explicitly enabled but no provider
@@ -99,7 +101,7 @@ class TestCoverageImprovement:
             patch.dict(os.environ, {"FEATURE_INSIGHT": "1"}),
             patch("llm.get_provider", return_value=None),
         ):
-            response = self.client.post("/insight", json={"text": "test"})
+            response = self.client.post("/insight", json={"text": "test"}, headers=self.vip_headers)
             assert response.status_code == 503
 
     def test_scheduler_uncovered_lines(self) -> None:

--- a/tests/test_insight_error_hygiene.py
+++ b/tests/test_insight_error_hygiene.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 
 
 def test_insight_legacy_does_not_leak_provider_exception(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
 ) -> None:
     """Ensure /insight never returns raw provider exception text."""
 
@@ -18,7 +18,7 @@ def test_insight_legacy_does_not_leak_provider_exception(
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
     monkeypatch.setattr(llm, "get_provider", lambda: FailingProvider(), raising=True)
 
-    resp = client.post("/insight", json={"text": "hello"})
+    resp = client.post("/insight", json={"text": "hello"}, headers=vip_headers)
     assert resp.status_code == 503
     assert resp.headers.get("content-type", "").startswith("application/json")
     data = resp.json()
@@ -27,7 +27,7 @@ def test_insight_legacy_does_not_leak_provider_exception(
 
 
 def test_insight_v1_does_not_leak_provider_exception(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
 ) -> None:
     """Ensure /api/v1/insight never returns raw provider exception text."""
 
@@ -40,13 +40,12 @@ def test_insight_v1_does_not_leak_provider_exception(
             raise RuntimeError("SENSITIVE: model=grok-4-latest path=/tmp/internal secret=abc")
 
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
-    monkeypatch.setenv("API_KEY", "test_key")
     monkeypatch.setattr(llm, "get_provider", lambda: FailingProvider(), raising=True)
 
     resp = client.post(
         "/api/v1/insight",
         json={"text": "hello"},
-        headers={"X-API-Key": "test_key"},
+        headers=vip_headers,
     )
     assert resp.status_code == 503
     assert resp.headers.get("content-type", "").startswith("application/json")
@@ -56,7 +55,7 @@ def test_insight_v1_does_not_leak_provider_exception(
 
 
 def test_insight_redacts_rag_source_headers(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
 ) -> None:
     """Ensure RAG context source lines are not forwarded to the LLM prompt."""
 
@@ -81,7 +80,7 @@ def test_insight_redacts_rag_source_headers(
         raising=True,
     )
 
-    resp = client.post("/insight", json={"text": "What is BMI?"})
+    resp = client.post("/insight", json={"text": "What is BMI?"}, headers=vip_headers)
     assert resp.status_code == 200
     assert resp.headers.get("content-type", "").startswith("application/json")
     data = resp.json()

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -47,4 +47,44 @@ def test_insight_v1_requires_vip_tier(
     assert data["insight"].startswith("ok:")
 
 
+def test_insight_legacy_requires_vip_tier(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    pro_headers: dict[str, str],
+    vip_headers: dict[str, str],
+) -> None:
+    """FREE/PRO are rejected; VIP can call legacy /insight (VIP-only).
+
+    Note: Legacy /insight is hidden from OpenAPI but still VIP-guarded.
+    """
+    import llm
+
+    class EchoProvider:
+        name = "echo"
+
+        async def generate(self, text: str) -> str:
+            return f"ok:{text}"
+
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    monkeypatch.setattr(llm, "get_provider", lambda: EchoProvider(), raising=True)
+
+    payload = {"text": "hello"}
+
+    # FREE → 403
+    r_free = client.post("/insight", json=payload)
+    assert r_free.status_code == 403
+
+    # PRO → 403
+    r_pro = client.post("/insight", json=payload, headers=pro_headers)
+    assert r_pro.status_code == 403
+
+    # VIP → 200
+    r_vip = client.post("/insight", json=payload, headers=vip_headers)
+    assert r_vip.status_code == 200
+    assert r_vip.headers.get("content-type", "").startswith("application/json")
+    data = r_vip.json()
+    assert data["provider"] == "echo"
+    assert data["insight"].startswith("ok:")
+
+
 # End of file

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -6,6 +6,8 @@ EN: P0 tests: insight endpoint must be strictly VIP-only.
 
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -19,7 +21,9 @@ class _EchoProvider:
         return f"ok:{text}"
 
 
+@patch("llm.get_provider", return_value=_EchoProvider())
 def test_insight_v1_requires_vip_tier(
+    mock_get_provider: Mock,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     pro_headers: dict[str, str],
@@ -29,10 +33,7 @@ def test_insight_v1_requires_vip_tier(
 
     Note: VIP guard returns 403 for missing key by policy (VIP is a feature-gate).
     """
-    import llm
-
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
-    monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
 
     payload = {"text": "hello"}
 
@@ -50,7 +51,9 @@ def test_insight_v1_requires_vip_tier(
     assert data["insight"].startswith("ok:")
 
 
+@patch("llm.get_provider", return_value=_EchoProvider())
 def test_insight_legacy_requires_vip_tier(
+    mock_get_provider: Mock,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     pro_headers: dict[str, str],
@@ -60,10 +63,7 @@ def test_insight_legacy_requires_vip_tier(
 
     Note: Legacy /insight is hidden from OpenAPI but still VIP-guarded.
     """
-    import llm
-
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
-    monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
 
     payload = {"text": "hello"}
 

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -1,0 +1,50 @@
+"""P0 tests: LLM insight must be VIP-only.
+
+RU: P0 тесты: insight endpoint должен быть строго VIP-only.
+EN: P0 tests: insight endpoint must be strictly VIP-only.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_insight_v1_requires_vip_tier(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    pro_headers: dict[str, str],
+    vip_headers: dict[str, str],
+) -> None:
+    """FREE/PRO are rejected; VIP can call /api/v1/insight.
+
+    Note: VIP guard returns 403 for missing key by policy (VIP is a feature-gate).
+    """
+    import llm
+
+    class EchoProvider:
+        name = "echo"
+
+        async def generate(self, text: str) -> str:
+            return f"ok:{text}"
+
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    monkeypatch.setattr(llm, "get_provider", lambda: EchoProvider(), raising=True)
+
+    payload = {"text": "hello"}
+
+    r_free = client.post("/api/v1/insight", json=payload)
+    assert r_free.status_code == 403
+
+    r_pro = client.post("/api/v1/insight", json=payload, headers=pro_headers)
+    assert r_pro.status_code == 403
+
+    r_vip = client.post("/api/v1/insight", json=payload, headers=vip_headers)
+    assert r_vip.status_code == 200
+    assert r_vip.headers.get("content-type", "").startswith("application/json")
+    data = r_vip.json()
+    assert data["provider"] == "echo"
+    assert data["insight"].startswith("ok:")
+
+
+# End of file

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -15,7 +15,7 @@ from fastapi.testclient import TestClient
 class _EchoProvider:
     """Deterministic mock provider for insight tests."""
 
-    name = "echo"
+    name: str = "echo"
 
     async def generate(self, text: str) -> str:
         return f"ok:{text}"

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -10,6 +10,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+class _EchoProvider:
+    """Deterministic mock provider for insight tests."""
+
+    name = "echo"
+
+    async def generate(self, text: str) -> str:
+        return f"ok:{text}"
+
+
 def test_insight_v1_requires_vip_tier(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -22,14 +31,8 @@ def test_insight_v1_requires_vip_tier(
     """
     import llm
 
-    class EchoProvider:
-        name = "echo"
-
-        async def generate(self, text: str) -> str:
-            return f"ok:{text}"
-
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
-    monkeypatch.setattr(llm, "get_provider", lambda: EchoProvider(), raising=True)
+    monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
 
     payload = {"text": "hello"}
 
@@ -59,14 +62,8 @@ def test_insight_legacy_requires_vip_tier(
     """
     import llm
 
-    class EchoProvider:
-        name = "echo"
-
-        async def generate(self, text: str) -> str:
-            return f"ok:{text}"
-
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
-    monkeypatch.setattr(llm, "get_provider", lambda: EchoProvider(), raising=True)
+    monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
 
     payload = {"text": "hello"}
 

--- a/tests/test_targeted_coverage_boost.py
+++ b/tests/test_targeted_coverage_boost.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 # Import the FastAPI app from the app package
 from app import app
+from app.middleware.api_tiers import TEST_KEY_VIP
 
 
 class TestTargetedCoverageBoost:
@@ -22,6 +23,7 @@ class TestTargetedCoverageBoost:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
+        self.vip_headers = {"X-API-Key": TEST_KEY_VIP}
 
     def teardown_method(self) -> None:
         """Clean up test environment."""
@@ -93,41 +95,23 @@ class TestTargetedCoverageBoost:
         assert result["premium"] is True
         assert "premium_reco" in result
 
-    def test_app_py_lines_758_760(self) -> None:
+    def test_app_py_lines_758_760(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test lines 758-760 in main.py (api_v1_insight with missing llm module)."""
         # Remove module from sys.modules to simulate it's not available
-        original_module = sys.modules.get("llm")
-        if "llm" in sys.modules:
-            del sys.modules["llm"]
-        try:
-            data = {"text": "test"}
-            response = self.client.post(
-                "/api/v1/insight", json=data, headers={"X-API-Key": "test_key"}
-            )
-            assert response.status_code == 503
-        finally:
-            # Restore original module
-            if original_module is not None:
-                sys.modules["llm"] = original_module
-            elif "llm" in sys.modules:
-                del sys.modules["llm"]
+        monkeypatch.delitem(sys.modules, "llm", raising=False)
 
-    def test_app_py_line_914(self) -> None:
+        data = {"text": "test"}
+        response = self.client.post("/api/v1/insight", json=data, headers=self.vip_headers)
+        assert response.status_code == 503
+
+    def test_app_py_line_914(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test line 914 in main.py (insight endpoint with missing llm module)."""
         # Remove module from sys.modules to simulate it's not available
-        original_module = sys.modules.get("llm")
-        if "llm" in sys.modules:
-            del sys.modules["llm"]
-        try:
-            data = {"text": "test"}
-            response = self.client.post("/insight", json=data)
-            assert response.status_code == 503
-        finally:
-            # Restore original module
-            if original_module is not None:
-                sys.modules["llm"] = original_module
-            elif "llm" in sys.modules:
-                del sys.modules["llm"]
+        monkeypatch.delitem(sys.modules, "llm", raising=False)
+
+        data = {"text": "test"}
+        response = self.client.post("/insight", json=data, headers=self.vip_headers)
+        assert response.status_code == 503
 
     def test_app_py_line_1215(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test line 1215 in main.py (get_database_status with missing scheduler)."""
@@ -328,9 +312,9 @@ class TestTargetedCoverageBoost:
         """Test line 425 in menu_engine.py (_enhance_meals_with_micros)."""
         from core.menu_engine import _enhance_meals_with_micros
 
-        meals = [{"title": "Test Meal"}]  # Fix the key name
-        food_db = {}
-        recipe_db = {}
+        meals: list[dict[str, str]] = [{"title": "Test Meal"}]  # Fix the key name
+        food_db: dict[str, object] = {}
+        recipe_db: dict[str, object] = {}
         result = _enhance_meals_with_micros(
             meals, food_db, recipe_db, set()
         )  # Changed None to set()
@@ -340,8 +324,8 @@ class TestTargetedCoverageBoost:
         """Test line 467 in menu_engine.py (_calculate_total_nutrients)."""
         from core.menu_engine import _calculate_total_nutrients
 
-        meals = []
-        food_db = {}
+        meals: list[object] = []
+        food_db: dict[str, object] = {}
         result = _calculate_total_nutrients(meals, food_db)
         assert isinstance(result, dict)
 
@@ -349,8 +333,8 @@ class TestTargetedCoverageBoost:
         """Test line 490 in menu_engine.py (_estimate_daily_cost)."""
         from core.menu_engine import _estimate_daily_cost
 
-        meals = []
-        food_db = {}
+        meals: list[object] = []
+        food_db: dict[str, object] = {}
         result = _estimate_daily_cost(meals, food_db)
         assert isinstance(result, (int, float))
 

--- a/tests/test_targeted_coverage_boost.py
+++ b/tests/test_targeted_coverage_boost.py
@@ -4,7 +4,6 @@ Targeted tests to boost coverage to 97%+ for specific uncovered lines.
 
 import logging
 import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +12,7 @@ from fastapi.testclient import TestClient
 # Import the FastAPI app from the app package
 from app import app
 from app.middleware.api_tiers import TEST_KEY_VIP
+import legacy_app
 
 
 class TestTargetedCoverageBoost:
@@ -97,8 +97,12 @@ class TestTargetedCoverageBoost:
 
     def test_app_py_lines_758_760(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test lines 758-760 in main.py (api_v1_insight with missing llm module)."""
-        # Remove module from sys.modules to simulate it's not available
-        monkeypatch.delitem(sys.modules, "llm", raising=False)
+
+        def _raise_import_error() -> None:
+            raise ImportError("LLM module is not available")
+
+        # Deterministic optional-dependency failure: patch the lazy loader (no sys.modules mutation).
+        monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
         response = self.client.post("/api/v1/insight", json=data, headers=self.vip_headers)
@@ -106,8 +110,12 @@ class TestTargetedCoverageBoost:
 
     def test_app_py_line_914(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test line 914 in main.py (insight endpoint with missing llm module)."""
-        # Remove module from sys.modules to simulate it's not available
-        monkeypatch.delitem(sys.modules, "llm", raising=False)
+
+        def _raise_import_error() -> None:
+            raise ImportError("LLM module is not available")
+
+        # Deterministic optional-dependency failure: patch the lazy loader (no sys.modules mutation).
+        monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
         response = self.client.post("/insight", json=data, headers=self.vip_headers)

--- a/tests/test_targeted_coverage_boost.py
+++ b/tests/test_targeted_coverage_boost.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 # Import the FastAPI app from the app package
 from app import app
+from app.middleware.api_tiers import TEST_KEY_VIP
 import legacy_app
 
 
@@ -22,6 +23,7 @@ class TestTargetedCoverageBoost:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
+        self.vip_headers = {"X-API-Key": TEST_KEY_VIP}
 
     def teardown_method(self) -> None:
         """Clean up test environment."""
@@ -93,9 +95,7 @@ class TestTargetedCoverageBoost:
         assert result["premium"] is True
         assert "premium_reco" in result
 
-    def test_app_py_lines_758_760(
-        self, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
-    ) -> None:
+    def test_app_py_lines_758_760(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test lines 758-760 in main.py (api_v1_insight with missing llm module)."""
 
         def _raise_import_error() -> None:
@@ -105,12 +105,10 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
-        response = self.client.post("/api/v1/insight", json=data, headers=vip_headers)
+        response = self.client.post("/api/v1/insight", json=data, headers=self.vip_headers)
         assert response.status_code == 503
 
-    def test_app_py_line_914(
-        self, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
-    ) -> None:
+    def test_app_py_line_914(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test line 914 in main.py (insight endpoint with missing llm module)."""
 
         def _raise_import_error() -> None:
@@ -120,7 +118,7 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
-        response = self.client.post("/insight", json=data, headers=vip_headers)
+        response = self.client.post("/insight", json=data, headers=self.vip_headers)
         assert response.status_code == 503
 
     def test_app_py_line_1215(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,7 +129,7 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(scheduler, "_scheduler_instance", None)
 
         # Patch get_update_scheduler to raise an exception
-        async def fake_get_scheduler_error() -> None:
+        async def fake_get_scheduler_error():
             raise Exception("Test error")
 
         # Patch scheduler module's get_update_scheduler

--- a/tests/test_targeted_coverage_boost.py
+++ b/tests/test_targeted_coverage_boost.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 
 # Import the FastAPI app from the app package
 from app import app
-from app.middleware.api_tiers import TEST_KEY_VIP
 import legacy_app
 
 
@@ -23,7 +22,6 @@ class TestTargetedCoverageBoost:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
-        self.vip_headers = {"X-API-Key": TEST_KEY_VIP}
 
     def teardown_method(self) -> None:
         """Clean up test environment."""
@@ -95,7 +93,9 @@ class TestTargetedCoverageBoost:
         assert result["premium"] is True
         assert "premium_reco" in result
 
-    def test_app_py_lines_758_760(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_app_py_lines_758_760(
+        self, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
+    ) -> None:
         """Test lines 758-760 in main.py (api_v1_insight with missing llm module)."""
 
         def _raise_import_error() -> None:
@@ -105,10 +105,12 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
-        response = self.client.post("/api/v1/insight", json=data, headers=self.vip_headers)
+        response = self.client.post("/api/v1/insight", json=data, headers=vip_headers)
         assert response.status_code == 503
 
-    def test_app_py_line_914(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_app_py_line_914(
+        self, monkeypatch: pytest.MonkeyPatch, vip_headers: dict[str, str]
+    ) -> None:
         """Test line 914 in main.py (insight endpoint with missing llm module)."""
 
         def _raise_import_error() -> None:
@@ -118,7 +120,7 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(legacy_app, "_load_llm_get_provider", _raise_import_error, raising=True)
 
         data = {"text": "test"}
-        response = self.client.post("/insight", json=data, headers=self.vip_headers)
+        response = self.client.post("/insight", json=data, headers=vip_headers)
         assert response.status_code == 503
 
     def test_app_py_line_1215(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -129,7 +131,7 @@ class TestTargetedCoverageBoost:
         monkeypatch.setattr(scheduler, "_scheduler_instance", None)
 
         # Patch get_update_scheduler to raise an exception
-        async def fake_get_scheduler_error():
+        async def fake_get_scheduler_error() -> None:
             raise Exception("Test error")
 
         # Patch scheduler module's get_update_scheduler


### PR DESCRIPTION
## Summary
This PR enforces VIP-tier access for the LLM Insight endpoint.

It also deprecates and hides the legacy `/insight` endpoint from OpenAPI (while keeping it VIP-guarded for compatibility), and regenerates OpenAPI artifacts for the frontend.

## Audit
- `docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md`

## DoD
- [x] **401/403/200 behavior**: VIP guard enforced for insight endpoints
- [x] **429 behavior**: rate limiting remains in place for the expensive Insight path
- [x] **OpenAPI**: legacy `/insight` hidden; regenerated `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts`

## Test plan
- [x] `make verify`

## Summary by Sourcery

Обеспечить доступ к LLM‑эндпоинтам инсайтов только для VIP‑тарифа, при этом оставить легаси‑путь под VIP‑защитой, но скрытым из OpenAPI, а также соответствующим образом обновить тесты и документацию.

Enhancements:
- Переключить канонический эндпоинт `/api/v1/insight` на использование VIP‑гварда и применить тот же гвард к легаси‑эндпоинту `/insight`, пометив его как устаревший и исключив из схемы OpenAPI.
- Ужесточить гигиену тестов вокруг изменения окружения, заголовков для тарифных уровней API и JSON‑ошибок, включая более точные проверки для путей health, error и PDF‑экспорта.

Documentation:
- Добавить аудит‑документ, описывающий миграцию LLM‑эндпоинтов инсайтов на VIP‑тариф и связанные изменения контракта API.
- Задокументировать проектную политику обработки обновлений `detect-secrets .secrets.baseline` в pre-commit.

Tests:
- Добавить отдельные тесты, подтверждающие, что клиенты с тарифами FREE и PRO получают запрет доступа, в то время как VIP‑клиенты могут обращаться как к `/api/v1/insight`, так и к легаси‑пути `/insight`, включая успешные и ошибочные сценарии.
- Обновить существующие тесты инсайтов, роутинга и обработки ошибок для использования тарифных заголовков (FREE/PRO/VIP) и проверки того, что легаси‑путь `/insight` скрыт из OpenAPI, тогда как канонический `/api/v1/insight` остаётся задокументированным.
- Уточнить покрывающие тесты в нескольких модулях, чтобы они учитывали новую модель тарифов, избегали прямой мутации `os.environ` и гарантировали устойчивое поведение при сбоях необязательных зависимостей или внешних сервисов.

Chores:
- Перегенерировать фронтенд‑артефакты OpenAPI, чтобы удалить легаси‑путь `/insight` и отразить обновлённый контракт эндпоинта инсайтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce VIP-tier access for all LLM insight endpoints while keeping the legacy path VIP-guarded but hidden from OpenAPI, and update tests and documentation accordingly.

Enhancements:
- Switch the canonical /api/v1/insight endpoint to use the VIP-tier guard and apply the same guard to the legacy /insight endpoint, marking it deprecated and excluding it from the OpenAPI schema.
- Tighten test hygiene around environment mutation, tiered API headers, and JSON error responses, including more precise assertions for health, error, and PDF export paths.

Documentation:
- Add an audit document describing the migration of LLM insight endpoints to VIP tier and the resulting API contract changes.
- Document the project policy for handling detect-secrets .secrets.baseline updates in pre-commit.

Tests:
- Add dedicated tests to assert that FREE and PRO clients are forbidden while VIP clients can access both /api/v1/insight and legacy /insight, covering success and error cases.
- Update existing insight, routing, and error-handling tests to use tiered headers (FREE/PRO/VIP) and to verify that the legacy /insight path is hidden from OpenAPI while the canonical /api/v1/insight remains documented.
- Refine coverage-oriented tests across multiple modules to respect the new tier model, avoid direct os.environ mutation, and ensure robust behavior when optional dependencies or external services fail.

Chores:
- Regenerate frontend OpenAPI artifacts to remove the legacy /insight path and reflect the updated insight contract.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Обеспечить доступ к LLM‑эндпоинтам инсайтов только для VIP‑тарифа, при этом оставить легаси‑путь под VIP‑защитой, но скрытым из OpenAPI, а также соответствующим образом обновить тесты и документацию.

Enhancements:
- Переключить канонический эндпоинт `/api/v1/insight` на использование VIP‑гварда и применить тот же гвард к легаси‑эндпоинту `/insight`, пометив его как устаревший и исключив из схемы OpenAPI.
- Ужесточить гигиену тестов вокруг изменения окружения, заголовков для тарифных уровней API и JSON‑ошибок, включая более точные проверки для путей health, error и PDF‑экспорта.

Documentation:
- Добавить аудит‑документ, описывающий миграцию LLM‑эндпоинтов инсайтов на VIP‑тариф и связанные изменения контракта API.
- Задокументировать проектную политику обработки обновлений `detect-secrets .secrets.baseline` в pre-commit.

Tests:
- Добавить отдельные тесты, подтверждающие, что клиенты с тарифами FREE и PRO получают запрет доступа, в то время как VIP‑клиенты могут обращаться как к `/api/v1/insight`, так и к легаси‑пути `/insight`, включая успешные и ошибочные сценарии.
- Обновить существующие тесты инсайтов, роутинга и обработки ошибок для использования тарифных заголовков (FREE/PRO/VIP) и проверки того, что легаси‑путь `/insight` скрыт из OpenAPI, тогда как канонический `/api/v1/insight` остаётся задокументированным.
- Уточнить покрывающие тесты в нескольких модулях, чтобы они учитывали новую модель тарифов, избегали прямой мутации `os.environ` и гарантировали устойчивое поведение при сбоях необязательных зависимостей или внешних сервисов.

Chores:
- Перегенерировать фронтенд‑артефакты OpenAPI, чтобы удалить легаси‑путь `/insight` и отразить обновлённый контракт эндпоинта инсайтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce VIP-tier access for all LLM insight endpoints while keeping the legacy path VIP-guarded but hidden from OpenAPI, and update tests and documentation accordingly.

Enhancements:
- Switch the canonical /api/v1/insight endpoint to use the VIP-tier guard and apply the same guard to the legacy /insight endpoint, marking it deprecated and excluding it from the OpenAPI schema.
- Tighten test hygiene around environment mutation, tiered API headers, and JSON error responses, including more precise assertions for health, error, and PDF export paths.

Documentation:
- Add an audit document describing the migration of LLM insight endpoints to VIP tier and the resulting API contract changes.
- Document the project policy for handling detect-secrets .secrets.baseline updates in pre-commit.

Tests:
- Add dedicated tests to assert that FREE and PRO clients are forbidden while VIP clients can access both /api/v1/insight and legacy /insight, covering success and error cases.
- Update existing insight, routing, and error-handling tests to use tiered headers (FREE/PRO/VIP) and to verify that the legacy /insight path is hidden from OpenAPI while the canonical /api/v1/insight remains documented.
- Refine coverage-oriented tests across multiple modules to respect the new tier model, avoid direct os.environ mutation, and ensure robust behavior when optional dependencies or external services fail.

Chores:
- Regenerate frontend OpenAPI artifacts to remove the legacy /insight path and reflect the updated insight contract.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Обеспечить доступ к LLM‑эндпоинтам инсайтов только для VIP‑тарифа, при этом оставить легаси‑путь под VIP‑защитой, но скрытым из OpenAPI, а также соответствующим образом обновить тесты и документацию.

Enhancements:
- Переключить канонический эндпоинт `/api/v1/insight` на использование VIP‑гварда и применить тот же гвард к легаси‑эндпоинту `/insight`, пометив его как устаревший и исключив из схемы OpenAPI.
- Ужесточить гигиену тестов вокруг изменения окружения, заголовков для тарифных уровней API и JSON‑ошибок, включая более точные проверки для путей health, error и PDF‑экспорта.

Documentation:
- Добавить аудит‑документ, описывающий миграцию LLM‑эндпоинтов инсайтов на VIP‑тариф и связанные изменения контракта API.
- Задокументировать проектную политику обработки обновлений `detect-secrets .secrets.baseline` в pre-commit.

Tests:
- Добавить отдельные тесты, подтверждающие, что клиенты с тарифами FREE и PRO получают запрет доступа, в то время как VIP‑клиенты могут обращаться как к `/api/v1/insight`, так и к легаси‑пути `/insight`, включая успешные и ошибочные сценарии.
- Обновить существующие тесты инсайтов, роутинга и обработки ошибок для использования тарифных заголовков (FREE/PRO/VIP) и проверки того, что легаси‑путь `/insight` скрыт из OpenAPI, тогда как канонический `/api/v1/insight` остаётся задокументированным.
- Уточнить покрывающие тесты в нескольких модулях, чтобы они учитывали новую модель тарифов, избегали прямой мутации `os.environ` и гарантировали устойчивое поведение при сбоях необязательных зависимостей или внешних сервисов.

Chores:
- Перегенерировать фронтенд‑артефакты OpenAPI, чтобы удалить легаси‑путь `/insight` и отразить обновлённый контракт эндпоинта инсайтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce VIP-tier access for all LLM insight endpoints while keeping the legacy path VIP-guarded but hidden from OpenAPI, and update tests and documentation accordingly.

Enhancements:
- Switch the canonical /api/v1/insight endpoint to use the VIP-tier guard and apply the same guard to the legacy /insight endpoint, marking it deprecated and excluding it from the OpenAPI schema.
- Tighten test hygiene around environment mutation, tiered API headers, and JSON error responses, including more precise assertions for health, error, and PDF export paths.

Documentation:
- Add an audit document describing the migration of LLM insight endpoints to VIP tier and the resulting API contract changes.
- Document the project policy for handling detect-secrets .secrets.baseline updates in pre-commit.

Tests:
- Add dedicated tests to assert that FREE and PRO clients are forbidden while VIP clients can access both /api/v1/insight and legacy /insight, covering success and error cases.
- Update existing insight, routing, and error-handling tests to use tiered headers (FREE/PRO/VIP) and to verify that the legacy /insight path is hidden from OpenAPI while the canonical /api/v1/insight remains documented.
- Refine coverage-oriented tests across multiple modules to respect the new tier model, avoid direct os.environ mutation, and ensure robust behavior when optional dependencies or external services fail.

Chores:
- Regenerate frontend OpenAPI artifacts to remove the legacy /insight path and reflect the updated insight contract.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Обеспечить доступ к LLM‑эндпоинтам инсайтов только для VIP‑тарифа, при этом оставить легаси‑путь под VIP‑защитой, но скрытым из OpenAPI, а также соответствующим образом обновить тесты и документацию.

Enhancements:
- Переключить канонический эндпоинт `/api/v1/insight` на использование VIP‑гварда и применить тот же гвард к легаси‑эндпоинту `/insight`, пометив его как устаревший и исключив из схемы OpenAPI.
- Ужесточить гигиену тестов вокруг изменения окружения, заголовков для тарифных уровней API и JSON‑ошибок, включая более точные проверки для путей health, error и PDF‑экспорта.

Documentation:
- Добавить аудит‑документ, описывающий миграцию LLM‑эндпоинтов инсайтов на VIP‑тариф и связанные изменения контракта API.
- Задокументировать проектную политику обработки обновлений `detect-secrets .secrets.baseline` в pre-commit.

Tests:
- Добавить отдельные тесты, подтверждающие, что клиенты с тарифами FREE и PRO получают запрет доступа, в то время как VIP‑клиенты могут обращаться как к `/api/v1/insight`, так и к легаси‑пути `/insight`, включая успешные и ошибочные сценарии.
- Обновить существующие тесты инсайтов, роутинга и обработки ошибок для использования тарифных заголовков (FREE/PRO/VIP) и проверки того, что легаси‑путь `/insight` скрыт из OpenAPI, тогда как канонический `/api/v1/insight` остаётся задокументированным.
- Уточнить покрывающие тесты в нескольких модулях, чтобы они учитывали новую модель тарифов, избегали прямой мутации `os.environ` и гарантировали устойчивое поведение при сбоях необязательных зависимостей или внешних сервисов.

Chores:
- Перегенерировать фронтенд‑артефакты OpenAPI, чтобы удалить легаси‑путь `/insight` и отразить обновлённый контракт эндпоинта инсайтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce VIP-tier access for all LLM insight endpoints while keeping the legacy path VIP-guarded but hidden from OpenAPI, and update tests and documentation accordingly.

Enhancements:
- Switch the canonical /api/v1/insight endpoint to use the VIP-tier guard and apply the same guard to the legacy /insight endpoint, marking it deprecated and excluding it from the OpenAPI schema.
- Tighten test hygiene around environment mutation, tiered API headers, and JSON error responses, including more precise assertions for health, error, and PDF export paths.

Documentation:
- Add an audit document describing the migration of LLM insight endpoints to VIP tier and the resulting API contract changes.
- Document the project policy for handling detect-secrets .secrets.baseline updates in pre-commit.

Tests:
- Add dedicated tests to assert that FREE and PRO clients are forbidden while VIP clients can access both /api/v1/insight and legacy /insight, covering success and error cases.
- Update existing insight, routing, and error-handling tests to use tiered headers (FREE/PRO/VIP) and to verify that the legacy /insight path is hidden from OpenAPI while the canonical /api/v1/insight remains documented.
- Refine coverage-oriented tests across multiple modules to respect the new tier model, avoid direct os.environ mutation, and ensure robust behavior when optional dependencies or external services fail.

Chores:
- Regenerate frontend OpenAPI artifacts to remove the legacy /insight path and reflect the updated insight contract.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Insight endpoint (POST /insight) removed from public API contract and restricted to VIP-tier users only.

* **Feature Changes**
  * Insight endpoints now require VIP tier authentication instead of standard API key access.
  * Legacy insight endpoint deprecated and hidden from API documentation.

* **Tests**
  * Updated test suite to reflect VIP-tier access requirements for insight endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->