### PR TITLE
docs(ledger): close GraphMap dev tooling item

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -450,11 +450,11 @@ If it is not recorded here — it does not exist.
 
 ## P1 — Improvements (Optional / polish)
 
-- [ ] Dev tooling: GraphMap viewer + deterministic graph builder (dev-only)
+- [x] Dev tooling: GraphMap viewer + deterministic graph builder (dev-only)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (developer experience)
-  - Target PR: TBD (tooling)
-  - Status: 📋 Planned
+  - Target PR: PR-695 + PR-696
+  - Status: ✅ Merged (PR-695 @ 2e3d1a5b, PR-696 @ 8e527c13; 2026-02-08)
   - Reason: Make SoT relationships (docs/agents/policies/tests) navigable as an interactive graph with strict determinism.
     This reduces repeated rediscovery work and improves reviewability without introducing a new SoT.
   - Links:
@@ -464,12 +464,12 @@ If it is not recorded here — it does not exist.
     - `docs/orchestration/AGENT_CAPABILITY_MATRIX.md`
     - `docs/agents/index.md`
   - DoD:
-    - PR A (docs-only) adds/updates `docs/graph/GRAPHMAP_SPEC.md` and records this ledger item
-    - PR B (tooling, dev-only) provides a deterministic builder that generates stable `graph.json` from explicit sources only
-    - Viewer supports filtering by `Level` and `NodeType`, plus search and legend
-    - Click opens GitHub file links (optionally `path:line` anchors) and never opens local absolute paths
-    - Forbidden edges are enforced (no semantic guessing / embeddings / AI-inferred relationships)
-    - No runtime impact; no secrets/tokens; safe for local usage (and optionally GitHub Pages)
+    - ✅ `docs/graph/GRAPHMAP_SPEC.md` defines GraphMap inputs and edge rules
+    - ✅ Deterministic builder generates stable `docs/graph/graph.json` from explicit sources only
+    - ✅ Viewer supports filtering by `Level` and `NodeType`, plus search, legend, and zoom controls
+    - ✅ Click opens GitHub file links (optionally `path:line` anchors) and never opens local absolute paths
+    - ✅ Forbidden edges are enforced (no semantic guessing / embeddings / AI-inferred relationships)
+    - ✅ No runtime impact; no secrets/tokens; safe for local usage (and optionally GitHub Pages)
 
 - [ ] Orchestration: implement AI multi-agent contracts (RAG/UQ/CV + safety) — runtime follow-up
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -467,7 +467,7 @@ If it is not recorded here — it does not exist.
     - ✅ `docs/graph/GRAPHMAP_SPEC.md` defines GraphMap inputs and edge rules
     - ✅ Deterministic builder generates stable `docs/graph/graph.json` from explicit sources only
     - ✅ Viewer supports filtering by `Level` and `NodeType`, plus search, legend, and zoom controls
-    - ✅ Click opens GitHub file links (optionally `path:line` anchors) and never opens local absolute paths
+    - ✅ Clicking opens GitHub file links (optionally `path:line` anchors) and never opens local absolute paths
     - ✅ Forbidden edges are enforced (no semantic guessing / embeddings / AI-inferred relationships)
     - ✅ No runtime impact; no secrets/tokens; safe for local usage (and optionally GitHub Pages)
 


### PR DESCRIPTION
## Summary
- Close the GraphMap dev tooling ledger item and link it to the merged implementation PRs (PR-695 + PR-696).

## Test plan
- [x] Verified PR scope is docs-only (only `docs/roadmap/BACKLOG_LEDGER.md`).
- [x] Ran `pre-commit run --all-files`.

## References
- PR-695 (merged): deterministic builder + viewer
- PR-696 (merged): viewer UX polish

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить BACKLOG_LEDGER, чтобы отразить завершение, документацию и детали деплоя для GraphMap viewer и инструментария детерминированного построителя графов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update BACKLOG_LEDGER to reflect completion, documentation, and deployment details of the GraphMap viewer and deterministic graph builder tooling.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the GraphMap dev tooling item as completed in BACKLOG_LEDGER.md, updates its status to merged, and links it to PR-695 and PR-696. Polishes DoD wording and checks off: deterministic builder, viewer filters/search/legend/zoom, safe GitHub links, forbidden-edge enforcement, and no runtime impact.

<sup>Written for commit 52b66436b09884bf9330070ec41d8772b12cd078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Roadmap updated: P1 Improvements marked as completed/merged with dates.
  * GraphMap viewer/tooling confirmed as shipped with deterministic graph outputs.
  * Viewer features: filtering (Level, NodeType), search, legend, and zoom.
  * Interaction and safety behaviors confirmed: GitHub link handling, avoidance of local paths, forbidden-edge enforcement, no runtime or secrets impact, and GitHub Pages compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->