### PR TITLE
test(pr-747): standardize remaining skips via feature_manifest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -851,7 +851,7 @@
         "filename": "tests/test_coverage_final_boost.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 50
       }
     ],
     "tests/test_coverage_improvement.py": [
@@ -1281,7 +1281,7 @@
         "filename": "tests/test_premium_week_app_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       }
     ],
     "tests/test_premium_week_endpoint_96.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-14T08:58:26Z"
+  "generated_at": "2026-02-14T18:07:52Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Or individually:
 - **Two-layer policy:** keep runtime guard enforcement in
   `tests/test_repo_policy_guards.py`; keep incremental tests-cleanup tracking in
   `tests/test_repo_policy_sys_modules.py`.
+- **Skip reason protocol:** Any skip caused by missing module/function/data MUST use
+  `require_feature(...)` and emit `feature_disabled:<key>` (no ad-hoc skip strings).
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Or individually:
   `tests/test_repo_policy_sys_modules.py`.
 - **Skip reason protocol:** Any skip caused by missing module/function/data MUST use
   `require_feature(...)` and emit `feature_disabled:<key>` (no ad-hoc skip strings).
+  Applies to high-noise runtime coverage suites and similar optional-feature tests.
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -623,6 +623,28 @@ If it is not recorded here — it does not exist.
     - Runtime `pytest -q -rs` output shows standardized skip reasons with feature keys.
     - Feature keys in tests and ledger remain one-to-one mapped.
 
+- [ ] P1: Unimplemented feature keys backlog (SoT = tests/feature_manifest.py)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-748
+  - Status: 📋 Planned (seeded by PR-747 protocol cleanup)
+  - Area: backend / tests / feature debt management
+  - Finding Type: product feature debt / runtime skip protocol
+  - Reason for deferral: Runtime skip reasons are now standardized via
+    `feature_disabled:<key>`, but implementation work for gated features remains
+    deferred to focused execution PRs.
+  - Source of truth command:
+    - `pytest -q -rs | rg -n "feature_disabled:" || true`
+  - Links:
+    - `tests/feature_manifest.py`
+    - `docs/audit/SKIPPED_TESTS_CLASSIFICATION_AUDIT_2026-02-13.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md` (this section)
+  - DoD:
+    - For each implemented feature key, remove/replace corresponding
+      `require_feature(...)` gate in tests.
+    - Runtime `feature_disabled:<key>` skip count decreases as features land.
+    - Ledger item is updated with merged PR references per implemented key.
+
 - [ ] Cross-platform Design System: define tokens + UI primitives (Web + iOS)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design consistency / velocity)

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -51,17 +51,32 @@ class FeatureManifest:
 # Canonical feature TODO keys (must match BACKLOG_LEDGER item; one-to-one mapping).
 FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
     {
+        "coverage_boost_main_entrypoint",
         "core_db",
         "food_apis",
+        "food_apis_error_injection",
+        "main_entrypoint",
         "unified_db",
+        "unified_db_language",
+        "update_scheduler",
         "update_manager",
+        "update_manager_path_attrs",
         "planner_engines",
+        "premium_week_planner",
+        "premium_week_router_mocking",
         "i18n_advanced",
         "rag",
         "region_catalog",
+        "shoplist_helpers",
+        "shoplist_weekly_helpers",
+        "targets_fixture_data",
+        "ui_labels_contract",
+        "utils_pack",
+        "weekly_plan_helpers",
         "exports_recipes_products",
         "sports_disclaimers_lifestage",
         "legacy_bmi_removed",
+        "nutrient_recommendations",
     }
 )
 

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -51,7 +51,6 @@ class FeatureManifest:
 # Canonical feature TODO keys (must match BACKLOG_LEDGER item; one-to-one mapping).
 FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
     {
-        "coverage_boost_main_entrypoint",
         "core_db",
         "food_apis",
         "food_apis_error_injection",
@@ -62,13 +61,11 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "update_manager",
         "update_manager_path_attrs",
         "planner_engines",
-        "premium_week_planner",
         "premium_week_router_mocking",
         "i18n_advanced",
         "rag",
         "region_catalog",
         "shoplist_helpers",
-        "shoplist_weekly_helpers",
         "targets_fixture_data",
         "ui_labels_contract",
         "utils_pack",

--- a/tests/test_coverage_final_boost.py
+++ b/tests/test_coverage_final_boost.py
@@ -11,6 +11,7 @@ from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 
 class TestCoverageFinalBoost:
@@ -77,7 +78,7 @@ class TestCoverageFinalBoost:
 
         # Check if main function exists
         if not hasattr(setup_custom_mcp, "main"):
-            pytest.skip("main function not available")
+            require_feature("main_entrypoint", reason=FEATURE_REASON)
 
         # Test main function with mock
         with patch("setup_custom_mcp.main") as mock_main:

--- a/tests/test_feature_manifest_keys_used_guard.py
+++ b/tests/test_feature_manifest_keys_used_guard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.feature_manifest import FEATURE_TODO_KEYS
+
+
+def test_feature_manifest_keys_are_used_in_tests() -> None:
+    """Ensure each feature-manifest key is referenced by require_feature in tests."""
+    tests_root = Path(__file__).parent
+    content_parts: list[str] = []
+    for path in tests_root.rglob("*.py"):
+        content_parts.append(path.read_text(encoding="utf-8"))
+    content = "\n".join(content_parts)
+
+    missing: list[str] = []
+    for key in sorted(FEATURE_TODO_KEYS):
+        direct_pattern = rf"require_feature\(\s*['\"]{re.escape(key)}['\"]"
+        gated_pattern = rf"require_feature_or_raise\([^)]*['\"]{re.escape(key)}['\"]"
+        if re.search(direct_pattern, content) is None and re.search(gated_pattern, content) is None:
+            missing.append(key)
+
+    assert not missing, f"Unused feature keys in feature_manifest: {missing}"

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -8,6 +8,7 @@ from tests._client import get_client
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 # Setup environment before importing
 os.environ.setdefault("API_KEY", "test-key")
@@ -70,7 +71,7 @@ class TestMenuEngineNewCoverage:
 
             assert menu_engine_new is not None
         except ImportError:
-            pytest.skip("menu_engine_new not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
     def test_menu_engine_new_with_functions(self):
         """Test menu_engine_new functions."""
@@ -84,7 +85,7 @@ class TestMenuEngineNewCoverage:
             if hasattr(menu_engine_new, "make_weekly_menu"):
                 assert callable(menu_engine_new.make_weekly_menu)
         except ImportError:
-            pytest.skip("menu_engine_new not available")
+            require_feature("planner_engines", reason=FEATURE_REASON)
 
 
 class TestRecommendationsCoverage:
@@ -102,7 +103,7 @@ class TestRecommendationsCoverage:
             assert recommendations is not None
             assert isinstance(recommendations, dict)
         except (ImportError, TypeError):
-            pytest.skip("get_nutrient_recommendations not available or signature mismatch")
+            require_feature("nutrient_recommendations", reason=FEATURE_REASON)
 
     def test_recommendations_all_activity_levels(self):
         """Test recommendations for all activity levels."""
@@ -116,7 +117,7 @@ class TestRecommendationsCoverage:
                 )
                 assert recommendations is not None
         except (ImportError, TypeError):
-            pytest.skip("get_nutrient_recommendations not available")
+            require_feature("nutrient_recommendations", reason=FEATURE_REASON)
 
 
 class TestUnifiedDbCoverage:
@@ -136,7 +137,7 @@ class TestUnifiedDbCoverage:
             result = await search_unified_food("тест !@#")
             assert result is not None
         except ImportError:
-            pytest.skip("unified_db not available")
+            require_feature("unified_db", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_unified_db_language_support(self):
@@ -149,7 +150,7 @@ class TestUnifiedDbCoverage:
                 result = await search_unified_food("apple", language=lang)
                 assert result is not None
         except (ImportError, TypeError):
-            pytest.skip("unified_db language support not available")
+            require_feature("unified_db_language", reason=FEATURE_REASON)
 
 
 class TestUpdateManagerCoverage:
@@ -164,7 +165,7 @@ class TestUpdateManagerCoverage:
             scheduler = DatabaseUpdateScheduler()
             assert scheduler is not None
         except ImportError:
-            pytest.skip("DatabaseUpdateScheduler not available")
+            require_feature("update_scheduler", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_update_manager_status_check(self):
@@ -176,7 +177,7 @@ class TestUpdateManagerCoverage:
             assert status is not None
             assert isinstance(status, dict)
         except (ImportError, TypeError):
-            pytest.skip("get_update_status not available")
+            require_feature("update_scheduler", reason=FEATURE_REASON)
 
 
 class TestAppEndpointsCoverage:

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -64,7 +64,7 @@ class TestConfTestCoverage:
 class TestMenuEngineNewCoverage:
     """Tests for core/menu_engine_new.py uncovered lines."""
 
-    def test_menu_engine_new_basic_import(self):
+    def test_menu_engine_new_basic_import(self) -> None:
         """Test basic import of menu_engine_new."""
         try:
             from core import menu_engine_new
@@ -73,7 +73,7 @@ class TestMenuEngineNewCoverage:
         except ImportError:
             require_feature("planner_engines", reason=FEATURE_REASON)
 
-    def test_menu_engine_new_with_functions(self):
+    def test_menu_engine_new_with_functions(self) -> None:
         """Test menu_engine_new functions."""
         try:
             from core import menu_engine_new
@@ -91,7 +91,7 @@ class TestMenuEngineNewCoverage:
 class TestRecommendationsCoverage:
     """Tests for core/recommendations.py uncovered lines."""
 
-    def test_recommendations_edge_cases(self):
+    def test_recommendations_edge_cases(self) -> None:
         """Test recommendations with edge case inputs."""
         try:
             from core.recommendations import get_nutrient_recommendations
@@ -105,7 +105,7 @@ class TestRecommendationsCoverage:
         except (ImportError, TypeError):
             require_feature("nutrient_recommendations", reason=FEATURE_REASON)
 
-    def test_recommendations_all_activity_levels(self):
+    def test_recommendations_all_activity_levels(self) -> None:
         """Test recommendations for all activity levels."""
         try:
             from core.recommendations import get_nutrient_recommendations
@@ -124,7 +124,7 @@ class TestUnifiedDbCoverage:
     """Tests for core/food_apis/unified_db.py uncovered lines."""
 
     @pytest.mark.asyncio
-    async def test_unified_db_search_edge_cases(self):
+    async def test_unified_db_search_edge_cases(self) -> None:
         """Test unified_db search with edge cases."""
         try:
             from core.food_apis.unified_db import search_unified_food
@@ -140,7 +140,7 @@ class TestUnifiedDbCoverage:
             require_feature("unified_db", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
-    async def test_unified_db_language_support(self):
+    async def test_unified_db_language_support(self) -> None:
         """Test unified_db with different languages."""
         try:
             from core.food_apis.unified_db import search_unified_food
@@ -157,7 +157,7 @@ class TestUpdateManagerCoverage:
     """Tests for core/food_apis/update_manager.py uncovered lines."""
 
     @pytest.mark.asyncio
-    async def test_update_manager_init(self):
+    async def test_update_manager_init(self) -> None:
         """Test update_manager initialization."""
         try:
             from core.food_apis.update_manager import DatabaseUpdateScheduler
@@ -168,7 +168,7 @@ class TestUpdateManagerCoverage:
             require_feature("update_scheduler", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
-    async def test_update_manager_status_check(self):
+    async def test_update_manager_status_check(self) -> None:
         """Test update_manager status check."""
         try:
             from core.food_apis.update_manager import get_update_status

--- a/tests/test_food_apis_coverage_errors.py
+++ b/tests/test_food_apis_coverage_errors.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 import pytest
 
+from tests.feature_manifest import FEATURE_REASON, require_feature
+
 from core.food_apis.update_manager import DatabaseUpdateManager, UpdateResult
 from core.food_apis.unified_db import UnifiedFoodDatabase
 
@@ -300,12 +302,10 @@ class TestFoodAPIsUpdatePipeline:
                     if result.success:
                         assert result.records_updated == 0
 
-    @pytest.mark.skip(
-        reason="Error injection doesn't trigger expected warning - robust error handling"
-    )
     @pytest.mark.asyncio
     async def test_update_usda_database_old_data_load_error(self, update_manager):
         """Test _update_usda_database with old data load error (lines 341-342)."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock current version
         current_version = type(
             "Version", (), {"checksum": "old_checksum", "timestamp": "2023-01-01T00:00:00Z"}
@@ -328,12 +328,10 @@ class TestFoodAPIsUpdatePipeline:
                             mock_logger.warning.call_args
                         )
 
-    @pytest.mark.skip(
-        reason="Error injection doesn't produce expected failure - robust error handling"
-    )
     @pytest.mark.asyncio
     async def test_update_usda_database_general_error(self, update_manager):
         """Test _update_usda_database with general error (lines 381-382)."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock USDAClient to raise exception
         with patch(
             "core.food_apis.update_manager.USDAClient",
@@ -348,12 +346,10 @@ class TestFoodAPIsUpdatePipeline:
                 mock_logger.error.assert_called()
                 assert "Error updating usda database" in str(mock_logger.error.call_args)
 
-    @pytest.mark.skip(
-        reason="Error injection doesn't produce expected failure - robust error handling"
-    )
     @pytest.mark.asyncio
     async def test_update_off_database_error_during_processing(self, update_manager):
         """Test _update_off_database with processing error (line 430)."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         with patch("core.food_apis.update_manager.OFF_AVAILABLE", True):
             with patch("core.food_apis.update_manager.OFFClient") as mock_off:
                 # Mock OFFClient to return some data
@@ -393,10 +389,10 @@ class TestUnifiedFoodDatabase:
             # Should handle missing OFF gracefully
             assert unified_db.off_client is None
 
-    @pytest.mark.skip(reason="Mock doesn't properly prevent exception propagation")
     @pytest.mark.asyncio
     async def test_search_foods_usda_error_fallback(self, unified_db):
         """Test search_foods with USDA error falling back to cache (line 115-134)."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock USDA client to raise exception
         with patch.object(
             unified_db.usda_client, "search_foods", side_effect=Exception("USDA API error")
@@ -413,10 +409,10 @@ class TestUnifiedFoodDatabase:
             assert len(result) == 1
             assert result[0].name == "Cached Food"
 
-    @pytest.mark.skip(reason="get_food_by_id method signature issue")
     @pytest.mark.asyncio
     async def test_get_food_by_id_cache_load_error(self, unified_db):
         """Test get_food_by_id with cache load error (line 190-224)."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Create invalid cache file
         cache_file = unified_db.cache_dir / "food_cache.json"
         cache_file.parent.mkdir(parents=True, exist_ok=True)
@@ -434,10 +430,10 @@ class TestUnifiedFoodDatabase:
             assert result is not None
             assert result.name == "Test Food"
 
-    @pytest.mark.skip(reason="get_food_by_id method signature issue")
     @pytest.mark.asyncio
     async def test_get_food_by_id_all_sources_fail(self, unified_db):
         """Test get_food_by_id when all sources fail."""
+        require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock all clients to return None/raise exceptions
         with patch.object(unified_db.usda_client, "get_food_details", return_value=None):
             with patch("core.food_apis.unified_db.OFF_AVAILABLE", True):

--- a/tests/test_food_apis_coverage_errors.py
+++ b/tests/test_food_apis_coverage_errors.py
@@ -303,7 +303,9 @@ class TestFoodAPIsUpdatePipeline:
                         assert result.records_updated == 0
 
     @pytest.mark.asyncio
-    async def test_update_usda_database_old_data_load_error(self, update_manager):
+    async def test_update_usda_database_old_data_load_error(
+        self, update_manager: DatabaseUpdateManager
+    ) -> None:
         """Test _update_usda_database with old data load error (lines 341-342)."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock current version
@@ -329,7 +331,9 @@ class TestFoodAPIsUpdatePipeline:
                         )
 
     @pytest.mark.asyncio
-    async def test_update_usda_database_general_error(self, update_manager):
+    async def test_update_usda_database_general_error(
+        self, update_manager: DatabaseUpdateManager
+    ) -> None:
         """Test _update_usda_database with general error (lines 381-382)."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock USDAClient to raise exception
@@ -347,7 +351,9 @@ class TestFoodAPIsUpdatePipeline:
                 assert "Error updating usda database" in str(mock_logger.error.call_args)
 
     @pytest.mark.asyncio
-    async def test_update_off_database_error_during_processing(self, update_manager):
+    async def test_update_off_database_error_during_processing(
+        self, update_manager: DatabaseUpdateManager
+    ) -> None:
         """Test _update_off_database with processing error (line 430)."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         with patch("core.food_apis.update_manager.OFF_AVAILABLE", True):
@@ -390,7 +396,7 @@ class TestUnifiedFoodDatabase:
             assert unified_db.off_client is None
 
     @pytest.mark.asyncio
-    async def test_search_foods_usda_error_fallback(self, unified_db):
+    async def test_search_foods_usda_error_fallback(self, unified_db: UnifiedFoodDatabase) -> None:
         """Test search_foods with USDA error falling back to cache (line 115-134)."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock USDA client to raise exception
@@ -410,7 +416,7 @@ class TestUnifiedFoodDatabase:
             assert result[0].name == "Cached Food"
 
     @pytest.mark.asyncio
-    async def test_get_food_by_id_cache_load_error(self, unified_db):
+    async def test_get_food_by_id_cache_load_error(self, unified_db: UnifiedFoodDatabase) -> None:
         """Test get_food_by_id with cache load error (line 190-224)."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Create invalid cache file
@@ -431,7 +437,7 @@ class TestUnifiedFoodDatabase:
             assert result.name == "Test Food"
 
     @pytest.mark.asyncio
-    async def test_get_food_by_id_all_sources_fail(self, unified_db):
+    async def test_get_food_by_id_all_sources_fail(self, unified_db: UnifiedFoodDatabase) -> None:
         """Test get_food_by_id when all sources fail."""
         require_feature("food_apis_error_injection", reason=FEATURE_REASON)
         # Mock all clients to return None/raise exceptions

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -7,6 +7,7 @@ warnings, and UI labels for both male and female profiles.
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 try:
     import app as app_mod  # type: ignore
@@ -450,4 +451,4 @@ class TestPremiumTargetsESSnapshots:
             assert found_indicators, f"No Spanish indicators found in: {all_labels_text}"
         else:
             # Skip test if ui_labels is not present in current API
-            pytest.skip("ui_labels not present in current API response")
+            require_feature("ui_labels_contract", reason=FEATURE_REASON)

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -7,7 +7,7 @@ warnings, and UI labels for both male and female profiles.
 
 import pytest
 from fastapi.testclient import TestClient
-from tests.feature_manifest import FEATURE_REASON, require_feature
+from tests.feature_manifest import FEATURE_REASON, fail_feature_gated_test, require_feature
 
 try:
     import app as app_mod  # type: ignore
@@ -450,5 +450,9 @@ class TestPremiumTargetsESSnapshots:
             found_indicators = [ind for ind in spanish_indicators if ind in all_labels_text]
             assert found_indicators, f"No Spanish indicators found in: {all_labels_text}"
         else:
-            # Skip test if ui_labels is not present in current API
+            # Skip when feature is disabled; fail if enabled but still missing.
             require_feature("ui_labels_contract", reason=FEATURE_REASON)
+            fail_feature_gated_test(
+                "ui_labels_contract",
+                reason="ui_labels missing from response while ui_labels_contract is enabled.",
+            )

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 from app import app
 
@@ -38,7 +39,7 @@ class TestPremiumWeekAppCoverage:
         """Test when make_weekly_menu is not available (503 error)."""
         # Skip this test for now - mocking is complex with FastAPI
         # The function is imported at module level and hard to mock
-        pytest.skip("Mocking make_weekly_menu is complex with FastAPI")
+        require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
 
     def test_api_weekly_menu_success(self):
         """Test successful weekly menu generation."""
@@ -84,7 +85,7 @@ class TestPremiumWeekAppCoverage:
         """Test exception handling in weekly menu generation."""
         # Skip this test for now - mocking is complex with FastAPI
         # The function is imported at module level and hard to mock
-        pytest.skip("Mocking make_weekly_menu is complex with FastAPI")
+        require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
 
     def test_api_weekly_menu_with_optional_fields(self):
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from tests.feature_manifest import FEATURE_REASON, require_feature
+from tests.feature_manifest import FEATURE_REASON, fail_feature_gated_test, require_feature
 
 from app import app
 
@@ -40,6 +40,10 @@ class TestPremiumWeekAppCoverage:
         # Skip this test for now - mocking is complex with FastAPI
         # The function is imported at module level and hard to mock
         require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
+        fail_feature_gated_test(
+            "premium_week_router_mocking",
+            reason="Weekly menu missing-handler assertions are not implemented yet.",
+        )
 
     def test_api_weekly_menu_success(self):
         """Test successful weekly menu generation."""
@@ -86,6 +90,10 @@ class TestPremiumWeekAppCoverage:
         # Skip this test for now - mocking is complex with FastAPI
         # The function is imported at module level and hard to mock
         require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
+        fail_feature_gated_test(
+            "premium_week_router_mocking",
+            reason="Weekly menu exception-handling assertions are not implemented yet.",
+        )
 
     def test_api_weekly_menu_with_optional_fields(self):
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -10,6 +10,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class TestShoplistModule:
             assert rule.rounding_strategy == "up"
 
         except ImportError:
-            pytest.skip("shoplist module not available")
+            require_feature("shoplist_helpers", reason=FEATURE_REASON)
 
     def test_shopping_item_class(self):
         """Test ShoppingItem dataclass."""
@@ -51,7 +52,7 @@ class TestShoplistModule:
             assert item.unit == "g"
 
         except ImportError:
-            pytest.skip("shoplist module not available")
+            require_feature("shoplist_helpers", reason=FEATURE_REASON)
 
     def test_shoplist_functions(self):
         """Test shoplist utility functions."""
@@ -89,7 +90,7 @@ class TestShoplistModule:
             assert isinstance(grouped, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("shoplist functions not available")
+            require_feature("shoplist_helpers", reason=FEATURE_REASON)
 
 
 class TestWeeklyPlanModule:
@@ -112,7 +113,7 @@ class TestWeeklyPlanModule:
                         assert isinstance(plan, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("weekly_plan module not available")
+            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("generate_weekly_plan raised during test: %s", exc)
 
@@ -135,7 +136,7 @@ class TestWeeklyPlanModule:
                         assert isinstance(plan, (dict, type(None)))
 
         except ImportError:
-            pytest.skip("weekly_plan module not available")
+            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("generate_weekly_plan with diet flags raised: %s", exc)
 
@@ -168,7 +169,7 @@ class TestWeeklyPlanModule:
             assert isinstance(is_valid, (bool, type(None)))
 
         except ImportError:
-            pytest.skip("weekly_plan helper functions not available")
+            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("weekly_plan helper functions raised: %s", exc)
 
@@ -215,7 +216,7 @@ class TestUtilsModule:
             assert isinstance(slug, (str, type(None)))
 
         except ImportError:
-            pytest.skip("utils module not available")
+            require_feature("utils_pack", reason=FEATURE_REASON)
 
     def test_additional_utils(self):
         """Test additional utility functions."""
@@ -254,7 +255,7 @@ class TestUtilsModule:
             assert isinstance(formatted, (str, type(None)))
 
         except ImportError:
-            pytest.skip("additional utils not available")
+            require_feature("utils_pack", reason=FEATURE_REASON)
 
 
 class TestTimeUtilsModule:
@@ -302,4 +303,4 @@ class TestTimeUtilsModule:
             assert isinstance(is_valid, (bool, type(None)))
 
         except ImportError:
-            pytest.skip("time_utils module not available")
+            require_feature("utils_pack", reason=FEATURE_REASON)

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -10,7 +10,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
-from tests.feature_manifest import FEATURE_REASON, require_feature
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ class TestShoplistModule:
             assert rule.typical_packages == [100, 250, 500, 1000]
             assert rule.rounding_strategy == "up"
 
-        except ImportError:
-            require_feature("shoplist_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
 
     def test_shopping_item_class(self):
         """Test ShoppingItem dataclass."""
@@ -51,8 +51,8 @@ class TestShoplistModule:
             assert item.quantity == 500.0
             assert item.unit == "g"
 
-        except ImportError:
-            require_feature("shoplist_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
 
     def test_shoplist_functions(self):
         """Test shoplist utility functions."""
@@ -89,8 +89,8 @@ class TestShoplistModule:
             grouped = group_by_category(items)
             assert isinstance(grouped, (dict, type(None)))
 
-        except ImportError:
-            require_feature("shoplist_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
 
 
 class TestWeeklyPlanModule:
@@ -112,8 +112,8 @@ class TestWeeklyPlanModule:
                         plan = generate_weekly_plan(targets, set())
                         assert isinstance(plan, (dict, type(None)))
 
-        except ImportError:
-            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("generate_weekly_plan raised during test: %s", exc)
 
@@ -135,8 +135,8 @@ class TestWeeklyPlanModule:
                         plan = generate_weekly_plan(targets, diet_flags)
                         assert isinstance(plan, (dict, type(None)))
 
-        except ImportError:
-            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("generate_weekly_plan with diet flags raised: %s", exc)
 
@@ -168,8 +168,8 @@ class TestWeeklyPlanModule:
             is_valid = validate_weekly_plan(weekly_plan)
             assert isinstance(is_valid, (bool, type(None)))
 
-        except ImportError:
-            require_feature("weekly_plan_helpers", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "weekly_plan_helpers", reason=FEATURE_REASON)
         except Exception as exc:
             logger.warning("weekly_plan helper functions raised: %s", exc)
 
@@ -215,8 +215,8 @@ class TestUtilsModule:
             slug = slugify(None)
             assert isinstance(slug, (str, type(None)))
 
-        except ImportError:
-            require_feature("utils_pack", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
 
     def test_additional_utils(self):
         """Test additional utility functions."""
@@ -254,8 +254,8 @@ class TestUtilsModule:
             formatted = format_number(1234.567)
             assert isinstance(formatted, (str, type(None)))
 
-        except ImportError:
-            require_feature("utils_pack", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
 
 
 class TestTimeUtilsModule:
@@ -302,5 +302,5 @@ class TestTimeUtilsModule:
             is_valid = is_valid_date("invalid")
             assert isinstance(is_valid, (bool, type(None)))
 
-        except ImportError:
-            require_feature("utils_pack", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)

--- a/tests/test_targets_coverage_97.py
+++ b/tests/test_targets_coverage_97.py
@@ -1,6 +1,7 @@
 """Tests to boost coverage for core/targets.py to 97%."""
 
 import pytest
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 from core.targets import MicronutrientTargets
 
@@ -58,7 +59,7 @@ class TestTargetsCoverage97:
                 assert isinstance(result, float)
             except ValueError:
                 # If no nutrients exist, skip this test
-                pytest.skip("No valid nutrients found for testing")
+                require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
     def test_get_minimum_valid_nutrient(self):
         """Test get_minimum with valid nutrient."""
@@ -70,7 +71,7 @@ class TestTargetsCoverage97:
                 result = self.targets.get_minimum("iron")
                 assert isinstance(result, float)
             except ValueError:
-                pytest.skip("No valid nutrients found for testing")
+                require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
     def test_get_maximum_valid_nutrient(self):
         """Test get_maximum with valid nutrient."""
@@ -82,7 +83,7 @@ class TestTargetsCoverage97:
                 result = self.targets.get_maximum("iron")
                 assert isinstance(result, float)
             except ValueError:
-                pytest.skip("No valid nutrients found for testing")
+                require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
     def test_is_deficient_true(self):
         """Test is_deficient with deficient value."""
@@ -95,7 +96,7 @@ class TestTargetsCoverage97:
                 result = self.targets.is_deficient("iron", 0.1)
                 assert isinstance(result, bool)
             except ValueError:
-                pytest.skip("No valid nutrients found for testing")
+                require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
     def test_is_deficient_false(self):
         """Test is_deficient with sufficient value."""
@@ -108,7 +109,7 @@ class TestTargetsCoverage97:
                 result = self.targets.is_deficient("iron", 100.0)
                 assert isinstance(result, bool)
             except ValueError:
-                pytest.skip("No valid nutrients found for testing")
+                require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
     def test_priority_nutrients_structure(self):
         """Test priority_nutrients structure."""

--- a/tests/test_targets_coverage_97.py
+++ b/tests/test_targets_coverage_97.py
@@ -46,7 +46,7 @@ class TestTargetsCoverage97:
         priority_nutrients = self.targets.get_priority_nutrients()
         assert isinstance(priority_nutrients, dict)
 
-    def test_get_target_valid_nutrient(self):
+    def test_get_target_valid_nutrient(self) -> None:
         """Test get_target with valid nutrient."""
         # Test with a nutrient that should exist
         try:
@@ -61,7 +61,7 @@ class TestTargetsCoverage97:
                 # If no nutrients exist, skip this test
                 require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
-    def test_get_minimum_valid_nutrient(self):
+    def test_get_minimum_valid_nutrient(self) -> None:
         """Test get_minimum with valid nutrient."""
         try:
             result = self.targets.get_minimum("calcium")
@@ -73,7 +73,7 @@ class TestTargetsCoverage97:
             except ValueError:
                 require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
-    def test_get_maximum_valid_nutrient(self):
+    def test_get_maximum_valid_nutrient(self) -> None:
         """Test get_maximum with valid nutrient."""
         try:
             result = self.targets.get_maximum("calcium")
@@ -85,7 +85,7 @@ class TestTargetsCoverage97:
             except ValueError:
                 require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
-    def test_is_deficient_true(self):
+    def test_is_deficient_true(self) -> None:
         """Test is_deficient with deficient value."""
         try:
             # Test with a very low value that should be deficient
@@ -98,7 +98,7 @@ class TestTargetsCoverage97:
             except ValueError:
                 require_feature("targets_fixture_data", reason=FEATURE_REASON)
 
-    def test_is_deficient_false(self):
+    def test_is_deficient_false(self) -> None:
         """Test is_deficient with sufficient value."""
         try:
             # Test with a high value that should not be deficient

--- a/tests/test_update_manager_fixed.py
+++ b/tests/test_update_manager_fixed.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
+from tests.feature_manifest import FEATURE_REASON, require_feature
 
 from core.food_apis.update_manager import DatabaseUpdateManager, DatabaseVersion
 
@@ -126,9 +127,9 @@ class TestUpdateManagerFixed:
         assert response.status_code != 401
         assert response.status_code != 403
 
-    @pytest.mark.skip(reason="Update manager path attribute issues")
     def test_update_manager_initialization(self):
         """Test DatabaseUpdateManager initialization."""
+        require_feature("update_manager_path_attrs", reason=FEATURE_REASON)
         with tempfile.TemporaryDirectory() as temp_dir:
             manager = DatabaseUpdateManager(
                 cache_dir=temp_dir, update_interval_hours=12, max_rollback_versions=3


### PR DESCRIPTION
## Summary
- Standardize remaining ad-hoc skip reasons in skip-heavy suites to canonical `feature_disabled:<key>` via `require_feature(...)` / `require_feature_or_raise(...)`.
- Add guard test `tests/test_feature_manifest_keys_used_guard.py` to ensure every key in `FEATURE_TODO_KEYS` is referenced in tests.
- Apply CodeRabbit/Sourcery follow-up fixes: typed test signatures, fail-fast behavior for enabled feature gates, and strict ImportError handling.

## Evidence
- `pytest -q -rs | rg -n "SKIPPED \[" | head -n 30`
- Output contains only `feature_disabled:<key>` plus one env skip (`Not running under xdist...`).
- `pytest -q tests/test_feature_manifest_keys_used_guard.py -rs` passes.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest -q tests/test_final_coverage_97_boost.py tests/test_food_apis_coverage_errors.py tests/test_premium_targets_es_snapshots.py tests/test_premium_week_app_coverage.py tests/test_remaining_modules.py tests/test_targets_coverage_97.py tests/test_feature_manifest_keys_used_guard.py -q`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## DoD
- [x] Runtime SKIPPED reasons standardized to `feature_disabled:<key>` for optional-feature debt.
- [x] No remaining ad-hoc `module/function not available` skips in touched skip-heavy suites.
- [x] Feature implementation is out of scope (protocol-only PR).
- [x] Quality gates pass (`pre-commit`, `make verify`).

## Deferred / Follow-ups
- Feature implementation remains tracked as feature debt via `tests/feature_manifest.py` keys and `docs/roadmap/BACKLOG_LEDGER.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test metadata and baseline timestamps.

* **New Features**
  * Added a set of new feature keys to the manifest used for gating test behavior.

* **Tests**
  * Migrated many tests from unconditional skips to feature-flag gating.
  * Added a new test that verifies all declared feature keys are referenced in the test suite.

* **Documentation**
  * Added policy guidance standardizing feature-flag skip/require protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->