### PR TITLE
feat(entrypoint): add setup_custom_mcp main and close main_entrypoint gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -851,7 +851,7 @@
         "filename": "tests/test_coverage_final_boost.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 49
       }
     ],
     "tests/test_coverage_improvement.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-14T18:07:52Z"
+  "generated_at": "2026-02-15T18:54:09Z"
 }

--- a/setup_custom_mcp.py
+++ b/setup_custom_mcp.py
@@ -151,9 +151,18 @@ def _write_json_config(cursor_dir: Path, filename: str, data: dict, success_mess
     print(f"{success_message}{config_file}")
 
 
+def main() -> None:
+    """Module entrypoint.
+
+    Keep this wrapper side-effect free at import time; runtime behavior stays in
+    setup_custom_mcp().
+    """
+    setup_custom_mcp()
+
+
 if __name__ == "__main__":
     try:
-        setup_custom_mcp()
+        main()
     except KeyboardInterrupt:
         print("\n❌ Setup cancelled by user.")
         sys.exit(1)

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -54,7 +54,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "core_db",
         "food_apis",
         "food_apis_error_injection",
-        "main_entrypoint",
         "unified_db",
         "unified_db_language",
         "update_manager",

--- a/tests/test_coverage_final_boost.py
+++ b/tests/test_coverage_final_boost.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tests.feature_manifest import FEATURE_REASON, require_feature
 
 
 class TestCoverageFinalBoost:
@@ -69,21 +68,19 @@ class TestCoverageFinalBoost:
                     assert payload["id"] == 1
                     assert payload["result"] == {"result": "success"}
 
-    def test_setup_custom_mcp_coverage(self):
+    def test_setup_custom_mcp_coverage(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test setup_custom_mcp.py coverage"""
-        try:
-            import setup_custom_mcp
-        except ImportError:
-            pytest.skip("setup_custom_mcp module not available")
+        import setup_custom_mcp as mod
 
-        # Check if main function exists
-        if not hasattr(setup_custom_mcp, "main"):
-            require_feature("main_entrypoint", reason=FEATURE_REASON)
+        called = {"v": False}
 
-        # Test main function with mock
-        with patch("setup_custom_mcp.main") as mock_main:
-            setup_custom_mcp.main()
-            mock_main.assert_called_once()
+        def _stub(argv: list[str] | None = None) -> None:
+            _ = argv
+            called["v"] = True
+
+        monkeypatch.setattr(mod, "setup_custom_mcp", _stub)
+        mod.main()
+        assert called["v"] is True
 
     def test_test_pro_access_coverage(self):
         """Test test_pro_access.py coverage"""

--- a/tests/test_coverage_final_boost.py
+++ b/tests/test_coverage_final_boost.py
@@ -69,7 +69,7 @@ class TestCoverageFinalBoost:
                     assert payload["result"] == {"result": "success"}
 
     def test_setup_custom_mcp_coverage(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test setup_custom_mcp.py coverage"""
+        """Test setup_custom_mcp.py main entrypoint delegation."""
         import setup_custom_mcp as mod
 
         called = {"v": False}


### PR DESCRIPTION
## Summary
- Add explicit `main()` thin-wrapper in `setup_custom_mcp.py` that delegates to `setup_custom_mcp()` and keeps import-time behavior side-effect free.
- Replace feature-gated assertion in `tests/test_coverage_final_boost.py` with deterministic monkeypatch-based delegation test for `main()`.
- Remove `main_entrypoint` from `tests/feature_manifest.py` now that the entrypoint is implemented.
- Include mandatory pre-commit hook artifact update in `.secrets.baseline`.

## Scope
- `setup_custom_mcp.py`
- `tests/test_coverage_final_boost.py`
- `tests/feature_manifest.py`
- `.secrets.baseline` (hook-generated)

## Verification
- `pre-commit run --all-files` ✅
- `pytest -q tests/test_coverage_final_boost.py -k setup_custom_mcp` ✅
- `make verify` ✅
- `pytest -q -rs | rg -n "feature_disabled:main_entrypoint"` → no matches ✅

## Security Notes
- No runtime side effects added on import path.
- `main()` is a thin delegating wrapper only.
- No new external calls, auth, or secrets behavior changes.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавлен отдельный обёрточный входной пункт main() для `setup_custom_mcp` и обновлены тесты и конфигурация в соответствии с новым, всегда активным входным пунктом.

Новые возможности:
- Добавлен не вызывающий побочных эффектов входной пункт `main()` в `setup_custom_mcp.py`, делегирующий выполнение функции `setup_custom_mcp()`.

Улучшения:
- Упрощено использование фича-флагов за счёт удаления флага `main_entrypoint` из манифеста тестовых фич.

Тесты:
- Тест покрытия `setup_custom_mcp`, зависящий от фича-флага, заменён на детерминированный тест на основе `monkeypatch`, который проверяет, что `main()` делегирует выполнение `setup_custom_mcp()`.

Рутинные задачи:
- Обновлён артефакт `.secrets.baseline`, генерируемый хуком pre-commit.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated main() entrypoint wrapper for setup_custom_mcp and update tests and configuration to reflect the new, always-on entrypoint.

New Features:
- Introduce a side-effect-free main() entrypoint in setup_custom_mcp.py that delegates to setup_custom_mcp().

Enhancements:
- Simplify feature flag usage by removing the main_entrypoint feature toggle from the test feature manifest.

Tests:
- Replace feature-gated setup_custom_mcp coverage test with a deterministic monkeypatch-based test that verifies main() delegates to setup_custom_mcp().

Chores:
- Refresh the .secrets.baseline artifact generated by the pre-commit hook.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a side-effect-free main() entrypoint in setup_custom_mcp that delegates to setup_custom_mcp(). Replaced the feature-gated test with a deterministic monkeypatch check, removed the main_entrypoint flag, and updated the detect-secrets baseline.

- **New Features**
  - Add main() that calls setup_custom_mcp().
  - No import-time side effects.

- **Refactors**
  - Replace feature-gated test with monkeypatch assertion for main() delegation.
  - Remove main_entrypoint from test feature manifest.

<sup>Written for commit f0a83da296f8ad130e1110c616ba0782e94b7c74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured initialization logic and exception handling for improved organization.

* **Chores**
  * Updated test baselines and metadata.
  * Refactored test implementation to use improved testing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->