### PR TITLE
docs(roadmap): mark legacy nutrition alias guard merged

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -66,11 +66,11 @@ If it is not recorded here — it does not exist.
     - Test excludes fixtures/mocks as needed (no false positives)
     - Documented allowlist policy (if any) in `ios/AGENTS.md`
 
-- [ ] Backend: Fix deprecated `/api/nutrition/{date_str}` legacy alias to enforce `require_pro_tier` (auth bypass risk)
+- [x] Backend: Fix deprecated `/api/nutrition/{date_str}` legacy alias to enforce `require_pro_tier` (auth bypass risk)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (security)
-  - Target PR: PR-654
-  - Status: 🟡 In progress (PR-654)
+  - Target PR: PR-664
+  - Status: ✅ Merged (PR-664, 2026-02-07)
   - Reason: `legacy_app.py` implements `/api/nutrition/{date_str}` as a legacy alias and uses `Depends(api_key_header)` (header extraction only), then calls `app/routers/pro.py:get_daily_nutrition()` directly. This bypasses the `require_pro_tier` dependency (tier validation) and does not pass the API key into any guard, risking unauthorized access if the alias is reachable.
   - Decision:
     - Preferred outcome: remove deprecated alias entirely (keep only canonical `GET /api/v1/pro/nutrition/daily`).


### PR DESCRIPTION
## Summary
- Mark the BACKLOG_LEDGER item for the deprecated `/api/nutrition/{date_str}` alias PRO-guard as merged (PR-664).

## Test plan
- `pre-commit run --all-files`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить запись в бэклоге дорожной карты, чтобы отразить, что исправление защиты устаревшего алиаса `/api/nutrition/{date_str}` было влито (PR-664) с указанием статуса завершения и даты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the roadmap backlog entry to reflect that the `/api/nutrition/{date_str}` legacy alias guard fix has been merged (PR-664) with completion status and date.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update BACKLOG_LEDGER to mark the deprecated /api/nutrition/{date_str} alias guard as merged in PR-664, keeping the security roadmap accurate. Replaces the old PR-654 reference and records the merge date.

<sup>Written for commit 62dfbb14e152aa9f5188f46de12ed0f0fb97481b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

