### PR TITLE
security: CVE-2026-26007 policy + ledger closure (cryptography 46.0.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1248,9 +1248,14 @@ git grep -nE "spec_from_file_location|exec_module|sys\.modules\[" -- scripts || 
 
 **Security: Dependency CVE bumps (application deps):**
 
-- Security CVE dependency bumps must update **all requirement surfaces** (e.g. `requirements.in`,
-  `requirements.txt`, `requirements-dev.txt`, `requirements-lock.txt`, `constraints.txt`) plus a
-  **dependency security guard test** and **evidence** (`docs/security/CVE-*.md` or equivalent).
+- **Scope:** Python application dependencies in this repo (e.g. `requirements*.in`/`requirements*.txt`,
+  `constraints.txt`). Other ecosystems (e.g. iOS SwiftPM, frontend npm) may have separate policies;
+  when in doubt, follow the same principle: all surfaces + guard + evidence.
+- Security CVE dependency bumps must update **all relevant requirement surfaces** for that ecosystem,
+  plus a **dependency security guard test** (deterministic CI check) and **evidence**.
+- **Evidence (canonical):** a doc in `docs/security/` that describes the CVE, fixed version, and
+  remediation (e.g. `docs/security/CVE-<id>-<package>.md`). Alternative locations (e.g. advisory link
+  in ledger only) are acceptable only when documented in the same PR.
 - Reduces drift risk from updating only one manifest.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1246,6 +1246,13 @@ git grep -nE "spec_from_file_location|exec_module|sys\.modules\[" -- scripts || 
 - Monitor: <https://security-tracker.debian.org/tracker/CVE-2026-0861>
 - See: `docs/security/CVE-2026-0861-glibc.md`
 
+**Security: Dependency CVE bumps (application deps):**
+
+- Security CVE dependency bumps must update **all requirement surfaces** (e.g. `requirements.in`,
+  `requirements.txt`, `requirements-dev.txt`, `requirements-lock.txt`, `constraints.txt`) plus a
+  **dependency security guard test** and **evidence** (`docs/security/CVE-*.md` or equivalent).
+- Reduces drift risk from updating only one manifest.
+
 ---
 
 ## CI: GitHub Container Registry (GHCR) Policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1256,6 +1256,8 @@ git grep -nE "spec_from_file_location|exec_module|sys\.modules\[" -- scripts || 
 - **Evidence (canonical):** a doc in `docs/security/` that describes the CVE, fixed version, and
   remediation (e.g. `docs/security/CVE-<id>-<package>.md`). Alternative locations (e.g. advisory link
   in ledger only) are acceptable only when documented in the same PR.
+- **Scoping:** One PR per CVE (traceability); exception: one dependency bump may fix multiple CVEs if
+  they share the same minimum fixed version.
 - Reduces drift risk from updating only one manifest.
 
 ---

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -817,7 +817,7 @@ If it is not recorded here — it does not exist.
 - [x] Resolve cryptography CVE-2026-26007 in runtime/dev/lock manifests
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: security/cve-2026-26007-cryptography-46-0-5 (policy + ledger closure)
+  - Target PR: PR-724 (security/cve-2026-26007-cryptography-46-0-5)
   - Status: ✅ Closed (remediation on main; guard test in place; this PR adds AGENTS policy + ledger)
   - Reason: Five GitHub security alerts (Dependabot #27/#28/#29 and Code Scanning #538/#539) report vulnerable
     `cryptography` (`<=46.0.4`); required fixed version is `46.0.5`.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -814,11 +814,11 @@ If it is not recorded here — it does not exist.
     - Production image contains `pip>=26.0,<27.0` in both `/usr/local/lib/.../pip-*.dist-info` and `/opt/venv/lib/.../pip-*.dist-info`
     - 🔄 Awaiting next scan for alerts #533/#534 to close (merged ≠ scanner rerun)
 
-- [ ] Resolve cryptography CVE-2026-26007 in runtime/dev/lock manifests
+- [x] Resolve cryptography CVE-2026-26007 in runtime/dev/lock manifests
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD (security/cve-2026-26007-cryptography-46-0-5)
-  - Status: 🟡 In progress (alerts triaged, remediation patch prepared)
+  - Target PR: security/cve-2026-26007-cryptography-46-0-5 (policy + ledger closure)
+  - Status: ✅ Closed (remediation on main; guard test in place; this PR adds AGENTS policy + ledger)
   - Reason: Five GitHub security alerts (Dependabot #27/#28/#29 and Code Scanning #538/#539) report vulnerable
     `cryptography` (`<=46.0.4`); required fixed version is `46.0.5`.
   - Links:
@@ -827,8 +827,8 @@ If it is not recorded here — it does not exist.
     - GitHub alerts: `security/code-scanning/538`, `security/code-scanning/539`
   - DoD:
     - `cryptography` bumped to `46.0.5` (or higher safe version) in `requirements.in`, `requirements.txt`,
-      `requirements-dev.txt`, `requirements-lock.txt`, and `constraints.txt`
-    - New dependency security guard test added and passing
+      `requirements-dev.txt`, `requirements-lock.txt`, and `constraints.txt` ✅
+    - New dependency security guard test added and passing ✅ (`tests/test_dependency_security_guard.py`)
     - Security/code scanning alerts close on next scan
 
 - [ ] Generalize dependency vulnerability guards beyond single-CVE floors

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -826,10 +826,11 @@ If it is not recorded here — it does not exist.
     - GitHub alerts: `security/dependabot/27`, `security/dependabot/28`, `security/dependabot/29`
     - GitHub alerts: `security/code-scanning/538`, `security/code-scanning/539`
   - DoD:
-    - `cryptography` bumped to `46.0.5` (or higher safe version) in `requirements.in`, `requirements.txt`,
-      `requirements-dev.txt`, `requirements-lock.txt`, and `constraints.txt` ✅
-    - New dependency security guard test added and passing ✅ (`tests/test_dependency_security_guard.py`)
-    - Security/code scanning alerts close on next scan
+    - [x] `cryptography` bumped to `46.0.5` (or higher safe version) in `requirements.in`,
+      `requirements.txt`, `requirements-dev.txt`, `requirements-lock.txt`, and `constraints.txt`
+    - [x] New dependency security guard test added and passing
+      (`tests/test_dependency_security_guard.py`)
+    - [ ] Security/code scanning alerts close on next scan
 
 - [ ] Generalize dependency vulnerability guards beyond single-CVE floors
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -817,8 +817,8 @@ If it is not recorded here — it does not exist.
 - [x] Resolve cryptography CVE-2026-26007 in runtime/dev/lock manifests
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-724 (security/cve-2026-26007-cryptography-46-0-5)
-  - Status: ✅ Closed (remediation on main; guard test in place; this PR adds AGENTS policy + ledger)
+  - Target PR: PR-716 (remediation: bump + guard); PR-724 = docs-only closure/policy
+  - Status: ✅ Closed (remediation on main via PR-716; guard test in place; PR-724 adds AGENTS policy + ledger)
   - Reason: Five GitHub security alerts (Dependabot #27/#28/#29 and Code Scanning #538/#539) report vulnerable
     `cryptography` (`<=46.0.4`); required fixed version is `46.0.5`.
   - Links:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -828,8 +828,8 @@ If it is not recorded here — it does not exist.
   - DoD:
     - [x] `cryptography` bumped to `46.0.5` (or higher safe version) in `requirements.in`,
       `requirements.txt`, `requirements-dev.txt`, `requirements-lock.txt`, and `constraints.txt`
-    - [x] New dependency security guard test added and passing
-      (`tests/test_dependency_security_guard.py`)
+    - [x] New dependency security guard test added to enforce cryptography floor version
+      (CVE-2026-26007) — `tests/test_dependency_security_guard.py`
     - [ ] Security/code scanning alerts close on next scan
 
 - [ ] Generalize dependency vulnerability guards beyond single-CVE floors


### PR DESCRIPTION
## Summary

Close CVE-2026-26007 ledger item and add AGENTS policy for dependency CVE bumps. Remediation (cryptography 46.0.5 in all requirement surfaces + guard test) is already on main; this PR adds the canonical rule and marks the backlog item closed.

## Scope

- `AGENTS.md`: new rule "Security: Dependency CVE bumps (application deps)" — all requirement surfaces + guard test + evidence.
- `docs/roadmap/BACKLOG_LEDGER.md`: mark "Resolve cryptography CVE-2026-26007" as closed; DoD satisfied on main.

No changes to `requirements*.txt`, `constraints.txt`, or guard test (already correct).

## Verification

- `pre-commit run --all-files` — passed
- `pytest -q tests/test_dependency_security_guard.py` — passed
- `make verify` — run locally before merge (lint/typecheck/test-fast/diff-cov)

## Deferred / Follow-ups

- **Security suppression expiry monitoring** (P1, ledger): expiry 2026-03-01; separate PR/automation after this. See `docs/roadmap/BACKLOG_LEDGER.md` (Security suppression expiry monitoring).
- **Generalize dependency vulnerability guards** (P1, ledger): allow/deny schema for multiple packages/CVEs; follow-up after this. See `docs/roadmap/BACKLOG_LEDGER.md` (Generalize dependency vulnerability guards).

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Summary by Sourcery

Задокументировать закрытие ремедиации уязвимости cryptography CVE-2026-26007 и формализовать политику обновления зависимостей с CVE во всех наборах требований.

Документация:
- Отметить пункт в журнале невыполненных задач по cryptography CVE-2026-26007 как закрытый с обновлённым статусом, целевым PR и деталями DoD.
- Добавить политику AGENTS, требующую, чтобы обновления зависимостей из‑за CVE охватывали все манифесты требований, включали защитный тест по безопасности и содержали подтверждающие доказательства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the closure of the cryptography CVE-2026-26007 remediation and formalize policy for dependency CVE upgrades across requirement surfaces.

Documentation:
- Mark the cryptography CVE-2026-26007 backlog ledger item as closed with updated status, target PR, and DoD details.
- Add an AGENTS policy requiring dependency CVE bumps to cover all requirement manifests, include a security guard test, and provide supporting evidence.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a security policy for CVE-driven dependency bumps and closes the cryptography CVE-2026-26007 ledger item. Remediation (cryptography 46.0.5 + guard test) is on main; this updates AGENTS guidance and sets the ledger Target PR to PR-716.

- **New Features**
  - AGENTS.md: policy for Python dependency CVE bumps — update all requirement surfaces, add a deterministic guard test, and include evidence; clarify cross-ecosystem principle and acceptable evidence locations.
  - BACKLOG_LEDGER.md: mark CVE-2026-26007 closed; Target PR set to PR-716 (remediation), PR-724 noted for docs/policy; DoD normalized and explicitly lists the guard test enforcing the cryptography floor (tests/test_dependency_security_guard.py).

<sup>Written for commit 143a6f033038a2535acd4b2af06bb8a8f5f37652. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy note describing dependency CVE update procedures, multi-file synchronization requirements, and a deterministic dependency security guard test; duplicate policy entry cleaned up.  
  * Updated backlog/roadmap entry to reflect closure and remediation details.

* **Bug Fixes**
  * CVE-2026-26007 (cryptography) resolved — dependency bumped across manifests and verified by the new security guard test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->