### PR TITLE
test: assert JSON content-type before response parsing

### DIFF
--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, AsyncGenerator, Generator, cast
 
 import pytest
 from fastapi.testclient import TestClient
+from requests import Response
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
@@ -17,6 +18,7 @@ from app.middleware.api_tiers import require_pro_tier
 from app.models import DayPlan, WeeklyPlan
 import core.db as core_db
 from core.models import User
+from tests._client import get_client
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -70,6 +72,15 @@ def _get_async_session_local() -> "async_sessionmaker[AsyncSession]":
     return cast("async_sessionmaker[AsyncSession]", session_local)
 
 
+def _assert_json_response(response: Response) -> dict[str, object]:
+    """Assert JSON content-type before body parsing and return JSON object."""
+    content_type = response.headers.get("content-type", "")
+    assert content_type.startswith("application/json")
+    body = response.json()
+    assert isinstance(body, dict)
+    return cast(dict[str, object], body)
+
+
 @pytest.fixture
 async def test_user() -> AsyncGenerator[User, None]:
     """Create test user in DB for FK constraints.
@@ -114,14 +125,17 @@ def client_with_pro_access(app_module: ModuleType) -> Generator[TestClient, None
 
     Returns pro_ctx with user_id for proper fetch_day_plan behavior.
     """
-    # Override PRO tier to return dict with user_id (not just string)
-    app_module.app.dependency_overrides[require_pro_tier] = lambda: {"user_id": TEST_USER_ID}
+    import app.main
 
-    client = TestClient(app_module.app)
-    yield client
-
-    # Cleanup: remove override after test
-    app_module.app.dependency_overrides.pop(require_pro_tier, None)
+    # Ensure override is attached to canonical app.main:app used by get_client().
+    app_instance = app.main.app
+    app_instance.dependency_overrides[require_pro_tier] = lambda: {"user_id": TEST_USER_ID}
+    try:
+        with get_client() as client:
+            yield client
+    finally:
+        # Cleanup: remove override after test
+        app_instance.dependency_overrides.pop(require_pro_tier, None)
 
 
 @pytest.mark.asyncio
@@ -176,9 +190,7 @@ async def test_fetch_day_plan_when_exists_in_db(
     )
 
     assert response.status_code == 200
-    content_type = response.headers.get("content-type", "")
-    assert content_type.startswith("application/json")
-    body = response.json()
+    body = _assert_json_response(response)
     assert body["warnings"] == []
     assert isinstance(body["items"], list)
 
@@ -195,9 +207,7 @@ async def test_fetch_day_plan_when_not_in_db(
         f"/api/v1/pro/shoplist/day?date={test_date}&lang=en",
     )
     assert r.status_code == 200
-    content_type = r.headers.get("content-type", "")
-    assert content_type.startswith("application/json")
-    body = r.json()
+    body = _assert_json_response(r)
 
     # Should return empty items with warning
     assert body["items"] == []

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -176,6 +176,8 @@ async def test_fetch_day_plan_when_exists_in_db(
     )
 
     assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert content_type.startswith("application/json")
     body = response.json()
     assert body["warnings"] == []
     assert isinstance(body["items"], list)
@@ -193,6 +195,8 @@ async def test_fetch_day_plan_when_not_in_db(
         f"/api/v1/pro/shoplist/day?date={test_date}&lang=en",
     )
     assert r.status_code == 200
+    content_type = r.headers.get("content-type", "")
+    assert content_type.startswith("application/json")
     body = r.json()
 
     # Should return empty items with warning

--- a/tests/test_shoplist_day_db_wiring.py
+++ b/tests/test_shoplist_day_db_wiring.py
@@ -5,7 +5,6 @@ EN: Tests for day shopping list database integration.
 """
 
 from datetime import date
-from types import ModuleType
 from typing import TYPE_CHECKING, AsyncGenerator, Generator, cast
 
 import pytest
@@ -120,7 +119,7 @@ async def test_user() -> AsyncGenerator[User, None]:
 
 
 @pytest.fixture
-def client_with_pro_access(app_module: ModuleType) -> Generator[TestClient, None, None]:
+def client_with_pro_access() -> Generator[TestClient, None, None]:
     """Create test client with PRO tier access bypassed.
 
     Returns pro_ctx with user_id for proper fetch_day_plan behavior.


### PR DESCRIPTION

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test validation to enforce JSON Content-Type and consistent parsing of API responses.
  * Updated test fixtures to reliably simulate premium/pro access and ensure dependency overrides apply and are cleaned up.
  * Aligned test setup/teardown for more consistent test DB state and environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that strengthen assertions and fixture wiring; low risk beyond potential test behavior tightening if endpoints return non-JSON content-types.
> 
> **Overview**
> Improves `test_shoplist_day_db_wiring` robustness by asserting the response `Content-Type` is JSON before parsing bodies (via a new `_assert_json_response` helper).
> 
> Refactors the PRO-tier bypass client fixture to use the canonical `get_client()`/`app.main.app` entrypoint for dependency overrides, avoiding mismatched app instances and ensuring overrides are reliably applied and cleaned up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a616708df92faa9b9f3e29653f2c73d769741c25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->