### PR TITLE
fix(ios): remove placeholder PRO key fallback

### DIFF
--- a/ios/PulsePlate/Info-Debug.plist
+++ b/ios/PulsePlate/Info-Debug.plist
@@ -15,8 +15,6 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>PRO_API_KEY</key>
-	<string>test_pro_key</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/PulsePlate/Services/KeychainStore.swift
+++ b/ios/PulsePlate/Services/KeychainStore.swift
@@ -9,7 +9,6 @@ struct KeychainStore: Sendable {
     enum KeychainError: Error, Equatable {
         case unexpectedStatus(OSStatus)
         case unexpectedData
-        case stringEncodingFailed
     }
 
     let service: String
@@ -48,7 +47,7 @@ struct KeychainStore: Sendable {
 
     func setString(_ value: String, account: String) throws {
         guard let data = value.data(using: .utf8) else {
-            throw KeychainError.stringEncodingFailed
+            throw KeychainError.unexpectedData
         }
 
         let query: [CFString: Any] = [

--- a/ios/PulsePlate/Services/KeychainStore.swift
+++ b/ios/PulsePlate/Services/KeychainStore.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Security
+
+/// Keychain wrapper for storing small secrets (strings).
+///
+/// RU: Обёртка над Keychain для хранения небольших секретов (строк).
+/// We keep this minimal, explicit, and easy to test.
+struct KeychainStore: Sendable {
+    enum KeychainError: Error, Equatable {
+        case unexpectedStatus(OSStatus)
+        case unexpectedData
+        case stringEncodingFailed
+    }
+
+    let service: String
+
+    init(service: String) {
+        self.service = service
+    }
+
+    func getString(account: String) throws -> String? {
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecReturnData: true,
+        ]
+
+        // Keep access group unset (default) to avoid entitlements complexity.
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+        guard let data = result as? Data else {
+            throw KeychainError.unexpectedData
+        }
+        guard let s = String(data: data, encoding: .utf8) else {
+            throw KeychainError.unexpectedData
+        }
+        return s
+    }
+
+    func setString(_ value: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.stringEncodingFailed
+        }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+
+        let attributes: [CFString: Any] = [
+            kSecValueData: data,
+            // Device-only storage: good default for API keys.
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        if status == errSecSuccess {
+            let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(updateStatus)
+            }
+            return
+        }
+        if status == errSecItemNotFound {
+            var addQuery = query
+            for (k, v) in attributes {
+                addQuery[k] = v
+            }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(addStatus)
+            }
+            return
+        }
+
+        throw KeychainError.unexpectedStatus(status)
+    }
+
+    func delete(account: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            return
+        }
+        throw KeychainError.unexpectedStatus(status)
+    }
+}

--- a/ios/PulsePlate/Services/ProKeyProvider.swift
+++ b/ios/PulsePlate/Services/ProKeyProvider.swift
@@ -1,10 +1,13 @@
 import Foundation
 
 enum ProKeyProvider {
+    private static let account = "pro_api_key"
+    private static let store = KeychainStore(service: "com.pulseplate.pro-key")
+
     static func value() -> String? {
         // For SPM projects: use ProcessInfo environment variables
         // Set via Xcode Scheme → Run → Environment Variables
-        // Example: PRO_API_KEY = test_pro_key
+        // Example: PRO_API_KEY = <your_pro_key>
 
         #if DEBUG
         // Development: check environment variable first
@@ -12,12 +15,18 @@ enum ProKeyProvider {
            !envKey.isEmpty {
             return envKey
         }
-        // Fallback for local testing
-        return "test_pro_key"
-        #else
-        // Production: retrieve from Keychain or secure storage
-        // TODO: Implement Keychain retrieval
-        return nil
         #endif
+
+        // Production-safe: retrieve from Keychain.
+        // RU: В релизе никаких fallback ключей быть не должно.
+        return (try? store.getString(account: account)) ?? nil
+    }
+
+    static func set(value: String) throws {
+        try store.setString(value, account: account)
+    }
+
+    static func clear() throws {
+        try store.delete(account: account)
     }
 }

--- a/ios/PulsePlate/Services/ProKeyProvider.swift
+++ b/ios/PulsePlate/Services/ProKeyProvider.swift
@@ -19,7 +19,14 @@ enum ProKeyProvider {
 
         // Production-safe: retrieve from Keychain.
         // RU: В релизе никаких fallback ключей быть не должно.
-        return (try? store.getString(account: account)) ?? nil
+        do {
+            return try store.getString(account: account)
+        } catch {
+            #if DEBUG
+            assertionFailure("Keychain error while reading PRO key: \(error)")
+            #endif
+            return nil
+        }
     }
 
     static func set(value: String) throws {

--- a/ios/PulsePlate/Views/Info-Debug.plist
+++ b/ios/PulsePlate/Views/Info-Debug.plist
@@ -13,8 +13,6 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>PRO_API_KEY</key>
-	<string>test_pro_key</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/PulsePlateTests/Services/KeychainStoreTests.swift
+++ b/ios/PulsePlateTests/Services/KeychainStoreTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import XCTest
+
+@testable import PulsePlate
+
+final class KeychainStoreTests: XCTestCase {
+    func test_set_get_delete_roundtrip() throws {
+        let service = "com.pulseplate.tests.keychain.\(UUID().uuidString)"
+        let store = KeychainStore(service: service)
+        let account = "pro_api_key"
+
+        try store.delete(account: account)
+        XCTAssertNil(try store.getString(account: account))
+
+        try store.setString("k_test_value_123", account: account)
+        XCTAssertEqual(try store.getString(account: account), "k_test_value_123")
+
+        try store.delete(account: account)
+        XCTAssertNil(try store.getString(account: account))
+    }
+}

--- a/ios/PulsePlateTests/Services/ProKeyProviderTests.swift
+++ b/ios/PulsePlateTests/Services/ProKeyProviderTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import PulsePlate
+
+final class ProKeyProviderTests: XCTestCase {
+    func test_value_returnsNil_whenNoEnvKeyAndNoKeychainKey() throws {
+        // We cannot reliably control ProcessInfo environment in tests,
+        // but in CI/local runs it should not contain PRO_API_KEY by default.
+        try ProKeyProvider.clear()
+        XCTAssertNil(ProKeyProvider.value())
+    }
+
+    func test_value_returnsKeychainValue_whenSet() throws {
+        try ProKeyProvider.clear()
+        try ProKeyProvider.set(value: "pro_key_abc_123")
+        XCTAssertEqual(ProKeyProvider.value(), "pro_key_abc_123")
+        try ProKeyProvider.clear()
+    }
+}

--- a/ios/PulsePlateTests/Services/ProKeyProviderTests.swift
+++ b/ios/PulsePlateTests/Services/ProKeyProviderTests.swift
@@ -4,13 +4,17 @@ import XCTest
 
 final class ProKeyProviderTests: XCTestCase {
     func test_value_returnsNil_whenNoEnvKeyAndNoKeychainKey() throws {
-        // We cannot reliably control ProcessInfo environment in tests,
-        // but in CI/local runs it should not contain PRO_API_KEY by default.
+        if ProcessInfo.processInfo.environment["PRO_API_KEY"] != nil {
+            throw XCTSkip("PRO_API_KEY is set; skipping no-env-key assertion.")
+        }
         try ProKeyProvider.clear()
         XCTAssertNil(ProKeyProvider.value())
     }
 
     func test_value_returnsKeychainValue_whenSet() throws {
+        if ProcessInfo.processInfo.environment["PRO_API_KEY"] != nil {
+            throw XCTSkip("PRO_API_KEY is set; skipping keychain value assertion.")
+        }
         try ProKeyProvider.clear()
         try ProKeyProvider.set(value: "pro_key_abc_123")
         XCTAssertEqual(ProKeyProvider.value(), "pro_key_abc_123")


### PR DESCRIPTION
## Summary
- Remove DEBUG placeholder PRO key fallback and make missing-key behavior explicit.
- Store/retrieve PRO API key via Keychain (release-safe), with minimal unit tests.

## Why
Placeholder fallback masked missing-key flows and was not release-safe. This makes the iOS thin client production-safe and deterministic.

## Verification
- `rg -n \"test_pro_key\" ios/PulsePlate` → 0 matches
- `make ios-test` → ✅

## Scope
- iOS-only. No backend/web changes.

## Follow-ups
- P0-B: add guard forbidding placeholder key strings in iOS sources (ledger item).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Удалить небезопасный временный PRO API-ключ и безопасно хранить реальный ключ в iOS с помощью Keychain.

New Features:
- Добавить утилиту `KeychainStore` для безопасного сохранения небольших строковых секретов, таких как PRO API-ключ.
- Добавить вспомогательные методы в `ProKeyProvider` для установки и очистки сохранённого PRO API-ключа.

Bug Fixes:
- Удалить резервный PRO API-ключ для режима debug, чтобы ситуации с отсутствующим ключом проявлялись явно, а не приводили к тихому использованию тестового ключа.

Enhancements:
- Обновить `ProKeyProvider`, чтобы в продакшене PRO API-ключ считывался из Keychain, при этом в debug-сборках всё ещё поддерживалась переопределяющая переменная окружения.

Tests:
- Добавить модульные тесты, покрывающие CRUD-поведение `KeychainStore`.
- Добавить модульные тесты, проверяющие поведение `ProKeyProvider` при наличии и отсутствии значения в Keychain.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the insecure placeholder PRO API key and store the real key securely in iOS using the Keychain.

New Features:
- Add a KeychainStore utility for securely persisting small string secrets like the PRO API key.
- Expose helper methods on ProKeyProvider to set and clear the stored PRO API key.

Bug Fixes:
- Eliminate the debug-only placeholder PRO API key fallback so missing-key scenarios surface explicitly instead of silently using a test key.

Enhancements:
- Update ProKeyProvider to read the PRO API key from Keychain in production while still honoring an environment variable override in debug builds.

Tests:
- Add unit tests covering KeychainStore CRUD behavior.
- Add unit tests verifying ProKeyProvider behavior with and without a stored Keychain value.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented secure keychain-based storage for API credentials with set, retrieve, and delete capabilities.
  * Updated credential provider to prefer keychain storage in production and removed embedded API keys from debug config.

* **Tests**
  * Added unit tests covering keychain round-trip and provider behavior (set, get, clear).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->