### PR TITLE
docs(ledger): mark API Tiers DB lookup (PR-721) closed

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Backlog Ledger (Canonical)
 
 **Purpose:** single source of truth for postponed / follow-up work.
@@ -1211,6 +1212,21 @@ If it is not recorded here — it does not exist.
     - Fallback to env-based detection only on DB MISS (not on ERROR/INVALID_TIER) ✅
     - Tests cover both paths ✅
 
+- [x] Greenlight iOS P0 report-only workflow
+  - Owner: @katsiaryna_kavaleuskaya
+  - Target PR: PR-722
+  - Status: ✅ Merged (PR-722, 2026-02-12)
+  - Priority: P0
+  - Area: CI / iOS
+  - Reason: Add report-only App Store readiness scan for iOS in CI.
+  - Links:
+    - docs/audit/PR_722_GREENLIGHT_INTEGRATION_AUDIT.md
+    - docs/runbook/IOS_GREENLIGHT.md
+  - DoD:
+    - Workflow `.github/workflows/greenlight-ios.yml` path-scoped ✅
+    - Report artifact + step summary ✅
+    - P0 report-only documented ✅
+
 - [ ] Security suppression expiry monitoring
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: N/A (ongoing)
@@ -1726,3 +1742,4 @@ If it is not recorded here — it does not exist.
 
 **Last updated:** 2026-01-28 (SCIENTIFIC_INNOVATION_ANALYSIS.md canonical doc, backlog links)
 **Maintainer:** @katsiaryna_kavaleuskaya
+<!-- markdownlint-enable MD013 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1193,22 +1193,23 @@ If it is not recorded here — it does not exist.
     - Stricter inline comment parsing
     - Test cases for edge cases
 
-- [ ] API Tiers database lookup implementation
+- [x] API Tiers database lookup implementation
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: TBD
+  - Target PR: PR-721
+  - Status: ✅ Merged (PR-721, 2026-02-12)
   - Priority: P1
   - Area: backend
   - Finding Type: TODO/FIXME
   - Locations:
-    - `app/middleware/api_tiers.py:146` — TODO: Implement database lookup for production
-    - `app/middleware/api_tiers.py:284` — TODO: Implement database lookup
-  - Reason: Currently uses env-based tier detection; needs DB lookup for production
+    - `app/middleware/api_tiers.py` — DB lookup + env fallback (MISS only); ERROR/INVALID_TIER fail-closed
+  - Reason: Previously env-only; now DB-first when SUBSCRIPTION_DB_ENABLED=true with explicit fail-closed policy.
   - Links:
     - docs/audit/PR_585_BACKLOG_SWEEP_AUDIT.md
+    - docs/audit/PR_XXX_API_TIERS_DB_LOOKUP_AUDIT.md (audit in PR-721)
   - DoD:
-    - Database lookup implemented when SUBSCRIPTION_DB_ENABLED=true
-    - Fallback to env-based detection when DB unavailable
-    - Tests cover both paths
+    - Database lookup implemented when SUBSCRIPTION_DB_ENABLED=true ✅
+    - Fallback to env-based detection only on DB MISS (not on ERROR/INVALID_TIER) ✅
+    - Tests cover both paths ✅
 
 - [ ] Security suppression expiry monitoring
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
Docs-only: mark BACKLOG_LEDGER item "API Tiers database lookup implementation" as closed after PR-721 merge.

## Scope
- `docs/roadmap/BACKLOG_LEDGER.md` only (no code/runtime changes).

## Verification
- `git diff --name-only origin/main` → only `docs/roadmap/BACKLOG_LEDGER.md`
- Per AGENTS.md: follow-up docs-only PR to close ledger item completed by PR-721.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Documentation:
- Отметить пункт бэклога о поиске в базе данных API Tiers как закрытый, задокументировав его статус как влитого, целевой PR, примечания по реализации и обновлённое определение готовности (definition of done).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mark the API Tiers database lookup backlog item as closed, documenting its merged status, target PR, implementation notes, and updated definition of done.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated roadmap/backlog entries to mark the API Tiers DB-first lookup and the Greenlight iOS P0 report-only workflow as completed.

* **Documentation**
  * Expanded acceptance criteria and test/DoD details for both items and added audit/documentation links to the backlog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments
