### PR TITLE
feat(contracts): add ui_labels to WHO targets response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Or individually:
 - PR MUST NOT be merged while any bot comment contains actionable items.
 - Before merge, confirm CodeRabbit, Sourcery, and Cubic are explicitly PASS / no-actionables.
 - Required checks must be PASS with no pending required jobs.
+- This gate applies to every non-draft PR before merge.
 
 **Pre-commit hook policy (mandatory before push):**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,14 @@ Or individually:
 3. Do NOT write "готово", "green", "mergeable"
 4. Fix the issue first, then re-run `make verify`
 
+**PR merge readiness (hard rule):**
+
+- Green CI alone is NOT sufficient for merge.
+- PR MUST NOT be merged while any review thread is unresolved.
+- PR MUST NOT be merged while any bot comment contains actionable items.
+- Before merge, confirm CodeRabbit, Sourcery, and Cubic are explicitly PASS / no-actionables.
+- Required checks must be PASS with no pending required jobs.
+
 **Pre-commit hook policy (mandatory before push):**
 
 - **Always run `pre-commit run --all-files` locally before pushing any PR.**
@@ -75,8 +83,6 @@ Or individually:
 - **Skip reason protocol:** Any skip caused by missing module/function/data MUST use
   `require_feature(...)` and emit `feature_disabled:<key>` (no ad-hoc skip strings).
   Applies to high-noise runtime coverage suites and similar optional-feature tests.
-- **UI labels contract policy:** UI response labels must live in schema-backed contracts (SoT)
-  and be asserted in snapshot tests; do not keep feature-gated skips after implementation.
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ Or individually:
 - **Skip reason protocol:** Any skip caused by missing module/function/data MUST use
   `require_feature(...)` and emit `feature_disabled:<key>` (no ad-hoc skip strings).
   Applies to high-noise runtime coverage suites and similar optional-feature tests.
+- **UI labels contract policy:** UI response labels must live in schema-backed contracts (SoT)
+  and be asserted in snapshot tests; do not keep feature-gated skips after implementation.
 
 **Dead code policy:**
 If diff-cover shows uncovered helpers that have zero call sites → **delete them**, don't write tests for unused code.

--- a/app/schemas/premium_contracts.py
+++ b/app/schemas/premium_contracts.py
@@ -120,6 +120,8 @@ class WHOTargetsUiLabels(BaseModel):
     warnings: str
 
 
+# RU: Единый источник переводов UI-лейблов; добавляйте новые языки только здесь и держите client i18n в sync.
+# EN: Single source of truth for UI label translations; add new languages here and keep client i18n in sync.
 _WHO_TARGETS_UI_LABELS_BY_LANG: dict[str, dict[str, str]] = {
     "en": {
         "kcal_daily": "Daily calories",
@@ -161,7 +163,12 @@ def build_who_targets_ui_labels(lang: str | None) -> WHOTargetsUiLabels:
     """Build canonical localized UI labels for WHO targets contract."""
 
     language = str(lang or "en").lower()
-    labels = _WHO_TARGETS_UI_LABELS_BY_LANG.get(language, _WHO_TARGETS_UI_LABELS_BY_LANG["en"])
+    base_lang = language.split("-", 1)[0].split("_", 1)[0]
+    labels = (
+        _WHO_TARGETS_UI_LABELS_BY_LANG.get(language)
+        or _WHO_TARGETS_UI_LABELS_BY_LANG.get(base_lang)
+        or _WHO_TARGETS_UI_LABELS_BY_LANG["en"]
+    )
     return WHOTargetsUiLabels(**labels)
 
 

--- a/app/schemas/premium_contracts.py
+++ b/app/schemas/premium_contracts.py
@@ -120,6 +120,51 @@ class WHOTargetsUiLabels(BaseModel):
     warnings: str
 
 
+_WHO_TARGETS_UI_LABELS_BY_LANG: dict[str, dict[str, str]] = {
+    "en": {
+        "kcal_daily": "Daily calories",
+        "macros_protein_g": "Protein (g)",
+        "macros_fat_g": "Fat (g)",
+        "macros_carbs_g": "Carbs (g)",
+        "macros_fiber_g": "Fiber (g)",
+        "water_ml": "Water (ml)",
+        "priority_micros": "Priority micros",
+        "activity_weekly": "Weekly activity",
+        "warnings": "Warnings",
+    },
+    "es": {
+        "kcal_daily": "Calorías diarias",
+        "macros_protein_g": "Proteínas (g)",
+        "macros_fat_g": "Grasas (g)",
+        "macros_carbs_g": "Carbohidratos (g)",
+        "macros_fiber_g": "Fibra (g)",
+        "water_ml": "Agua (ml)",
+        "priority_micros": "Micronutrientes prioritarios",
+        "activity_weekly": "Actividad semanal",
+        "warnings": "Advertencias",
+    },
+    "ru": {
+        "kcal_daily": "Ккал в день",
+        "macros_protein_g": "Белки (г)",
+        "macros_fat_g": "Жиры (г)",
+        "macros_carbs_g": "Углеводы (г)",
+        "macros_fiber_g": "Клетчатка (г)",
+        "water_ml": "Вода (мл)",
+        "priority_micros": "Приоритетные микроэлементы",
+        "activity_weekly": "Активность за неделю",
+        "warnings": "Предупреждения",
+    },
+}
+
+
+def build_who_targets_ui_labels(lang: str | None) -> WHOTargetsUiLabels:
+    """Build canonical localized UI labels for WHO targets contract."""
+
+    language = str(lang or "en").lower()
+    labels = _WHO_TARGETS_UI_LABELS_BY_LANG.get(language, _WHO_TARGETS_UI_LABELS_BY_LANG["en"])
+    return WHOTargetsUiLabels(**labels)
+
+
 class WHOTargetsResponse(BaseModel):
     """RU: Ответ с целевыми значениями по ВОЗ. EN: WHO targets response."""
 

--- a/app/schemas/premium_contracts.py
+++ b/app/schemas/premium_contracts.py
@@ -116,3 +116,4 @@ class WHOTargetsResponse(BaseModel):
     activity_weekly: Dict[str, int]
     calculation_date: str
     warnings: List[Dict[str, str]] = Field(default_factory=list)
+    ui_labels: Dict[str, str]

--- a/app/schemas/premium_contracts.py
+++ b/app/schemas/premium_contracts.py
@@ -106,6 +106,20 @@ class WHOTargetsRequest(BaseModel):
         return values
 
 
+class WHOTargetsUiLabels(BaseModel):
+    """RU: Локализованные UI-лейблы для thin clients. EN: Localized UI labels."""
+
+    kcal_daily: str
+    macros_protein_g: str
+    macros_fat_g: str
+    macros_carbs_g: str
+    macros_fiber_g: str
+    water_ml: str
+    priority_micros: str
+    activity_weekly: str
+    warnings: str
+
+
 class WHOTargetsResponse(BaseModel):
     """RU: Ответ с целевыми значениями по ВОЗ. EN: WHO targets response."""
 
@@ -116,4 +130,4 @@ class WHOTargetsResponse(BaseModel):
     activity_weekly: Dict[str, int]
     calculation_date: str
     warnings: List[Dict[str, str]] = Field(default_factory=list)
-    ui_labels: Dict[str, str]
+    ui_labels: WHOTargetsUiLabels

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1568,7 +1568,8 @@ If it is not recorded here — it does not exist.
 
 - [ ] P2: Product decision for removed/non-canonical optional fields in skip tests
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: PR-733
+  - Target PR: PR-749 (ui_labels contract), PR-733 (remaining fields)
+  - Status: 🟡 In progress (PR-749)
   - Priority: P2
   - Area: backend / product contract
   - Finding Type: intentional-scope decision
@@ -1576,7 +1577,7 @@ If it is not recorded here — it does not exist.
     - `tests/test_app_coverage_unit_combined.py:83`
     - `tests/test_app_coverage_unit_combined.py:88`
     - `tests/test_premium_targets_es_snapshots.py:453`
-  - Reason: `interpret_group` / `estimate_level` and optional `ui_labels` require product-contract decisions before code/test remediation.
+  - Reason: `ui_labels` contract is being promoted to required in PR-749; `interpret_group` / `estimate_level` still need explicit product-contract decisions.
   - Links:
     - `docs/audit/SKIPPED_TESTS_CLASSIFICATION_AUDIT_2026-02-13.md`
     - `app/schemas/premium_contracts.py:109`

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5316,6 +5316,13 @@
             "title": "Priority Micros",
             "type": "object"
           },
+          "ui_labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Ui Labels",
+            "type": "object"
+          },
           "warnings": {
             "items": {
               "additionalProperties": {
@@ -5337,7 +5344,8 @@
           "water_ml",
           "priority_micros",
           "activity_weekly",
-          "calculation_date"
+          "calculation_date",
+          "ui_labels"
         ],
         "title": "WHOTargetsResponse",
         "type": "object"

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5317,11 +5317,7 @@
             "type": "object"
           },
           "ui_labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "title": "Ui Labels",
-            "type": "object"
+            "$ref": "#/components/schemas/WHOTargetsUiLabels"
           },
           "warnings": {
             "items": {
@@ -5348,6 +5344,60 @@
           "ui_labels"
         ],
         "title": "WHOTargetsResponse",
+        "type": "object"
+      },
+      "WHOTargetsUiLabels": {
+        "description": "RU: Локализованные UI-лейблы для thin clients. EN: Localized UI labels.",
+        "properties": {
+          "activity_weekly": {
+            "title": "Activity Weekly",
+            "type": "string"
+          },
+          "kcal_daily": {
+            "title": "Kcal Daily",
+            "type": "string"
+          },
+          "macros_carbs_g": {
+            "title": "Macros Carbs G",
+            "type": "string"
+          },
+          "macros_fat_g": {
+            "title": "Macros Fat G",
+            "type": "string"
+          },
+          "macros_fiber_g": {
+            "title": "Macros Fiber G",
+            "type": "string"
+          },
+          "macros_protein_g": {
+            "title": "Macros Protein G",
+            "type": "string"
+          },
+          "priority_micros": {
+            "title": "Priority Micros",
+            "type": "string"
+          },
+          "warnings": {
+            "title": "Warnings",
+            "type": "string"
+          },
+          "water_ml": {
+            "title": "Water Ml",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kcal_daily",
+          "macros_protein_g",
+          "macros_fat_g",
+          "macros_carbs_g",
+          "macros_fiber_g",
+          "water_ml",
+          "priority_micros",
+          "activity_weekly",
+          "warnings"
+        ],
+        "title": "WHOTargetsUiLabels",
         "type": "object"
       },
       "WaistRiskResultSchema": {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4953,6 +4953,10 @@ export interface components {
             priority_micros: {
                 [key: string]: number;
             };
+            /** Ui Labels */
+            ui_labels: {
+                [key: string]: string;
+            };
             /** Warnings */
             warnings?: {
                 [key: string]: string;

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4953,16 +4953,37 @@ export interface components {
             priority_micros: {
                 [key: string]: number;
             };
-            /** Ui Labels */
-            ui_labels: {
-                [key: string]: string;
-            };
+            ui_labels: components["schemas"]["WHOTargetsUiLabels"];
             /** Warnings */
             warnings?: {
                 [key: string]: string;
             }[];
             /** Water Ml */
             water_ml: number;
+        };
+        /**
+         * WHOTargetsUiLabels
+         * @description RU: Локализованные UI-лейблы для thin clients. EN: Localized UI labels.
+         */
+        WHOTargetsUiLabels: {
+            /** Activity Weekly */
+            activity_weekly: string;
+            /** Kcal Daily */
+            kcal_daily: string;
+            /** Macros Carbs G */
+            macros_carbs_g: string;
+            /** Macros Fat G */
+            macros_fat_g: string;
+            /** Macros Fiber G */
+            macros_fiber_g: string;
+            /** Macros Protein G */
+            macros_protein_g: string;
+            /** Priority Micros */
+            priority_micros: string;
+            /** Warnings */
+            warnings: string;
+            /** Water Ml */
+            water_ml: string;
         };
     };
     responses: never;

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -69,6 +69,7 @@ from app.schemas.premium_contracts import (
     VisualShape,
     WHOTargetsRequest,
     WHOTargetsResponse,
+    WHOTargetsUiLabels,
 )
 from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
 from app.services import recipe_store
@@ -4046,42 +4047,49 @@ def _fallback_targets_response(
     )
 
 
-def _build_targets_ui_labels(lang: str | None) -> dict[str, str]:
-    """Return deterministic UI labels for WHO targets response."""
-
-    language = str(lang or "en").lower()
-    if language == "es":
-        return {
-            "kcal_daily": "Calorías diarias",
-            "macros_protein_g": "Proteínas (g)",
-            "macros_fat_g": "Grasas (g)",
-            "macros_carbs_g": "Carbohidratos (g)",
-            "water_ml": "Agua (ml)",
-            "priority_micros": "Micronutrientes prioritarios",
-            "activity_weekly": "Actividad semanal",
-            "warnings": "Advertencias",
-        }
-    if language == "ru":
-        return {
-            "kcal_daily": "Ккал в день",
-            "macros_protein_g": "Белки (г)",
-            "macros_fat_g": "Жиры (г)",
-            "macros_carbs_g": "Углеводы (г)",
-            "water_ml": "Вода (мл)",
-            "priority_micros": "Приоритетные микроэлементы",
-            "activity_weekly": "Активность за неделю",
-            "warnings": "Предупреждения",
-        }
-    return {
+_WHO_TARGETS_UI_LABELS_BY_LANG: dict[str, dict[str, str]] = {
+    "en": {
         "kcal_daily": "Daily calories",
         "macros_protein_g": "Protein (g)",
         "macros_fat_g": "Fat (g)",
         "macros_carbs_g": "Carbs (g)",
+        "macros_fiber_g": "Fiber (g)",
         "water_ml": "Water (ml)",
         "priority_micros": "Priority micros",
         "activity_weekly": "Weekly activity",
         "warnings": "Warnings",
-    }
+    },
+    "es": {
+        "kcal_daily": "Calorías diarias",
+        "macros_protein_g": "Proteínas (g)",
+        "macros_fat_g": "Grasas (g)",
+        "macros_carbs_g": "Carbohidratos (g)",
+        "macros_fiber_g": "Fibra (g)",
+        "water_ml": "Agua (ml)",
+        "priority_micros": "Micronutrientes prioritarios",
+        "activity_weekly": "Actividad semanal",
+        "warnings": "Advertencias",
+    },
+    "ru": {
+        "kcal_daily": "Ккал в день",
+        "macros_protein_g": "Белки (г)",
+        "macros_fat_g": "Жиры (г)",
+        "macros_carbs_g": "Углеводы (г)",
+        "macros_fiber_g": "Клетчатка (г)",
+        "water_ml": "Вода (мл)",
+        "priority_micros": "Приоритетные микроэлементы",
+        "activity_weekly": "Активность за неделю",
+        "warnings": "Предупреждения",
+    },
+}
+
+
+def _build_targets_ui_labels(lang: str | None) -> WHOTargetsUiLabels:
+    """Return deterministic UI labels for WHO targets response."""
+
+    language = str(lang or "en").lower()
+    labels = _WHO_TARGETS_UI_LABELS_BY_LANG.get(language, _WHO_TARGETS_UI_LABELS_BY_LANG["en"])
+    return WHOTargetsUiLabels(**labels)
 
 
 def _generate_who_targets_response(

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -4027,6 +4027,8 @@ def _fallback_targets_response(
         if not has_life_stage_warning:
             warnings.append({"code": "life_stage", "message": reason})
 
+    ui_labels = _build_targets_ui_labels(req.lang)
+
     return WHOTargetsResponse(
         kcal_daily=int(kcal_daily),
         macros={
@@ -4040,7 +4042,46 @@ def _fallback_targets_response(
         activity_weekly=activity_weekly,
         calculation_date=time.strftime("%Y-%m-%d"),
         warnings=warnings,
+        ui_labels=ui_labels,
     )
+
+
+def _build_targets_ui_labels(lang: str | None) -> dict[str, str]:
+    """Return deterministic UI labels for WHO targets response."""
+
+    language = str(lang or "en").lower()
+    if language == "es":
+        return {
+            "kcal_daily": "Calorías diarias",
+            "macros_protein_g": "Proteínas (g)",
+            "macros_fat_g": "Grasas (g)",
+            "macros_carbs_g": "Carbohidratos (g)",
+            "water_ml": "Agua (ml)",
+            "priority_micros": "Micronutrientes prioritarios",
+            "activity_weekly": "Actividad semanal",
+            "warnings": "Advertencias",
+        }
+    if language == "ru":
+        return {
+            "kcal_daily": "Ккал в день",
+            "macros_protein_g": "Белки (г)",
+            "macros_fat_g": "Жиры (г)",
+            "macros_carbs_g": "Углеводы (г)",
+            "water_ml": "Вода (мл)",
+            "priority_micros": "Приоритетные микроэлементы",
+            "activity_weekly": "Активность за неделю",
+            "warnings": "Предупреждения",
+        }
+    return {
+        "kcal_daily": "Daily calories",
+        "macros_protein_g": "Protein (g)",
+        "macros_fat_g": "Fat (g)",
+        "macros_carbs_g": "Carbs (g)",
+        "water_ml": "Water (ml)",
+        "priority_micros": "Priority micros",
+        "activity_weekly": "Weekly activity",
+        "warnings": "Warnings",
+    }
 
 
 def _generate_who_targets_response(
@@ -4162,6 +4203,7 @@ def _generate_who_targets_response(
             },
             calculation_date=targets.calculation_date,
             warnings=life_stage_warnings,
+            ui_labels=_build_targets_ui_labels(req.lang),
         )
     except HTTPException:
         raise

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -69,7 +69,7 @@ from app.schemas.premium_contracts import (
     VisualShape,
     WHOTargetsRequest,
     WHOTargetsResponse,
-    WHOTargetsUiLabels,
+    build_who_targets_ui_labels,
 )
 from app.schemas.nutrition_targets import TargetsIn as CanonicalTargetsIn
 from app.services import recipe_store
@@ -4028,7 +4028,7 @@ def _fallback_targets_response(
         if not has_life_stage_warning:
             warnings.append({"code": "life_stage", "message": reason})
 
-    ui_labels = _build_targets_ui_labels(req.lang)
+    ui_labels = build_who_targets_ui_labels(req.lang)
 
     return WHOTargetsResponse(
         kcal_daily=int(kcal_daily),
@@ -4045,51 +4045,6 @@ def _fallback_targets_response(
         warnings=warnings,
         ui_labels=ui_labels,
     )
-
-
-_WHO_TARGETS_UI_LABELS_BY_LANG: dict[str, dict[str, str]] = {
-    "en": {
-        "kcal_daily": "Daily calories",
-        "macros_protein_g": "Protein (g)",
-        "macros_fat_g": "Fat (g)",
-        "macros_carbs_g": "Carbs (g)",
-        "macros_fiber_g": "Fiber (g)",
-        "water_ml": "Water (ml)",
-        "priority_micros": "Priority micros",
-        "activity_weekly": "Weekly activity",
-        "warnings": "Warnings",
-    },
-    "es": {
-        "kcal_daily": "Calorías diarias",
-        "macros_protein_g": "Proteínas (g)",
-        "macros_fat_g": "Grasas (g)",
-        "macros_carbs_g": "Carbohidratos (g)",
-        "macros_fiber_g": "Fibra (g)",
-        "water_ml": "Agua (ml)",
-        "priority_micros": "Micronutrientes prioritarios",
-        "activity_weekly": "Actividad semanal",
-        "warnings": "Advertencias",
-    },
-    "ru": {
-        "kcal_daily": "Ккал в день",
-        "macros_protein_g": "Белки (г)",
-        "macros_fat_g": "Жиры (г)",
-        "macros_carbs_g": "Углеводы (г)",
-        "macros_fiber_g": "Клетчатка (г)",
-        "water_ml": "Вода (мл)",
-        "priority_micros": "Приоритетные микроэлементы",
-        "activity_weekly": "Активность за неделю",
-        "warnings": "Предупреждения",
-    },
-}
-
-
-def _build_targets_ui_labels(lang: str | None) -> WHOTargetsUiLabels:
-    """Return deterministic UI labels for WHO targets response."""
-
-    language = str(lang or "en").lower()
-    labels = _WHO_TARGETS_UI_LABELS_BY_LANG.get(language, _WHO_TARGETS_UI_LABELS_BY_LANG["en"])
-    return WHOTargetsUiLabels(**labels)
 
 
 def _generate_who_targets_response(
@@ -4211,7 +4166,7 @@ def _generate_who_targets_response(
             },
             calculation_date=targets.calculation_date,
             warnings=life_stage_warnings,
-            ui_labels=_build_targets_ui_labels(req.lang),
+            ui_labels=build_who_targets_ui_labels(req.lang),
         )
     except HTTPException:
         raise

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,7 @@
 - Preserve xdist DB isolation: each worker gets its own SQLite path.
 - Prefer `monkeypatch` over global mutations; avoid real sleeps.
 - Repo policy guards must not reference temporary/untracked files; AST scan path lists must filter by `.exists()`.
+- `ui_labels` is a required part of `WHOTargetsResponse` contract (SoT: `app/schemas/premium_contracts.py`); assert ES anchor string (`"Calorías diarias"`) in snapshot tests and do not feature-gate this contract after implementation.
 
 ### Module purge / reload invariant (xdist stability)
 

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -67,7 +67,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "region_catalog",
         "shoplist_helpers",
         "targets_fixture_data",
-        "ui_labels_contract",
         "utils_pack",
         "weekly_plan_helpers",
         "exports_recipes_products",

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -7,7 +7,6 @@ warnings, and UI labels for both male and female profiles.
 
 import pytest
 from fastapi.testclient import TestClient
-from tests.feature_manifest import FEATURE_REASON, fail_feature_gated_test, require_feature
 
 try:
     import app as app_mod  # type: ignore
@@ -400,7 +399,7 @@ class TestPremiumTargetsESSnapshots:
             assert all(micro in micros for micro in expected_micros)
 
     def test_ui_labels_spanish_consistency(self):
-        """Test that UI labels are consistently in Spanish (if present)"""
+        """Test that UI labels are consistently present and localized in Spanish."""
         payload = {
             "sex": "female",
             "age": 30,
@@ -418,41 +417,21 @@ class TestPremiumTargetsESSnapshots:
         assert resp.status_code == 200
 
         data = resp.json()
+        ui_labels = data.get("ui_labels")
+        assert isinstance(ui_labels, dict), "ui_labels must be a dict in response"
+        assert ui_labels, "ui_labels must be non-empty"
 
-        # Check if ui_labels is present in response
-        if "ui_labels" in data:
-            ui_labels = data["ui_labels"]
+        required_keys = {
+            "kcal_daily",
+            "macros_protein_g",
+            "macros_fat_g",
+            "macros_carbs_g",
+            "water_ml",
+            "priority_micros",
+            "activity_weekly",
+            "warnings",
+        }
+        missing = required_keys - set(ui_labels.keys())
+        assert not missing, f"ui_labels missing keys: {sorted(missing)}"
 
-            # Verify UI labels structure
-            assert isinstance(ui_labels, dict)
-            assert len(ui_labels) > 0
-
-            # Check that labels contain Spanish text
-            all_labels_text = " ".join(str(v) for v in ui_labels.values()).lower()
-
-            # Spanish indicators that should be present
-            spanish_indicators = [
-                "kcal",
-                "proteína",
-                "grasa",
-                "carbohidratos",
-                "fibra",
-                "agua",
-                "actividad",
-                "semanal",
-                "diario",
-                "mg",
-                "g",
-                "ml",
-            ]
-
-            # At least some Spanish indicators should be present
-            found_indicators = [ind for ind in spanish_indicators if ind in all_labels_text]
-            assert found_indicators, f"No Spanish indicators found in: {all_labels_text}"
-        else:
-            # Skip when feature is disabled; fail if enabled but still missing.
-            require_feature("ui_labels_contract", reason=FEATURE_REASON)
-            fail_feature_gated_test(
-                "ui_labels_contract",
-                reason="ui_labels missing from response while ui_labels_contract is enabled.",
-            )
+        assert ui_labels["kcal_daily"] == "Calorías diarias"

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -1,5 +1,6 @@
 """
-ES Snapshots for /api/v1/premium/targets
+ES snapshots for canonical /api/v1/pro/nutrition/targets
+(including legacy alias coverage: /api/v1/premium/targets).
 
 Detailed snapshot tests for Spanish localization covering all micronutrients,
 warnings, and UI labels for both male and female profiles.
@@ -8,16 +9,15 @@ warnings, and UI labels for both male and female profiles.
 import pytest
 from fastapi.testclient import TestClient
 
-try:
-    from app.main import app as app_instance
-except Exception as exc:  # pragma: no cover
-    pytest.skip(f"FastAPI app import failed: {exc}", allow_module_level=True)
-
-client = TestClient(app_instance)
-
 
 class TestPremiumTargetsESSnapshots:
     """ES snapshot tests for premium targets endpoint"""
+
+    client: TestClient
+
+    @pytest.fixture(autouse=True)
+    def _bind_client(self, client: TestClient) -> None:
+        self.client = client
 
     def test_female_adult_es_snapshot(self):
         """ES snapshot for female adult profile"""
@@ -32,7 +32,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -89,7 +89,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -146,7 +146,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -190,7 +190,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -234,7 +234,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -278,7 +278,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -322,7 +322,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
+        resp = self.client.post(
             "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
         )
         assert resp.status_code == 200
@@ -373,7 +373,7 @@ class TestPremiumTargetsESSnapshots:
                 "lang": "es",
             }
 
-            resp = client.post(
+            resp = self.client.post(
                 "/api/v1/premium/targets",
                 json=payload,
                 headers={"X-API-Key": "test_key"},
@@ -413,7 +413,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
+        resp = self.client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
         assert resp.status_code == 200
         assert resp.headers.get("content-type", "").startswith("application/json")
 

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -9,11 +9,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 try:
-    import app as app_mod  # type: ignore
+    import app as app_mod
 except Exception as exc:  # pragma: no cover
     pytest.skip(f"FastAPI app import failed: {exc}", allow_module_level=True)
 
-client = TestClient(app_mod.app)  # type: ignore
+client = TestClient(app_mod.app)
 
 
 class TestPremiumTargetsESSnapshots:
@@ -398,8 +398,11 @@ class TestPremiumTargetsESSnapshots:
         for micros in micro_values.values():
             assert all(micro in micros for micro in expected_micros)
 
-    def test_ui_labels_spanish_consistency(self):
+    def test_ui_labels_spanish_consistency(self, pro_headers: dict[str, str]) -> None:
         """Test that UI labels are consistently present and localized in Spanish."""
+        from app.main import app as main_app
+
+        pro_client = TestClient(main_app)
         payload = {
             "sex": "female",
             "age": 30,
@@ -411,10 +414,9 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
+        resp = pro_client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
 
         data = resp.json()
         ui_labels = data.get("ui_labels")
@@ -426,6 +428,7 @@ class TestPremiumTargetsESSnapshots:
             "macros_protein_g",
             "macros_fat_g",
             "macros_carbs_g",
+            "macros_fiber_g",
             "water_ml",
             "priority_micros",
             "activity_weekly",

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -9,11 +9,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 try:
-    import app as app_mod
+    from app.main import app as app_instance
 except Exception as exc:  # pragma: no cover
     pytest.skip(f"FastAPI app import failed: {exc}", allow_module_level=True)
 
-client = TestClient(app_mod.app)
+client = TestClient(app_instance)
 
 
 class TestPremiumTargetsESSnapshots:
@@ -398,11 +398,10 @@ class TestPremiumTargetsESSnapshots:
         for micros in micro_values.values():
             assert all(micro in micros for micro in expected_micros)
 
-    def test_ui_labels_spanish_consistency(self, pro_headers: dict[str, str]) -> None:
+    def test_ui_labels_spanish_consistency(
+        self, client: TestClient, pro_headers: dict[str, str]
+    ) -> None:
         """Test that UI labels are consistently present and localized in Spanish."""
-        from app.main import app as main_app
-
-        pro_client = TestClient(main_app)
         payload = {
             "sex": "female",
             "age": 30,
@@ -414,7 +413,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = pro_client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
+        resp = client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
         assert resp.status_code == 200
         assert resp.headers.get("content-type", "").startswith("application/json")
 


### PR DESCRIPTION
## Summary
`ui_labels` теперь **обязательная** часть контракта `/pro/nutrition/targets` (WHO targets). ES snapshot больше не feature-gated SKIP, контракт зафиксирован жёсткими assert-ами. OpenAPI/TS артефакты синхронизированы.

## Scope
- Contract SoT: `WHOTargetsResponse` расширен `ui_labels` (required) через типизированную модель `WHOTargetsUiLabels`.
- Runtime: детерминированная генерация `ui_labels` (es/ru/en) с полным набором macro labels, включая `macros_fiber_g`.
- Tests: ES snapshot теперь hard-guard (ключи + ES якорь `"Calorías diarias"`), использует `pro_headers`, type hints и JSON content-type assertion.
- Manifest/Policies: удалён `ui_labels_contract` как disabled feature; обновлены `tests/AGENTS.md`; в root `AGENTS.md` добавлен merge-gate v2 и удалён дублирующий scoped policy bullet.
- OpenAPI sync: обновлены `frontend/src/api/openapi.json` и `frontend/src/api/schema.ts` через `make openapi`.

## Files changed
- `app/schemas/premium_contracts.py`
- `legacy_app.py`
- `tests/test_premium_targets_es_snapshots.py`
- `tests/feature_manifest.py`
- `tests/AGENTS.md`
- `AGENTS.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `frontend/src/api/openapi.json`
- `frontend/src/api/schema.ts`

## Verification
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `pytest -q -rs tests/test_premium_targets_es_snapshots.py` ✅
- `ruff check tests/test_premium_targets_es_snapshots.py` ✅
- `mypy tests/test_premium_targets_es_snapshots.py` ✅

## Sanity checks (post-implementation)
- `rg -n "ui_labels_contract" -S` → 0 matches ✅
- `rg -n "WHOTargetsResponse\\(" -S` → constructors only in `legacy_app.py`, both include `ui_labels=...` ✅
- OpenAPI artifacts regenerated via approved pipeline (`make openapi`) ✅

## Security Notes
Read-only UI strings only. No new external calls, secrets, auth changes, or nutrient math changes.

## Marketing & GTM
Stable contract + TS sync reduces frontend drift and accelerates localization shipping (ES/RU/EN).

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/749#issuecomment-3902512269 -> 8c5de6cb
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/749#issuecomment-3902512269 -> 503db854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized UI labels added to WHO targets responses; ui_labels is now required in the API contract.

* **Tests**
  * Snapshot and integration tests updated to assert ui_labels presence and specific Spanish label values; endpoint usage and test client binding refined.

* **Documentation**
  * Contributor guidelines gain a PR merge readiness section; backlog/roadmap entries updated.

* **Chores**
  * Removed legacy feature gate for the ui_labels contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->