### PR TITLE
Docs: close ledger item for PR-703

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -766,14 +766,16 @@ If it is not recorded here — it does not exist.
     - 🔄 Monitor: GitHub alert #515 should auto-resolve after next Trivy scan on `main`
     - 🔄 Follow-up (after 2026-04-28 or when fixed): Remove suppression when Debian bookworm publishes fixed `gpgv` package (≥ 2.5.17 or backported fix), OR Trivy metadata includes fixed version
 
-- [ ] Move insight redaction/import helpers out of legacy_app.py
+- [x] Move insight redaction/import helpers out of legacy_app.py (merged 2026-02-10)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: TBD
+  - Target PR: PR-703 (merged)
+  - Status: ✅ Merged
   - Reason: Codex actionable — keep legacy_app thin proxy only. Move `_redact_rag_context_for_insight` and `_load_llm_get_provider` to canonical module (`core/insight/`) to maintain AGENTS invariant. Follow-up from PR-611.
   - Links:
     - docs/audit/PR_611_INSIGHT_SAFETY_ERROR_HYGIENE_AUDIT.md
     - PR-611 (merged 2026-01-28)
+    - PR-703 (merged 2026-02-10)
   - Preconditions (already true as of PR-611):
     - `_redact_rag_context_for_insight` lives in `core/insight/safety.py`
   - DoD:


### PR DESCRIPTION
## Summary
- Mark ledger item "Move insight redaction/import helpers out of legacy_app.py" as merged via PR-703.

## Scope
- Docs-only: `docs/roadmap/BACKLOG_LEDGER.md`.

## Verification
- Docs-only scope check (no runtime files).

## Summary by Sourcery

Документация:
- Записать сведения о выполнении задачи по помощникам редактирования/импорта инсайтов в реестр бэклога, включая дату слияния и ссылки на PR.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Record completion details for the insight redaction/import helpers task in the backlog ledger, including merge date and PR references.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation to reflect completed refactoring work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->