### PR TITLE
ci(ios): stabilize UI smoke simulator boot and launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,9 +909,9 @@ jobs:
             xcrun simctl boot "$UDID" || true
 
             # Enforce bootstatus verification (hard rule: simulator must be ready)
-            # Timeout: 180 seconds (GitHub runners may need 70-120s+ for data migrations)
+            # Timeout: 300 seconds (GitHub runners may need 70-120s+ for data migrations)
             # NOTE: Never interpolate shell vars into python code strings; pass via env + os.environ.get()
-            export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-180}"
+            export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-300}"
             echo "Waiting for simulator to be ready (timeout: ${SIM_BOOT_TIMEOUT_SECONDS}s)..."
             python3 - << 'PY'
           import os
@@ -919,7 +919,7 @@ jobs:
           import sys
 
           udid = os.environ.get("UDID", "")
-          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "180"))
+          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "300"))
 
           if not udid:
               print("::error::UDID is empty", file=sys.stderr)
@@ -1198,7 +1198,7 @@ jobs:
             echo "=== Booting simulator ==="
             echo "Booting simulator: $UDID"
             xcrun simctl boot "$UDID" || true
-            export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-180}"
+            export SIM_BOOT_TIMEOUT_SECONDS="${SIM_BOOT_TIMEOUT_SECONDS:-300}"
             echo "Waiting for simulator to be ready (timeout: ${SIM_BOOT_TIMEOUT_SECONDS}s)..."
             python3 - << 'PY'
           import os
@@ -1206,7 +1206,7 @@ jobs:
           import sys
 
           udid = os.environ.get("UDID", "")
-          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "180"))
+          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "300"))
 
           if not udid:
               print("::error::UDID is empty", file=sys.stderr)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,7 +919,14 @@ jobs:
           import sys
 
           udid = os.environ.get("UDID", "")
-          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "300"))
+          try:
+              timeout_s = int(os.environ["SIM_BOOT_TIMEOUT_SECONDS"])
+          except KeyError:
+              print(
+                  "::error::SIM_BOOT_TIMEOUT_SECONDS is not set (single-source timeout policy).",
+                  file=sys.stderr,
+              )
+              sys.exit(2)
 
           if not udid:
               print("::error::UDID is empty", file=sys.stderr)
@@ -1172,6 +1179,7 @@ jobs:
         working-directory: ios
         env:
           DEVELOPER_DIR: ${{ steps.select-xcode.outputs.developer_dir }}
+          UI_SMOKE_FOREGROUND_TIMEOUT_SECONDS: "60"
         run: |
           set -euo pipefail
 
@@ -1206,7 +1214,14 @@ jobs:
           import sys
 
           udid = os.environ.get("UDID", "")
-          timeout_s = int(os.environ.get("SIM_BOOT_TIMEOUT_SECONDS", "300"))
+          try:
+              timeout_s = int(os.environ["SIM_BOOT_TIMEOUT_SECONDS"])
+          except KeyError:
+              print(
+                  "::error::SIM_BOOT_TIMEOUT_SECONDS is not set (single-source timeout policy).",
+                  file=sys.stderr,
+              )
+              sys.exit(2)
 
           if not udid:
               print("::error::UDID is empty", file=sys.stderr)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1404,6 +1404,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 - **Allowed:** `continue-on-error: true` **only** as metadata at job/step level in YAML, when the step is genuinely optional (e.g., non-blocking notifications, optional reports).
 - **Note:** `continue-on-error: true` is allowed only at YAML level (job/step), **not** inside shell commands.
 - **Rationale:** Prevents "false green" CI runs where real issues are hidden. Shell-level masking (`|| true`) breaks `set -euo pipefail` safety; YAML-level `continue-on-error` is explicit and auditable.
+- **Timeout single-source-of-truth (hard rule):** CI timeouts must be defined in workflow env (or step env) and consumed from env by scripts/tests. Do not duplicate default timeout literals across shell + embedded scripts (drift/flake risk). If an env var is required for determinism, fail fast with a clear error.
 
 ---
 

--- a/ios/PulsePlateUITests/UISmokeTests.swift
+++ b/ios/PulsePlateUITests/UISmokeTests.swift
@@ -13,6 +13,10 @@ final class UISmokeTests: XCTestCase {
   func testLaunch() throws {
     let app = XCUIApplication()
     app.launch()
-    XCTAssertTrue(true)
+    // RU: На CI иногда бывают флейки симулятора/launch. Мы не ассертим "сразу",
+    // а ждём, пока приложение перейдёт в foreground.
+    // EN: CI simulator/app launch can be flaky. Wait for the app to reach foreground.
+    let didReachForeground = app.wait(for: .runningForeground, timeout: 60)
+    XCTAssertTrue(didReachForeground, "UI smoke: app did not reach runningForeground. state=\(app.state)")
   }
 }

--- a/ios/PulsePlateUITests/UISmokeTests.swift
+++ b/ios/PulsePlateUITests/UISmokeTests.swift
@@ -16,7 +16,10 @@ final class UISmokeTests: XCTestCase {
     // RU: На CI иногда бывают флейки симулятора/launch. Мы не ассертим "сразу",
     // а ждём, пока приложение перейдёт в foreground.
     // EN: CI simulator/app launch can be flaky. Wait for the app to reach foreground.
-    let didReachForeground = app.wait(for: .runningForeground, timeout: 60)
+    let timeoutSeconds = Int(
+      ProcessInfo.processInfo.environment["UI_SMOKE_FOREGROUND_TIMEOUT_SECONDS"] ?? "60"
+    ) ?? 60
+    let didReachForeground = app.wait(for: .runningForeground, timeout: TimeInterval(timeoutSeconds))
     XCTAssertTrue(didReachForeground, "UI smoke: app did not reach runningForeground. state=\(app.state)")
   }
 }

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -414,6 +414,7 @@ def test_docstring_tracker_known_limitation_triple_quotes_in_string_literals() -
     ), "Next line after false-positive toggle would be incorrectly skipped (known limitation)"
 
 
+@pytest.mark.serial
 def test_skip_context_does_not_filter_whr_thresholds() -> None:
     """Test that SKIP_CONTEXT filter does not skip WHR thresholds in type-hinted constants."""
     # Create test file outside tests/ to avoid whitelist (use app/ as it's scanned)


### PR DESCRIPTION
## Summary
- Increase simulator `bootstatus` timeout in CI to tolerate runner data migrations.
- Make UI smoke test wait for the app to reach `runningForeground` after `launch()`.

## Safety
- Keeps **UDID-only** destination strategy (per repo hard rule); no return to `OS=latest` / name+OS destinations.
- No production/runtime app code changes; only CI workflow + UI test stabilization.

## Scope
- In scope: `.github/workflows/ci.yml`, `ios/PulsePlateUITests/UISmokeTests.swift`.
- Out of scope: broader UI test suite refactors, simulator reset/erase strategies, or changing destination semantics.

## Evidence
- Addresses intermittent CI failures like `Timed out while acquiring background assertion` during `UISmokeTests.testLaunch`.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Стабилизировать выполнение smoke-тестов iOS UI в CI, сделав обработку запуска симулятора и приложения более устойчивой к медленным или нестабильным окружениям.

CI:
- Увеличить тайм-аут по умолчанию для `bootstatus` iOS-симулятора в GitHub Actions с 180s до 300s, чтобы учесть более медленную загрузку и миграцию данных на раннерах.

Tests:
- Обновить smoke-тест iOS UI так, чтобы он ждал перехода приложения в состояние `runningForeground` после запуска и завершался с информативным сообщением об ошибке, если этого не происходит.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize iOS UI smoke test execution in CI by making simulator boot and app launch handling more tolerant of slow or flaky environments.

CI:
- Increase the default iOS simulator bootstatus timeout in GitHub Actions from 180s to 300s to accommodate slower boot and data migrations on runners.

Tests:
- Update the iOS UI smoke test to wait for the app to reach the runningForeground state after launch, failing with a descriptive message if it does not.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes iOS UI smoke tests in CI by making simulator boot and app launch more resilient. Also marks a repository guard test to run serially to avoid races.

- **Bug Fixes**
  - CI: Raise simulator bootstatus timeout to 300s and make timeouts single-source via env (fail fast); keep UDID-only destinations.
  - UITest: After app.launch(), wait up to 60s for .runningForeground; read timeout from UI_SMOKE_FOREGROUND_TIMEOUT_SECONDS.
  - Tests: Run WHR skip-context guard test serially to avoid xdist race on temp file scan.

<sup>Written for commit 6a6fa03e072039237be40b72d1999aecf7c15eed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased iOS simulator boot timeout to improve CI stability.
  * Added stricter timeout handling in CI scripts so missing timeout variables fail fast.

* **Tests**
  * Improved UI smoke test to wait for and assert app foreground state using a configurable timeout.
  * Added a new serial test to verify WHR threshold detection during repository scans.

* **Documentation**
  * Added a rule requiring CI timeouts to be defined centrally and consumed by scripts/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->