### PR TITLE
iOS: re-enable AnimationTests.swift in PulsePlateTests target

### DIFF
--- a/ios/PulsePlate.xcodeproj/project.pbxproj
+++ b/ios/PulsePlate.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		B6169A8A2E893CF200B218D8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				AnimationTests.swift,
 				__CIAnchorTests.swift,
 			);
 			target = B6169A412E893CF200B218D8 /* PulsePlateTests */;


### PR DESCRIPTION
## Summary
- Root cause: `AnimationTests.swift` was excluded from the `PulsePlateTests` target via `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions` in `ios/PulsePlate.xcodeproj/project.pbxproj`.
- Fix: remove `AnimationTests.swift` from `membershipExceptions` (keep `__CIAnchorTests.swift` excluded as-is).

## Verification
- `make ios-test`
- `xcodebuild test -project ios/PulsePlate.xcodeproj -scheme PulsePlate -destination 'platform=iOS Simulator,name=iPhone 16e' -only-testing:PulsePlateTests/ProgressAnimationTests`
- `xcodebuild test -project ios/PulsePlate.xcodeproj -scheme PulsePlate -destination 'platform=iOS Simulator,name=iPhone 16e' -only-testing:PulsePlateTests/ViewExtensionTests`

## Notes
- Avoids `AnimationTests` name collision by targeting exact test classes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled AnimationTests.swift in the PulsePlateTests target by removing its exclusion from the Xcode project. This restores ProgressAnimationTests and ViewExtensionTests execution in CI.

- **Bug Fixes**
  - Removed AnimationTests.swift from PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions. Kept __CIAnchorTests.swift excluded.

<sup>Written for commit caee02b285a3707aaaa82a3b70082b31a0a27304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test build configuration for PulsePlateTests target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->