### PR TITLE
docs(ledger): add missing reason-for-deferral metadata

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -550,7 +550,9 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-737
-  - Reason for deferral: Runtime test suites currently surface optional-module skips with ad-hoc strings; defer execution until PR-737 introduces `tests/feature_manifest.py` and `require_feature(...)` to standardize skip reasons and keep ledger↔tests keys one-to-one.
+  - Reason for deferral: Runtime test suites currently surface optional-module skips with
+    ad-hoc strings; defer execution until PR-737 introduces `tests/feature_manifest.py` and
+    `require_feature(...)` to standardize skip reasons and keep ledger↔tests keys one-to-one.
   - Status: 📋 Planned (created in PR-736 docs-only; promoted from runtime snapshot on
     13 February 2026)
   - Area: backend / tests / feature debt management

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -549,9 +549,9 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Feature TODO from runtime SKIPPED suites (optional modules manifest)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-737
+  - Target PR: PR-738
   - Reason for deferral: Runtime test suites currently surface optional-module skips with
-    ad-hoc strings; defer execution until PR-737 introduces `tests/feature_manifest.py` and
+    ad-hoc strings; defer execution until PR-738 introduces `tests/feature_manifest.py` and
     `require_feature(...)` to standardize skip reasons and keep ledger↔tests keys one-to-one.
   - Status: 📋 Planned (created in PR-736 docs-only; promoted from runtime snapshot on
     13 February 2026)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -550,6 +550,7 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-737
+  - Reason for deferral: Runtime test suites currently surface optional-module skips with ad-hoc strings; defer execution until PR-737 introduces `tests/feature_manifest.py` and `require_feature(...)` to standardize skip reasons and keep ledger↔tests keys one-to-one.
   - Status: 📋 Planned (created in PR-736 docs-only; promoted from runtime snapshot on
     13 February 2026)
   - Area: backend / tests / feature debt management


### PR DESCRIPTION
## Summary
- Add missing `Reason for deferral` metadata line to the P1 backlog item:
  `Feature TODO from runtime SKIPPED suites (optional modules manifest)`.
- Keep scope docs-only and minimal for bot actionables.

## Changes
- `docs/roadmap/BACKLOG_LEDGER.md`
  - Added `Reason for deferral:` with explicit dependency on implementation PR introducing `tests/feature_manifest.py` and `require_feature(...)`.
  - Wrapped the new line across indented continuations for readability and markdown style consistency.
  - Aligned metadata to remove circular reference: `Target PR: PR-738` and matching deferral text.

## Validation
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/736 -> 27c1abe9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/737 -> d61d4b18
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/737 -> 5efa87d2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog entry: changed target PR from PR-737 to PR-738 and added a "Reason for deferral" clarifying that runtime skip reasons are currently ad‑hoc and work will wait for a standardized feature-manifest workflow to align skips with tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->