### PR TITLE
docs(ledger): close legacy nutrition alias observability item

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -489,15 +489,15 @@ If it is not recorded here — it does not exist.
     - Outputs include explicit `sources[]` and confidence/uncertainty fields per contract
     - No OpenAPI determinism regressions; `make verify` passes
 
-- [ ] Observability: measure legacy nutrition alias usage (deprecation removal readiness)
+- [x] Observability: measure legacy nutrition alias usage (deprecation removal readiness)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (observability / migration)
-  - Target PR: TBD (backend-only)
-  - Status: 📋 Planned
+  - Target PR: PR-698
+  - Status: ✅ Merged (PR-698, 2026-02-09)
   - Reason: `GET /api/nutrition/{date_str}` is a deprecated compatibility alias. Before removing it safely, we need
     basic usage telemetry (by client/platform) to confirm iOS migration completion and avoid breaking unknown consumers.
   - Links:
-    - `legacy_app.py` (`/api/nutrition/{date_str}` legacy alias)
+    - `app/routers/legacy_nutrition_alias.py` (`/api/nutrition/{date_str}` legacy alias)
     - `docs/roadmap/BACKLOG_LEDGER.md` (P0 security fix item for alias guard)
   - DoD:
     - Count requests to `/api/nutrition/{date_str}` with low-cardinality labels (e.g., platform/client + status)


### PR DESCRIPTION
## Summary
- Marked "Observability: measure legacy nutrition alias usage" as merged (PR-698).

## Why
- Ledger is the canonical SoT for deferred/follow-up work; we close items via a docs-only PR after the implementation PR merges.

## Evidence
- Implementation PR: #698

## Test plan
- N/A (docs-only)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить документацию по журналу бэклога, чтобы отметить, что устаревшая задача по наблюдаемости псевдонима nutrition была объединена, с ссылкой на PR-698 и текущее местоположение кода.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update backlog ledger documentation to mark the legacy nutrition alias observability task as merged with reference to PR-698 and the current code location.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked the backlog item “Observability: measure legacy nutrition alias usage” as merged and linked it to PR-698. Updated the code reference from legacy_app.py to app/routers/legacy_nutrition_alias.py.

<sup>Written for commit aeb15b39fc48ca312859f65a041790a44a6ee756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog tracking records to reflect completion of observability improvements and updated internal implementation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->