### PR TITLE
fix(tests): stabilize VIP insight guard on main

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,5 +3,3 @@
 RU: Пакет для удобных импортов helper-утилит тестов.
 EN: Package marker to allow importing shared test helpers.
 """
-
-"""Tests package."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,7 @@
+"""Test suite package marker.
+
+RU: Пакет для удобных импортов helper-утилит тестов.
+EN: Package marker to allow importing shared test helpers.
+"""
+
 """Tests package."""

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Test helpers package.
+
+RU: Вспомогательные модули для тестов.
+EN: Helper modules for tests.
+"""

--- a/tests/helpers/fake_llm_provider.py
+++ b/tests/helpers/fake_llm_provider.py
@@ -2,6 +2,10 @@
 
 RU: Детерминированный fake LLM provider для тестов (без сети).
 EN: Deterministic fake LLM provider for tests (no network).
+
+Interface notes:
+- Intentionally keeps a minimal surface area, but accepts ``**kwargs`` to reduce
+  breakage if the real provider API evolves.
 """
 
 from __future__ import annotations
@@ -12,7 +16,7 @@ class FakeLLMProvider:
 
     name: str = "fake-llm"
 
-    async def generate(self, prompt_text: str) -> str:
+    async def generate(self, prompt_text: str, **kwargs: object) -> str:  # noqa: ARG002
         # RU: Детерминированный ответ, без сети/SDK.
         # EN: Deterministic response, no network/SDK.
         return "ok"

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -11,7 +11,9 @@ from collections.abc import Callable
 import pytest
 from fastapi.testclient import TestClient
 
+import llm
 import legacy_app
+from tests.helpers.fake_llm_provider import FakeLLMProvider
 
 
 def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -26,18 +28,8 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
     def _noop_quota(_: str) -> None:
         return None
 
-    # Use the real endpoint implementation, but provide a deterministic fake provider.
-    # This avoids intermittent 503s when CI has no real provider configured.
-    import llm
-
-    class FakeProvider:
-        name = "fake-llm"
-
-        async def generate(self, text: str) -> str:
-            return "ok"
-
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)
-    monkeypatch.setattr(llm, "get_provider", lambda: FakeProvider(), raising=True)
+    monkeypatch.setattr(llm, "get_provider", lambda: FakeLLMProvider(), raising=True)
 
 
 def test_insight_v1_requires_vip_tier(

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -25,7 +25,7 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
     coupling to DB quota/provider internals.
     """
 
-    def _noop_quota(_: str) -> None:
+    def _noop_quota(*_args: object, **_kwargs: object) -> None:
         return None
 
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -26,15 +26,18 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
     def _noop_quota(_: str) -> None:
         return None
 
-    async def _ok_v1(_: legacy_app.InsightRequest) -> legacy_app.InsightResponse:
-        return legacy_app.InsightResponse(provider="fake-llm", insight="ok")
+    # Use the real endpoint implementation, but provide a deterministic fake provider.
+    # This avoids intermittent 503s when CI has no real provider configured.
+    import llm
 
-    async def _ok_legacy(_: legacy_app.InsightRequest) -> legacy_app.InsightResponse:
-        return legacy_app.InsightResponse(provider="fake-llm", insight="ok")
+    class FakeProvider:
+        name = "fake-llm"
+
+        async def generate(self, text: str) -> str:
+            return "ok"
 
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)
-    monkeypatch.setattr(legacy_app, "insight_v1", _ok_v1, raising=True)
-    monkeypatch.setattr(legacy_app, "insight", _ok_legacy, raising=True)
+    monkeypatch.setattr(llm, "get_provider", lambda: FakeProvider(), raising=True)
 
 
 def test_insight_v1_requires_vip_tier(
@@ -59,7 +62,9 @@ def test_insight_v1_requires_vip_tier(
     assert r_pro.status_code == 403
 
     r_vip = client.post("/api/v1/insight", json=payload, headers=vip_headers)
-    assert r_vip.status_code == 200
+    assert (
+        r_vip.status_code == 200
+    ), f"status={r_vip.status_code} content-type={r_vip.headers.get('content-type')} body={r_vip.text}"
     assert r_vip.headers.get("content-type", "").startswith("application/json")
     data = r_vip.json()
     assert data["provider"] == "fake-llm"
@@ -91,7 +96,9 @@ def test_insight_legacy_requires_vip_tier(
 
     # VIP → 200
     r_vip = client.post("/insight", json=payload, headers=vip_headers)
-    assert r_vip.status_code == 200
+    assert (
+        r_vip.status_code == 200
+    ), f"status={r_vip.status_code} content-type={r_vip.headers.get('content-type')} body={r_vip.text}"
     assert r_vip.headers.get("content-type", "").startswith("application/json")
     data = r_vip.json()
     assert data["provider"] == "fake-llm"


### PR DESCRIPTION
## Summary
- Stabilize `tests/test_insight_vip_guard_api.py` so VIP insight guard tests are deterministic in CI.
- Provide a fake LLM provider and bypass monthly quota enforcement in the test helper.

## Why
Main CI has intermittently failed with VIP insight guard tests expecting 200 but receiving 503 when no provider is configured.

## Test plan
- `pre-commit run --all-files`
- `pytest -q tests/test_insight_vip_guard_api.py -n 4 --dist=loadscope`
- `pytest -q tests/test_insight_vip_monthly_quota_api.py tests/test_insight_error_hygiene.py tests/test_insight_vip_guard_api.py -n 4 --dist=loadscope`

## Notes
- No runtime behavior changes; tests only.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Стабилизировать тесты VIP insight guard, используя детерминированного фиктивного провайдера LLM и улучшив диагностику сбоев.

Tests:
- Мокировать провайдера LLM с помощью детерминированного фиктивного провайдера и обходить проверки месячной квоты, чтобы предотвратить периодические ошибки 503 в тестах VIP insight guard.
- Улучшить утверждения (assertions) в тестах VIP insight guard, добавив более подробную отладочную информацию при получении ответов с кодом, отличным от 200.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize VIP insight guard tests by using a deterministic fake LLM provider and improving failure diagnostics.

Tests:
- Mock the LLM provider via a deterministic fake provider and bypass monthly quota checks to prevent intermittent 503s in VIP insight guard tests.
- Enhance VIP insight guard test assertions with richer debugging information when non-200 responses are returned.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched VIP Guard API tests to a provider-based fake LLM and strengthened success assertions for clearer failures and increased reliability.
  * Test flows now rely on the provider mock instead of legacy in-test endpoint mocks.

* **Documentation**
  * Added brief package docstrings to test packages for clarity.

* **Tests (Helpers)**
  * Made the fake LLM test helper accept additional call parameters for greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->