### PR TITLE
PR-646: Close VIP-only LLM insight ledger (docs-only)

### DIFF
--- a/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
+++ b/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
@@ -1,9 +1,9 @@
 ## PR-646 — VIP-only LLM Insight (P0 Security) — Audit
 
-**Date:** 5 February 2026  
-**Owner:** @katsiaryna_kavaleuskaya  
-**PR:** PR-646  
-**Branch (planned):** `security/p0-vip-only-llm-insight-pr646`  
+**Date:** 5 February 2026
+**Owner:** @katsiaryna_kavaleuskaya
+**PR:** PR-646
+**Branch (planned):** `security/p0-vip-only-llm-insight-pr646`
 **Scope (hard):** backend/security + docs only. **No frontend/iOS/product refactors.**
 
 ---
@@ -59,7 +59,7 @@ Exit code: `0`
 
 - **Allowed**: `legacy_app.py` / `app/security/*` / `tests/*` **only if** new behavior is needed; `docs/audit/*`,
   `docs/roadmap/BACKLOG_LEDGER.md` (ledger status).
-- **Forbidden**: `frontend/` and `ios/` runtime changes (frozen until P0 backend-security is done).  
+- **Forbidden**: `frontend/` and `ios/` runtime changes (frozen until P0 backend-security is done).
   **Note:** generated OpenAPI artifacts under `frontend/src/api/*` are allowed **only** when runtime OpenAPI changes
   in this PR require regeneration. In this specific case, OpenAPI already reflects the correct visibility.
 
@@ -314,15 +314,15 @@ Exit code: `0`
 
 ## 8) Exit Criteria (DoD) — Evidence Checklist
 
-- [x] **FREE → 403**, **PRO → 403**, **VIP → 200** for `/api/v1/insight`  
+- [x] **FREE → 403**, **PRO → 403**, **VIP → 200** for `/api/v1/insight`
   Evidence: `tests/test_insight_vip_guard_api.py` + `pytest -q ...` (see §5.1)
-- [x] `/api/v1/insight` does **not** use `_get_api_key_dynamic`  
+- [x] `/api/v1/insight` does **not** use `_get_api_key_dynamic`
   Evidence: decorator uses `require_vip_tier` + `_get_api_key_dynamic` not referenced for insight routes (see §3.2)
-- [x] `/insight` is **VIP-guarded** and **not exposed in OpenAPI**  
+- [x] `/insight` is **VIP-guarded** and **not exposed in OpenAPI**
   Evidence: `app.app.openapi()` membership is `False` (see §3.1), `include_in_schema=False` (see §3.2)
-- [x] Rate limiting present on both Insight endpoints  
+- [x] Rate limiting present on both Insight endpoints
   Evidence: `@limit_if_available(RATE_LIMIT_INSIGHT)` on both routes (see §3.3)
-- [ ] Ledger item updated: `P0: Move LLM insight to VIP tier` → ✅ Done, with link to PR #640 and this audit  
+- [ ] Ledger item updated: `P0: Move LLM insight to VIP tier` → ✅ Done, with link to PR #640 and this audit
   (Docs-only change; must not include runtime code changes.)
 
 ---
@@ -360,4 +360,3 @@ Raw output (truncated):
 ```
 
 Exit code: `0`
-

--- a/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
+++ b/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
@@ -1,0 +1,363 @@
+## PR-646 — VIP-only LLM Insight (P0 Security) — Audit
+
+**Date:** 5 February 2026  
+**Owner:** @katsiaryna_kavaleuskaya  
+**PR:** PR-646  
+**Branch (planned):** `security/p0-vip-only-llm-insight-pr646`  
+**Scope (hard):** backend/security + docs only. **No frontend/iOS/product refactors.**
+
+---
+
+## 1) Executive Summary
+
+### Goal (ledger)
+
+Make LLM Insight available **ONLY** to VIP tier:
+
+- `POST /api/v1/insight` → VIP-only
+- `POST /insight` (legacy) → removed **or** VIP-guarded (and not exposed in OpenAPI)
+- Both endpoints must remain **rate-limited** (cost-abuse control)
+
+### Audit finding (current `main`)
+
+**The target state is already implemented on `main`**:
+
+- `POST /api/v1/insight` is **VIP-guarded** with `require_vip_tier`
+- `POST /insight` is **VIP-guarded** with `require_vip_tier`, **deprecated**, and **hidden from OpenAPI**
+- Both endpoints are **rate-limited** with `@limit_if_available(RATE_LIMIT_INSIGHT)`
+- Tests already exist and pass for **FREE→403**, **PRO→403**, **VIP→200** + error hygiene (no exception leaks)
+
+**Implication:** a runtime PR that “implements VIP-only insight” would be **no-op** and is forbidden by repo workflow.
+PR-646 should be executed as a **docs-only ledger-correction closure** (this audit + ledger update to ✅ Done,
+linked to the already-merged implementation PR).
+
+---
+
+## 2) Audit Meta (Scope + Allowed files)
+
+### Ledger scope anchor
+
+**Question answered:** What exact ledger item is PR-646 supposed to close?
+
+**Evidence**
+
+Command:
+```bash
+rg -n "P0 Move LLM insight to VIP tier|Move LLM insight to VIP tier" docs/roadmap/BACKLOG_LEDGER.md -n -C 3
+```
+
+Raw output (truncated):
+```text
+211:### P0 Move LLM insight to VIP tier
+213:- [ ] P0 CRITICAL: Move LLM insight to VIP tier (prevent FREE tier abuse)
+216-  - Target PR: TBD (security fix)
+```
+
+Exit code: `0`
+
+### Allowed / forbidden areas (policy)
+
+- **Allowed**: `legacy_app.py` / `app/security/*` / `tests/*` **only if** new behavior is needed; `docs/audit/*`,
+  `docs/roadmap/BACKLOG_LEDGER.md` (ledger status).
+- **Forbidden**: `frontend/` and `ios/` runtime changes (frozen until P0 backend-security is done).  
+  **Note:** generated OpenAPI artifacts under `frontend/src/api/*` are allowed **only** when runtime OpenAPI changes
+  in this PR require regeneration. In this specific case, OpenAPI already reflects the correct visibility.
+
+---
+
+## 3) Current State (Evidence: BEFORE)
+
+### 3.1 Endpoint surface (what routes exist)
+
+**Question answered:** Do `/api/v1/insight` and `/insight` exist at runtime? Is `/insight` exposed in OpenAPI?
+
+**Evidence A — runtime route registration**
+
+Command:
+```bash
+python - <<'PY'
+import os
+os.environ['TESTING'] = 'true'
+import app
+paths = {r.path for r in app.app.routes}
+print('/api/v1/insight' in paths)
+print('/insight' in paths)
+PY
+```
+
+Raw output:
+```text
+True
+True
+```
+
+Exit code: `0`
+
+**Evidence B — OpenAPI visibility (canonical)**
+
+Command:
+```bash
+python - <<'PY'
+import os
+os.environ['TESTING'] = 'true'
+import app
+paths = set(app.app.openapi().get('paths', {}).keys())
+print('/api/v1/insight' in paths)
+print('/insight' in paths)
+PY
+```
+
+Raw output:
+```text
+True
+False
+```
+
+Exit code: `0`
+
+**Evidence C — generated frontend OpenAPI artifact contains only canonical path**
+
+Command:
+```bash
+rg -n "\"/api/v1/insight\"" frontend/src/api/openapi.json -n
+```
+
+Raw output (truncated):
+```text
+6685:    "/api/v1/insight": {
+```
+
+Exit code: `0`
+
+Command:
+```bash
+rg -n "\"/insight\"" frontend/src/api/openapi.json -n
+```
+
+Raw output:
+```text
+<no matches>
+```
+
+Exit code: `1`
+
+**Notes**
+
+- `app/static/openapi.json` currently contains `/insight`, but **it is not the canonical OpenAPI artifact**
+  for clients. Canonical OpenAPI for clients is generated via `make openapi` and committed into
+  `frontend/src/api/openapi.json` (per `AGENTS.md` OpenAPI policy).
+- Canonical evidence is **live** `app.app.openapi()` output + the generated client artifact.
+
+### 3.2 Auth & tier guard behavior
+
+**Question answered:** What guard is used now? Is `_get_api_key_dynamic` used for Insight?
+
+**Evidence — route decorators in `legacy_app.py`**
+
+Command:
+```bash
+rg -n "^@app\\.post\\(|\"/api/v1/insight\"|\"/insight\"|dependencies=\\[Depends\\(require_vip_tier\\)\\]|@limit_if_available\\(RATE_LIMIT_INSIGHT\\)|include_in_schema=False" legacy_app.py -m 30
+```
+
+Raw output (truncated):
+```text
+2180:    "/api/v1/insight",
+2181:    dependencies=[Depends(require_vip_tier)],
+2185:@limit_if_available(RATE_LIMIT_INSIGHT)
+```
+
+Raw output (truncated):
+```text
+2192:    "/insight",
+2193:    include_in_schema=False,
+2195:    dependencies=[Depends(require_vip_tier)],
+```
+
+Exit code: `0`
+
+**Evidence — `_get_api_key_dynamic` is present but not used on Insight**
+
+Command:
+```bash
+rg -n "_get_api_key_dynamic" legacy_app.py | rg -n "insight" || true
+```
+
+Raw output:
+```text
+<empty>
+```
+
+Exit code: `0`
+
+### 3.3 Rate limiting (cost-abuse control)
+
+**Question answered:** Are Insight endpoints rate-limited with `RATE_LIMIT_INSIGHT` and documented as 429?
+
+**Evidence**
+
+Command:
+```bash
+rg -n "limit_if_available\\(RATE_LIMIT_INSIGHT\\)|RATE_LIMIT_429_RESPONSES" legacy_app.py -n -m 20
+```
+
+Raw output (truncated):
+```text
+2183:    responses=RATE_LIMIT_429_RESPONSES,
+2185:@limit_if_available(RATE_LIMIT_INSIGHT)
+2198:    responses=RATE_LIMIT_429_RESPONSES,
+```
+
+Exit code: `0`
+
+---
+
+## 4) Target State (Policy Alignment)
+
+### 4.1 Canonical policy hooks (hard rules)
+
+- **Tier policy:** LLM Insight must be **VIP-only**.
+- **Rate limit policy:** All LLM endpoints must use `@limit_if_available(RATE_LIMIT_INSIGHT)` and document 429
+  via `responses=RATE_LIMIT_429_RESPONSES` (root `AGENTS.md`).
+- **Thin HTTP adapter policy:** No client-side (frontend/iOS) computation; clients are thin transport adapters.
+
+### 4.2 Alignment check
+
+Based on the evidence in §3:
+
+- `/api/v1/insight` uses `dependencies=[Depends(require_vip_tier)]` ✅
+- `/insight` uses `dependencies=[Depends(require_vip_tier)]`, is deprecated + hidden from schema ✅
+- Both are decorated with `@limit_if_available(RATE_LIMIT_INSIGHT)` and declare 429 responses ✅
+
+---
+
+## 5) Tests (Security-Critical)
+
+### 5.1 Tier guard matrix (FREE/PRO/VIP)
+
+**Question answered:** Do we have tests proving FREE→403, PRO→403, VIP→200?
+
+**Evidence — existing test file**
+
+Anchor: `tests/test_insight_vip_guard_api.py` (contains both `/api/v1/insight` and `/insight` assertions).
+
+**Evidence — test run**
+
+Command:
+```bash
+pytest -q tests/test_insight_vip_guard_api.py tests/test_insight_error_hygiene.py
+```
+
+Raw output:
+```text
+.....                                                                    [100%]
+```
+
+Exit code: `0`
+
+### 5.2 Error hygiene (no exception leak)
+
+**Question answered:** Do Insight endpoints avoid leaking provider exception text?
+
+Anchor: `tests/test_insight_error_hygiene.py` asserts sensitive substrings do not appear in response `detail`.
+
+---
+
+## 6) Decision (фиксируемое решение по `/insight`)
+
+**Decision:** Keep `/insight` as a **deprecated legacy alias** that is:
+
+- VIP-only (`require_vip_tier`)
+- Hidden from OpenAPI (`include_in_schema=False`)
+- Rate-limited (`@limit_if_available(RATE_LIMIT_INSIGHT)`)
+
+**Rationale (security + compatibility):**
+
+- Removes unauthenticated surface (VIP guard required).
+- Preserves backward compatibility for any legacy client that might still call `/insight`.
+- Avoids expanding public contract (legacy is not in OpenAPI, so new clients will not adopt it).
+
+**Evidence anchor:** `legacy_app.py` decorators for `/insight` show `include_in_schema=False` + VIP dependency + rate limit
+(see §3.2 and §3.3).
+
+---
+
+## 7) Ledger Drift Analysis (Why PR-646 is “already done”)
+
+### 7.1 Ledger item text is stale vs code reality
+
+Ledger claims:
+
+- `/api/v1/insight` uses `_get_api_key_dynamic`
+- `/insight` has no auth
+
+But code evidence shows both endpoints are VIP-guarded and rate-limited (see §3).
+
+### 7.2 Implementation PR already merged
+
+**Evidence**
+
+Command:
+```bash
+git show -s --format='%h %s' 98330ead
+```
+
+Raw output:
+```text
+98330ead P0: Enforce VIP tier for LLM Insight and close legacy /insight endpoint (#640)
+```
+
+Exit code: `0`
+
+**Conclusion:** PR-646 should not be a runtime PR; it should close the ledger item with evidence + audit doc.
+
+---
+
+## 8) Exit Criteria (DoD) — Evidence Checklist
+
+- [x] **FREE → 403**, **PRO → 403**, **VIP → 200** for `/api/v1/insight`  
+  Evidence: `tests/test_insight_vip_guard_api.py` + `pytest -q ...` (see §5.1)
+- [x] `/api/v1/insight` does **not** use `_get_api_key_dynamic`  
+  Evidence: decorator uses `require_vip_tier` + `_get_api_key_dynamic` not referenced for insight routes (see §3.2)
+- [x] `/insight` is **VIP-guarded** and **not exposed in OpenAPI**  
+  Evidence: `app.app.openapi()` membership is `False` (see §3.1), `include_in_schema=False` (see §3.2)
+- [x] Rate limiting present on both Insight endpoints  
+  Evidence: `@limit_if_available(RATE_LIMIT_INSIGHT)` on both routes (see §3.3)
+- [ ] Ledger item updated: `P0: Move LLM insight to VIP tier` → ✅ Done, with link to PR #640 and this audit  
+  (Docs-only change; must not include runtime code changes.)
+
+---
+
+## 9) PR-646 Recommended Execution (No-op prevention)
+
+**Hard rule:** Avoid no-op runtime PRs. Therefore:
+
+1. Create a **docs-only PR-646** containing:
+   - this audit: `docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md`
+   - ledger update: mark item ✅ Done and link PR #640 + this audit
+2. Verify docs-only scope (policy):
+   - `git diff --name-only origin/main...HEAD | rg -v "\\.md$|README\\.md$|AGENTS\\.md$|RUNBOOK_AGENT\\.md$|DEPLOYMENT\\.md$"` must be empty
+
+---
+
+## 10) Risk Notes (P0 Security)
+
+- **Financial risk (cost abuse):** LLM endpoints are expensive; VIP-only gating + rate limiting is the primary mitigation.
+- **Security risk (data handling):** Privacy text explicitly warns that `/insight` and `/api/v1/insight` may transmit user text
+  to external AI providers (anchor: `legacy_app.py` privacy info section includes these endpoints).
+- **Contract risk:** Keeping `/insight` hidden from OpenAPI prevents new client adoption and limits blast radius.
+
+### Evidence — $72k/month cost attack note
+
+Command:
+```bash
+rg -n "72k" docs/insights/RECURSIVE_METHODS_LLM_RAG.md -n -m 5
+```
+
+Raw output (truncated):
+```text
+982:> **Abuse / attack-surface note:** The repo backlog flags a **$72k/month cost attack risk** for LLM endpoints without
+985:> the same `multiplier` (e.g., ~$72k/month -> ~$216k-$360k/month at 3-5x) unless mitigations (rate limits,
+```
+
+Exit code: `0`
+

--- a/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
+++ b/docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
@@ -8,38 +8,139 @@
 
 ---
 
-## 1) Executive Summary
+## Summary (high signal)
+
+- The ledger item “Move LLM insight to VIP tier” exists and was stale vs runtime. Evidence: [E1]
+- Runtime routes exist for both `POST /api/v1/insight` and legacy `POST /insight`. Evidence: [E2]
+- OpenAPI includes **only** `/api/v1/insight` (legacy `/insight` is hidden). Evidence: [E3], [E4], [E5]
+- Both insight endpoints are **VIP-guarded** and **rate-limited**. Evidence: [E6], [E8]
+- `_get_api_key_dynamic` is not used on insight endpoints. Evidence: [E7]
+- Tests already prove **FREE→403**, **PRO→403**, **VIP→200** and error hygiene (no provider exception leaks). Evidence: [E9]
+- Runtime implementation landed earlier as PR #640 (ledger closure should reference it). Evidence: [E10]
+- Remaining gap (non-goal for PR-646): monthly hard quota/budget enforcement is **not** evidenced here. Per policy
+  `docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md`, the endpoint remains economically unsafe until quota exists; this must
+  be tracked as a separate open P0 ledger item.
+
+---
+
+## 1) Scope (PR-646)
 
 ### Goal (ledger)
 
 Make LLM Insight available **ONLY** to VIP tier:
 
 - `POST /api/v1/insight` → VIP-only
-- `POST /insight` (legacy) → removed **or** VIP-guarded (and not exposed in OpenAPI)
-- Both endpoints must remain **rate-limited** (cost-abuse control)
+- `POST /insight` (legacy) → VIP-guarded + hidden from OpenAPI (or removed)
+- Both endpoints remain **rate-limited** (`RATE_LIMIT_INSIGHT`)
 
-### Audit finding (current `main`)
+Ledger anchor evidence: [E1]
 
-**The target state is already implemented on `main`**:
+### Allowed / forbidden areas (docs-only)
 
-- `POST /api/v1/insight` is **VIP-guarded** with `require_vip_tier`
-- `POST /insight` is **VIP-guarded** with `require_vip_tier`, **deprecated**, and **hidden from OpenAPI**
-- Both endpoints are **rate-limited** with `@limit_if_available(RATE_LIMIT_INSIGHT)`
-- Tests already exist and pass for **FREE→403**, **PRO→403**, **VIP→200** + error hygiene (no exception leaks)
-
-**Implication:** a runtime PR that “implements VIP-only insight” would be **no-op** and is forbidden by repo workflow.
-PR-646 should be executed as a **docs-only ledger-correction closure** (this audit + ledger update to ✅ Done,
-linked to the already-merged implementation PR).
+- This PR is **docs-only**: audit + ledger status updates (+ policy doc).
+- Frontend/iOS are frozen (no runtime changes). OpenAPI client artifacts are **not** regenerated here because
+  OpenAPI already reflects correct visibility. Evidence: [E4], [E5]
 
 ---
 
-## 2) Audit Meta (Scope + Allowed files)
+## 2) Findings (current `main`)
 
-### Ledger scope anchor
+### 2.1 Endpoint surface
 
-**Question answered:** What exact ledger item is PR-646 supposed to close?
+Routes exist at runtime for both:
 
-**Evidence**
+1) `POST /api/v1/insight`
+2) `POST /insight` (legacy)
+
+Evidence: [E2]
+
+OpenAPI visibility:
+
+- `/api/v1/insight` **is present** in OpenAPI. Evidence: [E3], [E4]
+- `/insight` **is not present** in OpenAPI (hidden). Evidence: [E3], [E5]
+
+### 2.2 Auth / tier guard behavior
+
+Both insight endpoints are guarded with `require_vip_tier`.
+
+Evidence: [E6]
+
+`_get_api_key_dynamic` exists in `legacy_app.py` but is not used by insight endpoints.
+
+Evidence: [E7]
+
+### 2.3 Rate limiting (cost-abuse control)
+
+Both insight endpoints are decorated with:
+
+- `@limit_if_available(RATE_LIMIT_INSIGHT)`
+- `responses=RATE_LIMIT_429_RESPONSES` (OpenAPI 429 documentation)
+
+Evidence: [E8]
+
+---
+
+## 3) Decision: legacy `/insight`
+
+**Decision:** Keep `/insight` as a deprecated legacy alias that remains:
+
+- VIP-only (`require_vip_tier`)
+- Hidden from OpenAPI (`include_in_schema=False`)
+- Rate-limited (`RATE_LIMIT_INSIGHT`)
+
+Rationale (security + compatibility): removes unauthenticated surface while preserving backward compatibility,
+without expanding the public contract (hidden from OpenAPI).
+
+Evidence: [E6], [E3], [E8]
+
+---
+
+## 4) Tests (security-critical)
+
+Existing tests prove:
+
+- Tier matrix: **FREE → 403**, **PRO → 403**, **VIP → 200**
+- Error hygiene: provider exception text is not leaked
+
+Evidence: [E9]
+
+---
+
+## 5) Ledger drift + closure
+
+The ledger description for this item was stale vs runtime: it claimed `_get_api_key_dynamic` and unauthenticated
+legacy insight. Current runtime is already VIP-only + rate-limited. Evidence: [E6], [E7], [E8]
+
+Runtime implementation already merged in PR #640. Evidence: [E10]
+
+---
+
+## 6) Exit criteria (DoD)
+
+This audit is satisfied when the following are true (all evidence exists in Appendix):
+
+- VIP-only access: FREE/PRO rejected, VIP allowed. Evidence: [E9], [E6]
+- Rate limiting present + 429 documented. Evidence: [E8]
+- Legacy `/insight` not exposed in OpenAPI. Evidence: [E3], [E5]
+- `_get_api_key_dynamic` not used for insight routes. Evidence: [E7]
+- Ledger entry updated to ✅ Done with links to PR #640 and this audit. (docs-only)
+- Separate P0 ledger item exists for monthly hard quota enforcement per `docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md`.
+
+---
+
+## 7) Risk notes (P0 security)
+
+- **Financial risk:** cost-abuse surface for LLM; mitigations here are VIP-only + rate limiting.
+  Note: rate limiting is not a unit-economics cost cap; quotas/budgets are documented separately.
+- **Contract risk:** legacy `/insight` remains hidden from OpenAPI, preventing new client adoption.
+
+Evidence for “$72k/month cost attack risk” note: [E11]
+
+---
+
+## Appendix: Evidence (append-only)
+
+### [E1] Ledger item exists (before closure)
 
 Command:
 ```bash
@@ -55,23 +156,7 @@ Raw output (truncated):
 
 Exit code: `0`
 
-### Allowed / forbidden areas (policy)
-
-- **Allowed**: `legacy_app.py` / `app/security/*` / `tests/*` **only if** new behavior is needed; `docs/audit/*`,
-  `docs/roadmap/BACKLOG_LEDGER.md` (ledger status).
-- **Forbidden**: `frontend/` and `ios/` runtime changes (frozen until P0 backend-security is done).
-  **Note:** generated OpenAPI artifacts under `frontend/src/api/*` are allowed **only** when runtime OpenAPI changes
-  in this PR require regeneration. In this specific case, OpenAPI already reflects the correct visibility.
-
----
-
-## 3) Current State (Evidence: BEFORE)
-
-### 3.1 Endpoint surface (what routes exist)
-
-**Question answered:** Do `/api/v1/insight` and `/insight` exist at runtime? Is `/insight` exposed in OpenAPI?
-
-**Evidence A — runtime route registration**
+### [E2] Runtime route registration
 
 Command:
 ```bash
@@ -93,7 +178,7 @@ True
 
 Exit code: `0`
 
-**Evidence B — OpenAPI visibility (canonical)**
+### [E3] OpenAPI visibility (live)
 
 Command:
 ```bash
@@ -115,7 +200,7 @@ False
 
 Exit code: `0`
 
-**Evidence C — generated frontend OpenAPI artifact contains only canonical path**
+### [E4] Generated client OpenAPI contains canonical insight path
 
 Command:
 ```bash
@@ -129,6 +214,8 @@ Raw output (truncated):
 
 Exit code: `0`
 
+### [E5] Generated client OpenAPI does not include legacy `/insight`
+
 Command:
 ```bash
 rg -n "\"/insight\"" frontend/src/api/openapi.json -n
@@ -141,18 +228,7 @@ Raw output:
 
 Exit code: `1`
 
-**Notes**
-
-- `app/static/openapi.json` currently contains `/insight`, but **it is not the canonical OpenAPI artifact**
-  for clients. Canonical OpenAPI for clients is generated via `make openapi` and committed into
-  `frontend/src/api/openapi.json` (per `AGENTS.md` OpenAPI policy).
-- Canonical evidence is **live** `app.app.openapi()` output + the generated client artifact.
-
-### 3.2 Auth & tier guard behavior
-
-**Question answered:** What guard is used now? Is `_get_api_key_dynamic` used for Insight?
-
-**Evidence — route decorators in `legacy_app.py`**
+### [E6] VIP guard on both insight endpoints (route decorators)
 
 Command:
 ```bash
@@ -164,10 +240,6 @@ Raw output (truncated):
 2180:    "/api/v1/insight",
 2181:    dependencies=[Depends(require_vip_tier)],
 2185:@limit_if_available(RATE_LIMIT_INSIGHT)
-```
-
-Raw output (truncated):
-```text
 2192:    "/insight",
 2193:    include_in_schema=False,
 2195:    dependencies=[Depends(require_vip_tier)],
@@ -175,7 +247,7 @@ Raw output (truncated):
 
 Exit code: `0`
 
-**Evidence — `_get_api_key_dynamic` is present but not used on Insight**
+### [E7] `_get_api_key_dynamic` is not used for insight endpoints
 
 Command:
 ```bash
@@ -189,11 +261,7 @@ Raw output:
 
 Exit code: `0`
 
-### 3.3 Rate limiting (cost-abuse control)
-
-**Question answered:** Are Insight endpoints rate-limited with `RATE_LIMIT_INSIGHT` and documented as 429?
-
-**Evidence**
+### [E8] Rate limiting + 429 documentation for insight endpoints
 
 Command:
 ```bash
@@ -209,38 +277,7 @@ Raw output (truncated):
 
 Exit code: `0`
 
----
-
-## 4) Target State (Policy Alignment)
-
-### 4.1 Canonical policy hooks (hard rules)
-
-- **Tier policy:** LLM Insight must be **VIP-only**.
-- **Rate limit policy:** All LLM endpoints must use `@limit_if_available(RATE_LIMIT_INSIGHT)` and document 429
-  via `responses=RATE_LIMIT_429_RESPONSES` (root `AGENTS.md`).
-- **Thin HTTP adapter policy:** No client-side (frontend/iOS) computation; clients are thin transport adapters.
-
-### 4.2 Alignment check
-
-Based on the evidence in §3:
-
-- `/api/v1/insight` uses `dependencies=[Depends(require_vip_tier)]` ✅
-- `/insight` uses `dependencies=[Depends(require_vip_tier)]`, is deprecated + hidden from schema ✅
-- Both are decorated with `@limit_if_available(RATE_LIMIT_INSIGHT)` and declare 429 responses ✅
-
----
-
-## 5) Tests (Security-Critical)
-
-### 5.1 Tier guard matrix (FREE/PRO/VIP)
-
-**Question answered:** Do we have tests proving FREE→403, PRO→403, VIP→200?
-
-**Evidence — existing test file**
-
-Anchor: `tests/test_insight_vip_guard_api.py` (contains both `/api/v1/insight` and `/insight` assertions).
-
-**Evidence — test run**
+### [E9] Tests: VIP-only matrix + error hygiene
 
 Command:
 ```bash
@@ -254,47 +291,7 @@ Raw output:
 
 Exit code: `0`
 
-### 5.2 Error hygiene (no exception leak)
-
-**Question answered:** Do Insight endpoints avoid leaking provider exception text?
-
-Anchor: `tests/test_insight_error_hygiene.py` asserts sensitive substrings do not appear in response `detail`.
-
----
-
-## 6) Decision (фиксируемое решение по `/insight`)
-
-**Decision:** Keep `/insight` as a **deprecated legacy alias** that is:
-
-- VIP-only (`require_vip_tier`)
-- Hidden from OpenAPI (`include_in_schema=False`)
-- Rate-limited (`@limit_if_available(RATE_LIMIT_INSIGHT)`)
-
-**Rationale (security + compatibility):**
-
-- Removes unauthenticated surface (VIP guard required).
-- Preserves backward compatibility for any legacy client that might still call `/insight`.
-- Avoids expanding public contract (legacy is not in OpenAPI, so new clients will not adopt it).
-
-**Evidence anchor:** `legacy_app.py` decorators for `/insight` show `include_in_schema=False` + VIP dependency + rate limit
-(see §3.2 and §3.3).
-
----
-
-## 7) Ledger Drift Analysis (Why PR-646 is “already done”)
-
-### 7.1 Ledger item text is stale vs code reality
-
-Ledger claims:
-
-- `/api/v1/insight` uses `_get_api_key_dynamic`
-- `/insight` has no auth
-
-But code evidence shows both endpoints are VIP-guarded and rate-limited (see §3).
-
-### 7.2 Implementation PR already merged
-
-**Evidence**
+### [E10] Runtime implementation already merged (PR #640)
 
 Command:
 ```bash
@@ -308,45 +305,7 @@ Raw output:
 
 Exit code: `0`
 
-**Conclusion:** PR-646 should not be a runtime PR; it should close the ledger item with evidence + audit doc.
-
----
-
-## 8) Exit Criteria (DoD) — Evidence Checklist
-
-- [x] **FREE → 403**, **PRO → 403**, **VIP → 200** for `/api/v1/insight`
-  Evidence: `tests/test_insight_vip_guard_api.py` + `pytest -q ...` (see §5.1)
-- [x] `/api/v1/insight` does **not** use `_get_api_key_dynamic`
-  Evidence: decorator uses `require_vip_tier` + `_get_api_key_dynamic` not referenced for insight routes (see §3.2)
-- [x] `/insight` is **VIP-guarded** and **not exposed in OpenAPI**
-  Evidence: `app.app.openapi()` membership is `False` (see §3.1), `include_in_schema=False` (see §3.2)
-- [x] Rate limiting present on both Insight endpoints
-  Evidence: `@limit_if_available(RATE_LIMIT_INSIGHT)` on both routes (see §3.3)
-- [ ] Ledger item updated: `P0: Move LLM insight to VIP tier` → ✅ Done, with link to PR #640 and this audit
-  (Docs-only change; must not include runtime code changes.)
-
----
-
-## 9) PR-646 Recommended Execution (No-op prevention)
-
-**Hard rule:** Avoid no-op runtime PRs. Therefore:
-
-1. Create a **docs-only PR-646** containing:
-   - this audit: `docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md`
-   - ledger update: mark item ✅ Done and link PR #640 + this audit
-2. Verify docs-only scope (policy):
-   - `git diff --name-only origin/main...HEAD | rg -v "\\.md$|README\\.md$|AGENTS\\.md$|RUNBOOK_AGENT\\.md$|DEPLOYMENT\\.md$"` must be empty
-
----
-
-## 10) Risk Notes (P0 Security)
-
-- **Financial risk (cost abuse):** LLM endpoints are expensive; VIP-only gating + rate limiting is the primary mitigation.
-- **Security risk (data handling):** Privacy text explicitly warns that `/insight` and `/api/v1/insight` may transmit user text
-  to external AI providers (anchor: `legacy_app.py` privacy info section includes these endpoints).
-- **Contract risk:** Keeping `/insight` hidden from OpenAPI prevents new client adoption and limits blast radius.
-
-### Evidence — $72k/month cost attack note
+### [E11] $72k/month cost attack risk note (project context)
 
 Command:
 ```bash

--- a/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
+++ b/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
@@ -1,0 +1,90 @@
+## LLM Unit Economics Guardrails (Hard Policy)
+
+**Last updated:** 5 February 2026  
+**Scope:** Backend only (LLM endpoints, e.g. `/api/v1/insight`).  
+**Goal:** Guarantee **positive unit economics under worst-case usage**.
+
+---
+
+## 1) Core statement (invariant)
+
+**RU:** LLM — это не “фича”, а **metered resource**. Любой LLM endpoint считается **небезопасным**
+до тех пор, пока не введён **жёсткий верхний предел затрат** (quota/budget) на пользователя/ключ.
+
+**EN:** LLM is a **metered resource**, not a feature. Any LLM endpoint is **economically unsafe**
+until it has a **hard cost cap** (quota/budget) per user/key.
+
+---
+
+## 2) Why VIP-only + rate-limit is insufficient
+
+**RU:** Rate limit ограничивает **скорость**, но не ограничивает **интеграл затрат по времени**.
+VIP пользователь (или атакующий с VIP ключом) может стабильно “съедать” лимит каждый день.
+Следовательно, cost bounded per minute, но **unbounded per month**.
+
+**EN:** Rate limiting bounds request velocity, not the time-integrated cost. A VIP user can sustain max usage
+every day. Therefore, cost is bounded per minute but **unbounded per month**.
+
+---
+
+## 3) Hard requirement: quota / budget layer (P0 security)
+
+### 3.1 Hard cap definition
+
+At minimum, enforce one of:
+
+- **Requests/month** (simplest, coarse)
+- **Tokens/month** (better)
+- **Estimated cost USD/month** (best; requires cost estimation inputs)
+
+### 3.2 Enforcement semantics
+
+When quota is exceeded:
+
+- The server must **hard-stop** the LLM call (no provider request).
+- The API must return a deterministic, non-leaky error response (e.g. `429`).
+
+---
+
+## 4) Budget formula (upper bound)
+
+Define per-paying-user monthly LLM budget as an **upper bound**, not an average:
+
+\[
+LLM\_budget_{user/month}
+\le
+Price
+\times (1 - AppleFee)
+\times (1 - Tax)
+\times MarginTarget
+\]
+
+Where:
+
+- **Price**: subscription price
+- **AppleFee**: 0.15 or 0.30 depending on program/status
+- **Tax**: effective tax rate (use pessimistic estimate)
+- **MarginTarget**: desired retained margin (profit + reserves)
+
+**RU:** Квота в запросах/токенах должна быть производной от этого бюджета.  
+**EN:** Request/token quotas must be derived from this budget.
+
+---
+
+## 5) Minimal safe baseline (recommended)
+
+To guarantee a cost ceiling:
+
+1. VIP-only access (tier guard)
+2. Rate limiting (abuse burst protection)
+3. **Monthly hard quota** (cost ceiling)
+4. Cost shaping: input length cap, `max_tokens` cap, “cheap default model”
+5. Observability + kill-switch (rapid shutdown on anomaly)
+
+---
+
+## 6) Security notes
+
+**RU:** Quotas are security controls (economic DoS prevention), not “optimizations”.  
+**EN:** Quotas are security controls (economic DoS prevention), not “optimizations”.
+

--- a/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
+++ b/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
@@ -6,30 +6,21 @@
 
 ---
 
-## 1) Core statement (invariant)
+## English (Canonical)
 
-**RU:** LLM — это не “фича”, а **metered resource**. Любой LLM endpoint считается **небезопасным**
-до тех пор, пока не введён **жёсткий верхний предел затрат** (quota/budget) на пользователя/ключ.
+### 1) Invariant
 
-**EN:** LLM is a **metered resource**, not a feature. Any LLM endpoint is **economically unsafe**
-until it has a **hard cost cap** (quota/budget) per user/key.
+LLM is a **metered resource**, not a feature. Any LLM endpoint is **economically unsafe** until it has a
+**hard cost cap** (quota/budget) per user/key.
 
----
+### 2) Why VIP-only + rate limiting is insufficient
 
-## 2) Why VIP-only + rate-limit is insufficient
+Rate limiting bounds request velocity, not the time-integrated cost. A VIP user can sustain max usage every day.
+Therefore, cost is bounded per minute but **unbounded per month** without a quota/budget layer.
 
-**RU:** Rate limit ограничивает **скорость**, но не ограничивает **интеграл затрат по времени**.
-VIP пользователь (или атакующий с VIP ключом) может стабильно “съедать” лимит каждый день.
-Следовательно, cost bounded per minute, но **unbounded per month**.
+### 3) Hard requirement: quota / budget layer (P0 security)
 
-**EN:** Rate limiting bounds request velocity, not the time-integrated cost. A VIP user can sustain max usage
-every day. Therefore, cost is bounded per minute but **unbounded per month**.
-
----
-
-## 3) Hard requirement: quota / budget layer (P0 security)
-
-### 3.1 Hard cap definition
+#### 3.1 Hard cap definition
 
 At minimum, enforce one of:
 
@@ -37,16 +28,18 @@ At minimum, enforce one of:
 - **Tokens/month** (better)
 - **Estimated cost USD/month** (best; requires cost estimation inputs)
 
-### 3.2 Enforcement semantics
+#### 3.2 Enforcement semantics
 
 When quota is exceeded:
 
 - The server must **hard-stop** the LLM call (no provider request).
 - The API must return a deterministic, non-leaky error response (e.g. `429`).
 
----
+**Note:** VIP-only + rate limiting are necessary but not sufficient. Until a monthly hard quota is enforced,
+LLM endpoints remain **economically unsafe** by this policy and must be tracked as an open P0 security item in
+`docs/roadmap/BACKLOG_LEDGER.md`.
 
-## 4) Budget formula (upper bound)
+### 4) Budget formula (upper bound)
 
 Define per-paying-user monthly LLM budget as an **upper bound**, not an average:
 
@@ -66,12 +59,11 @@ Where:
 - **Tax**: effective tax rate (use pessimistic estimate)
 - **MarginTarget**: desired retained margin (profit + reserves)
 
-**RU:** Квота в запросах/токенах должна быть производной от этого бюджета.
-**EN:** Request/token quotas must be derived from this budget.
+Request/token quotas must be derived from this budget.
 
 ---
 
-## 5) Minimal safe baseline (recommended)
+### 5) Minimal safe baseline (recommended)
 
 To guarantee a cost ceiling:
 
@@ -83,7 +75,65 @@ To guarantee a cost ceiling:
 
 ---
 
-## 6) Security notes
+### 6) Security note
 
-**RU:** Quotas are security controls (economic DoS prevention), not “optimizations”.
-**EN:** Quotas are security controls (economic DoS prevention), not “optimizations”.
+Quotas are security controls (economic DoS prevention), not “optimizations”.
+
+---
+
+## Русская версия (Reference)
+
+### 1) Инвариант
+
+LLM — это **ресурс с учётом потребления**, а не “фича”. Любой LLM endpoint считается **экономически небезопасным**
+до тех пор, пока не введён **жёсткий верхний предел затрат** (quota/budget) на пользователя/ключ.
+
+### 2) Почему VIP-only + rate limit недостаточно
+
+Rate limit ограничивает скорость запросов, но не ограничивает **накопленную стоимость за месяц**.
+VIP пользователь (или атакующий с VIP ключом) может стабильно “съедать” лимит каждый день.
+Без quota/budget слой затрат остаётся **неограниченным во времени**.
+
+### 3) Требование (P0 security): quota / budget слой
+
+Минимально необходимо enforce один из вариантов:
+
+- **Requests/month** (самое простое)
+- **Tokens/month** (лучше)
+- **Estimated cost USD/month** (лучшее, требует оценки стоимости)
+
+При превышении квоты:
+
+- сервер **не делает** вызов провайдера (hard-stop),
+- API возвращает детерминированную ошибку без утечек (например `429`).
+
+**Примечание:** VIP-only + rate limiting необходимы, но недостаточны. Пока не введена monthly hard quota,
+LLM endpoints остаются **экономически небезопасными** по этой политике и должны быть отражены как открытый
+P0 security item в `docs/roadmap/BACKLOG_LEDGER.md`.
+
+### 4) Формула бюджета (upper bound)
+
+Бюджет LLM на платящего пользователя в месяц задаётся как upper bound:
+
+\[
+LLM\_budget_{user/month}
+\le
+Price
+\times (1 - AppleFee)
+\times (1 - Tax)
+\times MarginTarget
+\]
+
+Квоты в запросах/токенах должны быть производными от этого бюджета.
+
+### 5) Минимальный безопасный контур
+
+1. VIP-only (tier guard)
+2. Rate limiting (burst protection)
+3. **Monthly hard quota** (ceiling)
+4. Cost shaping (input cap, max_tokens, cheap default model)
+5. Observability + kill-switch
+
+### 6) Security note
+
+Квоты — это security control (защита от “денежного DoS”), а не “оптимизация”.

--- a/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
+++ b/docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
@@ -1,7 +1,7 @@
 ## LLM Unit Economics Guardrails (Hard Policy)
 
-**Last updated:** 5 February 2026  
-**Scope:** Backend only (LLM endpoints, e.g. `/api/v1/insight`).  
+**Last updated:** 5 February 2026
+**Scope:** Backend only (LLM endpoints, e.g. `/api/v1/insight`).
 **Goal:** Guarantee **positive unit economics under worst-case usage**.
 
 ---
@@ -66,7 +66,7 @@ Where:
 - **Tax**: effective tax rate (use pessimistic estimate)
 - **MarginTarget**: desired retained margin (profit + reserves)
 
-**RU:** Квота в запросах/токенах должна быть производной от этого бюджета.  
+**RU:** Квота в запросах/токенах должна быть производной от этого бюджета.
 **EN:** Request/token quotas must be derived from this budget.
 
 ---
@@ -85,6 +85,5 @@ To guarantee a cost ceiling:
 
 ## 6) Security notes
 
-**RU:** Quotas are security controls (economic DoS prevention), not “optimizations”.  
+**RU:** Quotas are security controls (economic DoS prevention), not “optimizations”.
 **EN:** Quotas are security controls (economic DoS prevention), not “optimizations”.
-

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -216,6 +216,8 @@ If it is not recorded here — it does not exist.
   - Target PR: PR-640 (runtime), PR-646 (docs-only closure)
   - Status: ✅ Done
   - Reason: Implemented VIP-only access for `/api/v1/insight` and legacy `/insight` (VIP-guarded, hidden from OpenAPI) + kept rate-limiting. This ledger entry was stale vs `main`.
+  - Residual risk / follow-up: monthly hard quota/budget enforcement is still required (see next P0 item). Until then,
+    LLM endpoints remain economically unsafe per `docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md`.
   - Links:
     - docs/audit/LEGACY_APP_MIGRATION_STATUS.md (Tier guards section)
     - docs/audit/AUDIT_GAPS_ANALYSIS.md (LLM cost control gap)
@@ -226,6 +228,26 @@ If it is not recorded here — it does not exist.
     - ✅ `/insight` is VIP-guarded (deprecated + hidden from OpenAPI)
     - ✅ Tests verify FREE/PRO users get 403, VIP users get 200
     - ✅ OpenAPI shows `/api/v1/insight` and hides `/insight`
+
+- [ ] P0 CRITICAL SECURITY: VIP LLM hard monthly quota (deterministic enforcement)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (CRITICAL security)
+  - Target PR: TBD (security fix)
+  - Status: 📋 Ready to start
+  - Reason: VIP-only + rate limit prevent bursts but do not provide a monthly cost ceiling; without quota, sustained
+    usage can still create an economic DoS. Policy requires a hard cost cap for LLM endpoints.
+  - Links:
+    - docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
+    - docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md
+  - DoD:
+    - Server-side authoritative quota per VIP key (requests/month OR tokens/month OR estimated cost/month)
+    - Hard-stop before provider call when quota exceeded
+    - Deterministic non-leaky error response on exceed (prefer `429`, e.g. `quota_exceeded`)
+    - Tests:
+      - VIP under quota → 200
+      - VIP over quota → 429
+      - FREE/PRO remain → 403
+    - Minimal observability: counters/logging for usage and quota decisions
 
 - [ ] P0: CI nightly — test DB schema bootstrap broken (users/nutrition_events missing)
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -210,21 +210,22 @@ If it is not recorded here — it does not exist.
 
 ### P0 Move LLM insight to VIP tier
 
-- [ ] P0 CRITICAL: Move LLM insight to VIP tier (prevent FREE tier abuse)
+- [x] P0 CRITICAL: Move LLM insight to VIP tier (prevent FREE tier abuse)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (CRITICAL security)
-  - Target PR: TBD (security fix)
-  - Status: 📋 Ready to start
-  - Reason: `/api/v1/insight` uses `_get_api_key_dynamic` (API key check only, not tier-aware) → FREE users can access expensive LLM API. `/insight` has no auth at all. LLM should be VIP-only feature.
+  - Target PR: PR-640 (runtime), PR-646 (docs-only closure)
+  - Status: ✅ Done
+  - Reason: Implemented VIP-only access for `/api/v1/insight` and legacy `/insight` (VIP-guarded, hidden from OpenAPI) + kept rate-limiting. This ledger entry was stale vs `main`.
   - Links:
     - docs/audit/LEGACY_APP_MIGRATION_STATUS.md (Tier guards section)
     - docs/audit/AUDIT_GAPS_ANALYSIS.md (LLM cost control gap)
-    - legacy_app.py:2256-2301 (`/api/v1/insight`), 2305-2348 (`/insight`)
+    - PR-640: Enforce VIP tier for LLM Insight (runtime implementation)
+    - docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md (evidence + ledger closure)
   - DoD:
-    - Replace `_get_api_key_dynamic` with `require_vip_tier()` on `/api/v1/insight`
-    - Remove `/insight` endpoint (deprecated, no auth) OR add VIP tier guard
-    - Tests verify FREE/PRO users get 403, VIP users get 200
-    - Update OpenAPI schema (insight endpoints require VIP tier)
+    - ✅ `/api/v1/insight` uses `require_vip_tier()` (VIP-only)
+    - ✅ `/insight` is VIP-guarded (deprecated + hidden from OpenAPI)
+    - ✅ Tests verify FREE/PRO users get 403, VIP users get 200
+    - ✅ OpenAPI shows `/api/v1/insight` and hides `/insight`
 
 - [ ] P0: CI nightly — test DB schema bootstrap broken (users/nutrition_events missing)
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
- Close stale P0 ledger item for VIP-only LLM insight by linking the already-merged runtime implementation (PR-640) to an evidence-driven audit.
- Add a hard policy doc defining LLM as a metered resource requiring a quota/budget layer to guarantee positive unit economics.

## Evidence
- See `docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md` (commands + raw outputs + exit codes).

## Scope
- Docs-only: `docs/audit/*`, `docs/roadmap/BACKLOG_LEDGER.md`, `docs/policy/*`.
- No runtime code changes.

## Test plan
- `pre-commit run --all-files`

## Deferred / Follow-ups
- Next P0: implement VIP monthly hard quota enforcement (separate PR).

## Summary by Sourcery

Закрыть устаревший пункт P0 в реестре задач о переводе LLM Insight в режим только для VIP, задокументировав существующее поведение на этапе выполнения и установив экономические ограничители для использования LLM.

Улучшения:
- Обновить реестр задач, чтобы пометить пункт P0 о VIP-режиме для LLM Insight как выполненный и сослаться на PR-ы реализации и аудита.

Документация:
- Добавить подробный аудиторский документ, фиксирующий доказательства того, что LLM Insight уже ограничен VIP-доступом, имеет лимиты скорости и протестирован, а также обосновывающий закрытие пункта реестра только за счёт документации.
- Ввести жёсткий политический документ, определяющий LLM как тарифицируемый ресурс, требующий лимитов затрат на основе квот/бюджета, и описывающий минимальные требования по безопасности для LLM-эндпоинтов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Close the stale P0 ledger item for making LLM Insight VIP-only by documenting existing runtime behavior and establishing economic guardrails for LLM usage.

Enhancements:
- Update the backlog ledger to mark the VIP-only LLM Insight P0 item as done and reference the implementing and audit PRs.

Documentation:
- Add a detailed audit document capturing evidence that LLM Insight is already VIP-gated, rate-limited, and tested, and justifying the docs-only closure of the ledger item.
- Introduce a hard policy document defining LLM as a metered resource that requires quota/budget-based cost caps and outlining minimum safety controls for LLM endpoints.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the P0 security ledger item by documenting that LLM Insight is VIP-only and rate-limited, and adds a hard unit-economics policy requiring monthly quotas/budgets for LLM endpoints. Docs-only; no runtime changes.

- **Docs**
  - Added an evidence-driven audit confirming VIP tier guards on `/api/v1/insight` and deprecated `/insight`, plus rate limiting and passing tests.
  - Added LLM Unit Economics Guardrails policy: quotas/budgets per user/month with hard-stop (429) enforcement.
  - Updated BACKLOG_LEDGER to mark the item Done, reference the audit, and add a new P0 for monthly quota enforcement.

<sup>Written for commit 2f5a942e7f191a9e7756ef01456ec4a0726c40ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new LLM unit-economics guardrails policy specifying hard monthly quota rules, deterministic enforcement, and recommended cost-shaping controls.
  * Added an audit documenting VIP-only access and visibility controls for LLM Insight endpoints, findings, and risk notes.
  * Updated the project roadmap/backlog to mark the LLM access-tier migration as done and to add a critical P0 item for deterministic hard monthly quotas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->