### PR TITLE
PR-A: Move LLM provider loader to core/insight (thin legacy alias)

### DIFF
--- a/core/insight/llm_provider_loader.py
+++ b/core/insight/llm_provider_loader.py
@@ -1,0 +1,27 @@
+"""LLM provider loader (insight).
+
+RU: Лоадер для ленивого импорта `llm.get_provider`.
+EN: Loader for lazily importing `llm.get_provider`.
+
+Hard invariants:
+- No import-time side effects (OpenAPI determinism): do NOT import `llm` at module scope.
+- Keep the behavior identical to legacy path; HTTP mapping happens in callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def load_llm_get_provider() -> Callable[[], Any]:
+    """Load `llm.get_provider` lazily.
+
+    RU: Вынесено из `legacy_app.py` чтобы legacy оставался thin shim и чтобы тесты могли
+    детерминированно покрывать ветку import-failure без sys.modules мутаций и без патча
+    builtins.__import__.
+    EN: Extracted from `legacy_app.py` to keep legacy thin and to allow deterministic testing
+    of the import-failure branch without sys.modules mutation and without patching builtins.__import__.
+    """
+    from llm import get_provider
+
+    return get_provider

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2057,18 +2057,9 @@ from core.insight.safety import (  # noqa: E402
     redact_rag_context_for_insight as _redact_rag_context_for_insight,
 )
 
-
-def _load_llm_get_provider() -> Callable[[], Any]:
-    """Load llm.get_provider lazily.
-
-    RU: Вынесено в helper для детерминированного тестирования ветки import-failure
-    без мутаций sys.modules и без патча builtins.__import__.
-    EN: Extracted for deterministic import-failure testing without sys.modules mutation.
-    """
-
-    from llm import get_provider
-
-    return get_provider
+from core.insight.llm_provider_loader import (  # noqa: E402
+    load_llm_get_provider as _load_llm_get_provider,
+)
 
 
 async def insight_v1(req: InsightRequest) -> InsightResponse:

--- a/tests/test_insight_vip_guard_api.py
+++ b/tests/test_insight_vip_guard_api.py
@@ -112,4 +112,28 @@ def test_insight_legacy_requires_vip_tier(
     assert data["insight"] == "ok"
 
 
+# --- Guards for loader extraction (PR-A) ---
+
+
+def test_core_llm_provider_loader_resolves_llm_get_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard: canonical loader must stay lazy and patchable.
+
+    We patch `llm.get_provider` first, then assert the loader returns the patched symbol.
+    This ensures `core.insight.llm_provider_loader.load_llm_get_provider()` is executed (diff-cover)
+    without relying on endpoint behavior.
+    """
+    llm = resolve_llm()
+
+    def _sentinel_get_provider() -> object:
+        return object()
+
+    monkeypatch.setattr(llm, "get_provider", _sentinel_get_provider, raising=True)
+
+    from core.insight.llm_provider_loader import load_llm_get_provider
+
+    assert load_llm_get_provider() is _sentinel_get_provider
+
+
 # End of file


### PR DESCRIPTION
## Summary
- Move `_load_llm_get_provider` implementation out of `legacy_app.py` into `core/insight/llm_provider_loader.py`.
- Keep `legacy_app.py` as a thin alias seam for tests.
- Add a minimal test to execute the new loader for diff-cover.

## Scope
- Only: `core/insight/llm_provider_loader.py`, `legacy_app.py`, `tests/test_insight_vip_guard_api.py`.
- Non-goals: no router/OpenAPI changes, no quota/rate-limit changes.

## Verification
- `pre-commit run --all-files`
- `make verify`

## Summary by Sourcery

Вынесен ленивый загрузчик провайдера LLM из устаревшего приложения insight в отдельный модуль ядра, при этом сохранён тонкий совместимый алиас и добавлен минимальный защитный тест.

Улучшения:
- Введён выделенный модуль `core.insight.llm_provider_loader` для инкапсуляции ленивого разрешения `llm.get_provider` и отделения его от устаревшего приложения.
- Сохранён `legacy_app._load_llm_get_provider` как тонкий алиас на новый загрузчик в ядре для сохранения существующего поведения.

Тесты:
- Добавлен защитный тест, который гарантирует, что новый загрузчик в ядре лениво разрешает и остаётся патчабельным для `llm.get_provider`, не полагаясь на HTTP-эндпоинты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract the lazy LLM provider loader from the legacy insight app into a dedicated core module while keeping a thin compatibility alias and adding a minimal guard test.

Enhancements:
- Introduce a dedicated core.insight.llm_provider_loader module to encapsulate lazy resolution of llm.get_provider and decouple it from the legacy app.
- Retain legacy_app._load_llm_get_provider as a thin alias to the new core loader to preserve existing behavior.

Tests:
- Add a guard test ensuring the new core loader lazily resolves and remains patchable for llm.get_provider without relying on HTTP endpoints.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the LLM provider lazy loader from legacy_app.py to core/insight/llm_provider_loader.py to keep legacy thin and preserve OpenAPI determinism; legacy_app now aliases it. Added a small guard test; behavior unchanged.

<sup>Written for commit 8b0029485eea719e6a75aa6c56967e1f54352631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized LLM provider loading mechanism to improve app initialization and eliminate potential side effects during startup.

* **Tests**
  * Added tests to verify lazy loading functionality operates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->