### PR TITLE
fix(ios): narrow ShoppingPlan stub API surface

### DIFF
--- a/docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md
+++ b/docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md
@@ -1,0 +1,33 @@
+# PR-TBD Audit — iOS ShoppingPlan public API fix
+
+**Date**: 7 February 2026
+**PR**: TBD (GitHub PR number is source of truth)
+**Type**: iOS runtime + tests
+
+## Summary
+
+Fix an iOS API-surface smell: `ShoppingPlan` was declared `public` but was not constructible outside the module (internal nested types and no public initializer). This was flagged in review tooling as “ShoppingPlan isn't constructible”.
+
+This PR **narrows the API surface** by making the “stub plan” types internal to the app module:
+
+- `ShoppingPlan`
+- `ShoppingListRequestPayload`
+
+These are implementation details of the Shopping List reader flow and are consumed only inside `PulsePlate` (tests use `@testable import PulsePlate`).
+
+## Evidence (why this is safe)
+
+- `PulsePlateTests` imports the app module with `@testable`, so internal symbols remain accessible to tests:
+  - `ios/PulsePlateTests/Fixtures/ShoppingListFixtures.swift:2`
+
+## Changes (file:line)
+
+- Narrow `ShoppingPlan` to internal:
+  - `ios/PulsePlate/Models/ShoppingList/ShoppingListStubPlan.swift:6`
+- Narrow `ShoppingListRequestPayload` to internal:
+  - `ios/PulsePlate/Models/ShoppingList/ShoppingListRequestPayload.swift:5-21`
+
+## Test plan
+
+- `pre-commit run --all-files`
+- `make ios-test`

--- a/docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md
+++ b/docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md
@@ -1,7 +1,7 @@
 # PR-TBD Audit — iOS ShoppingPlan public API fix
 
 **Date**: 7 February 2026
-**PR**: TBD (GitHub PR number is source of truth)
+**PR**: 677 (GitHub PR number is source of truth)
 **Type**: iOS runtime + tests
 
 ## Summary
@@ -14,6 +14,10 @@ This PR **narrows the API surface** by making the “stub plan” types internal
 - `ShoppingListRequestPayload`
 
 These are implementation details of the Shopping List reader flow and are consumed only inside `PulsePlate` (tests use `@testable import PulsePlate`).
+Evidence:
+- `ios/PulsePlate/ViewModels/ShoppingListReaderViewModel.swift:26-35`
+- `ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:6-17`
+- `ios/PulsePlateTests/Fixtures/ShoppingListFixtures.swift:2,45-47`
 
 ## Evidence (why this is safe)
 

--- a/ios/PulsePlate/Models/ShoppingList/ShoppingListRequestPayload.swift
+++ b/ios/PulsePlate/Models/ShoppingList/ShoppingListRequestPayload.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// Encodable request payload for Shopping List API
 /// Represents the typed structure sent to POST /api/v1/pro/meal/shopping-list
-public struct ShoppingListRequestPayload: Encodable {
-    public let planData: ShoppingPlan
-    public let preferences: [String: Any]?
+struct ShoppingListRequestPayload: Encodable {
+    let planData: ShoppingPlan
+    let preferences: [String: Any]?
 
-    public init(planData: ShoppingPlan, preferences: [String: Any]? = nil) {
+    init(planData: ShoppingPlan, preferences: [String: Any]? = nil) {
         self.planData = planData
         self.preferences = preferences
     }
@@ -17,7 +17,7 @@ public struct ShoppingListRequestPayload: Encodable {
     }
 
     // Manual encoding to support [String: Any] for preferences
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(planData, forKey: .planData)
 

--- a/ios/PulsePlate/Models/ShoppingList/ShoppingListStubPlan.swift
+++ b/ios/PulsePlate/Models/ShoppingList/ShoppingListStubPlan.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Typed Stub Plan Models
 
 /// Represents a weekly shopping plan with typed structure
-public struct ShoppingPlan: Codable {
+struct ShoppingPlan: Codable {
     let dailyMenus: [DailyMenu]
 
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
## Summary
- Make `ShoppingPlan` internal (stub plan model).
- Make `ShoppingListRequestPayload` internal (used only by ShoppingList reader flow).
- Add audit note capturing rationale + file pointers.

## Why
Code review tooling flagged that `ShoppingPlan` was public but not constructible outside the module (internal nested types + no public initializer). These types are app implementation details; tests use `@testable import PulsePlate`.

## Test plan
- `pre-commit run --all-files`
- `make ios-test`

## Scope
- iOS + `docs/audit/*`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Сузить область использования моделей плана списка покупок iOS до внутренних деталей реализации и задокументировать обоснование в аудиторской документации.

Улучшения:
- Ограничить видимость `ShoppingPlan` и `ShoppingListRequestPayload` с public до internal внутри модуля `PulsePlate`, чтобы уменьшить площадь открытого API.

Документация:
- Добавить аудиторский документ, объясняющий проблему с публичным API `ShoppingPlan`, обоснование перевода типов во внутренние (internal), а также указать связанные тесты и ссылки на файлы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Narrow the iOS Shopping List stub plan models to be internal-only implementation details and document the rationale in the audit docs.

Enhancements:
- Restrict ShoppingPlan and ShoppingListRequestPayload visibility from public to internal within the PulsePlate module to reduce exposed API surface.

Documentation:
- Add an audit document explaining the ShoppingPlan public API issue, the rationale for making the types internal, and the associated test and file references.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrow the iOS Shopping List stub API by making ShoppingPlan and ShoppingListRequestPayload internal to avoid exposing a non-constructible public type. Added an evidence-driven audit doc with file:line usage and @testable import rationale.

- **Refactors**
  - Set ShoppingPlan and ShoppingListRequestPayload to internal; made init/encode internal as needed.
  - Added an audit document citing concrete usage sites and explaining why tests still access these via @testable import.

<sup>Written for commit fff75171b929f9a28cf711f512e3944ea4cf192c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restricted visibility of internal Shopping List types used by the iOS module, reducing the public API surface.
  * No changes to encoding, runtime behavior, or user-facing functionality; tests and internal usage remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->