### PR TITLE
feat(ios): onboarding value + usage (P0-B)

### DIFF
--- a/docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md
+++ b/docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md
@@ -1,0 +1,55 @@
+# PR-678 Audit — iOS onboarding (Value + Usage, P0-B)
+
+**Date**: 7 February 2026
+**PR**: 678 (GitHub PR number is source of truth)
+**Type**: iOS runtime + localization
+
+## Summary
+
+Tighten first-launch onboarding to the minimal P0-B requirement:
+
+- **2 screens**: **Value** + **Usage**
+- **Gate before root UX** (before `RootTabs()`)
+- **No networking / paywall / analytics**
+- RU/EN/ES strings updated
+
+## Audit questions (evidence-driven answers)
+
+### 1) Where is the iOS root entry / “first screen” chosen?
+
+- App entrypoint:
+  - `ios/PulsePlate/PulsePlateApp.swift:3-9` (WindowGroup shows `WelcomeGateView()`)
+- Gate view:
+  - `ios/PulsePlate/Welcome/WelcomeGateView.swift:3-12`
+
+### 2) Where is first-launch persistence stored?
+
+- `@AppStorage("has_seen_welcome_v1")` in:
+  - `ios/PulsePlate/Welcome/WelcomeGateView.swift:4-11`
+
+### 3) Is there an existing onboarding flow?
+
+Yes — `WelcomeFlowView` is the onboarding flow presented by `WelcomeGateView`:
+
+- `ios/PulsePlate/Welcome/WelcomeFlowView.swift:10-64` (flow)
+- Localization keys:
+  - `ios/PulsePlate/Welcome/WelcomeFlowView.swift:66-97`
+
+## Changes (file:line)
+
+- Reduce welcome flow steps to **two** screens (Value + Usage):
+  - `ios/PulsePlate/Welcome/WelcomeFlowView.swift:3-85`
+- Update RU/EN/ES strings for `onboarding.welcome.screen1.*` and `screen2.*`:
+  - `ios/PulsePlate/en.lproj/Localizable.strings:84-97`
+  - `ios/PulsePlate/ru.lproj/Localizable.strings:100-113`
+  - `ios/PulsePlate/es.lproj/Localizable.strings:100-113`
+
+## Test plan (local)
+
+- `pre-commit run --all-files`
+- `make ios-test`
+
+## Risks and mitigations
+
+- **Risk**: Existing users who already have `has_seen_welcome_v1=true` will not see updated onboarding copy.
+  - **Mitigation**: Minimal-risk choice for P0-B (no surprise re-onboarding). If we need to re-show onboarding later, do it via a versioned key (new ledger item + explicit product decision).

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -31,10 +31,29 @@ If it is not recorded here — it does not exist.
   - Reason: Store readiness — ensure deterministic first-run value framing with a single entry gate (`has_seen_welcome_v1`) before `RootTabs()`.
   - Links:
     - docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md
+    - Follow-up: PR-678 (tighten to 2 screens: Value + Usage)
   - DoD:
     - iOS entrypoint gates `RootTabs()` via `WelcomeGateView`
     - `@AppStorage("has_seen_welcome_v1")` persists completion (welcome shown once)
     - RU/EN/ES strings ship for `onboarding.welcome.*`
+    - `make ios-test` passes
+
+- [ ] iOS: Tighten first-launch onboarding to Value + Usage (2 screens)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0-B (release readiness)
+  - Target PR: PR-678
+  - Status: 🚧 In progress (PR-678)
+  - Reason: P0-B requires a minimal onboarding (≥2 screens). Keep the existing first-launch gate and tighten the flow to the two essential screens (Value + Usage) without adding networking/paywall/analytics.
+  - Links:
+    - `ios/PulsePlate/PulsePlateApp.swift`
+    - `ios/PulsePlate/Welcome/WelcomeGateView.swift`
+    - `ios/PulsePlate/Welcome/WelcomeFlowView.swift`
+    - docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md
+  - DoD:
+    - On first launch, onboarding shows before `RootTabs()` (gate remains at app entry)
+    - On completion, onboarding is not shown again (`has_seen_welcome_v1` persists)
+    - Onboarding is exactly 2 screens (Value + Usage)
+    - RU/EN/ES strings updated for the 2 screens
     - `make ios-test` passes
 - [x] iOS: Remove placeholder PRO key fallback and implement release-safe key storage
   - Owner: @katsiaryna_kavaleuskaya

--- a/ios/PulsePlate/Welcome/WelcomeFlowView.swift
+++ b/ios/PulsePlate/Welcome/WelcomeFlowView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 private enum WelcomeStep: Int, CaseIterable {
     case first = 0
     case second = 1
-    case third = 2
-    case fourth = 3
 }
 
 struct WelcomeFlowView: View {
@@ -69,8 +67,6 @@ struct WelcomeFlowView: View {
         switch currentStep {
         case .first: return "onboarding.welcome.screen1.title"
         case .second: return "onboarding.welcome.screen2.title"
-        case .third: return "onboarding.welcome.screen3.title"
-        case .fourth: return "onboarding.welcome.screen4.title"
         }
     }
 
@@ -78,8 +74,6 @@ struct WelcomeFlowView: View {
         switch currentStep {
         case .first: return "onboarding.welcome.screen1.body"
         case .second: return "onboarding.welcome.screen2.body"
-        case .third: return "onboarding.welcome.screen3.body"
-        case .fourth: return "onboarding.welcome.screen4.body"
         }
     }
 

--- a/ios/PulsePlate/Welcome/WelcomeFlowView.swift
+++ b/ios/PulsePlate/Welcome/WelcomeFlowView.swift
@@ -1,27 +1,36 @@
 import SwiftUI
 
-private enum WelcomeStep: Int, CaseIterable {
-    case first = 0
-    case second = 1
+private enum WelcomeStep: Equatable {
+    case value
+    case usage
+
+    var index: Int {
+        switch self {
+        case .value: return 0
+        case .usage: return 1
+        }
+    }
+
+    func next() -> WelcomeStep? {
+        switch self {
+        case .value: return .usage
+        case .usage: return nil
+        }
+    }
+
+    func back() -> WelcomeStep? {
+        switch self {
+        case .value: return nil
+        case .usage: return .value
+        }
+    }
 }
 
 struct WelcomeFlowView: View {
     let onCompleted: () -> Void
 
-    @State private var stepIndex: Int = 0
-    private var totalSteps: Int { WelcomeStep.allCases.count }
-
-    private var clampedStepIndex: Int {
-        min(max(stepIndex, 0), max(0, totalSteps - 1))
-    }
-
-    private var currentStep: WelcomeStep {
-        WelcomeStep(rawValue: clampedStepIndex) ?? .first
-    }
-
-    private var isLastStep: Bool {
-        clampedStepIndex == totalSteps - 1
-    }
+    @State private var step: WelcomeStep = .value
+    private let totalSteps: Int = 2
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -40,19 +49,16 @@ struct WelcomeFlowView: View {
             Spacer()
 
             HStack {
-                if stepIndex > 0 {
-                    Button(backKey) { stepIndex -= 1 }
+                if step.back() != nil {
+                    Button(backKey) { step = step.back() ?? step }
                         .accessibilityLabel(Text(backKey))
                 }
 
                 Spacer()
 
                 Button(primaryCtaKey) {
-                    if !isLastStep {
-                        stepIndex += 1
-                    } else {
-                        onCompleted()
-                    }
+                    guard let next = step.next() else { return onCompleted() }
+                    step = next
                 }
                 .buttonStyle(.borderedProminent)
                 .accessibilityLabel(Text(primaryCtaKey))
@@ -64,21 +70,21 @@ struct WelcomeFlowView: View {
     // MARK: - Localization keys (match audit namespace onboarding.welcome.*)
 
     private var screenTitleKey: LocalizedStringKey {
-        switch currentStep {
-        case .first: return "onboarding.welcome.screen1.title"
-        case .second: return "onboarding.welcome.screen2.title"
+        switch step {
+        case .value: return "onboarding.welcome.screen1.title"
+        case .usage: return "onboarding.welcome.screen2.title"
         }
     }
 
     private var screenBodyKey: LocalizedStringKey {
-        switch currentStep {
-        case .first: return "onboarding.welcome.screen1.body"
-        case .second: return "onboarding.welcome.screen2.body"
+        switch step {
+        case .value: return "onboarding.welcome.screen1.body"
+        case .usage: return "onboarding.welcome.screen2.body"
         }
     }
 
     private var primaryCtaKey: LocalizedStringKey {
-        isLastStep ? "onboarding.welcome.cta.start" : "onboarding.welcome.cta.continue"
+        step.next() == nil ? "onboarding.welcome.cta.start" : "onboarding.welcome.cta.continue"
     }
 
     private var backKey: LocalizedStringKey {
@@ -87,6 +93,6 @@ struct WelcomeFlowView: View {
 
     private var stepA11yText: String {
         let template = NSLocalizedString("onboarding.welcome.stepA11y", comment: "")
-        return String(format: template, clampedStepIndex + 1, totalSteps)
+        return String(format: template, step.index + 1, totalSteps)
     }
 }

--- a/ios/PulsePlate/en.lproj/Localizable.strings
+++ b/ios/PulsePlate/en.lproj/Localizable.strings
@@ -82,10 +82,10 @@
 "Error" = "Error";
 
 /* Onboarding: Welcome (P0) */
-"onboarding.welcome.screen1.title" = "PulsePlate — your nutrition on track";
-"onboarding.welcome.screen1.body" = "Set your goals once. We’ll keep your plan, plate, and progress in sync.";
-"onboarding.welcome.screen2.title" = "Private by default";
-"onboarding.welcome.screen2.body" = "Your inputs stay on your device unless you explicitly export or share.";
+"onboarding.welcome.screen1.title" = "PulsePlate — nutrition, made simple";
+"onboarding.welcome.screen1.body" = "Track your metrics, understand your results, and keep a plan you can stick to — one calm screen at a time.";
+"onboarding.welcome.screen2.title" = "How to use it";
+"onboarding.welcome.screen2.body" = "Start with BMI, then refine with Plate and your PRO profile. Small inputs → clear next steps.";
 "onboarding.welcome.screen3.title" = "Pick your setup";
 "onboarding.welcome.screen3.body" = "Choose language, units, and a goal. You can change this anytime.";
 "onboarding.welcome.screen4.title" = "Ready to start";

--- a/ios/PulsePlate/en.lproj/Localizable.strings
+++ b/ios/PulsePlate/en.lproj/Localizable.strings
@@ -86,10 +86,6 @@
 "onboarding.welcome.screen1.body" = "Track your metrics, understand your results, and keep a plan you can stick to — one calm screen at a time.";
 "onboarding.welcome.screen2.title" = "How to use it";
 "onboarding.welcome.screen2.body" = "Start with BMI, then refine with Plate and your PRO profile. Small inputs → clear next steps.";
-"onboarding.welcome.screen3.title" = "Pick your setup";
-"onboarding.welcome.screen3.body" = "Choose language, units, and a goal. You can change this anytime.";
-"onboarding.welcome.screen4.title" = "Ready to start";
-"onboarding.welcome.screen4.body" = "Let’s build a simple plan you can follow today.";
 "onboarding.welcome.cta.continue" = "Continue";
 "onboarding.welcome.cta.back" = "Back";
 "onboarding.welcome.cta.start" = "Get started";

--- a/ios/PulsePlate/es.lproj/Localizable.strings
+++ b/ios/PulsePlate/es.lproj/Localizable.strings
@@ -102,10 +102,6 @@
 "onboarding.welcome.screen1.body" = "Sigue tus métricas, entiende tus resultados y mantén un plan que puedas sostener — paso a paso y sin ruido.";
 "onboarding.welcome.screen2.title" = "Cómo usarlo";
 "onboarding.welcome.screen2.body" = "Empieza con BMI, luego ajusta con Plate y tu perfil PRO. Pocos datos → próximos pasos claros.";
-"onboarding.welcome.screen3.title" = "Elige tu configuración";
-"onboarding.welcome.screen3.body" = "Idioma, unidades y objetivo: puedes cambiarlo cuando quieras.";
-"onboarding.welcome.screen4.title" = "Listo para empezar";
-"onboarding.welcome.screen4.body" = "Hagamos un plan simple que puedas seguir hoy.";
 "onboarding.welcome.cta.continue" = "Continuar";
 "onboarding.welcome.cta.back" = "Atrás";
 "onboarding.welcome.cta.start" = "Empezar";

--- a/ios/PulsePlate/es.lproj/Localizable.strings
+++ b/ios/PulsePlate/es.lproj/Localizable.strings
@@ -98,10 +98,10 @@
 "Error" = "Error";
 
 /* Onboarding: Welcome (P0) */
-"onboarding.welcome.screen1.title" = "PulsePlate — tu nutrición bajo control";
-"onboarding.welcome.screen1.body" = "Configura tus objetivos una vez. Mantendremos plan, plato y progreso sincronizados.";
-"onboarding.welcome.screen2.title" = "Privado por defecto";
-"onboarding.welcome.screen2.body" = "Tus datos quedan en tu dispositivo hasta que decidas exportar o compartir.";
+"onboarding.welcome.screen1.title" = "PulsePlate — nutrición sin complicaciones";
+"onboarding.welcome.screen1.body" = "Sigue tus métricas, entiende tus resultados y mantén un plan que puedas sostener — paso a paso y sin ruido.";
+"onboarding.welcome.screen2.title" = "Cómo usarlo";
+"onboarding.welcome.screen2.body" = "Empieza con BMI, luego ajusta con Plate y tu perfil PRO. Pocos datos → próximos pasos claros.";
 "onboarding.welcome.screen3.title" = "Elige tu configuración";
 "onboarding.welcome.screen3.body" = "Idioma, unidades y objetivo: puedes cambiarlo cuando quieras.";
 "onboarding.welcome.screen4.title" = "Listo para empezar";

--- a/ios/PulsePlate/ru.lproj/Localizable.strings
+++ b/ios/PulsePlate/ru.lproj/Localizable.strings
@@ -98,10 +98,10 @@
 "Error" = "Ошибка";
 
 /* Онбординг: Welcome (P0) */
-"onboarding.welcome.screen1.title" = "PulsePlate — питание под контролем";
-"onboarding.welcome.screen1.body" = "Настрой цели один раз. План, тарелка и прогресс будут согласованы.";
-"onboarding.welcome.screen2.title" = "Приватность по умолчанию";
-"onboarding.welcome.screen2.body" = "Данные остаются на устройстве, пока вы сами не экспортируете или не поделитесь.";
+"onboarding.welcome.screen1.title" = "PulsePlate — питание без лишнего шума";
+"onboarding.welcome.screen1.body" = "Отслеживайте показатели, понимайте результат и держите план, который реально выполнять — спокойно и по шагам.";
+"onboarding.welcome.screen2.title" = "Как пользоваться";
+"onboarding.welcome.screen2.body" = "Начните с BMI, затем уточните через Plate и профиль PRO. Маленькие вводы → понятные следующие шаги.";
 "onboarding.welcome.screen3.title" = "Выберите настройки";
 "onboarding.welcome.screen3.body" = "Язык, единицы и цель можно изменить в любой момент.";
 "onboarding.welcome.screen4.title" = "Можно начинать";

--- a/ios/PulsePlate/ru.lproj/Localizable.strings
+++ b/ios/PulsePlate/ru.lproj/Localizable.strings
@@ -102,10 +102,6 @@
 "onboarding.welcome.screen1.body" = "Отслеживайте показатели, понимайте результат и держите план, который реально выполнять — спокойно и по шагам.";
 "onboarding.welcome.screen2.title" = "Как пользоваться";
 "onboarding.welcome.screen2.body" = "Начните с BMI, затем уточните через Plate и профиль PRO. Маленькие вводы → понятные следующие шаги.";
-"onboarding.welcome.screen3.title" = "Выберите настройки";
-"onboarding.welcome.screen3.body" = "Язык, единицы и цель можно изменить в любой момент.";
-"onboarding.welcome.screen4.title" = "Можно начинать";
-"onboarding.welcome.screen4.body" = "Соберём простой план, который реально выполнить уже сегодня.";
 "onboarding.welcome.cta.continue" = "Дальше";
 "onboarding.welcome.cta.back" = "Назад";
 "onboarding.welcome.cta.start" = "Начать";


### PR DESCRIPTION
## Summary
- Keep first-launch gating at app entry via `WelcomeGateView`.
- Tighten the welcome flow to **two screens**: **Value** + **Usage**.
- Update localization strings for **EN/RU/ES**.

## Evidence (audit)
- App entry uses onboarding gate: `ios/PulsePlate/PulsePlateApp.swift:3-9`
- First-launch persistence key: `ios/PulsePlate/Welcome/WelcomeGateView.swift:3-11`
- Onboarding flow screens: `ios/PulsePlate/Welcome/WelcomeFlowView.swift:3-98`

## Test plan
- `pre-commit run --all-files`
- `make ios-test`

## Scope
- iOS only (no networking, no paywall/StoreKit, no analytics)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Упростить приветственный онбординг-поток на iOS до двух экранов и обновить связанный текст и записи локализации.

Улучшения:
- Сократить приветственный онбординг-поток с четырёх шагов до двух, удалив третий и четвёртый шаги из логики потока.

Документация:
- Обновить заголовки и основной текст для оставшихся приветственных экранов в локализациях EN, ES и RU.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the iOS onboarding welcome flow to two screens and update associated copy and localization entries.

Enhancements:
- Reduce the onboarding welcome flow from four steps to two by removing the third and fourth steps from the flow logic.

Documentation:
- Refresh onboarding titles and body text for the remaining welcome screens across EN, ES, and RU localizations.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened iOS onboarding to two screens (Value + Usage) with first‑launch gating via WelcomeGateView. Refactored the flow to an explicit 2‑step enum, removed screen3/4 localization keys, refreshed EN/RU/ES copy, and added an audit doc plus a BACKLOG_LEDGER entry for P0‑B.

<sup>Written for commit c1c34964f74da3e872c0bfaaf96d9eccfacece63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding simplified to two focused screens (Value + Usage) with streamlined CTA/back behavior and improved accessibility ("Step X of 2").

* **Documentation**
  * Updated onboarding copy in English, Spanish, and Russian for clearer, concise guidance.
  * Roadmap/backlog updated to reflect the tightened two‑screen onboarding scope.

* **Chores**
  * Removed the extra onboarding steps and obsolete messaging to streamline first‑launch experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->