### PR TITLE
docs(roadmap): mark PR-678 onboarding item as merged

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -38,17 +38,18 @@ If it is not recorded here — it does not exist.
     - RU/EN/ES strings ship for `onboarding.welcome.*`
     - `make ios-test` passes
 
-- [ ] iOS: Tighten first-launch onboarding to Value + Usage (2 screens)
+- [x] iOS: Tighten first-launch onboarding to Value + Usage (2 screens) — ✅ Merged (PR-678, 2026-02-07)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0-B (release readiness)
   - Target PR: PR-678
-  - Status: 🚧 In progress (PR-678)
+  - Status: ✅ Merged (PR-678, 2026-02-07)
   - Reason: P0-B requires a minimal onboarding (≥2 screens). Keep the existing first-launch gate and tighten the flow to the two essential screens (Value + Usage) without adding networking/paywall/analytics.
   - Links:
     - `ios/PulsePlate/PulsePlateApp.swift`
     - `ios/PulsePlate/Welcome/WelcomeGateView.swift`
     - `ios/PulsePlate/Welcome/WelcomeFlowView.swift`
     - docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/678>
   - DoD:
     - On first launch, onboarding shows before `RootTabs()` (gate remains at app entry)
     - On completion, onboarding is not shown again (`has_seen_welcome_v1` persists)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -875,13 +875,16 @@ If it is not recorded here — it does not exist.
     - Tests restored to PulsePlateTests target (if kept)
     - CI green with AnimationTests included (if restored)
 
-- [ ] Fix ShoppingPlan public API (make nested types public or narrow API surface)
+- [x] Fix ShoppingPlan public API (make nested types public or narrow API surface) — ✅ Merged (PR-677, 2026-02-07)
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: TBD (separate from PR-559)
+  - Priority: P1
+  - Target PR: PR-677
+  - Status: ✅ Merged (PR-677, 2026-02-07)
   - Reason: CodeRabbit flagged "ShoppingPlan isn't constructible" - public type with internal nested types (DailyMenu, Meal). Outside PR-559 scope but architectural smell.
   - Links:
     - ios/PulsePlate/Models/ShoppingList/ShoppingListStubPlan.swift
     - CodeRabbit comment (outside diff, actionable=0)
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/677>
   - DoD:
     - Either make DailyMenu/Meal public with explicit init
     - Or narrow API: make ShoppingPlan/ShoppingListRequestPayload internal if it's "stub" only

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -38,7 +38,7 @@ If it is not recorded here — it does not exist.
     - RU/EN/ES strings ship for `onboarding.welcome.*`
     - `make ios-test` passes
 
-- [x] iOS: Tighten first-launch onboarding to Value + Usage (2 screens) — ✅ Merged (PR-678, 2026-02-07)
+- [x] iOS: Tighten first-launch onboarding to Value + Usage (2 screens)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0-B (release readiness)
   - Target PR: PR-678
@@ -875,7 +875,7 @@ If it is not recorded here — it does not exist.
     - Tests restored to PulsePlateTests target (if kept)
     - CI green with AnimationTests included (if restored)
 
-- [x] Fix ShoppingPlan public API (make nested types public or narrow API surface) — ✅ Merged (PR-677, 2026-02-07)
+- [x] Fix ShoppingPlan public API (make nested types public or narrow API surface)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-677


### PR DESCRIPTION
## Summary
- Mark P0-B iOS onboarding item (PR-678) as merged in BACKLOG_LEDGER.

## Scope
- Docs-only

## Verification
- `pre-commit run --all-files`
- Docs-only guard: `git diff --name-only origin/main...HEAD | rg -v "\\.md$"` (empty)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked iOS first-launch onboarding (Value + Usage, PR-678) and ShoppingPlan public API fix (PR-677) as merged in BACKLOG_LEDGER. Updated checkboxes and statuses (2026-02-07), added PR links, set ShoppingPlan to P1, and deduped PR/date metadata to Status only.

<sup>Written for commit 5a70c6d5babd40f8730bc806616d9c1d562817c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Документация:
- Отметить элемент онбординга при первом запуске iOS Value + Usage как объединённый в BACKLOG_LEDGER, включая обновлённый статус, дату и ссылку на PR-678.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mark the iOS Value + Usage first-launch onboarding item as merged in BACKLOG_LEDGER, including updated status, date, and link to PR-678.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Backlog tracking updated: iOS onboarding marked complete — onboarding condensed to two screens (Value and Usage).
  * ShoppingPlan public API marked complete — public surface clarified (DailyMenu/Meal exposure adjusted).
  * Acceptance criteria and audit entries updated to reflect merged status and verification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->