### PR TITLE
test(contracts): normalize ES snapshots to canonical PRO targets

### DIFF
--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -26,25 +26,19 @@ class TestPremiumTargetsESSnapshots:
         self,
         payload: dict[str, Any],
         pro_headers: dict[str, str],
-        *,
-        legacy_alias: bool = False,
-        expected_status: int = 200,
-        expect_json: bool | None = None,
-    ) -> dict[str, Any] | None:
-        endpoint = self._LEGACY_ALIAS_ENDPOINT if legacy_alias else self._CANONICAL_ENDPOINT
-        resp = self.client.post(endpoint, json=payload, headers=pro_headers)
-        assert resp.status_code == expected_status
-
-        if expect_json is None:
-            expect_json = expected_status == 200
-
-        if expect_json:
-            assert resp.headers.get("content-type", "").startswith("application/json")
-            data = resp.json()
-            assert isinstance(data, dict)
-            return data
-
-        return None
+    ) -> dict[str, Any]:
+        resp = self.client.post(self._CANONICAL_ENDPOINT, json=payload, headers=pro_headers)
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        data = resp.json()
+        assert isinstance(data, dict)
+        ui_labels = data.get("ui_labels")
+        assert isinstance(ui_labels, dict), "ui_labels must be a dict in response"
+        assert ui_labels, "ui_labels must be non-empty"
+        assert (
+            ui_labels.get("kcal_daily") == "Calorías diarias"
+        ), "Expected Spanish ui_labels anchor for kcal_daily."
+        return data
 
     def test_female_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for female adult profile"""
@@ -110,13 +104,11 @@ class TestPremiumTargetsESSnapshots:
             "life_stage": "adult",
             "lang": "es",
         }
-        data = self._post_targets(
-            payload,
-            pro_headers,
-            legacy_alias=True,
-            expected_status=403,
-            expect_json=True,
-        )
+        # Legacy alias coverage — canonical snapshots use /api/v1/pro/nutrition/targets
+        resp = self.client.post(self._LEGACY_ALIAS_ENDPOINT, json=payload, headers=pro_headers)
+        assert resp.status_code == 403
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        data = resp.json()
         assert isinstance(data, dict)
 
     def test_male_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -28,14 +28,23 @@ class TestPremiumTargetsESSnapshots:
         pro_headers: dict[str, str],
         *,
         legacy_alias: bool = False,
-    ) -> dict[str, Any]:
+        expected_status: int = 200,
+        expect_json: bool | None = None,
+    ) -> dict[str, Any] | None:
         endpoint = self._LEGACY_ALIAS_ENDPOINT if legacy_alias else self._CANONICAL_ENDPOINT
         resp = self.client.post(endpoint, json=payload, headers=pro_headers)
-        assert resp.status_code == 200
-        assert resp.headers.get("content-type", "").startswith("application/json")
-        data = resp.json()
-        assert isinstance(data, dict)
-        return data
+        assert resp.status_code == expected_status
+
+        if expect_json is None:
+            expect_json = expected_status == 200
+
+        if expect_json:
+            assert resp.headers.get("content-type", "").startswith("application/json")
+            data = resp.json()
+            assert isinstance(data, dict)
+            return data
+
+        return None
 
     def test_female_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for female adult profile"""
@@ -101,11 +110,13 @@ class TestPremiumTargetsESSnapshots:
             "life_stage": "adult",
             "lang": "es",
         }
-        # Legacy alias coverage — canonical tests use /api/v1/pro/nutrition/targets
-        resp = self.client.post(self._LEGACY_ALIAS_ENDPOINT, json=payload, headers=pro_headers)
-        assert resp.status_code == 403
-        assert resp.headers.get("content-type", "").startswith("application/json")
-        data = resp.json()
+        data = self._post_targets(
+            payload,
+            pro_headers,
+            legacy_alias=True,
+            expected_status=403,
+            expect_json=True,
+        )
         assert isinstance(data, dict)
 
     def test_male_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:

--- a/tests/test_premium_targets_es_snapshots.py
+++ b/tests/test_premium_targets_es_snapshots.py
@@ -8,18 +8,36 @@ warnings, and UI labels for both male and female profiles.
 
 import pytest
 from fastapi.testclient import TestClient
+from typing import Any
 
 
 class TestPremiumTargetsESSnapshots:
     """ES snapshot tests for premium targets endpoint"""
 
     client: TestClient
+    _CANONICAL_ENDPOINT = "/api/v1/pro/nutrition/targets"
+    _LEGACY_ALIAS_ENDPOINT = "/api/v1/premium/targets"
 
     @pytest.fixture(autouse=True)
     def _bind_client(self, client: TestClient) -> None:
         self.client = client
 
-    def test_female_adult_es_snapshot(self):
+    def _post_targets(
+        self,
+        payload: dict[str, Any],
+        pro_headers: dict[str, str],
+        *,
+        legacy_alias: bool = False,
+    ) -> dict[str, Any]:
+        endpoint = self._LEGACY_ALIAS_ENDPOINT if legacy_alias else self._CANONICAL_ENDPOINT
+        resp = self.client.post(endpoint, json=payload, headers=pro_headers)
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        data = resp.json()
+        assert isinstance(data, dict)
+        return data
+
+    def test_female_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for female adult profile"""
         payload = {
             "sex": "female",
@@ -32,12 +50,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify all required keys are present
         required_keys = {
@@ -76,7 +89,26 @@ class TestPremiumTargetsESSnapshots:
         # Verify water intake is reasonable
         assert 1500 <= data["water_ml"] <= 3000
 
-    def test_male_adult_es_snapshot(self):
+    def test_legacy_alias_coverage_with_pro_headers(self, pro_headers: dict[str, str]) -> None:
+        """Legacy alias guard coverage with pro headers."""
+        payload = {
+            "sex": "female",
+            "age": 30,
+            "height_cm": 168,
+            "weight_kg": 60,
+            "activity": "moderate",
+            "goal": "maintain",
+            "life_stage": "adult",
+            "lang": "es",
+        }
+        # Legacy alias coverage — canonical tests use /api/v1/pro/nutrition/targets
+        resp = self.client.post(self._LEGACY_ALIAS_ENDPOINT, json=payload, headers=pro_headers)
+        assert resp.status_code == 403
+        assert resp.headers.get("content-type", "").startswith("application/json")
+        data = resp.json()
+        assert isinstance(data, dict)
+
+    def test_male_adult_es_snapshot(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for male adult profile"""
         payload = {
             "sex": "male",
@@ -89,12 +121,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify all required keys are present
         required_keys = {
@@ -133,7 +160,7 @@ class TestPremiumTargetsESSnapshots:
         # Verify water intake is reasonable
         assert 2000 <= data["water_ml"] <= 3500
 
-    def test_female_teen_es_snapshot_with_warnings(self):
+    def test_female_teen_es_snapshot_with_warnings(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for female teen with life stage warnings"""
         payload = {
             "sex": "female",
@@ -146,12 +173,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify warnings are present for teen
         assert len(data["warnings"]) > 0
@@ -177,7 +199,7 @@ class TestPremiumTargetsESSnapshots:
         }
         assert all(micro in data["priority_micros"] for micro in expected_micros)
 
-    def test_female_pregnant_es_snapshot_with_warnings(self):
+    def test_female_pregnant_es_snapshot_with_warnings(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for pregnant female with life stage warnings"""
         payload = {
             "sex": "female",
@@ -190,12 +212,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify warnings are present for pregnant
         assert len(data["warnings"]) > 0
@@ -221,7 +238,7 @@ class TestPremiumTargetsESSnapshots:
         }
         assert all(micro in data["priority_micros"] for micro in expected_micros)
 
-    def test_male_elderly_es_snapshot_with_warnings(self):
+    def test_male_elderly_es_snapshot_with_warnings(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for elderly male with life stage warnings"""
         payload = {
             "sex": "male",
@@ -234,12 +251,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify warnings are present for elderly
         assert len(data["warnings"]) > 0
@@ -265,7 +277,7 @@ class TestPremiumTargetsESSnapshots:
         }
         assert all(micro in data["priority_micros"] for micro in expected_micros)
 
-    def test_female_lactating_es_snapshot_with_warnings(self):
+    def test_female_lactating_es_snapshot_with_warnings(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for lactating female with life stage warnings"""
         payload = {
             "sex": "female",
@@ -278,12 +290,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify warnings are present for lactating
         assert len(data["warnings"]) > 0
@@ -309,7 +316,7 @@ class TestPremiumTargetsESSnapshots:
         }
         assert all(micro in data["priority_micros"] for micro in expected_micros)
 
-    def test_child_es_snapshot_with_warnings(self):
+    def test_child_es_snapshot_with_warnings(self, pro_headers: dict[str, str]) -> None:
         """ES snapshot for child with life stage warnings"""
         payload = {
             "sex": "male",
@@ -322,12 +329,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post(
-            "/api/v1/premium/targets", json=payload, headers={"X-API-Key": "test_key"}
-        )
-        assert resp.status_code == 200
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
 
         # Verify warnings are present for child
         assert len(data["warnings"]) > 0
@@ -353,7 +355,7 @@ class TestPremiumTargetsESSnapshots:
         }
         assert all(micro in data["priority_micros"] for micro in expected_micros)
 
-    def test_micronutrient_values_consistency(self):
+    def test_micronutrient_values_consistency(self, pro_headers: dict[str, str]) -> None:
         """Test that micronutrient values are consistent across different profiles"""
         profiles = [
             {"sex": "female", "age": 30, "life_stage": "adult"},
@@ -373,14 +375,7 @@ class TestPremiumTargetsESSnapshots:
                 "lang": "es",
             }
 
-            resp = self.client.post(
-                "/api/v1/premium/targets",
-                json=payload,
-                headers={"X-API-Key": "test_key"},
-            )
-            assert resp.status_code == 200
-
-            data = resp.json()
+            data = self._post_targets(payload, pro_headers)
             micro_values[profile["sex"] + "_" + profile["life_stage"]] = data["priority_micros"]
 
         # Verify all profiles have the same micronutrient keys
@@ -398,9 +393,7 @@ class TestPremiumTargetsESSnapshots:
         for micros in micro_values.values():
             assert all(micro in micros for micro in expected_micros)
 
-    def test_ui_labels_spanish_consistency(
-        self, client: TestClient, pro_headers: dict[str, str]
-    ) -> None:
+    def test_ui_labels_spanish_consistency(self, pro_headers: dict[str, str]) -> None:
         """Test that UI labels are consistently present and localized in Spanish."""
         payload = {
             "sex": "female",
@@ -413,11 +406,7 @@ class TestPremiumTargetsESSnapshots:
             "lang": "es",
         }
 
-        resp = self.client.post("/api/v1/pro/nutrition/targets", json=payload, headers=pro_headers)
-        assert resp.status_code == 200
-        assert resp.headers.get("content-type", "").startswith("application/json")
-
-        data = resp.json()
+        data = self._post_targets(payload, pro_headers)
         ui_labels = data.get("ui_labels")
         assert isinstance(ui_labels, dict), "ui_labels must be a dict in response"
         assert ui_labels, "ui_labels must be non-empty"


### PR DESCRIPTION
## Summary
Normalize ES snapshot tests to canonical PRO endpoint `/api/v1/pro/nutrition/targets`.

## Scope
- Switch snapshots to canonical endpoint + `pro_headers` fixture (no hardcoded keys).
- Add JSON Content-Type guard before every `resp.json()`.
- Add `-> None` return type hints to modified tests.
- Keep exactly one explicit test covering legacy alias `/api/v1/premium/targets`.
- Enforce `ui_labels[\"kcal_daily\"] == \"Calorías diarias\"` in `_post_targets` for contract validation across snapshots.

## Verification
- `pre-commit run --files tests/test_premium_targets_es_snapshots.py` ✅
- `pytest -q tests/test_premium_targets_es_snapshots.py` ✅
- `make verify` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/758#issuecomment-3904789653 -> b775203f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/758#issuecomment-3904789703 -> 360e479c