### PR TITLE
test(pr-739): fail fast for legacy_bmi_removed gated no-op tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,14 +646,14 @@
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "e2a41f90b2e59f1b35df9f6f500188988639f8de",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 112
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "ca6bef61e666e4c8985e5ea22e682f23a06040ba",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 114
       }
     ],
     "tests/test_app_exact_coverage_96.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-13T14:06:05Z"
+  "generated_at": "2026-02-13T14:47:25Z"
 }

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -85,12 +85,12 @@ class TestAppUnitTests:
     def test_bmi_categories(self) -> None:
         """Test BMI category interpretations."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pass
+        pytest.fail("Test disabled until BMI category assertions are implemented.")
 
     def test_estimate_level_categories(self) -> None:
         """Test estimate_level with different fitness experience levels."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pass
+        pytest.fail("Test disabled until estimate level assertions are implemented.")
 
     def test_get_api_key_requires_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """API key matching should be strict by default."""

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -85,12 +85,18 @@ class TestAppUnitTests:
     def test_bmi_categories(self) -> None:
         """Test BMI category interpretations."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pytest.fail("Test disabled until BMI category assertions are implemented.")
+        # TODO(pr-739): Replace with canonical assertions if legacy_bmi_removed is restored.
+        pytest.fail(
+            "legacy_bmi_removed enabled: test disabled until BMI category assertions are implemented."
+        )
 
     def test_estimate_level_categories(self) -> None:
         """Test estimate_level with different fitness experience levels."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pytest.fail("Test disabled until estimate level assertions are implemented.")
+        # TODO(pr-739): Replace with canonical assertions if legacy_bmi_removed is restored.
+        pytest.fail(
+            "legacy_bmi_removed enabled: test disabled until estimate level assertions are implemented."
+        )
 
     def test_get_api_key_requires_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """API key matching should be strict by default."""


### PR DESCRIPTION
## Summary
- Follow-up after PR-738 merge: replace no-op `pass` with explicit fail-fast when `legacy_bmi_removed` is enabled.
- Keep standardized `feature_disabled:legacy_bmi_removed` skip when feature is disabled (default CI path).
- Added explicit `TODO(pr-739)` tags in both guarded tests for tracking.

## Validation
- `pytest -q tests/test_app_coverage_unit_combined.py -rs`
- `PULSEPLATE_FEATURES=legacy_bmi_removed pytest -q tests/test_app_coverage_unit_combined.py -k 'bmi_categories or estimate_level_categories' -rs` (expected fail-fast)
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments
