### PR TITLE
test(coverage): remove stale region_catalog feature gate

### DIFF
--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -60,7 +60,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "premium_week_router_mocking",
         "i18n_advanced",
         "rag",
-        "region_catalog",
         "shoplist_helpers",
         "targets_fixture_data",
         "utils_pack",

--- a/tests/test_direct_core_functions.py
+++ b/tests/test_direct_core_functions.py
@@ -357,7 +357,7 @@ class TestDirectCoreFunctions:
             pass
 
     def test_region_catalog_functions_direct(self) -> None:
-        """Direct shape-level tests of current region catalog API."""
+        """Direct shape-level smoke for current region catalog API."""
         from core.region_catalog import RegionCatalog, get_available_regions, get_region_catalog
 
         assert callable(get_region_catalog)

--- a/tests/test_direct_core_functions.py
+++ b/tests/test_direct_core_functions.py
@@ -357,17 +357,22 @@ class TestDirectCoreFunctions:
             pass
 
     def test_region_catalog_functions_direct(self) -> None:
-        """Direct shape-level smoke for current region catalog API."""
+        """Direct smoke + behavior checks for current region catalog API."""
         from core.region_catalog import RegionCatalog, get_available_regions, get_region_catalog
 
         assert callable(get_region_catalog)
         assert callable(get_available_regions)
 
+        # Global catalog accessor should behave like a singleton.
         catalog = get_region_catalog()
         assert isinstance(catalog, RegionCatalog)
+        assert get_region_catalog() is catalog
 
+        # Public helper should match instance method output.
         regions = get_available_regions()
         assert isinstance(regions, list)
+        assert regions == catalog.get_available_regions()
+        assert all(isinstance(region, str) for region in regions)
 
     def test_utils_functions_direct(self):
         """Direct tests of utils functions."""

--- a/tests/test_direct_core_functions.py
+++ b/tests/test_direct_core_functions.py
@@ -356,48 +356,18 @@ class TestDirectCoreFunctions:
         except Exception:  # nosec B110 - intentional in test for coverage
             pass
 
-    def test_region_catalog_functions_direct(self):
-        """Direct tests of region catalog functions."""
-        try:
-            from core.region_catalog import (
-                get_default_region,
-                get_region_foods,
-                get_region_info,
-                list_regions,
-                update_region_data,
-                validate_region,
-            )
+    def test_region_catalog_functions_direct(self) -> None:
+        """Direct shape-level tests of current region catalog API."""
+        from core.region_catalog import RegionCatalog, get_available_regions, get_region_catalog
 
-            # Test listing regions
-            regions = list_regions()
-            assert isinstance(regions, (list, tuple, type(None)))
+        assert callable(get_region_catalog)
+        assert callable(get_available_regions)
 
-            # Test region validation
-            is_valid = validate_region("US")
-            assert isinstance(is_valid, (bool, type(None)))
+        catalog = get_region_catalog()
+        assert isinstance(catalog, RegionCatalog)
 
-            is_valid = validate_region("RU")
-            assert isinstance(is_valid, (bool, type(None)))
-
-            is_valid = validate_region("ES")
-            assert isinstance(is_valid, (bool, type(None)))
-
-            # Test default region
-            default = get_default_region()
-            assert isinstance(default, (str, type(None)))
-
-            # Test region info
-            info = get_region_info("US")
-            assert isinstance(info, (dict, type(None)))
-
-            # Test region foods
-            foods = get_region_foods("US")
-            assert isinstance(foods, (list, dict, type(None)))
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "region_catalog", reason=FEATURE_REASON)
-        except Exception:  # nosec B110 - intentional in test for coverage
-            pass
+        regions = get_available_regions()
+        assert isinstance(regions, list)
 
     def test_utils_functions_direct(self):
         """Direct tests of utils functions."""

--- a/tests/test_quick_coverage_boost.py
+++ b/tests/test_quick_coverage_boost.py
@@ -212,30 +212,26 @@ class TestQuickCoverageBoost:
 
     def test_region_catalog_edge_cases(self):
         """Покрытие core/region_catalog.py missing lines (89% -> 95%+)"""
-        try:
-            from core.region_catalog import RegionCatalog, get_available_regions
+        from core.region_catalog import RegionCatalog, get_available_regions
 
-            # Тест функций с edge cases
-            regions = get_available_regions()
-            assert isinstance(regions, list)
+        # Тест функций с edge cases
+        regions = get_available_regions()
+        assert isinstance(regions, list)
 
-            # Тест RegionCatalog
-            catalog = RegionCatalog()
+        # Тест RegionCatalog
+        catalog = RegionCatalog()
 
-            # Тест доступных регионов через catalog
-            catalog_regions = catalog.get_available_regions()
-            assert isinstance(catalog_regions, list)
+        # Тест доступных регионов через catalog
+        catalog_regions = catalog.get_available_regions()
+        assert isinstance(catalog_regions, list)
 
-            # Тест поиска продукта по ID
-            result = catalog.get_product_by_id("test_id", "XX")
-            assert result is None or hasattr(result, "product_id")
+        # Тест поиска продукта по ID
+        result = catalog.get_product_by_id("test_id", "XX")
+        assert result is None or hasattr(result, "product_id")
 
-            # Тест поиска продуктов по категории
-            result = catalog.get_products_by_category("test_category", "XX")
-            assert isinstance(result, list)
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "region_catalog", reason=FEATURE_REASON)
+        # Тест поиска продуктов по категории
+        result = catalog.get_products_by_category("test_category", "XX")
+        assert isinstance(result, list)
 
     def test_rag_simple_missing_paths(self):
         """Покрытие core/rag/simple_rag.py missing paths (77% -> 90%+)"""


### PR DESCRIPTION
## Summary
Remove stale `require_feature_or_raise(..., "region_catalog")` gating from `test_region_catalog_edge_cases` to prevent latent failure after `region_catalog` was removed from `FEATURE_TODO_KEYS`.

## Root cause
After removing `"region_catalog"` from `FEATURE_TODO_KEYS`, any ImportError path that still calls `require_feature_or_raise(..., "region_catalog")` would raise:
`AssertionError: Unknown feature key: 'region_catalog'`.

## Scope
- `tests/test_quick_coverage_boost.py`:
  - removed `try/except ImportError` + `require_feature_or_raise(..., "region_catalog")`
  - kept assertions unchanged
- `tests/test_direct_core_functions.py`:
  - strengthened direct behavior checks for current `core.region_catalog` public API
  - kept no feature-gating/import-skip behavior

## Verification
- `pre-commit run --all-files` ✅
- `pytest -q tests/test_quick_coverage_boost.py -k region_catalog_edge_cases -rs` ✅
- `pytest -q tests/test_direct_core_functions.py -k region_catalog -rs` ✅
- `rg "require_feature_or_raise\\(exc,\\s*\"region_catalog\"" tests` -> no matches ✅
- `pytest -q -rs | rg -n "feature_disabled:region_catalog"` -> empty ✅
- `make verify` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/762 -> c9b5d11a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined region management API for listing and accessing regions.

* **Refactor**
  * Replaced legacy region helpers with the new public interface to simplify usage.

* **Bug Fixes / Validation**
  * Removed a deprecated feature key from the canonical set; referencing it will now raise an unknown-feature validation error.

* **Tests**
  * Updated tests to exercise the new region API and simplified control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->