### PR TITLE
docs(architecture): align OpenAPI docs to full schema

### DIFF
--- a/docs/architecture/ADR-002-openapi-schema-only-mode.md
+++ b/docs/architecture/ADR-002-openapi-schema-only-mode.md
@@ -1,6 +1,6 @@
 # ADR-002: OpenAPI Schema-only Mode (Temporary) + Exit Criteria
 
-**Status:** Proposed (PR-630 evidence pack)
+**Status:** Superseded (removed by PR-631; full-schema is canonical)
 **Date:** 2026-02-02
 **Context:** OpenAPI determinism and thin-client contract velocity.
 
@@ -9,7 +9,16 @@
 - [Schema-only OpenAPI contract](#schema-only-openapi-contract)
 - [Exit criteria](#exit-criteria)
 
-## Decision
+## Resolution (current state)
+
+Schema-only mode has been removed. OpenAPI generation runs in **full-schema mode** and remains deterministic.
+
+**Evidence (file:line):**
+
+- `scripts/generate_openapi.py:94-120` — generator pins env to test context and enables feature-flagged routers, then imports `app.main:app` and calls `app.openapi()`
+- `tests/test_openapi_determinism.py:17-55` — asserts the full schema includes key PRO/business paths
+
+## Decision (historical; pre PR-631)
 
 Keep a **temporary schema-only mode** for OpenAPI generation to avoid import-time ORM/model double-loading, while explicitly documenting:
 - what is disabled,
@@ -20,52 +29,18 @@ Keep a **temporary schema-only mode** for OpenAPI generation to avoid import-tim
 
 OpenAPI generation must be deterministic (CI enforces this). Importing the full FastAPI app during schema generation can trigger SQLAlchemy model imports and double-load side effects (“Table already defined”), especially when routers import ORM models at module level.
 
-## Evidence (current implementation)
+## Evidence (historical implementation; no longer current)
 
-- Generator sets schema-only mode + disables some routers:
-  - `scripts/generate_openapi.py:94-113`
-- Schema-only is honored only in generation/test context (must not accidentally activate in prod):
-  - `app/routers/pro_registration.py:26-36`
-- PRO route registration avoids importing routers in schema-only mode:
-  - `app/routers/pro_registration.py:76-105`
-- CI determinism gate:
-  - `tests/test_openapi_determinism.py:16-64`
+- Prior art / original seam: see PR-630 evidence pack (kept for archaeology).
+- CI determinism gate (still current):
+  - `tests/test_openapi_determinism.py:17-77`
 
 <a id="schema-only-openapi-contract"></a>
-## Schema-only OpenAPI contract (single source of truth)
+## Schema-only OpenAPI contract (historical; removed)
 
-This section is the **canonical documentation** for schema-only OpenAPI generation behavior.
-Other docs should **link here** instead of duplicating env/flag lists.
+This section is kept for historical context only.
 
-**Activation (must all be true):**
-
-- `PULSEPLATE_OPENAPI=1`
-- `APP_ENV=test`
-- `ENVIRONMENT=test`
-
-**Generator invariants (must happen before importing `app.main:app`):**
-
-- `PULSEPLATE_OPENAPI` **must be set before** importing `app.main:app` to prevent import-time ORM
-  double-loading ("Table already defined").
-- The generator pins env to a safe non-prod context:
-  - `APP_ENV=test`
-  - `ENVIRONMENT=test`
-  - `ENABLE_TEST_ROUTES=1` (set by generator; not part of schema-only activation check)
-
-**Forced feature flags (temporary, schema-only only):**
-
-The generator forces these to disable routers that import SQLAlchemy models at module import time:
-
-- `FEATURE_PREMIUM_WEEK_ENABLED=false`
-- `FEATURE_BMI_PRO_ENABLED=false`
-- `BUSINESS_MODULE_ENABLED=false`
-
-**Implementation notes:**
-
-- Activation/guard is enforced in `app/routers/pro_registration.py:_is_openapi_schema_only_mode()`; it will
-  **not** activate in production unless all activation env vars are simultaneously mis-set.
-- Source of truth for env/flag values is `scripts/generate_openapi.py` (sets env + flags, then imports
-  `app.main:app`).
+Former activation relied on `PULSEPLATE_OPENAPI=1` + test env pinning. This is no longer used.
 
 ## Consequences
 
@@ -88,5 +63,4 @@ Schema-only mode can be removed when all are true:
 
 ## Follow-ups (Backlog)
 
-- Restore full OpenAPI schema (remove schema-only mode): `docs/roadmap/BACKLOG_LEDGER.md`
-- Eliminate import-time ORM/model imports in routers included in OpenAPI generation: `docs/roadmap/BACKLOG_LEDGER.md`
+- ✅ Closed in PR-631; see `docs/roadmap/BACKLOG_LEDGER.md` entries for closure notes.

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -48,14 +48,13 @@ Evidence:
 Runtime effect:
 - When VIP module is enabled, `vip_registration.register_vip_routes()` includes `app/routers/vip.py` with `api_key_header` dependency.
 
-### PRO routes (centralized; schema-only OpenAPI can short-circuit)
+### PRO routes (centralized)
 
-Anchor (stable): `legacy_app.py -> register_pro_routes(app)` and schema-only short-circuit in `pro_registration`
+Anchor (stable): `legacy_app.py -> _register_pro_routes(app)` delegates to centralized `pro_registration.register_pro_routes()`
 
 Evidence:
-- `legacy_app.py:826-828` — `pro_router, premium_week_router = _register_pro_routes(app)`
-- `app/routers/pro_registration.py:26-36` — schema-only guard conditions
-- `app/routers/pro_registration.py:76-105` — avoids importing PRO/premium routers in schema-only mode
+- `legacy_app.py:848-849` — `pro_router, premium_week_router = _register_pro_routes(app)`
+- `app/routers/pro_registration.py:26-86` — centralized registration + feature-flag gated `premium_week`
 
 Runtime effect:
 - In normal runtime: includes `app/routers/pro.py`.
@@ -120,15 +119,14 @@ Evidence: `legacy_app.py:890-902`
 
 ## OpenAPI generation behavior (important)
 
-**Schema-only OpenAPI contract (single source of truth):**
-See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract`
+OpenAPI generation runs in **full-schema mode** (schema-only mode removed in PR-631).
 
 **Evidence (implementation):**
 
-- Generator sets schema-only mode and pins env/feature flags:
-  - `scripts/generate_openapi.py:94-135`
-- PRO router registration honors schema-only mode to prevent ORM import hazards:
-  - `app/routers/pro_registration.py:26-36` and `76-105`
+- Generator pins env and enables feature-flagged routers, then imports canonical entrypoint:
+  - `scripts/generate_openapi.py:94-120`
+- Determinism gate asserts key routes exist in schema:
+  - `tests/test_openapi_determinism.py:17-55`
 
 ## Maintenance rule
 

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -67,13 +67,13 @@ flowchart LR
 
 ## OpenAPI generation mode (current)
 
-OpenAPI generator runs in **schema-only mode** to avoid import-time ORM double-loading.
+OpenAPI generator runs in **full-schema mode** (schema-only mode removed in PR-631).
 
-**Schema-only contract (single source of truth):**
-See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#schema-only-openapi-contract`
+**Evidence (file:line):**
+- `scripts/generate_openapi.py:94-120` (generator pins env + enables feature-flagged routers, then imports `app.main:app`)
+- `tests/test_openapi_determinism.py:17-55` (asserts key PRO/business paths exist in schema)
 
-**Exit criteria:**
-See: `docs/architecture/ADR-002-openapi-schema-only-mode.md#exit-criteria`
+Historical ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (superseded).
 
 ## Enforced invariants (selected, evidence-driven)
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -581,46 +581,31 @@ If it is not recorded here — it does not exist.
   - Reason: PR #617 scope reduced to docs-only (audit + handoff); markdownlint config moved out to avoid diff-coverage/CI scope. Add repo-wide markdownlint config in dedicated PR.
   - DoD: New PR with `.markdownlint.json` only; CI green; no mixing with code/audit PRs.
 
-- [ ] Restore full OpenAPI schema (remove temporary schema-only mode)
+- [x] Restore full OpenAPI schema (remove temporary schema-only mode)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (contract velocity)
-  - Target PR: TBD (post PR-628/629 to avoid scope collision)
-  - Status: 📋 Ready to start (technical work), but intentionally deferred while PR-628/629 are in flight
-  - Reason: OpenAPI generation currently runs in **schema-only mode** and forcibly disables multiple feature routers. This reduces thin-client contract velocity and increases silent drift risk.
+  - Target PR: PR-631
+  - Status: ✅ Merged (PR-631, 2026-02-03)
+  - Reason: Schema-only OpenAPI mode reduced thin-client contract velocity. PR-631 removed the schema-only seam and enabled full-schema generation with deterministic output.
   - Evidence:
-    - `scripts/generate_openapi.py:94-113` (schema-only mode + forced feature disables)
-    - `app/routers/pro_registration.py:26-36` (schema-only guard conditions)
-    - `docs/architecture/ADR-002-openapi-schema-only-mode.md` (exit criteria)
-  - Risk:
-    - Thin clients cannot “type reality” for excluded routes; integration slows and drift risk increases.
-  - Blocked-by:
-    - Process-only: PR-628/629 (avoid mixed-scope / CI churn); re-evaluate after they merge
-  - Exit criteria:
-    - `make openapi` succeeds without forcing `FEATURE_*_ENABLED=false` in the generator
-    - No SQLAlchemy “Table already defined” errors during OpenAPI generation
-    - `tests/test_openapi_determinism.py` remains green
-  - DoD:
+    - `scripts/generate_openapi.py:94-109` (FULL schema mode; enables feature-flagged routers in generator context)
+    - `tests/test_openapi_determinism.py:17-55` (asserts key PRO/business paths exist)
+  - DoD: ✅ Completed (PR-631)
     - OpenAPI generator runs in full-schema mode (no schema-only marker)
-    - `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts` regenerated + committed (if changed)
-    - Add/adjust any focused regression tests needed to prevent return of import-time ORM hazards
+    - `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts` in sync (`make openapi` produces no diff)
+    - Determinism test remains green
 
-- [ ] Eliminate import-time ORM/model imports in routers included in OpenAPI generation
+- [x] Eliminate import-time ORM/model imports in routers included in OpenAPI generation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (determinism / import hygiene)
-  - Target PR: TBD (post PR-628/629)
-  - Status: 📋 Ready to start
-  - Reason: Schema-only exists because some routers import SQLAlchemy models at module level, causing import-time side effects during OpenAPI generation.
+  - Target PR: PR-631
+  - Status: ✅ Merged (PR-631, 2026-02-03)
+  - Reason: OpenAPI generation must be side-effect free: routers reachable from `app.main:app` must not import ORM models at module import time.
   - Evidence:
-    - `app/routers/pro_registration.py:76-80` (documents import-time ORM hazard)
-    - `scripts/generate_openapi.py:100-113` (disables routers because of ORM import-time issues)
-  - Risk:
-    - Import-order nondeterminism, “double-load” failures, OpenAPI gaps.
-  - Blocked-by:
-    - Process-only: PR-628/629 (avoid scope collision)
-  - Exit criteria:
-    - Routers used in OpenAPI generation do not import ORM models at module import time
-  - DoD:
-    - Move ORM model imports to runtime (inside handlers/dependencies/services), one router at a time
+    - `app/routers/nutrition_log.py:26-73` (TYPE_CHECKING-only model import + runtime lazy import pattern)
+    - `scripts/generate_openapi.py:114-120` (imports canonical entrypoint and calls `app.openapi()` successfully)
+  - DoD: ✅ Completed (PR-631)
+    - ORM model imports moved to runtime (inside handlers/dependencies), preserving OpenAPI determinism
     - OpenAPI generation works with routers enabled
     - Determinism test stays green
 


### PR DESCRIPTION
## Summary
- Update architecture docs to reflect that OpenAPI generation runs in **full-schema mode** (schema-only mode removed in PR-631).
- Mark stale Backlog Ledger items as completed (PR-631).
- Update ADR-002 status to **Superseded** (kept for historical context).

## Why
- The codebase already generates a deterministic full OpenAPI schema (`make openapi`), but docs/ledger still described schema-only behavior.
- Keeping these docs stale slows down web/iOS contract work and creates onboarding confusion.

## Evidence anchors
- `scripts/generate_openapi.py:94-120`
- `tests/test_openapi_determinism.py:17-55`

## Test plan
- `make openapi`
- `pytest -q tests/test_openapi_determinism.py::test_openapi_and_schema_ts_are_deterministic`
- `pre-commit run --all-files`

## Deferred / Follow-ups
- None.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Привести архитектурную документацию в соответствие с текущим поведением генерации OpenAPI для полной схемы и зафиксировать завершение связанной работы из бэклога.

Документация:
- Пометить ADR-002 как Superseded, задокументировав генерацию OpenAPI для полной схемы как каноничное текущее поведение и отнеся детали, касающиеся только схемы, к историческому контексту.
- Обновить документацию по роутингу backend-а и обзор системы, чтобы описать централизованную регистрацию маршрутов PRO и генерацию OpenAPI для полной схемы с указанием конкретных доказательств (evidence anchors).

Рутинные задачи:
- Пометить элементы BACKLOG_LEDGER, связанные с восстановлением полной схемы OpenAPI и исправлением проблем ORM во время импорта, как выполненные, с ссылками на PR-631 и обновлённые доказательства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align architecture documentation with the current full-schema OpenAPI generation behavior and record completion of related backlog work.

Documentation:
- Mark ADR-002 as Superseded, documenting full-schema OpenAPI generation as the canonical current behavior and relegating schema-only details to historical context.
- Update backend routing and system overview docs to describe centralized PRO route registration and full-schema OpenAPI generation with concrete evidence anchors.

Chores:
- Mark BACKLOG_LEDGER items for restoring full OpenAPI schema and fixing import-time ORM issues as completed with references to PR-631 and updated evidence.

</details>

Документация:
- Пометить ADR-002 как утративший силу, задокументировав генерацию OpenAPI по полной схеме как каноничное текущее поведение и переведя детали режима «только схема» в разряд исторического контекста.
- Обновить карту маршрутизации backend’а и обзорные системные документы, чтобы описать централизованную регистрацию маршрутов PRO и подтверждённое практикой поведение генерации OpenAPI по полной схеме.

Служебные задачи:
- Пометить связанные элементы BACKLOG_LEDGER как выполненные, чтобы отразить удаление режима OpenAPI «только схема» и устранение проблем ORM во время импорта при генерации OpenAPI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Привести архитектурную документацию в соответствие с текущим поведением генерации OpenAPI для полной схемы и зафиксировать завершение связанной работы из бэклога.

Документация:
- Пометить ADR-002 как Superseded, задокументировав генерацию OpenAPI для полной схемы как каноничное текущее поведение и отнеся детали, касающиеся только схемы, к историческому контексту.
- Обновить документацию по роутингу backend-а и обзор системы, чтобы описать централизованную регистрацию маршрутов PRO и генерацию OpenAPI для полной схемы с указанием конкретных доказательств (evidence anchors).

Рутинные задачи:
- Пометить элементы BACKLOG_LEDGER, связанные с восстановлением полной схемы OpenAPI и исправлением проблем ORM во время импорта, как выполненные, с ссылками на PR-631 и обновлённые доказательства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align architecture documentation with the current full-schema OpenAPI generation behavior and record completion of related backlog work.

Documentation:
- Mark ADR-002 as Superseded, documenting full-schema OpenAPI generation as the canonical current behavior and relegating schema-only details to historical context.
- Update backend routing and system overview docs to describe centralized PRO route registration and full-schema OpenAPI generation with concrete evidence anchors.

Chores:
- Mark BACKLOG_LEDGER items for restoring full OpenAPI schema and fixing import-time ORM issues as completed with references to PR-631 and updated evidence.

</details>

</details>

Документация:
- Обновить ADR-002, чтобы пометить режим OpenAPI только-схемы как заменённый, описать полно-схемный OpenAPI как каноничное текущее поведение и чётко отделить исторический контекст от текущего состояния.
- Переработать документацию по маршрутизации бэкенда и обзору системы, чтобы задокументировать генерацию полно-схемного OpenAPI, обновлённые «evidence anchors» и централизованное поведение регистрации маршрутов PRO.

Рутинные задачи:
- Пометить связанные элементы бэклога как выполненные, чтобы отразить удаление режима OpenAPI только-схемы и очистку проблем ORM во время импорта при генерации OpenAPI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Привести архитектурную документацию в соответствие с текущим поведением генерации OpenAPI для полной схемы и зафиксировать завершение связанной работы из бэклога.

Документация:
- Пометить ADR-002 как Superseded, задокументировав генерацию OpenAPI для полной схемы как каноничное текущее поведение и отнеся детали, касающиеся только схемы, к историческому контексту.
- Обновить документацию по роутингу backend-а и обзор системы, чтобы описать централизованную регистрацию маршрутов PRO и генерацию OpenAPI для полной схемы с указанием конкретных доказательств (evidence anchors).

Рутинные задачи:
- Пометить элементы BACKLOG_LEDGER, связанные с восстановлением полной схемы OpenAPI и исправлением проблем ORM во время импорта, как выполненные, с ссылками на PR-631 и обновлённые доказательства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align architecture documentation with the current full-schema OpenAPI generation behavior and record completion of related backlog work.

Documentation:
- Mark ADR-002 as Superseded, documenting full-schema OpenAPI generation as the canonical current behavior and relegating schema-only details to historical context.
- Update backend routing and system overview docs to describe centralized PRO route registration and full-schema OpenAPI generation with concrete evidence anchors.

Chores:
- Mark BACKLOG_LEDGER items for restoring full OpenAPI schema and fixing import-time ORM issues as completed with references to PR-631 and updated evidence.

</details>

Документация:
- Пометить ADR-002 как утративший силу, задокументировав генерацию OpenAPI по полной схеме как каноничное текущее поведение и переведя детали режима «только схема» в разряд исторического контекста.
- Обновить карту маршрутизации backend’а и обзорные системные документы, чтобы описать централизованную регистрацию маршрутов PRO и подтверждённое практикой поведение генерации OpenAPI по полной схеме.

Служебные задачи:
- Пометить связанные элементы BACKLOG_LEDGER как выполненные, чтобы отразить удаление режима OpenAPI «только схема» и устранение проблем ORM во время импорта при генерации OpenAPI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Привести архитектурную документацию в соответствие с текущим поведением генерации OpenAPI для полной схемы и зафиксировать завершение связанной работы из бэклога.

Документация:
- Пометить ADR-002 как Superseded, задокументировав генерацию OpenAPI для полной схемы как каноничное текущее поведение и отнеся детали, касающиеся только схемы, к историческому контексту.
- Обновить документацию по роутингу backend-а и обзор системы, чтобы описать централизованную регистрацию маршрутов PRO и генерацию OpenAPI для полной схемы с указанием конкретных доказательств (evidence anchors).

Рутинные задачи:
- Пометить элементы BACKLOG_LEDGER, связанные с восстановлением полной схемы OpenAPI и исправлением проблем ORM во время импорта, как выполненные, с ссылками на PR-631 и обновлённые доказательства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align architecture documentation with the current full-schema OpenAPI generation behavior and record completion of related backlog work.

Documentation:
- Mark ADR-002 as Superseded, documenting full-schema OpenAPI generation as the canonical current behavior and relegating schema-only details to historical context.
- Update backend routing and system overview docs to describe centralized PRO route registration and full-schema OpenAPI generation with concrete evidence anchors.

Chores:
- Mark BACKLOG_LEDGER items for restoring full OpenAPI schema and fixing import-time ORM issues as completed with references to PR-631 and updated evidence.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align OpenAPI architecture docs to full-schema generation and remove references to schema-only mode. Supersedes ADR-002 and closes related backlog items to reduce confusion and speed up client contract work.

- **Refactors**
  - ADR-002 marked Superseded (kept for history).
  - system_overview and backend_routing_map updated to state full-schema mode with evidence links.
  - BACKLOG_LEDGER entries for restoring full schema and ORM import hygiene marked complete.

<sup>Written for commit f434f74458fef39afcf10ce36d2c2203c2acd743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation to confirm full-schema OpenAPI generation is now the canonical standard
  * Removed schema-only mode references; OpenAPI schema generation is now fully deterministic
  * Closed backlog items related to full-schema restoration and import-time safety optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->