### PR TITLE
PR-647: VIP LLM hard monthly quota (deterministic enforcement)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
 
           # Start container with tightened security
           docker run -d --name pulseplate-test -p 8000:8000 \
+            -e SERVER_SALT=ci-test-salt \
             --cap-drop=ALL \
             --security-opt no-new-privileges \
             pulseplate:test

--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Test health endpoint locally
         run: |
           echo "🏥 Testing health endpoint locally..."
-          docker run --rm -d --name pulseplate-test -p 8000:8000 ghcr.io/${{ steps.image-name.outputs.image_name }}:${{ github.event.workflow_run.head_sha }}
+          docker run --rm -d --name pulseplate-test -p 8000:8000 \
+            -e SERVER_SALT=ci-test-salt \
+            ghcr.io/${{ steps.image-name.outputs.image_name }}:${{ github.event.workflow_run.head_sha }}
           sleep 10
           curl -f http://localhost:8000/health || echo "⚠️ Health check failed (expected without frontend)"
           docker stop pulseplate-test

--- a/.github/workflows/docker-openapi-smoke.yml
+++ b/.github/workflows/docker-openapi-smoke.yml
@@ -55,12 +55,14 @@ jobs:
           # Build the env var names dynamically to avoid false positives while still configuring the container.
           api_key_name="API""_KEY"
           allow_dev_api_key_name="ALLOW_DEV_API""_KEY"
+          server_salt_name="SERVER""_SALT"
 
           args=(
             -d
             --rm
             -p 8000:8000
             -e "${api_key_name}=test_key"
+            -e "${server_salt_name}=ci-test-salt"
             -e APP_ENV=production
             -e ENVIRONMENT=production
             -e "${allow_dev_api_key_name}=false"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -449,7 +449,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 371
       }
     ],
     "tests/disabled_hypothesis/test_life_stage_error_branches_hypothesis.py": [
@@ -1627,5 +1627,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-05T08:19:31Z"
+  "generated_at": "2026-02-05T15:43:44Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ If adding rate-limit to endpoints, use thin **route wrappers**; do not change ca
 - Runtime behavior is env-gated: in tests (`TESTING=true`) rate limiting is disabled unless `RATE_LIMITING_IN_TESTS=true`.
 - Client identification uses proxy-aware key_func with CIDR support (`app/security/rate_limit.py`).
 
+**LLM Monthly Quota Policy (Hard rule):**
+
+- All LLM endpoints MUST enforce a **server-side monthly hard quota** **before** any provider call.
+- Minimal baseline quota unit is **`requests/month`** (budget/cost-based quotas may be added later).
+- Quota MUST be deterministic (no soft-limit-only behavior) and have tests that prove enforcement.
+
 **Rationale:**
 
 - LLM endpoints: $72k/month abuse risk (documented in `BACKLOG_LEDGER.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ If adding rate-limit to endpoints, use thin **route wrappers**; do not change ca
 - All LLM endpoints MUST enforce a **server-side monthly hard quota** **before** any provider call.
 - Minimal baseline quota unit is **`requests/month`** (budget/cost-based quotas may be added later).
 - Quota MUST be deterministic (no soft-limit-only behavior) and have tests that prove enforcement.
+- Feature flags MUST be checked **before** quota consumption (no charging when a feature is disabled).
 - CI container smoke-start MUST set `SERVER_SALT` (dummy value allowed) so app startup can pass fail-fast requirements.
 
 **Rationale:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ If adding rate-limit to endpoints, use thin **route wrappers**; do not change ca
 - All LLM endpoints MUST enforce a **server-side monthly hard quota** **before** any provider call.
 - Minimal baseline quota unit is **`requests/month`** (budget/cost-based quotas may be added later).
 - Quota MUST be deterministic (no soft-limit-only behavior) and have tests that prove enforcement.
+- CI container smoke-start MUST set `SERVER_SALT` (dummy value allowed) so app startup can pass fail-fast requirements.
 
 **Rationale:**
 

--- a/alembic/versions/202602050001_add_vip_llm_monthly_usage.py
+++ b/alembic/versions/202602050001_add_vip_llm_monthly_usage.py
@@ -1,0 +1,38 @@
+"""Add vip_llm_monthly_usage table (VIP LLM hard monthly quota).
+
+RU: Таблица vip_llm_monthly_usage для жёсткой месячной квоты VIP LLM (requests/month).
+EN: Add vip_llm_monthly_usage table for VIP LLM monthly hard quota (requests/month).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202602050001"
+down_revision = "20251225001838"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """RU: Создаём usage-таблицу для месячного счётчика VIP LLM.
+
+    EN: Create usage table for VIP LLM monthly counters.
+    """
+    op.create_table(
+        "vip_llm_monthly_usage",
+        sa.Column("key_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("month_start_date", sa.Date(), nullable=False),
+        sa.Column("used_requests", sa.Integer(), nullable=False, server_default="0"),
+        sa.PrimaryKeyConstraint("key_fingerprint", "month_start_date"),
+    )
+
+
+def downgrade() -> None:
+    """RU: Удаляем usage-таблицу.
+
+    EN: Drop usage table.
+    """
+    op.drop_table("vip_llm_monthly_usage")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,13 @@
 """Shared models for the application."""
 
 from app.models.events import JSONEncodedDict, NutritionEvent
+from app.models.llm_quota_usage import VipLlmMonthlyUsage
 from app.models.plans import DayPlan, WeeklyPlan
 
-__all__ = ["JSONEncodedDict", "NutritionEvent", "WeeklyPlan", "DayPlan"]
+__all__ = [
+    "DayPlan",
+    "JSONEncodedDict",
+    "NutritionEvent",
+    "VipLlmMonthlyUsage",
+    "WeeklyPlan",
+]

--- a/app/models/llm_quota_usage.py
+++ b/app/models/llm_quota_usage.py
@@ -22,7 +22,6 @@ class VipLlmMonthlyUsage(Base):
     """
 
     __tablename__ = "vip_llm_monthly_usage"
-    __table_args__ = {"extend_existing": True}
 
     key_fingerprint: Mapped[str] = mapped_column(String(64), primary_key=True)
     month_start_date: Mapped[date] = mapped_column(Date, primary_key=True)

--- a/app/models/llm_quota_usage.py
+++ b/app/models/llm_quota_usage.py
@@ -1,0 +1,29 @@
+"""LLM monthly usage models (VIP hard quota).
+
+RU: Модели учёта использования LLM по месячным корзинам (для hard quota).
+EN: Models for monthly LLM usage accounting (hard quota enforcement).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import Date, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.db import Base
+
+
+class VipLlmMonthlyUsage(Base):
+    """Monthly usage counter per VIP key fingerprint.
+
+    RU: Счётчик запросов по VIP ключу (fingerprint) и месяцу (UTC calendar month).
+    EN: Usage counter keyed by VIP key fingerprint and UTC calendar month.
+    """
+
+    __tablename__ = "vip_llm_monthly_usage"
+    __table_args__ = {"extend_existing": True}
+
+    key_fingerprint: Mapped[str] = mapped_column(String(64), primary_key=True)
+    month_start_date: Mapped[date] = mapped_column(Date, primary_key=True)
+    used_requests: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/app/security/llm_monthly_quota.py
+++ b/app/security/llm_monthly_quota.py
@@ -80,6 +80,10 @@ def month_start_date_utc(now: datetime | None = None) -> date:
     """Return UTC calendar month bucket start date (YYYY-MM-01)."""
 
     dt = now or datetime.now(timezone.utc)
+    # RU: Наивные datetime трактуем как UTC (а не local time), иначе astimezone() может сместить месяц.
+    # EN: Treat naive datetimes as UTC (not local time) to avoid month bucket drift.
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     dt_utc = dt.astimezone(timezone.utc)
     return date(dt_utc.year, dt_utc.month, 1)
 

--- a/app/security/llm_monthly_quota.py
+++ b/app/security/llm_monthly_quota.py
@@ -1,0 +1,118 @@
+"""VIP LLM monthly hard quota enforcement.
+
+RU: Жёсткая месячная квота для VIP LLM (requests/month), авторитетный счётчик в БД.
+EN: VIP monthly hard quota for LLM endpoints (requests/month), authoritative DB counter.
+
+Design goals (P0):
+- Deterministic hard-stop before provider call
+- Atomic check+increment (parallel-safe)
+- No raw key storage (fingerprint only, salted)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import date, datetime, timezone
+
+from sqlalchemy import text
+
+from core.db import session_scope
+
+from app.models.llm_quota_usage import VipLlmMonthlyUsage  # noqa: F401  # register table metadata
+
+_SERVER_SALT_ENV = "SERVER_SALT"
+_VIP_LIMIT_ENV = "VIP_LLM_INSIGHT_REQUESTS_PER_MONTH"
+
+# NOTE: Table name must match app/models/llm_quota_usage.py.
+_USAGE_TABLE = "vip_llm_monthly_usage"
+
+
+def require_server_salt() -> str:
+    """Return SERVER_SALT or raise (fail-fast contract).
+
+    RU: Возвращает SERVER_SALT или падает (fail-fast).
+    EN: Returns SERVER_SALT or raises (fail-fast).
+    """
+
+    salt = (os.getenv(_SERVER_SALT_ENV) or "").strip()
+    if not salt:
+        raise RuntimeError(
+            "SERVER_SALT is required for VIP LLM monthly quota enforcement. "
+            "Set SERVER_SALT to a non-empty secret value."
+        )
+    return salt
+
+
+def vip_llm_monthly_limit_requests() -> int:
+    """Return VIP monthly request limit (env-backed, safe default)."""
+
+    raw = (os.getenv(_VIP_LIMIT_ENV) or "").strip()
+    if not raw:
+        return 30
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{_VIP_LIMIT_ENV} must be an integer, got {raw!r}") from exc
+    if value < 1:
+        raise ValueError(f"{_VIP_LIMIT_ENV} must be >= 1, got {value}")
+    return value
+
+
+def month_start_date_utc(now: datetime | None = None) -> date:
+    """Return UTC calendar month bucket start date (YYYY-MM-01)."""
+
+    dt = now or datetime.now(timezone.utc)
+    dt_utc = dt.astimezone(timezone.utc)
+    return date(dt_utc.year, dt_utc.month, 1)
+
+
+def vip_key_fingerprint(raw_key: str) -> str:
+    """Return salted VIP key fingerprint (hex sha256).
+
+    RU: Никогда не хранить raw ключ; используем sha256(key + SERVER_SALT).
+    EN: Never store raw keys; fingerprint is sha256(key + SERVER_SALT).
+    """
+
+    salt = require_server_salt()
+    data = (raw_key + salt).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def attempt_consume_vip_llm_monthly_quota(
+    raw_vip_key: str,
+    *,
+    month_start: date | None = None,
+    limit_requests: int | None = None,
+) -> bool:
+    """Atomically consume one unit from the VIP monthly quota.
+
+    Returns:
+        True if quota was consumed (request may proceed),
+        False if quota is exceeded (hard stop).
+    """
+
+    fp = vip_key_fingerprint(raw_vip_key)
+    bucket = month_start or month_start_date_utc()
+    limit_val = limit_requests if limit_requests is not None else vip_llm_monthly_limit_requests()
+
+    # Single-statement upsert with guard:
+    # - First request: insert (used_requests=1)
+    # - Subsequent: update (used_requests += 1) only if current used_requests < limit
+    # NOTE: Keep table name as a literal string to satisfy Bandit B608.
+    # The table name is a fixed internal constant, not user input.
+    sql = text("""
+        INSERT INTO vip_llm_monthly_usage (key_fingerprint, month_start_date, used_requests)
+        VALUES (:fp, :month_start, 1)
+        ON CONFLICT(key_fingerprint, month_start_date)
+        DO UPDATE SET used_requests = used_requests + 1
+        WHERE used_requests < :limit_val
+        RETURNING used_requests
+        """)
+
+    with session_scope() as session:
+        row = session.execute(
+            sql,
+            {"fp": fp, "month_start": bucket, "limit_val": limit_val},
+        ).first()
+        return row is not None

--- a/app/security/llm_monthly_quota.py
+++ b/app/security/llm_monthly_quota.py
@@ -27,6 +27,8 @@ _VIP_LIMIT_ENV = "VIP_LLM_INSIGHT_REQUESTS_PER_MONTH"
 # NOTE: Table name must match app/models/llm_quota_usage.py.
 _USAGE_TABLE = "vip_llm_monthly_usage"
 
+DEFAULT_VIP_LLM_INSIGHT_REQUESTS_PER_MONTH = 30
+
 
 def require_server_salt() -> str:
     """Return SERVER_SALT or raise (fail-fast contract).
@@ -44,19 +46,34 @@ def require_server_salt() -> str:
     return salt
 
 
-def vip_llm_monthly_limit_requests() -> int:
-    """Return VIP monthly request limit (env-backed, safe default)."""
+def require_vip_llm_monthly_limit() -> int:
+    """Validate VIP LLM monthly limit at startup (fail-fast).
+
+    RU: Валидируем лимит на старте. Падаем сразу при некорректном значении.
+    EN: Validate quota limit at startup. Fail fast on invalid config.
+    """
 
     raw = (os.getenv(_VIP_LIMIT_ENV) or "").strip()
-    if not raw:
-        return 30
+    if raw == "":
+        return DEFAULT_VIP_LLM_INSIGHT_REQUESTS_PER_MONTH
+
     try:
         value = int(raw)
     except ValueError as exc:
-        raise ValueError(f"{_VIP_LIMIT_ENV} must be an integer, got {raw!r}") from exc
+        raise RuntimeError(f"{_VIP_LIMIT_ENV} must be an integer >= 1.") from exc
+
     if value < 1:
-        raise ValueError(f"{_VIP_LIMIT_ENV} must be >= 1, got {value}")
+        raise RuntimeError(f"{_VIP_LIMIT_ENV} must be an integer >= 1.")
+
     return value
+
+
+def vip_llm_monthly_limit_requests() -> int:
+    """Return VIP monthly request limit (env-backed, safe default)."""
+
+    # Keep this helper stable: runtime code may call it outside startup.
+    # Startup validation is enforced by require_vip_llm_monthly_limit().
+    return require_vip_llm_monthly_limit()
 
 
 def month_start_date_utc(now: datetime | None = None) -> date:

--- a/app/security/llm_monthly_quota.py
+++ b/app/security/llm_monthly_quota.py
@@ -113,6 +113,11 @@ def attempt_consume_vip_llm_monthly_quota(
     bucket = month_start or month_start_date_utc()
     limit_val = limit_requests if limit_requests is not None else vip_llm_monthly_limit_requests()
 
+    if limit_val < 1:
+        # RU: Fail closed — неверная конфигурация/параметр не должен давать доступ.
+        # EN: Fail closed — invalid config/param must not grant access.
+        return False
+
     # Single-statement upsert with guard:
     # - First request: insert (used_requests=1)
     # - Subsequent: update (used_requests += 1) only if current used_requests < limit
@@ -122,8 +127,8 @@ def attempt_consume_vip_llm_monthly_quota(
         INSERT INTO vip_llm_monthly_usage (key_fingerprint, month_start_date, used_requests)
         VALUES (:fp, :month_start, 1)
         ON CONFLICT(key_fingerprint, month_start_date)
-        DO UPDATE SET used_requests = used_requests + 1
-        WHERE used_requests < :limit_val
+        DO UPDATE SET used_requests = vip_llm_monthly_usage.used_requests + 1
+        WHERE vip_llm_monthly_usage.used_requests < :limit_val
         RETURNING used_requests
         """)
 

--- a/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
+++ b/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
@@ -103,6 +103,117 @@ Evidence: [E7]
 
 ---
 
+## 2) Quota Model (Design decisions)
+
+### Q10. Quota unit (first iteration)
+
+✅ **`requests/month` per VIP key**
+
+Rationale (budget-first P0):
+
+- Cheapest enforceable hard cap (does not require provider token accounting or pricing tables).
+- Provides a strict upper bound on LLM spend by limiting the number of paid provider calls per month.
+
+### Q11. Limit source (config)
+
+✅ **ENV**: `VIP_LLM_INSIGHT_REQUESTS_PER_MONTH` (with a safe default in code)
+
+Constraints:
+
+- Server-side authoritative (no trust in client).
+- Must be easy to tune without code changes (ops-friendly).
+
+### Q11. Counter storage (authoritative usage table)
+
+✅ **DB (SQLAlchemy) usage table**, authoritative
+
+Constraints (security + determinism):
+
+- **Never store raw VIP key**. Store `key_fingerprint = sha256(raw_key + server_salt)`, where `server_salt` is read from env.
+- `server_salt`: **required env (no default)**; rotation requires counter migration policy (non-goal for P0).
+- Bucket is **UTC calendar month**: `YYYY-MM-01T00:00:00Z`. Store as `month_start_date` (`date`) for simplicity.
+- **Atomicity (hard requirement):** check + increment must be one atomic operation (single statement or transactional
+  upsert/increment with guard), otherwise parallel requests can break the hard cap.
+
+### Q12. VIP tier binding (P0)
+
+✅ One shared limit for all VIP keys (per key), P0 baseline.
+
+Non-goals (explicitly out of scope for P0):
+
+- Per-plan quotas
+- Tokens/month or cost/month accounting
+- Paid add-ons / rollover / proration
+
+---
+
+## 3) Enforcement semantics (Hard)
+
+### 3.1 Where enforcement runs (hard stop seam)
+
+Quota enforcement must run **inside the handler** and must hard-stop **before** the provider call
+(`await provider.generate(...)`).
+
+Evidence seam: `legacy_app.py:2127` and `legacy_app.py:2172` (see [E7]).
+
+### 3.2 What enforcement does (attempt-consume semantics)
+
+Define a single server-side authoritative operation (conceptual name: `attempt_consume_quota(...)`):
+
+- If allowed: atomically **increment** usage for `(key_fingerprint, month_start_date)` and continue request handling.
+- If exceeded: return **HTTP 429** with deterministic payload:
+  - `{"detail": "quota_exceeded"}`
+  - No provider exception leakage (stable error contract).
+
+### 3.3 Bucket (monthly boundary)
+
+`month_start_date = first_day_utc(today_utc)` (UTC calendar month), stored as `date`:
+
+- Example: `2026-02-01` represents `2026-02-01T00:00:00Z`.
+
+### 3.4 Idempotency / retries (explicit non-goal for P0)
+
+Non-goal (P0): idempotency keys / deduplication.
+
+Constraints:
+
+- Quota counts **per request attempt**.
+- Clients must not automatically retry on 5xx without an idempotency key; otherwise retries may consume quota twice.
+
+---
+
+## 4) Reset semantics (Time boundaries)
+
+Reset is achieved by selecting a **new UTC calendar month bucket** (`month_start_date`) automatically:
+
+- No cron/job is required for reset.
+- Old usage rows are retained (non-goal for P0: cleanup/compaction).
+
+---
+
+## 5) Tests + DoD (P0 minimum)
+
+### 5.1 Tests (security-critical matrix)
+
+Minimum required tests for P0:
+
+1. **VIP under quota → 200**
+2. **VIP over quota → 429** with deterministic payload `{"detail": "quota_exceeded"}` and no-leak checks
+3. **FREE/PRO → 403** (no regression vs VIP tier guard)
+4. **Concurrency / atomicity proof**: `limit=1`, two parallel requests → exactly **1 succeeds**, **1 returns quota_exceeded**
+
+### 5.2 DoD (runtime)
+
+P0 is complete only if:
+
+- Quota enforcement runs **before** provider call (`provider.generate(...)`).
+- Counter is stored in DB keyed by `(key_fingerprint, month_start_date)`.
+- `server_salt` is **required env** (no default) and startup fails with a clear error if missing.
+- OpenAPI and client artifacts are unchanged.
+- Targeted pytest suite for quota is green, and `pre-commit` is green.
+
+---
+
 ## Appendix: Evidence (append-only)
 
 ### [E1] Ledger item exists (SoT)

--- a/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
+++ b/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
@@ -1,0 +1,218 @@
+## PR-647 — VIP LLM Monthly Hard Quota (P0 Security) — Audit
+
+**Date:** 5 February 2026
+**Owner:** @katsiaryna_kavaleuskaya
+**PR:** PR-647
+**Branch:** `security/p0-vip-llm-monthly-quota-pr647`
+**Scope (hard):** backend/security only. **No frontend / iOS / new LLM features / refactors.**
+
+---
+
+## Summary (high signal)
+
+- Policy requires a **monthly hard quota/budget** for any LLM endpoint to be economically safe. Evidence: [E2]
+- Current runtime has **VIP-only + rate limiting**, but **no monthly quota** (no symbols / no accounting layer). Evidence: [E3], [E4]
+- Provider call happens at `await provider.generate(prompt_text)` inside `legacy_app.py` — the interception seam for hard stop. Evidence: [E7]
+- Insight endpoints exist at runtime: `POST /api/v1/insight` and legacy `POST /insight`. Evidence: [E6]
+
+---
+
+## 0) Audit Meta
+
+### 0.1 Ledger item (SoT)
+
+This PR closes ledger item:
+**P0 CRITICAL SECURITY: VIP LLM hard monthly quota (deterministic enforcement)**.
+
+Evidence: [E1]
+
+### 0.2 Policy source (SoT)
+
+Quota is mandatory by policy:
+`docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md`.
+
+Evidence: [E2]
+
+### 0.3 Allowed files (PR-647)
+
+Allowed to change (non-exhaustive, scope-minimal):
+
+- `legacy_app.py` (insight endpoints; enforcement seam)
+- `app/security/*` (shared enforcement helpers, if any)
+- `core/*` (shared accounting primitives, if needed)
+- `tests/*` (deterministic enforcement tests)
+- `docs/audit/*`, `docs/roadmap/BACKLOG_LEDGER.md` (audit + ledger updates)
+
+Forbidden:
+
+- `frontend/`, `ios/`
+- any new LLM product features or business logic changes
+- soft limits without hard stop
+
+---
+
+## 1) Current State (Evidence: BEFORE)
+
+### 1.1 Usage accounting
+
+**Q4. Where is LLM usage accounted (requests/tokens/cost)?**
+
+Finding: no explicit accounting layer exists for LLM usage in runtime code (no requests/month, tokens/month, cost/month).
+
+Evidence: [E3], [E4]
+
+**Q5. Is there persistent storage for counters?**
+
+Finding: no evidence of quota counters/persistent store configuration for LLM quota in codebase at this time.
+(Rate limiting is configured via SlowAPI; explicit Redis/storage URI configuration is not found in repo code.)
+
+Evidence: [E5]
+
+**Q6. Reset semantics (monthly boundary)?**
+
+Finding: not applicable yet — there is no monthly quota/counter to reset.
+
+Evidence: [E3], [E4]
+
+### 1.2 Enforcement
+
+**Q7. Any hard stop by cumulative usage?**
+
+Finding: no hard stop exists for cumulative usage (monthly quota). Current stops are:
+
+- VIP tier guard (403) at route level
+- rate limiting (429) at route level
+- `FEATURE_INSIGHT` kill-switch (503) before provider call
+- provider missing (503) before provider call
+
+Evidence: [E2], [E7]
+
+**Q8. Where exactly is the provider call (interception seam)?**
+
+Finding: provider call occurs at:
+`await provider.generate(prompt_text)` inside `legacy_app.py` insight functions.
+
+Evidence: [E7]
+
+**Q9. Can we stop the request before provider call?**
+
+Finding: yes — the code path already has pre-provider gates (VIP guard, rate limiting, kill-switch),
+and PR-647 must add quota enforcement **before** `provider.generate(...)`.
+
+Evidence: [E7]
+
+---
+
+## Appendix: Evidence (append-only)
+
+### [E1] Ledger item exists (SoT)
+
+Command:
+```bash
+rg -n "P0 CRITICAL SECURITY: VIP LLM hard monthly quota" docs/roadmap/BACKLOG_LEDGER.md -n -C 3
+```
+
+Raw output (truncated):
+```text
+232:- [ ] P0 CRITICAL SECURITY: VIP LLM hard monthly quota (deterministic enforcement)
+233-  - Owner: @katsiaryna_kavaleuskaya
+234-  - Priority: P0 (CRITICAL security)
+235-  - Target PR: TBD (security fix)
+```
+
+Exit code: `0`
+
+### [E2] Policy requires monthly hard quota (SoT)
+
+Command:
+```bash
+rg -n "economically unsafe|hard cost cap|Monthly hard quota|monthly hard quota" docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md -n
+```
+
+Raw output (truncated):
+```text
+13:LLM is a **metered resource**, not a feature. Any LLM endpoint is **economically unsafe** until it has a
+14:**hard cost cap** (quota/budget) per user/key.
+38:**Note:** VIP-only + rate limiting are necessary but not sufficient. Until a monthly hard quota is enforced,
+39:LLM endpoints remain **economically unsafe** by this policy and must be tracked as an open P0 security item in
+72:3. **Monthly hard quota** (cost ceiling)
+```
+
+Exit code: `0`
+
+### [E3] No quota symbols in code (expected)
+
+Command:
+```bash
+rg -n "INSIGHT_QUOTA|LLM_QUOTA|quota_exceeded|monthly quota|hard quota" --type py app core legacy_app.py llm.py providers
+```
+
+Raw output:
+```text
+<empty>
+```
+
+Exit code: `1`
+
+### [E4] No token-usage accounting symbols in insight code (expected)
+
+Command:
+```bash
+rg -n "prompt_tokens|completion_tokens|total_tokens|token_usage" legacy_app.py llm.py providers
+```
+
+Raw output:
+```text
+<empty>
+```
+
+Exit code: `1`
+
+### [E5] No explicit rate-limit storage config found in repo code (expected)
+
+Command:
+```bash
+rg -n "redis://|storage_uri|RATELIMIT_STORAGE|RATE_LIMIT_STORAGE" --type py app core legacy_app.py
+```
+
+Raw output:
+```text
+<empty>
+```
+
+Exit code: `1`
+
+### [E6] Insight endpoints exist at runtime
+
+Command:
+```bash
+python - <<'PY'
+import os
+os.environ['TESTING'] = 'true'
+import app
+paths = {r.path for r in app.app.routes}
+print('/api/v1/insight' in paths)
+print('/insight' in paths)
+PY
+```
+
+Raw output (truncated):
+```text
+True
+True
+```
+
+Exit code: `0`
+
+### [E7] Provider call + pre-provider gates (interception seam)
+
+Evidence anchor: `legacy_app.py:2127` and `legacy_app.py:2172` (`provider.generate(...)`) and kill-switch gate
+`legacy_app.py:2142-2145` (`FEATURE_INSIGHT`).
+
+Source excerpt:
+```text
+legacy_app.py:2127  insight_text = await provider.generate(prompt_text)
+legacy_app.py:2142  flag_value = os.getenv("FEATURE_INSIGHT", "false")
+legacy_app.py:2143  if not _is_truthy(flag_value): ...
+legacy_app.py:2172  insight_text = await provider.generate(prompt_text)
+```

--- a/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
+++ b/docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
@@ -123,7 +123,7 @@ Constraints:
 - Server-side authoritative (no trust in client).
 - Must be easy to tune without code changes (ops-friendly).
 
-### Q11. Counter storage (authoritative usage table)
+### Q12. Counter storage (authoritative usage table)
 
 ✅ **DB (SQLAlchemy) usage table**, authoritative
 
@@ -135,7 +135,7 @@ Constraints (security + determinism):
 - **Atomicity (hard requirement):** check + increment must be one atomic operation (single statement or transactional
   upsert/increment with guard), otherwise parallel requests can break the hard cap.
 
-### Q12. VIP tier binding (P0)
+### Q13. VIP tier binding (P0)
 
 ✅ One shared limit for all VIP keys (per key), P0 baseline.
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -232,8 +232,8 @@ If it is not recorded here — it does not exist.
 - [ ] P0 CRITICAL SECURITY: VIP LLM hard monthly quota (deterministic enforcement)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (CRITICAL security)
-  - Target PR: TBD (security fix)
-  - Status: 📋 Ready to start
+  - Target PR: PR-647 (security fix)
+  - Status: 🟡 In progress (PR-647)
   - Reason: VIP-only + rate limit prevent bursts but do not provide a monthly cost ceiling; without quota, sustained
     usage can still create an economic DoS. Policy requires a hard cost cap for LLM endpoints.
   - Links:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -115,6 +115,7 @@ from app.middleware.api_tiers import require_vip_tier
 from app.security.llm_monthly_quota import (
     attempt_consume_vip_llm_monthly_quota,
     require_server_salt,
+    require_vip_llm_monthly_limit,
 )
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
@@ -499,6 +500,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # PR-647 (P0 security): Monthly quota fingerprinting requires a secret salt.
     # Fail-fast on startup to avoid running with predictable/empty fingerprints.
     require_server_salt()
+    require_vip_llm_monthly_limit()
 
     try:
         init_db()

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -112,6 +112,10 @@ from app.scheduler_helpers import (
 from app.utils.helpers import _resolve_app_callable, _short_git_sha
 from app.utils.feature_flags import _is_truthy
 from app.middleware.api_tiers import require_vip_tier
+from app.security.llm_monthly_quota import (
+    attempt_consume_vip_llm_monthly_quota,
+    require_server_salt,
+)
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
     _calculate_all_tdee_wrapper,
@@ -491,6 +495,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     env_name = (os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or "").strip().lower()
     is_production = env_name not in {"", "local", "dev", "development", "staging", "test", "ci"}
     truthy = {"1", "true", "yes", "on"}
+
+    # PR-647 (P0 security): Monthly quota fingerprinting requires a secret salt.
+    # Fail-fast on startup to avoid running with predictable/empty fingerprints.
+    require_server_salt()
 
     try:
         init_db()
@@ -2176,14 +2184,28 @@ async def insight(req: InsightRequest) -> InsightResponse:
         raise HTTPException(status_code=503, detail=INSIGHT_TEMP_UNAVAILABLE_MESSAGE) from None
 
 
+def _enforce_vip_llm_monthly_quota(vip_key: str) -> None:
+    """Enforce VIP monthly hard quota before any provider call.
+
+    RU: Жёсткий стоп-кран ДО provider.generate(...).
+    EN: Hard stop before provider.generate(...).
+    """
+
+    allowed = attempt_consume_vip_llm_monthly_quota(vip_key)
+    if not allowed:
+        raise HTTPException(status_code=429, detail="quota_exceeded")
+
+
 @app.post(
     "/api/v1/insight",
-    dependencies=[Depends(require_vip_tier)],
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
 )
 @limit_if_available(RATE_LIMIT_INSIGHT)
-async def insight_v1_route(request: Request, req: InsightRequest) -> InsightResponse:
+async def insight_v1_route(
+    request: Request, req: InsightRequest, vip_key: str = Depends(require_vip_tier)
+) -> InsightResponse:
+    await run_in_threadpool(_enforce_vip_llm_monthly_quota, vip_key)
     return await insight_v1(req)
 
 
@@ -2192,12 +2214,14 @@ async def insight_v1_route(request: Request, req: InsightRequest) -> InsightResp
     "/insight",
     include_in_schema=False,
     deprecated=True,
-    dependencies=[Depends(require_vip_tier)],
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
 )
 @limit_if_available(RATE_LIMIT_INSIGHT)
-async def insight_route(request: Request, req: InsightRequest) -> InsightResponse:
+async def insight_route(
+    request: Request, req: InsightRequest, vip_key: str = Depends(require_vip_tier)
+) -> InsightResponse:
+    await run_in_threadpool(_enforce_vip_llm_monthly_quota, vip_key)
     return await insight(req)
 
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2207,6 +2207,8 @@ def _enforce_vip_llm_monthly_quota(vip_key: str) -> None:
 async def insight_v1_route(
     request: Request, req: InsightRequest, vip_key: str = Depends(require_vip_tier)
 ) -> InsightResponse:
+    if not _is_truthy(os.getenv("FEATURE_INSIGHT", "false")):
+        raise HTTPException(status_code=503, detail="FEATURE_INSIGHT is disabled")
     await run_in_threadpool(_enforce_vip_llm_monthly_quota, vip_key)
     return await insight_v1(req)
 
@@ -2223,6 +2225,8 @@ async def insight_v1_route(
 async def insight_route(
     request: Request, req: InsightRequest, vip_key: str = Depends(require_vip_tier)
 ) -> InsightResponse:
+    if not _is_truthy(os.getenv("FEATURE_INSIGHT", "false")):
+        raise HTTPException(status_code=503, detail="FEATURE_INSIGHT is disabled")
     await run_in_threadpool(_enforce_vip_llm_monthly_quota, vip_key)
     return await insight(req)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,7 @@ def _block_external_network_in_ci(monkeypatch: pytest.MonkeyPatch) -> None:
 os.environ.setdefault("FEATURE_BMI_PRO_ENABLED", "true")
 os.environ.setdefault("BUSINESS_MODULE_ENABLED", "true")
 os.environ.setdefault("VIP_MODULE_ENABLED", "true")
+os.environ.setdefault("SERVER_SALT", "test-server-salt")
 
 # Configure logger for test cleanup operations
 logger = logging.getLogger(__name__)
@@ -587,6 +588,7 @@ def test_environment(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, N
     monkeypatch.setenv("API_KEY", "test_key")
     monkeypatch.setenv("API_KEY_REQUIRED", "false")
     monkeypatch.setenv("METRICS_ENABLED", "true")
+    monkeypatch.setenv("SERVER_SALT", os.environ.get("SERVER_SALT", "test-server-salt"))
     yield
     # Cleanup is automatic with monkeypatch
 

--- a/tests/helpers/fake_llm_provider.py
+++ b/tests/helpers/fake_llm_provider.py
@@ -1,0 +1,18 @@
+"""Deterministic fake LLM provider for tests (no network).
+
+RU: Детерминированный fake LLM provider для тестов (без сети).
+EN: Deterministic fake LLM provider for tests (no network).
+"""
+
+from __future__ import annotations
+
+
+class FakeLLMProvider:
+    """Deterministic provider stub used in tests."""
+
+    name: str = "fake-llm"
+
+    async def generate(self, prompt_text: str) -> str:
+        # RU: Детерминированный ответ, без сети/SDK.
+        # EN: Deterministic response, no network/SDK.
+        return "ok"

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -6,24 +6,30 @@ EN: P0 tests: insight endpoint must be strictly VIP-only.
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
-
 import pytest
 from fastapi.testclient import TestClient
 
+import legacy_app
 
-class _EchoProvider:
-    """Deterministic mock provider for insight tests."""
-
-    name: str = "echo"
-
-    async def generate(self, text: str) -> str:
-        return f"ok:{text}"
+from tests.helpers.fake_llm_provider import FakeLLMProvider
 
 
-@patch("llm.get_provider", return_value=_EchoProvider())
+def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch insight provider loader to return a deterministic fake provider.
+
+    RU: Подменяем loader так, чтобы handler всегда получал fake provider.
+    EN: Patch loader so the handler always gets fake provider.
+    """
+
+    def _fake_load_llm_get_provider():  # noqa: ANN202 - fixture helper
+        return lambda: FakeLLMProvider()
+
+    monkeypatch.setattr(
+        legacy_app, "_load_llm_get_provider", _fake_load_llm_get_provider, raising=True
+    )
+
+
 def test_insight_v1_requires_vip_tier(
-    mock_get_provider: Mock,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     pro_headers: dict[str, str],
@@ -34,6 +40,7 @@ def test_insight_v1_requires_vip_tier(
     Note: VIP guard returns 403 for missing key by policy (VIP is a feature-gate).
     """
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    _patch_llm_provider(monkeypatch)
 
     payload = {"text": "hello"}
 
@@ -47,13 +54,11 @@ def test_insight_v1_requires_vip_tier(
     assert r_vip.status_code == 200
     assert r_vip.headers.get("content-type", "").startswith("application/json")
     data = r_vip.json()
-    assert data["provider"] == "echo"
-    assert data["insight"].startswith("ok:")
+    assert data["provider"] == "fake-llm"
+    assert data["insight"] == "ok"
 
 
-@patch("llm.get_provider", return_value=_EchoProvider())
 def test_insight_legacy_requires_vip_tier(
-    mock_get_provider: Mock,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     pro_headers: dict[str, str],
@@ -64,6 +69,7 @@ def test_insight_legacy_requires_vip_tier(
     Note: Legacy /insight is hidden from OpenAPI but still VIP-guarded.
     """
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    _patch_llm_provider(monkeypatch)
 
     payload = {"text": "hello"}
 
@@ -80,8 +86,8 @@ def test_insight_legacy_requires_vip_tier(
     assert r_vip.status_code == 200
     assert r_vip.headers.get("content-type", "").startswith("application/json")
     data = r_vip.json()
-    assert data["provider"] == "echo"
-    assert data["insight"].startswith("ok:")
+    assert data["provider"] == "fake-llm"
+    assert data["insight"] == "ok"
 
 
 # End of file

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -6,6 +6,8 @@ EN: P0 tests: insight endpoint must be strictly VIP-only.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -21,7 +23,7 @@ def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     EN: Patch loader so the handler always gets fake provider.
     """
 
-    def _fake_load_llm_get_provider():  # noqa: ANN202 - fixture helper
+    def _fake_load_llm_get_provider() -> Callable[[], FakeLLMProvider]:
         return lambda: FakeLLMProvider()
 
     monkeypatch.setattr(

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import threading
+from collections.abc import Callable
 from datetime import date
 
 import pytest
@@ -33,7 +34,7 @@ def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     EN: Patch loader so the handler always gets fake provider.
     """
 
-    def _fake_load_llm_get_provider():  # noqa: ANN202 - fixture helper
+    def _fake_load_llm_get_provider() -> Callable[[], FakeLLMProvider]:
         return lambda: FakeLLMProvider()
 
     monkeypatch.setattr(

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -91,6 +91,31 @@ def test_insight_v1_over_quota_hard_stops_before_provider_call(
     assert r.json() == {"detail": "quota_exceeded"}
 
 
+def test_insight_legacy_over_quota_hard_stops_before_provider_call(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    vip_headers: dict[str, str],
+    configure_sqlite_database: object,
+) -> None:
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "1")
+    _patch_llm_provider(monkeypatch)
+
+    month_start = month_start_date_utc()
+    key_fp = vip_key_fingerprint(TEST_KEY_VIP)
+    _seed_usage_row(
+        configure_sqlite_database,
+        key_fp=key_fp,
+        month_start=month_start,
+        used_requests=1,
+    )
+
+    r = client.post("/insight", json={"text": "hello"}, headers=vip_headers)
+    assert r.status_code == 429
+    assert r.headers.get("content-type", "").startswith("application/json")
+    assert r.json() == {"detail": "quota_exceeded"}
+
+
 def test_vip_llm_monthly_quota_atomicity_limit_1_two_parallel_attempts(
     monkeypatch: pytest.MonkeyPatch,
     configure_sqlite_database: object,
@@ -119,3 +144,44 @@ def test_vip_llm_monthly_quota_atomicity_limit_1_two_parallel_attempts(
         results = list(executor.map(lambda _: _attempt(), range(2)))
 
     assert sorted(results) == [False, True]
+
+
+def test_vip_llm_monthly_quota_sequential_boundary_limit_2(
+    monkeypatch: pytest.MonkeyPatch,
+    configure_sqlite_database: object,
+) -> None:
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "2")
+
+    month_start = month_start_date_utc()
+    key_fp = vip_key_fingerprint(TEST_KEY_VIP)
+    _seed_usage_row(
+        configure_sqlite_database,
+        key_fp=key_fp,
+        month_start=month_start,
+        used_requests=0,
+    )
+
+    assert (
+        attempt_consume_vip_llm_monthly_quota(
+            TEST_KEY_VIP,
+            month_start=month_start,
+            limit_requests=2,
+        )
+        is True
+    )
+    assert (
+        attempt_consume_vip_llm_monthly_quota(
+            TEST_KEY_VIP,
+            month_start=month_start,
+            limit_requests=2,
+        )
+        is True
+    )
+    assert (
+        attempt_consume_vip_llm_monthly_quota(
+            TEST_KEY_VIP,
+            month_start=month_start,
+            limit_requests=2,
+        )
+        is False
+    )

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -50,7 +50,13 @@ def _seed_usage_row(
 ) -> None:
     session_scope = getattr(db_module, "session_scope")
     with session_scope() as session:
-        session.execute(text("DELETE FROM vip_llm_monthly_usage"))
+        session.execute(
+            text("""
+                DELETE FROM vip_llm_monthly_usage
+                WHERE key_fingerprint = :fp AND month_start_date = :month_start
+                """),
+            {"fp": key_fp, "month_start": month_start},
+        )
         session.execute(
             text("""
                 INSERT INTO vip_llm_monthly_usage (key_fingerprint, month_start_date, used_requests)

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -1,0 +1,111 @@
+"""P0 tests: VIP LLM monthly hard quota (requests/month).
+
+RU: P0 тесты: жёсткая месячная квота для VIP LLM (requests/month).
+EN: P0 tests: deterministic monthly hard quota for VIP LLM (requests/month).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+from datetime import date
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.middleware.api_tiers import TEST_KEY_VIP
+from app.security.llm_monthly_quota import (
+    attempt_consume_vip_llm_monthly_quota,
+    month_start_date_utc,
+    vip_key_fingerprint,
+)
+
+
+class _FailIfCalledProvider:
+    """Provider that fails test if generate() is called.
+
+    RU: Провайдер, который валит тест если generate() вызывается.
+    EN: Provider that fails the test if generate() is called.
+    """
+
+    name: str = "should_not_be_called"
+
+    async def generate(self, text: str) -> str:  # pragma: no cover
+        raise AssertionError("provider.generate() must not be called when quota is exceeded")
+
+
+def _seed_usage_row(
+    db_module: object,
+    *,
+    key_fp: str,
+    month_start: date,
+    used_requests: int,
+) -> None:
+    session_scope = getattr(db_module, "session_scope")
+    with session_scope() as session:
+        session.execute(text("DELETE FROM vip_llm_monthly_usage"))
+        session.execute(
+            text("""
+                INSERT INTO vip_llm_monthly_usage (key_fingerprint, month_start_date, used_requests)
+                VALUES (:fp, :month_start, :used_requests)
+                """),
+            {"fp": key_fp, "month_start": month_start, "used_requests": used_requests},
+        )
+
+
+@patch("llm.get_provider", return_value=_FailIfCalledProvider())
+def test_insight_v1_over_quota_hard_stops_before_provider_call(
+    mock_get_provider: Mock,
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    vip_headers: dict[str, str],
+    configure_sqlite_database: object,
+) -> None:
+    monkeypatch.setenv("FEATURE_INSIGHT", "true")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "1")
+
+    month_start = month_start_date_utc()
+    key_fp = vip_key_fingerprint(TEST_KEY_VIP)
+    _seed_usage_row(
+        configure_sqlite_database,
+        key_fp=key_fp,
+        month_start=month_start,
+        used_requests=1,
+    )
+
+    r = client.post("/api/v1/insight", json={"text": "hello"}, headers=vip_headers)
+    assert r.status_code == 429
+    assert r.headers.get("content-type", "").startswith("application/json")
+    assert r.json() == {"detail": "quota_exceeded"}
+
+
+def test_vip_llm_monthly_quota_atomicity_limit_1_two_parallel_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+    configure_sqlite_database: object,
+) -> None:
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "1")
+
+    # Clean bucket for deterministic test.
+    month_start = month_start_date_utc()
+    key_fp = vip_key_fingerprint(TEST_KEY_VIP)
+    _seed_usage_row(
+        configure_sqlite_database,
+        key_fp=key_fp,
+        month_start=month_start,
+        used_requests=0,
+    )
+
+    barrier = threading.Barrier(2)
+
+    def _attempt() -> bool:
+        barrier.wait(timeout=5)
+        return attempt_consume_vip_llm_monthly_quota(
+            TEST_KEY_VIP, month_start=month_start, limit_requests=1
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: _attempt(), range(2)))
+
+    assert sorted(results) == [False, True]

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import concurrent.futures
 import threading
 from datetime import date
-from unittest.mock import Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
+
+import legacy_app
 
 from app.middleware.api_tiers import TEST_KEY_VIP
 from app.security.llm_monthly_quota import (
@@ -22,18 +23,22 @@ from app.security.llm_monthly_quota import (
     vip_key_fingerprint,
 )
 
+from tests.helpers.fake_llm_provider import FakeLLMProvider
 
-class _FailIfCalledProvider:
-    """Provider that fails test if generate() is called.
 
-    RU: Провайдер, который валит тест если generate() вызывается.
-    EN: Provider that fails the test if generate() is called.
+def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch insight provider loader to return a deterministic fake provider.
+
+    RU: Подменяем loader так, чтобы handler всегда получал fake provider.
+    EN: Patch loader so the handler always gets fake provider.
     """
 
-    name: str = "should_not_be_called"
+    def _fake_load_llm_get_provider():  # noqa: ANN202 - fixture helper
+        return lambda: FakeLLMProvider()
 
-    async def generate(self, text: str) -> str:  # pragma: no cover
-        raise AssertionError("provider.generate() must not be called when quota is exceeded")
+    monkeypatch.setattr(
+        legacy_app, "_load_llm_get_provider", _fake_load_llm_get_provider, raising=True
+    )
 
 
 def _seed_usage_row(
@@ -55,9 +60,7 @@ def _seed_usage_row(
         )
 
 
-@patch("llm.get_provider", return_value=_FailIfCalledProvider())
 def test_insight_v1_over_quota_hard_stops_before_provider_call(
-    mock_get_provider: Mock,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     vip_headers: dict[str, str],
@@ -65,6 +68,7 @@ def test_insight_v1_over_quota_hard_stops_before_provider_call(
 ) -> None:
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
     monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "1")
+    _patch_llm_provider(monkeypatch)
 
     month_start = month_start_date_utc()
     key_fp = vip_key_fingerprint(TEST_KEY_VIP)

--- a/tests/test_llm_monthly_quota_config_validation.py
+++ b/tests/test_llm_monthly_quota_config_validation.py
@@ -1,0 +1,48 @@
+"""Tests: VIP LLM monthly quota config validation (fail-fast).
+
+RU: Тесты валидации конфигурации квоты (fail-fast) для VIP LLM.
+EN: Tests for VIP LLM monthly quota config validation (fail-fast).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.security import llm_monthly_quota as quota
+
+
+def test_require_server_salt_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SERVER_SALT", raising=False)
+    with pytest.raises(RuntimeError, match=r"SERVER_SALT is required"):
+        quota.require_server_salt()
+
+
+def test_require_vip_llm_monthly_limit_uses_default_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", raising=False)
+    assert quota.require_vip_llm_monthly_limit() == quota.DEFAULT_VIP_LLM_INSIGHT_REQUESTS_PER_MONTH
+
+
+def test_require_vip_llm_monthly_limit_raises_on_non_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "nope")
+    with pytest.raises(
+        RuntimeError, match=r"VIP_LLM_INSIGHT_REQUESTS_PER_MONTH must be an integer >= 1"
+    ):
+        quota.require_vip_llm_monthly_limit()
+
+
+def test_require_vip_llm_monthly_limit_raises_on_lt_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "0")
+    with pytest.raises(
+        RuntimeError, match=r"VIP_LLM_INSIGHT_REQUESTS_PER_MONTH must be an integer >= 1"
+    ):
+        quota.require_vip_llm_monthly_limit()
+
+
+def test_month_start_date_utc_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Cover month_start_date_utc(now=...) deterministic path.
+    now = datetime(2026, 2, 5, 12, 30, tzinfo=timezone.utc)
+    assert str(quota.month_start_date_utc(now)) == "2026-02-01"

--- a/tests/test_llm_monthly_quota_config_validation.py
+++ b/tests/test_llm_monthly_quota_config_validation.py
@@ -6,7 +6,7 @@ EN: Tests for VIP LLM monthly quota config validation (fail-fast).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -46,3 +46,8 @@ def test_month_start_date_utc_bucket() -> None:
     # Cover month_start_date_utc(now=...) deterministic path.
     now = datetime(2026, 2, 5, 12, 30, tzinfo=timezone.utc)
     assert str(quota.month_start_date_utc(now)) == "2026-02-01"
+
+
+def test_month_start_date_utc_naive_datetime_treated_as_utc() -> None:
+    naive = datetime(2026, 2, 15, 12, 0, 0)  # no tzinfo
+    assert quota.month_start_date_utc(now=naive) == date(2026, 2, 1)

--- a/tests/test_llm_monthly_quota_config_validation.py
+++ b/tests/test_llm_monthly_quota_config_validation.py
@@ -42,7 +42,7 @@ def test_require_vip_llm_monthly_limit_raises_on_lt_1(monkeypatch: pytest.Monkey
         quota.require_vip_llm_monthly_limit()
 
 
-def test_month_start_date_utc_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_month_start_date_utc_bucket() -> None:
     # Cover month_start_date_utc(now=...) deterministic path.
     now = datetime(2026, 2, 5, 12, 30, tzinfo=timezone.utc)
     assert str(quota.month_start_date_utc(now)) == "2026-02-01"

--- a/tests/test_llm_monthly_quota_sql_contract.py
+++ b/tests/test_llm_monthly_quota_sql_contract.py
@@ -1,0 +1,24 @@
+"""Tests: SQL contract for VIP LLM monthly quota.
+
+RU: Контрактный тест SQL для VIP LLM monthly quota (защита от регрессов).
+EN: SQL contract test for VIP LLM monthly quota (regression guard).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from app.security import llm_monthly_quota as quota
+
+
+def test_quota_sql_qualifies_used_requests_column() -> None:
+    """Ensure SQL keeps qualified used_requests reference for Postgres.
+
+    RU: Фиксируем, что SQL содержит квалификацию `vip_llm_monthly_usage.used_requests`,
+    чтобы не получить Postgres `column reference is ambiguous`.
+    EN: Assert SQL contains qualified `vip_llm_monthly_usage.used_requests` to avoid
+    Postgres `column reference is ambiguous`.
+    """
+
+    src = inspect.getsource(quota.attempt_consume_vip_llm_monthly_quota)
+    assert "vip_llm_monthly_usage.used_requests" in src


### PR DESCRIPTION
## Summary
- Add VIP LLM monthly hard quota enforcement (requests/month) before any provider call for `/api/v1/insight` and legacy `/insight`.
- Store authoritative usage counters in DB (`vip_llm_monthly_usage`) keyed by salted VIP key fingerprint + UTC month bucket.
- Fail fast on startup if `SERVER_SALT` is missing to prevent weak/empty fingerprinting.

## Implementation notes
- Quota consume is an atomic upsert with a `WHERE used_requests < limit` guard.
- Limit is env-backed: `VIP_LLM_INSIGHT_REQUESTS_PER_MONTH` (default stays in code).
- Deterministic exceed response: `429 {"detail":"quota_exceeded"}`.

## Migration
- Adds Alembic migration: `alembic/versions/202602050001_add_vip_llm_monthly_usage.py`.

## Test plan
- `pre-commit run --all-files`
- `pytest -q tests/test_insight_vip_guard_api.py tests/test_insight_vip_monthly_quota_api.py`

## Security notes
- Raw VIP keys are never stored; only `sha256(key + SERVER_SALT)` fingerprints are persisted.

## Summary by Sourcery

Реализовать серверную жёсткую месячную квоту для VIP LLM на insight-эндпоинтах с использованием солёного отпечатка ключа и обязательной конфигурацией серверной «соли».

New Features:
- Ввести основанный на базе данных счётчик ежемесячного использования VIP LLM, индексируемый по солёному отпечатку VIP-ключа и месячному UTC‑интервалу.
- Добавить детерминированные проверки жёсткой месячной квоты для VIP insight LLM-запросов до любых обращений к провайдерам, возвращающие HTTP 429 с стабильным полезным нагрузом при превышении.

Enhancements:
- Требовать наличие переменной окружения SERVER_SALT при запуске для обеспечения безопасного формирования отпечатка VIP-ключа и немедленного завершения работы при её отсутствии.
- Задокументировать политику ежемесячной квоты LLM и детали аудита безопасности для этого изменения.

Documentation:
- Добавить документ аудита и примечания к политике, описывающие модель жёсткой ежемесячной квоты VIP LLM и требования к её применению.

Tests:
- Добавить API- и конкурентные тесты для проверки детерминированного применения квоты, атомарности при параллельных запросах и защиты от вызовов провайдера после превышения квоты.

Chores:
- Добавить новую модель SQLAlchemy и миграцию Alembic для таблицы `vip_llm_monthly_usage`, используемой при применении квоты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a server-side VIP LLM monthly hard quota for insight endpoints with salted key fingerprinting and mandatory server salt configuration.

New Features:
- Introduce a database-backed VIP LLM monthly usage counter keyed by salted VIP key fingerprint and UTC month bucket.
- Add deterministic monthly hard quota checks for VIP insight LLM requests before any provider calls, returning HTTP 429 with a stable payload on exceed.

Enhancements:
- Require SERVER_SALT at startup to ensure secure VIP key fingerprinting and fail fast if missing.
- Document the LLM monthly quota policy and security audit details for this change.

Documentation:
- Add an audit document and policy notes describing the VIP LLM monthly hard quota model and enforcement requirements.

Tests:
- Add API and concurrency tests to verify deterministic quota enforcement, atomicity under parallel requests, and protection against provider calls once quota is exceeded.

Chores:
- Add a new SQLAlchemy model and Alembic migration for the vip_llm_monthly_usage table used by quota enforcement.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic VIP LLM hard monthly quota (requests/month) for /api/v1/insight and legacy /insight, enforced before any provider call. Usage is tracked in DB by salted VIP key fingerprint per UTC month; exceeding the quota returns 429 {"detail":"quota_exceeded"}.

- **New Features**
  - Enforce monthly quota before provider.generate(...) on both insight endpoints.
  - DB-backed counters in vip_llm_monthly_usage keyed by sha256(key + SERVER_SALT) and month bucket.
  - Atomic upsert consume with WHERE used_requests < limit, parallel-safe.
  - Limit set via VIP_LLM_INSIGHT_REQUESTS_PER_MONTH (safe default in code).
  - Fail fast on startup if SERVER_SALT is missing or VIP_LLM_INSIGHT_REQUESTS_PER_MONTH is invalid.
  - Skip quota consumption when FEATURE_INSIGHT is disabled.
  - Tests cover deterministic 429 and concurrency (limit=1 → exactly one succeeds).

- **Migration**
  - Run Alembic migration 202602050001 to create vip_llm_monthly_usage.
  - Set SERVER_SALT to a non-empty secret in all environments.
  - Optionally set VIP_LLM_INSIGHT_REQUESTS_PER_MONTH.

<sup>Written for commit d97a9a15b2e4c7f4d9858e8cc848f6d4c6909c3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VIP users now have a hard monthly LLM request limit; requests beyond the limit are blocked and return HTTP 429 before any LLM call.

* **Documentation**
  * Added audit and policy docs describing quota design, enforcement semantics, and operational/test requirements.

* **Tests**
  * Added deterministic tests for enforcement, atomic consumption under concurrency, config validation, and monthly boundary behavior; introduced a deterministic fake LLM test provider.

* **Chores**
  * CI/test environments now expose SERVER_SALT; added DB migration and model to track monthly VIP usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->