### PR TITLE
iOS: stabilize PlateViewTests and include in CI signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		if [ -n "$$ONLY_ITEMS" ]; then \
 			IFS=','; for t in $$ONLY_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && ONLY_FLAGS="$$ONLY_FLAGS -only-testing:$$t"; done; unset IFS; \
 		else \
-			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests -only-testing:PulsePlateTests/SoftPaywallCTARoutingTests"; \
+			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests -only-testing:PulsePlateTests/SoftPaywallCTARoutingTests -only-testing:PulsePlateTests/PlateViewTests -only-testing:PulsePlateTests/PlateRingTests -only-testing:PulsePlateTests/PlateSegmentsTests -only-testing:PulsePlateTests/SegmentDetailViewTests"; \
 		fi; \
 		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_PROVIDED" ]; then \
 			SKIP_FLAGS="-skip-testing:PulsePlateUITests"; \

--- a/ios/PulsePlate/Models/NutritionData.swift
+++ b/ios/PulsePlate/Models/NutritionData.swift
@@ -141,6 +141,7 @@ enum PlateLoadIssue: Equatable, Sendable {
   }
 }
 
+@MainActor
 class NutritionService: ObservableObject {
   @Published var nutritionData: NutritionData?
   @Published var isLoading = false

--- a/ios/PulsePlateTests/PlateViewTests.swift
+++ b/ios/PulsePlateTests/PlateViewTests.swift
@@ -12,7 +12,8 @@ class PlateViewTests: XCTestCase {
     XCTAssertNotNil(view)
   }
 
-  func testNutritionServiceMockData() {
+  @MainActor
+  func testNutritionServiceMockData() async {
     // Given
     let service = NutritionService()
 
@@ -25,7 +26,8 @@ class PlateViewTests: XCTestCase {
     XCTAssertEqual(service.nutritionData?.totalProgress, 0.68)
   }
 
-  func testNutritionSegmentDataMapping() {
+  @MainActor
+  func testNutritionSegmentDataMapping() async {
     // Given
     let service = NutritionService()
     service.loadMockData()


### PR DESCRIPTION
## Summary
- Stabilize PlateViewTests by running NutritionService mock-data assertions on the MainActor.
- Include Plate-related unit tests in the default `make ios-test` allowlist so they are exercised as part of the iOS CI signal.

## Root cause
- PlateViewTests crashed the test runner with `malloc: pointer being freed was not allocated` when calling `NutritionService.loadMockData()` off the main thread.

## Changes
- `ios/PulsePlate/Models/NutritionData.swift`: mark `NutritionService` as `@MainActor`.
- `ios/PulsePlateTests/PlateViewTests.swift`: mark the two NutritionService mock-data tests as `@MainActor` + `async`.
- `Makefile`: add PlateViewTests-related classes to the default `ios-test` `-only-testing` list.

## Verification
- `make ios-test`
- `xcodebuild test -project ios/PulsePlate.xcodeproj -scheme PulsePlate -destination 'platform=iOS Simulator,name=iPhone 16e' \
  -only-testing:PulsePlateTests/PlateViewTests \
  -only-testing:PulsePlateTests/PlateRingTests \
  -only-testing:PulsePlateTests/PlateSegmentsTests \
  -only-testing:PulsePlateTests/SegmentDetailViewTests`
- `pre-commit run --all-files`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Стабилизировать использование `NutritionService` и гарантировать, что тесты, связанные с Plate, выполняются по умолчанию в наборе iOS-тестов.

Исправления ошибок:
- Обеспечить выполнение `NutritionService` и использования его mock-данных на основном акторе, чтобы предотвратить падения в тестах представления Plate.

Сборка:
- Расширить allowlist по умолчанию для `ios-test` в Makefile, включив в него тестовые цели, связанные с Plate, чтобы они покрывались стандартной командой запуска тестов.

Тесты:
- Преобразовать тесты mock-данных `NutritionService` в `PlateViewTests` в асинхронные тесты `async @MainActor` в соответствии с поведением сервиса, работающего на основном акторе.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize NutritionService usage and ensure Plate-related tests are exercised by default in the iOS test suite.

Bug Fixes:
- Ensure NutritionService and its mock-data usage run on the main actor to prevent crashes in Plate view tests.

Build:
- Expand the default ios-test Makefile allowlist to include Plate-related test targets so they are covered by the standard test command.

Tests:
- Convert NutritionService mock-data tests in PlateViewTests to async @MainActor tests aligned with the service’s main-actor behavior.

</details>

Исправления ошибок:
- Гарантировать, что NutritionService и его тесты представления тарелки с mock-данными выполняются на основном акторе, чтобы предотвратить сбои во время выполнения тестов.

Сборка:
- Расширить список разрешений по умолчанию в Makefile для `ios-test`, чтобы Plate-связанные unit-тесты по умолчанию запускались в CI.

Тесты:
- Обновить тесты NutritionService в PlateViewTests до async-тестов на основном акторе, согласованных с поведением сервиса на основном акторе.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Стабилизировать использование `NutritionService` и гарантировать, что тесты, связанные с Plate, выполняются по умолчанию в наборе iOS-тестов.

Исправления ошибок:
- Обеспечить выполнение `NutritionService` и использования его mock-данных на основном акторе, чтобы предотвратить падения в тестах представления Plate.

Сборка:
- Расширить allowlist по умолчанию для `ios-test` в Makefile, включив в него тестовые цели, связанные с Plate, чтобы они покрывались стандартной командой запуска тестов.

Тесты:
- Преобразовать тесты mock-данных `NutritionService` в `PlateViewTests` в асинхронные тесты `async @MainActor` в соответствии с поведением сервиса, работающего на основном акторе.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize NutritionService usage and ensure Plate-related tests are exercised by default in the iOS test suite.

Bug Fixes:
- Ensure NutritionService and its mock-data usage run on the main actor to prevent crashes in Plate view tests.

Build:
- Expand the default ios-test Makefile allowlist to include Plate-related test targets so they are covered by the standard test command.

Tests:
- Convert NutritionService mock-data tests in PlateViewTests to async @MainActor tests aligned with the service’s main-actor behavior.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes PlateViewTests by marking NutritionService and its mock-data tests as @MainActor to prevent the malloc crash. Adds PlateViewTests, PlateRingTests, PlateSegmentsTests, and SegmentDetailViewTests to the default ios-test allowlist so they run in CI.

<sup>Written for commit 54ae666eaf04bd844b6a9eec9ea65fb1a11ba453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced nutrition data service with loading state management and comprehensive error handling for improved data fetching reliability.

* **Tests**
  * Expanded default iOS test suite to include additional test targets.
  * Updated test methods to support asynchronous execution patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->