### PR TITLE
fix(tests): avoid stale legacy_app patches under xdist

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,19 @@
 - Preserve xdist DB isolation: each worker gets its own SQLite path.
 - Prefer `monkeypatch` over global mutations; avoid real sleeps.
 
+### Module purge / reload invariant (xdist stability)
+
+Some tests intentionally purge/reload modules (e.g., via `module_purge.purge_modules(...)` or
+`importlib.reload(...)`) to validate import-time wiring. Under xdist, this can create **stale**
+module references and CI-only flakes if a test patches a module object captured before the purge.
+
+**Hard rules:**
+
+- If a test (directly or indirectly) purges/reloads modules, it **MUST** resolve modules at runtime
+  before patching/using them (preferred: `importlib.import_module("legacy_app")`).
+- Avoid `from pkg.mod import name` in purge/reload-sensitive code paths: imported symbols can become
+  stale after module re-import, breaking `monkeypatch.setattr()` and causing order-dependent flakes.
+
 ### SQLite test bootstrap rule (xdist / nightly)
 
 Any test touching DB must ensure full schema initialization (`import models` + `Base.metadata.create_all`) before execution. Teardown must be idempotent and tolerate missing tables (e.g. catch `OperationalError` and rollback instead of failing). This prevents "no such table" and thread-safety issues under `pytest -n auto`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -27,10 +27,12 @@ module references and CI-only flakes if a test patches a module object captured 
 
 **Hard rules:**
 
-- If a test (directly or indirectly) purges/reloads modules, it **MUST** resolve modules at runtime
-  before patching/using them (preferred: `importlib.import_module("legacy_app")`).
+- If a test (directly or indirectly) purges/reloads modules (including `module_purge.purge_modules(...)`
+  or `importlib.reload(...)`), it **MUST** resolve modules at runtime before patching/using them
+  (preferred: `importlib.import_module("legacy_app")`).
 - Avoid `from pkg.mod import name` in purge/reload-sensitive code paths: imported symbols can become
   stale after module re-import, breaking `monkeypatch.setattr()` and causing order-dependent flakes.
+  This usually manifests as “patch applied but request path still uses real code”.
 
 ### SQLite test bootstrap rule (xdist / nightly)
 

--- a/tests/helpers/module_resolve.py
+++ b/tests/helpers/module_resolve.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+def resolve_module(name: str) -> ModuleType:
+    """Resolve a module by name at runtime.
+
+    RU: Всегда резолвим модуль в runtime, чтобы не поймать stale refs после purge/reload.
+    EN: Always resolve module at runtime to avoid stale refs after purge/reload.
+    """
+
+    return importlib.import_module(name)
+
+
+def resolve_legacy_app() -> ModuleType:
+    return resolve_module("legacy_app")
+
+
+def resolve_llm() -> ModuleType:
+    return resolve_module("llm")

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import importlib
-
 import pytest
 from fastapi.testclient import TestClient
 
 from tests.helpers.fake_llm_provider import FakeLLMProvider
+from tests.helpers.module_resolve import resolve_legacy_app, resolve_llm
 
 
 def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,8 +30,8 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
     # IMPORTANT: resolve modules at runtime to avoid stale module references.
     # Some tests intentionally purge/reload modules (see module_purge), and under xdist this can
     # create multiple module instances. Patching a stale module object is a common CI-only flake.
-    legacy_app = importlib.import_module("legacy_app")
-    llm = importlib.import_module("llm")
+    legacy_app = resolve_legacy_app()
+    llm = resolve_llm()
 
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)
     # Provider mocking must be robust across CI import paths.

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import importlib
+
 import pytest
 from fastapi.testclient import TestClient
 
-import llm
-import legacy_app
 from tests.helpers.fake_llm_provider import FakeLLMProvider
 
 
@@ -27,6 +27,12 @@ def _patch_insight_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def _noop_quota(*_args: object, **_kwargs: object) -> None:
         return None
+
+    # IMPORTANT: resolve modules at runtime to avoid stale module references.
+    # Some tests intentionally purge/reload modules (see module_purge), and under xdist this can
+    # create multiple module instances. Patching a stale module object is a common CI-only flake.
+    legacy_app = importlib.import_module("legacy_app")
+    llm = importlib.import_module("llm")
 
     monkeypatch.setattr(legacy_app, "_enforce_vip_llm_monthly_quota", _noop_quota, raising=True)
     # Provider mocking must be robust across CI import paths.

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -7,7 +7,6 @@ EN: P0 tests: deterministic monthly hard quota for VIP LLM (requests/month).
 from __future__ import annotations
 
 import concurrent.futures
-import importlib
 import threading
 from collections.abc import Callable
 from datetime import date
@@ -24,6 +23,7 @@ from app.security.llm_monthly_quota import (
 )
 
 from tests.helpers.fake_llm_provider import FakeLLMProvider
+from tests.helpers.module_resolve import resolve_legacy_app
 
 
 def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -36,7 +36,7 @@ def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_load_llm_get_provider() -> Callable[[], FakeLLMProvider]:
         return lambda: FakeLLMProvider()
 
-    legacy_app = importlib.import_module("legacy_app")
+    legacy_app = resolve_legacy_app()
     monkeypatch.setattr(
         legacy_app, "_load_llm_get_provider", _fake_load_llm_get_provider, raising=True
     )

--- a/tests/test_insight_vip_monthly_quota_api.py
+++ b/tests/test_insight_vip_monthly_quota_api.py
@@ -7,6 +7,7 @@ EN: P0 tests: deterministic monthly hard quota for VIP LLM (requests/month).
 from __future__ import annotations
 
 import concurrent.futures
+import importlib
 import threading
 from collections.abc import Callable
 from datetime import date
@@ -14,8 +15,6 @@ from datetime import date
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-
-import legacy_app
 
 from app.middleware.api_tiers import TEST_KEY_VIP
 from app.security.llm_monthly_quota import (
@@ -37,6 +36,7 @@ def _patch_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_load_llm_get_provider() -> Callable[[], FakeLLMProvider]:
         return lambda: FakeLLMProvider()
 
+    legacy_app = importlib.import_module("legacy_app")
     monkeypatch.setattr(
         legacy_app, "_load_llm_get_provider", _fake_load_llm_get_provider, raising=True
     )


### PR DESCRIPTION
## Summary
- Fix CI-only flake where VIP insight guard tests could return 503 "No LLM provider configured" under xdist.
- Resolve `legacy_app`/`llm` modules at runtime in patch helpers to avoid stale module references after `module_purge`.
- Document the invariant in `tests/AGENTS.md`.

## Root cause
Some tests intentionally purge/reload modules (see `module_purge`). Under xdist scheduling, this can result in the FastAPI app using a freshly-imported `legacy_app` module while a test module holds an older module object imported at collection time. Monkeypatching the stale module object does not affect the live handler, producing 503.

## Test plan
- `pytest -q -n 4 --dist=loadscope tests/test_insight_vip_guard_api.py`
- `pytest -q -n 4 --dist=loadscope tests/test_insight_vip_monthly_quota_api.py`
- `make verify`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Обеспечить стабильность тестов VIP insight guard при использовании xdist, когда модули очищаются и перезагружаются.

Bug Fixes:
- Исправлена нестабильность в CI, при которой тесты VIP insight guard могли получать 503 из-за патчинга устаревших экземпляров модулей `legacy_app`/`llm` при работе под xdist.

Enhancements:
- Обновлены вспомогательные функции тестов VIP insight guard, чтобы разрешать модули `legacy_app` и `llm` во время выполнения перед применением monkeypatch.
- Задокументирован инвариант xdist-безопасной очистки/перезагрузки модулей для тестов, включая рекомендации по избеганию устаревших импортов в путях, чувствительных к очистке.

Documentation:
- Расширены рекомендации по тестированию AGENTS правилами для поведения при очистке/перезагрузке модулей и предотвращения устаревших импортов при работе под xdist.

Tests:
- Скорректированы тесты VIP insight guard и месячной квоты так, чтобы импортировать `legacy_app` во время выполнения перед monkeypatching, повышая устойчивость при сценариях с перезагрузкой модулей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure VIP insight guard tests remain stable under xdist when modules are purged and reloaded.

Bug Fixes:
- Resolve CI flakiness where VIP insight guard tests could hit a 503 due to patching stale legacy_app/llm module instances under xdist.

Enhancements:
- Update VIP insight guard test helpers to resolve legacy_app and llm modules at runtime before applying monkeypatches.
- Document an xdist-safe module purge/reload invariant for tests, including guidance on avoiding stale imports in purge-sensitive paths.

Documentation:
- Expand AGENTS testing guidelines with rules for module purge/reload behavior and avoiding stale imports under xdist.

Tests:
- Adjust VIP insight guard and monthly quota tests to import legacy_app at runtime before monkeypatching, improving robustness under module reload scenarios.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CI flake in VIP insight guard and monthly quota tests under pytest-xdist by resolving legacy_app and llm at runtime before monkeypatching. Prevents stale patches that caused 503 “No LLM provider configured” responses.

- **Bug Fixes**
  - Resolve modules at runtime in test patch helpers so patches hit the current instance after purge/reload.
  - Document the purge/reload invariant in tests/AGENTS.md and warn against from-imports in sensitive paths.

- **Refactors**
  - Centralize runtime module resolution in tests/helpers/module_resolve.py and update tests to use resolve_legacy_app/resolve_llm.

<sup>Written for commit a8a929844e0c5b1441d1e8bdd9e5385938e97e6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability in distributed/parallel runs by resolving modules at runtime to avoid stale references.
  * Updated patching strategy to target runtime-resolved modules, reducing flakes in CI.

* **Documentation**
  * Added guidance on module purge/reload invariants and safe patching practices for test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->