### PR TITLE
test(pr-738): standardize optional-feature skips via manifest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,14 +646,14 @@
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "e2a41f90b2e59f1b35df9f6f500188988639f8de",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "ca6bef61e666e4c8985e5ea22e682f23a06040ba",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 108
       }
     ],
     "tests/test_app_exact_coverage_96.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-13T13:48:09Z"
+  "generated_at": "2026-02-13T14:06:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,14 +646,14 @@
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "e2a41f90b2e59f1b35df9f6f500188988639f8de",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "ca6bef61e666e4c8985e5ea22e682f23a06040ba",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 110
       }
     ],
     "tests/test_app_exact_coverage_96.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-12T20:13:05Z"
+  "generated_at": "2026-02-13T13:48:09Z"
 }

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -1,0 +1,88 @@
+"""
+tests/feature_manifest.py
+
+Single source of truth for optional-feature availability in runtime SKIPPED suites.
+
+RU: Edinyi manifest optsionalnykh fich dlia testov. Liubye SKIPPED vida
+"module not available" dolzhny idti cherez require_feature(...), a ne cherez ad-hoc
+stroki v testakh.
+
+EN: A single manifest to standardize skip reasons for optional modules/features.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import FrozenSet
+
+import pytest
+
+ENV_FEATURES = "PULSEPLATE_FEATURES"
+
+
+@dataclass(frozen=True)
+class FeatureManifest:
+    """Feature availability manifest controlled via env.
+
+    RU: Upravliaetsia peremennoi okruzheniia PULSEPLATE_FEATURES:
+      - "all" -> vkliuchit vse fichi (dlia budushchego CI job)
+      - ""/unset -> vkliuchit tolko bazovye (po umolchaniiu pochti nichego)
+      - "a,b,c" -> vkliuchit konkretnye kliuchi
+    """
+
+    enabled: FrozenSet[str]
+
+    @staticmethod
+    def from_env() -> "FeatureManifest":
+        raw = (os.getenv(ENV_FEATURES) or "").strip()
+        if raw.lower() == "all":
+            return FeatureManifest(enabled=frozenset(FEATURE_TODO_KEYS))
+        if not raw:
+            return FeatureManifest(enabled=frozenset())
+        parts = [part.strip() for part in raw.split(",") if part.strip()]
+        return FeatureManifest(enabled=frozenset(parts))
+
+    def is_enabled(self, key: str) -> bool:
+        return key in self.enabled
+
+
+# Canonical feature TODO keys (must match BACKLOG_LEDGER item; one-to-one mapping).
+FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
+    {
+        "core_db",
+        "food_apis",
+        "unified_db",
+        "update_manager",
+        "planner_engines",
+        "i18n_advanced",
+        "rag",
+        "region_catalog",
+        "exports_recipes_products",
+        "sports_disclaimers_lifestage",
+        "legacy_bmi_removed",
+    }
+)
+
+
+def require_feature(key: str, reason: str, *, manifest: FeatureManifest | None = None) -> None:
+    """Skip test if optional feature isn't enabled.
+
+    RU: Zapreshcheny ad-hoc skip-stroki v high-noise suites. Ispolzui tolko eto.
+
+    Args:
+        key: canonical feature TODO key (must be in FEATURE_TODO_KEYS).
+        reason: human-readable reason; should reference BACKLOG_LEDGER + target PR.
+        manifest: optional injected manifest (mainly for testing).
+    """
+    if key not in FEATURE_TODO_KEYS:
+        raise AssertionError(
+            f"Unknown feature key: {key!r}. Must be one of: {sorted(FEATURE_TODO_KEYS)}"
+        )
+
+    active_manifest = manifest or FeatureManifest.from_env()
+    if active_manifest.is_enabled(key):
+        return
+
+    standardized = f"feature_disabled:{key} (enable via {ENV_FEATURES}=all or CSV). " f"{reason}"
+    pytest.skip(standardized)

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -19,6 +19,7 @@ from typing import FrozenSet
 import pytest
 
 ENV_FEATURES = "PULSEPLATE_FEATURES"
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 @dataclass(frozen=True)
@@ -86,3 +87,21 @@ def require_feature(key: str, reason: str, *, manifest: FeatureManifest | None =
 
     standardized = f"feature_disabled:{key} (enable via {ENV_FEATURES}=all or CSV). " f"{reason}"
     pytest.skip(standardized)
+
+
+def require_feature_or_raise(
+    exc: ImportError,
+    key: str,
+    reason: str,
+    *,
+    manifest: FeatureManifest | None = None,
+) -> None:
+    """Skip only when feature is disabled, otherwise re-raise ImportError.
+
+    RU: Esli feature vkliuchena v manifest, ImportError ne dolzhen byt skryt.
+    EN: If feature is enabled, preserve failure signal by re-raising ImportError.
+    """
+    active_manifest = manifest or FeatureManifest.from_env()
+    if active_manifest.is_enabled(key):
+        raise exc
+    require_feature(key, reason, manifest=active_manifest)

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -9,7 +9,7 @@ EN: Combined tests for app coverage and unit tests: main.py coverage, groups, in
 import pytest
 from fastapi.testclient import TestClient
 
-from tests.feature_manifest import require_feature
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 try:
     # Validate app module can be imported
@@ -18,8 +18,6 @@ except ImportError as exc:  # pragma: no cover
     pytest.skip(f"FastAPI app import failed: {exc}", allow_module_level=True)
 
 # client fixture is provided by conftest.py
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 @pytest.mark.usefixtures("test_environment")

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -9,6 +9,8 @@ EN: Combined tests for app coverage and unit tests: main.py coverage, groups, in
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.feature_manifest import require_feature
+
 try:
     # Validate app module can be imported
     import app  # noqa: F401
@@ -16,6 +18,8 @@ except ImportError as exc:  # pragma: no cover
     pytest.skip(f"FastAPI app import failed: {exc}", allow_module_level=True)
 
 # client fixture is provided by conftest.py
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 @pytest.mark.usefixtures("test_environment")
@@ -80,14 +84,14 @@ class TestAppUnitTests:
         assert isinstance(bmi_max, float)
         assert bmi_min < bmi_max
 
-    @pytest.mark.skip("interpret_group removed with bmi_core.py - no canonical equivalent yet")
     def test_bmi_categories(self) -> None:
         """Test BMI category interpretations."""
+        require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
         pass
 
-    @pytest.mark.skip("estimate_level removed with bmi_core.py - no canonical equivalent yet")
     def test_estimate_level_categories(self) -> None:
         """Test estimate_level with different fitness experience levels."""
+        require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
         pass
 
     def test_get_api_key_requires_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_database_apis_coverage.py
+++ b/tests/test_database_apis_coverage.py
@@ -14,8 +14,12 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.feature_manifest import require_feature
+
 # Run these tests serially (not in parallel) to avoid xdist hang issues
 pytestmark = pytest.mark.serial
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 class TestCoreDatabaseCoverage:
@@ -40,7 +44,7 @@ class TestCoreDatabaseCoverage:
             assert db is not None or db is None
 
         except ImportError:
-            pytest.skip("core.db module not available")
+            require_feature("core_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass  # Function may have requirements we can't meet
 
@@ -59,7 +63,7 @@ class TestCoreDatabaseCoverage:
                 assert result is not None or result is None
 
         except ImportError:
-            pytest.skip("food_apis.base module not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -79,7 +83,7 @@ class TestCoreDatabaseCoverage:
                     assert isinstance(result, (dict, list, type(None)))
 
         except ImportError:
-            pytest.skip("usda module not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -99,7 +103,7 @@ class TestCoreDatabaseCoverage:
                     assert isinstance(result, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("openfoodfacts module not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -121,7 +125,7 @@ class TestCoreDatabaseCoverage:
             assert isinstance(result, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("unified_db module not available")
+            require_feature("unified_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -148,7 +152,7 @@ class TestCoreDatabaseCoverage:
             assert isinstance(updates, (bool, dict, list, type(None)))
 
         except ImportError:
-            pytest.skip("update_manager module not available")
+            require_feature("update_manager", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -183,7 +187,7 @@ class TestCoreModulesAdvanced:
             assert isinstance(score, (int, float, type(None)))
 
         except ImportError:
-            pytest.skip("auto_repair advanced features not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -214,7 +218,7 @@ class TestCoreModulesAdvanced:
             assert isinstance(is_valid, (bool, dict, type(None)))
 
         except ImportError:
-            pytest.skip("menu_engine advanced features not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -241,7 +245,7 @@ class TestCoreModulesAdvanced:
             assert isinstance(improvements, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("plate advanced features not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -272,7 +276,7 @@ class TestCoreModulesAdvanced:
             assert isinstance(is_valid, (bool, dict, type(None)))
 
         except ImportError:
-            pytest.skip("targets advanced features not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -303,7 +307,7 @@ class TestCoreModulesAdvanced:
             assert isinstance(formatted, (str, type(None)))
 
         except ImportError:
-            pytest.skip("i18n advanced features not available")
+            require_feature("i18n_advanced", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -330,6 +334,6 @@ class TestCoreModulesAdvanced:
             assert isinstance(results, (list, type(None)))
 
         except ImportError:
-            pytest.skip("RAG advanced features not available")
+            require_feature("rag", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_database_apis_coverage.py
+++ b/tests/test_database_apis_coverage.py
@@ -14,12 +14,10 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.feature_manifest import require_feature
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 # Run these tests serially (not in parallel) to avoid xdist hang issues
 pytestmark = pytest.mark.serial
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 class TestCoreDatabaseCoverage:
@@ -43,8 +41,8 @@ class TestCoreDatabaseCoverage:
             db = get_unified_food_db()
             assert db is not None or db is None
 
-        except ImportError:
-            require_feature("core_db", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "core_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass  # Function may have requirements we can't meet
 
@@ -62,8 +60,8 @@ class TestCoreDatabaseCoverage:
                 result = provider.search_food("apple")
                 assert result is not None or result is None
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -82,8 +80,8 @@ class TestCoreDatabaseCoverage:
                     result = client.search("apple")
                     assert isinstance(result, (dict, list, type(None)))
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -102,8 +100,8 @@ class TestCoreDatabaseCoverage:
                     result = client.get_product("123456789")
                     assert isinstance(result, (dict, type(None)))
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -124,8 +122,8 @@ class TestCoreDatabaseCoverage:
             result = merge_food_sources([], [])
             assert isinstance(result, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("unified_db", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "unified_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -151,8 +149,8 @@ class TestCoreDatabaseCoverage:
             updates = check_for_updates()
             assert isinstance(updates, (bool, dict, list, type(None)))
 
-        except ImportError:
-            require_feature("update_manager", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "update_manager", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -186,8 +184,8 @@ class TestCoreModulesAdvanced:
             score = calculate_repair_score({}, {})
             assert isinstance(score, (int, float, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -217,8 +215,8 @@ class TestCoreModulesAdvanced:
             is_valid = validate_menu_nutrition({})
             assert isinstance(is_valid, (bool, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -244,8 +242,8 @@ class TestCoreModulesAdvanced:
             improvements = suggest_plate_improvements({})
             assert isinstance(improvements, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -275,8 +273,8 @@ class TestCoreModulesAdvanced:
             is_valid = validate_target_ranges({})
             assert isinstance(is_valid, (bool, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -306,8 +304,8 @@ class TestCoreModulesAdvanced:
             formatted = format_number_locale(123.45, "en")
             assert isinstance(formatted, (str, type(None)))
 
-        except ImportError:
-            require_feature("i18n_advanced", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "i18n_advanced", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -333,7 +331,7 @@ class TestCoreModulesAdvanced:
             results = similarity_search("query", [])
             assert isinstance(results, (list, type(None)))
 
-        except ImportError:
-            require_feature("rag", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "rag", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_direct_core_functions.py
+++ b/tests/test_direct_core_functions.py
@@ -8,9 +8,7 @@ EN: Direct core function tests to improve coverage
 
 import pytest
 
-from tests.feature_manifest import require_feature
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 
 class TestDirectCoreFunctions:
@@ -45,8 +43,8 @@ class TestDirectCoreFunctions:
             is_valid = validate_user_data({"age": 30, "weight": 70})
             assert isinstance(is_valid, (bool, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -97,8 +95,8 @@ class TestDirectCoreFunctions:
             priority = calculate_repair_priority({"protein": -20}, {"protein": 80})
             assert isinstance(priority, (int, float, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -141,8 +139,8 @@ class TestDirectCoreFunctions:
             shopping_list = generate_shopping_list(meal_plan)
             assert isinstance(shopping_list, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -185,8 +183,8 @@ class TestDirectCoreFunctions:
             viz_data = visualize_plate_data(foods)
             assert isinstance(viz_data, (dict, list, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -234,8 +232,8 @@ class TestDirectCoreFunctions:
             locale_info = get_locale_info("en")
             assert isinstance(locale_info, (dict, type(None)))
 
-        except ImportError:
-            require_feature("i18n_advanced", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "i18n_advanced", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -276,8 +274,8 @@ class TestDirectCoreFunctions:
             merged = merge_food_entries(food_data, food_data2)
             assert isinstance(merged, (dict, type(None)))
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -320,8 +318,8 @@ class TestDirectCoreFunctions:
             # Test adding knowledge
             add_knowledge("Protein is essential for muscle building and repair.")
 
-        except ImportError:
-            require_feature("rag", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "rag", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -353,8 +351,8 @@ class TestDirectCoreFunctions:
             db = get_unified_food_db()
             assert db is not None or db is None
 
-        except ImportError:
-            require_feature("core_db", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "core_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -396,8 +394,8 @@ class TestDirectCoreFunctions:
             foods = get_region_foods("US")
             assert isinstance(foods, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("region_catalog", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "region_catalog", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -441,7 +439,7 @@ class TestDirectCoreFunctions:
             sanitized = sanitize_html("<script>alert('xss')</script>")
             assert isinstance(sanitized, (str, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_direct_core_functions.py
+++ b/tests/test_direct_core_functions.py
@@ -8,6 +8,10 @@ EN: Direct core function tests to improve coverage
 
 import pytest
 
+from tests.feature_manifest import require_feature
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+
 
 class TestDirectCoreFunctions:
     """Direct tests of core functions to maximize coverage."""
@@ -42,7 +46,7 @@ class TestDirectCoreFunctions:
             assert isinstance(is_valid, (bool, type(None)))
 
         except ImportError:
-            pytest.skip("targets functions not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -94,7 +98,7 @@ class TestDirectCoreFunctions:
             assert isinstance(priority, (int, float, type(None)))
 
         except ImportError:
-            pytest.skip("auto_repair functions not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -138,7 +142,7 @@ class TestDirectCoreFunctions:
             assert isinstance(shopping_list, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("menu_engine functions not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -182,7 +186,7 @@ class TestDirectCoreFunctions:
             assert isinstance(viz_data, (dict, list, type(None)))
 
         except ImportError:
-            pytest.skip("plate functions not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -231,7 +235,7 @@ class TestDirectCoreFunctions:
             assert isinstance(locale_info, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("i18n functions not available")
+            require_feature("i18n_advanced", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -273,7 +277,7 @@ class TestDirectCoreFunctions:
             assert isinstance(merged, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("food_sources functions not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -317,7 +321,7 @@ class TestDirectCoreFunctions:
             add_knowledge("Protein is essential for muscle building and repair.")
 
         except ImportError:
-            pytest.skip("RAG functions not available")
+            require_feature("rag", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -350,7 +354,7 @@ class TestDirectCoreFunctions:
             assert db is not None or db is None
 
         except ImportError:
-            pytest.skip("db functions not available")
+            require_feature("core_db", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -393,7 +397,7 @@ class TestDirectCoreFunctions:
             assert isinstance(foods, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("region_catalog functions not available")
+            require_feature("region_catalog", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -438,6 +442,6 @@ class TestDirectCoreFunctions:
             assert isinstance(sanitized, (str, type(None)))
 
         except ImportError:
-            pytest.skip("utils functions not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_final_core_coverage.py
+++ b/tests/test_final_core_coverage.py
@@ -10,9 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.feature_manifest import require_feature
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 
 class TestFinalCoreCoverage:
@@ -38,8 +36,8 @@ class TestFinalCoreCoverage:
                     result = usda.get_food_data("123")
                     assert isinstance(result, (dict, type(None)))
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -69,8 +67,8 @@ class TestFinalCoreCoverage:
             is_valid = validate_category("fruit")
             assert isinstance(is_valid, (bool, type(None)))
 
-        except ImportError:
-            require_feature("food_apis", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -100,8 +98,8 @@ class TestFinalCoreCoverage:
             is_valid = validate_nutrition_data({})
             assert isinstance(is_valid, (bool, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -130,8 +128,8 @@ class TestFinalCoreCoverage:
             is_valid = validate_config({})
             assert isinstance(is_valid, (bool, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -232,8 +230,8 @@ class TestFinalCoreCoverage:
             improvements = suggest_meal_improvements({})
             assert isinstance(improvements, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -262,8 +260,8 @@ class TestFinalCoreCoverage:
             priority = calculate_repair_priority({}, {})
             assert isinstance(priority, (int, float, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -294,8 +292,8 @@ class TestFinalCoreCoverage:
             recommendations = get_plate_recommendations({})
             assert isinstance(recommendations, (list, dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -322,7 +320,7 @@ class TestFinalCoreCoverage:
             adjusted = adjust_for_activity_level({}, "high")
             assert isinstance(adjusted, (dict, type(None)))
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_final_core_coverage.py
+++ b/tests/test_final_core_coverage.py
@@ -10,6 +10,10 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.feature_manifest import require_feature
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+
 
 class TestFinalCoreCoverage:
     """Final tests to maximize core modules coverage."""
@@ -35,7 +39,7 @@ class TestFinalCoreCoverage:
                     assert isinstance(result, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("food sources not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -66,7 +70,7 @@ class TestFinalCoreCoverage:
             assert isinstance(is_valid, (bool, type(None)))
 
         except ImportError:
-            pytest.skip("food_categories not available")
+            require_feature("food_apis", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -97,7 +101,7 @@ class TestFinalCoreCoverage:
             assert isinstance(is_valid, (bool, dict, type(None)))
 
         except ImportError:
-            pytest.skip("nutrition_analysis not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -127,7 +131,7 @@ class TestFinalCoreCoverage:
             assert isinstance(is_valid, (bool, type(None)))
 
         except ImportError:
-            pytest.skip("config management not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -229,7 +233,7 @@ class TestFinalCoreCoverage:
             assert isinstance(improvements, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("menu_engine not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -259,7 +263,7 @@ class TestFinalCoreCoverage:
             assert isinstance(priority, (int, float, type(None)))
 
         except ImportError:
-            pytest.skip("auto_repair not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -291,7 +295,7 @@ class TestFinalCoreCoverage:
             assert isinstance(recommendations, (list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("plate not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
@@ -319,6 +323,6 @@ class TestFinalCoreCoverage:
             assert isinstance(adjusted, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("targets not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
         except Exception:  # nosec B110 - intentional in test for coverage
             pass

--- a/tests/test_quick_coverage_boost.py
+++ b/tests/test_quick_coverage_boost.py
@@ -8,11 +8,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from tests.feature_manifest import require_feature
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 logger = logging.getLogger(__name__)
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 class TestQuickCoverageBoost:
@@ -58,8 +56,8 @@ class TestQuickCoverageBoost:
             carb = calculate_who_carb_target(70, "male", 30, False, "very_active")
             assert carb > 0
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_i18n_fallback_coverage(self):
         """Покрытие core/i18n.py fallback scenarios (83% -> 95%+)"""
@@ -88,8 +86,8 @@ class TestQuickCoverageBoost:
             result = t("ru", None)
             assert isinstance(result, str)
 
-        except ImportError:
-            require_feature("i18n_advanced", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "i18n_advanced", reason=FEATURE_REASON)
 
     def test_food_merge_edge_cases(self):
         """Покрытие core/food_merge.py edge cases (89% -> 95%+)"""
@@ -115,8 +113,8 @@ class TestQuickCoverageBoost:
             result = merge_food_sources(None, None)
             assert isinstance(result, list)
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_auto_repair_edge_cases(self):
         """Покрытие core/auto_repair.py missing branches (94% -> 97%+)"""
@@ -144,8 +142,8 @@ class TestQuickCoverageBoost:
             gaps = repair_nutrition_gaps([], extreme_targets)
             assert isinstance(gaps, list)
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_menu_engine_missing_branches(self):
         """Покрытие core/menu_engine.py missing branches (95% -> 97%+)"""
@@ -176,8 +174,8 @@ class TestQuickCoverageBoost:
             result = optimize_meal_plan([], extreme_constraints)
             assert isinstance(result, list)
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_recommendations_edge_cases(self):
         """Покрытие core/recommendations.py scenarios (92% -> 97%+)"""
@@ -209,8 +207,8 @@ class TestQuickCoverageBoost:
             result = recommender.recommend_for_user(extreme_prefs, [])
             assert isinstance(result, list)
 
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_region_catalog_edge_cases(self):
         """Покрытие core/region_catalog.py missing lines (89% -> 95%+)"""
@@ -236,8 +234,8 @@ class TestQuickCoverageBoost:
             result = catalog.get_products_by_category("test_category", "XX")
             assert isinstance(result, list)
 
-        except ImportError:
-            require_feature("region_catalog", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "region_catalog", reason=FEATURE_REASON)
 
     def test_rag_simple_missing_paths(self):
         """Покрытие core/rag/simple_rag.py missing paths (77% -> 90%+)"""
@@ -269,8 +267,8 @@ class TestQuickCoverageBoost:
             result = rag.query(special_query)
             assert isinstance(result, str) or result is None
 
-        except ImportError:
-            require_feature("rag", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "rag", reason=FEATURE_REASON)
 
     def test_unified_db_error_paths(self):
         """Покрытие core/food_apis/unified_db.py error paths (94% -> 97%+)"""
@@ -299,8 +297,8 @@ class TestQuickCoverageBoost:
             result = unified_db.search_foods(long_query)
             assert isinstance(result, list)
 
-        except ImportError:
-            require_feature("unified_db", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "unified_db", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_update_manager_async_paths(self):
@@ -324,5 +322,5 @@ class TestQuickCoverageBoost:
                 except Exception as exc:  # pragma: no cover - depends on async extras
                     logger.warning("update_database raised during quick coverage test: %s", exc)
 
-        except ImportError:
-            require_feature("update_manager", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "update_manager", reason=FEATURE_REASON)

--- a/tests/test_quick_coverage_boost.py
+++ b/tests/test_quick_coverage_boost.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.feature_manifest import require_feature
+
 logger = logging.getLogger(__name__)
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
 
 
 class TestQuickCoverageBoost:
@@ -55,7 +59,7 @@ class TestQuickCoverageBoost:
             assert carb > 0
 
         except ImportError:
-            pytest.skip("targets module not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_i18n_fallback_coverage(self):
         """Покрытие core/i18n.py fallback scenarios (83% -> 95%+)"""
@@ -85,7 +89,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, str)
 
         except ImportError:
-            pytest.skip("i18n module not available")
+            require_feature("i18n_advanced", reason=FEATURE_REASON)
 
     def test_food_merge_edge_cases(self):
         """Покрытие core/food_merge.py edge cases (89% -> 95%+)"""
@@ -112,7 +116,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, list)
 
         except ImportError:
-            pytest.skip("food_merge module not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_auto_repair_edge_cases(self):
         """Покрытие core/auto_repair.py missing branches (94% -> 97%+)"""
@@ -141,7 +145,7 @@ class TestQuickCoverageBoost:
             assert isinstance(gaps, list)
 
         except ImportError:
-            pytest.skip("auto_repair module not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_menu_engine_missing_branches(self):
         """Покрытие core/menu_engine.py missing branches (95% -> 97%+)"""
@@ -173,7 +177,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, list)
 
         except ImportError:
-            pytest.skip("menu_engine module not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_recommendations_edge_cases(self):
         """Покрытие core/recommendations.py scenarios (92% -> 97%+)"""
@@ -206,7 +210,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, list)
 
         except ImportError:
-            pytest.skip("recommendations module not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_region_catalog_edge_cases(self):
         """Покрытие core/region_catalog.py missing lines (89% -> 95%+)"""
@@ -233,7 +237,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, list)
 
         except ImportError:
-            pytest.skip("region_catalog module not available")
+            require_feature("region_catalog", reason=FEATURE_REASON)
 
     def test_rag_simple_missing_paths(self):
         """Покрытие core/rag/simple_rag.py missing paths (77% -> 90%+)"""
@@ -266,7 +270,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, str) or result is None
 
         except ImportError:
-            pytest.skip("rag.simple_rag module not available")
+            require_feature("rag", reason=FEATURE_REASON)
 
     def test_unified_db_error_paths(self):
         """Покрытие core/food_apis/unified_db.py error paths (94% -> 97%+)"""
@@ -296,7 +300,7 @@ class TestQuickCoverageBoost:
             assert isinstance(result, list)
 
         except ImportError:
-            pytest.skip("unified_db module not available")
+            require_feature("unified_db", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_update_manager_async_paths(self):
@@ -321,4 +325,4 @@ class TestQuickCoverageBoost:
                     logger.warning("update_database raised during quick coverage test: %s", exc)
 
         except ImportError:
-            pytest.skip("update_manager module not available")
+            require_feature("update_manager", reason=FEATURE_REASON)

--- a/tests/test_zero_coverage_modules.py
+++ b/tests/test_zero_coverage_modules.py
@@ -9,9 +9,7 @@ EN: Tests for modules with zero coverage
 import logging
 import pytest
 
-from tests.feature_manifest import require_feature
-
-FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 
 class TestZeroCoverageModules:
@@ -45,8 +43,8 @@ class TestZeroCoverageModules:
             hydration = hydration_needs(weight_kg=70, duration_minutes=90, temperature_celsius=25)
             assert isinstance(hydration, (float, int, type(None)))
 
-        except ImportError:
-            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -90,8 +88,8 @@ class TestZeroCoverageModules:
             shopping = export_shopping_list(meal_plan)
             assert isinstance(shopping, (str, list, dict, type(None)))
 
-        except ImportError:
-            require_feature("exports_recipes_products", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -144,8 +142,8 @@ class TestZeroCoverageModules:
             )
             assert isinstance(substitutions, (list, type(None)))
 
-        except ImportError:
-            require_feature("exports_recipes_products", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -190,8 +188,8 @@ class TestZeroCoverageModules:
             )
             assert isinstance(comparison, (dict, list, type(None)))
 
-        except ImportError:
-            require_feature("exports_recipes_products", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -239,8 +237,8 @@ class TestZeroCoverageModules:
             )
             assert isinstance(nutrition_analysis, (dict, type(None)))
 
-        except ImportError:
-            require_feature("exports_recipes_products", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -275,8 +273,8 @@ class TestZeroCoverageModules:
             meal_export = quick_meal_export(meal)
             assert isinstance(meal_export, (str, type(None)))
 
-        except ImportError:
-            require_feature("exports_recipes_products", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -313,8 +311,8 @@ class TestZeroCoverageModules:
             child = child_nutrition(age_years=8, weight_kg=25, height_cm=130)
             assert isinstance(child, (dict, type(None)))
 
-        except ImportError:
-            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -345,8 +343,8 @@ class TestZeroCoverageModules:
             liability = get_liability_disclaimer("app_usage")
             assert isinstance(liability, (str, type(None)))
 
-        except ImportError:
-            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass

--- a/tests/test_zero_coverage_modules.py
+++ b/tests/test_zero_coverage_modules.py
@@ -9,6 +9,10 @@ EN: Tests for modules with zero coverage
 import logging
 import pytest
 
+from tests.feature_manifest import require_feature
+
+FEATURE_REASON = "Feature not implemented yet; see BACKLOG_LEDGER (Target PR: PR-738+)."
+
 
 class TestZeroCoverageModules:
     """Test modules that currently have 0% coverage."""
@@ -42,7 +46,7 @@ class TestZeroCoverageModules:
             assert isinstance(hydration, (float, int, type(None)))
 
         except ImportError:
-            pytest.skip("sports_nutrition module not available")
+            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -87,7 +91,7 @@ class TestZeroCoverageModules:
             assert isinstance(shopping, (str, list, dict, type(None)))
 
         except ImportError:
-            pytest.skip("exports module not available")
+            require_feature("exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -141,7 +145,7 @@ class TestZeroCoverageModules:
             assert isinstance(substitutions, (list, type(None)))
 
         except ImportError:
-            pytest.skip("recipe_synth module not available")
+            require_feature("exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -187,7 +191,7 @@ class TestZeroCoverageModules:
             assert isinstance(comparison, (dict, list, type(None)))
 
         except ImportError:
-            pytest.skip("product_finder module not available")
+            require_feature("exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -236,7 +240,7 @@ class TestZeroCoverageModules:
             assert isinstance(nutrition_analysis, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("product_varieties module not available")
+            require_feature("exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -272,7 +276,7 @@ class TestZeroCoverageModules:
             assert isinstance(meal_export, (str, type(None)))
 
         except ImportError:
-            pytest.skip("exports_simple module not available")
+            require_feature("exports_recipes_products", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -310,7 +314,7 @@ class TestZeroCoverageModules:
             assert isinstance(child, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("lifestage_nutrition module not available")
+            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass
@@ -342,7 +346,7 @@ class TestZeroCoverageModules:
             assert isinstance(liability, (str, type(None)))
 
         except ImportError:
-            pytest.skip("disclaimers module not available")
+            require_feature("sports_disclaimers_lifestage", reason=FEATURE_REASON)
         except Exception as e:
             logging.exception("Unexpected exception in tests: test_zero_coverage_modules.py")
             pass


### PR DESCRIPTION
## Summary
- Introduce a single source of truth for optional-feature test skips via `tests/feature_manifest.py`.
- Replace ad-hoc runtime skip reasons in high-noise suites with standardized `require_feature(...)` calls.
- Keep SKIPPED outcomes deterministic and ledger-mapped using canonical feature keys.

## Scope
- Added `tests/feature_manifest.py`:
  - `FEATURE_TODO_KEYS` SoT.
  - `FeatureManifest.from_env()` with `PULSEPLATE_FEATURES=all|csv`.
  - `require_feature(...)` helper producing standardized skip reason prefix `feature_disabled:<key>`.
- Migrated high-noise suites from ad-hoc `pytest.skip("... not available")` to `require_feature(...)`:
  - `tests/test_database_apis_coverage.py`
  - `tests/test_direct_core_functions.py`
  - `tests/test_final_core_coverage.py`
  - `tests/test_quick_coverage_boost.py`
  - `tests/test_zero_coverage_modules.py`
  - `tests/test_app_coverage_unit_combined.py` (`legacy_bmi_removed` skips)

## Validation
- `pre-commit run --all-files`
- `pytest -q -rs | rg -n "SKIPPED \[" || true`
  - includes standardized reasons, e.g. `feature_disabled:core_db`, `feature_disabled:planner_engines`.
- `make verify`

## Security Notes
- Standardized skip protocol reduces risk of hidden regressions behind inconsistent skip strings.
- Every optional-feature skip now carries a canonical key and env-enable contract.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Summary by Sourcery

Стандартизировать пропуски тестов с опциональными возможностями через общий манифест возможностей и вспомогательную функцию во всех «шумных» наборах тестов.

Enhancements:
- Ввести централизованный манифест возможностей с конфигурацией опциональных тестовых возможностей, управляемой через переменные окружения.

Tests:
- Заменить разрозненные вызовы `pytest.skip` в нескольких наборах тестов покрытия на стандартизированный помощник `require_feature`, работающий с каноническими именами возможностей.
- Добавить детерминированные, основанные на ключах причины пропуска для тестов с опциональными возможностями, что обеспечивает единообразную отчетность и создаёт основу для будущего управления через CI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize optional-feature test skips via a shared feature manifest and helper across high-noise test suites.

Enhancements:
- Introduce a centralized feature manifest with environment-driven configuration for optional test features.

Tests:
- Replace ad-hoc pytest.skip calls in several coverage suites with a standardized require_feature helper keyed by canonical feature names.
- Add deterministic, key-based skip reasons for optional-feature tests, enabling consistent reporting and future CI control.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes optional-feature test skips with a central manifest and adds require_feature_or_raise to avoid hiding real ImportErrors when a feature is enabled. SKIPPED reasons use canonical keys and can be toggled via PULSEPLATE_FEATURES.

- **Refactors**
  - Added tests/feature_manifest.py with FEATURE_TODO_KEYS, FeatureManifest.from_env(), FEATURE_REASON, require_feature(...), and require_feature_or_raise(...) that re-raises ImportError when the feature is enabled; require_feature emits feature_disabled:<key>.
  - Replaced ad-hoc pytest.skip(...) with require_feature_or_raise across noisy suites (coverage, direct-core, quick-boost, zero-coverage) and used require_feature for legacy BMI tests in app-combined.

- **Migration**
  - Enable optional features with PULSEPLATE_FEATURES=all or a CSV (e.g., PULSEPLATE_FEATURES=core_db,rag).
  - For new tests, use require_feature(...) or require_feature_or_raise(...) instead of ad-hoc skips.

<sup>Written for commit db92088c312875bdf7fdb501bc4b80856b184792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized feature-flag gating for many test suites so individual tests run only when optional features are enabled.
  * Replaced unconditional import-based skips with conditional feature checks to better control test execution.

* **Chores**
  * No user-facing functionality changed; this is testing infrastructure only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->