### PR TITLE
Fix/p1 legacy bmi removed failfast tests pr739

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,14 +646,14 @@
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "e2a41f90b2e59f1b35df9f6f500188988639f8de",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 112
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_unit_combined.py",
         "hashed_secret": "ca6bef61e666e4c8985e5ea22e682f23a06040ba",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 114
       }
     ],
     "tests/test_app_exact_coverage_96.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-13T14:06:05Z"
+  "generated_at": "2026-02-13T14:47:25Z"
 }

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -85,12 +85,12 @@ class TestAppUnitTests:
     def test_bmi_categories(self) -> None:
         """Test BMI category interpretations."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pass
+        pytest.fail("Test disabled until BMI category assertions are implemented.")
 
     def test_estimate_level_categories(self) -> None:
         """Test estimate_level with different fitness experience levels."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pass
+        pytest.fail("Test disabled until estimate level assertions are implemented.")
 
     def test_get_api_key_requires_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """API key matching should be strict by default."""

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -85,12 +85,18 @@ class TestAppUnitTests:
     def test_bmi_categories(self) -> None:
         """Test BMI category interpretations."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pytest.fail("Test disabled until BMI category assertions are implemented.")
+        # TODO(pr-739): Replace with canonical assertions if legacy_bmi_removed is restored.
+        pytest.fail(
+            "legacy_bmi_removed enabled: test disabled until BMI category assertions are implemented."
+        )
 
     def test_estimate_level_categories(self) -> None:
         """Test estimate_level with different fitness experience levels."""
         require_feature("legacy_bmi_removed", reason=FEATURE_REASON)
-        pytest.fail("Test disabled until estimate level assertions are implemented.")
+        # TODO(pr-739): Replace with canonical assertions if legacy_bmi_removed is restored.
+        pytest.fail(
+            "legacy_bmi_removed enabled: test disabled until estimate level assertions are implemented."
+        )
 
     def test_get_api_key_requires_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """API key matching should be strict by default."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `<review-comment-url>` -> `<commit-sha>`
- No actionable review comments

## Deferred / Follow-ups

- [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

<!-- markdownlint-enable MD013 MD033 -->

## Summary by Sourcery

Tests:
- Заменить тесты категорий ИМТ и уровня оценки, не выполняющие действий, на явные заглушки `pytest.fail` под флагом функциональности `legacy_bmi_removed`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Replace no-op BMI category and estimate level tests with explicit pytest.fail placeholders under the legacy_bmi_removed feature flag.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch legacy_bmi_removed-gated tests from pass-through to fail-fast so missing BMI assertions are visible immediately (PR-739). Refreshed secrets baseline to reflect line shifts.

- **Bug Fixes**
  - tests/test_app_coverage_unit_combined.py: add explicit pytest.fail with TODO(pr-739) messages for BMI category and estimate_level tests behind require_feature("legacy_bmi_removed").
  - .secrets.baseline: update line references and generated_at timestamp after test edits.

<sup>Written for commit 168daa4fc34b5755c3644821acef41ae261a86e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit test assertions to provide explicit failure feedback under specific conditions.

* **Chores**
  * Updated internal baseline configuration with revised line number references.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->