### PR TITLE
chore(sourcery): ignore detect-secrets baseline false positives

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,6 +1,13 @@
 # Sourcery AI Configuration for PulsePlate
 # https://docs.sourcery.ai/
 
+# Sourcery should not analyze generated / non-code artifacts.
+# In particular, `.secrets.baseline` contains hashed_secret fingerprints that can be
+# misclassified as "Generic API Key" by security scanners.
+ignore:
+  - ".secrets.baseline"
+  - "./.secrets.baseline"
+
 # GitHub integration
 github:
   request_review: always

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -6,7 +6,6 @@
 # misclassified as "Generic API Key" by security scanners.
 ignore:
   - ".secrets.baseline"
-  - "./.secrets.baseline"
 
 # GitHub integration
 github:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Or individually:
   2. Check `git status` for modified files (e.g., `.secrets.baseline`, whitespace fixes, formatting)
   3. **Commit hook modifications as a separate commit:** `chore(pre-commit): apply hook fixes`
   4. **Important:** If `detect-secrets` updated `.secrets.baseline`, this must be committed (it's a legitimate baseline update, not a secret leak)
+- **Policy note:** `.secrets.baseline` is a generated `detect-secrets` artifact with hashed fingerprints; it is excluded from Sourcery scans (false-positive “Generic API Key”).
 - CI runs `pre-commit run --all-files` and will fail if hooks would modify files that aren't committed.
 - This is not optional: uncommitted hook modifications guarantee CI failure.
 - **One-time setup:** Run `pre-commit install` locally once to enable automatic hook execution on `git commit` (reduces CI noise).


### PR DESCRIPTION
## Summary
- Sourcery security scan can misclassify `detect-secrets` baseline `hashed_secret` fingerprints in `.secrets.baseline` as a “Generic API Key”, blocking unrelated PRs.
- Configure Sourcery to ignore **only** `.secrets.baseline` (and `./.secrets.baseline`) and document the policy.

## Why
- `.secrets.baseline` is a generated artifact already enforced by `detect-secrets` via pre-commit.
- Sourcery should not block PRs on this file’s hashed metadata.

## Scope
- Only `.sourcery.yaml` and `AGENTS.md`.

## Test plan
- `pre-commit run -a`

## Summary by Sourcery

Настроить Sourcery так, чтобы игнорировать файл базовой линии detect-secrets, и задокументировать это исключение в руководстве для контрибьюторов.

Enhancements:
- Исключить `.secrets.baseline` (и его вариант с относительным путём) из анализа Sourcery, чтобы избежать ложных срабатываний на обнаружение секретов.

Documentation:
- Задокументировать политику, согласно которой `.secrets.baseline` является сгенерированным артефактом detect-secrets и исключается из сканирования Sourcery из‑за ложных совпадений типа «Generic API Key».

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Sourcery to ignore the detect-secrets baseline file and document this exclusion in contributor guidelines.

Enhancements:
- Exclude `.secrets.baseline` (and its relative path variant) from Sourcery analysis to avoid false-positive secret detections.

Documentation:
- Document the policy that `.secrets.baseline` is a generated detect-secrets artifact and is excluded from Sourcery scans due to false-positive “Generic API Key” matches.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore the detect-secrets baseline (.secrets.baseline) in Sourcery to stop false “Generic API Key” flags from hashed_secret fingerprints and prevent unrelated PRs from being blocked. Documented this exclusion policy in AGENTS.md.

<sup>Written for commit 323a6e1ee25d50b8b57518bf6b32bc7fa11afe8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated scanning configuration to exclude generated/non-code security baseline artifacts from analysis.

* **Documentation**
  * Added guidance explaining that security baseline files with hashed fingerprints are generated artifacts and are excluded from automated scans to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->