### PR TITLE
docs(agents): forbid skipping sys.modules policy guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,13 @@ Or individually:
   as **P0/P1** (technical debt priority; see Backlog Ledger Policy — not release
   P0-A/P0-B), with Owner, DoD, Target PR. Do not leave skipped checks untracked;
   "fix it or ledger it."
+- **sys.modules policy guard must never be skipped:** `tests/test_repo_policy_guards.py`
+  must run on-by-default; do not add `skip`/`xfail` wrappers to silence violations.
+- **If a temporary disable is unavoidable:** create a `docs/roadmap/BACKLOG_LEDGER.md`
+  entry (P0/P1) in the same PR with rationale, owner, and target PR to re-enable.
+- **Two-layer policy:** keep runtime guard enforcement in
+  `tests/test_repo_policy_guards.py`; keep incremental tests-cleanup tracking in
+  `tests/test_repo_policy_sys_modules.py`.
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.


### PR DESCRIPTION
## Summary
- Add explicit policy to root `AGENTS.md` that `sys.modules` policy guard must not be skipped.
- Define temporary-disable exception flow: mandatory `docs/roadmap/BACKLOG_LEDGER.md` P0/P1 item + owner + target PR.
- Clarify two-layer strategy: runtime guard in `tests/test_repo_policy_guards.py`, incremental cleanup in `tests/test_repo_policy_sys_modules.py`.

## Scope
- `AGENTS.md`

## Validation
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Summary by Sourcery

Документация:
- Задокументировать, что тест защиты политики `sys.modules` никогда не должен пропускаться и должен выполняться по умолчанию, описав требуемый процесс для любого временного отключения и прояснив стратегию двухуровневой защиты и очистки во всех соответствующих тестах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document that the sys.modules policy guard test must never be skipped and must run by default, outlining the required process for any temporary disable and clarifying the two-layer guard and cleanup strategy across the relevant tests.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document that the sys.modules policy guard test must always run and can’t be skipped. Define the temporary-disable process (Backlog Ledger P0/P1 with owner and target PR) and clarify the two-layer enforcement: runtime guard in tests/test_repo_policy_guards.py and cleanup tracking in tests/test_repo_policy_sys_modules.py.

<sup>Written for commit eba205f1649354a928b66735c8200fe6d0984bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal policy guidelines for code standards and maintenance procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->