### PR TITLE
docs(ledger): close AnimationTests item (PR-681 merged)

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -858,14 +858,16 @@ If it is not recorded here — it does not exist.
     - Add a short, canonical checklist line for audit PRs: include 1–3 raw stdout lines + exit code for each key verification command
     - No scope creep into runbook-level detail
 
-- [ ] Stabilize AnimationTests.swift (iOS)
+- [x] Stabilize AnimationTests.swift (iOS)
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: TBD (separate from PR-559)
-  - Reason: pre-existing compilation failures (missing types: PulsingView, ShimmerEffect, SlideInTransition, FadeTransition, AnimatedProgressRing, NutritionSegment; internal access issues). Excluded from PulsePlateTests target via `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions` to unblock PR-559 CI.
+  - Target PR: PR-681
+  - Status: ✅ Merged (PR-681, 2026-02-07)
+  - Reason: Root cause: `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions` excluded `AnimationTests.swift` from `PulsePlateTests`. Fix: removed `AnimationTests.swift` from `membershipExceptions` so the tests are included in `PulsePlateTests` again.
   - Links:
     - ios/PulsePlateTests/AnimationTests.swift
-    - ios/PulsePlate.xcodeproj/project.pbxproj (line 51: `AnimationTests.swift` in membershipExceptions)
+    - ios/PulsePlate.xcodeproj/project.pbxproj
     - ios/AGENTS.md (Animated/UI helper tests policy)
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/681>
   - DoD:
     - Either rewrite using available public components
     - Or extract to separate test target

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -860,6 +860,7 @@ If it is not recorded here — it does not exist.
 
 - [x] Stabilize AnimationTests.swift (iOS)
   - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
   - Target PR: PR-681
   - Status: ✅ Merged (PR-681, 2026-02-07)
   - Reason: Root cause: `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions` excluded `AnimationTests.swift` from `PulsePlateTests`. Fix: removed `AnimationTests.swift` from `membershipExceptions` so the tests are included in `PulsePlateTests` again.


### PR DESCRIPTION
Docs-only. Bring BACKLOG_LEDGER in sync with merged PR-681: close the stale AnimationTests.swift stabilization item (membershipExceptions root cause, PR-681 fix).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Отметить пункт стабилизации `AnimationTests.swift` как завершённый в `BACKLOG_LEDGER` с обновлённым статусом, целевым PR, обоснованием и ссылками на источники.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mark the AnimationTests.swift stabilization item as completed in BACKLOG_LEDGER with updated status, target PR, reasoning, and reference links.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close the AnimationTests.swift stabilization item in BACKLOG_LEDGER per PR-681. Set Priority P1, mark as merged, document the membershipExceptions root cause and fix, and add project/PR links.

<sup>Written for commit 1c4a7043c0ab634d62f8a45132d2419ffc1f70ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Backlog updated to record completion of iOS test stabilization, marking the task as merged.
  * Rationale and root cause summarized; fix and affected tests noted.
  * Acceptance criteria and verification updated to confirm tests compile and run in the intended test suite.
  * Public references and tracking links added for traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->