### PR TITLE
docs(roadmap): mark PR-644 merged

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -289,7 +289,8 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (maintainability)
   - Target PR: PR #644
-  - Status: 🟡 In progress (PR #644)
+  - Status: ✅ Merged (PR #644)
+  - Merge SHA: fda459d743e848b72c2c818b8dd7bef62af99aec
   - Reason: BMR formula constants and export formats are hardcoded in `legacy_app.py`. Should be extracted to `core.bmr` module and `ExportFormat` enum for maintainability.
   - Links:
     - PR #644


### PR DESCRIPTION
## Summary
- Update BACKLOG_LEDGER: mark P1 constants extraction as merged.
- Record merge SHA for PR #644.

## Scope
- Docs-only change.

## Test plan
- N/A (docs-only)

## Summary by Sourcery

Документация:
- Отметить пункт извлечения констант P1 BMR как смёрженный в `BACKLOG_LEDGER` и зафиксировать его SHA коммита слияния.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mark the P1 BMR constants extraction item as merged in BACKLOG_LEDGER and record its merge SHA.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark PR #644 (P1 constants extraction) as merged in BACKLOG_LEDGER and record its merge SHA. Keeps the roadmap ledger current.

<sup>Written for commit e7f7ca84a1011972dc06b2136b2520720299e47b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog ledger to record merged pull request status and corresponding commit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->