### PR TITLE
observability: measure legacy nutrition alias usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ make diff-cov   # Diff-coverage ≥97% on changed lines
 - Forbidden: registering middleware, observability/instrumentation, infra routes (/metrics), or any runtime behavior changes.
 - All middleware/observability registration must live in bootstrap modules (e.g., `app/bootstrap/metrics.py`) and be called from the primary app entrypoint (e.g., `app/main.py`).
 - `legacy_app.py` must only contain: thin proxies, response formatting, legacy endpoint shims.
+- Legacy alias observability (e.g., counters for deprecated routes) must live in **shim routers under `app/routers/`**, not inside `legacy_app.py`.
 - This prevents drift and keeps legacy as a pure compatibility layer.
 
 **DB fallback policy (hard, TP2):**

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -16,10 +16,17 @@ from typing import Any, Callable, Protocol, cast
 
 logger = logging.getLogger(__name__)
 
+# Canonical legacy nutrition alias route template (SoT for allowlist/tests).
+# RU: Канонический route template для legacy nutrition alias (SoT для allowlist/тестов).
+# EN: Canonical route template for legacy nutrition alias (SoT for allowlist/tests).
+LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE = "/api/nutrition/{date_str}"
+
 # Explicit allowlist for legacy alias routes (low cardinality).
 # RU: Явный allowlist legacy-алиасов (низкая кардинальность).
 # EN: Explicit allowlist for legacy aliases (low cardinality).
-LEGACY_ALIAS_ROUTE_ALLOWLIST: frozenset[str] = frozenset({"/api/nutrition/{date_str}"})
+LEGACY_ALIAS_ROUTE_ALLOWLIST: set[str] = {
+    LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE,
+}
 
 
 class _CounterChild(Protocol):

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,99 @@
+"""Application-level Prometheus metrics helpers.
+
+RU: Хелперы Prometheus-метрик на уровне приложения.
+EN: Prometheus metrics helpers at the application level.
+
+Policy (hard):
+- Only low-cardinality labels (explicit allowlist).
+- Labels MUST use route templates (never raw paths, query params, user-correlated labels).
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+from typing import Any, Callable, Protocol, cast
+
+logger = logging.getLogger(__name__)
+
+# Explicit allowlist for legacy alias routes (low cardinality).
+# RU: Явный allowlist legacy-алиасов (низкая кардинальность).
+# EN: Explicit allowlist for legacy aliases (low cardinality).
+LEGACY_ALIAS_ROUTE_ALLOWLIST: frozenset[str] = frozenset({"/api/nutrition/{date_str}"})
+
+
+class _CounterChild(Protocol):
+    def inc(self, amount: float = 1.0) -> None: ...
+
+
+class _Counter(Protocol):
+    def labels(self, *, alias_route: str) -> _CounterChild: ...
+
+
+_Importer = Callable[[str], Any]
+
+
+def _import_prometheus(importer: _Importer = import_module) -> Any:
+    """Import prometheus_client.Counter in a patchable way.
+
+    Returns:
+        prometheus_client.Counter
+
+    Raises:
+        ImportError: If prometheus_client is not installed.
+    """
+    prometheus_client = importer("prometheus_client")
+    return prometheus_client.Counter
+
+
+def _build_legacy_alias_requests_total() -> _Counter | None:
+    """Initialize legacy alias usage counter.
+
+    Returns None if prometheus_client is unavailable OR metric registration fails
+    (e.g., module reload causes duplicate names in the default registry).
+    """
+    try:
+        Counter = _import_prometheus()
+    except ImportError:
+        return None
+
+    try:
+        legacy_alias_requests_total: _Counter = cast(
+            _Counter,
+            Counter(
+                "legacy_alias_requests_total",
+                "Total number of requests to deprecated legacy alias routes",
+                labelnames=("alias_route",),
+            ),
+        )
+    except ValueError:
+        logger.warning(
+            "Duplicate prometheus metric registration for legacy_alias_requests_total "
+            "(metric disabled)",
+            exc_info=True,
+        )
+        return None
+
+    return legacy_alias_requests_total
+
+
+LEGACY_ALIAS_REQUESTS_TOTAL: _Counter | None = _build_legacy_alias_requests_total()
+
+
+def record_legacy_alias_hit(alias_route: str) -> None:
+    """Record a hit to a deprecated legacy alias route (best-effort).
+
+    RU: Зафиксировать обращение к legacy-алиасу (best-effort).
+    EN: Record request to a legacy alias (best-effort).
+    """
+    if alias_route not in LEGACY_ALIAS_ROUTE_ALLOWLIST:
+        return
+
+    counter = LEGACY_ALIAS_REQUESTS_TOTAL
+    if counter is None:
+        return
+
+    try:
+        counter.labels(alias_route=alias_route).inc()
+    except Exception:  # nosec B110 - metrics must never affect request handling
+        pass

--- a/app/routers/legacy_nutrition_alias.py
+++ b/app/routers/legacy_nutrition_alias.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, Query
+
+from app.metrics import LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE, record_legacy_alias_hit
+from app.middleware.api_tiers import require_pro_tier
+from app.routers.pro import get_daily_nutrition
+
+router = APIRouter(tags=["pro", "legacy"], include_in_schema=False)
+
+
+@router.get(
+    LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE,
+    deprecated=True,
+)
+async def legacy_nutrition_date_alias(
+    date_str: str,
+    sex: str = Query("female", description="Biological sex (female/male)"),
+    age: int = Query(30, gt=10, lt=100, description="Age in years"),
+    height_cm: float = Query(165, gt=100, lt=250, description="Height in cm"),
+    weight_kg: float = Query(65, gt=30, lt=300, description="Weight in kg"),
+    activity: str = Query("moderate", description="Activity level"),
+    goal: str = Query("maintain", description="Nutrition goal"),
+    _: str = Depends(require_pro_tier),
+) -> Dict[str, Any]:
+    """Legacy alias for iOS nutrition endpoint compatibility.
+
+    RU: Устаревший алиас для iOS совместимости — делегирует на PRO endpoint.
+    EN: Legacy alias for iOS compatibility — delegates to PRO endpoint.
+
+    Observability is allowed here; legacy_app.py stays thin-only.
+    """
+    record_legacy_alias_hit(LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE)
+
+    response = await get_daily_nutrition(
+        date_str=date_str,
+        sex=sex,  # type: ignore
+        age=age,
+        height_cm=height_cm,
+        weight_kg=weight_kg,
+        activity=activity,  # type: ignore
+        goal=goal,  # type: ignore
+    )
+    return response.model_dump()

--- a/app/routers/legacy_nutrition_alias.py
+++ b/app/routers/legacy_nutrition_alias.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 
@@ -24,7 +24,7 @@ async def legacy_nutrition_date_alias(
     activity: str = Query("moderate", description="Activity level"),
     goal: str = Query("maintain", description="Nutrition goal"),
     _: str = Depends(require_pro_tier),
-) -> Dict[str, Any]:
+) -> Any:
     """Legacy alias for iOS nutrition endpoint compatibility.
 
     RU: Устаревший алиас для iOS совместимости — делегирует на PRO endpoint.
@@ -43,4 +43,5 @@ async def legacy_nutrition_date_alias(
         activity=activity,  # type: ignore
         goal=goal,  # type: ignore
     )
-    return response.model_dump()
+    # Return canonical response as-is (avoid serialization drift in shim).
+    return response

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -896,7 +896,10 @@ async def get_daily_nutrition_legacy(
 
     NOTE: This route is deprecated. Use /api/v1/pro/nutrition/daily instead.
     """
+    from app.metrics import record_legacy_alias_hit
     from app.routers.pro import get_daily_nutrition
+
+    record_legacy_alias_hit("/api/nutrition/{date_str}")
 
     # Call the canonical PRO endpoint with profile parameters
     response = await get_daily_nutrition(

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 import dotenv
-from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import (
     BaseModel,
@@ -44,7 +44,6 @@ from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 
 from app.dependencies import validate_template_dir
-from app.middleware.api_tiers import require_pro_tier
 from app.routers.api_key import api_key_header
 from app.routers.bmi import router as bmi_router
 from app.routers.bmi_pro import router as bmi_pro_router
@@ -871,47 +870,13 @@ app.include_router(shopping_list_pro_router)
 app.include_router(shoplist_day_router)
 
 
-# Legacy alias for iOS nutrition endpoint compatibility
-# Maps /api/nutrition/{date} to /api/v1/pro/nutrition/daily with default profile
-@app.get(
-    "/api/nutrition/{date_str}",
-    tags=["pro", "legacy"],
-    deprecated=True,
-    include_in_schema=False,
-)
-async def get_daily_nutrition_legacy(
-    date_str: str,
-    sex: str = Query("female", description="Biological sex (female/male)"),
-    age: int = Query(30, gt=10, lt=100, description="Age in years"),
-    height_cm: float = Query(165, gt=100, lt=250, description="Height in cm"),
-    weight_kg: float = Query(65, gt=30, lt=300, description="Weight in kg"),
-    activity: str = Query("moderate", description="Activity level"),
-    goal: str = Query("maintain", description="Nutrition goal"),
-    _: str = Depends(require_pro_tier),
-) -> Dict[str, Any]:
-    """Legacy alias for iOS nutrition endpoint - redirects to PRO endpoint.
+# Legacy nutrition alias router (thin include only; no instrumentation here).
+try:
+    from app.routers.legacy_nutrition_alias import router as legacy_nutrition_alias_router
 
-    RU: Устаревший алиас для iOS совместимости - перенаправляет на PRO endpoint.
-    EN: Legacy alias for iOS compatibility - redirects to PRO endpoint.
-
-    NOTE: This route is deprecated. Use /api/v1/pro/nutrition/daily instead.
-    """
-    from app.metrics import record_legacy_alias_hit
-    from app.routers.pro import get_daily_nutrition
-
-    record_legacy_alias_hit("/api/nutrition/{date_str}")
-
-    # Call the canonical PRO endpoint with profile parameters
-    response = await get_daily_nutrition(
-        date_str=date_str,
-        sex=sex,  # type: ignore
-        age=age,
-        height_cm=height_cm,
-        weight_kg=weight_kg,
-        activity=activity,  # type: ignore
-        goal=goal,  # type: ignore
-    )
-    return response.model_dump()
+    app.include_router(legacy_nutrition_alias_router)
+except ImportError as e:  # pragma: no cover
+    logger.warning("Legacy nutrition alias router not loaded: %s", e)  # pragma: no cover
 
 
 # Premium week router registration is now handled in

--- a/tests/test_nutrition_daily.py
+++ b/tests/test_nutrition_daily.py
@@ -395,6 +395,50 @@ def test_legacy_nutrition_endpoint_defaults(client: TestClient) -> None:
     assert len(data["segments"]) == 4
 
 
+def _get_legacy_alias_metric_value() -> float:
+    # prom-client API: stable, no scraping needed
+    from prometheus_client import REGISTRY
+
+    value = REGISTRY.get_sample_value(
+        "legacy_alias_requests_total",
+        {"alias_route": "/api/nutrition/{date_str}"},
+    )
+    return float(value or 0.0)
+
+
+def test_legacy_alias_increments_counter(client: TestClient) -> None:
+    before = _get_legacy_alias_metric_value()
+
+    resp = client.get(
+        "/api/nutrition/2025-12-15",
+        headers={"X-API-Key": "test_pro_key"},
+    )
+    assert resp.status_code == 200
+
+    after = _get_legacy_alias_metric_value()
+    assert after == before + 1.0
+
+
+def test_canonical_does_not_increment_legacy_counter(client: TestClient) -> None:
+    before = _get_legacy_alias_metric_value()
+
+    resp = client.get(
+        "/api/v1/pro/nutrition/daily",
+        params={
+            "date": "2025-12-15",
+            "sex": "female",
+            "age": 30,
+            "height_cm": 165,
+            "weight_kg": 65,
+        },
+        headers={"X-API-Key": "test_pro_key"},
+    )
+    assert resp.status_code == 200
+
+    after = _get_legacy_alias_metric_value()
+    assert after == before
+
+
 def test_nutrition_targets_integration(client: TestClient) -> None:
     """Test WHO targets are correctly integrated and calculated.
 

--- a/tests/test_nutrition_daily.py
+++ b/tests/test_nutrition_daily.py
@@ -406,7 +406,32 @@ def _get_legacy_alias_metric_value() -> float:
     return float(value or 0.0)
 
 
+LEGACY_ALIAS_ROUTE = "/api/nutrition/{date_str}"
+
+
+def _reset_legacy_alias_counter_for_tests() -> None:
+    """Reset legacy alias counter to ensure deterministic tests.
+
+    RU: Сбрасывает счётчик legacy alias для детерминизма тестов.
+    EN: Resets legacy alias counter for deterministic tests.
+    """
+    # IMPORTANT: import by module path (avoid `from app import metrics` due to app/__init__.py shim).
+    import importlib
+
+    app_metrics = importlib.import_module("app.metrics")
+    counter = getattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", None)
+    if counter is None:
+        pytest.skip("prometheus_client not available (legacy alias counter disabled)")
+
+    child = counter.labels(alias_route=LEGACY_ALIAS_ROUTE)
+    # prom-client internals: Counter child uses a ValueClass with .set()
+    # RU: тестовая изоляция; прод-код не трогаем.
+    # EN: test isolation; do not touch prod behavior.
+    child._value.set(0)  # type: ignore[attr-defined]
+
+
 def test_legacy_alias_increments_counter(client: TestClient) -> None:
+    _reset_legacy_alias_counter_for_tests()
     before = _get_legacy_alias_metric_value()
 
     resp = client.get(
@@ -420,6 +445,7 @@ def test_legacy_alias_increments_counter(client: TestClient) -> None:
 
 
 def test_canonical_does_not_increment_legacy_counter(client: TestClient) -> None:
+    _reset_legacy_alias_counter_for_tests()
     before = _get_legacy_alias_metric_value()
 
     resp = client.get(

--- a/tests/test_nutrition_daily.py
+++ b/tests/test_nutrition_daily.py
@@ -376,6 +376,7 @@ def test_legacy_nutrition_endpoint_auth_guard_contract(
 def test_legacy_nutrition_endpoint_hidden_from_openapi(client: TestClient) -> None:
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
     schema = resp.json()
     assert LEGACY_ALIAS_ROUTE not in schema.get("paths", {})
 
@@ -388,15 +389,19 @@ def test_legacy_nutrition_endpoint_defaults(
     RU: Тест использования дефолтов в устаревшем endpoint.
     EN: Test using defaults in legacy endpoint for optional params.
     """
-    response = client.get(
-        "/api/nutrition/2025-12-15",
-        headers=pro_headers,
-    )
+    _reset_legacy_alias_counter_for_tests()
+    before = _get_legacy_alias_metric_value()
+
+    response = client.get("/api/nutrition/2025-12-15", headers=pro_headers)
 
     assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
     data = response.json()
     # Should work with all defaults
     assert len(data["segments"]) == 4
+
+    after = _get_legacy_alias_metric_value()
+    assert after == before + 1.0
 
 
 def _get_legacy_alias_metric_value() -> float:
@@ -432,20 +437,6 @@ def _reset_legacy_alias_counter_for_tests() -> None:
     # RU: тестовая изоляция; прод-код не трогаем.
     # EN: test isolation; do not touch prod behavior.
     child._value.set(0)  # type: ignore[attr-defined]
-
-
-def test_legacy_alias_increments_counter(client: TestClient, pro_headers: dict[str, str]) -> None:
-    _reset_legacy_alias_counter_for_tests()
-    before = _get_legacy_alias_metric_value()
-
-    resp = client.get(
-        "/api/nutrition/2025-12-15",
-        headers=pro_headers,
-    )
-    assert resp.status_code == 200
-
-    after = _get_legacy_alias_metric_value()
-    assert after == before + 1.0
 
 
 def test_canonical_does_not_increment_legacy_counter(

--- a/tests/test_nutrition_daily.py
+++ b/tests/test_nutrition_daily.py
@@ -465,6 +465,74 @@ def test_canonical_does_not_increment_legacy_counter(client: TestClient) -> None
     assert after == before
 
 
+def test_app_metrics_build_legacy_alias_requests_total_returns_none_on_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard: app.metrics must handle missing prometheus_client deterministically."""
+    import app.metrics as app_metrics
+
+    monkeypatch.setattr(
+        app_metrics, "_import_prometheus", lambda: (_ for _ in ()).throw(ImportError("boom"))
+    )
+    assert app_metrics._build_legacy_alias_requests_total() is None
+
+
+def test_app_metrics_build_legacy_alias_requests_total_returns_none_on_duplicate_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard: duplicate metric registration must disable legacy counter (no crash)."""
+    import app.metrics as app_metrics
+
+    def _bad_counter(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("duplicate metric name")
+
+    monkeypatch.setattr(app_metrics, "_import_prometheus", lambda: _bad_counter)
+    assert app_metrics._build_legacy_alias_requests_total() is None
+
+
+def test_record_legacy_alias_hit_noop_when_not_in_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_legacy_alias_hit must be low-cardinality (allowlist-only)."""
+    import app.metrics as app_metrics
+
+    class _ExplodeCounter:
+        def labels(self, *, alias_route: str) -> object:  # pragma: no cover
+            raise RuntimeError(f"labels called unexpectedly for {alias_route}")
+
+    monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", _ExplodeCounter())
+    app_metrics.record_legacy_alias_hit("/not-allowed")
+
+
+def test_record_legacy_alias_hit_noop_when_counter_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_legacy_alias_hit must be best-effort when counter is disabled."""
+    import app.metrics as app_metrics
+
+    monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", None)
+    app_metrics.record_legacy_alias_hit("/api/nutrition/{date_str}")
+
+
+def test_record_legacy_alias_hit_swallows_counter_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_legacy_alias_hit must never raise (observability best-effort)."""
+    import app.metrics as app_metrics
+
+    class _BadChild:
+        def inc(self, amount: float = 1.0) -> None:
+            raise RuntimeError("boom")
+
+    class _BadCounter:
+        def labels(self, *, alias_route: str) -> _BadChild:
+            assert alias_route == "/api/nutrition/{date_str}"
+            return _BadChild()
+
+    monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", _BadCounter())
+    app_metrics.record_legacy_alias_hit("/api/nutrition/{date_str}")
+
+
 def test_nutrition_targets_integration(client: TestClient) -> None:
     """Test WHO targets are correctly integrated and calculated.
 

--- a/tests/test_nutrition_daily.py
+++ b/tests/test_nutrition_daily.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from app.metrics import LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE as LEGACY_ALIAS_ROUTE
+
 
 def test_daily_nutrition_success_with_profile(client: TestClient) -> None:
     """Test daily nutrition endpoint with valid user profile.
@@ -375,10 +377,12 @@ def test_legacy_nutrition_endpoint_hidden_from_openapi(client: TestClient) -> No
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
     schema = resp.json()
-    assert "/api/nutrition/{date_str}" not in schema.get("paths", {})
+    assert LEGACY_ALIAS_ROUTE not in schema.get("paths", {})
 
 
-def test_legacy_nutrition_endpoint_defaults(client: TestClient) -> None:
+def test_legacy_nutrition_endpoint_defaults(
+    client: TestClient, pro_headers: dict[str, str]
+) -> None:
     """Test legacy endpoint uses defaults for missing optional params.
 
     RU: Тест использования дефолтов в устаревшем endpoint.
@@ -386,7 +390,7 @@ def test_legacy_nutrition_endpoint_defaults(client: TestClient) -> None:
     """
     response = client.get(
         "/api/nutrition/2025-12-15",
-        headers={"X-API-Key": "test_pro_key"},
+        headers=pro_headers,
     )
 
     assert response.status_code == 200
@@ -397,16 +401,16 @@ def test_legacy_nutrition_endpoint_defaults(client: TestClient) -> None:
 
 def _get_legacy_alias_metric_value() -> float:
     # prom-client API: stable, no scraping needed
-    from prometheus_client import REGISTRY
+    try:
+        from prometheus_client import REGISTRY
+    except ImportError:
+        pytest.skip("prometheus_client not installed; metrics tests skipped")
 
     value = REGISTRY.get_sample_value(
         "legacy_alias_requests_total",
-        {"alias_route": "/api/nutrition/{date_str}"},
+        {"alias_route": LEGACY_ALIAS_ROUTE},
     )
     return float(value or 0.0)
-
-
-LEGACY_ALIAS_ROUTE = "/api/nutrition/{date_str}"
 
 
 def _reset_legacy_alias_counter_for_tests() -> None:
@@ -430,13 +434,13 @@ def _reset_legacy_alias_counter_for_tests() -> None:
     child._value.set(0)  # type: ignore[attr-defined]
 
 
-def test_legacy_alias_increments_counter(client: TestClient) -> None:
+def test_legacy_alias_increments_counter(client: TestClient, pro_headers: dict[str, str]) -> None:
     _reset_legacy_alias_counter_for_tests()
     before = _get_legacy_alias_metric_value()
 
     resp = client.get(
         "/api/nutrition/2025-12-15",
-        headers={"X-API-Key": "test_pro_key"},
+        headers=pro_headers,
     )
     assert resp.status_code == 200
 
@@ -444,7 +448,9 @@ def test_legacy_alias_increments_counter(client: TestClient) -> None:
     assert after == before + 1.0
 
 
-def test_canonical_does_not_increment_legacy_counter(client: TestClient) -> None:
+def test_canonical_does_not_increment_legacy_counter(
+    client: TestClient, pro_headers: dict[str, str]
+) -> None:
     _reset_legacy_alias_counter_for_tests()
     before = _get_legacy_alias_metric_value()
 
@@ -457,7 +463,7 @@ def test_canonical_does_not_increment_legacy_counter(client: TestClient) -> None
             "height_cm": 165,
             "weight_kg": 65,
         },
-        headers={"X-API-Key": "test_pro_key"},
+        headers=pro_headers,
     )
     assert resp.status_code == 200
 
@@ -511,7 +517,7 @@ def test_record_legacy_alias_hit_noop_when_counter_disabled(
     import app.metrics as app_metrics
 
     monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", None)
-    app_metrics.record_legacy_alias_hit("/api/nutrition/{date_str}")
+    app_metrics.record_legacy_alias_hit(LEGACY_ALIAS_ROUTE)
 
 
 def test_record_legacy_alias_hit_swallows_counter_errors(
@@ -526,11 +532,11 @@ def test_record_legacy_alias_hit_swallows_counter_errors(
 
     class _BadCounter:
         def labels(self, *, alias_route: str) -> _BadChild:
-            assert alias_route == "/api/nutrition/{date_str}"
+            assert alias_route == LEGACY_ALIAS_ROUTE
             return _BadChild()
 
     monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", _BadCounter())
-    app_metrics.record_legacy_alias_hit("/api/nutrition/{date_str}")
+    app_metrics.record_legacy_alias_hit(LEGACY_ALIAS_ROUTE)
 
 
 def test_nutrition_targets_integration(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Add a low-cardinality Prometheus counter to measure usage of the deprecated legacy nutrition alias.
- Increment the counter strictly inside the legacy alias handler (no double-counting).
- Add deterministic tests that assert alias increments and canonical does not.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Notes
- Label is allowlist + route template only (no raw paths, no PII).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Отслеживать использование устаревших маршрутов псевдонимов для питания с помощью метрики Prometheus, сохраняя наблюдаемость по принципу best-effort и изолированной от обработки запросов.

Новые возможности:
- Ввести счетчик Prometheus на уровне приложения для запросов к устаревшим псевдонимам, ключом которого является маршрутный шаблон из списка разрешённых (allowlist).

Улучшения:
- Подключить устаревшую конечную точку псевдонима питания (nutrition legacy alias endpoint) для записи срабатываний метрик без воздействия на каноническую конечную точку.
- Укрепить логику инициализации и записи метрик, чтобы корректно обрабатывать отсутствие `prometheus_client`, повторные регистрации и ошибки счётчика.

Тесты:
- Добавить интеграционные тесты, проверяющие, что устаревший псевдоним увеличивает счётчик, в то время как канонический маршрут этого не делает.
- Добавить модульные тесты, покрывающие резервные сценарии инициализации метрик, поведение allowlist и обработку ошибок при записи срабатываний устаревшего псевдонима.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track usage of deprecated legacy nutrition alias routes with a Prometheus metric while keeping observability best-effort and isolated from request handling.

New Features:
- Introduce an application-level Prometheus counter for legacy alias requests keyed by an allowlisted route template.

Enhancements:
- Wire the deprecated nutrition legacy alias endpoint to record metric hits without affecting the canonical endpoint.
- Harden metric initialization and recording to gracefully handle missing prometheus_client, duplicate registrations, and counter errors.

Tests:
- Add integration tests verifying the legacy alias increments the counter while the canonical route does not.
- Add unit tests covering metric initialization fallbacks, allowlist behavior, and error handling in legacy alias hit recording.

</details>

Новые возможности:
- Добавлен прикладной счетчик Prometheus для запросов к устаревшим псевдонимам, ключом которого является разрешённый шаблон маршрута.

Улучшения:
- Обработчик устаревших псевдонимов для раздела питания подключён к записи срабатываний метрик без влияния на поведение канонической конечной точки.
- Усилена инициализация и запись метрик для корректной обработки отсутствующего клиента Prometheus, повторных регистраций и ошибок счётчика.

Тесты:
- Добавлены интеграционные тесты, проверяющие, что устаревший псевдоним инкрементирует счётчик, в то время как канонический маршрут этого не делает, а также модульные тесты для инициализации метрик и обработки ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Отслеживать использование устаревших маршрутов псевдонимов для питания с помощью метрики Prometheus, сохраняя наблюдаемость по принципу best-effort и изолированной от обработки запросов.

Новые возможности:
- Ввести счетчик Prometheus на уровне приложения для запросов к устаревшим псевдонимам, ключом которого является маршрутный шаблон из списка разрешённых (allowlist).

Улучшения:
- Подключить устаревшую конечную точку псевдонима питания (nutrition legacy alias endpoint) для записи срабатываний метрик без воздействия на каноническую конечную точку.
- Укрепить логику инициализации и записи метрик, чтобы корректно обрабатывать отсутствие `prometheus_client`, повторные регистрации и ошибки счётчика.

Тесты:
- Добавить интеграционные тесты, проверяющие, что устаревший псевдоним увеличивает счётчик, в то время как канонический маршрут этого не делает.
- Добавить модульные тесты, покрывающие резервные сценарии инициализации метрик, поведение allowlist и обработку ошибок при записи срабатываний устаревшего псевдонима.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track usage of deprecated legacy nutrition alias routes with a Prometheus metric while keeping observability best-effort and isolated from request handling.

New Features:
- Introduce an application-level Prometheus counter for legacy alias requests keyed by an allowlisted route template.

Enhancements:
- Wire the deprecated nutrition legacy alias endpoint to record metric hits without affecting the canonical endpoint.
- Harden metric initialization and recording to gracefully handle missing prometheus_client, duplicate registrations, and counter errors.

Tests:
- Add integration tests verifying the legacy alias increments the counter while the canonical route does not.
- Add unit tests covering metric initialization fallbacks, allowlist behavior, and error handling in legacy alias hit recording.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track usage of the deprecated /api/nutrition/{date_str} alias with a low-cardinality Prometheus counter. Adds safe, best-effort observability without affecting request flow, OpenAPI schema, or the canonical endpoint.

- **New Features**
  - Added legacy_alias_requests_total with alias_route (allowlisted route template); auto-disables if prometheus_client is missing or registration is duplicate.
  - Instrumentation lives in the shim router only; legacy_app stays thin and the canonical endpoint does not increment the counter.
  - Centralized the legacy alias route template and hardened tests with content-type checks and deterministic counter resets.

<sup>Written for commit f1fa26b5eefa824f6b6dcacb0d33de0c7a368db1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an optional, deprecated legacy nutrition alias endpoint that forwards to the PRO endpoint and is hidden from the public schema.
  * Adds application-level metrics helpers and a best-effort counter to track legacy alias hits; safe no-op if metrics are unavailable.

* **Tests**
  * Adds integration tests covering legacy alias behavior, metrics recording, and error/edge cases.

* **Chores**
  * Moves legacy-alias observability into a dedicated router pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->