### PR TITLE
docs(ledger): close P0 nightly DB bootstrap item (resolved)

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -251,11 +251,11 @@ If it is not recorded here — it does not exist.
       - FREE/PRO remain → 403
     - Minimal observability: counters/logging for usage and quota decisions
 
-- [ ] P0: CI nightly — test DB schema bootstrap broken (users/nutrition_events missing)
+- [x] P0: CI nightly — test DB schema bootstrap broken (users/nutrition_events missing)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (CRITICAL)
   - Target PR: PR-629
-  - Status: 🟡 In progress (PR-629)
+  - Status: ✅ Merged (PR-629)
   - Reason: CI/nightly shows DB schema is not created before API tests (`no such table: users`, `no such table: nutrition_events`), causing secondary thread errors. Root cause: metadata/bootstrap ordering (missing model package import before create_all).
   - Signals: "no such table: users / nutrition_events" + "SQLite objects created in a thread..." / check_same_thread/threadpool
   - Scope: tests/conftest + tests/test_nutrition_log_api.py (bootstrap ordering) + minimal agent rule update (implemented in PR-629)
@@ -269,7 +269,8 @@ If it is not recorded here — it does not exist.
     - Fail-fast guard: if schema missing after init_db(), tests fail with clear message (no silent warn+continue)
   - Notes (3 February 2026, America/New_York):
     - Fix: close leaked TestClients (context-managed `tests/conftest.py::client` + close in `tests/test_nutrition_log_api.py` teardown) to ensure lifespan runs deterministically under xdist.
-    - Verification (local): `pytest -q tests/test_nutrition_log_api.py -n 2 --dist=loadgroup` passed; CI link: TBD (after run completes).
+    - Verification (local, 6 February 2026): `pytest -q tests/test_nutrition_log_api.py -n 2 --dist=loadgroup` passed on `main` (post-merge).
+    - Verification (local, 6 February 2026): `pytest -q tests/test_db_engine_reuse_diff_coverage.py tests/test_sqlite_engine_sot.py` passed on `main`.
 
 - [x] P1: Verify and secure WebSocket endpoint (if exists) — RESOLVED
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
- Close the P0 ledger item for nightly DB schema bootstrap determinism.
- PR-629 is already merged; local verification on `main` passes under xdist.

## Scope
- Docs only (`docs/roadmap/BACKLOG_LEDGER.md`).

## Verification
- `pre-commit run --files docs/roadmap/BACKLOG_LEDGER.md`
- Local (evidence recorded in ledger notes):
  - `pytest -q tests/test_nutrition_log_api.py -n 2 --dist=loadgroup`
  - `pytest -q tests/test_db_engine_reuse_diff_coverage.py tests/test_sqlite_engine_sot.py`

## Deferred / Follow-ups
- None.

## Summary by Sourcery

Документация:
- Обновить список задач по ledger, чтобы отметить пункт P0 по ночной инициализации схемы БД как выполненный и задокументировать итоговые локальные прогоны проверки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the ledger backlog to mark the nightly DB schema bootstrap P0 item as resolved and document the final local verification runs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project backlog to reflect successful resolution of a database schema initialization issue. The fix addresses proper setup of user and event data table structures within the system. This infrastructure improvement has been thoroughly verified before merging into the main codebase, ensuring stable database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->