### PR TITLE
chore(tooling): markdownlint exclude BACKLOG_LEDGER from MD013 (PR-727)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "ignores": ["docs/roadmap/BACKLOG_LEDGER.md"]
+}


### PR DESCRIPTION
## Summary

P0: Exclude `docs/roadmap/BACKLOG_LEDGER.md` from markdownlint (MD013 line-length) so Docs Phase1 gates no longer fail when PRs touch the ledger. Config-only; no reformatting of the ledger.

- **Scope:** `.markdownlint.json` with `ignores: ["docs/roadmap/BACKLOG_LEDGER.md"]`.
- **Gates:** `pre-commit run --all-files` passed. Run `make verify` locally before merge.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Summary by Sourcery

Build:
- Добавлен файл конфигурации markdownlint, чтобы исключить `docs/roadmap/BACKLOG_LEDGER.md` из проверки правила MD013 (ограничение длины строки).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add markdownlint configuration file to ignore docs/roadmap/BACKLOG_LEDGER.md for MD013 line-length enforcement.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude docs/roadmap/BACKLOG_LEDGER.md from markdownlint MD013 (line length) via .markdownlint.json to prevent docs gates from failing when the ledger changes. Config-only; no reformatting.

<sup>Written for commit 2fe2b5eb06833dee0715aa416f6dc1e4a9c5cf5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->