### PR TITLE
feat(ci): add report-only greenlight iOS preflight workflow

### DIFF
--- a/.github/workflows/greenlight-ios.yml
+++ b/.github/workflows/greenlight-ios.yml
@@ -23,7 +23,9 @@ jobs:
   greenlight-ios:
     name: Greenlight preflight (report-only)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    env:
+      GREENLIGHT_TIMEOUT_MINUTES: "10"
+    timeout-minutes: ${{ fromJSON(env.GREENLIGHT_TIMEOUT_MINUTES) }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -31,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version: "1.22"
 
       - name: Run Greenlight preflight
         env:

--- a/.github/workflows/greenlight-ios.yml
+++ b/.github/workflows/greenlight-ios.yml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Greenlight iOS Preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - "ios/**"
+      - "scripts/ci/greenlight_ios_preflight.sh"
+      - ".github/workflows/greenlight-ios.yml"
+  push:
+    branches: [main, feat/**, fix/**]
+    paths:
+      - "ios/**"
+      - "scripts/ci/greenlight_ios_preflight.sh"
+      - ".github/workflows/greenlight-ios.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  greenlight-ios:
+    name: Greenlight preflight (report-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+
+      - name: Run Greenlight preflight
+        env:
+          GREENLIGHT_VERSION: v0.1.0
+          GREENLIGHT_BLOCKING: "false"
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/greenlight_ios_preflight.sh
+          scripts/ci/greenlight_ios_preflight.sh ios greenlight-report.json
+
+      - name: Upload Greenlight report artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: greenlight-ios-report
+          path: greenlight-report.json
+          if-no-files-found: error

--- a/.github/workflows/greenlight-ios.yml
+++ b/.github/workflows/greenlight-ios.yml
@@ -23,9 +23,9 @@ jobs:
   greenlight-ios:
     name: Greenlight preflight (report-only)
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(vars.GREENLIGHT_TIMEOUT_MINUTES || '10') }}
     env:
-      GREENLIGHT_TIMEOUT_MINUTES: "10"
-    timeout-minutes: ${{ fromJSON(env.GREENLIGHT_TIMEOUT_MINUTES) }}
+      GREENLIGHT_TIMEOUT_MINUTES: ${{ vars.GREENLIGHT_TIMEOUT_MINUTES || '10' }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1385,7 +1385,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 **GitHub Actions shell script policy:**
 
 - **ShellCheck compliance required:** All shell scripts in `.github/workflows/*.yml` must pass `actionlint` (which enforces ShellCheck rules).
-- **Job timeout:** Do not use `env` context in `job.timeout-minutes`; use `vars` (e.g. `fromJSON(vars.VAR || '10')`) — `env` is not available there (actionlint).
+- **Job timeout:** `job.timeout-minutes` cannot use `env` context (GitHub Actions limitation: `env` is not available at job level). Use `vars` with `fromJSON` and a default. Step-level scripts inside the job can read timeout from `env` (timeout SSOT rule).
 - **Forbidden patterns:** `ls | grep` (SC2010) — use glob + for loop or `find` instead.
 - **Rationale:** Prevents shell script bugs and ensures CI workflow reliability.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1385,6 +1385,7 @@ This section complements the earlier **"Docs-only PR Rule"** and clarifies the *
 **GitHub Actions shell script policy:**
 
 - **ShellCheck compliance required:** All shell scripts in `.github/workflows/*.yml` must pass `actionlint` (which enforces ShellCheck rules).
+- **Job timeout:** Do not use `env` context in `job.timeout-minutes`; use `vars` (e.g. `fromJSON(vars.VAR || '10')`) — `env` is not available there (actionlint).
 - **Forbidden patterns:** `ls | grep` (SC2010) — use glob + for loop or `find` instead.
 - **Rationale:** Prevents shell script bugs and ensures CI workflow reliability.
 

--- a/docs/audit/PR_722_GREENLIGHT_INTEGRATION_AUDIT.md
+++ b/docs/audit/PR_722_GREENLIGHT_INTEGRATION_AUDIT.md
@@ -1,4 +1,4 @@
-# PR Audit: Greenlight iOS Preflight Integration (P0)
+# PR Audit: Greenlight iOS Preflight Integration (P0) — PR #722
 
 ## Scope
 
@@ -17,7 +17,7 @@
 
 - `.github/workflows/greenlight-ios.yml`
 - `scripts/ci/greenlight_ios_preflight.sh`
-- `docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md`
+- `docs/audit/PR_722_GREENLIGHT_INTEGRATION_AUDIT.md`
 - `docs/runbook/IOS_GREENLIGHT.md`
 
 ## Repo-truth Evidence (file:line)

--- a/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
+++ b/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
@@ -20,6 +20,19 @@
 - `docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md`
 - `docs/runbook/IOS_GREENLIGHT.md`
 
+## Repo-truth Evidence (file:line)
+
+- Workflow entrypoint: `.github/workflows/greenlight-ios.yml:2`
+- Pinned tool/version env: `.github/workflows/greenlight-ios.yml:38`
+- Report-only mode env: `.github/workflows/greenlight-ios.yml:39`
+- Artifact upload step: `.github/workflows/greenlight-ios.yml:45`
+- Script version pin default: `scripts/ci/greenlight_ios_preflight.sh:6`
+- Script blocking flag default: `scripts/ci/greenlight_ios_preflight.sh:7`
+- Preflight command invocation: `scripts/ci/greenlight_ios_preflight.sh:29`
+- Blocking-on-critical condition: `scripts/ci/greenlight_ios_preflight.sh:83`
+- Runbook workflow reference: `docs/runbook/IOS_GREENLIGHT.md:10`
+- Runbook report-only policy: `docs/runbook/IOS_GREENLIGHT.md:19`
+
 ## Repo-truth evidence commands
 
 - `rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh`

--- a/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
+++ b/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
@@ -35,9 +35,11 @@
 
 ## Repo-truth evidence commands
 
-- `rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" \
-  .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh`
-- `rg -n "report-only|critical|artifact|blocking" docs/runbook/IOS_GREENLIGHT.md`
+```shell
+rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" \
+  .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh
+rg -n "report-only|critical|artifact|blocking" docs/runbook/IOS_GREENLIGHT.md
+```
 
 ## Failure modes and expected behavior
 

--- a/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
+++ b/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
@@ -8,10 +8,10 @@
 
 ## Non-goals
 
-- No backend runtime changes.
-- No blocking policy on findings (P0 is report-only).
-- No App Store Connect authenticated scan (offline preflight only).
-- No local Makefile target in this phase (planned for P1).
+- Backend runtime remains unchanged.
+- Findings do not block merges in P0 (report-only).
+- App Store Connect authenticated scans excluded (offline preflight only).
+- Local Makefile target deferred to P1.
 
 ## Files changed
 
@@ -35,7 +35,8 @@
 
 ## Repo-truth evidence commands
 
-- `rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh`
+- `rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" \
+  .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh`
 - `rg -n "report-only|critical|artifact|blocking" docs/runbook/IOS_GREENLIGHT.md`
 
 ## Failure modes and expected behavior
@@ -46,7 +47,7 @@
 | docs-only PR | Greenlight workflow does not run |
 | greenlight install failure | Job fails (explicit error) |
 | greenlight execution error | Job fails (no error masking) |
-| report-only with findings | Job succeeds, findings visible in summary + artifact |
+| report-only with findings | Job succeeds; findings in summary + artifact |
 | future blocking mode + critical findings | Job fails deterministically |
 
 ## Security guardrails

--- a/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
+++ b/docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md
@@ -1,0 +1,52 @@
+# PR Audit: Greenlight iOS Preflight Integration (P0)
+
+## Scope
+
+- Add report-only App Store readiness scan for iOS in CI.
+- Integrate `greenlight preflight` as a standalone workflow and CI script.
+- Publish JSON report as workflow artifact and short step summary.
+
+## Non-goals
+
+- No backend runtime changes.
+- No blocking policy on findings (P0 is report-only).
+- No App Store Connect authenticated scan (offline preflight only).
+- No local Makefile target in this phase (planned for P1).
+
+## Files changed
+
+- `.github/workflows/greenlight-ios.yml`
+- `scripts/ci/greenlight_ios_preflight.sh`
+- `docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md`
+- `docs/runbook/IOS_GREENLIGHT.md`
+
+## Repo-truth evidence commands
+
+- `rg -n "greenlight preflight|GREENLIGHT_BLOCKING|GREENLIGHT_VERSION" .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh`
+- `rg -n "report-only|critical|artifact|blocking" docs/runbook/IOS_GREENLIGHT.md`
+
+## Failure modes and expected behavior
+
+| Scenario | Expected behavior |
+| --- | --- |
+| iOS changes in PR | Greenlight workflow runs, report uploaded |
+| docs-only PR | Greenlight workflow does not run |
+| greenlight install failure | Job fails (explicit error) |
+| greenlight execution error | Job fails (no error masking) |
+| report-only with findings | Job succeeds, findings visible in summary + artifact |
+| future blocking mode + critical findings | Job fails deterministically |
+
+## Security guardrails
+
+- Pinned tool version via `GREENLIGHT_VERSION=v0.1.0`.
+- No `|| true` in execution path.
+- JSON report kept as artifact; no raw key material printed by script.
+- Scope isolated to iOS workflow; backend quality gates remain unchanged.
+
+## Definition of Done (P0)
+
+- [x] Separate iOS workflow added with path scoping.
+- [x] `greenlight preflight` runs in CI and outputs JSON.
+- [x] Report uploaded as artifact.
+- [x] Report-only mode documented in runbook.
+- [x] No backend/runtime contracts changed.

--- a/docs/runbook/IOS_GREENLIGHT.md
+++ b/docs/runbook/IOS_GREENLIGHT.md
@@ -3,7 +3,8 @@
 ## Purpose
 
 `greenlight` provides an App Store pre-submission readiness scan for iOS projects.
-Current phase is **P0 report-only** to measure signal quality before enabling blocking gates.
+Current phase is **P0 report-only** to measure signal quality before enabling
+blocking gates.
 
 ## CI workflow
 

--- a/docs/runbook/IOS_GREENLIGHT.md
+++ b/docs/runbook/IOS_GREENLIGHT.md
@@ -1,0 +1,48 @@
+# iOS Greenlight Runbook (P0)
+
+## Purpose
+
+`greenlight` provides an App Store pre-submission readiness scan for iOS projects.
+Current phase is **P0 report-only** to measure signal quality before enabling blocking gates.
+
+## CI workflow
+
+- Workflow: `.github/workflows/greenlight-ios.yml`
+- Script: `scripts/ci/greenlight_ios_preflight.sh`
+- Trigger scope: `ios/**` and Greenlight workflow/script changes
+- Output:
+  - GitHub step summary with severity counts
+  - Artifact: `greenlight-ios-report` (`greenlight-report.json`)
+
+## Policy (P0)
+
+- Mode: report-only (`GREENLIGHT_BLOCKING=false`)
+- Tool version is pinned: `GREENLIGHT_VERSION=v0.1.0`
+- CI must fail on tool execution errors (no shell error masking)
+- Findings do not block merge in P0
+
+## Local execution
+
+```bash
+GREENLIGHT_VERSION=v0.1.0 GREENLIGHT_BLOCKING=false \
+  scripts/ci/greenlight_ios_preflight.sh ios greenlight-report.json
+```
+
+## Interpreting results
+
+- `critical`: potential App Store rejection risks with highest priority
+- `high/medium/low/info`: descending priority for remediation backlog
+- Use artifact JSON for detailed diagnostics and issue triage
+
+## P1 transition criteria (blocking mode)
+
+Before switching to blocking:
+
+1. Two weeks of stable report-only runs.
+2. False positive rate is acceptable for CI friction.
+3. Team agrees on baseline/allowlist process for known non-actionable findings.
+
+Then enable:
+
+- `GREENLIGHT_BLOCKING=true`
+- Fail job only when `critical > 0`

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -22,6 +22,18 @@
   `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`.
 - This is a workflow reference only (no runtime behavior).
 
+## CI: Greenlight iOS preflight (P0 report-only)
+
+- Workflow: `.github/workflows/greenlight-ios.yml`
+- Purpose: iOS-only preflight checks via Greenlight to measure signal quality before enabling blocking gates.
+- Triggers: path-scoped (iOS/CI-related changes only).
+- Preflight script: `scripts/ci/greenlight_ios_preflight.sh`
+  - Runs: `greenlight preflight --format json` (report artifact)
+  - Deterministic version pin: `GREENLIGHT_VERSION=v0.1.0`
+  - Report-only by default: `GREENLIGHT_BLOCKING=false`
+- Timeouts: Job-level `timeout-minutes` must use `vars` (GitHub Actions: `env` not available at job level; actionlint). Step-level scripts can read timeout from `env` (see root AGENTS.md timeout SSOT rule).
+- Runner/approvals: Uses default runner; does not modify backend runtime.
+
 ## Backend coordination (important)
 
 - Some backend endpoints (e.g. export / premium features) may be gated by

--- a/scripts/ci/greenlight_ios_preflight.sh
+++ b/scripts/ci/greenlight_ios_preflight.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_PATH="${1:-ios}"
+REPORT_PATH="${2:-greenlight-report.json}"
+GREENLIGHT_VERSION="${GREENLIGHT_VERSION:-v0.1.0}"
+GREENLIGHT_BLOCKING="${GREENLIGHT_BLOCKING:-false}"
+
+echo "Running Greenlight preflight for: ${PROJECT_PATH}"
+echo "Pinned Greenlight version: ${GREENLIGHT_VERSION}"
+
+if ! command -v greenlight >/dev/null 2>&1; then
+  if ! command -v go >/dev/null 2>&1; then
+    echo "go is required to install greenlight but was not found in PATH" >&2
+    exit 2
+  fi
+
+  echo "Installing greenlight ${GREENLIGHT_VERSION} via go install..."
+  go install "github.com/RevylAI/greenlight/cmd/greenlight@${GREENLIGHT_VERSION}"
+fi
+
+export PATH="$(go env GOPATH)/bin:${PATH}"
+
+if ! command -v greenlight >/dev/null 2>&1; then
+  echo "greenlight was not found after installation" >&2
+  exit 2
+fi
+
+greenlight preflight "${PROJECT_PATH}" --format json --output "${REPORT_PATH}"
+
+python3 - "${REPORT_PATH}" "${GREENLIGHT_BLOCKING}" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+report_path = Path(sys.argv[1])
+blocking_raw = sys.argv[2].strip().lower()
+blocking = blocking_raw in {"1", "true", "yes", "on"}
+
+if not report_path.exists():
+    print(f"Report file not found: {report_path}", file=sys.stderr)
+    raise SystemExit(2)
+
+payload = json.loads(report_path.read_text(encoding="utf-8"))
+summary = payload.get("summary", {})
+
+critical = int(summary.get("critical", 0))
+high = int(summary.get("high", 0))
+medium = int(summary.get("medium", 0))
+low = int(summary.get("low", 0))
+info = int(summary.get("info", 0))
+
+line = (
+    f"Greenlight summary: critical={critical}, high={high}, "
+    f"medium={medium}, low={low}, info={info}"
+)
+print(line)
+
+step_summary_path = Path.cwd() / Path(".github_step_summary_fallback.md")
+if "GITHUB_STEP_SUMMARY" in os.environ:
+    step_summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+step_summary_path.write_text(
+    "\n".join(
+        [
+            "## Greenlight iOS preflight",
+            "",
+            f"- critical: `{critical}`",
+            f"- high: `{high}`",
+            f"- medium: `{medium}`",
+            f"- low: `{low}`",
+            f"- info: `{info}`",
+            f"- mode: `{'blocking' if blocking else 'report-only'}`",
+            "",
+            f"Report file: `{report_path}`",
+        ]
+    )
+    + "\n",
+    encoding="utf-8",
+)
+
+if blocking and critical > 0:
+    print("Blocking mode active and critical findings > 0", file=sys.stderr)
+    raise SystemExit(1)
+PY

--- a/scripts/ci/greenlight_ios_preflight.sh
+++ b/scripts/ci/greenlight_ios_preflight.sh
@@ -9,6 +9,12 @@ GREENLIGHT_BLOCKING="${GREENLIGHT_BLOCKING:-false}"
 echo "Running Greenlight preflight for: ${PROJECT_PATH}"
 echo "Pinned Greenlight version: ${GREENLIGHT_VERSION}"
 
+# Add GOPATH/bin to PATH before checking so we can reuse an already-installed binary.
+# Only call go env when go is available (avoids failure when greenlight is in PATH but go is not).
+if command -v go >/dev/null 2>&1; then
+  export PATH="$(go env GOPATH)/bin:${PATH}"
+fi
+
 if ! command -v greenlight >/dev/null 2>&1; then
   if ! command -v go >/dev/null 2>&1; then
     echo "go is required to install greenlight but was not found in PATH" >&2
@@ -18,8 +24,6 @@ if ! command -v greenlight >/dev/null 2>&1; then
   echo "Installing greenlight ${GREENLIGHT_VERSION} via go install..."
   go install "github.com/RevylAI/greenlight/cmd/greenlight@${GREENLIGHT_VERSION}"
 fi
-
-export PATH="$(go env GOPATH)/bin:${PATH}"
 
 if ! command -v greenlight >/dev/null 2>&1; then
   echo "greenlight was not found after installation" >&2


### PR DESCRIPTION
## Summary
- add standalone iOS App Store readiness workflow using `greenlight preflight` in report-only mode
- add deterministic CI script with pinned `GREENLIGHT_VERSION=v0.1.0`, JSON report output, and GitHub step summary
- document scope, failure modes, and rollout policy in audit + runbook docs

## Scope
- `.github/workflows/greenlight-ios.yml`
- `scripts/ci/greenlight_ios_preflight.sh`
- `docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md`
- `docs/runbook/IOS_GREENLIGHT.md`

## Rollout policy
- P0 mode is report-only (`GREENLIGHT_BLOCKING=false`)
- no backend/runtime behavior changes
- blocking mode is deferred to P1 after stability/false-positive evaluation

## Verification
- `pre-commit run --files .github/workflows/greenlight-ios.yml scripts/ci/greenlight_ios_preflight.sh docs/audit/PR_XXX_GREENLIGHT_INTEGRATION_AUDIT.md docs/runbook/IOS_GREENLIGHT.md` ✅
- `pre-commit run --all-files` ✅

## Security notes
- fixed tool version pin (`v0.1.0`) for deterministic behavior
- no shell error masking (`set -euo pipefail`, no `|| true`)
- findings are reported as artifact + summary; P0 does not block merges on findings

## DoD
- [x] Greenlight CI workflow exists and is path-scoped to iOS/workflow/script
- [x] Preflight script emits JSON report and step summary
- [x] Report artifact uploaded
- [x] P0 report-only policy documented
- [x] No backend runtime changes

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- P1: enable blocking on critical findings only
- P1: add optional local convenience target (`make ios-greenlight`)
- P2: evaluate IPA scan path for release workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Greenlight iOS preflight CI workflow that runs on PRs/targeted pushes, produces a JSON report artifact and human-readable CI summary, and can be configured to fail on critical findings.

* **Documentation**
  * Added audit docs with scope, guardrails, verification steps, and DoD.
  * Added an iOS runbook with usage, result interpretation, local execution, and triage guidance.
  * Clarified CI workflow timing guidance in policy docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->