### PR TITLE
docs(runbook): add implementation reference for upload-artifact 403 entry

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -110,6 +110,9 @@ Rule: RUNBOOK does not duplicate checklists; it only links to the canonical sour
 
 ## 0.1) CI: `actions/upload-artifact` fails with `FinalizeArtifact 403 Forbidden`
 
+**Reference:** Documentation: [PR #712](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/712). Fix required a
+repo-admin setting change (`default_workflow_permissions=write`; no repo commit).
+
 **Symptom (GitHub Actions logs):**
 
 - `Error: Failed to FinalizeArtifact: ... (403) Forbidden`


### PR DESCRIPTION
## Summary
- Add an implementation/reference line to the `FinalizeArtifact 403 Forbidden` runbook entry, per bot policy.

## Test plan
- [x] `pre-commit run --all-files`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Добавлена ссылка в записи runbook для ошибок 403 в `actions/upload-artifact`, указывающая на конкретный PR и требуемую настройку прав workflow репозитория.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a reference in the runbook entry for `actions/upload-artifact` 403 errors pointing to a specific PR and required repository workflow permission setting.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added troubleshooting guidance for CI artifact upload failures, including diagnostic steps and configuration recommendations for resolving 403 Forbidden errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->