### PR TITLE
docs+tests: vendor-agnostic analytics indexes and guards

### DIFF
--- a/.cursor/agents/data-scientist-agent.md
+++ b/.cursor/agents/data-scientist-agent.md
@@ -24,6 +24,7 @@ Turn “we think it’s better” into measurable outcomes:
 - No new telemetry collection without explicit privacy/retention decisions.
 - No medical outcomes claims; wellness-only.
 - No runtime changes unless coordinator requests it.
+- No PII in outputs (aggregate or anonymize); prefer reproducible queries + caveats over “narrative answers”.
 
 ## When invoked
 
@@ -31,6 +32,7 @@ Turn “we think it’s better” into measurable outcomes:
 2. Designing offline evaluation for RAG grounding and contradiction rates
 3. Planning calibration evaluation for uncertainty outputs
 4. Proposing experiment sequencing and MVP measurement
+5. Defining vendor-agnostic product analytics artifacts (metrics catalog, experiment registry) and review checklists
 
 ## Required pre-flight (SoT)
 
@@ -49,9 +51,30 @@ When applicable:
 - Insight/RAG/coach work: see “Insight / AI Assistant Research Corpus (Conditional)” in
   `docs/orchestration/AGENT_CONTEXT_MAP.md`.
 
+- Product analytics / experiments (vendor-agnostic SoT; if present):
+  - `docs/analytics/ANALYTICS_INDEX.md`
+  - `docs/analytics/METRICS_CATALOG.md`
+  - `docs/analytics/DATA_CATALOG.md`
+  - `docs/analytics/EXPERIMENT_REGISTRY.md`
+
 ## Deliverable (return to coordinator)
 
 - **Metrics table**: definitions + how measured + expected ranges
 - **Eval plan**: dataset, sampling, thresholds, failure modes
 - **Experiment roadmap**: MVP → iteration → scale
 - **Privacy notes**: what data is collected and why (policy-level)
+
+## Expanded scope (analytics / metrics / experimentation)
+
+This role also serves as the single “analytics drafting hub” (without introducing a separate analytics agent) for:
+
+- **Product analytics artifacts**: metric definitions (prose + formula), metric owners, update cadence.
+- **Experiment design**: falsifiable hypothesis, success criteria, MDE/power checklist, decision rules (ship/reject).
+- **Reproducibility**: every analysis deliverable must include enough detail to be reproduced (query/pseudocode +
+  assumptions + caveats), even when the actual data source is not available in dev.
+
+## Handoffs (recommended)
+
+- To `marketing-strategist`: funnel hypotheses, paywall/onboarding messaging experiments, GTM measurement framing.
+- To `epistemology-discovery-agent`: falsifiability + negative controls + promotion recommendation (promote/reject).
+- To `ml-engineer-agent`: determinism/cost budgets when analytics touches AI/RAG/CV evaluation.

--- a/docs/analytics/ANALYTICS_INDEX.md
+++ b/docs/analytics/ANALYTICS_INDEX.md
@@ -1,0 +1,36 @@
+# Analytics Index (Catalog)
+
+**Purpose:** A vendor-agnostic catalog of what we measure and where it lives.
+
+**Status:** Canonical (docs-only). Runtime telemetry is out of scope here.
+
+---
+
+## Tracked Metrics
+
+| Metric | Definition (short) | Owner | Source of truth | Update frequency |
+|--------|---------------------|-------|-----------------|------------------|
+| Activation (first_success) | % users who complete the first core success action | TBD | `METRICS_CATALOG.md` | TBD |
+| Free → Pro conversion | % FREE users upgrading to PRO within a defined window | TBD | `METRICS_CATALOG.md` | TBD |
+| Retention D7 | % users active on day 7 after first success | TBD | `METRICS_CATALOG.md` | TBD |
+
+Notes:
+- “Source of truth” for metric semantics is `METRICS_CATALOG.md` (not dashboards).
+
+---
+
+## Data Sources
+
+| Source | Type | Schema/contract location | Access control | Notes |
+|--------|------|---------------------------|----------------|-------|
+| Primary DB | transactional | `DATA_CATALOG.md` | TBD | Vendor-agnostic |
+| Client events | telemetry/events | `DATA_CATALOG.md` | TBD | Requires privacy decision before collection |
+| Billing | payments/subscriptions | `DATA_CATALOG.md` | TBD | Vendor-agnostic |
+
+---
+
+## Dashboards (optional)
+
+| Dashboard | Tool | Owner | Update frequency | Notes |
+|----------|------|-------|------------------|------|
+| Product health | TBD | TBD | TBD | Vendor-agnostic placeholder |

--- a/docs/analytics/DATA_CATALOG.md
+++ b/docs/analytics/DATA_CATALOG.md
@@ -1,0 +1,44 @@
+# Data Catalog (Schemas + Semantics)
+
+**Purpose:** Document the meaning of fields and event properties so analyses are consistent and privacy-safe.
+
+**Status:** Canonical (docs-only). Vendor-agnostic.
+
+---
+
+## Data sources (high-level)
+
+| Source | What it contains | Owner | Notes |
+|--------|-------------------|-------|------|
+| Primary DB | users, subscriptions, core domain entities | TBD | Vendor-agnostic |
+| Client events | user actions and UI state transitions | TBD | Requires privacy/retention decisions before collection |
+
+---
+
+## Tables / entities (example templates)
+
+### users
+
+| Field | Type | Meaning | Example | Notes |
+|------|------|---------|---------|------|
+| user_id | string/uuid | stable user identifier | `...` | Never export raw IDs outside trusted contexts |
+| created_at | timestamp | account creation time (UTC) | `...` |  |
+
+### subscriptions
+
+| Field | Type | Meaning | Example | Notes |
+|------|------|---------|---------|------|
+| user_id | string/uuid | FK to users | `...` |  |
+| tier | enum | FREE / PRO / VIP | `PRO` | SoT for tiers is backend policy (`app/middleware/api_tiers.py`) |
+| created_at | timestamp | subscription start time (UTC) | `...` |  |
+
+---
+
+## Events (vendor-agnostic)
+
+### event: <event_name>
+
+| Property | Type | Meaning | Example | Notes |
+|----------|------|---------|---------|------|
+| user_id | string/uuid | stable identifier | `...` | Anonymize in analysis outputs |
+| occurred_at | timestamp | event time (UTC) | `...` |  |

--- a/docs/analytics/EXPERIMENT_REGISTRY.md
+++ b/docs/analytics/EXPERIMENT_REGISTRY.md
@@ -1,0 +1,22 @@
+# Experiment Registry
+
+**Purpose:** Track experiments end-to-end and prevent “zombie experiments” or p-hacking by making hypotheses and
+success criteria explicit.
+
+**Status:** Canonical (docs-only). Vendor-agnostic.
+
+---
+
+## Active Experiments
+
+| Experiment | Hypothesis (falsifiable) | Start date | End date | Owner | Status |
+|-----------|---------------------------|------------|----------|-------|--------|
+| TBD | TBD | TBD | TBD | TBD | Planned |
+
+---
+
+## Completed Experiments
+
+| Experiment | Result (summary) | Decision | Date | Evidence |
+|-----------|-------------------|----------|------|----------|
+| TBD | TBD | TBD | TBD | PR/ADR link |

--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -1,0 +1,63 @@
+# Metrics Catalog (Definitions)
+
+**Purpose:** Prevent metric drift by making metric **semantics** explicit and reviewable.
+
+**Status:** Canonical (docs-only). This file is the SoT for metric definitions.
+
+---
+
+## Metric template (copy/paste)
+
+### <Metric Name>
+
+#### Definition
+
+1–2 sentences, unambiguous.
+
+#### Formula
+
+Provide a reproducible query or pseudocode (vendor-agnostic is fine):
+
+```sql
+-- Replace with the canonical query/pseudocode.
+-- Include time window, cohort definition, and exclusions explicitly.
+SELECT 1;
+```
+
+#### Owner
+
+Who owns this metric definition and approves changes (team or person).
+
+#### Update frequency
+
+Real-time / daily / weekly (and when it is computed).
+
+#### Change history
+
+- YYYY-MM-DD: what changed and why (link PR/ADR if applicable)
+
+---
+
+## Activation (first_success)
+
+#### Definition
+
+Percent of new users who complete the first core success action within a defined time window after first launch.
+
+#### Formula
+
+```text
+activation = users_with_first_success_within_window / eligible_new_users
+```
+
+#### Owner
+
+TBD
+
+#### Update frequency
+
+TBD
+
+#### Change history
+
+- 2026-02-11: initial placeholder definition (vendor-agnostic)

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -1,0 +1,28 @@
+# Analytics (Vendor-agnostic)
+
+**Purpose:** Provide repo-native, vendor-agnostic artifacts for product analytics and experimentation so that:
+
+- metric definitions do not drift silently
+- experiments are tracked end-to-end (hypothesis → decision → promotion)
+- analysis requests and outputs are reproducible (query/pseudocode + assumptions + caveats)
+
+**Non-goal:** This folder does not prescribe a specific vendor stack (Amplitude/Mixpanel/Grafana/etc.).
+Integrations and runtime telemetry changes must land in separate runtime PRs with privacy decisions.
+
+---
+
+## Files (canonical surfaces)
+
+- `ANALYTICS_INDEX.md` — catalog of metrics / dashboards / data sources (high-level, “what exists”)
+- `METRICS_CATALOG.md` — formal metric definitions (SoT for semantics)
+- `DATA_CATALOG.md` — data source and schema semantics (SoT for fields/meaning)
+- `EXPERIMENT_REGISTRY.md` — active + completed experiments and decisions
+
+---
+
+## Ownership (recommended)
+
+- **Primary owner:** `data-scientist-agent` (drafting hub; see `.cursor/agents/data-scientist-agent.md`)
+- **Reviewers (task-dependent):**
+  - `marketing-strategist` for growth funnels/CTA experiments
+  - `epistemology-discovery-agent` for falsifiability + negative controls

--- a/docs/audit/PR_TBD_ANALYTICS_INDEX_AND_GUARDS_AUDIT_2026-02-11.md
+++ b/docs/audit/PR_TBD_ANALYTICS_INDEX_AND_GUARDS_AUDIT_2026-02-11.md
@@ -1,0 +1,91 @@
+# PR Audit — Analytics Indexes + Guards (Vendor-agnostic)
+
+**Date:** 11 February 2026
+**Scope:** docs + tests (no runtime changes)
+**Status:** Opinion + Evidence (commands are reproducible; outputs are examples)
+
+---
+
+## Summary
+
+This PR adds a minimal, vendor-agnostic analytics surface under `docs/analytics/*` and enforces its existence and
+minimum structure via deterministic guard tests.
+
+The goal is to prevent two recurring failure modes:
+
+1. **Metric drift**: metric semantics exist only in dashboards or in memory, and change silently.
+2. **Experiment drift**: experiments run without a registry, owners, or explicit “ship/reject” decision trails.
+
+This PR explicitly avoids introducing new agent roles. Instead, it expands the scope of the existing
+`data-scientist-agent` to serve as the single drafting hub for analytics/metrics/experimentation artifacts.
+
+---
+
+## Scope / Non-goals
+
+### In scope
+
+- Vendor-agnostic analytics docs (templates + minimal SoT)
+- Deterministic guard tests that prevent accidental deletion/drift of those docs
+- Updating the existing `data-scientist-agent` instructions to reference these artifacts
+
+### Out of scope
+
+- Any runtime telemetry collection
+- Any vendor/tool decisions (Amplitude/Mixpanel/Grafana/etc.)
+- Any “analytics database” or pipelines
+- Creating new agents (analytics/BI/data-quality/etc.)
+
+---
+
+## Evidence (repo truth)
+
+### 1) Analytics docs are present
+
+Command:
+
+```bash
+ls docs/analytics
+```
+
+Expected files:
+
+- `README.md`
+- `ANALYTICS_INDEX.md`
+- `METRICS_CATALOG.md`
+- `DATA_CATALOG.md`
+- `EXPERIMENT_REGISTRY.md`
+
+### 2) Data scientist agent references analytics artifacts (no new agent added)
+
+Command:
+
+```bash
+rg -n \"docs/analytics/\" .cursor/agents/data-scientist-agent.md
+```
+
+Interpretation:
+
+- Analytics/metrics/experiments are handled by the existing `data-scientist-agent` role.
+
+### 3) Guards are deterministic and do not write snapshots
+
+Command:
+
+```bash
+pytest -q tests/test_analytics_docs_guards.py
+```
+
+Interpretation:
+
+- Tests fail with actionable messages if canonical docs are missing or stripped of required sections.
+- Tests do not perform time-based checks and do not write any snapshot files.
+
+---
+
+## DoD (what “done” means)
+
+- [ ] `docs/analytics/*` exists and is vendor-agnostic (templates usable immediately)
+- [ ] `data-scientist-agent` explicitly references `docs/analytics/*` as its context (no new agent added)
+- [ ] Guard tests enforce existence + minimum structure deterministically
+- [ ] Quality gates pass (`make verify`)

--- a/tests/test_analytics_docs_guards.py
+++ b/tests/test_analytics_docs_guards.py
@@ -1,0 +1,76 @@
+"""Documentation policy guards for vendor-agnostic analytics artifacts.
+
+These guards intentionally avoid:
+- time-based checks (no `datetime.now()` / overdue logic)
+- snapshot writes or any file system mutation
+
+They enforce that canonical analytics doc surfaces exist and keep a minimum structure,
+so future PRs don't silently delete or hollow out the contracts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relpath: str) -> str:
+    return (REPO_ROOT / relpath).read_text(encoding="utf-8", errors="replace")
+
+
+def test_analytics_docs_exist() -> None:
+    required = [
+        "docs/analytics/README.md",
+        "docs/analytics/ANALYTICS_INDEX.md",
+        "docs/analytics/METRICS_CATALOG.md",
+        "docs/analytics/DATA_CATALOG.md",
+        "docs/analytics/EXPERIMENT_REGISTRY.md",
+    ]
+
+    missing = [p for p in required if not (REPO_ROOT / p).exists()]
+    assert not missing, (
+        "Missing analytics canonical docs.\n"
+        f"- missing: {missing}\n"
+        "Fix: add vendor-agnostic templates under docs/analytics/ (see plan)."
+    )
+
+
+def test_metrics_catalog_contains_required_sections() -> None:
+    content = _read("docs/analytics/METRICS_CATALOG.md")
+
+    required_markers = [
+        "#### Definition",
+        "#### Formula",
+        "#### Owner",
+        "#### Update frequency",
+        "#### Change history",
+    ]
+    missing = [m for m in required_markers if m not in content]
+    assert not missing, (
+        "docs/analytics/METRICS_CATALOG.md missing required template sections.\n"
+        f"- missing_markers: {missing}\n"
+        "Fix: restore the metric template sections so definitions stay reviewable."
+    )
+
+
+def test_experiment_registry_contains_active_and_completed_sections() -> None:
+    content = _read("docs/analytics/EXPERIMENT_REGISTRY.md")
+    required_markers = ["## Active Experiments", "## Completed Experiments"]
+    missing = [m for m in required_markers if m not in content]
+    assert not missing, (
+        "docs/analytics/EXPERIMENT_REGISTRY.md missing required sections.\n"
+        f"- missing_markers: {missing}\n"
+        "Fix: keep both Active and Completed sections for end-to-end tracking."
+    )
+
+
+def test_analytics_index_contains_metrics_and_sources_sections() -> None:
+    content = _read("docs/analytics/ANALYTICS_INDEX.md")
+    required_markers = ["## Tracked Metrics", "## Data Sources"]
+    missing = [m for m in required_markers if m not in content]
+    assert not missing, (
+        "docs/analytics/ANALYTICS_INDEX.md missing required sections.\n"
+        f"- missing_markers: {missing}\n"
+        "Fix: keep metrics and data sources catalog sections."
+    )

--- a/tests/test_analytics_docs_guards.py
+++ b/tests/test_analytics_docs_guards.py
@@ -14,21 +14,52 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+ANALYTICS_DOCS_REQUIRED_MARKERS: dict[str, list[str]] = {
+    "docs/analytics/README.md": [
+        "## Files (canonical surfaces)",
+        "## Ownership (recommended)",
+    ],
+    "docs/analytics/ANALYTICS_INDEX.md": [
+        "## Tracked Metrics",
+        "## Data Sources",
+    ],
+    "docs/analytics/METRICS_CATALOG.md": [
+        "#### Definition",
+        "#### Formula",
+        "#### Owner",
+        "#### Update frequency",
+        "#### Change history",
+    ],
+    "docs/analytics/DATA_CATALOG.md": [
+        # Enforce semantic skeleton to prevent hollow placeholders.
+        "## Data sources (high-level)",
+        "## Tables / entities (example templates)",
+        "### users",
+        "## Events (vendor-agnostic)",
+        "### event: <event_name>",
+    ],
+    "docs/analytics/EXPERIMENT_REGISTRY.md": [
+        "## Active Experiments",
+        "## Completed Experiments",
+    ],
+}
+
 
 def _read(relpath: str) -> str:
     return (REPO_ROOT / relpath).read_text(encoding="utf-8", errors="replace")
 
 
-def test_analytics_docs_exist() -> None:
-    required = [
-        "docs/analytics/README.md",
-        "docs/analytics/ANALYTICS_INDEX.md",
-        "docs/analytics/METRICS_CATALOG.md",
-        "docs/analytics/DATA_CATALOG.md",
-        "docs/analytics/EXPERIMENT_REGISTRY.md",
-    ]
+def _assert_required_markers(path: str, content: str, markers: list[str]) -> None:
+    missing = [marker for marker in markers if marker not in content]
+    assert not missing, (
+        f"{path} missing required structure markers.\n"
+        f"- missing_markers: {missing}\n"
+        "Fix: restore canonical headings/sections required by analytics docs guards."
+    )
 
-    missing = [p for p in required if not (REPO_ROOT / p).exists()]
+
+def test_analytics_docs_exist() -> None:
+    missing = [p for p in ANALYTICS_DOCS_REQUIRED_MARKERS if not (REPO_ROOT / p).exists()]
     assert not missing, (
         "Missing analytics canonical docs.\n"
         f"- missing: {missing}\n"
@@ -36,41 +67,6 @@ def test_analytics_docs_exist() -> None:
     )
 
 
-def test_metrics_catalog_contains_required_sections() -> None:
-    content = _read("docs/analytics/METRICS_CATALOG.md")
-
-    required_markers = [
-        "#### Definition",
-        "#### Formula",
-        "#### Owner",
-        "#### Update frequency",
-        "#### Change history",
-    ]
-    missing = [m for m in required_markers if m not in content]
-    assert not missing, (
-        "docs/analytics/METRICS_CATALOG.md missing required template sections.\n"
-        f"- missing_markers: {missing}\n"
-        "Fix: restore the metric template sections so definitions stay reviewable."
-    )
-
-
-def test_experiment_registry_contains_active_and_completed_sections() -> None:
-    content = _read("docs/analytics/EXPERIMENT_REGISTRY.md")
-    required_markers = ["## Active Experiments", "## Completed Experiments"]
-    missing = [m for m in required_markers if m not in content]
-    assert not missing, (
-        "docs/analytics/EXPERIMENT_REGISTRY.md missing required sections.\n"
-        f"- missing_markers: {missing}\n"
-        "Fix: keep both Active and Completed sections for end-to-end tracking."
-    )
-
-
-def test_analytics_index_contains_metrics_and_sources_sections() -> None:
-    content = _read("docs/analytics/ANALYTICS_INDEX.md")
-    required_markers = ["## Tracked Metrics", "## Data Sources"]
-    missing = [m for m in required_markers if m not in content]
-    assert not missing, (
-        "docs/analytics/ANALYTICS_INDEX.md missing required sections.\n"
-        f"- missing_markers: {missing}\n"
-        "Fix: keep metrics and data sources catalog sections."
-    )
+def test_analytics_docs_keep_required_structure_markers() -> None:
+    for path, markers in ANALYTICS_DOCS_REQUIRED_MARKERS.items():
+        _assert_required_markers(path=path, content=_read(path), markers=markers)


### PR DESCRIPTION
## Summary
- Add vendor-agnostic analytics surfaces under `docs/analytics/*` (index, metrics catalog, data catalog, experiment registry).
- Expand existing `data-scientist-agent` scope to own analytics/metrics/experimentation artifacts (no new agents).
- Add deterministic guard tests to prevent accidental deletion/drift of the analytics doc templates.
- Add an evidence-driven audit note for PR scope + DoD.

## Test plan
- [x] `pytest -q tests/test_analytics_docs_guards.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Non-goals
- No runtime telemetry changes.
- No vendor/tooling decisions (Amplitude/Mixpanel/Grafana/etc.).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ввести независимые от поставщика поверхности документации по аналитике и детерминированные тесты, которые гарантируют их наличие и структуру, одновременно расширив область ответственности существующего агента data-scientist так, чтобы он владел этими артефактами.

Новые возможности:
- Добавить независимый от поставщика комплект документации по аналитике в `docs/analytics` для метрик, данных и отслеживания экспериментов.
- Определить реестр экспериментов и каталог метрик как каноничные, предназначенные только для документации источники истины для семантики аналитики.

Улучшения:
- Расширить роль агента data-scientist, чтобы он отвечал за артефакты аналитики, метрик и экспериментов и координировал передачу материалов связанным агентам.
- Задокументировать аудит-примечание, фиксирующее область охвата, свидетельства и определение готовности (definition of done) для индексов аналитики и защитных механизмов.

Тесты:
- Добавить защитные тесты, которые обеспечивают наличие и минимально необходимые разделы ключевых артефактов документации по аналитике.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce vendor-agnostic analytics documentation surfaces and deterministic tests to guard their presence and structure, while expanding the existing data-scientist agent’s scope to own these artifacts.

New Features:
- Add a vendor-agnostic analytics documentation suite under docs/analytics for metrics, data, and experiment tracking.
- Define an experiment registry and metrics catalog as canonical, docs-only sources of truth for analytics semantics.

Enhancements:
- Expand the data-scientist agent role to own analytics, metrics, and experimentation artifacts and coordinate handoffs to related agents.
- Document an audit note capturing scope, evidence, and definition of done for the analytics indexes and guards.

Tests:
- Add guard tests that enforce the existence and minimum required sections of the core analytics documentation artifacts.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds vendor-agnostic analytics docs and deterministic guard tests to prevent metric/experiment drift. Expands the data-scientist-agent’s scope to own these artifacts; no runtime telemetry or vendor changes.

- **New Features**
  - Added docs under docs/analytics: README, ANALYTICS_INDEX, METRICS_CATALOG, DATA_CATALOG, EXPERIMENT_REGISTRY.
  - Added tests/test_analytics_docs_guards.py to enforce file presence and required sections.
  - Updated .cursor/agents/data-scientist-agent.md to own analytics/metrics/experimentation artifacts.
  - Added docs/audit/PR_TBD_ANALYTICS_INDEX_AND_GUARDS_AUDIT_2026-02-11.md for scope and DoD.

- **Refactors**
  - Centralized guard markers into a single file→markers schema to reduce duplication and brittleness.
  - Strengthened checks to enforce Data Catalog structural markers so hollow docs can’t pass on path existence alone.

<sup>Written for commit b019c3a784153d3191aac188bd9109b125ad0a5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive vendor-agnostic analytics documentation: metrics catalog with standardized metric definitions, data catalog with schemas and privacy notes (no PII in outputs), experiment registry for tracking experiments, and an analytics index plus README describing scope, ownership, pre‑flight artifacts, expanded analytics role, and recommended handoffs.
* **Tests**
  * Added guardrail tests to enforce analytics documentation presence and minimum structural completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->