### PR TITLE
fix(tests): stabilize VIP insight guard when no LLM provider

### DIFF
--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -29,6 +29,16 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)
+    # Provider mocking must be robust across CI import paths.
+    # RU: В CI реальный путь резолва провайдера идёт через legacy_app._load_llm_get_provider().
+    # EN: In CI the effective provider resolution path goes through legacy_app._load_llm_get_provider().
+    monkeypatch.setattr(
+        legacy_app,
+        "_load_llm_get_provider",
+        lambda: (lambda: FakeLLMProvider()),
+        raising=True,
+    )
+    # Keep llm.get_provider patched as a secondary safety net.
     monkeypatch.setattr(llm, "get_provider", lambda: FakeLLMProvider(), raising=True)
 
 


### PR DESCRIPTION
## Summary
- Make VIP insight guard tests deterministic in CI by patching `legacy_app._load_llm_get_provider()` to return `FakeLLMProvider`.
- Keep `llm.get_provider` patch as a secondary safety net.

## Why
CI on `main` intermittently returns `503 {\"detail\": \"No LLM provider configured\"}` for VIP insight tests, which are intended to validate **VIP gating (403/200)** and not depend on env/provider wiring.

## Test plan
- `pytest -q tests/test_insight_vip_guard_api.py`
- `make test-fast`
- `pre-commit run --all-files`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes VIP insight guard tests in CI by mocking the LLM provider resolution to always use FakeLLMProvider. Prevents intermittent 503 errors and keeps tests focused on VIP gating.

- **Bug Fixes**
  - Patch legacy_app._load_llm_get_provider to return a FakeLLMProvider factory.
  - Keep llm.get_provider monkeypatched as a fallback.

<sup>Written for commit 8fa9a99f19421802a77f057adafcbbfabca89766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for provider mocking to improve CI reliability and robustness across different import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->