### PR TITLE
docs(ledger): add feature TODO map for runtime skipped suites

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -546,6 +546,72 @@ If it is not recorded here — it does not exist.
     - Remaining intentional skips are documented as product decisions
     - `make verify` passes in PR-732
 
+- [ ] P1: Feature TODO from runtime SKIPPED suites (optional modules manifest)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-737
+  - Status: 📋 Planned (created in PR-736 docs-only; promoted from runtime snapshot on
+    13 February 2026)
+  - Area: backend / tests / feature debt management
+  - Finding Type: technical debt / optional-feature protocol
+  - Source of truth command:
+    - `pytest -q -rs | rg -n "SKIPPED \\[" || true`
+  - Feature TODO keys (aggregated from runtime SKIPPED):
+    - `core_db`: `tests/test_database_apis_coverage.py:43`,
+      `tests/test_direct_core_functions.py:353`
+    - `food_apis`: `tests/test_database_apis_coverage.py:62`,
+      `tests/test_database_apis_coverage.py:82`,
+      `tests/test_database_apis_coverage.py:102`
+    - `unified_db`: `tests/test_database_apis_coverage.py:124`,
+      `tests/test_final_coverage_97_boost.py:139`
+    - `update_manager`: `tests/test_database_apis_coverage.py:151`,
+      `tests/test_final_coverage_97_boost.py:167`,
+      `tests/test_final_coverage_97_boost.py:179`,
+      `tests/test_update_manager_fixed.py:129`
+    - `planner_engines`: `tests/test_direct_core_functions.py:45`,
+      `tests/test_direct_core_functions.py:97`,
+      `tests/test_direct_core_functions.py:141`,
+      `tests/test_direct_core_functions.py:185`,
+      `tests/test_final_core_coverage.py:232`,
+      `tests/test_final_core_coverage.py:262`,
+      `tests/test_final_core_coverage.py:294`,
+      `tests/test_final_core_coverage.py:322`
+    - `i18n_advanced`: `tests/test_database_apis_coverage.py:306`,
+      `tests/test_direct_core_functions.py:234`
+    - `rag`: `tests/test_database_apis_coverage.py:333`,
+      `tests/test_direct_core_functions.py:320`,
+      `tests/test_quick_coverage_boost.py:269`
+    - `region_catalog`: `tests/test_direct_core_functions.py:396`
+    - `exports_recipes_products`: `tests/test_zero_coverage_modules.py:90`,
+      `tests/test_zero_coverage_modules.py:144`,
+      `tests/test_zero_coverage_modules.py:190`,
+      `tests/test_zero_coverage_modules.py:239`,
+      `tests/test_zero_coverage_modules.py:275`
+    - `sports_disclaimers_lifestage`: `tests/test_zero_coverage_modules.py:45`,
+      `tests/test_zero_coverage_modules.py:313`,
+      `tests/test_zero_coverage_modules.py:345`
+    - `legacy_bmi_removed`: `tests/test_app_coverage_unit_combined.py:83`,
+      `tests/test_app_coverage_unit_combined.py:88`
+  - Protocol:
+    - Any runtime skip reason matching `module not available` /
+      `advanced features not available` MUST map to one feature key above.
+    - No ad-hoc skip reasons for optional modules in high-noise suites.
+    - Follow-up execution PR introduces `tests/feature_manifest.py` and a shared
+      `require_feature(...)` helper for standardized skip reasons.
+  - Links:
+    - `docs/audit/SKIPPED_TESTS_CLASSIFICATION_AUDIT_2026-02-13.md`
+    - `tests/test_database_apis_coverage.py`
+    - `tests/test_direct_core_functions.py`
+    - `tests/test_final_core_coverage.py`
+    - `tests/test_quick_coverage_boost.py`
+    - `tests/test_zero_coverage_modules.py`
+  - DoD:
+    - `tests/feature_manifest.py` exists with SoT feature keys and env opt-in
+      (`PULSEPLATE_FEATURES=all` or CSV list).
+    - High-noise suites use shared helper instead of custom ad-hoc skip strings.
+    - Runtime `pytest -q -rs` output shows standardized skip reasons with feature keys.
+    - Feature keys in tests and ledger remain one-to-one mapped.
+
 - [ ] Cross-platform Design System: define tokens + UI primitives (Web + iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design consistency / velocity)


### PR DESCRIPTION
## Summary
- Add a new P1 ledger epic for runtime SKIPPED feature debt management.
- Introduce aggregated feature TODO keys mapped to current `pytest -q -rs` SKIPPED evidence.
- Define protocol: `module not available` / `advanced features not available` skips must map to SoT feature keys (no ad-hoc reasons).

## Scope
- `docs/roadmap/BACKLOG_LEDGER.md`

## Evidence
- `pytest -q -rs | rg -n "SKIPPED \[" || true` runtime snapshot (13 February 2026)
- Representative anchors are listed in the new epic by feature key.

## Validation
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Summary by Sourcery

Добавить новый эпик P1 для Ledger, чтобы отслеживать и стандартизировать TODO, связанные с функциональностью, возникающие из пропущенных во время выполнения (SKIPPED) тестовых наборов для необязательных модулей.

Улучшения:
- Задокументировать протокол, сопоставляющий причины пропуска (runtime SKIPPED) из‑за отсутствующих или более продвинутых модулей с каноническим набором ключей функций, используя единую команду как источник истины.
- Записывать агрегированные ключи TODO по функциям с их представительными тестовыми якорями и определить DoD для внедрения общего манифеста функций и вспомогательного средства для пропуска тестов.
- Связать новый эпик с поддерживающими файлами аудита и тестов, чтобы централизовать управление техническим долгом, связанным с пропусками по признаку функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new P1 ledger epic to track and standardize feature-related TODOs arising from runtime SKIPPED test suites for optional modules.

Enhancements:
- Document a protocol mapping runtime SKIPPED reasons for missing or advanced modules to a canonical set of feature keys with a single source-of-truth command.
- Record aggregated feature TODO keys with their representative test anchors and define DoD for introducing a shared feature manifest and skip helper.
- Link the new epic to supporting audit and test files to centralize management of feature skip debt.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a P1 ledger epic to map runtime SKIPPED test suites for optional modules to canonical feature keys. This standardizes skip reasons and sets a plan for a shared feature manifest and skip helper.

- **New Features**
  - Recorded aggregated feature TODO keys with representative test anchors from pytest -q -rs (2026-02-13 snapshot).
  - Set protocol: “module not available” / “advanced features not available” must map to a known feature key; no ad‑hoc skip reasons.
  - Defined DoD and follow-up: add tests/feature_manifest.py and require_feature(...) helper; standardize skip output; env opt-in via PULSEPLATE_FEATURES.

<sup>Written for commit 9a8a3bde40687ecf6a2c02cc809929a98c8e6b6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new P1 backlog entry for handling runtime-skipped optional modules, including a structured workflow for tracking feature TODOs, standardized skip reason mapping, verification prerequisites, and definition-of-done criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->