### PR TITLE
test(guards): enforce runtime module resolve after purge

### DIFF
--- a/tests/test_module_purge_runtime_resolve_guard.py
+++ b/tests/test_module_purge_runtime_resolve_guard.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from module_purge import purge_modules
+
+from tests.helpers.module_resolve import resolve_legacy_app
+
+
+def test_runtime_resolve_after_purge_returns_new_module_object() -> None:
+    """RU: Guard против stale module refs после purge/reload под xdist.
+    EN: Guard against stale module refs after purge/reload under xdist.
+
+    Если кто-то снова начнёт держать ссылку на legacy_app, а потом вызывать purge,
+    последующие monkeypatch/setattr могут патчить stale объект. Этот тест гарантирует,
+    что runtime-resolve действительно возвращает новый объект модуля после purge.
+    """
+    legacy_before = resolve_legacy_app()
+    before_id = id(legacy_before)
+
+    purge_modules(prefixes=("legacy_app",))
+
+    legacy_after = resolve_legacy_app()
+    after_id = id(legacy_after)
+
+    assert after_id != before_id, (
+        "Expected legacy_app module object identity to change after purge_modules(); "
+        "otherwise stale module references may persist and monkeypatch.setattr() can patch "
+        "a module that is no longer used by the running FastAPI app."
+    )

--- a/tests/test_module_purge_runtime_resolve_guard.py
+++ b/tests/test_module_purge_runtime_resolve_guard.py
@@ -14,14 +14,13 @@ def test_runtime_resolve_after_purge_returns_new_module_object() -> None:
     что runtime-resolve действительно возвращает новый объект модуля после purge.
     """
     legacy_before = resolve_legacy_app()
-    before_id = id(legacy_before)
 
     purge_modules(prefixes=("legacy_app",))
 
     legacy_after = resolve_legacy_app()
-    after_id = id(legacy_after)
 
-    assert after_id != before_id, (
+    assert legacy_after.__name__ == "legacy_app"
+    assert legacy_after is not legacy_before, (
         "Expected legacy_app module object identity to change after purge_modules(); "
         "otherwise stale module references may persist and monkeypatch.setattr() can patch "
         "a module that is no longer used by the running FastAPI app."


### PR DESCRIPTION
## Summary
- Add a small guard test that enforces the runtime-resolve invariant after `module_purge.purge_modules(...)`.

## Why
- Prevent regression where tests patch a stale `legacy_app` module object after purge/reimport under xdist, leading to CI-only flakes.

## Test plan
- `pytest -q tests/test_module_purge_runtime_resolve_guard.py`
- `make verify`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Тесты:
- Добавлен тест, проверяющий, что при выполнении runtime‑разрешения `legacy_app` возвращается новый экземпляр модуля после вызова `purge_modules()`, чтобы предотвратить устаревшие ссылки на модуль при использовании xdist.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add a test verifying that runtime resolution of legacy_app returns a new module instance after purge_modules() to prevent stale module references under xdist.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying that after purging modules, resolving a previously loaded module at runtime yields a new module instance.
  * Ensures stale module references are not retained after purge/reload, improving reliability of multi-process or concurrent test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->