### PR TITLE
tooling(graphmap): viewer UX polish (zoom + readability)

### DIFF
--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -117,6 +117,9 @@ function wireUI(cy) {
   const typeFilter = document.getElementById("typeFilter");
   const levelFilter = document.getElementById("levelFilter");
   const reset = document.getElementById("reset");
+  const zoomIn = document.getElementById("zoomIn");
+  const zoomOut = document.getElementById("zoomOut");
+  const fit = document.getElementById("fit");
 
   const onChange = () => applyFilters(cy);
 
@@ -124,13 +127,27 @@ function wireUI(cy) {
   typeFilter.addEventListener("change", onChange);
   levelFilter.addEventListener("change", onChange);
 
+  const renderedCenter = () => ({ x: cy.width() / 2, y: cy.height() / 2 });
+
   reset.addEventListener("click", () => {
     search.value = "";
     typeFilter.selectedIndex = -1;
     levelFilter.selectedIndex = -1;
     applyFilters(cy);
-    cy.fit();
+    cy.fit(undefined, 30);
     setDetails(null);
+  });
+
+  zoomIn.addEventListener("click", () => {
+    cy.zoom({ level: cy.zoom() * 1.2, renderedPosition: renderedCenter() });
+  });
+
+  zoomOut.addEventListener("click", () => {
+    cy.zoom({ level: cy.zoom() / 1.2, renderedPosition: renderedCenter() });
+  });
+
+  fit.addEventListener("click", () => {
+    cy.fit(undefined, 30);
   });
 }
 
@@ -138,19 +155,24 @@ function initCy(elements) {
   const cy = cytoscape({
     container: document.getElementById("cy"),
     elements,
-    layout: { name: "cose", animate: false },
+    layout: { name: "cose", animate: false, padding: 30 },
+    wheelSensitivity: 0.2,
     style: [
       {
         selector: "node",
         style: {
           label: "data(label)",
-          "font-size": 10,
+          "font-size": 12,
           "text-wrap": "wrap",
-          "text-max-width": 160,
+          "text-max-width": 220,
+          "text-valign": "center",
+          "text-halign": "center",
           "background-color": "#2d6cdf",
           color: "#e6edf3",
           "border-width": 1,
           "border-color": "#243244",
+          width: 28,
+          height: 28,
         },
       },
       { selector: 'node[type = "module"]', style: { "background-color": "#6c2ddf" } },
@@ -159,14 +181,15 @@ function initCy(elements) {
       {
         selector: "edge",
         style: {
-          width: 1,
+          width: 1.4,
           "line-color": "#243244",
           "target-arrow-color": "#243244",
           "target-arrow-shape": "triangle",
           "curve-style": "bezier",
-          label: "data(type)",
-          "font-size": 8,
+          label: "",
+          "font-size": 9,
           color: "#9aa4b2",
+          opacity: 0.8,
         },
       },
     ],
@@ -183,7 +206,8 @@ function initCy(elements) {
     const cy = initCy(makeElements(graph));
     wireUI(cy);
     applyFilters(cy);
-    cy.fit();
+    cy.fit(undefined, 30);
+    cy.zoom(Math.min(1.25, cy.zoom()));
 
     cy.on("tap", "node", (evt) => {
       const n = evt.target;

--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -8,6 +8,19 @@ const GRAPH_URL = "../graph.json";
 
 const LEVELS = ["theme", "project", "architecture", "module", "safety", "execution"];
 
+const ZOOM = {
+  factor: 1.2,
+  fitPadding: 30,
+  initialMax: 1.25,
+  min: 0.15,
+  max: 2.5,
+  wheelSensitivity: 0.2,
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
 function unique(arr) {
   return Array.from(new Set(arr)).sort();
 }
@@ -134,20 +147,22 @@ function wireUI(cy) {
     typeFilter.selectedIndex = -1;
     levelFilter.selectedIndex = -1;
     applyFilters(cy);
-    cy.fit(undefined, 30);
+    cy.fit(undefined, ZOOM.fitPadding);
     setDetails(null);
   });
 
   zoomIn.addEventListener("click", () => {
-    cy.zoom({ level: cy.zoom() * 1.2, renderedPosition: renderedCenter() });
+    const next = clamp(cy.zoom() * ZOOM.factor, ZOOM.min, ZOOM.max);
+    cy.zoom({ level: next, renderedPosition: renderedCenter() });
   });
 
   zoomOut.addEventListener("click", () => {
-    cy.zoom({ level: cy.zoom() / 1.2, renderedPosition: renderedCenter() });
+    const next = clamp(cy.zoom() / ZOOM.factor, ZOOM.min, ZOOM.max);
+    cy.zoom({ level: next, renderedPosition: renderedCenter() });
   });
 
   fit.addEventListener("click", () => {
-    cy.fit(undefined, 30);
+    cy.fit(undefined, ZOOM.fitPadding);
   });
 }
 
@@ -156,7 +171,9 @@ function initCy(elements) {
     container: document.getElementById("cy"),
     elements,
     layout: { name: "cose", animate: false, padding: 30 },
-    wheelSensitivity: 0.2,
+    minZoom: ZOOM.min,
+    maxZoom: ZOOM.max,
+    wheelSensitivity: ZOOM.wheelSensitivity,
     style: [
       {
         selector: "node",
@@ -206,8 +223,8 @@ function initCy(elements) {
     const cy = initCy(makeElements(graph));
     wireUI(cy);
     applyFilters(cy);
-    cy.fit(undefined, 30);
-    cy.zoom(Math.min(1.25, cy.zoom()));
+    cy.fit(undefined, ZOOM.fitPadding);
+    cy.zoom(clamp(Math.min(ZOOM.initialMax, cy.zoom()), ZOOM.min, ZOOM.max));
 
     cy.on("tap", "node", (evt) => {
       const n = evt.target;

--- a/docs/graph/viewer/app.js
+++ b/docs/graph/viewer/app.js
@@ -1,3 +1,8 @@
+/**
+ * Read query string parameter.
+ * @param {string} name
+ * @returns {string|null}
+ */
 function qs(name) {
   return new URLSearchParams(window.location.search).get(name);
 }
@@ -8,6 +13,10 @@ const GRAPH_URL = "../graph.json";
 
 const LEVELS = ["theme", "project", "architecture", "module", "safety", "execution"];
 
+/**
+ * Viewer zoom configuration (single source of truth).
+ * @type {{factor:number, fitPadding:number, initialMax:number, min:number, max:number, wheelSensitivity:number}}
+ */
 const ZOOM = {
   factor: 1.2,
   fitPadding: 30,
@@ -17,18 +26,42 @@ const ZOOM = {
   wheelSensitivity: 0.2,
 };
 
+/**
+ * Clamp number into [min, max].
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+/**
+ * Get unique sorted values.
+ * @template T
+ * @param {Array<T>} arr
+ * @returns {Array<T>}
+ */
 function unique(arr) {
   return Array.from(new Set(arr)).sort();
 }
 
+/**
+ * Read selected values from a multi-select.
+ * @param {HTMLSelectElement} selectEl
+ * @returns {Array<string>}
+ */
 function selectedValues(selectEl) {
   return Array.from(selectEl.selectedOptions).map((o) => o.value);
 }
 
+/**
+ * Build GitHub URL for a node. If any evidence matches node.path, prefer #L<line>.
+ * @param {any} node
+ * @param {{edges:Array<{source:string,target:string,type:string,evidence?:Array<string>} >}} graph
+ * @returns {string|null}
+ */
 function buildGitHubUrlForNode(node, graph) {
   const path = node.data("path");
   if (!path) return null;
@@ -57,17 +90,32 @@ function buildGitHubUrlForNode(node, graph) {
   return bestLine ? `${base}#L${bestLine}` : base;
 }
 
+/**
+ * Render current selection into the details panel.
+ * @param {any|null} node
+ * @returns {void}
+ */
 function setDetails(node) {
   const payload = node ? node.data() : { hint: "(click a node)" };
   document.getElementById("details").textContent = JSON.stringify(payload, null, 2);
 }
 
+/**
+ * Load graph.json for the viewer.
+ * @async
+ * @returns {Promise<{nodes:Array<object>,edges:Array<object>}>}
+ */
 async function loadGraph() {
   const res = await fetch(GRAPH_URL, { cache: "no-store" });
   if (!res.ok) throw new Error(`Failed to load ${GRAPH_URL}: ${res.status}`);
   return res.json();
 }
 
+/**
+ * Convert graph.json to Cytoscape elements.
+ * @param {{nodes:Array<object>,edges:Array<object>}} graph
+ * @returns {Array<object>}
+ */
 function makeElements(graph) {
   const nodes = graph.nodes.map((n) => ({ data: n }));
   // Note: graph.json schema does not include edge IDs. Let Cytoscape generate unique IDs
@@ -76,6 +124,11 @@ function makeElements(graph) {
   return nodes.concat(edges);
 }
 
+/**
+ * Apply UI filters (search/type/level) to the graph.
+ * @param {any} cy
+ * @returns {void}
+ */
 function applyFilters(cy) {
   const q = document.getElementById("search").value.trim().toLowerCase();
   const types = selectedValues(document.getElementById("typeFilter"));
@@ -102,6 +155,11 @@ function applyFilters(cy) {
   });
 }
 
+/**
+ * Populate filter controls from the loaded graph.
+ * @param {{nodes:Array<{type:string}>,edges:Array<object>}} graph
+ * @returns {void}
+ */
 function fillFilters(graph) {
   const typeFilter = document.getElementById("typeFilter");
   const levelFilter = document.getElementById("levelFilter");
@@ -125,6 +183,11 @@ function fillFilters(graph) {
   }
 }
 
+/**
+ * Wire up UI controls (filters + zoom controls).
+ * @param {any} cy
+ * @returns {void}
+ */
 function wireUI(cy) {
   const search = document.getElementById("search");
   const typeFilter = document.getElementById("typeFilter");
@@ -140,32 +203,70 @@ function wireUI(cy) {
   typeFilter.addEventListener("change", onChange);
   levelFilter.addEventListener("change", onChange);
 
+  /**
+   * Get rendered center of the graph container.
+   * @returns {{x:number,y:number}}
+   */
   const renderedCenter = () => ({ x: cy.width() / 2, y: cy.height() / 2 });
 
-  reset.addEventListener("click", () => {
+  /**
+   * Reset filters and fit view.
+   * @param {MouseEvent} e
+   * @returns {void}
+   */
+  function onResetClick(e) {
+    void e;
     search.value = "";
     typeFilter.selectedIndex = -1;
     levelFilter.selectedIndex = -1;
     applyFilters(cy);
     cy.fit(undefined, ZOOM.fitPadding);
     setDetails(null);
-  });
+  }
 
-  zoomIn.addEventListener("click", () => {
+  /**
+   * Zoom in.
+   * @param {MouseEvent} e
+   * @returns {void}
+   */
+  function onZoomInClick(e) {
+    void e;
     const next = clamp(cy.zoom() * ZOOM.factor, ZOOM.min, ZOOM.max);
     cy.zoom({ level: next, renderedPosition: renderedCenter() });
-  });
+  }
 
-  zoomOut.addEventListener("click", () => {
+  /**
+   * Zoom out.
+   * @param {MouseEvent} e
+   * @returns {void}
+   */
+  function onZoomOutClick(e) {
+    void e;
     const next = clamp(cy.zoom() / ZOOM.factor, ZOOM.min, ZOOM.max);
     cy.zoom({ level: next, renderedPosition: renderedCenter() });
-  });
+  }
 
-  fit.addEventListener("click", () => {
+  /**
+   * Fit graph to viewport.
+   * @param {MouseEvent} e
+   * @returns {void}
+   */
+  function onFitClick(e) {
+    void e;
     cy.fit(undefined, ZOOM.fitPadding);
-  });
+  }
+
+  reset.addEventListener("click", onResetClick);
+  zoomIn.addEventListener("click", onZoomInClick);
+  zoomOut.addEventListener("click", onZoomOutClick);
+  fit.addEventListener("click", onFitClick);
 }
 
+/**
+ * Initialize Cytoscape instance.
+ * @param {Array<object>} elements
+ * @returns {any}
+ */
 function initCy(elements) {
   const cy = cytoscape({
     container: document.getElementById("cy"),

--- a/docs/graph/viewer/index.html
+++ b/docs/graph/viewer/index.html
@@ -28,6 +28,12 @@
         </label>
 
         <button id="reset">Reset</button>
+
+        <div class="zoom">
+          <button id="zoomIn" type="button">Zoom +</button>
+          <button id="zoomOut" type="button">Zoom -</button>
+          <button id="fit" type="button">Fit</button>
+        </div>
       </div>
 
       <div class="hint">

--- a/docs/graph/viewer/styles.css
+++ b/docs/graph/viewer/styles.css
@@ -41,7 +41,7 @@ body {
 label {
   display: grid;
   gap: 6px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--muted);
 }
 
@@ -59,6 +59,12 @@ button {
   cursor: pointer;
 }
 
+.zoom {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
 .hint {
   margin-top: 10px;
   color: var(--muted);
@@ -67,7 +73,7 @@ button {
 
 main {
   display: grid;
-  grid-template-columns: 1fr 360px;
+  grid-template-columns: 1fr 420px;
   flex: 1 1 auto;
   min-height: 0; /* allow graph area to shrink without overflow */
 }


### PR DESCRIPTION
Dev-only viewer UX polish for GraphMap.

Scope:
- Viewer-only changes under 
- No builder/schema changes;  behavior preserved

Changes:
- Add Zoom+/Zoom-/Fit controls
- Increase default readability (font sizes, node size, sidebar width)
- Reduce visual noise (hide edge labels; details remain in sidebar)

Security notes:
- Viewer remains read-only; no tokens/secrets; only fetches .

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Улучшен пользовательский опыт просмотра GraphMap для повышения читаемости и добавлены базовые элементы управления масштабированием при сохранении неизменного поведения базового графа.

Новые возможности:
- Добавлены элементы управления увеличением, уменьшением и подгонкой под размер области просмотра в интерфейс GraphMap viewer.

Улучшения:
- Повышена читаемость графа за счёт увеличения размеров узлов/подписей, центрирования текста в узлах и расширения боковой панели.
- Подправлены начальные отступы макета, уровень масштабирования и чувствительность колеса прокрутки для более комфортного вида по умолчанию.
- Снижено визуальное «шумовое» оформление за счёт скрытия подписей рёбер и уменьшения непрозрачности их оформления.
- Незначительно увеличен размер шрифта подписей полей форм для улучшения читаемости.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish the GraphMap viewer UX to improve readability and add basic zoom controls while keeping the underlying graph behavior unchanged.

New Features:
- Add zoom in, zoom out, and fit-to-view controls to the GraphMap viewer UI.

Enhancements:
- Increase graph readability by enlarging node/label sizing, centering node text, and widening the sidebar panel.
- Tweak initial layout padding, zoom level, and scroll wheel sensitivity for a more comfortable default view.
- Reduce visual noise by hiding edge labels and softening edge styling opacity.
- Slightly increase general form label font sizes for better legibility.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the GraphMap viewer with Zoom+/Zoom-/Fit controls, bounded zoom, and clearer visuals for easier reading. No builder/schema changes; viewer stays read-only.

- **New Features**
  - Zoom controls (in/out, fit) with viewport-centered zoom, min/max limits, and fit padding.
  - Improved readability and reduced noise: larger fonts/nodes, centered node text, wider sidebar, hidden edge labels, softer edges.
  - Tuned defaults: layout padding, wheel sensitivity, initial zoom cap, and auto-fit with padding.

- **Refactors**
  - Added JSDoc type hints and centralized zoom config with clamp for safer, consistent bounds.

<sup>Written for commit bc938d7dccce71b5d6537f1ce7995eb2184c28bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom controls (Zoom +, Zoom -, Fit) and centered zooming; details panel now shows node payloads.
  * Filter UI to populate and apply type/level filters; reset and filter interactions wired.

* **Improvements**
  * Initial view now fits with padding, centers on load, and clamps initial zoom within bounds.
  * Preserves per-edge evidence and allows distinct parallel edges; improved node/edge styling and wider right-side panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->