### PR TITLE
docs(ios): add welcome gate packets and playbook links

### DIFF
--- a/docs/design/WELCOME_GATE_VISUAL_DIRECTION.md
+++ b/docs/design/WELCOME_GATE_VISUAL_DIRECTION.md
@@ -1,0 +1,100 @@
+# iOS Welcome Gate — Visual Direction (SwiftUI-ready)
+
+**Date:** 6 February 2026
+**Scope:** Welcome Gate (PR-653) visual system and asset handoff checklist
+**Goal:** trust-first, HIG-clean, minimal, accessible; motion is subtle and optional
+
+---
+
+## 1) Visual direction
+
+### Color system (PulsePlate palette)
+
+- **Background**: Navy `#0F172A`
+- **Primary text**: White `#FFFFFF`
+- **Secondary text**: White 80% (`#FFFFFFCC`)
+- **Tertiary text**: White 60% (`#FFFFFF99`)
+- **Accent blue (CTA / active)**: `#339FFF`
+- **Accent green (success / pulse highlights, optional)**: `#20C997`
+- **Surface elevation**: navy + white overlay ~5% (cards/panels)
+
+### Typography (system-native)
+
+- Use **SF Pro Display** for headings and **SF Pro Text** for body.
+- Keep hierarchy simple:
+  - Hero: `.largeTitle`
+  - Titles: `.title2` / `.title3`
+  - Body: `.body`
+  - Footer: `.footnote`
+- **Dynamic Type** must work out of the box (no hard-coded heights).
+
+### Spacing (touch-friendly)
+
+- Base unit: 4pt
+- Horizontal padding: 24–32pt (device-dependent)
+- CTA area: at least 32pt above bottom safe area
+- Tap targets: **≥44×44pt** everywhere
+
+### Icon / illustration approach
+
+- Prefer **SF Symbols** (line icons, rounded) for consistency and low asset overhead.
+- FitChef is optional:
+  - If used: only on Screen 1 as a small, friendly “trust anchor”.
+  - If not used: use abstract pulse-wave geometry (subtle, non-medical).
+
+---
+
+## 2) Screen concepts (2–3, consistent system)
+
+### Concept A — “Hero + calm promise” (Screen 1)
+
+- Navy background, small FitChef (optional) in the top third.
+- Large headline + 1–2 line subtitle.
+- One primary CTA (blue) + a gentle “Skip” link (with 44pt hit area).
+
+**Motion:** fade-in + tiny scale-up for hero; subtle pulse-wave ring every ~3s.
+Respect Reduce Motion (disable pulse; keep fade-only).
+
+### Concept B — “Feature cards” (Screens 2–3)
+
+- Left-aligned icon + title + 2–3 lines body.
+- Plenty of breathing room.
+- Consistent “Continue” CTA.
+
+**Motion:** slide-in from right on advance; swipe supported (if already implemented).
+
+### Concept C — “Ready” (Screen 4)
+
+- Icon + final title, short reassurance line.
+- Primary CTA (“Get started”) emphasized; optional dot indicator.
+
+**Motion:** gentle CTA emphasis on appear (small scale), then haptic success on completion.
+
+---
+
+## 3) Accessibility notes
+
+- **Contrast:** white-on-navy is AAA; ensure CTA blue has sufficient contrast.
+- **Dynamic Type:** layout must reflow; avoid text clipping.
+- **VoiceOver:** focus order = icon → title → body → CTA → footer; headings marked as headers.
+- **Reduce Motion:** pulse-wave disabled when Reduce Motion is on.
+
+---
+
+## 4) Asset checklist (designer handoff)
+
+### Required (if not using SF Symbols)
+
+- FitChef hero (optional): Lottie JSON or PNG @3x, base ~120×120pt.
+- 3–4 icons (24pt line style) as vectors or PNG @3x.
+- Page indicator dots (only if not using system default).
+
+### Motion spec (for dev)
+
+- Pulse wave:
+  - radius 0 → 200pt
+  - duration ~2s
+  - repeat interval ~3s
+  - stroke ~2pt
+  - opacity 0.3 → 0
+  - optional gradient green → blue

--- a/docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md
+++ b/docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md
@@ -1,0 +1,18 @@
+# Pulse Membrane
+
+“Pulse Membrane” treats interface as a **selective threshold**: not a wall, not a funnel, but a quiet, disciplined boundary that lets only clarity pass. Space is used like breath—measured, intentional, never crowded—so the user feels held rather than handled. The work must look **meticulously crafted**, the product of deep expertise and countless refinements, where every margin and interval has been calibrated with **painstaking attention** until the composition reads like certainty.
+
+Form is architectural: rectilinear frames, gates, and cutouts that imply passage without spectacle. Repetition is not decoration but measurement—ticks, steps, and subtle progress marks that accumulate meaning through patient, master-level execution. The “membrane” is always present as a thin boundary line or a slightly-offset plane, giving the sense that the interface is an instrument panel for something invisible yet precise. Every element should feel **labored over with care**, engineered and refined until nothing is incidental.
+
+Color behaves as signal under restraint. A near-monochrome foundation carries the weight of trust, while accents appear sparingly, like clinical annotations in a lab notebook. Accents should be used with **expert restraint**—never noisy, never ornamental—arriving only to mark a threshold, a decision, or a moment of readiness. The palette must feel cohesive and intentional, the result of **painstaking calibration** rather than taste alone, so the final artifact could pass as a museum-grade study of control and warmth.
+
+Typography is a quiet instrument. Use two distinct voices: one for structural headings (clean, confident geometry), another for whispered labels (serif or humanist texture) that reads like marginalia. Text is never explanatory paragraphs; it is sparse, essential-only, integrated into the visual architecture as measurement, indexing, and annotation. The typographic hierarchy should appear **masterfully executed**—kerning, weight, and placement tuned with obsessive discipline so that even the smallest label feels inevitable.
+
+Composition is a choreography of entry and release. The eye is guided by asymmetry balanced with an underlying grid—enough structure to feel safe, enough irregularity to feel alive. The “pulse” is not an icon; it is rhythm: spacing, repetition, and line-work that implies time. The whole must feel like an artifact that took countless hours—**meticulously crafted**, **painstakingly refined**, and unmistakably executed by someone at the top of their field.
+
+---
+
+## Canvas artifact
+
+The visual canvas is maintained outside the repo (Figma) to keep docs-only PRs markdown-only.
+If needed, attach the latest PNG in the PR thread.

--- a/docs/marketing/WELCOME_GATE_COPY_DECK.md
+++ b/docs/marketing/WELCOME_GATE_COPY_DECK.md
@@ -1,0 +1,143 @@
+# Welcome Gate Copy Deck (RU/EN/ES) — `onboarding.welcome.*`
+
+**Date:** 6 February 2026
+**Scope:** Welcome Gate (PR-653) copy system + future-safe extensions
+**Tone:** wellness-first, trust-first, **no medical claims**, short sentences (VoiceOver-friendly)
+
+> Canonical key set for PR-653 is documented in `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`.
+
+---
+
+## 0) How to use this deck
+
+- **Variant A vs B** is meant for *client-side* A/B (TestFlight cohorts) without backend changes.
+- Keep strings **short** (small screens + better a11y cadence).
+- Avoid “diagnose / treat / cure / medical advice”.
+
+---
+
+## 1) Required keys (P0) — 2 variants each
+
+### Screen 1
+
+- `onboarding.welcome.screen1.title`
+  - **EN A**: PulsePlate — your nutrition on track
+  - **EN B**: PulsePlate — stay on track
+  - **RU A**: PulsePlate — питание под контролем
+  - **RU B**: PulsePlate — держим курс легко
+  - **ES A**: PulsePlate — tu nutrición bajo control
+  - **ES B**: PulsePlate — mantén el rumbo
+
+- `onboarding.welcome.screen1.body`
+  - **EN A**: Set your goals once. Your plan and progress stay aligned.
+  - **EN B**: Simple setup now. Clear progress later.
+  - **RU A**: Настрой цели один раз. План и прогресс будут согласованы.
+  - **RU B**: Простая настройка сейчас — ясный прогресс потом.
+  - **ES A**: Configura tus objetivos una vez. Plan y progreso en sintonía.
+  - **ES B**: Configura hoy. Ve tu progreso mañana.
+
+### Screen 2 (privacy / trust)
+
+- `onboarding.welcome.screen2.title`
+  - **EN A**: Private by default
+  - **EN B**: Your data, your control
+  - **RU A**: Приватность по умолчанию
+  - **RU B**: Ваши данные — ваш контроль
+  - **ES A**: Privado por defecto
+  - **ES B**: Tus datos, tu control
+
+- `onboarding.welcome.screen2.body`
+  - **EN A**: Your inputs stay on your device unless you choose to export.
+  - **EN B**: You decide what to share and when.
+  - **RU A**: Данные остаются на устройстве, пока вы сами не экспортируете.
+  - **RU B**: Вы решаете, чем делиться и когда.
+  - **ES A**: Tus datos quedan en tu dispositivo hasta que decidas exportar.
+  - **ES B**: Tú decides qué compartir y cuándo.
+
+### Screen 3 (setup)
+
+- `onboarding.welcome.screen3.title`
+  - **EN A**: Pick your setup
+  - **EN B**: Make it yours
+  - **RU A**: Выберите настройки
+  - **RU B**: Сделайте под себя
+  - **ES A**: Elige tu configuración
+  - **ES B**: Hazlo tuyo
+
+- `onboarding.welcome.screen3.body`
+  - **EN A**: Language, units, and goals — you can change this anytime.
+  - **EN B**: Set your preferences now. Update them anytime.
+  - **RU A**: Язык, единицы и цель можно изменить в любой момент.
+  - **RU B**: Настройте сейчас. Измените когда угодно.
+  - **ES A**: Idioma, unidades y objetivo: puedes cambiarlo cuando quieras.
+  - **ES B**: Ajusta ahora. Cambia cuando quieras.
+
+### Screen 4 (start)
+
+- `onboarding.welcome.screen4.title`
+  - **EN A**: Ready to start
+  - **EN B**: Let’s begin
+  - **RU A**: Можно начинать
+  - **RU B**: Поехали
+  - **ES A**: Listo para empezar
+  - **ES B**: Empecemos
+
+- `onboarding.welcome.screen4.body`
+  - **EN A**: Build a simple plan you can follow today.
+  - **EN B**: Start small. Stay consistent.
+  - **RU A**: Соберём простой план, который реально выполнить уже сегодня.
+  - **RU B**: Начните с малого. Держите ритм.
+  - **ES A**: Hagamos un plan simple que puedas seguir hoy.
+  - **ES B**: Empieza pequeño. Sé constante.
+
+### CTAs
+
+- `onboarding.welcome.cta.continue`
+  - **EN A**: Continue
+  - **EN B**: Next
+  - **RU A**: Дальше
+  - **RU B**: Далее
+  - **ES A**: Continuar
+  - **ES B**: Siguiente
+
+- `onboarding.welcome.cta.back`
+  - **EN A**: Back
+  - **EN B**: Previous
+  - **RU A**: Назад
+  - **RU B**: Вернуться
+  - **ES A**: Atrás
+  - **ES B**: Volver
+
+- `onboarding.welcome.cta.start`
+  - **EN A**: Get started
+  - **EN B**: Start now
+  - **RU A**: Начать
+  - **RU B**: Начать сейчас
+  - **ES A**: Empezar
+  - **ES B**: Empezar ahora
+
+### Accessibility format
+
+- `onboarding.welcome.stepA11y` (format string)
+  - **EN A**: Step %d of %d
+  - **EN B**: Screen %d of %d
+  - **RU A**: Шаг %d из %d
+  - **RU B**: Экран %d из %d
+  - **ES A**: Paso %d de %d
+  - **ES B**: Pantalla %d de %d
+
+---
+
+## 2) Optional extensions (future-safe keys)
+
+These keys are optional; add them only when the UI truly needs them.
+
+- `onboarding.welcome.disclaimer`
+  - **EN**: For wellness purposes only. Not medical advice.
+  - **RU**: Для велнес-целей. Не медицинский совет.
+  - **ES**: Solo para bienestar. No es consejo médico.
+
+- `onboarding.welcome.privacy.note`
+  - **EN**: You can export anytime.
+  - **RU**: Экспорт — когда захотите.
+  - **ES**: Puedes exportar cuando quieras.

--- a/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
+++ b/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
@@ -25,19 +25,12 @@ Example keys:
 - **Variant B:** uses “start small / stay consistent” framing (momentum-first)
 
 **Primary metric (manual for now):**
-- % of testers who complete welcome and reach the main app screen
+- % of testers who complete welcome and reach `RootTabs()`
 
 **Secondary metric:**
 - Time from launch → first core action (BMI calculate / first meaningful tap)
 
 ---
-
-## Variant Mapping (Single Reference)
-
-| Variant key                | Copy block | UI behavior |
-|---------------------------|------------|-------------|
-| welcome_copy_variant_v1_A | Copy A     | Standard welcome flow, CTA = Continue |
-| welcome_copy_variant_v1_B | Copy B     | Same flow, CTA emphasizes speed/value |
 
 ## 3) Experiment E2 — Upgrade prompt timing (after value)
 
@@ -71,7 +64,6 @@ Example keys:
 For the first iteration:
 - Use **TestFlight tester feedback** + a simple checklist (“did you see X? did you tap Y?”).
 - Prefer **small cohorts** (20–50 users) and fast iteration over fake precision.
-  - See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 When backend analytics is ready (separate scope):
 - Add server-side event ingestion + dashboards.

--- a/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
+++ b/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
@@ -1,0 +1,69 @@
+# Welcome Gate Experiment Plan (iOS-only, no backend required)
+
+**Date:** 6 February 2026
+**Scope:** client-side cohorts for copy + timing; extendable later to backend analytics
+**Constraint:** must remain iOS-only unless a separate backend PR is planned
+
+---
+
+## 1) Cohort assignment (deterministic, local)
+
+- Assign a variant once per install (store in UserDefaults).
+- Keep a **versioned key** for experiment assignment to avoid sticky migrations.
+
+Example keys:
+- `welcome_copy_variant_v1` = `A|B`
+- `welcome_paywall_timing_variant_v1` = `A|B`
+
+---
+
+## 2) Experiment E1 — Welcome copy (A vs B)
+
+**Hypothesis:** tighter, more concrete copy improves completion and first action.
+
+- **Variant A:** uses “track / plan / privacy” framing (trust-first)
+- **Variant B:** uses “start small / stay consistent” framing (momentum-first)
+
+**Primary metric (manual for now):**
+- % of testers who complete welcome and reach `RootTabs()`
+
+**Secondary metric:**
+- Time from launch → first core action (BMI calculate / first meaningful tap)
+
+---
+
+## 3) Experiment E2 — Upgrade prompt timing (after value)
+
+**Hypothesis:** delaying upgrade messaging until after 1–3 value moments increases conversion quality.
+
+- **Variant A:** soft hook after first value moment
+- **Variant B:** soft hook after third value moment
+
+**Primary metric:**
+- Tap-through rate on soft hook
+
+**Guardrail metric:**
+- D1 retention proxy (TestFlight qualitative feedback)
+
+---
+
+## 4) Experiment E3 — CTA wording on paywall entry
+
+**Hypothesis:** benefit-first CTA increases intent without pressure.
+
+- **Variant A:** “Unlock advanced insights”
+- **Variant B:** “Get PRO features”
+
+**Primary metric:**
+- CTA tap-through
+
+---
+
+## 5) How we measure without backend (TestFlight stage)
+
+For the first iteration:
+- Use **TestFlight tester feedback** + a simple checklist (“did you see X? did you tap Y?”).
+- Prefer **small cohorts** (20–50 users) and fast iteration over fake precision.
+
+When backend analytics is ready (separate scope):
+- Add server-side event ingestion + dashboards.

--- a/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
+++ b/docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md
@@ -25,12 +25,19 @@ Example keys:
 - **Variant B:** uses “start small / stay consistent” framing (momentum-first)
 
 **Primary metric (manual for now):**
-- % of testers who complete welcome and reach `RootTabs()`
+- % of testers who complete welcome and reach the main app screen
 
 **Secondary metric:**
 - Time from launch → first core action (BMI calculate / first meaningful tap)
 
 ---
+
+## Variant Mapping (Single Reference)
+
+| Variant key                | Copy block | UI behavior |
+|---------------------------|------------|-------------|
+| welcome_copy_variant_v1_A | Copy A     | Standard welcome flow, CTA = Continue |
+| welcome_copy_variant_v1_B | Copy B     | Same flow, CTA emphasizes speed/value |
 
 ## 3) Experiment E2 — Upgrade prompt timing (after value)
 
@@ -64,6 +71,7 @@ Example keys:
 For the first iteration:
 - Use **TestFlight tester feedback** + a simple checklist (“did you see X? did you tap Y?”).
 - Prefer **small cohorts** (20–50 users) and fast iteration over fake precision.
+  - See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 When backend analytics is ready (separate scope):
 - Add server-side event ingestion + dashboards.

--- a/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
+++ b/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
@@ -13,7 +13,9 @@
   - “Did you understand what to do next?”
   - “Did anything feel pushy or confusing?”
 
-See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
+**Artifacts per build:**
+- 6–10 screenshots (Light/Dark, RU/EN; ES spot-check)
+- 20–30s screen recording of the full welcome flow
 
 ---
 

--- a/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
+++ b/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
@@ -1,0 +1,51 @@
+# Welcome Gate GTM Outline (TestFlight → App Store)
+
+**Date:** 6 February 2026
+**Goal:** ship Welcome Gate as a trust-first first-run experience; improve activation; avoid App Store review risk
+
+---
+
+## 1) TestFlight loop (weekly cadence)
+
+- **Build cadence:** 2–3 builds/week (small deltas, visible improvements).
+- **Tester prompt:** 3 questions only (keep response rate high):
+  - “Was the welcome clear and calm?”
+  - “Did you understand what to do next?”
+  - “Did anything feel pushy or confusing?”
+
+**Artifacts per build:**
+- 6–10 screenshots (Light/Dark, RU/EN; ES spot-check)
+- 20–30s screen recording of the full welcome flow
+
+---
+
+## 2) App Store screenshot strategy (trust > hype)
+
+- Show:
+  - 1 welcome screen (value statement)
+  - 1 core result screen (wellness framing)
+  - 1 “progress / plan” screen if available
+- Avoid:
+  - medical-looking imagery
+  - claims that imply diagnosis or treatment
+
+---
+
+## 3) Review risk mitigation checklist (pre-submit)
+
+- Copy:
+  - no “treat/cure/diagnose”
+  - wellness phrasing + short sentences
+- Subscription:
+  - pricing clarity
+  - restore purchases visible
+  - cancel-anytime phrasing
+  - “continue free” path exists
+
+---
+
+## 4) Launch success signals (early)
+
+- Welcome completion rate (qualitative + basic counters)
+- “First meaningful action” rate
+- Low negative sentiment (“pushy”, “confusing”, “too many screens”)

--- a/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
+++ b/docs/marketing/WELCOME_GATE_GTM_OUTLINE.md
@@ -13,9 +13,7 @@
   - “Did you understand what to do next?”
   - “Did anything feel pushy or confusing?”
 
-**Artifacts per build:**
-- 6–10 screenshots (Light/Dark, RU/EN; ES spot-check)
-- 20–30s screen recording of the full welcome flow
+See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ---
 

--- a/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
+++ b/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
@@ -11,7 +11,7 @@
 - No forced subscription during onboarding.
 - No fake urgency (“limited time”), no fake scarcity.
 - No hiding pricing, restore, or cancellation info.
-- No framing the free tier as broken (e.g., “basic only”, “you can’t use the app”).
+- No framing-free tier as broken (“basic only”, “you can’t use the app”).
 
 ---
 

--- a/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
+++ b/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
@@ -11,7 +11,7 @@
 - No forced subscription during onboarding.
 - No fake urgency (“limited time”), no fake scarcity.
 - No hiding pricing, restore, or cancellation info.
-- No framing-free tier as broken (“basic only”, “you can’t use the app”).
+- No framing the free tier as broken (e.g., “basic only”, “you can’t use the app”).
 
 ---
 

--- a/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
+++ b/docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md
@@ -1,0 +1,67 @@
+# Welcome Gate → Paywall Positioning (Ethical, App Store-safe)
+
+**Date:** 6 February 2026
+**Scope:** how to message PRO/VIP upgrades without dark patterns
+**Principle:** value-first, clarity-first, “continue free” is always real
+
+---
+
+## 1) What we must not do (dark patterns)
+
+- No forced subscription during onboarding.
+- No fake urgency (“limited time”), no fake scarcity.
+- No hiding pricing, restore, or cancellation info.
+- No framing-free tier as broken (“basic only”, “you can’t use the app”).
+
+---
+
+## 2) What we *do* instead (ethical upgrade UX)
+
+- **Contextual prompt** after user receives value (e.g., after a successful result or after exploring a feature).
+- **Transparent comparison**: FREE / PRO / VIP, with 3–6 bullets each.
+- **Easy dismissal**: “Continue Free” always available and respectful.
+- **Frequency cap**: show upgrade prompts at most 1×/day per trigger (avoid annoyance).
+
+---
+
+## 3) Recommended funnel placement (iOS-first)
+
+### Stage A: Welcome Gate
+
+- **No paywall** inside the 4-screen welcome (PR-653 scope discipline).
+- Goal: trust + clarity + “start now”.
+
+### Stage B: First value moment
+
+- Show a **soft hook** (banner / card) that is dismissible:
+  - EN: “Want deeper insights? Try PRO.”
+  - RU: “Хотите больше инсайтов? Попробуйте PRO.”
+  - ES: “¿Quieres más insights? Prueba PRO.”
+
+### Stage C: Paywall screen (only when user opts in)
+
+Structure:
+- Title (benefit-oriented)
+- 3 key benefits
+- Clear pricing + trial terms (if present)
+- Primary CTA (subscribe / start trial)
+- Secondary CTA: **Continue Free**
+- Links: restore purchases, terms, privacy
+
+---
+
+## 4) CTA language (recommended)
+
+**Primary CTA (benefit-first):**
+- EN: “Unlock advanced insights”
+- RU: “Открыть расширенные инсайты”
+- ES: “Desbloquear insights avanzados”
+
+**Secondary CTA (non-shaming):**
+- EN: “Continue Free”
+- RU: “Продолжить бесплатно”
+- ES: “Continuar gratis”
+
+Avoid:
+- “No thanks”
+- “Skip forever”

--- a/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
+++ b/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
@@ -79,7 +79,14 @@ Follow `docs/orchestration/workflow.md`, but for iOS/frontend tasks add these **
 
 ---
 
-## 3) “Visibility loop” (so progress is undeniable)
+## Visibility Loop (Single Source of Truth)
+
+Daily visibility requirements:
+- 6–10 screenshots (RU/EN, light/dark if relevant)
+- 20–30s screen recording of the flow
+- Short daily changelog (3–7 bullets)
+
+This section is the canonical reference. Other documents must link here and must not duplicate the rules.
 
 ### Daily artifacts (required while a task is in progress)
 
@@ -104,10 +111,10 @@ Anchor audit: `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`
 Supporting packets:
 
 - Design direction: `docs/design/WELCOME_GATE_VISUAL_DIRECTION.md`
-- Visual philosophy + canvas artifact: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md`, `docs/design/WELCOME_GATE_CANVAS.png`
+- Visual philosophy: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md` (canvas is maintained externally in Figma / PR thread)
 - Copy deck (RU/EN/ES variants): `docs/marketing/WELCOME_GATE_COPY_DECK.md`
 - Paywall positioning (ethical): `docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md`
-- iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md`
+- iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md#variant-mapping-single-reference`
 - GTM outline: `docs/marketing/WELCOME_GATE_GTM_OUTLINE.md`
 
 ### Required keys (namespace)

--- a/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
+++ b/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
@@ -104,7 +104,7 @@ Anchor audit: `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`
 Supporting packets:
 
 - Design direction: `docs/design/WELCOME_GATE_VISUAL_DIRECTION.md`
-- Visual philosophy + canvas artifact: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md`, `docs/design/WELCOME_GATE_CANVAS.png`
+- Visual philosophy: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md` (canvas is maintained externally in Figma / PR thread)
 - Copy deck (RU/EN/ES variants): `docs/marketing/WELCOME_GATE_COPY_DECK.md`
 - Paywall positioning (ethical): `docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md`
 - iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md`

--- a/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
+++ b/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
@@ -79,14 +79,7 @@ Follow `docs/orchestration/workflow.md`, but for iOS/frontend tasks add these **
 
 ---
 
-## Visibility Loop (Single Source of Truth)
-
-Daily visibility requirements:
-- 6–10 screenshots (RU/EN, light/dark if relevant)
-- 20–30s screen recording of the flow
-- Short daily changelog (3–7 bullets)
-
-This section is the canonical reference. Other documents must link here and must not duplicate the rules.
+## 3) “Visibility loop” (so progress is undeniable)
 
 ### Daily artifacts (required while a task is in progress)
 
@@ -111,10 +104,10 @@ Anchor audit: `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`
 Supporting packets:
 
 - Design direction: `docs/design/WELCOME_GATE_VISUAL_DIRECTION.md`
-- Visual philosophy: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md` (canvas is maintained externally in Figma / PR thread)
+- Visual philosophy + canvas artifact: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md`, `docs/design/WELCOME_GATE_CANVAS.png`
 - Copy deck (RU/EN/ES variants): `docs/marketing/WELCOME_GATE_COPY_DECK.md`
 - Paywall positioning (ethical): `docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md`
-- iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md#variant-mapping-single-reference`
+- iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md`
 - GTM outline: `docs/marketing/WELCOME_GATE_GTM_OUTLINE.md`
 
 ### Required keys (namespace)

--- a/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
+++ b/docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md
@@ -1,0 +1,147 @@
+# iOS + Frontend Multi‑Agent Playbook (Welcome Gate → Backend Realization)
+
+**Last updated:** 6 February 2026
+**Owner:** @katsiaryna_kavaleuskaya
+**Scope:** iOS (`ios/**`) + Web (`frontend/**`) tasks that must ship as **thin clients** against backend contracts.
+
+This playbook is intentionally practical: it describes **what artifacts must exist** so progress is visible and tasks are solved “by the whole team”.
+
+---
+
+## 0) Canonical anchors (do not duplicate rules)
+
+- Global invariants + quality gates: `AGENTS.md`
+- iOS invariants (thin client + CI): `ios/AGENTS.md`
+- Web invariants (thin HTTP adapter + OpenAPI types): `frontend/AGENTS.md`
+- Orchestration workflow (single SoT): `docs/orchestration/workflow.md`
+- Canonical backlog (single SoT): `docs/roadmap/BACKLOG_LEDGER.md`
+
+---
+
+## 1) Team roles (who owns what)
+
+- **Coordinator (agent-coordinator / PM-brain):**
+  - writes Task Analysis + assigns tracks
+  - owns “scope discipline” and ledger hygiene
+  - enforces sync points and DoD
+- **Architecture specialist:**
+  - validates placement, invariants, thin-client constraints
+  - flags forbidden patterns early (before implementation)
+- **Creative designer:**
+  - visual direction + assets checklist
+  - a11y / HIG consistency review (spacing, readability, motion restraint)
+- **Marketing strategist:**
+  - copy deck (RU/EN/ES keys + variants)
+  - value prop + CTA strategy (App Store-safe, no dark patterns)
+- **Implementation (iOS/frontend dev):**
+  - builds the slice using canonical HTTP/client seams
+  - adds tests and keeps guard tests green
+- **QA (human + automated):**
+  - deterministic demo script + regression checklist
+  - verifies localization + accessibility + key flows
+
+---
+
+## 2) “One task” lifecycle (mandatory)
+
+Follow `docs/orchestration/workflow.md`, but for iOS/frontend tasks add these **hard deliverables**.
+
+### 2.1 Pre-flight (must exist before coding)
+
+- **Ledger item** in `docs/roadmap/BACKLOG_LEDGER.md` (or confirm it already exists)
+  - Owner, Priority, Target PR, Reason, Links, DoD
+- **Contract pointer**
+  - Backend endpoint path(s) and response model(s)
+  - If OpenAPI needs regeneration: note “requires `make openapi`” (backend work)
+- **Design packet**
+  - Figma link (or “temporary wireframe in doc” if no Figma yet)
+  - Asset list (icons/illustrations), no text baked into images
+- **Copy packet**
+  - Key list (e.g. `onboarding.welcome.*`) and translations RU/EN/ES
+  - 1–2 copy variants for A/B (optional; can be deferred)
+- **Acceptance criteria**
+  - “What the user sees” (screens, states, and the exact happy-path)
+  - Error/empty/loading states included
+
+### 2.2 Implementation track (thin slice)
+
+- **iOS:** SwiftUI UI + storage + navigation wired at the single gate point
+- **Web:** use `frontend/src/api/client.ts` only; types from `frontend/src/api/schema.ts`
+- **Both:** no business logic duplication, no tier inference on clients
+
+### 2.3 Verification track (before calling it “done”)
+
+- **iOS local:** `make ios-test` (recommended before push)
+- **Web local:** run thin-client guard test + build
+  - `npm test -- --run src/api/__tests__/thin-client-guards.test.ts`
+  - `npm run build`
+- **Backend involved?** then `make verify` (root gate)
+
+---
+
+## 3) “Visibility loop” (so progress is undeniable)
+
+### Daily artifacts (required while a task is in progress)
+
+- **Screenshots (6–10):**
+  - Light/Dark
+  - RU + EN (ES spot-check if touched)
+  - at least 1 screenshot with larger Dynamic Type (iOS)
+- **20–30s screen recording:** happy path end-to-end
+- **Short changelog:** 3–7 bullets (what changed in the app today)
+
+### Where to put artifacts
+
+- Prefer: PR description + PR comments (keeps review context)
+- Optional: `docs/roadmap/` notes only if it changes long-term plans
+
+---
+
+## 4) Welcome Gate (PR-653) — standard operating packet
+
+Anchor audit: `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`
+
+Supporting packets:
+
+- Design direction: `docs/design/WELCOME_GATE_VISUAL_DIRECTION.md`
+- Visual philosophy + canvas artifact: `docs/design/WELCOME_GATE_VISUAL_PHILOSOPHY.md`, `docs/design/WELCOME_GATE_CANVAS.png`
+- Copy deck (RU/EN/ES variants): `docs/marketing/WELCOME_GATE_COPY_DECK.md`
+- Paywall positioning (ethical): `docs/marketing/WELCOME_GATE_PAYWALL_POSITIONING.md`
+- iOS-only experiment plan: `docs/marketing/WELCOME_GATE_EXPERIMENT_PLAN.md`
+- GTM outline: `docs/marketing/WELCOME_GATE_GTM_OUTLINE.md`
+
+### Required keys (namespace)
+
+- `onboarding.welcome.screen{1..4}.{title,body}`
+- `onboarding.welcome.cta.{continue,back,start}`
+- `onboarding.welcome.stepA11y` (format string)
+
+### Persistence (versioned)
+
+- `has_seen_welcome_v1` only (future: `v2`, never mutate semantics in-place)
+
+---
+
+## 5) Scaling beyond Welcome Gate (backend realization)
+
+Use `docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md` as the “what ships next”.
+
+**Rule:** every “backend feature” must become an **app-visible** slice with:
+
+- contract pointer
+- iOS screen(s)
+- loading/error/empty states
+- i18n + a11y
+- tests + guard tests green
+- daily screenshots/video evidence
+
+---
+
+## 6) Stop conditions (fail fast)
+
+Stop execution immediately if any of these is true:
+
+- No ledger item exists for a deferred / postponed decision.
+- iOS/web client introduces domain logic (BMI math/thresholds, tier inference).
+- New networking path appears (direct `URLSession` or direct `fetch()`).
+- CI/guard tests fail and are not addressed.

--- a/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
+++ b/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
@@ -95,15 +95,7 @@ This is the canonical mapping format for turning backend capability into a **shi
 
 ## 4) “Visibility loop” (so you *see* progress daily)
 
-### Daily (required for iOS work days)
-
-- **Build:** TestFlight (or local simulator build) with the latest Welcome Gate + current slice.
-- **Screenshots:** 6–10 screenshots:
-  - Light/Dark
-  - RU/EN (ES weekly spot-check)
-  - Dynamic Type (one screenshot at larger text)
-- **Video:** 20–30s capture of the main happy path.
-- **Changelog:** 5 bullets posted in PR description or a daily note (“What changed in the app today”).
+See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ### Weekly (required)
 

--- a/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
+++ b/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
@@ -95,7 +95,15 @@ This is the canonical mapping format for turning backend capability into a **shi
 
 ## 4) “Visibility loop” (so you *see* progress daily)
 
-See canonical visibility loop: `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
+### Daily (required for iOS work days)
+
+- **Build:** TestFlight (or local simulator build) with the latest Welcome Gate + current slice.
+- **Screenshots:** 6–10 screenshots:
+  - Light/Dark
+  - RU/EN (ES weekly spot-check)
+  - Dynamic Type (one screenshot at larger text)
+- **Video:** 20–30s capture of the main happy path.
+- **Changelog:** 5 bullets posted in PR description or a daily note (“What changed in the app today”).
 
 ### Weekly (required)
 

--- a/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
+++ b/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
@@ -1,0 +1,120 @@
+# iOS Backend Realization Roadmap (App-Visible Delivery Map)
+
+**Last updated:** 6 February 2026
+**Owner:** @katsiaryna_kavaleuskaya
+**Purpose:** Make backend progress **visibly real in the iOS app** via a deterministic, thin-client delivery plan.
+
+> This document is **roadmap / planning**, not a policy. Hard rules remain in root `AGENTS.md` + `ios/AGENTS.md`.
+
+---
+
+## 0) Non-negotiables (policy anchors)
+
+- **Thin client (iOS):** iOS renders backend fields; it does not compute BMI logic/thresholds.
+  Anchor: `ios/AGENTS.md` (Thin Client Policy) + guard `ios/PulsePlateTests/Guards/ThinClientGuardsTests.swift`.
+- **One HTTP seam:** all runtime networking goes through `ios/PulsePlate/Networking/{APIClient,HTTPClient}`.
+  Anchor: `docs/audit/PR_595_IOS_THIN_HTTP_ADAPTER_AUDIT.md`, `docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md`.
+- **Entry + navigation SoT:** `ios/PulsePlate/PulsePlateApp.swift` → gate → `RootTabs()`.
+  Anchor: `docs/roadmap/IOS_ROADMAP.md`.
+- **Scope discipline:** iOS-only PRs must not mix web/backend/analytics/deeplinks/Lottie unless explicitly planned.
+  Anchor: `ios/AGENTS.md` (“PR-653 scope guard (P0 Welcome)”).
+
+---
+
+## 1) Current “App-visible” state (repo-truth)
+
+### ✅ Welcome Gate (P0) — done
+
+- **Status:** shipped (PR-653)
+- **What you can see:** 4-screen welcome onboarding shown once per install.
+- **Persistence key:** `has_seen_welcome_v1` (versioned)
+- **Localization:** RU/EN/ES (`onboarding.welcome.*`)
+- **Audit:** `docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md`
+
+---
+
+## 2) Next P0 (Release-safety) — must land before scaling feature surface
+
+### P0-A) Remove placeholder PRO key fallback (release-safe)
+
+- **Backlog item:** `docs/roadmap/BACKLOG_LEDGER.md` (“iOS: Remove placeholder PRO key fallback…”)
+- **Goal:** no implicit `test_pro_key` (or similar) returned in any build configuration.
+- **App-visible outcome:** missing-key state becomes explicit (clear UX, deterministic).
+- **DoD (high level):**
+  - No placeholder key string is returned by any provider.
+  - Missing-key path is explicit, testable, and user-visible.
+
+### P0-B) Guard: forbid placeholder API keys in iOS sources
+
+- **Backlog item:** `docs/roadmap/BACKLOG_LEDGER.md` (“iOS: Guard test forbids placeholder API keys…”)
+- **Goal:** CI fails if placeholder keys appear in `ios/PulsePlate/**`.
+- **Implementation constraint:** avoid false positives (fixtures/mocks allowlist as needed).
+
+---
+
+## 3) “Backend → iOS” delivery map (make it visible)
+
+This is the canonical mapping format for turning backend capability into a **ship-ready iOS surface**.
+
+> **Rule of thumb:** each item below should be delivered as a **thin vertical slice**: API contract → iOS DTO decode/encode → SwiftUI screen → a11y + i18n → tests → TestFlight demo.
+
+### 3.1 Free-tier core (must feel complete)
+
+#### Slice F1) BMI calculate (canonical)
+
+- **Backend:** `POST /api/v1/bmi/calculate` (exists; contract-driven)
+- **iOS surfaces:** BMI calculator screen + results screen
+- **Guards:** no BMI thresholds/logic locally (already enforced)
+- **Evidence/audit:** `docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md`
+- **Visibility:** record a 20–30s screen capture “input → result → back”.
+
+#### Slice F2) Error contract polish (422/403/5xx UX)
+
+- **Goal:** user never sees “undefined”, raw JSON, or silent failures.
+- **iOS outcome:** deterministic error banners/states (localized), retry path, offline messaging.
+
+### 3.2 Pro/VIP surfaces (contract-first, gated by backend)
+
+> iOS must not infer tier; it should render backend-provided tier/paywall hook data.
+
+#### Slice P1) Key entry & tier UX (safe + explicit)
+
+- **Goal:** replacing placeholder key logic with a clear “enter key / upgrade” flow.
+- **Constraints:** no new networking paths; use existing `APIClient`.
+- **Visibility:** TestFlight build where user can:
+  - open key entry
+  - paste key
+  - see success/failure states deterministically
+
+#### Slice V1) Plan / Weekly plan reader (if backend supports)
+
+- **Goal:** show the plan in a “trustworthy Apple-native” way (loading/error/empty states).
+- **Note:** if backend endpoint contract is still changing, keep iOS implementation behind a debug-only toggle until stable.
+
+---
+
+## 4) “Visibility loop” (so you *see* progress daily)
+
+### Daily (required for iOS work days)
+
+- **Build:** TestFlight (or local simulator build) with the latest Welcome Gate + current slice.
+- **Screenshots:** 6–10 screenshots:
+  - Light/Dark
+  - RU/EN (ES weekly spot-check)
+  - Dynamic Type (one screenshot at larger text)
+- **Video:** 20–30s capture of the main happy path.
+- **Changelog:** 5 bullets posted in PR description or a daily note (“What changed in the app today”).
+
+### Weekly (required)
+
+- **Demo script:** 2-minute deterministic demo flow (no flaky backend dependencies).
+- **Ledger sync:** any deferred work is written to `docs/roadmap/BACKLOG_LEDGER.md` with DoD.
+
+---
+
+## 5) How this connects to agent workflow
+
+All iOS+frontend slices must follow:
+
+- `docs/orchestration/workflow.md` (canonical orchestration)
+- **iOS+frontend playbook:** `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -16,6 +16,8 @@
 - API base is `/api/v1`; keep client paths aligned with backend routers.
 - OpenAPI types are generated from `src/api/openapi.json` into `src/api/schema.ts`.
 - Keep UI changes in sync with backend schema updates.
+- For coordinated iOS+frontend work (designer/marketing/dev), follow:
+  `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -18,6 +18,7 @@
 - Keep UI changes in sync with backend schema updates.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
+- Visibility loop (SoT): `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -18,7 +18,6 @@
 - Keep UI changes in sync with backend schema updates.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
-- Visibility loop (SoT): `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -18,6 +18,7 @@
 - Keep UI changes in sync with backend schema updates.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
+- This is a workflow reference only (no runtime behavior).
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -20,6 +20,7 @@
 - PR-653 scope guard (P0 Welcome): iOS only — do not mix web/backend/analytics/Lottie/deeplinks.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
+- Visibility loop (SoT): `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ## Backend coordination (important)
 

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -20,6 +20,7 @@
 - PR-653 scope guard (P0 Welcome): iOS only — do not mix web/backend/analytics/Lottie/deeplinks.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
+- This is a workflow reference only (no runtime behavior).
 
 ## Backend coordination (important)
 

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -18,6 +18,8 @@
   (`app.app` == `legacy_app.app`). Missing endpoints on iOS usually indicate
   backend feature flags or environment issues, not iOS routing bugs.
 - PR-653 scope guard (P0 Welcome): iOS only — do not mix web/backend/analytics/Lottie/deeplinks.
+- For coordinated iOS+frontend work (designer/marketing/dev), follow:
+  `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
 
 ## Backend coordination (important)
 

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -20,7 +20,6 @@
 - PR-653 scope guard (P0 Welcome): iOS only — do not mix web/backend/analytics/Lottie/deeplinks.
 - For coordinated iOS+frontend work (designer/marketing/dev), follow:
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
-- Visibility loop (SoT): `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md#visibility-loop-single-source-of-truth`
 
 ## Backend coordination (important)
 


### PR DESCRIPTION
Docs-only PR. Adds welcome gate packets, iOS/frontend playbook links, and design/marketing guidance. No runtime changes.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить перекрёстные ссылки и подробные многоагентные плейбуки, документацию по дизайну, маркетингу и роадмапу для iOS Welcome Gate и iOS+frontend thin‑client рабочих процессов без изменения поведения во время выполнения.

Документация:
- Связать руководства по агентам frontend и iOS с новым общим iOS+frontend плейбуком по оркестрации многоагентных систем.
- Задокументировать многоагентный рабочий процесс iOS+frontend, артефакты и условия остановки для thin‑client Welcome Gate и связанных функций.
- Добавить многоязычную текстовую матрицу (copy deck) для Welcome Gate, определяющую канонические ключи локализации и варианты для онбординговых экранов и CTA.
- Представить роадмап реализации iOS‑бэкенда, сопоставляющий возможности бэкенда с видимыми в приложении thin‑client iOS‑слайсами и практиками доставки.
- Задокументировать визуальное направление Welcome Gate и общую визуальную философию для iOS‑онбординга.
- Добавить маркетинговые рекомендации для экспериментов с Welcome Gate, этичного позиционирования paywall и стратегии вывода на рынок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add cross-references and detailed multi-agent playbooks, design, marketing, and roadmap documentation for the iOS Welcome Gate and iOS+frontend thin-client workflows, without changing runtime behavior.

Documentation:
- Link frontend and iOS agent guides to a new shared iOS+frontend multi-agent orchestration playbook.
- Document the iOS+frontend multi-agent workflow, artifacts, and stop conditions for thin-client Welcome Gate and related features.
- Add a multilingual Welcome Gate copy deck defining canonical localization keys and variants for onboarding screens and CTAs.
- Introduce an iOS backend realization roadmap mapping backend capabilities to app-visible, thin-client iOS slices and delivery practices.
- Document Welcome Gate visual direction and overarching visual philosophy for iOS onboarding.
- Add marketing guidance for Welcome Gate experiments, ethical paywall positioning, and go-to-market strategy.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Welcome Gate design and marketing packets plus an iOS+frontend multi‑agent playbook to guide the iOS onboarding rollout. Supports PR‑653 and aligns design, copy, and GTM; no runtime changes.

- **New Features**
  - Design: Visual Direction and Visual Philosophy for the iOS Welcome Gate (SwiftUI-ready, a11y notes, asset checklist).
  - Marketing: RU/EN/ES copy deck; iOS-only experiment plan; GTM outline; ethical paywall positioning.
  - Orchestration: iOS+frontend Multi‑Agent Playbook; iOS Backend Realization Roadmap.
  - Docs links: added playbook references in ios/AGENTS.md and frontend/AGENTS.md.

<sup>Written for commit 064d71d3b90ba4140483ed67f05225c268e3d982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Welcome Gate visual direction and underlying visual philosophy.
  * Added multilingual Welcome Gate copy deck and client-side experiment plan (A/B variants, metrics).
  * Added go‑to‑market outline, ethical paywall positioning, and experiment/measurement guidance.
  * Added orchestration playbook and iOS backend realization roadmap for cross‑team delivery.
  * Updated frontend and iOS coordination and hand‑off conventions (assets, motion, accessibility notes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->