### PR TITLE
fix(update_manager): expose Path wrapper .path and close feature flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,6 +579,7 @@ Source of truth:
 - Pre-commit hooks run tests on changed files; keep changes minimal and focused.
 - Pre-push backend tests are diff-based; see `scripts/AGENTS.md` for details.
 - Use Pydantic v2 APIs and FastAPI best practices for backend changes.
+- Path wrappers: if using a patchable wrapper around `pathlib.Path`, expose an explicit `.path: Path` property; do not rely on `__getattr__` for contract-level attributes.
 
 **Ruff ANN* rules (type hints) policy:**
 

--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -62,9 +62,10 @@ class _PatchablePathWrapper:
 
     @property
     def path(self) -> Path:
-        """Canonical public accessor for the underlying Path.
+        """Explicit public accessor for the underlying pathlib.Path.
 
-        RU: Yavnyi publichnyi dostup k Path nuzhen dlia stabilnogo kontrakta i testov.
+        This property exists to provide a stable contract for tests and
+        integrations. Do not rely on __getattr__ for contract-level attributes.
         """
         return self._path
 
@@ -84,7 +85,7 @@ class _PatchablePathWrapper:
     def __repr__(self) -> str:
         return f"_PatchablePathWrapper({self._path!r})"
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> object:
         # Delegate any other attribute access to the underlying Path
         return getattr(self._path, name)
 

--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -57,8 +57,16 @@ class _PatchablePathWrapper:
     the underlying Path instance while remaining patch-friendly.
     """
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         self._path = path
+
+    @property
+    def path(self) -> Path:
+        """Canonical public accessor for the underlying Path.
+
+        RU: Yavnyi publichnyi dostup k Path nuzhen dlia stabilnogo kontrakta i testov.
+        """
+        return self._path
 
     # Commonly used methods/ops
     def glob(self, pattern: str):
@@ -76,7 +84,7 @@ class _PatchablePathWrapper:
     def __repr__(self) -> str:
         return f"_PatchablePathWrapper({self._path!r})"
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         # Delegate any other attribute access to the underlying Path
         return getattr(self._path, name)
 

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -58,7 +58,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "unified_db",
         "unified_db_language",
         "update_manager",
-        "update_manager_path_attrs",
         "planner_engines",
         "premium_week_router_mocking",
         "i18n_advanced",

--- a/tests/test_update_manager_fixed.py
+++ b/tests/test_update_manager_fixed.py
@@ -14,7 +14,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
-from tests.feature_manifest import FEATURE_REASON, require_feature
 
 from core.food_apis.update_manager import DatabaseUpdateManager, DatabaseVersion
 
@@ -129,7 +128,6 @@ class TestUpdateManagerFixed:
 
     def test_update_manager_initialization(self):
         """Test DatabaseUpdateManager initialization."""
-        require_feature("update_manager_path_attrs", reason=FEATURE_REASON)
         with tempfile.TemporaryDirectory() as temp_dir:
             manager = DatabaseUpdateManager(
                 cache_dir=temp_dir, update_interval_hours=12, max_rollback_versions=3


### PR DESCRIPTION
## Summary
Close `feature_disabled:update_manager_path_attrs` by exposing an explicit `.path: Path` accessor on `_PatchablePathWrapper`.

## Scope (single-path)
- Add `@property path -> Path` to `_PatchablePathWrapper`.
- Remove `update_manager_path_attrs` from `FEATURE_TODO_KEYS`.
- Remove the now-obsolete `require_feature("update_manager_path_attrs")` gate from `test_update_manager_initialization`.
- Update `AGENTS.md` rule: patchable `Path` wrappers must expose explicit `.path: Path` (do not rely on `__getattr__`).

## Evidence (repo-truth)
- `rg -n "update_manager_path_attrs" -S tests core app docs` now returns no TODO key usage.
- `rg -n "feature_disabled:update_manager_path_attrs" -S tests` -> empty.
- Local gates:
  - `pre-commit run --all-files` ✅
  - `pytest -q tests/test_update_manager_fixed.py -k initialization` ✅
  - `make verify` ✅ (diff-cover 100% for changed lines)

## Risk
Low. No lifecycle/background side effects. Contract-only accessor + test/manifest cleanup.

## Security Notes
No new external API surface; `.path` is internal and used by tests/wrapper contract only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Предоставить стабильный аксессор Path в обёртке patchable path менеджера обновлений и удалить связанный feature flag и механизмы его включения.

New Features:
- Добавлена каноническая свойство `.path: Path` в `_PatchablePathWrapper` для явного доступа к базовому `Path`.

Enhancements:
- Задокументирован контракт, согласно которому обёртки над `pathlib.Path`, поддерживающие патчинг, должны предоставлять явное свойство `.path: Path` в `AGENTS.md`.

Tests:
- Очистка тестов за счёт удаления устаревшего feature gate `update_manager_path_attrs` из тестов инициализации `DatabaseUpdateManager`.

Chores:
- Удалён устаревший feature flag `update_manager_path_attrs` из манифеста тестовых feature-флагов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a stable Path accessor on the update manager's patchable path wrapper and remove the associated feature flag and gating.

New Features:
- Add a canonical .path: Path property to the _PatchablePathWrapper for explicit access to the underlying Path.

Enhancements:
- Document the contract that patchable pathlib.Path wrappers must expose an explicit .path: Path property in AGENTS.md.

Tests:
- Clean up tests by removing the obsolete update_manager_path_attrs feature gate from DatabaseUpdateManager initialization tests.

Chores:
- Remove the deprecated update_manager_path_attrs feature flag from the test feature manifest.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a .path property on the patchable Path wrapper and remove the update_manager_path_attrs feature flag. This makes the wrapper contract explicit and cleans up related tests and docs.

- **Refactors**
  - Add path property to _PatchablePathWrapper for stable access to the underlying Path; unify and clarify the property docstring.
  - Remove update_manager_path_attrs from the feature manifest and the test gate.
  - Update AGENTS.md: Path wrappers must expose .path, not rely on __getattr__.

<sup>Written for commit 03bbc5b5949be88efd5979fa5837a74f1886ef85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced an explicit property for accessing wrapped path objects and tightened type annotations to make path behavior more predictable and safer.

* **Tests**
  * Removed a conditional feature-flag guard from tests, simplifying test execution and ensuring the related initialization tests run unconditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->