### PR TITLE
feat(api-tiers): add db-first tier resolution with env fallback

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -578,7 +578,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 270
+        "line_number": 266
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T16:27:18Z"
+  "generated_at": "2026-02-12T19:59:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -571,14 +571,14 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 62
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 230
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T14:15:42Z"
+  "generated_at": "2026-02-12T15:38:20Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -578,7 +578,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 270
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T16:12:13Z"
+  "generated_at": "2026-02-12T16:27:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -569,16 +569,9 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/test_api_tiers.py",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 64
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 266
+        "line_number": 285
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T19:59:16Z"
+  "generated_at": "2026-02-12T20:13:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -571,14 +571,14 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 64
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 230
+        "line_number": 242
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T15:38:20Z"
+  "generated_at": "2026-02-12T16:11:41Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -578,7 +578,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 244
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T16:11:41Z"
+  "generated_at": "2026-02-12T16:12:13Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,6 +705,9 @@ Source of truth:
 - **Do not use `Header(...)` in tier dependencies** — use `Security(api_key_header)` to ensure OpenAPI models credentials as security scheme (not per-operation header params). This prevents OpenAPI drift and dirty TypeScript types.
 - **Tier guard order**: Tier checks (403) must run before payload validation (422). Principle: "tier wins over payload".
 - **New metrics/features policy**: Any new metrics (e.g., WHR) must be added via tier-specific schemas + endpoints; FREE contract must not be extended without explicit tier policy decision.
+- **DB lookup policy** (when `SUBSCRIPTION_DB_ENABLED=true`): `ERROR` and `INVALID_TIER` are
+  **fail-closed** (no env fallback). `MISS` may fallback **only during migration**; plan a
+  follow-up to make DB authoritative.
 
 **See:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,20 @@ python scripts/ci/check_pr_body_phase2_gates.py --body "## Discussion Thread Pas
 - CI trigger requirement: workflow `pull_request` types MUST include `edited` so body updates re-run the gate.
 - Timeout policy: `pr_body_phase2_gates` timeout must be sourced from workflow context compatible with `timeout-minutes` (use `vars` + `fromJSON(...)`; `env` is not available at this key).
 
+### 5a) Docs Phase1 gates (audit/security markdown contract)
+
+Run this locally for changed docs under `docs/audit/` or `docs/security/`:
+
+```bash
+python scripts/ci/check_docs_phase1_gates.py --files docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+```
+
+**Rules:**
+
+- Files in `docs/audit/*.md` must not contain unresolved placeholder `PR: TBD`.
+- Files in `docs/audit/*.md` and `docs/security/*.md` must include at least one `file:line` evidence anchor (example: `app/middleware/api_tiers.py:109`).
+- If CI shows `missing \`file:line\` evidence anchor`, add explicit repo path anchors (not prose-only claims).
+
 ## Canonical navigation
 
 Start here: AGENTS.md → RUNBOOK_AGENT.md → module AGENTS.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -171,6 +171,9 @@ curl -fsS https://.../metrics | grep http_requests_total
 - Use `fastapi.status` for status codes and `HTTPException` for errors.
 - Keep API schema changes in sync with `app/schemas/` and tests.
 - Apply tier guards (`require_pro_tier`, VIP) consistently on gated endpoints.
+- Tier resolution policy: DB-first when `SUBSCRIPTION_DB_ENABLED=true`.
+- On DB lookup error/unavailable, fall back to env-based detection.
+- Never fail-open on tier checks.
 
 ### Typing rule: Pydantic v2 `model_validate()` + mypy
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -172,7 +172,8 @@ curl -fsS https://.../metrics | grep http_requests_total
 - Keep API schema changes in sync with `app/schemas/` and tests.
 - Apply tier guards (`require_pro_tier`, VIP) consistently on gated endpoints.
 - Tier resolution policy: DB-first when `SUBSCRIPTION_DB_ENABLED=true`.
-- On DB lookup error/unavailable, fall back to env-based detection.
+- **DB lookup policy** (when enabled): `ERROR` and `INVALID_TIER` are **fail-closed** (no env
+  fallback). `MISS` may fallback only during migration; plan DB-authoritative follow-up.
 - Never fail-open on tier checks.
 
 ### Typing rule: Pydantic v2 `model_validate()` + mypy

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -228,7 +228,7 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
     return False
 
 
-async def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
+def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
     """Require PRO tier API key for endpoint access.
 
     RU: Требуется API ключ уровня PRO для доступа к endpoint.
@@ -268,7 +268,7 @@ async def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) 
     return x_api_key
 
 
-async def require_vip_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
+def require_vip_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
     """Require VIP tier API key for endpoint access.
 
     RU: Требуется API ключ уровня VIP для доступа к endpoint.

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -124,7 +124,11 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         finally:
             session.close()
     except Exception:
-        logger.warning("Subscription DB lookup failed; denying env fallback for safety")
+        logger.warning(
+            "Subscription DB lookup failed; denying env fallback for safety",
+            exc_info=True,
+            extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.ERROR.value},
+        )
         return DBLookupResult(status=DBLookupStatus.ERROR)
 
     if raw_tier is None:
@@ -132,16 +136,24 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
 
     parsed_tier = _parse_tier_value(str(raw_tier))
     if parsed_tier is None:
-        logger.warning("Subscription DB lookup returned unknown tier value; denying env fallback")
+        logger.warning(
+            "Subscription DB lookup returned unknown tier value; denying env fallback",
+            extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.INVALID_TIER.value},
+        )
         return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
     return DBLookupResult(status=DBLookupStatus.HIT, tier=parsed_tier)
 
 
-def _resolve_tier_from_env(api_key: str) -> SubscriptionTier | None:
-    """Resolve tier via environment/test-key fallback."""
-    if api_key == TEST_KEY_VIP:
+def _resolve_tier_from_env(
+    api_key: str, *, allow_test_keys: bool = True
+) -> SubscriptionTier | None:
+    """Resolve tier via environment fallback.
+
+    Test keys are accepted only when allow_test_keys=True.
+    """
+    if allow_test_keys and api_key == TEST_KEY_VIP:
         return SubscriptionTier.VIP
-    if api_key == TEST_KEY_PRO:
+    if allow_test_keys and api_key == TEST_KEY_PRO:
         return SubscriptionTier.PRO
 
     vip_keys = os.getenv("VIP_API_KEYS", "")
@@ -194,7 +206,7 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
         if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
             return False
 
-    resolved_env_tier = _resolve_tier_from_env(api_key)
+    resolved_env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
     if resolved_env_tier is not None:
         return _tier_allows_access(resolved_env_tier, required_tier)
 
@@ -311,6 +323,8 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         Returns FREE if API key is invalid or not found.
         In development mode, test keys return their respective tiers.
     """
+    is_production, _ = _is_production_environment()
+
     if _is_subscription_db_enabled():
         db_lookup = _lookup_tier_from_db(api_key)
         if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
@@ -318,7 +332,7 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
             return SubscriptionTier.FREE
 
-    env_tier = _resolve_tier_from_env(api_key)
+    env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
     return env_tier if env_tier is not None else SubscriptionTier.FREE
 
 

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -31,6 +31,7 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Security, status
+from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
 
@@ -66,6 +67,76 @@ ALLOW_ANONYMOUS_API_KEYS = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower(
 # Note: SUBSCRIPTION_DB_ENABLED is checked dynamically in code to support testing
 
 
+def _is_subscription_db_enabled() -> bool:
+    """Return True when DB-backed subscription lookup is enabled."""
+    return os.getenv("SUBSCRIPTION_DB_ENABLED", "false").lower() in ("true", "1", "yes", "on")
+
+
+def _tier_allows_access(tier: SubscriptionTier, required_tier: SubscriptionTier) -> bool:
+    """Return whether a resolved tier satisfies the required tier."""
+    if required_tier == SubscriptionTier.PRO:
+        return tier in (SubscriptionTier.PRO, SubscriptionTier.VIP)
+    if required_tier == SubscriptionTier.VIP:
+        return tier == SubscriptionTier.VIP
+    return True
+
+
+def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
+    """Convert DB/env tier string to SubscriptionTier enum safely."""
+    normalized = raw_tier.strip().upper()
+    if normalized in SubscriptionTier.__members__:
+        return SubscriptionTier[normalized]
+    return None
+
+
+def _lookup_tier_from_db(api_key: str) -> SubscriptionTier | None:
+    """Try to resolve API key tier from DB; return None on misses/errors.
+
+    RU: Пытается определить tier из БД; возвращает None при промахе/ошибке.
+    EN: Attempts to resolve tier from DB; returns None on miss/error.
+    """
+    query = text("SELECT tier FROM api_keys WHERE api_key = :api_key LIMIT 1")
+
+    try:
+        from core.db import get_session_factory
+
+        session_factory = get_session_factory()
+        session = session_factory()
+        try:
+            raw_tier = session.execute(query, {"api_key": api_key}).scalar_one_or_none()
+        finally:
+            session.close()
+    except Exception:
+        logger.warning("Subscription DB lookup failed; falling back to env-based tier detection")
+        return None
+
+    if raw_tier is None:
+        return None
+
+    parsed_tier = _parse_tier_value(str(raw_tier))
+    if parsed_tier is None:
+        logger.warning("Subscription DB lookup returned unknown tier value; using env fallback")
+    return parsed_tier
+
+
+def _resolve_tier_from_env(api_key: str) -> SubscriptionTier | None:
+    """Resolve tier via environment/test-key fallback."""
+    if api_key == TEST_KEY_VIP:
+        return SubscriptionTier.VIP
+    if api_key == TEST_KEY_PRO:
+        return SubscriptionTier.PRO
+
+    vip_keys = os.getenv("VIP_API_KEYS", "")
+    if api_key and api_key in {value.strip() for value in vip_keys.split(",") if value.strip()}:
+        return SubscriptionTier.VIP
+
+    pro_keys = os.getenv("PRO_API_KEYS", "")
+    if api_key and api_key in {value.strip() for value in pro_keys.split(",") if value.strip()}:
+        return SubscriptionTier.PRO
+
+    return None
+
+
 def _is_production_environment() -> tuple[bool, str]:
     """Determine if we're in production mode.
 
@@ -98,17 +169,23 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
     """
     is_production, app_env = _is_production_environment()
 
-    # Development mode: Accept test keys
-    if not is_production:
-        if api_key == TEST_KEY_VIP:
-            # VIP key grants access to both PRO and VIP
-            return True
-        if api_key == TEST_KEY_PRO and required_tier == SubscriptionTier.PRO:
-            # PRO key grants access only to PRO
-            return True
+    if _is_subscription_db_enabled():
+        db_tier = _lookup_tier_from_db(api_key)
+        if db_tier is not None:
+            return _tier_allows_access(db_tier, required_tier)
 
-        # In dev mode with anonymous access enabled, allow any key
-        # Check env var dynamically to support testing with mock.patch.dict
+        logger.warning(
+            "Subscription DB lookup unavailable. Falling back to env-based tier detection for tier %s.",
+            required_tier.value,
+        )
+
+    resolved_env_tier = _resolve_tier_from_env(api_key)
+    if resolved_env_tier is not None:
+        return _tier_allows_access(resolved_env_tier, required_tier)
+
+    # In non-production mode with anonymous access enabled, allow any key.
+    # Check env var dynamically to support testing with mock.patch.dict.
+    if not is_production:
         allow_anonymous = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in (
             "true",
             "1",
@@ -121,45 +198,7 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
             )
             return True
 
-        # Invalid key in dev mode: reject
-        return False
-
-    # Production mode: Query database
-    # Fail-fast if database not configured
-    # Check env var dynamically to support testing with mock.patch.dict
-    subscription_db_enabled = os.getenv("SUBSCRIPTION_DB_ENABLED", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-        "on",
-    )
-    if not subscription_db_enabled:
-        logger.critical(
-            "Production mode requires SUBSCRIPTION_DB_ENABLED=true. "
-            "Set environment variable and implement subscription database lookup."
-        )
-        raise NotImplementedError(
-            "API key validation not implemented for production. "
-            "Set SUBSCRIPTION_DB_ENABLED=true and implement get_subscription_by_api_key() function."
-        )
-
-    # TODO: Implement database lookup for production when SUBSCRIPTION_DB_ENABLED=true
-    # from app.services.subscriptions import get_subscription_by_api_key
-    # subscription = get_subscription_by_api_key(api_key)
-    # if not subscription or subscription.is_expired():
-    #     return False
-    # if required_tier == SubscriptionTier.VIP:
-    #     return subscription.tier == SubscriptionTier.VIP
-    # elif required_tier == SubscriptionTier.PRO:
-    #     return subscription.tier in [SubscriptionTier.PRO, SubscriptionTier.VIP]
-    # return True
-
-    # This code path should never be reached after DB implementation
-    logger.error(f"Subscription database lookup not implemented. Tier: {required_tier.value}")
-    raise NotImplementedError(
-        "Subscription database lookup not implemented. "
-        "Implement get_subscription_by_api_key() in app/services/subscriptions.py"
-    )
+    return False
 
 
 async def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
@@ -257,36 +296,16 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         Returns FREE if API key is invalid or not found.
         In development mode, test keys return their respective tiers.
     """
-    is_production, _ = _is_production_environment()
-
-    # Development mode: Check test keys
-    if not is_production:
-        if api_key == TEST_KEY_VIP:
-            return SubscriptionTier.VIP
-        if api_key == TEST_KEY_PRO:
-            return SubscriptionTier.PRO
-
-    # Production mode: Query database
-    # Fail-fast if database not configured
-    # Check env var dynamically to support testing with mock.patch.dict
-    subscription_db_enabled = os.getenv("SUBSCRIPTION_DB_ENABLED", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-        "on",
-    )
-    if is_production and not subscription_db_enabled:
-        raise NotImplementedError(
-            "Subscription database not implemented. "
-            "Set SUBSCRIPTION_DB_ENABLED=true and implement get_subscription_by_api_key()."
+    if _is_subscription_db_enabled():
+        db_tier = _lookup_tier_from_db(api_key)
+        if db_tier is not None:
+            return db_tier
+        logger.warning(
+            "Subscription DB lookup unavailable for get_subscription_tier; using env fallback"
         )
 
-    # TODO: Implement database lookup
-    # from app.services.subscriptions import get_subscription_by_api_key
-    # subscription = get_subscription_by_api_key(api_key)
-    # return subscription.tier if subscription else SubscriptionTier.FREE
-
-    return SubscriptionTier.FREE
+    env_tier = _resolve_tier_from_env(api_key)
+    return env_tier if env_tier is not None else SubscriptionTier.FREE
 
 
 def derive_subject_id_from_api_key(api_key: str) -> int:

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -52,6 +52,23 @@ class SubscriptionTier(str, Enum):
     VIP = "VIP"
 
 
+class DBLookupStatus(str, Enum):
+    """Outcome of DB-backed API key tier lookup."""
+
+    HIT = "HIT"
+    MISS = "MISS"
+    ERROR = "ERROR"
+    INVALID_TIER = "INVALID_TIER"
+
+
+@dataclass(frozen=True)
+class DBLookupResult:
+    """Structured DB lookup result to avoid ambiguous None semantics."""
+
+    status: DBLookupStatus
+    tier: SubscriptionTier | None = None
+
+
 # Test API keys for development/testing (nosec B105)
 TEST_KEY_PRO = "test_pro_key"  # nosec B105
 TEST_KEY_VIP = "test_vip_key"  # nosec B105
@@ -89,11 +106,11 @@ def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
     return None
 
 
-def _lookup_tier_from_db(api_key: str) -> SubscriptionTier | None:
-    """Try to resolve API key tier from DB; return None on misses/errors.
+def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
+    """Try to resolve API key tier from DB with explicit outcome.
 
-    RU: Пытается определить tier из БД; возвращает None при промахе/ошибке.
-    EN: Attempts to resolve tier from DB; returns None on miss/error.
+    RU: Пытается определить tier из БД и возвращает статус lookup.
+    EN: Attempts to resolve tier from DB and returns structured status.
     """
     query = text("SELECT tier FROM api_keys WHERE api_key = :api_key LIMIT 1")
 
@@ -107,16 +124,17 @@ def _lookup_tier_from_db(api_key: str) -> SubscriptionTier | None:
         finally:
             session.close()
     except Exception:
-        logger.warning("Subscription DB lookup failed; falling back to env-based tier detection")
-        return None
+        logger.warning("Subscription DB lookup failed; denying env fallback for safety")
+        return DBLookupResult(status=DBLookupStatus.ERROR)
 
     if raw_tier is None:
-        return None
+        return DBLookupResult(status=DBLookupStatus.MISS)
 
     parsed_tier = _parse_tier_value(str(raw_tier))
     if parsed_tier is None:
-        logger.warning("Subscription DB lookup returned unknown tier value; using env fallback")
-    return parsed_tier
+        logger.warning("Subscription DB lookup returned unknown tier value; denying env fallback")
+        return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
+    return DBLookupResult(status=DBLookupStatus.HIT, tier=parsed_tier)
 
 
 def _resolve_tier_from_env(api_key: str) -> SubscriptionTier | None:
@@ -170,14 +188,11 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
     is_production, app_env = _is_production_environment()
 
     if _is_subscription_db_enabled():
-        db_tier = _lookup_tier_from_db(api_key)
-        if db_tier is not None:
-            return _tier_allows_access(db_tier, required_tier)
-
-        logger.warning(
-            "Subscription DB lookup unavailable. Falling back to env-based tier detection for tier %s.",
-            required_tier.value,
-        )
+        db_lookup = _lookup_tier_from_db(api_key)
+        if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
+            return _tier_allows_access(db_lookup.tier, required_tier)
+        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
+            return False
 
     resolved_env_tier = _resolve_tier_from_env(api_key)
     if resolved_env_tier is not None:
@@ -297,12 +312,11 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         In development mode, test keys return their respective tiers.
     """
     if _is_subscription_db_enabled():
-        db_tier = _lookup_tier_from_db(api_key)
-        if db_tier is not None:
-            return db_tier
-        logger.warning(
-            "Subscription DB lookup unavailable for get_subscription_tier; using env fallback"
-        )
+        db_lookup = _lookup_tier_from_db(api_key)
+        if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
+            return db_lookup.tier
+        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
+            return SubscriptionTier.FREE
 
     env_tier = _resolve_tier_from_env(api_key)
     return env_tier if env_tier is not None else SubscriptionTier.FREE

--- a/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+++ b/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
@@ -19,7 +19,7 @@
 | Scenario | Expected behavior |
 | --- | --- |
 | DB enabled + valid key in DB | Use DB tier |
-| DB enabled + unknown key | 403 (guard rejects) |
+| DB enabled + key unknown in both DB and env | 403 (guard rejects after env fallback) |
 | DB enabled + DB error/unavailable | Fallback to env-based tier detection |
 | DB disabled | Env-only tier detection |
 | Neither DB nor env resolves | 403 (guard rejects) |

--- a/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+++ b/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
@@ -8,6 +8,17 @@
 - No service-layer refactor
 - No cache
 
+## Repo-truth Evidence (file:line)
+
+- DB lookup outcome contract: `app/middleware/api_tiers.py:55`, `app/middleware/api_tiers.py:65`
+- DB lookup implementation: `app/middleware/api_tiers.py:109`
+- Tier guard validation flow: `app/middleware/api_tiers.py:171`
+- Subscription tier inference flow: `app/middleware/api_tiers.py:298`
+- DB error deny test: `tests/test_api_tiers.py:110`
+- DB exception helper test: `tests/test_api_tiers.py:160`
+- Invalid DB tier test: `tests/test_api_tiers.py:187`
+- get_subscription_tier fail-closed test: `tests/test_api_tiers.py:355`
+
 ## Non-goals
 
 - No TTL cache
@@ -19,23 +30,25 @@
 | Scenario | Expected behavior |
 | --- | --- |
 | DB enabled + valid key in DB | Use DB tier |
-| DB enabled + key unknown in both DB and env | 403 (guard rejects after env fallback) |
-| DB enabled + DB error/unavailable | Fallback to env-based tier detection |
+| DB enabled + key missing in DB | Env fallback allowed (migration path) |
+| DB enabled + DB error/unavailable | Fail-closed for access checks; no env fallback |
+| DB enabled + invalid/unparseable DB tier | Fail-closed for access checks; no env fallback |
 | DB disabled | Env-only tier detection |
 | Neither DB nor env resolves | 403 (guard rejects) |
 
 ## Implementation Notes
 
 - Added DB-first resolver in `app/middleware/api_tiers.py` gated by `SUBSCRIPTION_DB_ENABLED`.
-- DB lookup returns `None` on not found/errors, then code falls back to env-based resolution.
-- No fail-open path introduced: unresolved keys remain forbidden by existing guard flow.
+- DB lookup now returns explicit statuses (`HIT`, `MISS`, `ERROR`, `INVALID_TIER`) to avoid ambiguous `None` semantics.
+- Policy: env fallback is allowed only for `MISS`; `ERROR` and `INVALID_TIER` are fail-closed in guards.
 - Legacy behavior for `API_KEY`-based VIP bypass was intentionally not added to env fallback to preserve PRO guard divergence tests.
 
 ## Test Coverage Added/Updated
 
 - `tests/test_api_tiers.py` now covers:
   - DB enabled path with DB tier results
-  - DB error/miss fallback to env path
+  - DB error and invalid-tier fail-closed behavior
+  - DB miss-only fallback to env path
   - DB disabled env-only path
   - Unknown key rejection behavior
 

--- a/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+++ b/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
@@ -1,0 +1,46 @@
+# PR XXX — API Tiers DB Lookup Audit
+
+## Scope
+
+- Changed file: `app/middleware/api_tiers.py`
+- Changed tests: `tests/test_api_tiers.py`
+- Focus: tier resolution only (FREE/PRO/VIP)
+- No service-layer refactor
+- No cache
+
+## Non-goals
+
+- No TTL cache
+- No migrations
+- No OpenAPI contract changes
+
+## Failure Modes and Expected Behavior
+
+| Scenario | Expected behavior |
+| --- | --- |
+| DB enabled + valid key in DB | Use DB tier |
+| DB enabled + unknown key | 403 (guard rejects) |
+| DB enabled + DB error/unavailable | Fallback to env-based tier detection |
+| DB disabled | Env-only tier detection |
+| Neither DB nor env resolves | 403 (guard rejects) |
+
+## Implementation Notes
+
+- Added DB-first resolver in `app/middleware/api_tiers.py` gated by `SUBSCRIPTION_DB_ENABLED`.
+- DB lookup returns `None` on not found/errors, then code falls back to env-based resolution.
+- No fail-open path introduced: unresolved keys remain forbidden by existing guard flow.
+- Legacy behavior for `API_KEY`-based VIP bypass was intentionally not added to env fallback to preserve PRO guard divergence tests.
+
+## Test Coverage Added/Updated
+
+- `tests/test_api_tiers.py` now covers:
+  - DB enabled path with DB tier results
+  - DB error/miss fallback to env path
+  - DB disabled env-only path
+  - Unknown key rejection behavior
+
+## DoD (Ledger 1:1)
+
+- [x] Database lookup implemented when `SUBSCRIPTION_DB_ENABLED=true`
+- [x] Fallback to env-based detection when DB unavailable
+- [x] Tests cover both paths

--- a/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+++ b/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
@@ -30,18 +30,19 @@
 | Scenario | Expected behavior |
 | --- | --- |
 | DB enabled + valid key in DB | Use DB tier |
-| DB enabled + key missing in DB | Env fallback allowed (migration path) |
-| DB enabled + DB error/unavailable | Fail-closed for access checks; no env fallback |
-| DB enabled + invalid/unparseable DB tier | Fail-closed for access checks; no env fallback |
+| DB enabled + key missing | Env fallback allowed (migration path) |
+| DB enabled + DB error | Fail-closed; no env fallback |
+| DB enabled + invalid tier | Fail-closed; no env fallback |
 | DB disabled | Env-only tier detection |
 | Neither DB nor env resolves | 403 (guard rejects) |
 
 ## Implementation Notes
 
-- Added DB-first resolver in `app/middleware/api_tiers.py` gated by `SUBSCRIPTION_DB_ENABLED`.
-- DB lookup now returns explicit statuses (`HIT`, `MISS`, `ERROR`, `INVALID_TIER`) to avoid ambiguous `None` semantics.
-- Policy: env fallback is allowed only for `MISS`; `ERROR` and `INVALID_TIER` are fail-closed in guards.
-- Legacy behavior for `API_KEY`-based VIP bypass was intentionally not added to env fallback to preserve PRO guard divergence tests.
+- DB-first resolver in `app/middleware/api_tiers.py` gated by `SUBSCRIPTION_DB_ENABLED`.
+- DB lookup returns explicit statuses (`HIT`, `MISS`, `ERROR`, `INVALID_TIER`)
+  to avoid ambiguous `None` semantics.
+- Env fallback only for `MISS`; `ERROR`/`INVALID_TIER` are fail-closed in guards.
+- Legacy `API_KEY` VIP bypass not added to env fallback; preserves PRO guard tests.
 
 ## Test Coverage Added/Updated
 

--- a/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
+++ b/docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md
@@ -38,6 +38,7 @@
 
 ## Implementation Notes
 
+- **Policy:** MISS falls back to env for migration; ERROR/INVALID are fail-closed.
 - DB-first resolver in `app/middleware/api_tiers.py` gated by `SUBSCRIPTION_DB_ENABLED`.
 - DB lookup returns explicit statuses (`HIT`, `MISS`, `ERROR`, `INVALID_TIER`)
   to avoid ambiguous `None` semantics.
@@ -56,5 +57,5 @@
 ## DoD (Ledger 1:1)
 
 - [x] Database lookup implemented when `SUBSCRIPTION_DB_ENABLED=true`
-- [x] Fallback to env-based detection when DB unavailable
+- [x] Fallback to env-based detection only on DB MISS (not on ERROR/INVALID_TIER)
 - [x] Tests cover both paths

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -238,73 +238,65 @@ class TestDBLookupHelpers:
 
 
 class TestRequireProTier:
-    """Test require_pro_tier dependency function."""
+    """Test require_pro_tier dependency function (sync, runs in threadpool in FastAPI)."""
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_pro_key_accepted(self) -> None:
+    def test_pro_key_accepted(self) -> None:
         """Test PRO key is accepted for PRO tier."""
-        result = await require_pro_tier(x_api_key=TEST_KEY_PRO)
+        result = require_pro_tier(x_api_key=TEST_KEY_PRO)
         assert result == TEST_KEY_PRO
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_vip_key_accepted_for_pro(self) -> None:
+    def test_vip_key_accepted_for_pro(self) -> None:
         """Test VIP key is accepted for PRO tier (VIP includes PRO)."""
-        result = await require_pro_tier(x_api_key=TEST_KEY_VIP)
+        result = require_pro_tier(x_api_key=TEST_KEY_VIP)
         assert result == TEST_KEY_VIP
 
-    @pytest.mark.asyncio
-    async def test_missing_key_raises_401(self) -> None:
+    def test_missing_key_raises_401(self) -> None:
         """Test missing API key raises 401 Unauthorized."""
         with pytest.raises(HTTPException) as exc_info:
-            await require_pro_tier(x_api_key=None)
+            require_pro_tier(x_api_key=None)
         assert exc_info.value.status_code == 401
         assert "API key required" in exc_info.value.detail
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_invalid_key_raises_403(self) -> None:
+    def test_invalid_key_raises_403(self) -> None:
         """Test invalid API key raises 403 Forbidden."""
         with pytest.raises(HTTPException) as exc_info:
-            await require_pro_tier(x_api_key="invalid_key")
+            require_pro_tier(x_api_key="invalid_key")
         assert exc_info.value.status_code == 403
         assert "does not have PRO tier access" in exc_info.value.detail
 
 
 class TestRequireVIPTier:
-    """Test require_vip_tier dependency function."""
+    """Test require_vip_tier dependency function (sync, runs in threadpool in FastAPI)."""
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_vip_key_accepted(self) -> None:
+    def test_vip_key_accepted(self) -> None:
         """Test VIP key is accepted for VIP tier."""
-        result = await require_vip_tier(x_api_key=TEST_KEY_VIP)
+        result = require_vip_tier(x_api_key=TEST_KEY_VIP)
         assert result == TEST_KEY_VIP
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_pro_key_rejected_for_vip(self) -> None:
+    def test_pro_key_rejected_for_vip(self) -> None:
         """Test PRO key is rejected for VIP tier."""
         with pytest.raises(HTTPException) as exc_info:
-            await require_vip_tier(x_api_key=TEST_KEY_PRO)
+            require_vip_tier(x_api_key=TEST_KEY_PRO)
         assert exc_info.value.status_code == 403
         assert "does not have VIP tier access" in exc_info.value.detail
 
-    @pytest.mark.asyncio
-    async def test_missing_key_raises_403(self) -> None:
+    def test_missing_key_raises_403(self) -> None:
         """Test missing API key raises 403 Forbidden (VIP = feature-gate)."""
         with pytest.raises(HTTPException) as exc_info:
-            await require_vip_tier(x_api_key=None)
+            require_vip_tier(x_api_key=None)
         assert exc_info.value.status_code == 403
         assert "VIP access" in exc_info.value.detail or "API key required" in exc_info.value.detail
 
     @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    @pytest.mark.asyncio
-    async def test_invalid_key_raises_403(self) -> None:
+    def test_invalid_key_raises_403(self) -> None:
         """Test invalid API key raises 403 Forbidden."""
         with pytest.raises(HTTPException) as exc_info:
-            await require_vip_tier(x_api_key="invalid_key")
+            require_vip_tier(x_api_key="invalid_key")
         assert exc_info.value.status_code == 403
         assert "Upgrade to VIP" in exc_info.value.detail
 

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 
+import app.middleware.api_tiers as api_tiers_mod
 from app.middleware.api_tiers import (
     CurrentUser,
     SubscriptionTier,
@@ -66,29 +67,134 @@ class TestValidateAPIKeyTier:
         assert _validate_api_key_tier("any_random_key", SubscriptionTier.VIP) is True
 
     @patch.dict(
-        os.environ, {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"}
+        os.environ,
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "false",
+            "VIP_API_KEYS": "prod_key",  # pragma: allowlist secret
+        },
+        clear=False,
     )
-    def test_production_mode_raises_not_implemented(self) -> None:
-        """Test production mode raises NotImplementedError when DB not enabled."""
-        with pytest.raises(NotImplementedError, match="API key validation not implemented"):
-            _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP)
-        with pytest.raises(NotImplementedError, match="API key validation not implemented"):
-            _validate_api_key_tier(TEST_KEY_PRO, SubscriptionTier.PRO)
+    def test_production_mode_without_db_uses_env_fallback(self) -> None:
+        """Test production mode falls back to env-based detection when DB is disabled."""
+        assert _validate_api_key_tier("prod_key", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("prod_key", SubscriptionTier.VIP) is True
 
     @patch.dict(
         os.environ,
         {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "true"},
     )
-    def test_production_db_enabled_raises_lookup_not_implemented(
-        self, caplog: pytest.LogCaptureFixture
+    def test_production_db_enabled_uses_db_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test production mode with DB enabled validates access via DB tier."""
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: SubscriptionTier.PRO,
+        )
+        assert _validate_api_key_tier("prodtoken", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("prodtoken", SubscriptionTier.VIP) is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "true",
+            "VIP_API_KEYS": "env_fallback_key",  # pragma: allowlist secret
+        },
+        clear=False,
+    )
+    def test_production_db_error_falls_back_to_env_tier(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test production mode with DB enabled reaches the lookup placeholder path."""
-        caplog.set_level("ERROR")
-        with pytest.raises(
-            NotImplementedError, match="Subscription database lookup not implemented"
-        ):
-            _validate_api_key_tier("prod_key", SubscriptionTier.PRO)
-        assert "Subscription database lookup not implemented" in caplog.text
+        """Test DB lookup error path falls back to env-based tier detection."""
+        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: None)
+        assert _validate_api_key_tier("env_fallback_key", SubscriptionTier.VIP) is True
+        assert _validate_api_key_tier("unknown_key", SubscriptionTier.PRO) is False
+
+
+class _FakeResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, value: object) -> None:
+        self._value = value
+        self.closed = False
+
+    def execute(self, _query: object, _params: dict[str, str]) -> _FakeResult:
+        return _FakeResult(self._value)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestDBLookupHelpers:
+    """Test low-level DB tier lookup helpers."""
+
+    def test_tier_allows_access_helper(self) -> None:
+        """Test tier inclusion matrix helper."""
+        assert api_tiers_mod._tier_allows_access(SubscriptionTier.VIP, SubscriptionTier.PRO) is True
+        assert (
+            api_tiers_mod._tier_allows_access(SubscriptionTier.PRO, SubscriptionTier.VIP) is False
+        )
+        assert (
+            api_tiers_mod._tier_allows_access(SubscriptionTier.FREE, SubscriptionTier.FREE) is True
+        )
+
+    def test_parse_tier_value(self) -> None:
+        """Test tier parsing from raw values."""
+        assert api_tiers_mod._parse_tier_value(" vip ") == SubscriptionTier.VIP
+        assert api_tiers_mod._parse_tier_value("PRO") == SubscriptionTier.PRO
+        assert api_tiers_mod._parse_tier_value("unknown") is None
+
+    def test_lookup_tier_from_db_handles_db_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB lookup returns None on DB/session exceptions."""
+        import core.db as core_db
+
+        def _boom() -> object:
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(core_db, "get_session_factory", _boom)
+        assert api_tiers_mod._lookup_tier_from_db("key") is None
+
+    def test_lookup_tier_from_db_handles_missing_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB lookup returns None when no record is found."""
+        import core.db as core_db
+
+        session = _FakeSession(None)
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        assert api_tiers_mod._lookup_tier_from_db("key") is None
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_handles_unknown_tier_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB lookup returns None for unknown tier string values."""
+        import core.db as core_db
+
+        session = _FakeSession("not_a_tier")
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        assert api_tiers_mod._lookup_tier_from_db("key") is None
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_returns_parsed_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test DB lookup returns parsed tier for valid DB value."""
+        import core.db as core_db
+
+        session = _FakeSession("VIP")
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        assert api_tiers_mod._lookup_tier_from_db("key") == SubscriptionTier.VIP
+        assert session.closed is True
 
 
 class TestRequireProTier:
@@ -182,15 +288,39 @@ class TestGetSubscriptionTier:
         assert get_subscription_tier("invalid_key") == SubscriptionTier.FREE
 
     @patch.dict(
-        os.environ, {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"}
+        os.environ,
+        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"},
+        clear=False,
     )
-    def test_production_raises_not_implemented(self) -> None:
-        """Test production mode raises NotImplementedError when DB not enabled."""
-        # Database not implemented yet, should raise NotImplementedError
-        with pytest.raises(NotImplementedError):
-            get_subscription_tier(TEST_KEY_VIP)
-        with pytest.raises(NotImplementedError):
-            get_subscription_tier(TEST_KEY_PRO)
+    def test_production_db_disabled_uses_env_detection(self) -> None:
+        """Test production mode with DB disabled uses env/test-key detection."""
+        assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.VIP
+        assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.PRO
+
+    @patch.dict(
+        os.environ,
+        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "true"},
+    )
+    def test_production_db_enabled_uses_db_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test get_subscription_tier returns DB tier when available."""
+        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: SubscriptionTier.VIP)
+        assert get_subscription_tier("db_key") == SubscriptionTier.VIP
+
+    @patch.dict(
+        os.environ,
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "true",
+            "VIP_API_KEYS": "env_key",  # pragma: allowlist secret
+        },
+        clear=False,
+    )
+    def test_production_db_enabled_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test get_subscription_tier falls back to env when DB lookup misses/errors."""
+        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: None)
+        assert get_subscription_tier("env_key") == SubscriptionTier.VIP
+        assert get_subscription_tier("unknown_key") == SubscriptionTier.FREE
 
 
 class TestGetProSubjectId:

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -4,9 +4,6 @@ RU: Тесты для промежуточного ПО проверки уро�
 EN: Tests for API tier validation middleware.
 """
 
-import os
-from unittest.mock import patch
-
 import pytest
 from fastapi import HTTPException
 
@@ -20,6 +17,7 @@ from app.middleware.api_tiers import (
     TEST_KEY_VIP,
     _validate_api_key_tier,
     derive_subject_id_from_api_key,
+    get_current_user,
     get_pro_subject_id,
     get_subscription_tier,
     require_pro_tier,
@@ -40,81 +38,76 @@ class TestSubscriptionTier:
 class TestValidateAPIKeyTier:
     """Test _validate_api_key_tier function."""
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_vip_key_grants_vip_access(self) -> None:
+    def test_vip_key_grants_vip_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP key grants VIP access in development."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is True
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_vip_key_grants_pro_access(self) -> None:
+    def test_vip_key_grants_pro_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP key also grants PRO access (VIP includes PRO)."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.PRO) is True
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_pro_key_grants_pro_access(self) -> None:
+    def test_pro_key_grants_pro_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test PRO key grants PRO access in development."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert _validate_api_key_tier(TEST_KEY_PRO, SubscriptionTier.PRO) is True
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_pro_key_denies_vip_access(self) -> None:
+    def test_pro_key_denies_vip_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test PRO key does NOT grant VIP access."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert _validate_api_key_tier(TEST_KEY_PRO, SubscriptionTier.VIP) is False
 
-    @patch.dict(
-        os.environ, {"APP_ENV": "local", "DEBUG": "true", "ALLOW_ANONYMOUS_API_KEYS": "true"}
-    )
-    def test_anonymous_allowed_in_dev(self) -> None:
+    def test_anonymous_allowed_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test any key accepted when ALLOW_ANONYMOUS_API_KEYS=true in dev."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
         assert _validate_api_key_tier("any_random_key", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("any_random_key", SubscriptionTier.VIP) is True
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "false",
-            "VIP_API_KEYS": "prod_key",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
-    def test_production_mode_without_db_uses_env_fallback(self) -> None:
+    def test_production_mode_without_db_uses_env_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test production mode falls back to env-based detection when DB is disabled."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+        monkeypatch.setenv("VIP_API_KEYS", "prod_key")  # pragma: allowlist secret
         assert _validate_api_key_tier("prod_key", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("prod_key", SubscriptionTier.VIP) is True
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "false",
-            "PRO_API_KEYS": "  pro_key_a , pro_key_b  ",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
-    def test_production_mode_without_db_resolves_pro_api_keys_csv(self) -> None:
+    def test_production_mode_without_db_resolves_pro_api_keys_csv(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test production env fallback resolves PRO_API_KEYS CSV with whitespace."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+        monkeypatch.setenv("PRO_API_KEYS", "  pro_key_a , pro_key_b  ")  # pragma: allowlist secret
         assert _validate_api_key_tier("pro_key_a", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("pro_key_b", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("pro_key_b", SubscriptionTier.VIP) is False
 
-    @patch.dict(
-        os.environ,
-        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"},
-        clear=False,
-    )
-    def test_production_mode_blocks_test_keys_in_env_fallback(self) -> None:
+    def test_production_mode_blocks_test_keys_in_env_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test production env fallback does not accept hardcoded test keys."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
         assert _validate_api_key_tier(TEST_KEY_PRO, SubscriptionTier.PRO) is False
         assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is False
 
-    @patch.dict(
-        os.environ,
-        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "true"},
-    )
     def test_production_db_enabled_uses_db_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test production mode with DB enabled validates access via DB tier."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
@@ -123,20 +116,14 @@ class TestValidateAPIKeyTier:
         assert _validate_api_key_tier("prodtoken", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("prodtoken", SubscriptionTier.VIP) is False
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "true",
-            "VIP_API_KEYS": "env_fallback_key",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
     def test_production_db_error_does_not_fallback_to_env_tier(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test DB lookup error path denies access instead of env fallback."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("VIP_API_KEYS", "env_fallback_key")  # pragma: allowlist secret
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
@@ -144,6 +131,35 @@ class TestValidateAPIKeyTier:
         )
         assert _validate_api_key_tier("env_fallback_key", SubscriptionTier.VIP) is False
         assert _validate_api_key_tier("unknown_key", SubscriptionTier.PRO) is False
+
+    def test_production_db_invalid_tier_does_not_fallback_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB lookup INVALID_TIER denies access (fail-closed), no env fallback."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("VIP_API_KEYS", "env_key")  # pragma: allowlist secret
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.INVALID_TIER),
+        )
+        assert _validate_api_key_tier("env_key", SubscriptionTier.VIP) is False
+
+    def test_production_db_miss_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test DB MISS allows env fallback (migration path)."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("PRO_API_KEYS", "miss_then_env_key")  # pragma: allowlist secret
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.MISS),
+        )
+        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.VIP) is False
 
 
 class _FakeResult:
@@ -188,7 +204,7 @@ class TestDBLookupHelpers:
     def test_lookup_tier_from_db_handles_db_exception(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test DB lookup returns None on DB/session exceptions."""
+        """Test _lookup_tier_from_db returns DBLookupResult with status ERROR on DB/session exceptions."""
         import core.db as core_db
 
         def _boom() -> object:
@@ -202,7 +218,7 @@ class TestDBLookupHelpers:
     def test_lookup_tier_from_db_handles_missing_record(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test DB lookup returns None when no record is found."""
+        """Test _lookup_tier_from_db returns DBLookupResult with status MISS when no record is found."""
         import core.db as core_db
 
         session = _FakeSession(None)
@@ -215,7 +231,7 @@ class TestDBLookupHelpers:
     def test_lookup_tier_from_db_handles_unknown_tier_value(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test DB lookup returns None for unknown tier string values."""
+        """Test _lookup_tier_from_db returns DBLookupResult with status INVALID_TIER for unknown tier values."""
         import core.db as core_db
 
         session = _FakeSession("not_a_tier")
@@ -240,15 +256,17 @@ class TestDBLookupHelpers:
 class TestRequireProTier:
     """Test require_pro_tier dependency function (sync, runs in threadpool in FastAPI)."""
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_pro_key_accepted(self) -> None:
+    def test_pro_key_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test PRO key is accepted for PRO tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         result = require_pro_tier(x_api_key=TEST_KEY_PRO)
         assert result == TEST_KEY_PRO
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_vip_key_accepted_for_pro(self) -> None:
+    def test_vip_key_accepted_for_pro(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP key is accepted for PRO tier (VIP includes PRO)."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         result = require_pro_tier(x_api_key=TEST_KEY_VIP)
         assert result == TEST_KEY_VIP
 
@@ -259,9 +277,10 @@ class TestRequireProTier:
         assert exc_info.value.status_code == 401
         assert "API key required" in exc_info.value.detail
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_invalid_key_raises_403(self) -> None:
+    def test_invalid_key_raises_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invalid API key raises 403 Forbidden."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         with pytest.raises(HTTPException) as exc_info:
             require_pro_tier(x_api_key="invalid_key")
         assert exc_info.value.status_code == 403
@@ -271,15 +290,17 @@ class TestRequireProTier:
 class TestRequireVIPTier:
     """Test require_vip_tier dependency function (sync, runs in threadpool in FastAPI)."""
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_vip_key_accepted(self) -> None:
+    def test_vip_key_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP key is accepted for VIP tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         result = require_vip_tier(x_api_key=TEST_KEY_VIP)
         assert result == TEST_KEY_VIP
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_pro_key_rejected_for_vip(self) -> None:
+    def test_pro_key_rejected_for_vip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test PRO key is rejected for VIP tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         with pytest.raises(HTTPException) as exc_info:
             require_vip_tier(x_api_key=TEST_KEY_PRO)
         assert exc_info.value.status_code == 403
@@ -292,9 +313,10 @@ class TestRequireVIPTier:
         assert exc_info.value.status_code == 403
         assert "VIP access" in exc_info.value.detail or "API key required" in exc_info.value.detail
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_invalid_key_raises_403(self) -> None:
+    def test_invalid_key_raises_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invalid API key raises 403 Forbidden."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         with pytest.raises(HTTPException) as exc_info:
             require_vip_tier(x_api_key="invalid_key")
         assert exc_info.value.status_code == 403
@@ -304,46 +326,46 @@ class TestRequireVIPTier:
 class TestGetSubscriptionTier:
     """Test get_subscription_tier helper function."""
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_vip_key_returns_vip_tier(self) -> None:
+    def test_vip_key_returns_vip_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP key returns VIP tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.VIP
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_pro_key_returns_pro_tier(self) -> None:
+    def test_pro_key_returns_pro_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test PRO key returns PRO tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.PRO
 
-    @patch.dict(os.environ, {"APP_ENV": "local", "DEBUG": "true"})
-    def test_invalid_key_returns_free_tier(self) -> None:
+    def test_invalid_key_returns_free_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invalid key returns FREE tier."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
         assert get_subscription_tier("invalid_key") == SubscriptionTier.FREE
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "false",
-            "VIP_API_KEYS": "vip_prod",  # pragma: allowlist secret
-            "PRO_API_KEYS": "  pro_prod_a , pro_prod_b  ",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
-    def test_production_db_disabled_uses_env_detection(self) -> None:
+    def test_production_db_disabled_uses_env_detection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test production mode with DB disabled uses env keys (not test keys)."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+        monkeypatch.setenv("VIP_API_KEYS", "vip_prod")  # pragma: allowlist secret
+        monkeypatch.setenv(
+            "PRO_API_KEYS", "  pro_prod_a , pro_prod_b  "
+        )  # pragma: allowlist secret
         assert get_subscription_tier("vip_prod") == SubscriptionTier.VIP
         assert get_subscription_tier("pro_prod_a") == SubscriptionTier.PRO
         assert get_subscription_tier("pro_prod_b") == SubscriptionTier.PRO
         assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.FREE
         assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.FREE
 
-    @patch.dict(
-        os.environ,
-        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "true"},
-    )
     def test_production_db_enabled_uses_db_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test get_subscription_tier returns DB tier when available."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
@@ -351,20 +373,14 @@ class TestGetSubscriptionTier:
         )
         assert get_subscription_tier("db_key") == SubscriptionTier.VIP
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "true",
-            "VIP_API_KEYS": "env_key",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
     def test_production_db_enabled_falls_back_to_env_on_db_miss(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test get_subscription_tier falls back to env only when DB lookup misses."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("VIP_API_KEYS", "env_key")  # pragma: allowlist secret
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
@@ -373,26 +389,35 @@ class TestGetSubscriptionTier:
         assert get_subscription_tier("env_key") == SubscriptionTier.VIP
         assert get_subscription_tier("unknown_key") == SubscriptionTier.FREE
 
-    @patch.dict(
-        os.environ,
-        {
-            "APP_ENV": "production",
-            "DEBUG": "false",
-            "SUBSCRIPTION_DB_ENABLED": "true",
-            "VIP_API_KEYS": "env_key",  # pragma: allowlist secret
-        },
-        clear=False,
-    )
     def test_production_db_error_returns_free_without_env_fallback(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test DB errors are fail-closed for tier inference when DB mode is enabled."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("VIP_API_KEYS", "env_key")  # pragma: allowlist secret
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
             lambda _: DBLookupResult(status=DBLookupStatus.ERROR),
         )
         assert get_subscription_tier("env_key") == SubscriptionTier.FREE
+
+
+class TestGetCurrentUser:
+    """Test get_current_user dependency."""
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_returns_derived_user(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test get_current_user returns CurrentUser with derived subject_id and api_key."""
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
+        user = await get_current_user(api_key=TEST_KEY_PRO)
+        assert user.api_key == TEST_KEY_PRO
+        assert user.user_id == derive_subject_id_from_api_key(TEST_KEY_PRO)
 
 
 class TestGetProSubjectId:
@@ -428,27 +453,29 @@ class TestDeriveSubjectIdFromApiKey:
 class TestEnvironmentConfiguration:
     """Test environment configuration handling."""
 
-    @patch.dict(os.environ, {"APP_ENV": "local"})
-    def test_local_env_not_production(self) -> None:
+    def test_local_env_not_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test local environment is not production."""
+        monkeypatch.setenv("APP_ENV", "local")
         from app.middleware.api_tiers import _is_production_environment
 
         is_prod, env = _is_production_environment()
         assert is_prod is False
         assert env == "local"
 
-    @patch.dict(os.environ, {"APP_ENV": "production", "DEBUG": "false"})
-    def test_production_env_is_production(self) -> None:
+    def test_production_env_is_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test production environment is detected."""
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
         from app.middleware.api_tiers import _is_production_environment
 
         is_prod, env = _is_production_environment()
         assert is_prod is True
         assert env == "production"
 
-    @patch.dict(os.environ, {"APP_ENV": "staging", "DEBUG": "false"})
-    def test_staging_env_is_production(self) -> None:
+    def test_staging_env_is_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test staging environment is treated as production."""
+        monkeypatch.setenv("APP_ENV", "staging")
+        monkeypatch.setenv("DEBUG", "false")
         from app.middleware.api_tiers import _is_production_environment
 
         is_prod, env = _is_production_environment()

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -12,6 +12,8 @@ from fastapi import HTTPException
 
 import app.middleware.api_tiers as api_tiers_mod
 from app.middleware.api_tiers import (
+    DBLookupResult,
+    DBLookupStatus,
     CurrentUser,
     SubscriptionTier,
     TEST_KEY_PRO,
@@ -90,7 +92,7 @@ class TestValidateAPIKeyTier:
         monkeypatch.setattr(
             api_tiers_mod,
             "_lookup_tier_from_db",
-            lambda _: SubscriptionTier.PRO,
+            lambda _: DBLookupResult(status=DBLookupStatus.HIT, tier=SubscriptionTier.PRO),
         )
         assert _validate_api_key_tier("prodtoken", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("prodtoken", SubscriptionTier.VIP) is False
@@ -105,12 +107,16 @@ class TestValidateAPIKeyTier:
         },
         clear=False,
     )
-    def test_production_db_error_falls_back_to_env_tier(
+    def test_production_db_error_does_not_fallback_to_env_tier(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test DB lookup error path falls back to env-based tier detection."""
-        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: None)
-        assert _validate_api_key_tier("env_fallback_key", SubscriptionTier.VIP) is True
+        """Test DB lookup error path denies access instead of env fallback."""
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.ERROR),
+        )
+        assert _validate_api_key_tier("env_fallback_key", SubscriptionTier.VIP) is False
         assert _validate_api_key_tier("unknown_key", SubscriptionTier.PRO) is False
 
 
@@ -163,7 +169,9 @@ class TestDBLookupHelpers:
             raise RuntimeError("db down")
 
         monkeypatch.setattr(core_db, "get_session_factory", _boom)
-        assert api_tiers_mod._lookup_tier_from_db("key") is None
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.ERROR
+        assert result.tier is None
 
     def test_lookup_tier_from_db_handles_missing_record(
         self, monkeypatch: pytest.MonkeyPatch
@@ -173,7 +181,9 @@ class TestDBLookupHelpers:
 
         session = _FakeSession(None)
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
-        assert api_tiers_mod._lookup_tier_from_db("key") is None
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.MISS
+        assert result.tier is None
         assert session.closed is True
 
     def test_lookup_tier_from_db_handles_unknown_tier_value(
@@ -184,7 +194,9 @@ class TestDBLookupHelpers:
 
         session = _FakeSession("not_a_tier")
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
-        assert api_tiers_mod._lookup_tier_from_db("key") is None
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.INVALID_TIER
+        assert result.tier is None
         assert session.closed is True
 
     def test_lookup_tier_from_db_returns_parsed_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -193,7 +205,9 @@ class TestDBLookupHelpers:
 
         session = _FakeSession("VIP")
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
-        assert api_tiers_mod._lookup_tier_from_db("key") == SubscriptionTier.VIP
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.HIT
+        assert result.tier == SubscriptionTier.VIP
         assert session.closed is True
 
 
@@ -303,7 +317,11 @@ class TestGetSubscriptionTier:
     )
     def test_production_db_enabled_uses_db_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test get_subscription_tier returns DB tier when available."""
-        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: SubscriptionTier.VIP)
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.HIT, tier=SubscriptionTier.VIP),
+        )
         assert get_subscription_tier("db_key") == SubscriptionTier.VIP
 
     @patch.dict(
@@ -316,11 +334,38 @@ class TestGetSubscriptionTier:
         },
         clear=False,
     )
-    def test_production_db_enabled_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test get_subscription_tier falls back to env when DB lookup misses/errors."""
-        monkeypatch.setattr(api_tiers_mod, "_lookup_tier_from_db", lambda _: None)
+    def test_production_db_enabled_falls_back_to_env_on_db_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test get_subscription_tier falls back to env only when DB lookup misses."""
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.MISS),
+        )
         assert get_subscription_tier("env_key") == SubscriptionTier.VIP
         assert get_subscription_tier("unknown_key") == SubscriptionTier.FREE
+
+    @patch.dict(
+        os.environ,
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "true",
+            "VIP_API_KEYS": "env_key",  # pragma: allowlist secret
+        },
+        clear=False,
+    )
+    def test_production_db_error_returns_free_without_env_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB errors are fail-closed for tier inference when DB mode is enabled."""
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_lookup_tier_from_db",
+            lambda _: DBLookupResult(status=DBLookupStatus.ERROR),
+        )
+        assert get_subscription_tier("env_key") == SubscriptionTier.FREE
 
 
 class TestGetProSubjectId:

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -85,6 +85,32 @@ class TestValidateAPIKeyTier:
 
     @patch.dict(
         os.environ,
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "false",
+            "PRO_API_KEYS": "  pro_key_a , pro_key_b  ",  # pragma: allowlist secret
+        },
+        clear=False,
+    )
+    def test_production_mode_without_db_resolves_pro_api_keys_csv(self) -> None:
+        """Test production env fallback resolves PRO_API_KEYS CSV with whitespace."""
+        assert _validate_api_key_tier("pro_key_a", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("pro_key_b", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("pro_key_b", SubscriptionTier.VIP) is False
+
+    @patch.dict(
+        os.environ,
+        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"},
+        clear=False,
+    )
+    def test_production_mode_blocks_test_keys_in_env_fallback(self) -> None:
+        """Test production env fallback does not accept hardcoded test keys."""
+        assert _validate_api_key_tier(TEST_KEY_PRO, SubscriptionTier.PRO) is False
+        assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is False
+
+    @patch.dict(
+        os.environ,
         {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "true"},
     )
     def test_production_db_enabled_uses_db_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -303,13 +329,22 @@ class TestGetSubscriptionTier:
 
     @patch.dict(
         os.environ,
-        {"APP_ENV": "production", "DEBUG": "false", "SUBSCRIPTION_DB_ENABLED": "false"},
+        {
+            "APP_ENV": "production",
+            "DEBUG": "false",
+            "SUBSCRIPTION_DB_ENABLED": "false",
+            "VIP_API_KEYS": "vip_prod",  # pragma: allowlist secret
+            "PRO_API_KEYS": "  pro_prod_a , pro_prod_b  ",  # pragma: allowlist secret
+        },
         clear=False,
     )
     def test_production_db_disabled_uses_env_detection(self) -> None:
-        """Test production mode with DB disabled uses env/test-key detection."""
-        assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.VIP
-        assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.PRO
+        """Test production mode with DB disabled uses env keys (not test keys)."""
+        assert get_subscription_tier("vip_prod") == SubscriptionTier.VIP
+        assert get_subscription_tier("pro_prod_a") == SubscriptionTier.PRO
+        assert get_subscription_tier("pro_prod_b") == SubscriptionTier.PRO
+        assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.FREE
+        assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.FREE
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary
- implement DB-first API tier resolution in `app/middleware/api_tiers.py` when `SUBSCRIPTION_DB_ENABLED=true`
- enforce fail-closed behavior for DB error/invalid-tier outcomes (no env fallback in those cases)
- keep env fallback only for explicit DB miss to preserve migration compatibility
- add focused tests for DB-enabled, DB-miss, DB-error, and invalid-tier paths; document policy in `app/AGENTS.md`

## Scope
- `app/middleware/api_tiers.py`
- `tests/test_api_tiers.py`
- `app/AGENTS.md`
- `docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md`

## Verification Evidence
- `pre-commit run --all-files` ✅
- `pytest -q tests/test_api_tiers.py` ✅
- `make verify` ✅
- `diff-cover --fail-under=97` via `make verify`: **100%** ✅

## DoD
- [x] `SUBSCRIPTION_DB_ENABLED=true` uses DB lookup
- [x] DB miss uses env fallback
- [x] DB error/invalid tier fail closed (no env fallback for access checks)
- [x] unknown/unresolved key remains denied by tier guards
- [x] tests cover db-enabled/db-miss/db-error/invalid-tier paths
- [x] `make verify` green and diff-cover >=97%
- [x] AGENTS policy updated

## Security Notes
- DB query is parameterized and fixed-schema (no dynamic identifier interpolation)
- DB error/invalid-tier outcomes are fail-closed for guard checks
- raw API keys are not logged in tier resolution events

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- next PR: OpenAPI contract hygiene for `/api/v1/export/sign` (typed response + regenerated frontend artifacts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DB-backed subscription tier resolution with environment-based fallback when DB is disabled or misses.
* **Bug Fixes / Security**
  * Fail-closed behavior: deny access on DB errors or invalid tier data to avoid accidental privilege escalation.
* **Documentation**
  * Added audit/gating docs clarifying DB-first policy, failure modes, and acceptance criteria.
* **Tests**
  * Expanded tests covering DB-enabled/disabled paths, fallback rules, and edge cases.
* **Chores**
  * Updated baseline metadata/timestamp entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->