### PR TITLE
docs(runbook): triage upload-artifact FinalizeArtifact 403

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -108,6 +108,39 @@ Rule: RUNBOOK does not duplicate checklists; it only links to the canonical sour
 
 **This is the authoritative procedural checklist.** Thresholds/policy live in `AGENTS.md`.
 
+## 0.1) CI: `actions/upload-artifact` fails with `FinalizeArtifact 403 Forbidden`
+
+**Symptom (GitHub Actions logs):**
+
+- `Error: Failed to FinalizeArtifact: ... (403) Forbidden`
+- often in steps like “Upload JUnit test report” / “Upload coverage artifact”
+
+**Likely cause:** repository-level **default** workflow token permissions were set to `read`, which can break artifact
+finalization even when the byte upload succeeded.
+
+**Check (repo setting):**
+
+```bash
+gh api repos/<OWNER>/<REPO>/actions/permissions/workflow
+```
+
+Expected (for this repo’s CI which uploads/downloads artifacts):
+
+```json
+{"default_workflow_permissions":"write", ...}
+```
+
+**Fix (requires repo admin):**
+
+```bash
+gh api -X PUT repos/<OWNER>/<REPO>/actions/permissions/workflow -f default_workflow_permissions=write
+```
+
+**Also verify workflow/job permissions:** the job that uploads artifacts should request `actions: write`.
+(Example: in CI workflows, see job-level `permissions:` blocks for test jobs.)
+
+**Post-fix:** re-run the failed workflow run (`gh run rerun <RUN_ID> --failed`) and confirm artifact steps pass.
+
 ## 0) Golden Rule
 
 Before editing imports / `__init__` / sys.path / sys.modules:

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -124,13 +124,19 @@ finalization even when the byte upload succeeded.
 gh api repos/<OWNER>/<REPO>/actions/permissions/workflow
 ```
 
-Expected (for this repo’s CI which uploads/downloads artifacts):
+Expected (for this repo’s CI, which uploads/downloads artifacts):
 
 ```json
 {"default_workflow_permissions":"write", ...}
 ```
 
 **Fix (requires repo admin):**
+
+**Scope note:** changing repository-level `default_workflow_permissions` affects **all workflows** in this repository.
+Coordinate with repo owners / security if needed before changing the default.
+
+**Reference docs:** GitHub Actions `GITHUB_TOKEN` permissions:
+`https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication`
 
 ```bash
 gh api -X PUT repos/<OWNER>/<REPO>/actions/permissions/workflow -f default_workflow_permissions=write


### PR DESCRIPTION
## Summary
Adds a short CI triage note to `RUNBOOK_AGENT.md` for GitHub Actions failures where `actions/upload-artifact` uploads bytes but fails on `FinalizeArtifact` with `403 Forbidden`.

## What changed
- Documents how to check/fix default workflow token permissions via `gh api`
- Reminds to verify job-level `permissions: actions: write`
- Provides a safe rerun command for failed runs

## Test plan
- `pre-commit run --all-files`

## Notes
- Docs-only change.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Добавлен раздел runbook, описывающий, как диагностировать и исправлять ошибки `actions/upload-artifact` `FinalizeArtifact 403 Forbidden` в GitHub Actions, включая информацию о необходимых разрешениях и рекомендации по повторному запуску.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a runbook section describing how to diagnose and fix `actions/upload-artifact` `FinalizeArtifact 403 Forbidden` errors in GitHub Actions, including required permissions and rerun guidance.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for resolving GitHub Actions artifact finalization failures, including diagnostic procedures and step-by-step remediation instructions.
  * Documentation covers symptom identification, permission configuration verification, repository setting validation, and post-fix verification steps to ensure successful artifact deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->