### PR TITLE
test(guards): enforce agent index and context map sync

### DIFF
--- a/docs/audit/PR_TBD_AGENT_INDEX_GUARDS_AUDIT_2026-02-11.md
+++ b/docs/audit/PR_TBD_AGENT_INDEX_GUARDS_AUDIT_2026-02-11.md
@@ -1,0 +1,116 @@
+# PR Audit — Agent Index + Guard Tests (Analytics/Web block)
+
+**Date:** 11 February 2026
+**Scope:** tests + docs (guard-style tests for agent registry + canonical protocol references)
+**Status:** Opinion + Evidence (commands are reproducible; outputs are examples)
+
+---
+
+## Summary
+
+We now have multiple canonical “agent surfaces” that must stay in sync:
+
+- `.cursor/agents/*.md` (canonical agent specs)
+- `docs/agents/index.md` (canonical index)
+- `docs/orchestration/AGENT_CONTEXT_MAP.md` (canonical required-reading map)
+
+Drift between these surfaces is a recurring failure mode (new agent/spec added, but index or context map forgotten),
+which directly reduces orchestration quality and increases “missing context” errors in multi-agent work.
+
+This PR adds deterministic guard tests to prevent registry drift and accidental removal of canonical protocol links.
+
+---
+
+## Evidence (repo truth)
+
+### 1) Canonical agent specs exist under `.cursor/agents/`
+
+Command:
+
+```bash
+ls .cursor/agents
+```
+
+Example output (may drift as agents are added/removed):
+
+```text
+agent-coordinator.md
+ai-app-architect.md
+ai-innovation-specialist.md
+architecture-specialist.md
+bayesian-uq-agent.md
+bug-hunter.md
+cbt-psychologist-agent.md
+creative-designer.md
+cv-agent.md
+data-scientist-agent.md
+epistemology-discovery-agent.md
+logic-agent.md
+marketing-strategist.md
+ml-engineer-agent.md
+nutritionist-agent.md
+philosophy-agent.md
+physics-sensor-agent.md
+rag-systems-agent.md
+security-auditor.md
+web-research-agent.md
+AGENTS.md
+```
+
+Interpretation:
+
+- `AGENTS.md` is a meta file (no YAML frontmatter); it is **not** an agent spec.
+- Each real agent spec has YAML frontmatter including `name: ...`.
+
+### 2) Index and context map are the required sync surfaces
+
+Canonical registration path is documented in `docs/agents/UPDATE_INSTRUCTIONS.md`:
+
+- agent spec: `.cursor/agents/<agent>.md`
+- index: `docs/agents/index.md`
+- context map: `docs/orchestration/AGENT_CONTEXT_MAP.md`
+
+---
+
+## Changes (what this PR enforces)
+
+### Guard: agent registry sync
+
+New test: `tests/test_agent_docs_registry_guard.py`
+
+Enforces:
+
+- Every agent spec in `.cursor/agents/*.md` with YAML `name:` is listed in `docs/agents/index.md`
+- Every agent spec is listed in `docs/orchestration/AGENT_CONTEXT_MAP.md`
+- No “extra” entries exist in index/context map without a corresponding agent spec
+
+### Guard: canonical protocol references are not accidentally removed
+
+Also enforces that both:
+
+- `AGENTS.md`, and
+- `docs/orchestration/workflow.md`
+
+continue to reference the canonical protocols:
+
+- `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`
+- `docs/orchestration/RESEARCH_TRACK_PROTOCOL.md`
+- `docs/orchestration/RESEARCH_BRAINSTORMING_PROTOCOL.md`
+- `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md`
+
+---
+
+## Test plan
+
+```bash
+pytest -q tests/test_agent_docs_registry_guard.py
+make verify
+```
+
+---
+
+## Non-goals
+
+- No runtime behavior changes
+- No changes to the agent protocol semantics (only guard enforcement of registry consistency)
+- No “auto-generation” of indexes (kept manual + enforced by tests to avoid hidden drift)

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -344,6 +344,28 @@ Use: `make verify`, `make cov-check`, and `git push` as described there (force p
 
 This file (`tests/AGENTS.md`) contains ONLY test-specific rules (diff coverage, mocking constraints, forbidden patterns).
 
+## Guard tests (docs registry)
+
+The repo uses deterministic, repo-local “guard tests” to prevent instruction drift.
+
+- **Agent registry guard**: `tests/test_agent_docs_registry_guard.py`
+  - **What it enforces**:
+    - `.cursor/agents/*.md` entries with YAML frontmatter `name:` must be registered in:
+      - `docs/agents/index.md` (the **"## Available Agents"** table only)
+      - `docs/orchestration/AGENT_CONTEXT_MAP.md`
+    - Canonical protocol references must not be accidentally removed from:
+      - `AGENTS.md`
+      - `docs/orchestration/workflow.md`
+  - **How to run**:
+
+```bash
+pytest -q tests/test_agent_docs_registry_guard.py
+```
+
+  - **How to fix failures**:
+    - If an agent spec is added/renamed in `.cursor/agents/`, update the index and context map in the same PR.
+    - Keep the agent table under the `## Available Agents` heading in `docs/agents/index.md`.
+
 ## Type hints policy (tests)
 
 ### Hard rules

--- a/tests/test_agent_docs_registry_guard.py
+++ b/tests/test_agent_docs_registry_guard.py
@@ -1,0 +1,155 @@
+"""Documentation registry guards for agent surfaces.
+
+Goal: prevent drift between canonical agent specs and the documented indexes/maps.
+
+This is a guard-style test (deterministic, repo-local) similar in spirit to
+`tests/test_repo_policy_guards.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    file_relpath: str
+    name: str
+
+
+def _read(relpath: str) -> str:
+    return (REPO_ROOT / relpath).read_text(encoding="utf-8", errors="replace")
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _parse_frontmatter_name(content: str) -> str | None:
+    """Return `name:` from YAML frontmatter, or None if absent."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    # Parse until the closing `---` (frontmatter end).
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return None
+        m = re.match(r"^name:\s*(.+?)\s*$", line)
+        if m:
+            return m.group(1).strip().strip('"').strip("'")
+    return None
+
+
+def _load_agent_specs() -> tuple[list[AgentSpec], list[str]]:
+    """Return (agent_specs, non_agent_files) from `.cursor/agents/*.md`."""
+    agent_dir = REPO_ROOT / ".cursor/agents"
+    specs: list[AgentSpec] = []
+    non_agent: list[str] = []
+
+    for path in sorted(agent_dir.glob("*.md")):
+        rel = _rel(path)
+        name = _parse_frontmatter_name(path.read_text(encoding="utf-8", errors="replace"))
+        if name is None:
+            non_agent.append(rel)
+            continue
+        specs.append(AgentSpec(file_relpath=rel, name=name))
+
+    return specs, non_agent
+
+
+def _parse_agent_index_names(index_md: str) -> list[str]:
+    """Parse agent `name` values from `docs/agents/index.md` markdown table."""
+    names: list[str] = []
+    for raw in index_md.splitlines():
+        line = raw.strip()
+        if not line.startswith("|"):
+            continue
+        if line.startswith("| Agent |"):
+            continue
+        # Skip separator row.
+        if set(line.replace("|", "").strip()) <= {"-"}:
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if not cells:
+            continue
+        first = cells[0]
+        if first:
+            names.append(first)
+    return names
+
+
+def _parse_context_map_agent_names(context_map_md: str) -> list[str]:
+    """Extract agent names from headings like: `### X (`agent-name`)`."""
+    names: list[str] = []
+    heading_re = re.compile(r"^### .*\(`(?P<name>[a-z0-9-]+)`\)\s*$")
+    for raw in context_map_md.splitlines():
+        m = heading_re.match(raw.strip())
+        if m:
+            names.append(m.group("name"))
+    return names
+
+
+def test_agent_specs_are_registered_in_index_and_context_map() -> None:
+    specs, non_agent_files = _load_agent_specs()
+    non_agent_set = set(non_agent_files)
+    assert non_agent_set <= {".cursor/agents/AGENTS.md"}, (
+        "Unexpected .cursor/agents/*.md without frontmatter `name:`. "
+        f"Allowed: .cursor/agents/AGENTS.md. Found: {sorted(non_agent_set)}"
+    )
+
+    spec_names = sorted({s.name for s in specs})
+    assert len(spec_names) == len(specs), "Duplicate agent `name:` values in .cursor/agents/*.md"
+
+    index_names = _parse_agent_index_names(_read("docs/agents/index.md"))
+    assert len(index_names) == len(
+        set(index_names)
+    ), "Duplicate agent names in docs/agents/index.md"
+
+    context_names = _parse_context_map_agent_names(_read("docs/orchestration/AGENT_CONTEXT_MAP.md"))
+    assert len(context_names) == len(
+        set(context_names)
+    ), "Duplicate agent headings in docs/orchestration/AGENT_CONTEXT_MAP.md"
+
+    missing_in_index = sorted(set(spec_names) - set(index_names))
+    extra_in_index = sorted(set(index_names) - set(spec_names))
+    assert not missing_in_index and not extra_in_index, (
+        "Agent index drift detected.\n"
+        f"- missing_in_index: {missing_in_index}\n"
+        f"- extra_in_index: {extra_in_index}\n"
+        "Fix: update docs/agents/index.md to match .cursor/agents/*.md"
+    )
+
+    missing_in_context = sorted(set(spec_names) - set(context_names))
+    extra_in_context = sorted(set(context_names) - set(spec_names))
+    assert not missing_in_context and not extra_in_context, (
+        "Agent context map drift detected.\n"
+        f"- missing_in_context: {missing_in_context}\n"
+        f"- extra_in_context: {extra_in_context}\n"
+        "Fix: update docs/orchestration/AGENT_CONTEXT_MAP.md to match .cursor/agents/*.md"
+    )
+
+
+def test_canonical_workflow_surfaces_reference_research_protocols() -> None:
+    """Prevent accidental removal of canonical protocol links."""
+    agents_md = _read("AGENTS.md")
+    workflow_md = _read("docs/orchestration/workflow.md")
+
+    required = [
+        "docs/orchestration/AGENT_MESSAGE_PROTOCOL.md",
+        "docs/orchestration/RESEARCH_TRACK_PROTOCOL.md",
+        "docs/orchestration/RESEARCH_BRAINSTORMING_PROTOCOL.md",
+        "docs/orchestration/AGENT_REFLECTION_PROTOCOL.md",
+    ]
+
+    missing_agents = [p for p in required if p not in agents_md]
+    assert not missing_agents, f"AGENTS.md missing canonical protocol refs: {missing_agents}"
+
+    missing_workflow = [p for p in required if p not in workflow_md]
+    assert not missing_workflow, (
+        "docs/orchestration/workflow.md missing canonical protocol refs: " f"{missing_workflow}"
+    )

--- a/tests/test_agent_docs_registry_guard.py
+++ b/tests/test_agent_docs_registry_guard.py
@@ -39,10 +39,20 @@ def _parse_frontmatter_name(content: str) -> str | None:
     for line in lines[1:]:
         if line.strip() == "---":
             return None
-        m = re.match(r"^name:\s*(.+?)\s*$", line)
+        m = re.match(r"^\s*name:\s*(.+?)\s*$", line)
         if m:
             return m.group(1).strip().strip('"').strip("'")
     return None
+
+
+def _is_markdown_table_separator_row(line: str) -> bool:
+    """Return True for markdown separator rows like: |---|, |:---|, |---:|, |:---:|."""
+    core = line.replace("|", "").strip()
+    if not core:
+        return False
+    core_no_ws = core.replace(" ", "")
+    # Must contain at least one dash, and only use '-' / ':' for alignment.
+    return "-" in core_no_ws and set(core_no_ws) <= {"-", ":"}
 
 
 def _load_agent_specs() -> tuple[list[AgentSpec], list[str]]:
@@ -63,23 +73,47 @@ def _load_agent_specs() -> tuple[list[AgentSpec], list[str]]:
 
 
 def _parse_agent_index_names(index_md: str) -> list[str]:
-    """Parse agent `name` values from `docs/agents/index.md` markdown table."""
+    """Parse agent `name` values from the '## Available Agents' table in `docs/agents/index.md`."""
     names: list[str] = []
+
+    in_available_agents_section = False
+    in_agent_table = False
+
     for raw in index_md.splitlines():
         line = raw.strip()
+
+        if line.startswith("## "):
+            if line == "## Available Agents":
+                in_available_agents_section = True
+                in_agent_table = False
+                continue
+            if in_available_agents_section:
+                break
+
+        if not in_available_agents_section:
+            continue
+
         if not line.startswith("|"):
+            # Stop once we've left the agent table (prevents misparsing other content).
+            if in_agent_table:
+                break
             continue
+
         if line.startswith("| Agent |"):
+            in_agent_table = True
             continue
-        # Skip separator row.
-        if set(line.replace("|", "").strip()) <= {"-"}:
+        if _is_markdown_table_separator_row(line):
+            in_agent_table = True
             continue
+
+        in_agent_table = True
         cells = [c.strip() for c in line.strip("|").split("|")]
         if not cells:
             continue
         first = cells[0]
         if first:
             names.append(first)
+
     return names
 
 


### PR DESCRIPTION
## Summary
Adds deterministic guard tests to prevent drift between canonical agent specs and the documented indexes/maps used by the analytics/web multi-agent workflows.

## What changed
- Added `tests/test_agent_docs_registry_guard.py`:
  - Ensures every `.cursor/agents/*.md` agent spec (frontmatter `name:`) is registered in:
    - `docs/agents/index.md`
    - `docs/orchestration/AGENT_CONTEXT_MAP.md`
  - Prevents accidental removal of canonical protocol references from:
    - `AGENTS.md`
    - `docs/orchestration/workflow.md`
- Added evidence-driven audit doc:
  - `docs/audit/PR_TBD_AGENT_INDEX_GUARDS_AUDIT_2026-02-11.md`

## Test plan
- `pytest -q tests/test_agent_docs_registry_guard.py`
- `make verify`

## Notes
- No runtime behavior changes; guard-only enforcement.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить тесты-гарды, чтобы поддерживать спецификации документации агентов в синхронизации с их индексом и картой контекста, а также гарантировать, что канонические ссылки на протоколы не удаляются.

Документация:
- Добавить аудиторский документ, описывающий новые гарды индекса агентов, соответствующие доказательства и контролируемые поверхности документации.

Тесты:
- Добавить детерминированные тесты, которые проверяют, что все канонические спецификации агентов зарегистрированы в индексе агентов и карте контекста оркестрации, а также что нет лишних или дублирующихся записей.
- Добавить тесты, которые подтверждают, что AGENTS.md и документация по рабочим процессам оркестрации продолжают ссылаться на канонические документы протокола агентов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add guard-style tests to keep agent documentation specs in sync with their index and context map and to ensure canonical protocol references are not removed.

Documentation:
- Add an audit document describing the new agent index guards, their evidence, and the enforced documentation surfaces.

Tests:
- Add deterministic tests that validate all canonical agent specs are registered in the agents index and orchestration context map, and that there are no extra or duplicate entries.
- Add tests that assert AGENTS.md and the orchestration workflow documentation continue to reference the canonical agent protocol documents.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guard tests to keep agent specs in sync with the docs index and context map, and to protect canonical protocol links. Parsing is hardened for the agents index table and YAML frontmatter to reduce false positives; no runtime changes.

- **New Features**
  - Enforces that each `.cursor/agents/*.md` with `name:` is listed in `docs/agents/index.md` (the "## Available Agents" table) and `docs/orchestration/AGENT_CONTEXT_MAP.md`, and flags extras.
  - Prevents removal of required protocol links in `AGENTS.md` and `docs/orchestration/workflow.md`.
  - Hardens parsing (frontmatter whitespace tolerance; ignores markdown alignment rows) and adds guard usage/fix instructions to `tests/AGENTS.md`, plus an audit doc.

<sup>Written for commit e93d8c54f49293c938ffeda2a415d95f949702c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added guard tests to ensure agent documentation stays synchronized with canonical specifications, index registries, and context maps.
  * Added validation tests to enforce presence of canonical protocol references across documentation surfaces.

* **Documentation**
  * Added audit docs and guidance describing the guard tests, expected verification steps, and how to resolve detected drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->