### PR TITLE
feat(ios): wire soft paywall CTA to paywall router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		if [ -n "$$ONLY_ITEMS" ]; then \
 			IFS=','; for t in $$ONLY_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && ONLY_FLAGS="$$ONLY_FLAGS -only-testing:$$t"; done; unset IFS; \
 		else \
-			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests"; \
+			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests -only-testing:PulsePlateTests/SoftPaywallCTARoutingTests"; \
 		fi; \
 		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_PROVIDED" ]; then \
 			SKIP_FLAGS="-skip-testing:PulsePlateUITests"; \

--- a/docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md
+++ b/docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md
@@ -14,18 +14,18 @@ This PR wires the existing **soft paywall** CTA (rendered after BMI calculation)
 
 ## Repo-truth (before)
 
-### 1) Soft paywall hook is rendered, but CTA is a no-op
+### 1) Soft paywall hook is rendered and requires CTA wiring
 
 - DTO contract field exists: `soft_paywall` and `SoftPaywallHookDTO` (client renders it only when present).
   - Evidence: `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift:12-43`
   - Evidence: `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift:6-58`
 
-- UI renders the hook inside `BMICalculatorScreen`, but the CTA closure was empty (no navigation).
-  - Evidence: `ios/PulsePlate/Screens/BMICalculatorScreen.swift:60-90`
+- Backlog explicitly tracks that the hook is rendered but CTA navigation was missing.
+  - Evidence: `docs/roadmap/BACKLOG_LEDGER.md:869-881`
 
 ### 2) Backlog item exists (P1) explicitly for wiring CTA → router
 
-- Evidence: `docs/roadmap/BACKLOG_LEDGER.md:869-879`
+- Evidence: `docs/roadmap/BACKLOG_LEDGER.md:869-881`
 
 ## Canonical contract (backend-owned)
 
@@ -39,25 +39,25 @@ This PR wires the existing **soft paywall** CTA (rendered after BMI calculation)
 
 - `PaywallRouter` manages paywall presentation state and keeps last routing context (source/target).
 - It contains **no subscription logic**; it is purely a navigation handler.
-- Evidence: `ios/PulsePlate/Routing/PaywallRouter.swift:1-28`
+- Evidence: `ios/PulsePlate/Routing/PaywallRouter.swift:1-26`
 
 ### 2) Add a minimal paywall screen backed by StoreKit
 
 - `PaywallScreen` uses existing `StoreKitManager` to list products, purchase, and restore.
-- Evidence: `ios/PulsePlate/Screens/PaywallScreen.swift:1-66`
+- Evidence: `ios/PulsePlate/Screens/PaywallScreen.swift:1-81`
 - Evidence: `ios/PulsePlate/Models/StoreKitManager.swift:6-73`
 
 ### 3) Wire soft paywall CTA → router and present paywall
 
 - `BMICalculatorScreen` now calls `paywallRouter.presentPaywall(source:target:)` from the CTA handler and presents `PaywallScreen` via `.sheet`.
-- Evidence: `ios/PulsePlate/Screens/BMICalculatorScreen.swift:60-110`
+- Evidence: `ios/PulsePlate/Screens/BMICalculatorScreen.swift:61-103`
 
 ## Tests
 
 ### CTA routing unit test
 
 - Added a small unit test to ensure `PaywallRouter` toggles presentation state and stores context (source/target).
-- Evidence: `ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift:1-24`
+- Evidence: `ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift:1-31`
 
 ### Test execution (CI-relevant)
 

--- a/docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md
+++ b/docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md
@@ -1,0 +1,91 @@
+# PR-674 Audit — iOS: Wire soft paywall CTA → paywall router
+
+**Date**: 7 February 2026
+**PR**: #674
+**Branch**: `feat/ios-soft-paywall-cta-router-pr-674`
+**Type**: iOS runtime + audit doc
+
+## Summary
+
+This PR wires the existing **soft paywall** CTA (rendered after BMI calculation) to a **real paywall navigation handler** and a minimal paywall screen.
+
+**Goal:** remove the current no-op CTA handler and route users to an actual paywall flow.
+**Non-goal:** change product logic, pricing, offers, or subscription business rules.
+
+## Repo-truth (before)
+
+### 1) Soft paywall hook is rendered, but CTA is a no-op
+
+- DTO contract field exists: `soft_paywall` and `SoftPaywallHookDTO` (client renders it only when present).
+  - Evidence: `ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift:12-43`
+  - Evidence: `ios/PulsePlate/Models/BMI/SoftPaywallHookDTO.swift:6-58`
+
+- UI renders the hook inside `BMICalculatorScreen`, but the CTA closure was empty (no navigation).
+  - Evidence: `ios/PulsePlate/Screens/BMICalculatorScreen.swift:60-90`
+
+### 2) Backlog item exists (P1) explicitly for wiring CTA → router
+
+- Evidence: `docs/roadmap/BACKLOG_LEDGER.md:869-879`
+
+## Canonical contract (backend-owned)
+
+- Soft paywall hook contract: `docs/contracts/soft_paywall.md`
+  - Purpose: text-only hook; client must render and navigate only (no BMI logic).
+  - Evidence: `docs/contracts/soft_paywall.md:1-156`
+
+## Implementation (this PR)
+
+### 1) Add a paywall router (navigation handler)
+
+- `PaywallRouter` manages paywall presentation state and keeps last routing context (source/target).
+- It contains **no subscription logic**; it is purely a navigation handler.
+- Evidence: `ios/PulsePlate/Routing/PaywallRouter.swift:1-28`
+
+### 2) Add a minimal paywall screen backed by StoreKit
+
+- `PaywallScreen` uses existing `StoreKitManager` to list products, purchase, and restore.
+- Evidence: `ios/PulsePlate/Screens/PaywallScreen.swift:1-66`
+- Evidence: `ios/PulsePlate/Models/StoreKitManager.swift:6-73`
+
+### 3) Wire soft paywall CTA → router and present paywall
+
+- `BMICalculatorScreen` now calls `paywallRouter.presentPaywall(source:target:)` from the CTA handler and presents `PaywallScreen` via `.sheet`.
+- Evidence: `ios/PulsePlate/Screens/BMICalculatorScreen.swift:60-110`
+
+## Tests
+
+### CTA routing unit test
+
+- Added a small unit test to ensure `PaywallRouter` toggles presentation state and stores context (source/target).
+- Evidence: `ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift:1-24`
+
+### Test execution (CI-relevant)
+
+`make ios-test` runs an explicit allowlist of iOS tests via `-only-testing:` flags.
+This PR adds `SoftPaywallCTARoutingTests` to that default allowlist.
+
+- Evidence: `Makefile:310-352`
+
+## Scope / Non-scope
+
+### In scope
+
+- Wire existing soft paywall CTA to paywall navigation handler
+- Minimal paywall screen using existing StoreKit manager
+- Deterministic unit test + ensure it runs in `make ios-test`
+
+### Out of scope
+
+- Changing paywall copy, pricing, or offers
+- Adding subscription eligibility / tier inference in iOS
+- Refactoring navigation across the app
+- Backend changes
+
+## Verification
+
+### Local commands
+
+```bash
+pre-commit run --all-files
+make ios-test
+```

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -869,10 +869,12 @@ If it is not recorded here — it does not exist.
 - [ ] Wire soft paywall CTA to real paywall router (iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: TBD
+  - Target PR: PR-674
+  - Status: 🚧 In progress (PR-674)
   - Reason: paywall navigation infrastructure not yet available; hook is rendered but CTA is no-op
   - Links:
     - ios/PulsePlate/Screens/BMICalculatorScreen.swift (line ~73)
+    - docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md
   - DoD:
     - Paywall router/navigation handler implemented
     - SoftPaywallHookView CTA wired to navigation

--- a/ios/PulsePlate/Routing/PaywallRouter.swift
+++ b/ios/PulsePlate/Routing/PaywallRouter.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Observation
+
+/// Paywall router (navigation handler) for soft-paywall CTAs.
+///
+/// Thin-client rule:
+/// - This router only manages presentation state.
+/// - It must not contain subscription business logic (pricing/eligibility/tiers).
+@MainActor
+@Observable
+final class PaywallRouter {
+    private(set) var isPaywallPresented: Bool = false
+    private(set) var lastSource: String? = nil
+    private(set) var lastTarget: String? = nil
+
+    func presentPaywall(source: String, target: String) {
+        lastSource = source
+        lastTarget = target
+        isPaywallPresented = true
+    }
+
+    func dismissPaywall() {
+        isPaywallPresented = false
+    }
+}

--- a/ios/PulsePlate/Routing/PaywallRouter.swift
+++ b/ios/PulsePlate/Routing/PaywallRouter.swift
@@ -32,4 +32,20 @@ enum PaywallSource: String, Equatable {
 enum PaywallTarget: String, Equatable {
     case pro
     case vip
+
+    /// Map backend soft-paywall `hook.target` strings to typed enum.
+    ///
+    /// Backend currently emits `pro_paywall` (see app.schemas.bmi.SoftPaywallHook).
+    /// This mapping keeps iOS routing forward-compatible if backend adds new targets.
+    static func fromSoftPaywallHookTarget(_ target: String) -> PaywallTarget? {
+        let normalized = target.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "pro_paywall", "pro":
+            return .pro
+        case "vip_paywall", "vip":
+            return .vip
+        default:
+            return nil
+        }
+    }
 }

--- a/ios/PulsePlate/Routing/PaywallRouter.swift
+++ b/ios/PulsePlate/Routing/PaywallRouter.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Paywall router (navigation handler) for soft-paywall CTAs.
 ///
@@ -7,13 +7,12 @@ import Observation
 /// - This router only manages presentation state.
 /// - It must not contain subscription business logic (pricing/eligibility/tiers).
 @MainActor
-@Observable
-final class PaywallRouter {
-    private(set) var isPaywallPresented: Bool = false
-    private(set) var lastSource: String? = nil
-    private(set) var lastTarget: String? = nil
+final class PaywallRouter: ObservableObject {
+    @Published var isPaywallPresented: Bool = false
+    @Published var lastSource: PaywallSource? = nil
+    @Published var lastTarget: PaywallTarget? = nil
 
-    func presentPaywall(source: String, target: String) {
+    func presentPaywall(source: PaywallSource, target: PaywallTarget) {
         lastSource = source
         lastTarget = target
         isPaywallPresented = true
@@ -21,5 +20,16 @@ final class PaywallRouter {
 
     func dismissPaywall() {
         isPaywallPresented = false
+        lastSource = nil
+        lastTarget = nil
     }
+}
+
+enum PaywallSource: String, Equatable {
+    case bmiSoftPaywallCTA
+}
+
+enum PaywallTarget: String, Equatable {
+    case pro
+    case vip
 }

--- a/ios/PulsePlate/Screens/BMICalculatorScreen.swift
+++ b/ios/PulsePlate/Screens/BMICalculatorScreen.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct BMICalculatorScreen: View {
     @StateObject private var vm = BMICalculatorViewModel()
-    @State private var paywallRouter = PaywallRouter()
+    @StateObject private var paywallRouter = PaywallRouter()
 
     @State private var weightKg = "70"
     @State private var heightCm = "175"
@@ -76,8 +76,8 @@ struct BMICalculatorScreen: View {
                             if let hook = res.softPaywall {
                                 SoftPaywallHookView(hook: hook) {
                                     paywallRouter.presentPaywall(
-                                        source: "bmi_soft_paywall",
-                                        target: hook.target
+                                        source: .bmiSoftPaywallCTA,
+                                        target: .pro
                                     )
                                 }
                             }
@@ -88,14 +88,10 @@ struct BMICalculatorScreen: View {
             .padding()
         }
         .navigationTitle("BMI")
-        .sheet(isPresented: Binding(
-            get: { paywallRouter.isPaywallPresented },
-            set: { newValue in
-                if !newValue {
-                    paywallRouter.dismissPaywall()
-                }
-            }
-        )) {
+        .sheet(
+            isPresented: $paywallRouter.isPaywallPresented,
+            onDismiss: { paywallRouter.dismissPaywall() }
+        ) {
             NavigationStack {
                 PaywallScreen()
             }

--- a/ios/PulsePlate/Screens/BMICalculatorScreen.swift
+++ b/ios/PulsePlate/Screens/BMICalculatorScreen.swift
@@ -77,7 +77,7 @@ struct BMICalculatorScreen: View {
                                 SoftPaywallHookView(hook: hook) {
                                     paywallRouter.presentPaywall(
                                         source: .bmiSoftPaywallCTA,
-                                        target: .pro
+                                        target: PaywallTarget.fromSoftPaywallHookTarget(hook.target) ?? .pro
                                     )
                                 }
                             }

--- a/ios/PulsePlate/Screens/BMICalculatorScreen.swift
+++ b/ios/PulsePlate/Screens/BMICalculatorScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BMICalculatorScreen: View {
     @StateObject private var vm = BMICalculatorViewModel()
+    @State private var paywallRouter = PaywallRouter()
 
     @State private var weightKg = "70"
     @State private var heightCm = "175"
@@ -72,11 +73,12 @@ struct BMICalculatorScreen: View {
                                 Text("Ranges: \(vis.ranges.count)")
                             }
 
-                            // Soft paywall hook: only render if navigation handler is available
-                            // Deferred: wire to real paywall router (see BACKLOG_LEDGER.md)
                             if let hook = res.softPaywall {
                                 SoftPaywallHookView(hook: hook) {
-                                    // Navigation deferred until paywall router is available
+                                    paywallRouter.presentPaywall(
+                                        source: "bmi_soft_paywall",
+                                        target: hook.target
+                                    )
                                 }
                             }
                         }
@@ -86,6 +88,18 @@ struct BMICalculatorScreen: View {
             .padding()
         }
         .navigationTitle("BMI")
+        .sheet(isPresented: Binding(
+            get: { paywallRouter.isPaywallPresented },
+            set: { newValue in
+                if !newValue {
+                    paywallRouter.dismissPaywall()
+                }
+            }
+        )) {
+            NavigationStack {
+                PaywallScreen()
+            }
+        }
     }
 
     private func onCalculate() async {

--- a/ios/PulsePlate/Screens/PaywallScreen.swift
+++ b/ios/PulsePlate/Screens/PaywallScreen.swift
@@ -1,0 +1,80 @@
+import StoreKit
+import SwiftUI
+
+/// Minimal paywall screen powered by StoreKitManager.
+///
+/// This is wiring/UI only:
+/// - No tier/business logic in the client.
+/// - Purchases are handled by StoreKit.
+struct PaywallScreen: View {
+    @StateObject private var storeKit = StoreKitManager()
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Upgrade to PRO")
+                        .font(.title3.weight(.semibold))
+                    Text("Unlock more detailed wellness insights and planning features.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 6)
+            }
+
+            if storeKit.isPremium {
+                Section {
+                    Label("Premium active", systemImage: "checkmark.seal.fill")
+                        .foregroundStyle(.green)
+                }
+            }
+
+            Section("Plans") {
+                if storeKit.products.isEmpty {
+                    Text("Loading plans…")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(storeKit.products, id: \.id) { product in
+                        Button {
+                            Task { await storeKit.purchase(product) }
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(product.displayName)
+                                    Text(product.displayPrice)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Button("Restore Purchases") {
+                    Task { await storeKit.restorePurchases() }
+                }
+            }
+
+            if let error = storeKit.error {
+                Section("Error") {
+                    Text(error.localizedDescription)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("PRO")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PaywallScreen()
+    }
+}

--- a/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
+++ b/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
@@ -6,25 +6,22 @@ final class SoftPaywallCTARoutingTests: XCTestCase {
     func test_presentPaywall_setsPresented_andStoresContext() async {
         let router = PaywallRouter()
 
-        router.presentPaywall(source: "bmi_soft_paywall", target: "pro_paywall")
+        router.presentPaywall(source: .bmiSoftPaywallCTA, target: .pro)
 
-        let isPaywallPresented = router.isPaywallPresented
-        let lastSource = router.lastSource
-        let lastTarget = router.lastTarget
-
-        XCTAssertTrue(isPaywallPresented)
-        XCTAssertEqual(lastSource, "bmi_soft_paywall")
-        XCTAssertEqual(lastTarget, "pro_paywall")
+        XCTAssertTrue(router.isPaywallPresented)
+        XCTAssertEqual(router.lastSource, .bmiSoftPaywallCTA)
+        XCTAssertEqual(router.lastTarget, .pro)
     }
 
     @MainActor
     func test_dismissPaywall_clearsPresentedFlag() async {
         let router = PaywallRouter()
-        router.presentPaywall(source: "bmi_soft_paywall", target: "pro_paywall")
+        router.presentPaywall(source: .bmiSoftPaywallCTA, target: .pro)
 
         router.dismissPaywall()
 
-        let isPaywallPresented = router.isPaywallPresented
-        XCTAssertFalse(isPaywallPresented)
+        XCTAssertFalse(router.isPaywallPresented)
+        XCTAssertNil(router.lastSource)
+        XCTAssertNil(router.lastTarget)
     }
 }

--- a/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
+++ b/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
@@ -24,4 +24,14 @@ final class SoftPaywallCTARoutingTests: XCTestCase {
         XCTAssertNil(router.lastSource)
         XCTAssertNil(router.lastTarget)
     }
+
+    func test_softPaywallTargetMapping_mapsVipPaywall() {
+        XCTAssertEqual(PaywallTarget.fromSoftPaywallHookTarget("vip_paywall"), .vip)
+        XCTAssertEqual(PaywallTarget.fromSoftPaywallHookTarget("vip"), .vip)
+    }
+
+    func test_softPaywallTargetMapping_fallsBackToNilForUnknown() {
+        XCTAssertNil(PaywallTarget.fromSoftPaywallHookTarget("unknown"))
+        XCTAssertNil(PaywallTarget.fromSoftPaywallHookTarget(""))
+    }
 }

--- a/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
+++ b/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import PulsePlate
+
+final class SoftPaywallCTARoutingTests: XCTestCase {
+    @MainActor
+    func test_presentPaywall_setsPresented_andStoresContext() async {
+        let router = PaywallRouter()
+
+        router.presentPaywall(source: "bmi_soft_paywall", target: "pro_paywall")
+
+        let isPaywallPresented = router.isPaywallPresented
+        let lastSource = router.lastSource
+        let lastTarget = router.lastTarget
+
+        XCTAssertTrue(isPaywallPresented)
+        XCTAssertEqual(lastSource, "bmi_soft_paywall")
+        XCTAssertEqual(lastTarget, "pro_paywall")
+    }
+
+    @MainActor
+    func test_dismissPaywall_clearsPresentedFlag() async {
+        let router = PaywallRouter()
+        router.presentPaywall(source: "bmi_soft_paywall", target: "pro_paywall")
+
+        router.dismissPaywall()
+
+        let isPaywallPresented = router.isPaywallPresented
+        XCTAssertFalse(isPaywallPresented)
+    }
+}


### PR DESCRIPTION
## Summary
- Wire BMI soft paywall CTA to a real paywall navigation handler and present a minimal paywall screen.
- Add unit tests for the router and ensure they run under `make ios-test` default allowlist.

## Scope / Non-scope
- In scope: CTA handler wiring + minimal paywall screen + unit tests
- Out of scope: pricing/offers logic, paywall copy redesign, StoreKit product strategy changes, navigation refactors

## Test plan
- `pre-commit run --all-files`
- `make ios-test`

## Notes
- GitHub PR number is the source of truth; branch name may contain a legacy slot number.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the BMI soft paywall CTA to a paywall router and presented a minimal paywall screen. Mapped backend hook.target to typed PaywallTarget with a safe PRO fallback and added tests to the default ios-test run.

- **New Features**
  - PaywallRouter (ObservableObject) manages sheet presentation; stores source/target and clears on dismiss.
  - BMI CTA calls router.presentPaywall and shows PaywallScreen via sheet.
  - PaywallScreen with basic StoreKit purchase/restore.
  - Map hook.target (e.g., pro_paywall, vip_paywall) to PaywallTarget; fallback to .pro.
  - Added SoftPaywallCTARoutingTests (incl. target mapping) to make ios-test; updated audit and backlog docs.

<sup>Written for commit b8c26d9742a148caaadcbfa04d4cef670b1fc608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft paywall CTA routing added with a router and sheet-based in-app paywall integrated into the BMI calculator flow.

* **Tests**
  * Added unit tests validating paywall presentation, context storage/clearing, and target-mapping logic.
  * Test runner default now includes the new soft-paywall routing tests when running the iOS test target.

* **Documentation**
  * Added audit notes for the soft paywall implementation and updated backlog tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->