### PR TITLE
test(guards): ignore stale transient files in AST scan

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,6 +18,7 @@
 - Never mock `builtins.__import__` or `builtins.float`.
 - Preserve xdist DB isolation: each worker gets its own SQLite path.
 - Prefer `monkeypatch` over global mutations; avoid real sleeps.
+- Repo policy guards must not reference temporary/untracked files; AST scan path lists must filter by `.exists()`.
 
 ### Module purge / reload invariant (xdist stability)
 

--- a/tests/test_repo_policy_guards.py
+++ b/tests/test_repo_policy_guards.py
@@ -412,6 +412,9 @@ def _iter_repo_py_files_for_ast_scan(root: Path) -> Iterable[Path]:
     for p in root.rglob("*.py"):
         if any(part in SKIP_DIRS_FOR_AST_SCAN for part in p.parts):
             continue
+        if not p.exists():
+            # CI TOCTOU safety: transient files can disappear between discovery and scan.
+            continue
         paths.append(p)
     yield from sorted(paths, key=lambda x: x.as_posix())
 
@@ -634,6 +637,11 @@ def _scan_file_ast(path: Path) -> list[_AstViolation]:
         return []
     try:
         src = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        rel = _rel(path)
+        if any(pattern.match(rel) for pattern in _TRANSIENT_POLICY_SCAN_PATHS):
+            return []
+        raise
     except UnicodeDecodeError:
         return []
     try:


### PR DESCRIPTION
## Summary
- Fix CI red on `main` caused by stale transient path reads in repo policy guard AST scan.
- Add `Path.exists()` filtering during AST scan path collection to avoid scanning files that disappeared between discovery/read.
- Add `FileNotFoundError` handling in `_scan_file_ast()` for transient guard temp paths (`app/test_guard_*_temp.py`).
- Add test-scope policy note in `tests/AGENTS.md` to require `.exists()` filtering for AST scan path lists.

## Root cause
`tests/test_repo_policy_guards.py` attempted to read a transient file path that did not exist in CI checkout:
`app/test_guard_whr_skip_temp.py`.
This is a TOCTOU issue (file can vanish after discovery).

## Test plan
- [x] `pytest -q tests/test_repo_policy_guards.py::test_repo_policy_guards_ast_reload_and_sys_modules_clear -rs`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Risk
Low. Change is guard/test-only and narrows scan input to files that exist.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ужесточить проверку репозиторным guard’ом при AST-сканировании, защитив её от временных файлов, которые могут исчезнуть между обнаружением и чтением, и задокументировать соответствующую политику тестирования.

Bug Fixes:
- Исключить попытки AST-сканировать Python-файлы, которые больше не существуют, путём фильтрации собранных путей с помощью проверки `Path.exists()`.
- Обрабатывать `FileNotFoundError` во время AST-сканирования известных временных guard-файлов, рассматривая их как отсутствие нарушений, а не как причину падения сканирования.

Documentation:
- Задокументировать в `tests/AGENTS.md`, что списки путей для AST-сканирования в repo policy guard должны фильтроваться с помощью `.exists()` и не должны полагаться на временные или неотслеживаемые файлы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden repo policy guard AST scanning against transient files that can disappear between discovery and read, and document the corresponding testing policy.

Bug Fixes:
- Avoid attempting to AST-scan Python files that no longer exist by filtering collected paths with a Path.exists() check.
- Handle FileNotFoundError during AST scanning of known transient guard temp paths by treating them as non-violations instead of failing the scan.

Documentation:
- Document in tests/AGENTS.md that repo policy guard AST scan path lists must filter by .exists() and must not rely on temporary or untracked files.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Repository policy scanning now gracefully handles transient files that may disappear during concurrent file system operations, reducing false violation reports during CI execution.

* **Documentation**
  * Updated testing guidelines to establish standards for handling temporary files and proper existence validation procedures in repository scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->