### PR TITLE
feat(ios): mount WeeklyPlanReader behind feature flag

### DIFF
--- a/docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md
+++ b/docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md
@@ -1,7 +1,7 @@
-# PR-TBD Audit — iOS: Mount WeeklyPlanReader behind feature flag
+# PR-673 Audit — iOS: Mount WeeklyPlanReader behind feature flag
 
 **Date**: 7 February 2026
-**PR**: TBD
+**PR**: #673
 **Branch**: `feat/ios-weekly-plan-reader-flag`
 **Type**: iOS runtime + audit doc
 

--- a/docs/audit/PR_TBD_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md
+++ b/docs/audit/PR_TBD_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md
@@ -1,0 +1,72 @@
+# PR-TBD Audit — iOS: Mount WeeklyPlanReader behind feature flag
+
+**Date**: 7 February 2026
+**PR**: TBD
+**Branch**: `feat/ios-weekly-plan-reader-flag`
+**Type**: iOS runtime + audit doc
+
+---
+
+## Summary
+
+We already have a Weekly Plan Reader implementation (view + view model + service), but it is not
+reachable from the running app. This PR mounts it behind an existing feature flag
+(`FeatureFlags.weeklyPlanReaderEnabled`) via a controlled entrypoint (Debug Tools), and tightens
+error UX for common auth failures (400/401/403) without adding any domain logic on the client.
+
+---
+
+## Scope
+
+- Mount `WeeklyPlanReader` behind `FeatureFlags.weeklyPlanReaderEnabled`.
+- Expose the entrypoint via Debug Tools (controlled, non-user-facing in release).
+- Ensure 400/401/403 failures render as user-readable UI states (no crashes / no raw debug dumps).
+
+## Non-scope
+
+- No backend changes.
+- No paywall implementation / StoreKit wiring.
+- No “unify all tabs under NavigationStack” refactor.
+- No new client-side business logic (thin client policy).
+
+---
+
+## Evidence (repo-truth)
+
+### Feature flag exists
+
+- `ios/PulsePlate/Utilities/FeatureFlags.swift:12-36`
+
+### WeeklyPlanReader implementation exists (but is not mounted)
+
+- View: `ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift:8-67`
+- ViewModel: `ios/PulsePlate/ViewModels/WeeklyPlanReaderViewModel.swift:9-105`
+- Service: `ios/PulsePlate/Services/WeeklyPlanService.swift:3-38`
+
+### Debug Tools exists as a controlled entrypoint
+
+- `ios/PulsePlate/Views/DebugToolsScreen.swift:11-72`
+
+### Test coverage (ViewModel error/auth mapping)
+
+- `ios/PulsePlateTests/WeeklyPlanReaderViewModelTests.swift:1-120`
+
+---
+
+## Implementation plan (one path)
+
+1. Add a conditional Debug Tools entry for WeeklyPlanReader when the feature flag is enabled.
+2. Ensure WeeklyPlanReader screen integrates cleanly with existing navigation (no nested stacks).
+3. Improve ViewModel error mapping for HTTP 400/401/403 into user-readable messages.
+4. Add focused unit tests for the ViewModel auth/error mapping.
+
+---
+
+## Verification
+
+Local commands used:
+
+```bash
+pre-commit run --all-files
+make ios-test
+```

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -457,16 +457,17 @@ If it is not recorded here — it does not exist.
     - Tests patch quota/provider paths deterministically
     - `diff-coverage` passes on PRs touching these guard tests
 
-- [ ] iOS: Expose BMI screen from Home / RootTabs (Free MVP UX)
+- [x] iOS: Expose BMI screen from Home / RootTabs (Free MVP UX)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (Free MVP polish)
-  - Target PR: TBD (iOS-only)
-  - Status: 📋 Ready to start
+  - Target PR: PR-671
+  - Status: ✅ Merged (PR-671, 2026-02-07)
   - Reason: BMI calculator exists but is not clearly reachable from the main navigation (Free MVP must make value moment obvious).
   - Links:
     - `ios/PulsePlate/Views/RootTabs.swift`
     - `ios/PulsePlate/Screens/BMICalculatorScreen.swift`
     - `ios/PulsePlate/ViewModels/BMICalculatorViewModel.swift`
+    - `docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md`
   - DoD:
     - User can reach BMI from the default tab flow (Home card or dedicated tab)
     - Loading/error/validation states remain user-friendly (no debug-y messages)
@@ -503,8 +504,8 @@ If it is not recorded here — it does not exist.
 - [ ] iOS: Mount WeeklyPlanReader behind feature flag (PRO demo slice)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (Demo / TestFlight)
-  - Target PR: TBD (iOS-only)
-  - Status: 📋 Ready to start
+  - Target PR: TBD (this PR)
+  - Status: 🚧 In progress (branch: `feat/ios-weekly-plan-reader-flag`)
   - Reason: WeeklyPlanReaderView + VM exist but are not mounted in the app; feature flag is defined but only shown as a usage example.
   - Links:
     - `ios/PulsePlate/Utilities/FeatureFlags.swift` (`weeklyPlanReaderEnabled`)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -504,7 +504,7 @@ If it is not recorded here — it does not exist.
 - [ ] iOS: Mount WeeklyPlanReader behind feature flag (PRO demo slice)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (Demo / TestFlight)
-  - Target PR: TBD (this PR)
+  - Target PR: PR-673
   - Status: 🚧 In progress (branch: `feat/ios-weekly-plan-reader-flag`)
   - Reason: WeeklyPlanReaderView + VM exist but are not mounted in the app; feature flag is defined but only shown as a usage example.
   - Links:
@@ -512,6 +512,7 @@ If it is not recorded here — it does not exist.
     - `ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift`
     - `ios/PulsePlate/ViewModels/WeeklyPlanReaderViewModel.swift`
     - `ios/PulsePlate/Services/WeeklyPlanService.swift`
+    - `docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md`
   - DoD:
     - When `FeatureFlags.weeklyPlanReaderEnabled` is true, the screen is reachable (Debug tools or a controlled entrypoint)
     - Requests use `APIClient` and include `X-API-Key` where required (no auth bypass in production code)

--- a/ios/PulsePlate/ViewModels/WeeklyPlanReaderViewModel.swift
+++ b/ios/PulsePlate/ViewModels/WeeklyPlanReaderViewModel.swift
@@ -57,6 +57,11 @@ public final class WeeklyPlanReaderViewModel {
         // Store targets for retry
         lastTargets = targets
 
+        guard let apiKey else {
+            state = .failed("PRO API key not configured. Add it in Debug Tools / Keychain.")
+            return
+        }
+
         state = .loading
 
         do {
@@ -98,9 +103,26 @@ public final class WeeklyPlanReaderViewModel {
                 state = .empty
                 return
             }
+            if case .api(let statusCode, _) = error {
+                state = .failed(Self.userFacingHTTPError(statusCode: statusCode))
+                return
+            }
             state = .failed(error.localizedDescription)
         } catch {
             state = .failed(error.localizedDescription)
+        }
+    }
+
+    private static func userFacingHTTPError(statusCode: Int) -> String {
+        switch statusCode {
+        case 400:
+            return "Bad request (HTTP 400). Please review inputs and try again."
+        case 401:
+            return "Unauthorized (HTTP 401). Check your PRO API key."
+        case 403:
+            return "Forbidden (HTTP 403). Your PRO key may be missing access."
+        default:
+            return "Server error (HTTP \(statusCode)). Please try again later."
         }
     }
 

--- a/ios/PulsePlate/Views/DebugToolsScreen.swift
+++ b/ios/PulsePlate/Views/DebugToolsScreen.swift
@@ -22,6 +22,12 @@ struct DebugToolsScreen: View {
                 NavigationLink("Shopping List Generator") {
                     makeShoppingListScreen()
                 }
+
+                if FeatureFlags.weeklyPlanReaderEnabled {
+                    NavigationLink("Weekly Plan Reader") {
+                        makeWeeklyPlanReaderScreen()
+                    }
+                }
             }
 
             Section("Network Test") {
@@ -93,6 +99,15 @@ struct DebugToolsScreen: View {
             vm: vm,
             planData: ShoppingListStubPlan.minimal()
         )
+    }
+
+    private func makeWeeklyPlanReaderScreen() -> some View {
+        let service = DefaultWeeklyPlanService(apiClient: apiClient)
+        let vm = WeeklyPlanReaderViewModel(
+            service: service,
+            apiKey: ProKeyProvider.value()
+        )
+        return WeeklyPlanReaderView(vm: vm)
     }
 
     private func testBackendConnection() async {

--- a/ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift
+++ b/ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift
@@ -13,23 +13,21 @@ struct WeeklyPlanReaderView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            content
-                .navigationTitle("Weekly Plan")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            // TODO: Share (future)
-                        } label: {
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                        .disabled(!canShare)
-                        .accessibilityLabel("Share weekly plan")
+        content
+            .navigationTitle("Weekly Plan")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        // TODO: Share (future)
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
                     }
+                    .disabled(!canShare)
+                    .accessibilityLabel("Share weekly plan")
                 }
-        }
-        .task { await ensureLoadedOnce() }
+            }
+            .task { await ensureLoadedOnce() }
     }
 
     private var canShare: Bool {
@@ -181,11 +179,14 @@ private struct VipCTASection: View {
 }
 
 #Preview {
-    WeeklyPlanReaderView(
-        vm: WeeklyPlanReaderViewModel(
-            service: MockWeeklyPlanService()
+    NavigationStack {
+        WeeklyPlanReaderView(
+            vm: WeeklyPlanReaderViewModel(
+                service: MockWeeklyPlanService(),
+                apiKey: "preview" // pragma: allowlist secret
+            )
         )
-    )
+    }
 }
 
 // MARK: - Mock Service (for preview)

--- a/ios/PulsePlateTests/WeeklyPlanReaderViewModelTests.swift
+++ b/ios/PulsePlateTests/WeeklyPlanReaderViewModelTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import PulsePlate
+
+final class WeeklyPlanReaderViewModelTests: XCTestCase {
+
+    func test_load_withoutApiKey_setsFailed_andDoesNotCallService() async {
+        let service = CapturingWeeklyPlanService(result: .failure(.unknown("should not be called")))
+        let vm = await MainActor.run {
+            WeeklyPlanReaderViewModel(service: service, apiKey: nil)
+        }
+
+        await MainActor.run {
+            vm.load()
+        }
+
+        let state = await awaitEventuallyState(vm)
+        let callCount = await service.callCount
+        XCTAssertEqual(callCount, 0)
+
+        guard case .failed(let message) = state else {
+            return XCTFail("Expected failed state, got: \(state)")
+        }
+        XCTAssertTrue(message.contains("PRO API key not configured"))
+    }
+
+    func test_load_maps401_toUserFacingMessage() async {
+        let service = CapturingWeeklyPlanService(result: .failure(.api(statusCode: 401, message: "nope")))
+        let vm = await MainActor.run {
+            WeeklyPlanReaderViewModel(service: service, apiKey: "pp-placeholder") // pragma: allowlist secret
+        }
+
+        await MainActor.run {
+            vm.load()
+        }
+
+        let state = await awaitEventuallyState(vm)
+        let callCount = await service.callCount
+        XCTAssertEqual(callCount, 1)
+
+        guard case .failed(let message) = state else {
+            return XCTFail("Expected failed state, got: \(state)")
+        }
+        XCTAssertEqual(message, "Unauthorized (HTTP 401). Check your PRO API key.")
+    }
+
+    func test_load_maps403_toUserFacingMessage() async {
+        let service = CapturingWeeklyPlanService(result: .failure(.api(statusCode: 403, message: "nope")))
+        let vm = await MainActor.run {
+            WeeklyPlanReaderViewModel(service: service, apiKey: "pp-placeholder") // pragma: allowlist secret
+        }
+
+        await MainActor.run {
+            vm.load()
+        }
+
+        let state = await awaitEventuallyState(vm)
+        let callCount = await service.callCount
+        XCTAssertEqual(callCount, 1)
+
+        guard case .failed(let message) = state else {
+            return XCTFail("Expected failed state, got: \(state)")
+        }
+        XCTAssertEqual(message, "Forbidden (HTTP 403). Your PRO key may be missing access.")
+    }
+
+    // MARK: - Helpers
+
+    private func awaitEventuallyState(_ vm: WeeklyPlanReaderViewModel) async -> WeeklyPlanState {
+        // load() runs in an internal Task; we yield + short sleep until it updates state.
+        for _ in 0..<200 {
+            let state = await MainActor.run { vm.state }
+            if case .idle = state {
+                await Task.yield()
+                continue
+            }
+            if case .loading = state {
+                await Task.yield()
+                continue
+            }
+            return state
+        }
+
+        // Last attempt with a tiny sleep (keeps tests deterministic enough in CI).
+        try? await Task.sleep(for: .milliseconds(10))
+        return await MainActor.run { vm.state }
+    }
+}
+
+// MARK: - Test Double
+
+private actor CapturingWeeklyPlanService: WeeklyPlanServicing {
+    private let result: Result<WeeklyPlanDTO, APIError>
+    private(set) var callCount: Int = 0
+
+    init(result: Result<WeeklyPlanDTO, APIError>) {
+        self.result = result
+    }
+
+    func fetchWeeklyPlan(request: WeeklyPlanRequest) async throws -> WeeklyPlanDTO {
+        callCount += 1
+        switch result {
+        case .success(let dto):
+            return dto
+        case .failure(let error):
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Mount WeeklyPlanReader behind `FeatureFlags.weeklyPlanReaderEnabled` via Debug Tools entrypoint.
- Improve user-facing error states for common auth failures (400/401/403).
- Update `BACKLOG_LEDGER` to reflect PR #671 merged and WeeklyPlanReader work in progress.

## Test plan
- `pre-commit run --all-files`
- `make ios-test`

## Deferred / Follow-ups
- WeeklyPlanReader rollout beyond Debug Tools (paywall/router/UX entrypoint) stays out of scope for this PR.

---

### Change type
- iOS P1 feature (Debug-only slice) + tracking updates (ledger/audit)

### What changed
- Mounted **WeeklyPlanReader** behind feature flag `FeatureFlags.weeklyPlanReaderEnabled` via **Debug Tools** entrypoint.
- Removed **nested `NavigationStack`** inside `WeeklyPlanReaderView` to ensure correct push navigation from the app’s existing navigation container.
- `WeeklyPlanReaderViewModel`: added user-friendly messages for **HTTP 400/401/403** and explicit error when **PRO key is missing**.
- Added unit tests: `WeeklyPlanReaderViewModelTests` covering auth/error mapping.

### Scope / Non-scope

**In scope**
- iOS UI wiring behind flag (Debug Tools only)
- ViewModel error mapping + unit tests
- Minimal docs/ledger tracking for the P1 item

**Out of scope**
- Any backend/API changes
- Any changes to product UX entrypoints (non-Debug)
- Paywall / StoreKit flows
- Refactors outside WeeklyPlanReader wiring

### Risk / Impact
- **Low risk**: feature is behind a flag and only reachable via Debug Tools.
- Removes nested navigation container → **improves navigation correctness** (prevents broken title/push behavior).
- No domain logic added; iOS remains thin client.

### CI / Gates
- `pre-commit run --all-files` ✅
- `make ios-test` ✅
- CI checks ✅ (including `diff-coverage`)
- CodeRabbit/Sourcery/cubic ✅

### Manual sanity
- Toggle flag in Debug Tools → WeeklyPlanReader opens.
- Without PRO key → explicit user-facing error.
- With invalid/unauthorized responses → correct message mapping.

### Checklist
- [x] Behind feature flag + Debug-only entrypoint
- [x] No nested `NavigationStack` inside reader view
- [x] Unit tests added for error/auth mapping
- [x] No backend changes