### PR TITLE
security(trivy): suppress CVE-2026-2100 (libp11-kit0)

### DIFF
--- a/docs/security/CVE-2026-2100-libp11-kit0.md
+++ b/docs/security/CVE-2026-2100-libp11-kit0.md
@@ -1,0 +1,48 @@
+# CVE-2026-2100 — libp11-kit0 (Debian bookworm) — Trivy code scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2026-2100
+- **Package**: `libp11-kit0`
+- **Installed version (observed)**: `0.24.1-2`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: Medium
+- **GitHub alert**: `security/code-scanning/535`
+
+This finding is reported by Trivy against an OS package present in our Debian bookworm base image.
+At the time of triage, **Trivy reports no fixed version** for bookworm for this CVE.
+
+## Why we suppress (temporarily)
+
+- This is an **OS package** vulnerability in the base image, not application (Python/FastAPI) code.
+- A repo-level remediation would normally be a **base image update** or an **apt upgrade** to a fixed
+  distro package version.
+- **No fixed version is available** for the observed bookworm package at triage time, so there is no
+  actionable upgrade we can apply without changing distro/suite.
+
+We therefore add a **narrow suppression** (package + exact installed version + matching PkgID prefix)
+to keep code-scanning alerts actionable, while we monitor upstream/distro status.
+
+## Monitor / upstream status
+
+- **Debian Security Tracker**: https://security-tracker.debian.org/tracker/CVE-2026-2100
+
+## Removal condition
+
+Remove the suppression when **either**:
+
+1. Debian bookworm publishes a fixed `libp11-kit0` package version for CVE-2026-2100, or
+2. Trivy metadata begins to include a `Fixed Version` for this CVE in bookworm.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-2100"`
+  - `input.PkgName == "libp11-kit0"`
+  - `input.InstalledVersion == "0.24.1-2"`
+  - `startswith(input.PkgID, "libp11-kit0@0.24.1-2")`
+
+## Expiry (manual)
+
+- **Suppression expires**: 2026-05-09

--- a/docs/security/CVE-2026-2100-libp11-kit0.md
+++ b/docs/security/CVE-2026-2100-libp11-kit0.md
@@ -20,7 +20,7 @@ At the time of triage, **Trivy reports no fixed version** for bookworm for this 
 - **No fixed version is available** for the observed bookworm package at triage time, so there is no
   actionable upgrade we can apply without changing distro/suite.
 
-We therefore add a **narrow suppression** (package + exact installed version + matching PkgID prefix)
+We therefore add a **narrow suppression** (package + exact installed version + PkgID substring match)
 to keep code-scanning alerts actionable, while we monitor upstream/distro status.
 
 ## Monitor / upstream status
@@ -41,7 +41,7 @@ Remove the suppression when **either**:
   - `input.VulnerabilityID == "CVE-2026-2100"`
   - `input.PkgName == "libp11-kit0"`
   - `input.InstalledVersion == "0.24.1-2"`
-  - `startswith(input.PkgID, "libp11-kit0@0.24.1-2")`
+  - `contains(input.PkgID, "libp11-kit0@0.24.1-2")`
 
 ## Expiry (manual)
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -112,3 +112,28 @@ ignore if {
 	cve_2026_24882_version_match
 	cve_2026_24882_pkgid_match
 }
+
+# CVE-2026-2100 (libp11-kit0) - upstream unfixed in Debian bookworm
+# Suppression expires: 2026-05-09
+# Review-by: 2026-05-09 (manual removal)
+# Rationale: Unfixed distro CVE; no actionable repo-level remediation besides base image bump (no fixed version available)
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-2100
+# Documented in: docs/security/CVE-2026-2100-libp11-kit0.md
+# Removal condition: Remove when Debian bookworm publishes a fixed libp11-kit0 package or Trivy metadata includes Fixed Version
+
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_2100_version_match if {
+	input.InstalledVersion == "0.24.1-2"
+}
+
+# Helper rule: check if PkgID matches observed libp11-kit0 package
+cve_2026_2100_pkgid_match if {
+	startswith(input.PkgID, "libp11-kit0@0.24.1-2")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-2100"
+	input.PkgName == "libp11-kit0"
+	cve_2026_2100_version_match
+	cve_2026_2100_pkgid_match
+}

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -114,7 +114,7 @@ ignore if {
 }
 
 # CVE-2026-2100 (libp11-kit0) - upstream unfixed in Debian bookworm
-# Review-by: 2026-05-09 (manual removal)
+# Review-by: see docs/security/CVE-2026-2100-libp11-kit0.md
 # Rationale: Unfixed distro CVE; no actionable repo-level remediation besides base image bump (no fixed version available)
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-2100
 # Documented in: docs/security/CVE-2026-2100-libp11-kit0.md
@@ -125,9 +125,14 @@ cve_2026_2100_version_match if {
 	input.InstalledVersion == "0.24.1-2"
 }
 
-# Helper rule: check if PkgID matches observed libp11-kit0 package
+# Helper rule: check if PkgID matches observed libp11-kit0 package.
+#
+# Trivy's PkgID format is not a stable API. In practice it has contained the
+# substring "<PkgName>@<InstalledVersion>" for OS packages; we match via
+# contains() (not startswith) to avoid silent mismatches if Trivy prepends
+# distro/arch qualifiers.
 cve_2026_2100_pkgid_match if {
-	startswith(input.PkgID, "libp11-kit0@0.24.1-2")
+	contains(input.PkgID, "libp11-kit0@0.24.1-2")
 }
 
 ignore if {

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -114,7 +114,7 @@ ignore if {
 }
 
 # CVE-2026-2100 (libp11-kit0) - upstream unfixed in Debian bookworm
-# Review-by: see docs/security/CVE-2026-2100-libp11-kit0.md
+# Review-by: 2026-05-09 (manual removal)
 # Rationale: Unfixed distro CVE; no actionable repo-level remediation besides base image bump (no fixed version available)
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-2100
 # Documented in: docs/security/CVE-2026-2100-libp11-kit0.md

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -114,7 +114,6 @@ ignore if {
 }
 
 # CVE-2026-2100 (libp11-kit0) - upstream unfixed in Debian bookworm
-# Suppression expires: 2026-05-09
 # Review-by: 2026-05-09 (manual removal)
 # Rationale: Unfixed distro CVE; no actionable repo-level remediation besides base image bump (no fixed version available)
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-2100


### PR DESCRIPTION
## Summary
- Suppress Trivy OS package vulnerability finding for CVE-2026-2100 on Debian bookworm package `libp11-kit0` (installed `0.24.1-2`) where Trivy reports no fixed version.
- Add narrow `ignore-policy` rule scoped by VulnerabilityID + PkgName + InstalledVersion + PkgID prefix.
- Document monitoring and removal conditions with an explicit expiry.

## Security context
- GitHub code scanning alert: `security/code-scanning/535`
- Monitor: `https://security-tracker.debian.org/tracker/CVE-2026-2100`
- Expiry: 2026-05-09

## Test plan
- `pre-commit run --all-files`
- `make verify`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Задокументировать временное подавление Trivy для CVE-2026-2100 в libp11-kit0, включая область действия, ссылку для мониторинга, условия удаления и дату ручного истечения срока действия.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the temporary Trivy suppression for CVE-2026-2100 in libp11-kit0, including scope, monitoring link, removal conditions, and manual expiry date.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Trivy finding CVE-2026-2100 for Debian bookworm libp11-kit0 (0.24.1-2) with a narrow Rego ignore-policy to keep scans actionable until a fix exists. Adds docs, links monitoring (Debian tracker), sets file-level expiry 2026-05-09, and references GitHub alert security/code-scanning/535.

- **Bug Fixes**
  - Conform ignore-policy to CI by keeping a single file-level expiry and adding an explicit per-entry Review-by date; remove the extra per-entry expiry tag.
  - Relax PkgID match to contains("<PkgName>@<InstalledVersion>") to reduce coupling to Trivy PkgID formatting.

<sup>Written for commit 5b496afefecc6547ad5239a84e0fc5fb1acc4d29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance documenting a temporary suppression for OS package vulnerability CVE-2026-2100 (libp11-kit0), including context, rationale, monitoring links, removal conditions, and a manual expiry date.

* **Chores**
  * Introduced a narrowly scoped suppression policy that targets the exact package and installed version, with metadata to keep alerts actionable and time-limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->