### PR TITLE
docs(agents): require docs-only closure for completed ledger items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1293,6 +1293,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 4. Every PR description MUST include a "Deferred / Follow-ups" section with links to ledger items (and GitHub issues if present).
 5. Closing a ledger item requires:
    - PR merged OR explicit "won't do" decision recorded (with reason).
+6. If a merged PR completes a ledger item, you MUST open a follow-up **docs-only** PR immediately after merge to mark the item as closed in `docs/roadmap/BACKLOG_LEDGER.md` (set checkbox + `Target PR` + `Status`).
 
 **Agent enforcement:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1293,7 +1293,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 4. Every PR description MUST include a "Deferred / Follow-ups" section with links to ledger items (and GitHub issues if present).
 5. Closing a ledger item requires:
    - PR merged OR explicit "won't do" decision recorded (with reason).
-6. If a merged PR completes a ledger item, you MUST open a follow-up **docs-only** PR immediately after merge to mark the item as closed in `docs/roadmap/BACKLOG_LEDGER.md` (set checkbox + `Target PR` + `Status`).
+6. If a merged PR completes one or more ledger items, you MUST open a follow-up **docs-only** PR within the same working day (or the next working day if merged late) to mark the affected item(s) as closed in `docs/roadmap/BACKLOG_LEDGER.md` (set checkbox + `Target PR` + `Status`). One follow-up docs-only PR MAY update multiple ledger items if they were completed by the same merged PR or merge cycle.
 
 **Agent enforcement:**
 


### PR DESCRIPTION
Docs-only. Add a Backlog Ledger Policy rule: when a merged PR completes a ledger item, follow up immediately with a docs-only PR to mark the item closed (checkbox + Target PR + Status).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить документацию по политике журнала незавершённых задач, чтобы требовать немедленного PR, касающегося только документов, для закрытия выполненных пунктов журнала в дорожной карте.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update backlog ledger policy docs to require an immediate docs-only PR to close completed ledger items in the roadmap ledger.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new process rule: when a merged PR completes backlog items, open a follow-up docs-only PR the same (or next) working day to mark those items closed (update checkbox, target PR, status). One docs-only PR may close multiple related backlog items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->