### PR TITLE
feat(ios): expose BMI screen in RootTabs

### DIFF
--- a/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
+++ b/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
@@ -23,13 +23,14 @@
 
 ### RootTabs exists and defines TabView items
 
-- `ios/PulsePlate/Views/RootTabs.swift:3-20`
+- `ios/PulsePlate/Views/RootTabs.swift:4-26`
 
 Raw excerpt:
 
 ```text
 TabView {
   HomeView().tabItem { Label("Home", systemImage: "house") }
+  BMICalculatorScreen().tabItem { Label("BMI", systemImage: bmiTabSymbol) }
   PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
   ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
   WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }
@@ -37,10 +38,10 @@ TabView {
 }
 ```
 
-### BMICalculatorScreen exists but is not wired from RootTabs (currently “dangling”)
+### BMICalculatorScreen exists and is now wired from RootTabs (added in this PR)
 
-- `ios/PulsePlate/Screens/BMICalculatorScreen.swift:3-133`
-- No references from RootTabs before this PR: `ios/PulsePlate/Views/RootTabs.swift:3-20`
+- `ios/PulsePlate/Screens/BMICalculatorScreen.swift:3-132`
+- `ios/PulsePlate/Views/RootTabs.swift:11-16`
 
 ### iOS BMI adapter exists and is thin (transport-only)
 
@@ -74,12 +75,69 @@ Exit code: 1
 
 `RootTabs` currently uses hardcoded `Label("...")` strings (not Localizable keys):
 
-- `ios/PulsePlate/Views/RootTabs.swift:6-10`
+- `ios/PulsePlate/Views/RootTabs.swift:11-16`
 
-Localization exists broadly via `NSLocalizedString(...)` and `LocalizedStringKey(...)`, but no tab-label keys
-were found in this pass:
+Localization exists broadly via `NSLocalizedString(...)` and `LocalizedStringKey(...)`:
+
+```bash
+rg -n "NSLocalizedString\\(" ios/PulsePlate -S --max-count 50
+```
+
+Raw stdout (truncated):
+
+```text
+ios/PulsePlate/Models/ShoppingList/ShoppingListAdapter.swift:39:            format: NSLocalizedString("shopping_list_total_items_fmt", comment: "Total items format"),
+ios/PulsePlate/Models/ShoppingList/ShoppingListAdapter.swift:60:        let header = NSLocalizedString("shopping_list_title", comment: "Shopping List title")
+ios/PulsePlate/Models/ShoppingList/ShoppingListAdapter.swift:62:            String(format: NSLocalizedString("shopping_list_source_fmt", comment: "Source format"), dto.meta.source)
+ios/PulsePlate/Models/NutritionData.swift:55:    NSLocalizedString(key, comment: "")
+ios/PulsePlate/Welcome/WelcomeFlowView.swift:95:        let template = NSLocalizedString("onboarding.welcome.stepA11y", comment: "")
+ios/PulsePlate/Models/LocalizationManager.swift:25:        return NSLocalizedString(key, bundle: bundle, comment: "")
+ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:21:            .navigationTitle(NSLocalizedString("shopping_list_title", comment: ""))
+ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:35:                NSLocalizedString("shopping_list_empty_title", comment: ""),
+ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:37:                description: Text(NSLocalizedString("shopping_list_empty_description", comment: ""))
+ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:42:                Text(NSLocalizedString("shopping_list_error_title", comment: ""))
+ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:78:                    Section(header: Text(NSLocalizedString("shopping_list_warnings_title", comment: ""))) {
+```
+
+Exit code: 0
+
+```bash
+rg -n "LocalizedStringKey" ios/PulsePlate -S --max-count 50
+```
+
+Raw stdout (truncated):
+
+```text
+ios/PulsePlate/Views/Components/PlateRing.swift:39:        Text(LocalizedStringKey("progress.complete"))
+ios/PulsePlate/Views/Components/PlateRing.swift:52:    .accessibilityLabel(LocalizedStringKey("progress.label"))
+ios/PulsePlate/Views/Components/ValidationErrorsView.swift:19:            Text(LocalizedStringKey("Error"))
+ios/PulsePlate/Welcome/WelcomeFlowView.swift:68:    private var screenTitleKey: LocalizedStringKey {
+ios/PulsePlate/Welcome/WelcomeFlowView.swift:77:    private var screenBodyKey: LocalizedStringKey {
+ios/PulsePlate/Welcome/WelcomeFlowView.swift:86:    private var primaryCtaKey: LocalizedStringKey {
+ios/PulsePlate/Welcome/WelcomeFlowView.swift:90:    private var backKey: LocalizedStringKey {
+ios/PulsePlate/Views/Components/LottieAnimationView.swift:102:    var textKey: LocalizedStringKey
+ios/PulsePlate/Views/Components/AnimatedFitChef.swift:50:    var textKey: LocalizedStringKey
+ios/PulsePlate/Views/Components/VideoPlayerView.swift:132:    var textKey: LocalizedStringKey
+ios/PulsePlate/Views/Components/MascotBubble.swift:6:  var textKey: LocalizedStringKey
+```
+
+Exit code: 0
+
+No dedicated tab-label keys were observed in `en.lproj/Localizable.strings`:
 
 - `ios/PulsePlate/en.lproj/Localizable.strings` exists (and `ru/es` equivalents)
+
+```bash
+rg -n "tab\\.|home_tab|plate_tab|progress_tab|week_tab|profile_tab|bmi_tab" ios/PulsePlate/en.lproj/Localizable.strings -S
+```
+
+Raw stdout:
+
+```text
+# (no output)
+```
+
+Exit code: 1
 
 ---
 

--- a/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
+++ b/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
@@ -1,7 +1,8 @@
 # PR-671 Audit — iOS: Expose BMI screen in RootTabs
 
 **Date**: 7 February 2026
-**Branch**: `feat/ios-expose-bmi-root-tabs-pr-672`
+**PR**: #671
+**Branch**: `feat/ios-expose-bmi-root-tabs-pr-672` (legacy name; GitHub PR number is source of truth)
 **Type**: iOS runtime + audit doc
 
 ---
@@ -30,7 +31,10 @@ Raw excerpt:
 ```text
 TabView {
   HomeView().tabItem { Label("Home", systemImage: "house") }
-  BMICalculatorScreen().tabItem { Label("BMI", systemImage: bmiTabSymbol) }
+  NavigationStack {
+    BMICalculatorScreen()
+  }
+  .tabItem { Label("BMI", systemImage: bmiTabSymbol) }
   PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
   ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
   WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }

--- a/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
+++ b/docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
@@ -1,4 +1,4 @@
-# PR-672 Audit — iOS: Expose BMI screen in RootTabs
+# PR-671 Audit — iOS: Expose BMI screen in RootTabs
 
 **Date**: 7 February 2026
 **Branch**: `feat/ios-expose-bmi-root-tabs-pr-672`

--- a/docs/audit/PR_672_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
+++ b/docs/audit/PR_672_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md
@@ -1,0 +1,114 @@
+# PR-672 Audit — iOS: Expose BMI screen in RootTabs
+
+**Date**: 7 February 2026
+**Branch**: `feat/ios-expose-bmi-root-tabs-pr-672`
+**Type**: iOS runtime + audit doc
+
+---
+
+## Scope
+
+- Expose the existing BMI screen as a first-class entrypoint from `RootTabs` (TabView).
+- No BMI math / thresholds / categorization logic is added on iOS (thin client policy).
+
+## Non-scope
+
+- No backend changes.
+- No refactors or “drive-by” cleanups outside RootTabs + BMI entry wiring.
+- No new domain logic or interpretation on the client.
+
+---
+
+## Evidence (repo-truth)
+
+### RootTabs exists and defines TabView items
+
+- `ios/PulsePlate/Views/RootTabs.swift:3-20`
+
+Raw excerpt:
+
+```text
+TabView {
+  HomeView().tabItem { Label("Home", systemImage: "house") }
+  PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
+  ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
+  WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }
+  ProfileView().tabItem { Label("Profile", systemImage: "person") }
+}
+```
+
+### BMICalculatorScreen exists but is not wired from RootTabs (currently “dangling”)
+
+- `ios/PulsePlate/Screens/BMICalculatorScreen.swift:3-133`
+- No references from RootTabs before this PR: `ios/PulsePlate/Views/RootTabs.swift:3-20`
+
+### iOS BMI adapter exists and is thin (transport-only)
+
+- `ios/PulsePlate/Services/BMIService.swift:3-35`
+  - Calls canonical endpoint: `path: "/api/v1/bmi/calculate"` (`:30-34`)
+  - Explicitly forbids BMI logic (doc comment): `:14-18`
+
+### Existing tests cover BMI transport/service (but not RootTabs)
+
+There are multiple unit tests asserting the canonical BMI path and DTO behavior:
+
+- `ios/PulsePlateTests/BMI/BMIServiceTests.swift:6-146`
+- `ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift:4-151`
+- `ios/PulsePlateTests/Networking/APIClientTests.swift:25-94`
+
+And there are **no existing tests** referencing RootTabs/TabView/tabItem:
+
+```bash
+rg -n "RootTabs|TabView|tabItem|UITabBar|NavigationStack" ios/PulsePlateTests ios/PulsePlateUITests -S
+```
+
+Raw stdout:
+
+```text
+# (no output)
+```
+
+Exit code: 1
+
+### i18n pattern for tab labels
+
+`RootTabs` currently uses hardcoded `Label("...")` strings (not Localizable keys):
+
+- `ios/PulsePlate/Views/RootTabs.swift:6-10`
+
+Localization exists broadly via `NSLocalizedString(...)` and `LocalizedStringKey(...)`, but no tab-label keys
+were found in this pass:
+
+- `ios/PulsePlate/en.lproj/Localizable.strings` exists (and `ru/es` equivalents)
+
+---
+
+## Decision
+
+- Implement BMI exposure as a **new Tab** in `RootTabs` (TabView-level entrypoint), matching the ledger wording
+  “Expose BMI screen from Home / RootTabs”.
+
+---
+
+## Implementation plan (one path)
+
+1. Update `ios/PulsePlate/Views/RootTabs.swift`
+   - Add a new `.tabItem` for BMI
+   - Content: `BMICalculatorScreen()`
+   - Label + icon: follow existing RootTabs pattern (hardcoded label + SF Symbol)
+
+2. Keep `ios/PulsePlate/Screens/BMICalculatorScreen.swift` unchanged unless a minimal navigation wrapper is needed.
+
+3. Tests
+   - No existing RootTabs UI/unit test harness found; do not introduce new test frameworks in this PR.
+   - Rely on existing BMI service/transport tests + `make ios-test`.
+
+---
+
+## Pre-push checklist
+
+```bash
+pre-commit run --all-files
+make ios-test
+git diff --name-only origin/main...HEAD
+```

--- a/ios/PulsePlate/Views/RootTabs.swift
+++ b/ios/PulsePlate/Views/RootTabs.swift
@@ -1,13 +1,15 @@
 import SwiftUI
+import UIKit
 
 struct RootTabs: View {
+  private let bmiTabSymbol: String = {
+    UIImage(systemName: "scalemass") == nil ? "gauge" : "scalemass"
+  }()
+
   var body: some View {
     TabView {
       HomeView().tabItem { Label("Home", systemImage: "house") }
-      NavigationStack {
-        BMICalculatorScreen()
-      }
-      .tabItem { Label("BMI", systemImage: "scalemass") }
+      BMICalculatorScreen().tabItem { Label("BMI", systemImage: bmiTabSymbol) }
       PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
       ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
       WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }

--- a/ios/PulsePlate/Views/RootTabs.swift
+++ b/ios/PulsePlate/Views/RootTabs.swift
@@ -9,7 +9,10 @@ struct RootTabs: View {
   var body: some View {
     TabView {
       HomeView().tabItem { Label("Home", systemImage: "house") }
-      BMICalculatorScreen().tabItem { Label("BMI", systemImage: bmiTabSymbol) }
+      NavigationStack {
+        BMICalculatorScreen()
+      }
+      .tabItem { Label("BMI", systemImage: bmiTabSymbol) }
       PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
       ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
       WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }

--- a/ios/PulsePlate/Views/RootTabs.swift
+++ b/ios/PulsePlate/Views/RootTabs.swift
@@ -4,6 +4,10 @@ struct RootTabs: View {
   var body: some View {
     TabView {
       HomeView().tabItem { Label("Home", systemImage: "house") }
+      NavigationStack {
+        BMICalculatorScreen()
+      }
+      .tabItem { Label("BMI", systemImage: "scalemass") }
       PlateViewPP().tabItem { Label("Plate", systemImage: "fork.knife") }
       ProgressViewPP().tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
       WeeklyProgressView().tabItem { Label("Неделя", systemImage: "calendar") }


### PR DESCRIPTION
## Summary

- Expose `BMICalculatorScreen` as a first-class entrypoint in `RootTabs` (new TabView tab).
- Adds evidence-driven audit: `docs/audit/PR_672_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md`.

## Scope

- **In scope**: RootTabs navigation/tab wiring + BMI screen entry only.
- **Out of scope**: Any BMI formulas/thresholds/categorization logic on iOS; backend changes; refactors.

## Evidence

- RootTabs tabs: `ios/PulsePlate/Views/RootTabs.swift`
- BMI screen + thin adapter + tests inventory: `docs/audit/PR_672_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md`

## Test plan

- [x] `pre-commit run --all-files`
- [x] `make ios-test`

## Deferred / Follow-ups

- Ledger/roadmap updates for PR-672 will be done in a separate docs-only PR after merge.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Сделать существующий калькулятор ИМТ отдельной вкладкой в навигации iOS RootTabs и добавить сопроводительный аудиторский документ, описывающий охват, доказательства и принятые решения.

Новые возможности:
- Добавить новую вкладку BMI в iOS RootTabs TabView, которая отображает `BMICalculatorScreen` через `NavigationStack`.

Документация:
- Добавить аудиторский документ с детализацией обоснования, охвата и доказательств для вынесения экрана BMI в RootTabs.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose the existing BMI calculator as a dedicated tab in the iOS RootTabs navigation and add an accompanying audit document describing scope, evidence, and decisions.

New Features:
- Add a new BMI tab in the iOS RootTabs TabView that presents the BMICalculatorScreen via a NavigationStack.

Documentation:
- Introduce an audit document detailing the rationale, scope, and evidence for exposing the BMI screen from RootTabs.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed the BMI calculator as a new tab in RootTabs, with BMICalculatorScreen wrapped in a NavigationStack for proper titles and links. Added an SF Symbol fallback (use "gauge" if "scalemass" is unavailable), kept BMI logic unchanged, and updated the audit doc (PR-671) with RootTabs evidence and i18n proof.

<sup>Written for commit 9289d39bfedc4e61824ec703df0367743a99ab28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BMI Calculator tab to the main navigation, placed between Home and Plate for easy access; the tab shows the best-available icon depending on device capabilities.
* **Documentation**
  * Added audit documentation detailing scope, decisions, testing considerations, localization notes, and a pre-push checklist for exposing the BMI screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->