### PR TITLE
docs: add Project Memory Layer (PML) capsules + KPP

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -98,12 +98,7 @@ After agents complete work:
 2. **Synthesize multi-agent work**: Combine outputs into coherent solution
 3. **Final quality check**: Verify quality gates pass (see Quality Gates section)
 4. **Promote reusable knowledge (KPP)**:
-   - If a reusable insight was discovered, promote it to exactly one durable repo artifact:
-     - Canonical doc/policy/ADR, or
-     - Guard test (preferred), or
-     - Ledger item (`docs/roadmap/BACKLOG_LEDGER.md`), or
-     - Memory capsule (`docs/memory/index.md`)
-   - Evidence must be attached (`file:line` and/or reproducible commands + output + exit code).
+   - Follow the canonical KPP: `docs/memory/kpp_knowledge_promotion_pipeline.md`.
 5. **Generate final conclusion**: Summary, effectiveness, corrective actions, follow-ups
 
 ## Available Agents

--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -97,7 +97,14 @@ After agents complete work:
 1. **Review agent outputs**: Requirements met, conventions followed, conflicts resolved
 2. **Synthesize multi-agent work**: Combine outputs into coherent solution
 3. **Final quality check**: Verify quality gates pass (see Quality Gates section)
-4. **Generate final conclusion**: Summary, effectiveness, corrective actions, follow-ups
+4. **Promote reusable knowledge (KPP)**:
+   - If a reusable insight was discovered, promote it to exactly one durable repo artifact:
+     - Canonical doc/policy/ADR, or
+     - Guard test (preferred), or
+     - Ledger item (`docs/roadmap/BACKLOG_LEDGER.md`), or
+     - Memory capsule (`docs/memory/index.md`)
+   - Evidence must be attached (`file:line` and/or reproducible commands + output + exit code).
+5. **Generate final conclusion**: Summary, effectiveness, corrective actions, follow-ups
 
 ## Available Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,27 @@ A **task** is any unit of work that:
 
 **Rationale:** Ensures consistent task start, proper agent routing, quality gates, and systematic tracking of postponed work.
 
+## Project Memory Layer (PML) / Knowledge Promotion Pipeline (KPP)
+
+**Hard rule:** Agents do not “learn” by silently storing canonical knowledge. **Repo artifacts remain the only Source of Truth.**
+
+### What counts as “project memory”
+
+- **L0 (non-SoT):** chat history / model memory / prompts (never cited as truth)
+- **L1 (working notes):** task analysis / review / synthesis docs (short-lived)
+- **L2 (canonical):** rules, contracts, ADRs, and guard tests in the repo
+
+### Promotion rule (KPP)
+
+If an agent discovers a reusable insight, it must be promoted via **exactly one** durable repo artifact:
+
+- a canonical doc/policy/ADR update, or
+- a guard test (preferred for invariants), or
+- a ledger item in `docs/roadmap/BACKLOG_LEDGER.md`, or
+- a short “memory capsule” under `docs/memory/` (index: `docs/memory/index.md`)
+
+**Evidence requirement:** every promoted claim must include `file:line` pointers and/or reproducible commands + raw output + exit code.
+
 ## If you feel lost
 
 Run: `pytest -q tests/test_repo_policy_guards.py` and follow RUNBOOK_AGENT.md section "PR Specific Checks".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,22 +152,9 @@ A **task** is any unit of work that:
 
 **Hard rule:** Agents do not “learn” by silently storing canonical knowledge. **Repo artifacts remain the only Source of Truth.**
 
-### What counts as “project memory”
+### Canonical KPP (SoT)
 
-- **L0 (non-SoT):** chat history / model memory / prompts (never cited as truth)
-- **L1 (working notes):** task analysis / review / synthesis docs (short-lived)
-- **L2 (canonical):** rules, contracts, ADRs, and guard tests in the repo
-
-### Promotion rule (KPP)
-
-If an agent discovers a reusable insight, it must be promoted via **exactly one** durable repo artifact:
-
-- a canonical doc/policy/ADR update, or
-- a guard test (preferred for invariants), or
-- a ledger item in `docs/roadmap/BACKLOG_LEDGER.md`, or
-- a short “memory capsule” under `docs/memory/` (index: `docs/memory/index.md`)
-
-**Evidence requirement:** every promoted claim must include `file:line` pointers and/or reproducible commands + raw output + exit code.
+See `docs/memory/kpp_knowledge_promotion_pipeline.md`.
 
 ## If you feel lost
 

--- a/docs/memory/api_tiers_and_namespaces.md
+++ b/docs/memory/api_tiers_and_namespaces.md
@@ -1,0 +1,51 @@
+# Memory Capsule: API tiers + canonical namespaces
+
+**Topic:** FREE / PRO / VIP tier boundaries and URL namespaces
+**Type:** Invariants + test hygiene reminders
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+PulsePlate has canonical API tier namespaces and strict tier guard rules.
+
+Key rule: tier enforcement must run **before** payload validation (tier wins over payload).
+
+---
+
+## Why
+
+Tier namespace drift causes:
+
+- frontend/iOS calling deprecated paths
+- incorrect auth behavior (403 vs 422 confusion)
+- OpenAPI/type generation drift (wrong paths leak into clients)
+
+---
+
+## Invariants (SoT)
+
+- Tiers are FREE/PRO/VIP and `/premium/*` is deprecated: `AGENTS.md:540`, `AGENTS.md:541`
+- VIP namespace: `AGENTS.md:542`
+- PRO namespace: `AGENTS.md:657`
+- Canonical namespaces list: `AGENTS.md:663`
+- Tier guard order (403 before 422): `AGENTS.md:660`
+- Premium aliases are shims only (no business logic): `AGENTS.md:664`, `AGENTS.md:675`
+
+---
+
+## Commands (verification / triage)
+
+- Tier guard policy tests (fast signal):
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “Product tiers and API namespaces (canonical)”
+- `docs/contracts/PRODUCT_TIER_MAP.md`

--- a/docs/memory/bmi_one_engine_invariant.md
+++ b/docs/memory/bmi_one_engine_invariant.md
@@ -1,0 +1,60 @@
+# Memory Capsule: One BMI Engine Invariant
+
+**Topic:** BMI canonical computation path
+**Type:** Invariant + enforcement pointers
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+PulsePlate has a hard rule: **exactly one canonical BMI engine** is the sole calculation path for BMI-related computations.
+
+This is not “style”. It is an architectural invariant enforced by guard tests.
+
+---
+
+## Why
+
+Multiple BMI computation paths cause:
+
+- inconsistent results (“BMI undefined” class of issues)
+- broken debugging (cannot trust which path was used)
+- client drift (thin client policy violations)
+- increased test flakiness and coverage waste
+
+---
+
+## Invariants (SoT)
+
+- BMI engine invariant (canonical): `AGENTS.md:813`–`AGENTS.md:829`
+- Enforcement tests: see “Enforcement” bullets in `AGENTS.md:817`–`AGENTS.md:822`
+
+---
+
+## Commands (verification / triage)
+
+- Guard policy suite (fast signal):
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+- BMI canonical guard (if investigating BMI-path drift):
+
+```bash
+pytest -q tests/test_bmi_canonical_guard.py
+```
+
+- Anti-duplication guard (BMI math outside `core/`):
+
+```bash
+pytest -q tests/test_no_bmi_math_outside_core.py
+```
+
+---
+
+## Links (canonical)
+
+- Root rules: `AGENTS.md` → “BMI Engine Invariant (Hard Rule)”
+- Guard entrypoints: `tests/test_bmi_canonical_guard.py`, `tests/test_no_bmi_math_outside_core.py`

--- a/docs/memory/bmi_one_engine_invariant.md
+++ b/docs/memory/bmi_one_engine_invariant.md
@@ -27,8 +27,9 @@ Multiple BMI computation paths cause:
 
 ## Invariants (SoT)
 
-- BMI engine invariant (canonical): `AGENTS.md:813`–`AGENTS.md:829`
-- Enforcement tests: see “Enforcement” bullets in `AGENTS.md:817`–`AGENTS.md:822`
+- BMI engine invariant (canonical): `AGENTS.md:813`, `AGENTS.md:815`
+- Enforcement pointers: `AGENTS.md:819`, `AGENTS.md:821`
+- Shim constraints (legacy compatibility): `AGENTS.md:826`, `AGENTS.md:828`, `AGENTS.md:829`
 
 ---
 

--- a/docs/memory/db_fallback_single_source_of_truth.md
+++ b/docs/memory/db_fallback_single_source_of_truth.md
@@ -1,0 +1,52 @@
+# Memory Capsule: DB fallback single source of truth
+
+**Topic:** DB fallback invariants and test hygiene
+**Type:** Hard rules + safe test patterns
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+DB fallback is owned by **one canonical module**: `core/db_fallback.py`.
+
+No other module may define or directly read/write fallback global state. All access must go through the public helpers.
+
+---
+
+## Why
+
+Fallback drift causes:
+
+- stale-global bugs (import-time copies of state)
+- xdist pollution (tests leaking env/session state)
+- “works locally, fails in CI” failures
+
+---
+
+## Invariants (SoT)
+
+- Single source of truth: `AGENTS.md:222`
+- `legacy_app.py` must delegate only (no fallback helpers/flags): `AGENTS.md:223`
+- SessionLocal lifecycle invariant (no `SessionLocal.configure()`): `AGENTS.md:224`
+- State mutation policy (helpers only): `AGENTS.md:225`
+- Forbidden stale import pattern: `AGENTS.md:226`
+- Test hygiene (restore SessionLocal + env keys): `AGENTS.md:228`
+- Module/package collision rule: `AGENTS.md:230`
+
+---
+
+## Commands (verification)
+
+- Guard policies (fast signal):
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “DB fallback policy (hard, TP2)”
+- Implementation: `core/db_fallback.py`

--- a/docs/memory/docs_only_and_pr_scope_guard.md
+++ b/docs/memory/docs_only_and_pr_scope_guard.md
@@ -1,0 +1,53 @@
+# Memory Capsule: Docs-only PR rule + PR scope guard
+
+**Topic:** Keeping documentation PRs safe and reviewable
+**Type:** Hard rules + commands
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+A docs-only PR is strictly limited to documentation files and must not change runtime behavior, CI, or configuration.
+
+This is enforced by policy and an early CI scope guard.
+
+---
+
+## Why
+
+Docs PRs should be:
+
+- low-risk (no runtime regressions)
+- fast to review
+- deterministic in CI
+
+Mixing runtime/config/code into docs PRs repeatedly caused failures and accidental behavior changes.
+
+---
+
+## Invariants (SoT)
+
+- CI PR scope guard overview: `AGENTS.md:279`
+- Docs-only PR Rule (mandatory): `AGENTS.md:744`, `AGENTS.md:746`
+- Forbidden in docs-only PRs: `AGENTS.md:757`, `AGENTS.md:758`, `AGENTS.md:760`
+- Special note (do not touch `legacy_app.py` in docs-only): `AGENTS.md:776`, `AGENTS.md:778`
+
+---
+
+## Commands (before push)
+
+- Docs-only enforcement check (must be empty output):
+
+```bash
+git diff --name-only origin/main...HEAD \
+  | rg -v "\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$"
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “Docs-only PR Rule (Mandatory)”
+- `docs/policy/PR_SCOPE_RULES.md`
+- `docs/policy/PR_SCOPE_GUARD_CI_SETUP.md`

--- a/docs/memory/import_hygiene_and_single_app_entrypoint.md
+++ b/docs/memory/import_hygiene_and_single_app_entrypoint.md
@@ -1,0 +1,57 @@
+# Memory Capsule: Import hygiene + single app entrypoint
+
+**Topic:** Preventing Dual Base / import drift
+**Type:** Invariants + verification commands
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+PulsePlate enforces strict **import hygiene** to prevent dual-namespace imports, xdist hangs, and “two apps” bugs.
+
+Key idea: there must be exactly **one** FastAPI app entrypoint and no test-time import hacks that create parallel module graphs.
+
+---
+
+## Why
+
+Import drift can cause:
+
+- duplicated module state (“Dual Base”)
+- test hangs/timeouts under xdist
+- missing legacy exports / broken shims
+- nondeterministic behavior in CI vs local
+
+---
+
+## Invariants (SoT)
+
+- Import hygiene invariants: `AGENTS.md:348`
+- Entrypoint must be `app.main:app`: `AGENTS.md:352`
+- Forbidden patterns (dynamic imports, sys.path/sys.modules): `AGENTS.md:357`, `AGENTS.md:358`, `AGENTS.md:359`
+- ENV gating order (`TESTING=true` before imports): `AGENTS.md:363`
+
+---
+
+## Commands (fast checks)
+
+- Guard policies:
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+- Import hygiene checklist greps (see canonical checklist):
+
+```bash
+pytest -q tests/test_import_hygiene_guard.py tests/test_env_guards.py
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “PR #403 specific invariants (Import Hygiene)”
+- `AGENTS.md` → “Import Hygiene Checklist (must-run before PR)”
+- `RUNBOOK_AGENT.md` (triage playbook)

--- a/docs/memory/index.md
+++ b/docs/memory/index.md
@@ -1,0 +1,21 @@
+# Project Memory (Capsules Index)
+
+**Status:** Canonical index (SoT pointers only)
+**Scope:** Dev-only project memory (not runtime user memory)
+**Last updated:** 8 February 2026
+
+---
+
+## What this is
+
+“Memory capsules” are short, stable, single-topic notes that help agents avoid repeating the same rediscovery work.
+
+Hard rule: capsules are **not** a second Source of Truth. They only point to canonical rules and commands.
+
+---
+
+## Capsules
+
+- `docs/memory/bmi_one_engine_invariant.md` — One BMI Engine invariant (canonical rule + enforcement pointers)
+- `docs/memory/openapi_determinism_and_side_effect_free_generation.md` — OpenAPI determinism + side‑effect‑free generation rules
+- `docs/memory/llm_cost_abuse_controls.md` — LLM cost‑abuse controls (rate limiting + monthly quota + budgets)

--- a/docs/memory/index.md
+++ b/docs/memory/index.md
@@ -19,6 +19,7 @@ Hard rule: capsules are **not** a second Source of Truth. They only point to can
 - `docs/memory/bmi_one_engine_invariant.md` — One BMI Engine invariant (canonical rule + enforcement pointers)
 - `docs/memory/openapi_determinism_and_side_effect_free_generation.md` — OpenAPI determinism + side‑effect‑free generation rules
 - `docs/memory/llm_cost_abuse_controls.md` — LLM cost‑abuse controls (rate limiting + monthly quota + budgets)
+- `docs/memory/kpp_knowledge_promotion_pipeline.md` — Knowledge Promotion Pipeline (KPP) (canonical promotion process)
 - `docs/memory/import_hygiene_and_single_app_entrypoint.md` — Import hygiene + single app entrypoint invariants
 - `docs/memory/docs_only_and_pr_scope_guard.md` — Docs-only PR rule + PR scope guard expectations
 - `docs/memory/api_tiers_and_namespaces.md` — FREE/PRO/VIP namespaces + tier guard order rules

--- a/docs/memory/index.md
+++ b/docs/memory/index.md
@@ -19,3 +19,10 @@ Hard rule: capsules are **not** a second Source of Truth. They only point to can
 - `docs/memory/bmi_one_engine_invariant.md` — One BMI Engine invariant (canonical rule + enforcement pointers)
 - `docs/memory/openapi_determinism_and_side_effect_free_generation.md` — OpenAPI determinism + side‑effect‑free generation rules
 - `docs/memory/llm_cost_abuse_controls.md` — LLM cost‑abuse controls (rate limiting + monthly quota + budgets)
+- `docs/memory/import_hygiene_and_single_app_entrypoint.md` — Import hygiene + single app entrypoint invariants
+- `docs/memory/docs_only_and_pr_scope_guard.md` — Docs-only PR rule + PR scope guard expectations
+- `docs/memory/api_tiers_and_namespaces.md` — FREE/PRO/VIP namespaces + tier guard order rules
+- `docs/memory/legacy_app_thin_proxy_policy.md` — `legacy_app.py` must stay a thin compat proxy
+- `docs/memory/db_fallback_single_source_of_truth.md` — DB fallback single source of truth + test hygiene
+- `docs/memory/ios_ci_udid_destination_policy.md` — iOS CI deterministic destination (UDID-only) rules
+- `docs/memory/quality_gates_precommit_and_verify.md` — pre-commit + `make verify` quality gates

--- a/docs/memory/ios_ci_udid_destination_policy.md
+++ b/docs/memory/ios_ci_udid_destination_policy.md
@@ -1,0 +1,42 @@
+# Memory Capsule: iOS CI destination must be UDID-only
+
+**Topic:** Deterministic iOS simulator destination in CI
+**Type:** Hard rule + debugging pointers
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+In CI, `xcodebuild` destination must be **UDID-only**:
+
+- `platform=iOS Simulator,id=<UDID>`
+
+Using `OS=latest` is forbidden in CI destination strings.
+
+---
+
+## Why
+
+UDID-only eliminates nondeterminism and runner drift:
+
+- “latest” ambiguity across GitHub runners
+- name/OS version mismatches
+- ineligible simulator destinations
+
+---
+
+## Invariants (SoT)
+
+- iOS destination policy header: `AGENTS.md:1350`
+- UDID-only requirement: `AGENTS.md:1352`
+- `OS=latest` forbidden: `AGENTS.md:1353`
+- “No return to OS=latest” hard rule: `AGENTS.md:1361`
+- Boot requirement remediation: `AGENTS.md:1362`
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “iOS CI destination policy (canonical)”
+- iOS agent scope: `ios/AGENTS.md`

--- a/docs/memory/kpp_knowledge_promotion_pipeline.md
+++ b/docs/memory/kpp_knowledge_promotion_pipeline.md
@@ -1,0 +1,74 @@
+# Memory Capsule: Knowledge Promotion Pipeline (KPP)
+
+**Topic:** Controlled “project learning” via repo artifacts
+**Type:** Process invariant (SoT pointer)
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+KPP is the canonical process for turning reusable insights into durable repo memory **without** breaking Source of Truth.
+
+Hard rule:
+
+- Agents do not “learn” by silently storing canonical knowledge.
+- “Self-learning” happens only via **promoting** insights into repo artifacts (docs/tests/ledger), with evidence.
+
+---
+
+## Why
+
+KPP prevents:
+
+- hidden memory becoming “truth”
+- drift from duplicated wording across docs
+- repeated rediscovery work between sessions
+
+---
+
+## Promotion rule (single path)
+
+If a reusable insight is discovered, promote it into **exactly one** durable repo artifact:
+
+- canonical doc / policy / ADR update, or
+- guard test (preferred for invariants), or
+- backlog item in `docs/roadmap/BACKLOG_LEDGER.md`, or
+- memory capsule under `docs/memory/` (index: `docs/memory/index.md`)
+
+---
+
+## Evidence requirements (non-negotiable)
+
+Every promoted claim must include one of:
+
+- `file:line` pointers (prefer **single-line anchors**, avoid ranges), and/or
+- reproducible commands + raw output + exit code
+
+Forbidden:
+
+- “common knowledge” as evidence
+- “the model remembers”
+
+---
+
+## Anti-drift rule
+
+If the same wording/policy appears in more than one place, create a single SoT doc and replace copies with links.
+
+Example SoT:
+
+- Wellness disclaimer wording: `docs/safety/WELLNESS_DISCLAIMER_CANONICAL.md`
+
+---
+
+## Who can promote to canonical
+
+`agent-coordinator` is the final authority for promotions and decides the destination artifact.
+
+---
+
+## Links (canonical)
+
+- Coordinator-first workflow: `AGENTS.md` → “Agent Coordination (Coordinator-First Rule)”
+- Backlog ledger rules: `docs/roadmap/BACKLOG_LEDGER.md`

--- a/docs/memory/legacy_app_thin_proxy_policy.md
+++ b/docs/memory/legacy_app_thin_proxy_policy.md
@@ -1,0 +1,49 @@
+# Memory Capsule: `legacy_app.py` must stay a thin compat proxy
+
+**Topic:** Preventing drift in legacy entrypoint
+**Type:** Hard rule + guard pointers
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+`legacy_app.py` is a **thin compatibility proxy only**.
+
+It must not accumulate new runtime behavior (middleware, metrics, infra routes) and must delegate to canonical bootstrap/app layers.
+
+---
+
+## Why
+
+Legacy drift creates:
+
+- duplicate registration / subtle behavior divergence
+- broken observability and routing assumptions
+- “fix it once, breaks elsewhere” regressions
+
+---
+
+## Invariants (SoT)
+
+- Legacy policy header: `AGENTS.md:212`
+- Forbidden behavior changes (middleware/observability/infra routes): `AGENTS.md:215`
+- Middleware/observability must live in bootstrap called from `app/main.py`: `AGENTS.md:216`
+- Allowed contents (thin proxies/shims only): `AGENTS.md:217`
+
+---
+
+## Commands (verification)
+
+- Guard policies (fast signal):
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “legacy_app.py policy (hard)”
+- Entrypoint invariant: `AGENTS.md:352` (runtime uses `app.main:app`)

--- a/docs/memory/llm_cost_abuse_controls.md
+++ b/docs/memory/llm_cost_abuse_controls.md
@@ -26,8 +26,9 @@ Without hard controls, a single endpoint can become a predictable cost sink / Do
 
 ## Invariants (SoT)
 
-- Rate limiting hard rule + enforcement list: `AGENTS.md:65`–`AGENTS.md:79`
-- Monthly quota hard rule + gating order: `AGENTS.md:81`–`AGENTS.md:87`
+- Rate limiting hard rule section: `AGENTS.md:65`, `AGENTS.md:67`
+- Enforcement pointers: `AGENTS.md:73`, `AGENTS.md:74`, `AGENTS.md:76`
+- Monthly quota hard rule section: `AGENTS.md:81`, `AGENTS.md:83`
 - Feature flags checked before quota consumption: `AGENTS.md:86`
 
 ---

--- a/docs/memory/llm_cost_abuse_controls.md
+++ b/docs/memory/llm_cost_abuse_controls.md
@@ -1,0 +1,61 @@
+# Memory Capsule: LLM cost‑abuse controls (rate limit + quota + budgets)
+
+**Topic:** Protecting expensive AI endpoints from abuse
+**Type:** Hard rules + enforcement pointers
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+PulsePlate treats LLM endpoints as **abuse-prone** and enforces:
+
+- **rate limiting** (deterministic 429 tests)
+- **monthly hard quota** (enforced before provider calls)
+- **feature-flag gating before charging/quota consumption**
+
+Recursive/multi-agent pipelines amplify calls, so **budgets/stop conditions** are required in future runtime work.
+
+---
+
+## Why
+
+Without hard controls, a single endpoint can become a predictable cost sink / DoS vector.
+
+---
+
+## Invariants (SoT)
+
+- Rate limiting hard rule + enforcement list: `AGENTS.md:65`–`AGENTS.md:79`
+- Monthly quota hard rule + gating order: `AGENTS.md:81`–`AGENTS.md:87`
+- Feature flags checked before quota consumption: `AGENTS.md:86`
+
+---
+
+## Commands (verification)
+
+- Verify repo policy guards (fast signal):
+
+```bash
+pytest -q tests/test_repo_policy_guards.py
+```
+
+- Rate limiting tests (deterministic 200 → 429 transitions):
+
+```bash
+pytest -q tests/test_rate_limit_llm_and_exports_api.py
+pytest -q tests/test_rate_limit_client_key_api.py
+```
+
+- Full local gate (when preparing merge):
+
+```bash
+make verify
+```
+
+---
+
+## Links (canonical)
+
+- Policy + references: `AGENTS.md` → “Rate Limiting Policy” and “LLM Monthly Quota Policy”
+- Related audit: `docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md`

--- a/docs/memory/openapi_determinism_and_side_effect_free_generation.md
+++ b/docs/memory/openapi_determinism_and_side_effect_free_generation.md
@@ -8,7 +8,7 @@
 
 ## What
 
-OpenAPI generation is **determinism-gated** and must be **side-effect free** on the import path.
+OpenAPI generation is **determinism-gated** and must be **side-effect-free** on the import path.
 This protects CI and prevents accidental ORM/model side effects when generating schema.
 
 ---

--- a/docs/memory/openapi_determinism_and_side_effect_free_generation.md
+++ b/docs/memory/openapi_determinism_and_side_effect_free_generation.md
@@ -25,11 +25,11 @@ If OpenAPI generation drifts or triggers side effects:
 
 ## Invariants (SoT)
 
-- Canonical section: `AGENTS.md:668`–`AGENTS.md:717`
+- Canonical section header: `AGENTS.md:668`
 - Must use `make openapi` (not direct script): `AGENTS.md:675`
 - Side-effect free requirement wording: `AGENTS.md:682`
 - Determinism test gate: `AGENTS.md:688`
-- Update flow + artifacts to commit: `AGENTS.md:701`–`AGENTS.md:710`
+- Update flow (artifacts to commit): `AGENTS.md:703`, `AGENTS.md:706`, `AGENTS.md:707`, `AGENTS.md:709`
 
 ---
 

--- a/docs/memory/openapi_determinism_and_side_effect_free_generation.md
+++ b/docs/memory/openapi_determinism_and_side_effect_free_generation.md
@@ -1,0 +1,61 @@
+# Memory Capsule: OpenAPI determinism + side‑effect‑free generation
+
+**Topic:** Deterministic OpenAPI artifacts for frontend types
+**Type:** Invariant + commands
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+OpenAPI generation is **determinism-gated** and must be **side-effect free** on the import path.
+This protects CI and prevents accidental ORM/model side effects when generating schema.
+
+---
+
+## Why
+
+If OpenAPI generation drifts or triggers side effects:
+
+- frontend generated types (`schema.ts`) drift unpredictably
+- CI fails on OpenAPI sync/determinism checks
+- imports may trigger ORM table registration (breaking “schema-only” assumptions)
+
+---
+
+## Invariants (SoT)
+
+- Canonical section: `AGENTS.md:668`–`AGENTS.md:717`
+- Must use `make openapi` (not direct script): `AGENTS.md:675`
+- Side-effect free requirement wording: `AGENTS.md:682`
+- Determinism test gate: `AGENTS.md:688`
+- Update flow + artifacts to commit: `AGENTS.md:701`–`AGENTS.md:710`
+
+---
+
+## Commands (local workflow)
+
+- Generate OpenAPI + regenerate frontend artifacts:
+
+```bash
+make openapi
+```
+
+- Verify artifacts are in sync:
+
+```bash
+make openapi-check
+```
+
+- Run determinism test directly (debug):
+
+```bash
+pytest -q tests/test_openapi_determinism.py
+```
+
+---
+
+## Links (canonical artifacts)
+
+- Generated artifacts: `frontend/src/api/openapi.json`, `frontend/src/api/schema.ts`
+- Generator entrypoint: `scripts/generate_openapi.py` (invoked via `make openapi`)

--- a/docs/memory/openapi_determinism_and_side_effect_free_generation.md
+++ b/docs/memory/openapi_determinism_and_side_effect_free_generation.md
@@ -27,7 +27,7 @@ If OpenAPI generation drifts or triggers side effects:
 
 - Canonical section header: `AGENTS.md:668`
 - Must use `make openapi` (not direct script): `AGENTS.md:675`
-- Side-effect free requirement wording: `AGENTS.md:682`
+- Side-effect-free requirement wording: `AGENTS.md:682`
 - Determinism test gate: `AGENTS.md:688`
 - Update flow (artifacts to commit): `AGENTS.md:703`, `AGENTS.md:706`, `AGENTS.md:707`, `AGENTS.md:709`
 

--- a/docs/memory/quality_gates_precommit_and_verify.md
+++ b/docs/memory/quality_gates_precommit_and_verify.md
@@ -1,0 +1,58 @@
+# Memory Capsule: Quality gates (`pre-commit` + `make verify`)
+
+**Topic:** When we can say “ready” and how to avoid CI failures
+**Type:** Hard gates + commands
+**Last updated:** 8 February 2026
+
+---
+
+## What
+
+PulsePlate has non-negotiable local gates for readiness claims:
+
+- `make verify` is the canonical “all gates” command
+- `pre-commit run --all-files` must run locally before push
+
+---
+
+## Why
+
+These gates prevent:
+
+- false-green PRs
+- CI failures due to uncommitted hook fixes
+- coverage drift below required thresholds
+
+---
+
+## Invariants (SoT)
+
+- “Don’t claim green unless `make verify` passes”: `AGENTS.md:5`, `AGENTS.md:8`
+- `pre-commit run --all-files` mandatory before push: `AGENTS.md:25`, `AGENTS.md:27`
+- Coverage gate commands: `AGENTS.md:200`, `AGENTS.md:201`
+- Coverage rule (only cov-check + diff-cov counts): `AGENTS.md:206`, `AGENTS.md:207`
+
+---
+
+## Commands (local)
+
+```bash
+pre-commit run --all-files
+make verify
+```
+
+If you need to break it down:
+
+```bash
+make lint
+make typecheck
+make test-fast
+make diff-cov
+```
+
+---
+
+## Links (canonical)
+
+- `AGENTS.md` → “Hard Gates (Non-negotiable)”
+- `AGENTS.md` → coverage policy section


### PR DESCRIPTION
## Summary
- Add a lightweight Project Memory Layer (PML) based on short, single-topic memory capsules under `docs/memory/`.
- Define a Knowledge Promotion Pipeline (KPP) rule in `AGENTS.md`: reusable insights must be promoted to one durable repo artifact with evidence.
- Add a small KPP checklist step to `agent-coordinator` to prevent silent drift.

## Test plan
- [x] `pre-commit run --all-files`
- [x] Docs-only scope check (no non-`.md` changes)

## Notes
- Capsules are pointer docs only; they do not replace canonical rules.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Задокументировать слой проектной памяти (Project Memory Layer) с однотематическими капсулами памяти (single-topic memory capsules) и ввести правило конвейера продвижения знаний (Knowledge Promotion Pipeline) для перевода повторно используемых инсайтов в устойчивые артефакты репозитория.

Документация:
- Добавить раздел Project Memory Layer / Knowledge Promotion Pipeline в `AGENTS.md`, определяющий уровни проектной памяти, правила продвижения и требования к подтверждающим данным.
- Добавить шаг в чек-лист координатора-агента (agent-coordinator checklist), который обеспечивает продвижение повторно используемых инсайтов в единый устойчивый артефакт репозитория.
- Добавить канонический индекс и три документа капсул памяти в `docs/memory/` для инвариантов BMI-движка, детерминизма OpenAPI и контролей злоупотребления стоимостью LLM (LLM cost-abuse controls), каждый из которых ссылается на свои соответствующие источники истины и команды для проверки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document a Project Memory Layer with single-topic memory capsules and enforce a Knowledge Promotion Pipeline rule for promoting reusable insights into durable repo artifacts.

Documentation:
- Add a Project Memory Layer / Knowledge Promotion Pipeline section to AGENTS.md defining project memory levels, promotion rules, and evidence requirements.
- Introduce an agent-coordinator checklist step to enforce promotion of reusable insights into a single durable repo artifact.
- Add a canonical index and three memory capsule docs under docs/memory/ for BMI engine invariants, OpenAPI determinism, and LLM cost-abuse controls, each pointing to their respective sources of truth and verification commands.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a Knowledge Promotion Pipeline (KPP) / Project Memory Layer requiring promotion of reusable insights into a single durable repo artifact with evidence.
  * Updated agent coordination flow to promote reusable knowledge earlier and moved the final conclusion step later.
  * Expanded agent guidance with one-command smoke checks and duplicated KPP guidance in two spots.
  * Added numerous new memory-capsule docs covering BMI invariants, OpenAPI determinism, LLM cost controls, API tiers, import hygiene, DB-fallback SoT, docs-only PR guard, iOS CI UDID policy, legacy thin-proxy, and quality gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->