### PR TITLE
tooling(graphmap): deterministic builder + viewer (PR B)

### DIFF
--- a/docs/agents/UPDATE_INSTRUCTIONS.md
+++ b/docs/agents/UPDATE_INSTRUCTIONS.md
@@ -56,3 +56,23 @@ Each `.cursor/agents/<agent>.md` must include:
 
 - Docs-only agent registration **does not** grant runtime permissions or change application behavior.
 - Any runtime behavior change must land in a separate runtime PR with tests/guards and required quality gates.
+
+---
+
+## 5) Dev tooling: GraphMap (deterministic builder + viewer)
+
+This repo includes **dev-only** GraphMap tooling to visualize relationships between canonical artifacts.
+
+- **SoT spec**: `docs/graph/GRAPHMAP_SPEC.md`
+- **Builder**: `tools/graphmap/build_graph.py`
+  - Inputs: `AGENTS.md`, `docs/orchestration/**`, `docs/agents/index.md`, `docs/audit/**`, `.cursor/agents/*.md`
+  - Output: `docs/graph/graph.json` (deterministic; no timestamps/UUIDs/absolute paths)
+- **Viewer**: `docs/graph/viewer/` (static Cytoscape page; reads `../graph.json`)
+
+Run (from repo root):
+
+```bash
+python tools/graphmap/build_graph.py --out docs/graph/graph.json
+python -m http.server 8000
+# http://localhost:8000/docs/graph/viewer/?repo=Katsiarynakavaleuskaya/PulsePlate&ref=main
+```

--- a/docs/graph/graph.json
+++ b/docs/graph/graph.json
@@ -1,0 +1,1732 @@
+{
+  "edges": [
+    {
+      "evidence": [
+        "docs/agents/index.md:17"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/agent-coordinator.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:29"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/ai-app-architect.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:18"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/ai-innovation-specialist.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:19"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/architecture-specialist.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:26"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/bayesian-uq-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:20"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/bug-hunter.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:33"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/cbt-psychologist-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:21"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/creative-designer.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:28"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/cv-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:30"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/data-scientist-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:34"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/epistemology-discovery-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:25"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/logic-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:22"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/marketing-strategist.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:31"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/ml-engineer-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:32"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/nutritionist-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:24"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/philosophy-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:35"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/physics-sensor-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:27"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/rag-systems-agent.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/agents/index.md:23"
+      ],
+      "source": "doc:docs/agents/index.md",
+      "target": "doc:cursor/agents/security-auditor.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:294",
+        "docs/audit/BACKEND_AUDIT_SUMMARY.md:61"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_AUDIT_SUMMARY.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:122",
+        "docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md:296"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:381",
+        "docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md:296"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:293",
+        "docs/audit/BACKEND_STUB_MODULES_AUDIT.md:51"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_STUB_MODULES_AUDIT.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:292",
+        "docs/audit/BACKEND_TODO_FIXME_AUDIT.md:27"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_TODO_FIXME_AUDIT.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/AUDIT_GAPS_ANALYSIS.md:236",
+        "docs/audit/BACKEND_XFAILED_TESTS_AUDIT.md:100"
+      ],
+      "source": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "target": "doc:docs/audit/BACKEND_XFAILED_TESTS_AUDIT.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/audit/PR_510_PR_DESCRIPTION.md:11"
+      ],
+      "source": "doc:docs/audit/PR_510_PR_DESCRIPTION.md",
+      "target": "doc:docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md",
+      "type": "references"
+    },
+    {
+      "evidence": [
+        "docs/orchestration/task_analysis.template.md:17"
+      ],
+      "source": "doc:docs/orchestration/task_analysis.template.md",
+      "target": "doc:AGENTS.md",
+      "type": "references"
+    }
+  ],
+  "generated_from": {
+    "inputs": [
+      "AGENTS.md",
+      "docs/graph/GRAPHMAP_SPEC.md",
+      "docs/agents/index.md",
+      "docs/orchestration/**/*.md",
+      "docs/audit/**/*.md",
+      ".cursor/agents/*.md"
+    ],
+    "repo_ref": "origin/main"
+  },
+  "nodes": [
+    {
+      "id": "doc:AGENTS.md",
+      "label": "AGENTS.md",
+      "path": "AGENTS.md",
+      "tags": [
+        "project",
+        "safety"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/AGENTS.md",
+      "label": ".cursor/agents/AGENTS.md",
+      "path": ".cursor/agents/AGENTS.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/agent-coordinator.md",
+      "label": ".cursor/agents/agent-coordinator.md",
+      "path": ".cursor/agents/agent-coordinator.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/ai-app-architect.md",
+      "label": ".cursor/agents/ai-app-architect.md",
+      "path": ".cursor/agents/ai-app-architect.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/ai-innovation-specialist.md",
+      "label": ".cursor/agents/ai-innovation-specialist.md",
+      "path": ".cursor/agents/ai-innovation-specialist.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/architecture-specialist.md",
+      "label": ".cursor/agents/architecture-specialist.md",
+      "path": ".cursor/agents/architecture-specialist.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/bayesian-uq-agent.md",
+      "label": ".cursor/agents/bayesian-uq-agent.md",
+      "path": ".cursor/agents/bayesian-uq-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/bug-hunter.md",
+      "label": ".cursor/agents/bug-hunter.md",
+      "path": ".cursor/agents/bug-hunter.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/cbt-psychologist-agent.md",
+      "label": ".cursor/agents/cbt-psychologist-agent.md",
+      "path": ".cursor/agents/cbt-psychologist-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/creative-designer.md",
+      "label": ".cursor/agents/creative-designer.md",
+      "path": ".cursor/agents/creative-designer.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/cv-agent.md",
+      "label": ".cursor/agents/cv-agent.md",
+      "path": ".cursor/agents/cv-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/data-scientist-agent.md",
+      "label": ".cursor/agents/data-scientist-agent.md",
+      "path": ".cursor/agents/data-scientist-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/epistemology-discovery-agent.md",
+      "label": ".cursor/agents/epistemology-discovery-agent.md",
+      "path": ".cursor/agents/epistemology-discovery-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/logic-agent.md",
+      "label": ".cursor/agents/logic-agent.md",
+      "path": ".cursor/agents/logic-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/marketing-strategist.md",
+      "label": ".cursor/agents/marketing-strategist.md",
+      "path": ".cursor/agents/marketing-strategist.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/ml-engineer-agent.md",
+      "label": ".cursor/agents/ml-engineer-agent.md",
+      "path": ".cursor/agents/ml-engineer-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/nutritionist-agent.md",
+      "label": ".cursor/agents/nutritionist-agent.md",
+      "path": ".cursor/agents/nutritionist-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/philosophy-agent.md",
+      "label": ".cursor/agents/philosophy-agent.md",
+      "path": ".cursor/agents/philosophy-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/physics-sensor-agent.md",
+      "label": ".cursor/agents/physics-sensor-agent.md",
+      "path": ".cursor/agents/physics-sensor-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/rag-systems-agent.md",
+      "label": ".cursor/agents/rag-systems-agent.md",
+      "path": ".cursor/agents/rag-systems-agent.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:cursor/agents/security-auditor.md",
+      "label": ".cursor/agents/security-auditor.md",
+      "path": ".cursor/agents/security-auditor.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/agents/index.md",
+      "label": "docs/agents/index.md",
+      "path": "docs/agents/index.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/API_ALIGNMENT_CHECKLIST.md",
+      "label": "docs/audit/API_ALIGNMENT_CHECKLIST.md",
+      "path": "docs/audit/API_ALIGNMENT_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/API_ALIGNMENT_PR_TEMPLATE.md",
+      "label": "docs/audit/API_ALIGNMENT_PR_TEMPLATE.md",
+      "path": "docs/audit/API_ALIGNMENT_PR_TEMPLATE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "label": "docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "path": "docs/audit/AUDIT_GAPS_ANALYSIS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_AUDIT_SUMMARY.md",
+      "label": "docs/audit/BACKEND_AUDIT_SUMMARY.md",
+      "path": "docs/audit/BACKEND_AUDIT_SUMMARY.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_BUSINESS_LOGIC_AUDIT.md",
+      "label": "docs/audit/BACKEND_BUSINESS_LOGIC_AUDIT.md",
+      "path": "docs/audit/BACKEND_BUSINESS_LOGIC_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_COMPLETE_AUDIT_INDEX.md",
+      "label": "docs/audit/BACKEND_COMPLETE_AUDIT_INDEX.md",
+      "path": "docs/audit/BACKEND_COMPLETE_AUDIT_INDEX.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_DUPLICATION_AUDIT.md",
+      "label": "docs/audit/BACKEND_DUPLICATION_AUDIT.md",
+      "path": "docs/audit/BACKEND_DUPLICATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md",
+      "label": "docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md",
+      "path": "docs/audit/BACKEND_EXTERNAL_APIS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_HIP_WHR_AUDIT.md",
+      "label": "docs/audit/BACKEND_HIP_WHR_AUDIT.md",
+      "path": "docs/audit/BACKEND_HIP_WHR_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_P0_GUARD_POLICY_PROPOSAL.md",
+      "label": "docs/audit/BACKEND_P0_GUARD_POLICY_PROPOSAL.md",
+      "path": "docs/audit/BACKEND_P0_GUARD_POLICY_PROPOSAL.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_P0_REMEDIATION_PLAN.md",
+      "label": "docs/audit/BACKEND_P0_REMEDIATION_PLAN.md",
+      "path": "docs/audit/BACKEND_P0_REMEDIATION_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_STUB_MODULES_AUDIT.md",
+      "label": "docs/audit/BACKEND_STUB_MODULES_AUDIT.md",
+      "path": "docs/audit/BACKEND_STUB_MODULES_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_TODO_FIXME_AUDIT.md",
+      "label": "docs/audit/BACKEND_TODO_FIXME_AUDIT.md",
+      "path": "docs/audit/BACKEND_TODO_FIXME_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKEND_XFAILED_TESTS_AUDIT.md",
+      "label": "docs/audit/BACKEND_XFAILED_TESTS_AUDIT.md",
+      "path": "docs/audit/BACKEND_XFAILED_TESTS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/BACKLOG_LEDGER_CHECKBOX_HYGIENE_AUDIT_2026-02-07.md",
+      "label": "docs/audit/BACKLOG_LEDGER_CHECKBOX_HYGIENE_AUDIT_2026-02-07.md",
+      "path": "docs/audit/BACKLOG_LEDGER_CHECKBOX_HYGIENE_AUDIT_2026-02-07.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/DECISION_LOG_BMI_UNDEFINED.md",
+      "label": "docs/audit/DECISION_LOG_BMI_UNDEFINED.md",
+      "path": "docs/audit/DECISION_LOG_BMI_UNDEFINED.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/DESIGN_AUDIT_PRIORITIES_CORRECTED.md",
+      "label": "docs/audit/DESIGN_AUDIT_PRIORITIES_CORRECTED.md",
+      "path": "docs/audit/DESIGN_AUDIT_PRIORITIES_CORRECTED.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/DESIGN_AUDIT_SUMMARY.md",
+      "label": "docs/audit/DESIGN_AUDIT_SUMMARY.md",
+      "path": "docs/audit/DESIGN_AUDIT_SUMMARY.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/DESIGN_CONCEPT_IMPLEMENTATION_AUDIT.md",
+      "label": "docs/audit/DESIGN_CONCEPT_IMPLEMENTATION_AUDIT.md",
+      "path": "docs/audit/DESIGN_CONCEPT_IMPLEMENTATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/FRONTEND_BACKEND_ALIGNMENT_AUDIT.md",
+      "label": "docs/audit/FRONTEND_BACKEND_ALIGNMENT_AUDIT.md",
+      "path": "docs/audit/FRONTEND_BACKEND_ALIGNMENT_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/FRONTEND_COMPONENTS_QUICK_START.md",
+      "label": "docs/audit/FRONTEND_COMPONENTS_QUICK_START.md",
+      "path": "docs/audit/FRONTEND_COMPONENTS_QUICK_START.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/FRONTEND_MODERN_COMPONENTS_AUDIT.md",
+      "label": "docs/audit/FRONTEND_MODERN_COMPONENTS_AUDIT.md",
+      "path": "docs/audit/FRONTEND_MODERN_COMPONENTS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/GHCR_TOKEN_SETUP.md",
+      "label": "docs/audit/GHCR_TOKEN_SETUP.md",
+      "path": "docs/audit/GHCR_TOKEN_SETUP.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/GREENLET_PR_DESCRIPTION.md",
+      "label": "docs/audit/GREENLET_PR_DESCRIPTION.md",
+      "path": "docs/audit/GREENLET_PR_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/IOS_DOCS_DRIFT_AUDIT_2026-02-07.md",
+      "label": "docs/audit/IOS_DOCS_DRIFT_AUDIT_2026-02-07.md",
+      "path": "docs/audit/IOS_DOCS_DRIFT_AUDIT_2026-02-07.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-06.md",
+      "label": "docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-06.md",
+      "path": "docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-06.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-07.md",
+      "label": "docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-07.md",
+      "path": "docs/audit/IOS_DOCS_LEDGER_ALIGNMENT_AUDIT_2026-02-07.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/IOS_WEB_THIN_CLIENT_AUDIT.md",
+      "label": "docs/audit/IOS_WEB_THIN_CLIENT_AUDIT.md",
+      "path": "docs/audit/IOS_WEB_THIN_CLIENT_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/LEGACY_APP_MIGRATION_STATUS.md",
+      "label": "docs/audit/LEGACY_APP_MIGRATION_STATUS.md",
+      "path": "docs/audit/LEGACY_APP_MIGRATION_STATUS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/LENNYS_PODCAST_INTEGRATION_AUDIT.md",
+      "label": "docs/audit/LENNYS_PODCAST_INTEGRATION_AUDIT.md",
+      "path": "docs/audit/LENNYS_PODCAST_INTEGRATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/LOOT_DROP_STARTUP_GRAVEYARD_AUDIT.md",
+      "label": "docs/audit/LOOT_DROP_STARTUP_GRAVEYARD_AUDIT.md",
+      "path": "docs/audit/LOOT_DROP_STARTUP_GRAVEYARD_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PERSONAPLEX_INTEGRATION_AUDIT.md",
+      "label": "docs/audit/PERSONAPLEX_INTEGRATION_AUDIT.md",
+      "path": "docs/audit/PERSONAPLEX_INTEGRATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md",
+      "label": "docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md",
+      "path": "docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_510_PR_DESCRIPTION.md",
+      "label": "docs/audit/PR_510_PR_DESCRIPTION.md",
+      "path": "docs/audit/PR_510_PR_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_510_legacy_app_audit.md",
+      "label": "docs/audit/PR_510_legacy_app_audit.md",
+      "path": "docs/audit/PR_510_legacy_app_audit.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_518_VIP_GUARD_MATRIX_HYGIENE_AUDIT.md",
+      "label": "docs/audit/PR_518_VIP_GUARD_MATRIX_HYGIENE_AUDIT.md",
+      "path": "docs/audit/PR_518_VIP_GUARD_MATRIX_HYGIENE_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_519_AUDIT.md",
+      "label": "docs/audit/PR_519_AUDIT.md",
+      "path": "docs/audit/PR_519_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_519_AUDIT_STATUS.md",
+      "label": "docs/audit/PR_519_AUDIT_STATUS.md",
+      "path": "docs/audit/PR_519_AUDIT_STATUS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_520_INSIGHTS.md",
+      "label": "docs/audit/PR_520_INSIGHTS.md",
+      "path": "docs/audit/PR_520_INSIGHTS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_520_SCOPE_CREEP_RESPONSE_TEMPLATE.md",
+      "label": "docs/audit/PR_520_SCOPE_CREEP_RESPONSE_TEMPLATE.md",
+      "path": "docs/audit/PR_520_SCOPE_CREEP_RESPONSE_TEMPLATE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521A_CODERABBIT_RESPONSES.md",
+      "label": "docs/audit/PR_521A_CODERABBIT_RESPONSES.md",
+      "path": "docs/audit/PR_521A_CODERABBIT_RESPONSES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521A_FINAL_STATUS.md",
+      "label": "docs/audit/PR_521A_FINAL_STATUS.md",
+      "path": "docs/audit/PR_521A_FINAL_STATUS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521A_MERGE_CHECKLIST.md",
+      "label": "docs/audit/PR_521A_MERGE_CHECKLIST.md",
+      "path": "docs/audit/PR_521A_MERGE_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521A_REVIEWER_GUIDE.md",
+      "label": "docs/audit/PR_521A_REVIEWER_GUIDE.md",
+      "path": "docs/audit/PR_521A_REVIEWER_GUIDE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521A_SOURCERY_RESPONSES.md",
+      "label": "docs/audit/PR_521A_SOURCERY_RESPONSES.md",
+      "path": "docs/audit/PR_521A_SOURCERY_RESPONSES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521B_FINAL_PLAN.md",
+      "label": "docs/audit/PR_521B_FINAL_PLAN.md",
+      "path": "docs/audit/PR_521B_FINAL_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521B_PR_DESCRIPTION.md",
+      "label": "docs/audit/PR_521B_PR_DESCRIPTION.md",
+      "path": "docs/audit/PR_521B_PR_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_521B_REVIEWER_CHECKLIST.md",
+      "label": "docs/audit/PR_521B_REVIEWER_CHECKLIST.md",
+      "path": "docs/audit/PR_521B_REVIEWER_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_524_EXACT_PATCHES.md",
+      "label": "docs/audit/PR_524_EXACT_PATCHES.md",
+      "path": "docs/audit/PR_524_EXACT_PATCHES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_524_GITHUB_DESCRIPTION.md",
+      "label": "docs/audit/PR_524_GITHUB_DESCRIPTION.md",
+      "path": "docs/audit/PR_524_GITHUB_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_524_SUMMARY.md",
+      "label": "docs/audit/PR_524_SUMMARY.md",
+      "path": "docs/audit/PR_524_SUMMARY.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_524_WEEKLY_PLAN_MIGRATION_AUDIT.md",
+      "label": "docs/audit/PR_524_WEEKLY_PLAN_MIGRATION_AUDIT.md",
+      "path": "docs/audit/PR_524_WEEKLY_PLAN_MIGRATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_525_BMI_FIX_PATCH.md",
+      "label": "docs/audit/PR_525_BMI_FIX_PATCH.md",
+      "path": "docs/audit/PR_525_BMI_FIX_PATCH.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_525_GITHUB_DESCRIPTION.md",
+      "label": "docs/audit/PR_525_GITHUB_DESCRIPTION.md",
+      "path": "docs/audit/PR_525_GITHUB_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_525_READY_CHECKLIST.md",
+      "label": "docs/audit/PR_525_READY_CHECKLIST.md",
+      "path": "docs/audit/PR_525_READY_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_526_DESCRIPTION.md",
+      "label": "docs/audit/PR_526_DESCRIPTION.md",
+      "path": "docs/audit/PR_526_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_526_SHADCN_COMPONENTS_PATCH.md",
+      "label": "docs/audit/PR_526_SHADCN_COMPONENTS_PATCH.md",
+      "path": "docs/audit/PR_526_SHADCN_COMPONENTS_PATCH.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_527_DESCRIPTION.md",
+      "label": "docs/audit/PR_527_DESCRIPTION.md",
+      "path": "docs/audit/PR_527_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_528_PLAN.md",
+      "label": "docs/audit/PR_528_PLAN.md",
+      "path": "docs/audit/PR_528_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_529_PLAN.md",
+      "label": "docs/audit/PR_529_PLAN.md",
+      "path": "docs/audit/PR_529_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_529_WORKING_MAP.md",
+      "label": "docs/audit/PR_529_WORKING_MAP.md",
+      "path": "docs/audit/PR_529_WORKING_MAP.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_560_CI_IOS_STABILITY_AUDIT.md",
+      "label": "docs/audit/PR_560_CI_IOS_STABILITY_AUDIT.md",
+      "path": "docs/audit/PR_560_CI_IOS_STABILITY_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_563_REVIEW.md",
+      "label": "docs/audit/PR_563_REVIEW.md",
+      "path": "docs/audit/PR_563_REVIEW.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_573_PRIORITY_MAPPING_AUDIT.md",
+      "label": "docs/audit/PR_573_PRIORITY_MAPPING_AUDIT.md",
+      "path": "docs/audit/PR_573_PRIORITY_MAPPING_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md",
+      "label": "docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md",
+      "path": "docs/audit/PR_574_CI_IOS_PATH_FILTER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_585_BACKLOG_SWEEP_AUDIT.md",
+      "label": "docs/audit/PR_585_BACKLOG_SWEEP_AUDIT.md",
+      "path": "docs/audit/PR_585_BACKLOG_SWEEP_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md",
+      "label": "docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md",
+      "path": "docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md",
+      "label": "docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md",
+      "path": "docs/audit/PR_587_WEB_THIN_HTTP_ADAPTER_REMEDIATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_595_IOS_THIN_HTTP_ADAPTER_AUDIT.md",
+      "label": "docs/audit/PR_595_IOS_THIN_HTTP_ADAPTER_AUDIT.md",
+      "path": "docs/audit/PR_595_IOS_THIN_HTTP_ADAPTER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md",
+      "label": "docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md",
+      "path": "docs/audit/PR_598_IOS_BMI_THIN_CLIENT_DEDUP_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_599_WEB_THIN_CLIENT_ALIGNMENT_AUDIT.md",
+      "label": "docs/audit/PR_599_WEB_THIN_CLIENT_ALIGNMENT_AUDIT.md",
+      "path": "docs/audit/PR_599_WEB_THIN_CLIENT_ALIGNMENT_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_600_QUALITY_TESTS_AUDIT.md",
+      "label": "docs/audit/PR_600_QUALITY_TESTS_AUDIT.md",
+      "path": "docs/audit/PR_600_QUALITY_TESTS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_611_INSIGHT_SAFETY_ERROR_HYGIENE_AUDIT.md",
+      "label": "docs/audit/PR_611_INSIGHT_SAFETY_ERROR_HYGIENE_AUDIT.md",
+      "path": "docs/audit/PR_611_INSIGHT_SAFETY_ERROR_HYGIENE_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md",
+      "label": "docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md",
+      "path": "docs/audit/PR_617_SQLITE_ENGINE_SOT_NIGHTLY_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md",
+      "label": "docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md",
+      "path": "docs/audit/PR_628_RATE_LIMIT_LLM_EXPORTS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md",
+      "label": "docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md",
+      "path": "docs/audit/PR_630_ARCHITECTURE_EVIDENCE_PACK_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md",
+      "label": "docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md",
+      "path": "docs/audit/PR_633_TARGETSIN_UNIFY_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_634_AGENT_ORCHESTRATION_V2_AUDIT.md",
+      "label": "docs/audit/PR_634_AGENT_ORCHESTRATION_V2_AUDIT.md",
+      "path": "docs/audit/PR_634_AGENT_ORCHESTRATION_V2_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md",
+      "label": "docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md",
+      "path": "docs/audit/PR_646_VIP_ONLY_LLM_INSIGHT_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md",
+      "label": "docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md",
+      "path": "docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_649_ENV_REQUIRED_SERVER_SALT_AUDIT.md",
+      "label": "docs/audit/PR_649_ENV_REQUIRED_SERVER_SALT_AUDIT.md",
+      "path": "docs/audit/PR_649_ENV_REQUIRED_SERVER_SALT_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md",
+      "label": "docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md",
+      "path": "docs/audit/PR_653_P0_WELCOME_ONBOARDING_4SCREENS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_654_BACKEND_LEGACY_NUTRITION_ALIAS_PRO_GUARD_AUDIT.md",
+      "label": "docs/audit/PR_654_BACKEND_LEGACY_NUTRITION_ALIAS_PRO_GUARD_AUDIT.md",
+      "path": "docs/audit/PR_654_BACKEND_LEGACY_NUTRITION_ALIAS_PRO_GUARD_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_667_IOS_PLATE_PRO_DAILY_MIGRATION_AUDIT.md",
+      "label": "docs/audit/PR_667_IOS_PLATE_PRO_DAILY_MIGRATION_AUDIT.md",
+      "path": "docs/audit/PR_667_IOS_PLATE_PRO_DAILY_MIGRATION_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md",
+      "label": "docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md",
+      "path": "docs/audit/PR_671_IOS_EXPOSE_BMI_ROOTTABS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md",
+      "label": "docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md",
+      "path": "docs/audit/PR_673_IOS_WEEKLY_PLAN_READER_FLAG_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md",
+      "label": "docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md",
+      "path": "docs/audit/PR_674_IOS_SOFT_PAYWALL_CTA_ROUTER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md",
+      "label": "docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md",
+      "path": "docs/audit/PR_678_IOS_ONBOARDING_VALUE_USAGE_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_A_DESCRIPTION.md",
+      "label": "docs/audit/PR_A_DESCRIPTION.md",
+      "path": "docs/audit/PR_A_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_A_POST_MERGE_NOTES.md",
+      "label": "docs/audit/PR_A_POST_MERGE_NOTES.md",
+      "path": "docs/audit/PR_A_POST_MERGE_NOTES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_B_ANALYSIS.md",
+      "label": "docs/audit/PR_B_ANALYSIS.md",
+      "path": "docs/audit/PR_B_ANALYSIS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_B_MERGE_MESSAGE.md",
+      "label": "docs/audit/PR_B_MERGE_MESSAGE.md",
+      "path": "docs/audit/PR_B_MERGE_MESSAGE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_B_VIP_GUARD_CONSISTENCY_AUDIT.md",
+      "label": "docs/audit/PR_B_VIP_GUARD_CONSISTENCY_AUDIT.md",
+      "path": "docs/audit/PR_B_VIP_GUARD_CONSISTENCY_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_GUARD_COMMANDS.md",
+      "label": "docs/audit/PR_GUARD_COMMANDS.md",
+      "path": "docs/audit/PR_GUARD_COMMANDS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_GUARD_POLICY_GITHUB_DESCRIPTION.md",
+      "label": "docs/audit/PR_GUARD_POLICY_GITHUB_DESCRIPTION.md",
+      "path": "docs/audit/PR_GUARD_POLICY_GITHUB_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_GUARD_POLICY_LOCAL_TEST_RESULTS.md",
+      "label": "docs/audit/PR_GUARD_POLICY_LOCAL_TEST_RESULTS.md",
+      "path": "docs/audit/PR_GUARD_POLICY_LOCAL_TEST_RESULTS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_GUARD_POLICY_SKELETON.md",
+      "label": "docs/audit/PR_GUARD_POLICY_SKELETON.md",
+      "path": "docs/audit/PR_GUARD_POLICY_SKELETON.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md",
+      "label": "docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md",
+      "path": "docs/audit/PR_P0_MOVE_LLM_INSIGHT_TO_VIP_TIER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_PLAN_FRONTEND_FIXES.md",
+      "label": "docs/audit/PR_PLAN_FRONTEND_FIXES.md",
+      "path": "docs/audit/PR_PLAN_FRONTEND_FIXES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_POST_CLEANUP_AUDIT.md",
+      "label": "docs/audit/PR_POST_CLEANUP_AUDIT.md",
+      "path": "docs/audit/PR_POST_CLEANUP_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_POST_REMEDIATION_FOLLOWUP.md",
+      "label": "docs/audit/PR_POST_REMEDIATION_FOLLOWUP.md",
+      "path": "docs/audit/PR_POST_REMEDIATION_FOLLOWUP.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_PRODUCT_SOFT_PAYWALL_SKELETON.md",
+      "label": "docs/audit/PR_PRODUCT_SOFT_PAYWALL_SKELETON.md",
+      "path": "docs/audit/PR_PRODUCT_SOFT_PAYWALL_SKELETON.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md",
+      "label": "docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md",
+      "path": "docs/audit/PR_Q2B_IOS_UITESTS_BUNDLE_LOAD_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_Q2_IOS_UI_TESTS_RESTORE_AUDIT.md",
+      "label": "docs/audit/PR_Q2_IOS_UI_TESTS_RESTORE_AUDIT.md",
+      "path": "docs/audit/PR_Q2_IOS_UI_TESTS_RESTORE_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_BMI_EXTRAS_ANALYSIS.md",
+      "label": "docs/audit/PR_REMEDIATION_BMI_EXTRAS_ANALYSIS.md",
+      "path": "docs/audit/PR_REMEDIATION_BMI_EXTRAS_ANALYSIS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_CHERRY_PICK_GUIDE.md",
+      "label": "docs/audit/PR_REMEDIATION_CHERRY_PICK_GUIDE.md",
+      "path": "docs/audit/PR_REMEDIATION_CHERRY_PICK_GUIDE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_EXACT_PATCHES.md",
+      "label": "docs/audit/PR_REMEDIATION_EXACT_PATCHES.md",
+      "path": "docs/audit/PR_REMEDIATION_EXACT_PATCHES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md",
+      "label": "docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md",
+      "path": "docs/audit/PR_REMEDIATION_EXACT_PATCHES_CONSOLIDATED.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_PRE_FLIGHT_CHECKLIST.md",
+      "label": "docs/audit/PR_REMEDIATION_PRE_FLIGHT_CHECKLIST.md",
+      "path": "docs/audit/PR_REMEDIATION_PRE_FLIGHT_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_SELF_AUDIT.md",
+      "label": "docs/audit/PR_REMEDIATION_SELF_AUDIT.md",
+      "path": "docs/audit/PR_REMEDIATION_SELF_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_REMEDIATION_SKELETON.md",
+      "label": "docs/audit/PR_REMEDIATION_SKELETON.md",
+      "path": "docs/audit/PR_REMEDIATION_SKELETON.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_SOFT_PAYWALL_AUDIT.md",
+      "label": "docs/audit/PR_SOFT_PAYWALL_AUDIT.md",
+      "path": "docs/audit/PR_SOFT_PAYWALL_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_TBD_BACKLOG_LEDGER_POST_MERGE_SYNC_2026-02-07.md",
+      "label": "docs/audit/PR_TBD_BACKLOG_LEDGER_POST_MERGE_SYNC_2026-02-07.md",
+      "path": "docs/audit/PR_TBD_BACKLOG_LEDGER_POST_MERGE_SYNC_2026-02-07.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md",
+      "label": "docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md",
+      "path": "docs/audit/PR_TBD_IOS_SHOPPINGPLAN_PUBLIC_API_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_TBD_SCIENTIFIC_DISCOVERY_LAYER_AUDIT.md",
+      "label": "docs/audit/PR_TBD_SCIENTIFIC_DISCOVERY_LAYER_AUDIT.md",
+      "path": "docs/audit/PR_TBD_SCIENTIFIC_DISCOVERY_LAYER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_TBD_UNIVERSAL_AGENT_ORCHESTRATION_LAYER_AUDIT.md",
+      "label": "docs/audit/PR_TBD_UNIVERSAL_AGENT_ORCHESTRATION_LAYER_AUDIT.md",
+      "path": "docs/audit/PR_TBD_UNIVERSAL_AGENT_ORCHESTRATION_LAYER_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_TP2_DB_FALLBACK_AUDIT.md",
+      "label": "docs/audit/PR_TP2_DB_FALLBACK_AUDIT.md",
+      "path": "docs/audit/PR_TP2_DB_FALLBACK_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PR_XXX_DOMAIN_HINTS_AUDIT.md",
+      "label": "docs/audit/PR_XXX_DOMAIN_HINTS_AUDIT.md",
+      "path": "docs/audit/PR_XXX_DOMAIN_HINTS_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/PYTHON_SETUPTOOLS_LOCKFILE_AUDIT.md",
+      "label": "docs/audit/PYTHON_SETUPTOOLS_LOCKFILE_AUDIT.md",
+      "path": "docs/audit/PYTHON_SETUPTOOLS_LOCKFILE_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/ROOT_CAUSE_ANALYSIS_BMI_UNDEFINED.md",
+      "label": "docs/audit/ROOT_CAUSE_ANALYSIS_BMI_UNDEFINED.md",
+      "path": "docs/audit/ROOT_CAUSE_ANALYSIS_BMI_UNDEFINED.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/SHIM_AUDIT_BMI_PRO.md",
+      "label": "docs/audit/SHIM_AUDIT_BMI_PRO.md",
+      "path": "docs/audit/SHIM_AUDIT_BMI_PRO.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/WEBSOCKET_ANALYSIS.md",
+      "label": "docs/audit/WEBSOCKET_ANALYSIS.md",
+      "path": "docs/audit/WEBSOCKET_ANALYSIS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/WEB_SOFT_PAYWALL_AUDIT.md",
+      "label": "docs/audit/WEB_SOFT_PAYWALL_AUDIT.md",
+      "path": "docs/audit/WEB_SOFT_PAYWALL_AUDIT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_COMMIT_CHECKLIST.md",
+      "label": "docs/audit/_local/PR_521A_COMMIT_CHECKLIST.md",
+      "path": "docs/audit/_local/PR_521A_COMMIT_CHECKLIST.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_FINAL_PLAN.md",
+      "label": "docs/audit/_local/PR_521A_FINAL_PLAN.md",
+      "path": "docs/audit/_local/PR_521A_FINAL_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_FRONTEND_ANSWERS.md",
+      "label": "docs/audit/_local/PR_521A_FRONTEND_ANSWERS.md",
+      "path": "docs/audit/_local/PR_521A_FRONTEND_ANSWERS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_GATES.md",
+      "label": "docs/audit/_local/PR_521A_GATES.md",
+      "path": "docs/audit/_local/PR_521A_GATES.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_PRE_PUSH.md",
+      "label": "docs/audit/_local/PR_521A_PRE_PUSH.md",
+      "path": "docs/audit/_local/PR_521A_PRE_PUSH.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521A_PR_DESCRIPTION.md",
+      "label": "docs/audit/_local/PR_521A_PR_DESCRIPTION.md",
+      "path": "docs/audit/_local/PR_521A_PR_DESCRIPTION.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521B_FINAL_PLAN.md",
+      "label": "docs/audit/_local/PR_521B_FINAL_PLAN.md",
+      "path": "docs/audit/_local/PR_521B_FINAL_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521B_REVIEW_COMMENT.md",
+      "label": "docs/audit/_local/PR_521B_REVIEW_COMMENT.md",
+      "path": "docs/audit/_local/PR_521B_REVIEW_COMMENT.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521_DIFF_MENTAL_MODEL.md",
+      "label": "docs/audit/_local/PR_521_DIFF_MENTAL_MODEL.md",
+      "path": "docs/audit/_local/PR_521_DIFF_MENTAL_MODEL.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521_FINAL_SUMMARY.md",
+      "label": "docs/audit/_local/PR_521_FINAL_SUMMARY.md",
+      "path": "docs/audit/_local/PR_521_FINAL_SUMMARY.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521_PLAN_REVISED.md",
+      "label": "docs/audit/_local/PR_521_PLAN_REVISED.md",
+      "path": "docs/audit/_local/PR_521_PLAN_REVISED.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_521_PR_DESCRIPTION_TEMPLATE.md",
+      "label": "docs/audit/_local/PR_521_PR_DESCRIPTION_TEMPLATE.md",
+      "path": "docs/audit/_local/PR_521_PR_DESCRIPTION_TEMPLATE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/audit/_local/PR_522_FINAL_PLAN.md",
+      "label": "docs/audit/_local/PR_522_FINAL_PLAN.md",
+      "path": "docs/audit/_local/PR_522_FINAL_PLAN.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/graph/GRAPHMAP_SPEC.md",
+      "label": "docs/graph/GRAPHMAP_SPEC.md",
+      "path": "docs/graph/GRAPHMAP_SPEC.md",
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/AGENT_CAPABILITY_MATRIX.md",
+      "label": "docs/orchestration/AGENT_CAPABILITY_MATRIX.md",
+      "path": "docs/orchestration/AGENT_CAPABILITY_MATRIX.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/AGENT_CONTEXT_MAP.md",
+      "label": "docs/orchestration/AGENT_CONTEXT_MAP.md",
+      "path": "docs/orchestration/AGENT_CONTEXT_MAP.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md",
+      "label": "docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md",
+      "path": "docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/AGENT_HANDOFF_PROTOCOL.md",
+      "label": "docs/orchestration/AGENT_HANDOFF_PROTOCOL.md",
+      "path": "docs/orchestration/AGENT_HANDOFF_PROTOCOL.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md",
+      "label": "docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md",
+      "path": "docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/PARALLEL_WORK_PROTOCOL.md",
+      "label": "docs/orchestration/PARALLEL_WORK_PROTOCOL.md",
+      "path": "docs/orchestration/PARALLEL_WORK_PROTOCOL.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/contracts/AGENT_ROLE_CONTRACTS.md",
+      "label": "docs/orchestration/contracts/AGENT_ROLE_CONTRACTS.md",
+      "path": "docs/orchestration/contracts/AGENT_ROLE_CONTRACTS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/contracts/AI_OUTPUT_CONTRACTS.md",
+      "label": "docs/orchestration/contracts/AI_OUTPUT_CONTRACTS.md",
+      "path": "docs/orchestration/contracts/AI_OUTPUT_CONTRACTS.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/contracts/SAFETY_LANGUAGE_POLICY.md",
+      "label": "docs/orchestration/contracts/SAFETY_LANGUAGE_POLICY.md",
+      "path": "docs/orchestration/contracts/SAFETY_LANGUAGE_POLICY.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/dod.template.md",
+      "label": "docs/orchestration/dod.template.md",
+      "path": "docs/orchestration/dod.template.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/synthesis.template.md",
+      "label": "docs/orchestration/synthesis.template.md",
+      "path": "docs/orchestration/synthesis.template.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/task_analysis.template.md",
+      "label": "docs/orchestration/task_analysis.template.md",
+      "path": "docs/orchestration/task_analysis.template.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/work_review.template.md",
+      "label": "docs/orchestration/work_review.template.md",
+      "path": "docs/orchestration/work_review.template.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    },
+    {
+      "id": "doc:docs/orchestration/workflow.md",
+      "label": "docs/orchestration/workflow.md",
+      "path": "docs/orchestration/workflow.md",
+      "tags": [
+        "architecture"
+      ],
+      "type": "document"
+    }
+  ],
+  "schema_version": "1.0"
+}

--- a/docs/graph/graph.json
+++ b/docs/graph/graph.json
@@ -5,7 +5,7 @@
         "docs/agents/index.md:17"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/agent-coordinator.md",
+      "target": "agent:agent-coordinator",
       "type": "references"
     },
     {
@@ -13,7 +13,7 @@
         "docs/agents/index.md:29"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/ai-app-architect.md",
+      "target": "agent:ai-app-architect",
       "type": "references"
     },
     {
@@ -21,7 +21,7 @@
         "docs/agents/index.md:18"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/ai-innovation-specialist.md",
+      "target": "agent:ai-innovation-specialist",
       "type": "references"
     },
     {
@@ -29,7 +29,7 @@
         "docs/agents/index.md:19"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/architecture-specialist.md",
+      "target": "agent:architecture-specialist",
       "type": "references"
     },
     {
@@ -37,7 +37,7 @@
         "docs/agents/index.md:26"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/bayesian-uq-agent.md",
+      "target": "agent:bayesian-uq-agent",
       "type": "references"
     },
     {
@@ -45,7 +45,7 @@
         "docs/agents/index.md:20"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/bug-hunter.md",
+      "target": "agent:bug-hunter",
       "type": "references"
     },
     {
@@ -53,7 +53,7 @@
         "docs/agents/index.md:33"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/cbt-psychologist-agent.md",
+      "target": "agent:cbt-psychologist-agent",
       "type": "references"
     },
     {
@@ -61,7 +61,7 @@
         "docs/agents/index.md:21"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/creative-designer.md",
+      "target": "agent:creative-designer",
       "type": "references"
     },
     {
@@ -69,7 +69,7 @@
         "docs/agents/index.md:28"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/cv-agent.md",
+      "target": "agent:cv-agent",
       "type": "references"
     },
     {
@@ -77,7 +77,7 @@
         "docs/agents/index.md:30"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/data-scientist-agent.md",
+      "target": "agent:data-scientist-agent",
       "type": "references"
     },
     {
@@ -85,7 +85,7 @@
         "docs/agents/index.md:34"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/epistemology-discovery-agent.md",
+      "target": "agent:epistemology-discovery-agent",
       "type": "references"
     },
     {
@@ -93,7 +93,7 @@
         "docs/agents/index.md:25"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/logic-agent.md",
+      "target": "agent:logic-agent",
       "type": "references"
     },
     {
@@ -101,7 +101,7 @@
         "docs/agents/index.md:22"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/marketing-strategist.md",
+      "target": "agent:marketing-strategist",
       "type": "references"
     },
     {
@@ -109,7 +109,7 @@
         "docs/agents/index.md:31"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/ml-engineer-agent.md",
+      "target": "agent:ml-engineer-agent",
       "type": "references"
     },
     {
@@ -117,7 +117,7 @@
         "docs/agents/index.md:32"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/nutritionist-agent.md",
+      "target": "agent:nutritionist-agent",
       "type": "references"
     },
     {
@@ -125,7 +125,7 @@
         "docs/agents/index.md:24"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/philosophy-agent.md",
+      "target": "agent:philosophy-agent",
       "type": "references"
     },
     {
@@ -133,7 +133,7 @@
         "docs/agents/index.md:35"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/physics-sensor-agent.md",
+      "target": "agent:physics-sensor-agent",
       "type": "references"
     },
     {
@@ -141,7 +141,7 @@
         "docs/agents/index.md:27"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/rag-systems-agent.md",
+      "target": "agent:rag-systems-agent",
       "type": "references"
     },
     {
@@ -149,7 +149,7 @@
         "docs/agents/index.md:23"
       ],
       "source": "doc:docs/agents/index.md",
-      "target": "doc:cursor/agents/security-auditor.md",
+      "target": "agent:security-auditor",
       "type": "references"
     },
     {
@@ -236,6 +236,186 @@
   },
   "nodes": [
     {
+      "id": "agent:AGENTS",
+      "label": ".cursor/agents/AGENTS.md",
+      "path": ".cursor/agents/AGENTS.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:agent-coordinator",
+      "label": ".cursor/agents/agent-coordinator.md",
+      "path": ".cursor/agents/agent-coordinator.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:ai-app-architect",
+      "label": ".cursor/agents/ai-app-architect.md",
+      "path": ".cursor/agents/ai-app-architect.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:ai-innovation-specialist",
+      "label": ".cursor/agents/ai-innovation-specialist.md",
+      "path": ".cursor/agents/ai-innovation-specialist.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:architecture-specialist",
+      "label": ".cursor/agents/architecture-specialist.md",
+      "path": ".cursor/agents/architecture-specialist.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:bayesian-uq-agent",
+      "label": ".cursor/agents/bayesian-uq-agent.md",
+      "path": ".cursor/agents/bayesian-uq-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:bug-hunter",
+      "label": ".cursor/agents/bug-hunter.md",
+      "path": ".cursor/agents/bug-hunter.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:cbt-psychologist-agent",
+      "label": ".cursor/agents/cbt-psychologist-agent.md",
+      "path": ".cursor/agents/cbt-psychologist-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:creative-designer",
+      "label": ".cursor/agents/creative-designer.md",
+      "path": ".cursor/agents/creative-designer.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:cv-agent",
+      "label": ".cursor/agents/cv-agent.md",
+      "path": ".cursor/agents/cv-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:data-scientist-agent",
+      "label": ".cursor/agents/data-scientist-agent.md",
+      "path": ".cursor/agents/data-scientist-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:epistemology-discovery-agent",
+      "label": ".cursor/agents/epistemology-discovery-agent.md",
+      "path": ".cursor/agents/epistemology-discovery-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:logic-agent",
+      "label": ".cursor/agents/logic-agent.md",
+      "path": ".cursor/agents/logic-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:marketing-strategist",
+      "label": ".cursor/agents/marketing-strategist.md",
+      "path": ".cursor/agents/marketing-strategist.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:ml-engineer-agent",
+      "label": ".cursor/agents/ml-engineer-agent.md",
+      "path": ".cursor/agents/ml-engineer-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:nutritionist-agent",
+      "label": ".cursor/agents/nutritionist-agent.md",
+      "path": ".cursor/agents/nutritionist-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:philosophy-agent",
+      "label": ".cursor/agents/philosophy-agent.md",
+      "path": ".cursor/agents/philosophy-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:physics-sensor-agent",
+      "label": ".cursor/agents/physics-sensor-agent.md",
+      "path": ".cursor/agents/physics-sensor-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:rag-systems-agent",
+      "label": ".cursor/agents/rag-systems-agent.md",
+      "path": ".cursor/agents/rag-systems-agent.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
+      "id": "agent:security-auditor",
+      "label": ".cursor/agents/security-auditor.md",
+      "path": ".cursor/agents/security-auditor.md",
+      "tags": [
+        "project"
+      ],
+      "type": "agent"
+    },
+    {
       "id": "doc:AGENTS.md",
       "label": "AGENTS.md",
       "path": "AGENTS.md",
@@ -243,126 +423,6 @@
         "project",
         "safety"
       ],
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/AGENTS.md",
-      "label": ".cursor/agents/AGENTS.md",
-      "path": ".cursor/agents/AGENTS.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/agent-coordinator.md",
-      "label": ".cursor/agents/agent-coordinator.md",
-      "path": ".cursor/agents/agent-coordinator.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/ai-app-architect.md",
-      "label": ".cursor/agents/ai-app-architect.md",
-      "path": ".cursor/agents/ai-app-architect.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/ai-innovation-specialist.md",
-      "label": ".cursor/agents/ai-innovation-specialist.md",
-      "path": ".cursor/agents/ai-innovation-specialist.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/architecture-specialist.md",
-      "label": ".cursor/agents/architecture-specialist.md",
-      "path": ".cursor/agents/architecture-specialist.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/bayesian-uq-agent.md",
-      "label": ".cursor/agents/bayesian-uq-agent.md",
-      "path": ".cursor/agents/bayesian-uq-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/bug-hunter.md",
-      "label": ".cursor/agents/bug-hunter.md",
-      "path": ".cursor/agents/bug-hunter.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/cbt-psychologist-agent.md",
-      "label": ".cursor/agents/cbt-psychologist-agent.md",
-      "path": ".cursor/agents/cbt-psychologist-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/creative-designer.md",
-      "label": ".cursor/agents/creative-designer.md",
-      "path": ".cursor/agents/creative-designer.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/cv-agent.md",
-      "label": ".cursor/agents/cv-agent.md",
-      "path": ".cursor/agents/cv-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/data-scientist-agent.md",
-      "label": ".cursor/agents/data-scientist-agent.md",
-      "path": ".cursor/agents/data-scientist-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/epistemology-discovery-agent.md",
-      "label": ".cursor/agents/epistemology-discovery-agent.md",
-      "path": ".cursor/agents/epistemology-discovery-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/logic-agent.md",
-      "label": ".cursor/agents/logic-agent.md",
-      "path": ".cursor/agents/logic-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/marketing-strategist.md",
-      "label": ".cursor/agents/marketing-strategist.md",
-      "path": ".cursor/agents/marketing-strategist.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/ml-engineer-agent.md",
-      "label": ".cursor/agents/ml-engineer-agent.md",
-      "path": ".cursor/agents/ml-engineer-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/nutritionist-agent.md",
-      "label": ".cursor/agents/nutritionist-agent.md",
-      "path": ".cursor/agents/nutritionist-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/philosophy-agent.md",
-      "label": ".cursor/agents/philosophy-agent.md",
-      "path": ".cursor/agents/philosophy-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/physics-sensor-agent.md",
-      "label": ".cursor/agents/physics-sensor-agent.md",
-      "path": ".cursor/agents/physics-sensor-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/rag-systems-agent.md",
-      "label": ".cursor/agents/rag-systems-agent.md",
-      "path": ".cursor/agents/rag-systems-agent.md",
-      "type": "document"
-    },
-    {
-      "id": "doc:cursor/agents/security-auditor.md",
-      "label": ".cursor/agents/security-auditor.md",
-      "path": ".cursor/agents/security-auditor.md",
       "type": "document"
     },
     {

--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -57,12 +57,12 @@ async function loadGraph() {
 
 function makeElements(graph) {
   const nodes = graph.nodes.map((n) => ({ data: n }));
-  const edges = graph.edges.map((e) => ({
+  const edges = graph.edges.map((e, idx) => ({
     data: {
-      id: `edge:${e.type}:${e.source}->${e.target}`,
-      source: e.source,
-      target: e.target,
-      type: e.type,
+      ...e,
+      // Sourcery: avoid ID collisions for parallel edges.
+      // Cytoscape element IDs are viewer-internal; graph.json schema does not include edge ids.
+      id: `edge:${idx}`,
       evidence: e.evidence || null,
     },
   }));

--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -1,0 +1,208 @@
+function qs(name) {
+  return new URLSearchParams(window.location.search).get(name);
+}
+
+const GITHUB_REPO = qs("repo") || "Katsiarynakavaleuskaya/PulsePlate";
+const GITHUB_REF = qs("ref") || "main";
+const GRAPH_URL = "../graph.json";
+
+const LEVELS = ["theme", "project", "architecture", "module", "safety", "execution"];
+
+function unique(arr) {
+  return Array.from(new Set(arr)).sort();
+}
+
+function selectedValues(selectEl) {
+  return Array.from(selectEl.selectedOptions).map((o) => o.value);
+}
+
+function buildGitHubUrlForNode(node, graph) {
+  const path = node.data("path");
+  if (!path) return null;
+
+  // Spec: open anchored location if evidence contains path:line.
+  let bestLine = null;
+  for (const e of graph.edges) {
+    if (e.source !== node.id() && e.target !== node.id()) continue;
+    if (!Array.isArray(e.evidence)) continue;
+
+    for (const ev of e.evidence) {
+      const idx = ev.lastIndexOf(":");
+      if (idx <= 0) continue;
+      const evPath = ev.slice(0, idx);
+      const evLine = Number(ev.slice(idx + 1));
+      if (!Number.isInteger(evLine) || evLine <= 0) continue;
+      if (evPath !== path) continue;
+
+      if (bestLine === null || evLine < bestLine) {
+        bestLine = evLine;
+      }
+    }
+  }
+
+  const base = `https://github.com/${GITHUB_REPO}/blob/${GITHUB_REF}/${path}`;
+  return bestLine ? `${base}#L${bestLine}` : base;
+}
+
+function setDetails(node) {
+  const payload = node ? node.data() : { hint: "(click a node)" };
+  document.getElementById("details").textContent = JSON.stringify(payload, null, 2);
+}
+
+async function loadGraph() {
+  const res = await fetch(GRAPH_URL, { cache: "no-store" });
+  if (!res.ok) throw new Error(`Failed to load ${GRAPH_URL}: ${res.status}`);
+  return res.json();
+}
+
+function makeElements(graph) {
+  const nodes = graph.nodes.map((n) => ({ data: n }));
+  const edges = graph.edges.map((e) => ({
+    data: {
+      id: `edge:${e.type}:${e.source}->${e.target}`,
+      source: e.source,
+      target: e.target,
+      type: e.type,
+      evidence: e.evidence || null,
+    },
+  }));
+  return nodes.concat(edges);
+}
+
+function applyFilters(cy) {
+  const q = document.getElementById("search").value.trim().toLowerCase();
+  const types = selectedValues(document.getElementById("typeFilter"));
+  const levels = selectedValues(document.getElementById("levelFilter"));
+
+  cy.nodes().forEach((n) => {
+    const label = (n.data("label") || "").toLowerCase();
+    const t = n.data("type");
+    const tags = Array.isArray(n.data("tags")) ? n.data("tags") : [];
+
+    const okSearch = q === "" || label.includes(q);
+    const okType = types.length === 0 || types.includes(t);
+    const okLevel = levels.length === 0 || levels.some((lvl) => tags.includes(lvl));
+
+    n.style("display", okSearch && okType && okLevel ? "element" : "none");
+  });
+
+  // Hide edges if either endpoint is hidden
+  cy.edges().forEach((e) => {
+    const s = e.source();
+    const t = e.target();
+    const ok = s.style("display") !== "none" && t.style("display") !== "none";
+    e.style("display", ok ? "element" : "none");
+  });
+}
+
+function fillFilters(graph) {
+  const typeFilter = document.getElementById("typeFilter");
+  const levelFilter = document.getElementById("levelFilter");
+
+  const types = unique(graph.nodes.map((n) => n.type));
+
+  typeFilter.innerHTML = "";
+  for (const t of types) {
+    const opt = document.createElement("option");
+    opt.value = t;
+    opt.textContent = t;
+    typeFilter.appendChild(opt);
+  }
+
+  levelFilter.innerHTML = "";
+  for (const l of LEVELS) {
+    const opt = document.createElement("option");
+    opt.value = l;
+    opt.textContent = l;
+    levelFilter.appendChild(opt);
+  }
+}
+
+function wireUI(cy) {
+  const search = document.getElementById("search");
+  const typeFilter = document.getElementById("typeFilter");
+  const levelFilter = document.getElementById("levelFilter");
+  const reset = document.getElementById("reset");
+
+  const onChange = () => applyFilters(cy);
+
+  search.addEventListener("input", onChange);
+  typeFilter.addEventListener("change", onChange);
+  levelFilter.addEventListener("change", onChange);
+
+  reset.addEventListener("click", () => {
+    search.value = "";
+    typeFilter.selectedIndex = -1;
+    levelFilter.selectedIndex = -1;
+    applyFilters(cy);
+    cy.fit();
+    setDetails(null);
+  });
+}
+
+function initCy(elements) {
+  const cy = cytoscape({
+    container: document.getElementById("cy"),
+    elements,
+    layout: { name: "cose", animate: false },
+    style: [
+      {
+        selector: "node",
+        style: {
+          label: "data(label)",
+          "font-size": 10,
+          "text-wrap": "wrap",
+          "text-max-width": 160,
+          "background-color": "#2d6cdf",
+          color: "#e6edf3",
+          "border-width": 1,
+          "border-color": "#243244",
+        },
+      },
+      { selector: 'node[type = "module"]', style: { "background-color": "#6c2ddf" } },
+      { selector: 'node[type = "agent"]', style: { "background-color": "#df9a2d" } },
+      { selector: 'node[type = "test"]', style: { "background-color": "#df2d6c" } },
+      {
+        selector: "edge",
+        style: {
+          width: 1,
+          "line-color": "#243244",
+          "target-arrow-color": "#243244",
+          "target-arrow-shape": "triangle",
+          "curve-style": "bezier",
+          label: "data(type)",
+          "font-size": 8,
+          color: "#9aa4b2",
+        },
+      },
+    ],
+  });
+
+  return cy;
+}
+
+(async function main() {
+  try {
+    const graph = await loadGraph();
+    fillFilters(graph);
+
+    const cy = initCy(makeElements(graph));
+    wireUI(cy);
+    applyFilters(cy);
+    cy.fit();
+
+    cy.on("tap", "node", (evt) => {
+      const n = evt.target;
+      setDetails(n);
+      const url = buildGitHubUrlForNode(n, graph);
+      if (!url) return;
+      window.open(url, "_blank", "noopener,noreferrer");
+    });
+
+    cy.on("tap", (evt) => {
+      if (evt.target === cy) setDetails(null);
+    });
+  } catch (e) {
+    document.getElementById("details").textContent = String(e);
+  }
+})();

--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -57,15 +57,9 @@ async function loadGraph() {
 
 function makeElements(graph) {
   const nodes = graph.nodes.map((n) => ({ data: n }));
-  const edges = graph.edges.map((e, idx) => ({
-    data: {
-      ...e,
-      // Sourcery: avoid ID collisions for parallel edges.
-      // Cytoscape element IDs are viewer-internal; graph.json schema does not include edge ids.
-      id: `edge:${idx}`,
-      evidence: e.evidence || null,
-    },
-  }));
+  // Note: graph.json schema does not include edge IDs. Let Cytoscape generate unique IDs
+  // so parallel edges (same source/target/type but different evidence) never collide.
+  const edges = graph.edges.map((e) => ({ data: { ...e, evidence: e.evidence || null } }));
   return nodes.concat(edges);
 }
 

--- a/docs/graph/viewer/index.html
+++ b/docs/graph/viewer/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>GraphMap Viewer</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="title">GraphMap (dev-only)</div>
+
+      <div class="controls">
+        <label>
+          Search:
+          <input id="search" type="text" placeholder="label contains…" />
+        </label>
+
+        <label>
+          NodeType:
+          <select id="typeFilter" multiple size="7"></select>
+        </label>
+
+        <label>
+          Level:
+          <select id="levelFilter" multiple size="6"></select>
+        </label>
+
+        <button id="reset">Reset</button>
+      </div>
+
+      <div class="hint">
+        Click node → open GitHub link (repo/ref from query string). Example:
+        <code>?repo=Katsiarynakavaleuskaya/PulsePlate&ref=main</code>
+      </div>
+    </header>
+
+    <main>
+      <div id="cy"></div>
+      <aside class="sidebar">
+        <div class="panel">
+          <div class="panel-title">Selection</div>
+          <pre id="details">(click a node)</pre>
+        </div>
+      </aside>
+    </main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/docs/graph/viewer/styles.css
+++ b/docs/graph/viewer/styles.css
@@ -15,6 +15,9 @@ body {
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
   background: var(--bg);
   color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .topbar {
@@ -65,12 +68,14 @@ button {
 main {
   display: grid;
   grid-template-columns: 1fr 360px;
-  height: calc(100vh - 170px);
+  flex: 1 1 auto;
+  min-height: 0; /* allow graph area to shrink without overflow */
 }
 
 #cy {
   width: 100%;
   height: 100%;
+  min-height: 0;
 }
 
 .sidebar {

--- a/docs/graph/viewer/styles.css
+++ b/docs/graph/viewer/styles.css
@@ -1,0 +1,99 @@
+:root {
+  --bg: #0b0f14;
+  --panel: #111824;
+  --text: #e6edf3;
+  --muted: #9aa4b2;
+  --border: #243244;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.title {
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+input,
+select,
+button {
+  background: #0f1520;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+button {
+  cursor: pointer;
+}
+
+.hint {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+main {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  height: calc(100vh - 170px);
+}
+
+#cy {
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar {
+  border-left: 1px solid var(--border);
+  background: #0d1320;
+  padding: 12px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.panel-title {
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  color: var(--text);
+}

--- a/tools/graphmap/README.md
+++ b/tools/graphmap/README.md
@@ -1,0 +1,32 @@
+# GraphMap (dev-only tooling)
+
+Deterministic builder + static viewer per `docs/graph/GRAPHMAP_SPEC.md`.
+
+## Build
+
+```bash
+python tools/graphmap/build_graph.py --out docs/graph/graph.json
+```
+
+## Determinism check
+
+```bash
+python tools/graphmap/build_graph.py --out docs/graph/graph.json
+python tools/graphmap/build_graph.py --out /tmp/graph.json
+python - << 'PY'
+import hashlib
+import pathlib
+
+a = pathlib.Path("docs/graph/graph.json").read_bytes()
+b = pathlib.Path("/tmp/graph.json").read_bytes()
+print("same:", hashlib.sha256(a).hexdigest() == hashlib.sha256(b).hexdigest())
+PY
+```
+
+## View locally
+
+```bash
+python -m http.server 8000
+# open:
+# http://localhost:8000/docs/graph/viewer/?repo=Katsiarynakavaleuskaya/PulsePlate&ref=main
+```

--- a/tools/graphmap/__init__.py
+++ b/tools/graphmap/__init__.py
@@ -1,0 +1,1 @@
+# Intentionally empty (dev-only tooling package).

--- a/tools/graphmap/build_graph.py
+++ b/tools/graphmap/build_graph.py
@@ -142,7 +142,7 @@ def _node_id_for_path(node_type: str, rel_path: str) -> str:
     if rel_path.startswith("./"):
         rel_path = rel_path[2:]
     if node_type == "agent":
-        # Prefer frontmatter `name:` when possible; fallback to file stem.
+        # Use file stem for agent IDs (frontmatter name parsing not implemented here).
         name = Path(rel_path).stem
         return f"agent:{name}"
     if node_type == "module":
@@ -155,10 +155,8 @@ def _guess_node_type(rel_path: str) -> str:
         rel_path = rel_path[2:]
     if rel_path.startswith(".cursor/agents/") and rel_path.endswith(".md"):
         return "agent"
-    if (
-        rel_path.startswith("tests/")
-        or rel_path.startswith("ios/")
-        and rel_path.endswith("Tests.swift")
+    if rel_path.startswith("tests/") or (
+        rel_path.startswith("ios/") and rel_path.endswith("Tests.swift")
     ):
         return "test"
     if rel_path.startswith("docs/"):

--- a/tools/graphmap/build_graph.py
+++ b/tools/graphmap/build_graph.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+GraphMap deterministic builder (dev-only).
+
+RU: Генерирует `docs/graph/graph.json` строго по SoT `docs/graph/GRAPHMAP_SPEC.md`.
+EN: Deterministically builds `docs/graph/graph.json` per `docs/graph/GRAPHMAP_SPEC.md`.
+
+Non-goals:
+- No inferred/semantic edges
+- No placeholder/UNKNOWN nodes
+- No absolute paths, secrets, tokens, UUIDs, timestamps in output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+RE_MD_LINK = re.compile(r"\]\((?P<target>[^)]+)\)")
+RE_PATH_LINE = re.compile(r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9]+):(?P<line>\d{1,6})")
+
+INPUT_GLOBS: tuple[str, ...] = (
+    "AGENTS.md",
+    "docs/graph/GRAPHMAP_SPEC.md",
+    "docs/agents/index.md",
+    "docs/orchestration/**/*.md",
+    "docs/audit/**/*.md",
+    ".cursor/agents/*.md",
+)
+
+MODULE_ROOTS: tuple[str, ...] = ("core", "app", "providers", "tests", "frontend", "ios", "deploy")
+
+NODE_TYPES: frozenset[str] = frozenset(
+    {"topic", "module", "document", "agent", "invariant", "test", "risk"}
+)
+EDGE_TYPES: frozenset[str] = frozenset(
+    {"defines", "constrains", "implements", "validates", "references", "risks"}
+)
+
+LEVEL_TAGS: frozenset[str] = frozenset(
+    {"theme", "project", "architecture", "module", "safety", "execution"}
+)
+
+
+@dataclass(frozen=True)
+class Node:
+    id: str
+    type: str
+    label: str
+    path: Optional[str] = None
+    tags: Optional[tuple[str, ...]] = None
+
+
+@dataclass(frozen=True)
+class Edge:
+    source: str
+    target: str
+    type: str
+    evidence: Optional[tuple[str, ...]] = None
+
+
+def _repo_root() -> Path:
+    return Path.cwd()
+
+
+def _posix(p: Path) -> str:
+    return p.as_posix()
+
+
+def _read_text(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return p.read_text(encoding="utf-8", errors="replace")
+
+
+def _iter_input_files(repo: Path) -> list[Path]:
+    files: set[Path] = set()
+    for pattern in INPUT_GLOBS:
+        for p in repo.glob(pattern):
+            if p.is_file():
+                files.add(p)
+    return sorted(files, key=lambda p: _posix(p.relative_to(repo)))
+
+
+def _strip_fragment_and_query(raw: str) -> str:
+    return raw.split("#", 1)[0].split("?", 1)[0].strip()
+
+
+def _normalize_rel_path(repo: Path, src_file: Path, raw: str) -> Optional[str]:
+    raw = raw.strip()
+    if not raw or raw.startswith("#"):
+        return None
+    if re.match(r"^(https?:|mailto:)", raw, flags=re.IGNORECASE):
+        return None
+
+    cleaned = _strip_fragment_and_query(raw)
+    if not cleaned:
+        return None
+
+    resolved = (src_file.parent / cleaned).resolve()
+    try:
+        rel = resolved.relative_to(repo.resolve())
+    except Exception:
+        return None
+
+    return _posix(rel)
+
+
+def _node_id_for_path(node_type: str, rel_path: str) -> str:
+    rel_path = rel_path.lstrip("./")
+    if node_type == "agent":
+        # Prefer frontmatter `name:` when possible; fallback to file stem.
+        name = Path(rel_path).stem
+        return f"agent:{name}"
+    if node_type == "module":
+        return f"module:{rel_path.rstrip('/')}"
+    return f"doc:{rel_path}"
+
+
+def _guess_node_type(rel_path: str) -> str:
+    rel_path = rel_path.lstrip("./")
+    if rel_path.startswith(".cursor/agents/") and rel_path.endswith(".md"):
+        return "agent"
+    if (
+        rel_path.startswith("tests/")
+        or rel_path.startswith("ios/")
+        and rel_path.endswith("Tests.swift")
+    ):
+        return "test"
+    if rel_path.startswith("docs/"):
+        return "document"
+    if rel_path in MODULE_ROOTS or rel_path.rstrip("/") in MODULE_ROOTS:
+        return "module"
+    if rel_path.endswith("/"):
+        root = rel_path.rstrip("/").split("/", 1)[0]
+        if root in MODULE_ROOTS:
+            return "module"
+    return "document"
+
+
+def _default_tags_for_path(rel_path: str, node_type: str) -> tuple[str, ...]:
+    rel_path = rel_path.lstrip("./")
+    tags: list[str] = []
+
+    if node_type == "module":
+        tags.append("module")
+    if node_type == "test":
+        tags.append("execution")
+
+    if rel_path == "AGENTS.md":
+        tags.extend(["project", "safety"])
+    elif rel_path.startswith("docs/orchestration/") or rel_path.startswith("docs/architecture/"):
+        tags.append("architecture")
+    elif rel_path.startswith("docs/safety/") or rel_path.startswith("docs/security/"):
+        tags.append("safety")
+    elif rel_path.startswith("docs/roadmap/"):
+        tags.append("project")
+    elif rel_path.startswith("docs/audit/"):
+        tags.append("architecture")
+    elif rel_path.startswith(".cursor/agents/"):
+        tags.append("project")
+
+    # Dedup while preserving deterministic order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in tags:
+        if t in LEVEL_TAGS and t not in seen:
+            seen.add(t)
+            out.append(t)
+    return tuple(out)
+
+
+def _extract_markdown_links_by_line(text: str) -> Iterator[tuple[int, str]]:
+    for idx, line in enumerate(text.splitlines(), start=1):
+        for m in RE_MD_LINK.finditer(line):
+            yield idx, m.group("target")
+
+
+def _extract_path_line_tokens_by_line(text: str) -> Iterator[tuple[int, str, int]]:
+    for idx, line in enumerate(text.splitlines(), start=1):
+        for m in RE_PATH_LINE.finditer(line):
+            yield idx, m.group("path"), int(m.group("line"))
+
+
+def _stable_sorted_unique(items: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted(set(items)))
+
+
+def _validate_schema(graph: dict) -> None:
+    allowed_root = {"schema_version", "generated_from", "nodes", "edges"}
+    extra_root = set(graph.keys()) - allowed_root
+    if extra_root:
+        raise ValueError(f"extra root keys: {sorted(extra_root)}")
+
+    if graph.get("schema_version") != "1.0":
+        raise ValueError("schema_version must be '1.0'")
+
+    if not isinstance(graph.get("nodes"), list) or not isinstance(graph.get("edges"), list):
+        raise ValueError("nodes/edges must be lists")
+
+    if "generated_from" in graph:
+        gf = graph["generated_from"]
+        if not isinstance(gf, dict):
+            raise ValueError("generated_from must be an object")
+        allowed_gf = {"repo_ref", "inputs"}
+        extra_gf = set(gf.keys()) - allowed_gf
+        if extra_gf:
+            raise ValueError(f"extra generated_from keys: {sorted(extra_gf)}")
+        if "repo_ref" not in gf or "inputs" not in gf:
+            raise ValueError("generated_from must contain repo_ref and inputs")
+        if not isinstance(gf["inputs"], list):
+            raise ValueError("generated_from.inputs must be a list")
+
+    allowed_node = {"id", "type", "label", "path", "tags"}
+    for i, node in enumerate(graph["nodes"]):
+        if not isinstance(node, dict):
+            raise ValueError(f"node[{i}] must be object")
+        extra = set(node.keys()) - allowed_node
+        if extra:
+            raise ValueError(f"node[{i}] extra keys: {sorted(extra)}")
+        for req in ("id", "type", "label"):
+            if req not in node:
+                raise ValueError(f"node[{i}] missing {req}")
+        if node["type"] not in NODE_TYPES:
+            raise ValueError(f"node[{i}] invalid type: {node['type']}")
+        if "path" in node and (node["path"].startswith("/") or node["path"].startswith("~")):
+            raise ValueError(f"node[{i}] path must be repo-relative: {node['path']}")
+        if "tags" in node:
+            if not isinstance(node["tags"], list):
+                raise ValueError(f"node[{i}] tags must be list")
+
+    allowed_edge = {"source", "target", "type", "evidence"}
+    node_ids = {n["id"] for n in graph["nodes"]}
+    for i, edge in enumerate(graph["edges"]):
+        if not isinstance(edge, dict):
+            raise ValueError(f"edge[{i}] must be object")
+        extra = set(edge.keys()) - allowed_edge
+        if extra:
+            raise ValueError(f"edge[{i}] extra keys: {sorted(extra)}")
+        for req in ("source", "target", "type"):
+            if req not in edge:
+                raise ValueError(f"edge[{i}] missing {req}")
+        if edge["type"] not in EDGE_TYPES:
+            raise ValueError(f"edge[{i}] invalid type: {edge['type']}")
+        if edge["source"] not in node_ids or edge["target"] not in node_ids:
+            raise ValueError(f"edge[{i}] references missing node")
+        if "evidence" in edge:
+            if not isinstance(edge["evidence"], list):
+                raise ValueError(f"edge[{i}] evidence must be list")
+            for ev in edge["evidence"]:
+                if not isinstance(ev, str) or ":" not in ev:
+                    raise ValueError(f"edge[{i}] invalid evidence token: {ev!r}")
+                p, line = ev.rsplit(":", 1)
+                if not line.isdigit():
+                    raise ValueError(f"edge[{i}] invalid evidence line: {ev!r}")
+                if p.startswith("/") or p.startswith("~"):
+                    raise ValueError(f"edge[{i}] evidence must be repo-relative: {ev!r}")
+
+
+def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
+    # Error handling rule: if an input file cannot be parsed, we skip it.
+    input_files = _iter_input_files(repo)
+
+    nodes: dict[str, Node] = {}
+    edges: list[Edge] = []
+
+    def ensure_node_for_file(rel_path: str) -> str:
+        node_type = _guess_node_type(rel_path)
+        if node_type not in NODE_TYPES:
+            # Spec: drop node if cannot type.
+            raise ValueError(f"untypable node_type: {node_type}")
+
+        node_id = _node_id_for_path(node_type, rel_path)
+        if node_id in nodes:
+            return node_id
+
+        tags = _default_tags_for_path(rel_path, node_type)
+        nodes[node_id] = Node(
+            id=node_id,
+            type=node_type,
+            label=rel_path,
+            path=rel_path if not rel_path.endswith("/") else rel_path,
+            tags=tags or None,
+        )
+        return node_id
+
+    def ensure_module_root_for_path(rel_path: str) -> Optional[str]:
+        parts = Path(rel_path).parts
+        if not parts:
+            return None
+        root = parts[0]
+        if root not in MODULE_ROOTS:
+            return None
+        module_path = f"{root}/"
+        module_id = _node_id_for_path("module", root)
+        if module_id not in nodes:
+            nodes[module_id] = Node(
+                id=module_id,
+                type="module",
+                label=root,
+                path=module_path,
+                tags=("module",),
+            )
+        return module_id
+
+    def add_edge(
+        *,
+        source_id: str,
+        target_id: str,
+        edge_type: str,
+        evidence: Optional[tuple[str, ...]] = None,
+    ) -> None:
+        if edge_type not in EDGE_TYPES:
+            return
+        # Spec: if edge references missing nodes, drop it.
+        if source_id not in nodes or target_id not in nodes:
+            return
+        edges.append(Edge(source=source_id, target=target_id, type=edge_type, evidence=evidence))
+
+    # Seed: create nodes for all input files.
+    for src_abs in input_files:
+        rel_src = _posix(src_abs.relative_to(repo))
+        try:
+            ensure_node_for_file(rel_src)
+        except Exception:
+            # Skip untypable nodes per error handling.
+            continue
+
+    # Parse each input file for explicit sources.
+    for src_abs in input_files:
+        rel_src = _posix(src_abs.relative_to(repo))
+        try:
+            src_id = ensure_node_for_file(rel_src)
+        except Exception:
+            continue
+
+        try:
+            text = _read_text(src_abs)
+        except Exception:
+            # Skip unreadable input per spec.
+            continue
+
+        for line_no, raw_target in _extract_markdown_links_by_line(text):
+            rel_target = _normalize_rel_path(repo, src_abs, raw_target)
+            if rel_target is None:
+                continue
+            target_abs = (repo / rel_target).resolve()
+            if not target_abs.is_file():
+                # Spec: skip unresolved link edges.
+                continue
+
+            try:
+                tgt_id = ensure_node_for_file(rel_target)
+            except Exception:
+                continue
+
+            evidence = (f"{rel_src}:{line_no}",)
+            add_edge(source_id=src_id, target_id=tgt_id, edge_type="references", evidence=evidence)
+
+            module_id = ensure_module_root_for_path(rel_target)
+            if module_id is not None:
+                add_edge(
+                    source_id=src_id, target_id=module_id, edge_type="references", evidence=evidence
+                )
+
+        for line_no, raw_path, token_line in _extract_path_line_tokens_by_line(text):
+            rel_target = _normalize_rel_path(repo, src_abs, raw_path)
+            if rel_target is None:
+                continue
+            target_abs = (repo / rel_target).resolve()
+            if not target_abs.is_file():
+                continue
+
+            try:
+                tgt_id = ensure_node_for_file(rel_target)
+            except Exception:
+                continue
+
+            evidence = (f"{rel_src}:{line_no}", f"{rel_target}:{token_line}")
+            add_edge(source_id=src_id, target_id=tgt_id, edge_type="references", evidence=evidence)
+
+            module_id = ensure_module_root_for_path(rel_target)
+            if module_id is not None:
+                add_edge(
+                    source_id=src_id, target_id=module_id, edge_type="references", evidence=evidence
+                )
+
+    # Minimal agent registration mapping: docs/agents/index.md mentions .cursor/agents/*.
+    agents_index = repo / "docs/agents/index.md"
+    if agents_index.is_file():
+        try:
+            idx_id = ensure_node_for_file("docs/agents/index.md")
+            text = _read_text(agents_index)
+        except Exception:
+            text = ""
+            idx_id = ""
+
+        if text and idx_id:
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                m = re.search(r"(?P<path>\.cursor/agents/[A-Za-z0-9_\-]+\.md)", line)
+                if not m:
+                    continue
+                rel_target = m.group("path")
+                target_abs = (repo / rel_target).resolve()
+                if not target_abs.is_file():
+                    continue
+
+                try:
+                    agent_id = ensure_node_for_file(rel_target)
+                except Exception:
+                    continue
+
+                evidence = (f"docs/agents/index.md:{line_no}",)
+                add_edge(
+                    source_id=idx_id, target_id=agent_id, edge_type="references", evidence=evidence
+                )
+
+    # Determinism: stable ordering of nodes/edges
+    node_list = sorted(nodes.values(), key=lambda n: n.id)
+    edge_list = sorted(edges, key=lambda e: (e.source, e.target, e.type, e.evidence or ()))
+
+    # Drop edges that reference missing nodes (if any were dropped) deterministically.
+    node_ids = {n.id for n in node_list}
+    edge_list = [e for e in edge_list if e.source in node_ids and e.target in node_ids]
+
+    return node_list, edge_list
+
+
+def _graph_to_dict(nodes: list[Node], edges: list[Edge]) -> dict:
+    graph: dict = {
+        "schema_version": "1.0",
+        "generated_from": {
+            "repo_ref": "origin/main",
+            "inputs": list(INPUT_GLOBS),
+        },
+        "nodes": [],
+        "edges": [],
+    }
+
+    for n in nodes:
+        obj: dict = {"id": n.id, "type": n.type, "label": n.label}
+        if n.path is not None:
+            obj["path"] = n.path
+        if n.tags is not None:
+            obj["tags"] = list(n.tags)
+        graph["nodes"].append(obj)
+
+    for e in edges:
+        obj = {"source": e.source, "target": e.target, "type": e.type}
+        if e.evidence is not None:
+            obj["evidence"] = list(e.evidence)
+        graph["edges"].append(obj)
+
+    _validate_schema(graph)
+    return graph
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build GraphMap graph.json deterministically.")
+    parser.add_argument("--out", required=True, help="Output path (e.g., docs/graph/graph.json)")
+    args = parser.parse_args()
+
+    repo = _repo_root()
+    out_path = Path(args.out)
+
+    nodes, edges = build_graph(repo)
+    graph = _graph_to_dict(nodes, edges)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Stable formatting: sorted keys, fixed indentation, trailing newline.
+    out_path.write_text(
+        json.dumps(graph, ensure_ascii=False, sort_keys=True, indent=2) + "\n", "utf-8"
+    )
+
+    print(f"OK: wrote {out_path} (nodes={len(nodes)}, edges={len(edges)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/graphmap/build_graph.py
+++ b/tools/graphmap/build_graph.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
@@ -64,6 +66,30 @@ class Edge:
 
 
 def _repo_root() -> Path:
+    """
+    RU: Определяем корень репозитория детерминированно и независимо от cwd.
+    EN: Resolve repository root deterministically and independent of cwd.
+
+    Priority:
+    1) `git rev-parse --show-toplevel`
+    2) Walk up from this script to find `.git` or `AGENTS.md`
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return Path(out)
+    except Exception:
+        pass
+
+    here = Path(__file__).resolve()
+    for parent in [here.parent] + list(here.parents):
+        if (parent / ".git").exists() or (parent / "AGENTS.md").exists():
+            return parent
+
     return Path.cwd()
 
 
@@ -191,6 +217,11 @@ def _stable_sorted_unique(items: Iterable[str]) -> tuple[str, ...]:
     return tuple(sorted(set(items)))
 
 
+def _dbg(enabled: bool, msg: str) -> None:
+    if enabled:
+        print(f"[graphmap] {msg}", file=sys.stderr)
+
+
 def _validate_schema(graph: dict) -> None:
     allowed_root = {"schema_version", "generated_from", "nodes", "edges"}
     extra_root = set(graph.keys()) - allowed_root
@@ -262,18 +293,19 @@ def _validate_schema(graph: dict) -> None:
                     raise ValueError(f"edge[{i}] evidence must be repo-relative: {ev!r}")
 
 
-def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
+def build_graph(repo: Path, *, debug: bool) -> tuple[list[Node], list[Edge]]:
     # Error handling rule: if an input file cannot be parsed, we skip it.
     input_files = _iter_input_files(repo)
 
     nodes: dict[str, Node] = {}
     edges: list[Edge] = []
 
-    def ensure_node_for_file(rel_path: str) -> str:
+    def ensure_node_for_file(rel_path: str) -> Optional[str]:
         node_type = _guess_node_type(rel_path)
         if node_type not in NODE_TYPES:
             # Spec: drop node if cannot type.
-            raise ValueError(f"untypable node_type: {node_type}")
+            _dbg(debug, f"skip node (untypable): {rel_path} -> {node_type}")
+            return None
 
         node_id = _node_id_for_path(node_type, rel_path)
         if node_id in nodes:
@@ -325,24 +357,20 @@ def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
     # Seed: create nodes for all input files.
     for src_abs in input_files:
         rel_src = _posix(src_abs.relative_to(repo))
-        try:
-            ensure_node_for_file(rel_src)
-        except Exception:
-            # Skip untypable nodes per error handling.
-            continue
+        ensure_node_for_file(rel_src)
 
     # Parse each input file for explicit sources.
     for src_abs in input_files:
         rel_src = _posix(src_abs.relative_to(repo))
-        try:
-            src_id = ensure_node_for_file(rel_src)
-        except Exception:
+        src_id = ensure_node_for_file(rel_src)
+        if not src_id:
             continue
 
         try:
             text = _read_text(src_abs)
         except Exception:
             # Skip unreadable input per spec.
+            _dbg(debug, f"skip source (unreadable): {rel_src}")
             continue
 
         for line_no, raw_target in _extract_markdown_links_by_line(text):
@@ -352,11 +380,11 @@ def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
             target_abs = (repo / rel_target).resolve()
             if not target_abs.is_file():
                 # Spec: skip unresolved link edges.
+                _dbg(debug, f"skip edge (missing file): {rel_src}:{line_no} -> {rel_target}")
                 continue
 
-            try:
-                tgt_id = ensure_node_for_file(rel_target)
-            except Exception:
+            tgt_id = ensure_node_for_file(rel_target)
+            if not tgt_id:
                 continue
 
             evidence = (f"{rel_src}:{line_no}",)
@@ -374,11 +402,14 @@ def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
                 continue
             target_abs = (repo / rel_target).resolve()
             if not target_abs.is_file():
+                _dbg(
+                    debug,
+                    f"skip token edge (missing file): {rel_src}:{line_no} -> {rel_target}:{token_line}",
+                )
                 continue
 
-            try:
-                tgt_id = ensure_node_for_file(rel_target)
-            except Exception:
+            tgt_id = ensure_node_for_file(rel_target)
+            if not tgt_id:
                 continue
 
             evidence = (f"{rel_src}:{line_no}", f"{rel_target}:{token_line}")
@@ -408,11 +439,11 @@ def build_graph(repo: Path) -> tuple[list[Node], list[Edge]]:
                 rel_target = m.group("path")
                 target_abs = (repo / rel_target).resolve()
                 if not target_abs.is_file():
+                    _dbg(debug, f"skip agent index edge (missing file): {rel_target}")
                     continue
 
-                try:
-                    agent_id = ensure_node_for_file(rel_target)
-                except Exception:
+                agent_id = ensure_node_for_file(rel_target)
+                if not agent_id:
                     continue
 
                 evidence = (f"docs/agents/index.md:{line_no}",)
@@ -463,12 +494,17 @@ def _graph_to_dict(nodes: list[Node], edges: list[Edge]) -> dict:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build GraphMap graph.json deterministically.")
     parser.add_argument("--out", required=True, help="Output path (e.g., docs/graph/graph.json)")
+    parser.add_argument("--debug", action="store_true", help="Verbose stderr logs (dev-only)")
     args = parser.parse_args()
 
     repo = _repo_root()
-    out_path = Path(args.out)
+    debug = bool(args.debug)
 
-    nodes, edges = build_graph(repo)
+    out_path = Path(args.out)
+    if not out_path.is_absolute():
+        out_path = repo / out_path
+
+    nodes, edges = build_graph(repo, debug=debug)
     graph = _graph_to_dict(nodes, edges)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/graphmap/build_graph.py
+++ b/tools/graphmap/build_graph.py
@@ -128,7 +128,12 @@ def _normalize_rel_path(repo: Path, src_file: Path, raw: str) -> Optional[str]:
     if not cleaned:
         return None
 
-    resolved = (src_file.parent / cleaned).resolve()
+    if cleaned.startswith("/"):
+        # RU: Ссылки вида "/docs/..." считаем путями от корня репозитория, не FS-absolute.
+        # EN: Treat "/docs/..." as repo-root-relative, not filesystem-absolute.
+        resolved = (repo.resolve() / cleaned.lstrip("/")).resolve()
+    else:
+        resolved = (src_file.parent / cleaned).resolve()
     try:
         rel = resolved.relative_to(repo.resolve())
     except Exception:
@@ -318,7 +323,7 @@ def build_graph(repo: Path, *, debug: bool) -> tuple[list[Node], list[Edge]]:
             id=node_id,
             type=node_type,
             label=rel_path,
-            path=rel_path if not rel_path.endswith("/") else rel_path,
+            path=rel_path,
             tags=tags or None,
         )
         return node_id

--- a/tools/graphmap/build_graph.py
+++ b/tools/graphmap/build_graph.py
@@ -138,7 +138,9 @@ def _normalize_rel_path(repo: Path, src_file: Path, raw: str) -> Optional[str]:
 
 
 def _node_id_for_path(node_type: str, rel_path: str) -> str:
-    rel_path = rel_path.lstrip("./")
+    # Only strip a literal leading "./" (do NOT strip leading ".cursor/").
+    if rel_path.startswith("./"):
+        rel_path = rel_path[2:]
     if node_type == "agent":
         # Prefer frontmatter `name:` when possible; fallback to file stem.
         name = Path(rel_path).stem
@@ -149,7 +151,8 @@ def _node_id_for_path(node_type: str, rel_path: str) -> str:
 
 
 def _guess_node_type(rel_path: str) -> str:
-    rel_path = rel_path.lstrip("./")
+    if rel_path.startswith("./"):
+        rel_path = rel_path[2:]
     if rel_path.startswith(".cursor/agents/") and rel_path.endswith(".md"):
         return "agent"
     if (
@@ -170,7 +173,8 @@ def _guess_node_type(rel_path: str) -> str:
 
 
 def _default_tags_for_path(rel_path: str, node_type: str) -> tuple[str, ...]:
-    rel_path = rel_path.lstrip("./")
+    if rel_path.startswith("./"):
+        rel_path = rel_path[2:]
     tags: list[str] = []
 
     if node_type == "module":


### PR DESCRIPTION
Dev-only tooling per docs/graph/GRAPHMAP_SPEC.md.

Adds:
- tools/graphmap/build_graph.py (deterministic builder)
- docs/graph/graph.json (generated artifact for viewer)
- docs/graph/viewer/* (static Cytoscape viewer)

Security notes:
- Viewer is read-only; no tokens/secrets.
- Builder extracts only explicit sources (markdown links + path:line tokens + agent index mentions); no inferred edges.
- Output contains no timestamps/UUIDs/absolute paths; missing files => skip edges; edges to missing nodes => dropped.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавлен детерминированный GraphMap JSON‑билдер и статический встроенный в репозиторий viewer для визуализации графа репозитория в соответствии со спецификацией GRAPHMAP.

Новые возможности:
- Введён Python‑базированный GraphMap‑билдер, который сканирует markdown‑ и agent‑файлы для генерации детерминированного артефакта `docs/graph/graph.json`.
- Добавлен статический HTML/JS‑viewer на базе Cytoscape для исследования сгенерированного графа с базовыми возможностями поиска и фильтрации.

Улучшения:
- Задокументировано использование инструментов GraphMap, включая сборку, проверки детерминизма и инструкции по локальному просмотру.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a deterministic GraphMap JSON builder and a static in-repo viewer for visualizing the repository graph per GRAPHMAP spec.

New Features:
- Introduce a Python-based GraphMap builder that scans markdown and agent files to produce a deterministic docs/graph/graph.json artifact.
- Add a static Cytoscape-powered HTML/JS viewer for exploring the generated graph with basic search and filtering controls.

Enhancements:
- Document GraphMap tooling usage, including build, determinism checks, and local viewing instructions.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dev-only GraphMap tooling with a deterministic builder and a static viewer for explicit doc links. Hardens repo-root detection, adds repo-root–relative Markdown link support, fixes viewer edge ID collisions and layout consistency, improves test/agent typing, and adds quick-start instructions.

- **Bug Fixes**
  - Builder: CWD‑independent repo‑root; supports repo‑root‑relative Markdown links (e.g., /docs/...); agents typed from .cursor/agents/*.md with stable IDs; correct test typing (tests/ and iOS *Tests.swift); skips unreadable inputs and unresolved links with debug logs; validates output against GRAPHMAP_SPEC.
  - Viewer: avoids edge ID collisions; consistent COSE layout; edges hide when either endpoint is hidden.

<sup>Written for commit 3c9cad2fb320a4bb9621ac8060f346aa95d6ff26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Graph Viewer: explore docs with search, type/level filters, node details, and clickable links to source lines.
  * Static Graph Artifact: reproducible graph JSON representing documents, nodes, edges, and metadata.
  * Deterministic graph builder (dev-only) with a CLI to generate the graph artifact.

* **Style**
  * Dark theme and layout for the viewer UI.

* **Documentation**
  * Developer README and updated dev instructions for building and previewing the graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->