### PR TITLE
feat(scheduler): expose DatabaseUpdateScheduler and get_update_status

### DIFF
--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -1037,6 +1037,29 @@ async def run_scheduled_update(
     return results
 
 
+async def get_update_status() -> dict[str, object]:
+    """
+    Async wrapper returning current scheduler status.
+
+    Deterministic and side-effect free:
+    - does not start background updates
+    - does not mutate scheduler state
+    """
+    from .scheduler import get_update_scheduler
+
+    scheduler = await get_update_scheduler()
+    return scheduler.get_status()
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy re-export of scheduler API to avoid import cycle at module import time."""
+    if name in {"DatabaseUpdateScheduler", "get_update_scheduler"}:
+        from . import scheduler as scheduler_mod
+
+        return getattr(scheduler_mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 if __name__ == "__main__":  # pragma: no cover
     # Test the update manager
     async def test_update_manager():

--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -1037,21 +1037,36 @@ async def run_scheduled_update(
     return results
 
 
+def _empty_scheduler_status() -> dict[str, object]:
+    """Return deterministic status payload when scheduler is not initialized."""
+    return {
+        "scheduler": {
+            "is_running": False,
+            "last_update_check": None,
+            "update_interval_hours": None,
+            "retry_counts": {},
+        },
+        "databases": {},
+    }
+
+
 async def get_update_status() -> dict[str, object]:
     """
     Async wrapper returning current scheduler status.
 
     Deterministic and side-effect free:
-    - does not start background updates
+    - does not create or start scheduler instance
     - does not mutate scheduler state
     """
-    from .scheduler import get_update_scheduler
+    from . import scheduler as scheduler_mod
 
-    scheduler = await get_update_scheduler()
+    scheduler = scheduler_mod._scheduler_instance
+    if scheduler is None:
+        return _empty_scheduler_status()
     return scheduler.get_status()
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     """Lazy re-export of scheduler API to avoid import cycle at module import time."""
     if name in {"DatabaseUpdateScheduler", "get_update_scheduler"}:
         from . import scheduler as scheduler_mod

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -57,7 +57,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "main_entrypoint",
         "unified_db",
         "unified_db_language",
-        "update_scheduler",
         "update_manager",
         "update_manager_path_attrs",
         "planner_engines",

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -168,16 +168,39 @@ class TestUpdateManagerCoverage:
             pytest.fail(f"DatabaseUpdateScheduler import must be available: {exc}")
 
     @pytest.mark.asyncio
-    async def test_update_manager_status_check(self) -> None:
+    async def test_update_manager_status_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test update_manager status check."""
         try:
+            from core.food_apis import scheduler as scheduler_mod
             from core.food_apis.update_manager import get_update_status
 
+            # Force uninitialized singleton path to validate side-effect-free status payload.
+            monkeypatch.setattr(scheduler_mod, "_scheduler_instance", None)
             status = await get_update_status()
             assert status is not None
             assert isinstance(status, dict)
+            assert status["scheduler"]["is_running"] is False
         except (ImportError, TypeError) as exc:
             pytest.fail(f"get_update_status must be available and callable: {exc}")
+
+    @pytest.mark.asyncio
+    async def test_update_manager_status_check_with_existing_scheduler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test update status path when scheduler singleton already exists."""
+        try:
+            from core.food_apis import scheduler as scheduler_mod
+            from core.food_apis.update_manager import get_update_status
+
+            class _FakeScheduler:
+                def get_status(self) -> dict[str, object]:
+                    return {"scheduler": {"is_running": True}, "databases": {"usda": {}}}
+
+            monkeypatch.setattr(scheduler_mod, "_scheduler_instance", _FakeScheduler())
+            status = await get_update_status()
+            assert status["scheduler"]["is_running"] is True
+        except (ImportError, TypeError) as exc:
+            pytest.fail(f"get_update_status must use existing scheduler status: {exc}")
 
 
 class TestAppEndpointsCoverage:

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -164,8 +164,8 @@ class TestUpdateManagerCoverage:
 
             scheduler = DatabaseUpdateScheduler()
             assert scheduler is not None
-        except ImportError:
-            require_feature("update_scheduler", reason=FEATURE_REASON)
+        except ImportError as exc:
+            pytest.fail(f"DatabaseUpdateScheduler import must be available: {exc}")
 
     @pytest.mark.asyncio
     async def test_update_manager_status_check(self) -> None:
@@ -176,8 +176,8 @@ class TestUpdateManagerCoverage:
             status = await get_update_status()
             assert status is not None
             assert isinstance(status, dict)
-        except (ImportError, TypeError):
-            require_feature("update_scheduler", reason=FEATURE_REASON)
+        except (ImportError, TypeError) as exc:
+            pytest.fail(f"get_update_status must be available and callable: {exc}")
 
 
 class TestAppEndpointsCoverage:


### PR DESCRIPTION
## Summary
- Expose scheduler API surface from `core.food_apis.update_manager` via lazy re-export for `DatabaseUpdateScheduler` and `get_update_scheduler`.
- Add async `get_update_status()` wrapper that reads scheduler status without creating/starting scheduler instances.
- Remove `update_scheduler` from `tests/feature_manifest.py` and convert scheduler coverage tests to fail loudly on missing imports instead of skipping.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/750#issuecomment-3902717487 -> a49f651a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/750#issuecomment-3902716407 -> 73b5ea6f

## Verification
- `pytest -q tests/test_final_coverage_97_boost.py::TestUpdateManagerCoverage::test_update_manager_init tests/test_final_coverage_97_boost.py::TestUpdateManagerCoverage::test_update_manager_status_check`
- `pre-commit run --files core/food_apis/update_manager.py tests/feature_manifest.py tests/test_final_coverage_97_boost.py`
- `make verify`

## Security Notes
- Read-only status exposure only; no new background auto-start, no lifecycle hook changes, no auth/config changes.

## Marketing & GTM
- Reduces CI skip noise and improves release predictability by converting scheduler checks from feature-gated skips to enforced API contract validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe, read-only way to query scheduler/update status and indirect access to the scheduler when present.

* **Tests**
  * Improved tests to assert status payloads explicitly and to fail with clearer messages on errors.
  * Updated test manifest defaults to no longer treat the scheduler feature as enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->