### PR TITLE
docs(architecture): stabilize OpenAPI evidence anchors

### DIFF
--- a/docs/architecture/ADR-002-openapi-schema-only-mode.md
+++ b/docs/architecture/ADR-002-openapi-schema-only-mode.md
@@ -13,12 +13,18 @@
 
 Schema-only mode has been removed. OpenAPI generation runs in **full-schema mode** and remains deterministic.
 
+Canonical docs for current behavior (recommended first read):
+- `docs/architecture/system_overview.md#openapi-generation-mode-current`
+- `docs/architecture/backend_routing_map.md#openapi-generation-behavior-important`
+
 **Evidence (file:line):**
 
-- `scripts/generate_openapi.py:94-120` — generator pins env to test context and enables feature-flagged routers, then imports `app.main:app` and calls `app.openapi()`
-- `tests/test_openapi_determinism.py:17-55` — asserts the full schema includes key PRO/business paths
+- Anchor (stable): `scripts/generate_openapi.py -> main()` (FULL schema mode + env pinning)
+  - Evidence: `scripts/generate_openapi.py:94`
+- Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+  - Evidence: `tests/test_openapi_determinism.py:17`
 
-## Decision (historical; pre PR-631)
+## Decision (historical; pre-PR-631)
 
 Keep a **temporary schema-only mode** for OpenAPI generation to avoid import-time ORM/model double-loading, while explicitly documenting:
 - what is disabled,
@@ -33,7 +39,8 @@ OpenAPI generation must be deterministic (CI enforces this). Importing the full 
 
 - Prior art / original seam: see PR-630 evidence pack (kept for archaeology).
 - CI determinism gate (still current):
-  - `tests/test_openapi_determinism.py:17-77`
+  - Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+  - Evidence: `tests/test_openapi_determinism.py:17`
 
 <a id="schema-only-openapi-contract"></a>
 ## Schema-only OpenAPI contract (historical; removed)

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -124,9 +124,11 @@ OpenAPI generation runs in **full-schema mode** (schema-only mode removed in PR-
 **Evidence (implementation):**
 
 - Generator pins env and enables feature-flagged routers, then imports canonical entrypoint:
-  - `scripts/generate_openapi.py:94-120`
+  - Anchor (stable): `scripts/generate_openapi.py -> main()`
+  - Evidence: `scripts/generate_openapi.py:94`
 - Determinism gate asserts key routes exist in schema:
-  - `tests/test_openapi_determinism.py:17-55`
+  - Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+  - Evidence: `tests/test_openapi_determinism.py:17`
 
 ## Maintenance rule
 

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -70,8 +70,10 @@ flowchart LR
 OpenAPI generator runs in **full-schema mode** (schema-only mode removed in PR-631).
 
 **Evidence (file:line):**
-- `scripts/generate_openapi.py:94-120` (generator pins env + enables feature-flagged routers, then imports `app.main:app`)
-- `tests/test_openapi_determinism.py:17-55` (asserts key PRO/business paths exist in schema)
+- Anchor (stable): `scripts/generate_openapi.py -> main()` (FULL schema mode + env pinning)
+  - Evidence: `scripts/generate_openapi.py:94`
+- Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+  - Evidence: `tests/test_openapi_determinism.py:17`
 
 Historical ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (superseded).
 
@@ -86,7 +88,8 @@ Historical ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (superse
     - `tests/test_import_hygiene_guard.py:12-41`
 - **OpenAPI determinism**
   - `make openapi` must be deterministic; guard:
-    - `tests/test_openapi_determinism.py:16-64` (hash comparison)
+    - Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+      - Evidence: `tests/test_openapi_determinism.py:17` (hash comparison)
 - **Rate limiting for expensive endpoints**
   - LLM/exports endpoints must be rate-limited and have deterministic 429 tests; rate limiting is proxy-aware and privacy-friendly.
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -588,8 +588,10 @@ If it is not recorded here — it does not exist.
   - Status: ✅ Merged (PR-631, 2026-02-03)
   - Reason: Schema-only OpenAPI mode reduced thin-client contract velocity. PR-631 removed the schema-only seam and enabled full-schema generation with deterministic output.
   - Evidence:
-    - `scripts/generate_openapi.py:94-109` (FULL schema mode; enables feature-flagged routers in generator context)
-    - `tests/test_openapi_determinism.py:17-55` (asserts key PRO/business paths exist)
+    - Anchor (stable): `scripts/generate_openapi.py -> main()` (FULL schema mode; enables feature-flagged routers)
+      - Evidence: `scripts/generate_openapi.py:94`
+    - Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
+      - Evidence: `tests/test_openapi_determinism.py:17`
   - DoD: ✅ Completed (PR-631)
     - OpenAPI generator runs in full-schema mode (no schema-only marker)
     - `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts` in sync (`make openapi` produces no diff)
@@ -603,7 +605,8 @@ If it is not recorded here — it does not exist.
   - Reason: OpenAPI generation must be side-effect free: routers reachable from `app.main:app` must not import ORM models at module import time.
   - Evidence:
     - `app/routers/nutrition_log.py:26-73` (TYPE_CHECKING-only model import + runtime lazy import pattern)
-    - `scripts/generate_openapi.py:114-120` (imports canonical entrypoint and calls `app.openapi()` successfully)
+    - Anchor (stable): `scripts/generate_openapi.py -> main()` (imports canonical entrypoint and calls `app.openapi()`)
+      - Evidence: `scripts/generate_openapi.py:114`
   - DoD: ✅ Completed (PR-631)
     - ORM model imports moved to runtime (inside handlers/dependencies), preserving OpenAPI determinism
     - OpenAPI generation works with routers enabled

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -588,10 +588,8 @@ If it is not recorded here — it does not exist.
   - Status: ✅ Merged (PR-631, 2026-02-03)
   - Reason: Schema-only OpenAPI mode reduced thin-client contract velocity. PR-631 removed the schema-only seam and enabled full-schema generation with deterministic output.
   - Evidence:
-    - Anchor (stable): `scripts/generate_openapi.py -> main()` (FULL schema mode; enables feature-flagged routers)
-      - Evidence: `scripts/generate_openapi.py:94`
-    - Anchor (stable): `tests/test_openapi_determinism.py -> test_openapi_and_schema_ts_are_deterministic()`
-      - Evidence: `tests/test_openapi_determinism.py:17`
+    - `scripts/generate_openapi.py:94-109` (FULL schema mode; enables feature-flagged routers in generator context)
+    - `tests/test_openapi_determinism.py:17-55` (asserts key PRO/business paths exist)
   - DoD: ✅ Completed (PR-631)
     - OpenAPI generator runs in full-schema mode (no schema-only marker)
     - `frontend/src/api/openapi.json` + `frontend/src/api/schema.ts` in sync (`make openapi` produces no diff)
@@ -605,8 +603,7 @@ If it is not recorded here — it does not exist.
   - Reason: OpenAPI generation must be side-effect free: routers reachable from `app.main:app` must not import ORM models at module import time.
   - Evidence:
     - `app/routers/nutrition_log.py:26-73` (TYPE_CHECKING-only model import + runtime lazy import pattern)
-    - Anchor (stable): `scripts/generate_openapi.py -> main()` (imports canonical entrypoint and calls `app.openapi()`)
-      - Evidence: `scripts/generate_openapi.py:114`
+    - `scripts/generate_openapi.py:114-120` (imports canonical entrypoint and calls `app.openapi()` successfully)
   - DoD: ✅ Completed (PR-631)
     - ORM model imports moved to runtime (inside handlers/dependencies), preserving OpenAPI determinism
     - OpenAPI generation works with routers enabled


### PR DESCRIPTION
## Summary
- Address Sourcery feedback on PR-684 docs: replace brittle `file:start-end` evidence ranges with stable anchors (function/test names) + single-line evidence pointers.
- Clarify `ADR-002` as historical/superseded and link to canonical current docs.
- Minor consistency: hyphenate `pre-PR-631`.

## Why
Line ranges drift over time. Using stable anchors improves doc longevity while preserving the evidence-driven style.

## Test plan
- `pre-commit run --all-files`

## Deferred / Follow-ups
- None.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Стабилизировать ссылки в архитектурной документации и дорожной карте для генерации OpenAPI, переключившись с хрупких указателей на основе строк файлов на якоря по именам функций/тестов и прояснив исторический статус ADR для режима только схем (schema-only mode).

Документация:
- Заменить ссылки на доказательства в виде диапазонов строк файлов на стабильные якоря по именам функций/тестов плюс указатели на одну строку в архитектурной документации, связанной с OpenAPI, и в записях реестра бэклога.
- Прояснить, что ADR-002 для режима OpenAPI schema-only носит исторический/устаревший характер и направить читателей к каноничной текущей документации по поведению OpenAPI.
- Унифицировать формулировки, связанные с пометкой исторического решения (например, использование дефиса в выражении pre-PR-631) в ADR-002.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize architecture and roadmap documentation references for OpenAPI generation by switching from fragile line-based evidence pointers to function/test-name anchors and clarifying the historical status of the schema-only mode ADR.

Documentation:
- Replace file line-range evidence references with stable function/test-name anchors plus single-line evidence pointers across OpenAPI-related architecture docs and backlog ledger entries.
- Clarify that ADR-002 for OpenAPI schema-only mode is historical/superseded and point readers to the canonical current OpenAPI behavior documentation.
- Normalize wording around the historical decision label (e.g., hyphenating pre-PR-631) in ADR-002.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized OpenAPI evidence in architecture docs by replacing brittle file:line ranges with stable anchors (function/test names) and single-line pointers. Clarified ADR-002 as historical with links to canonical docs, standardized pre-PR-631 wording, and dropped unrelated ledger changes to keep scope focused.

<sup>Written for commit 6415078b1c05133564f19c93f01625c1e4968946. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural documentation with stable reference anchors to improve documentation maintainability and reduce brittleness from code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->