### PR TITLE
tooling(make): remove pytest --lf from verify/quick_check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,14 @@ Or individually:
 
 - `make lint` — ruff/flake8 checks
 - `make typecheck` — mypy with no cache (`--no-incremental --cache-dir=/dev/null`)
-- `make test-fast` — pytest quick run
+- `make test-fast` — deterministic smoke subset (`tests/edges` + `tests/test_remaining_modules.py`)
 - `make diff-cov` — diff-cover ≥97% against origin/main
+
+**Tooling behavior contract (test-fast / quick-check):**
+
+- `test-fast` is deterministic and does not use `.pytest_cache`/`--lf`.
+- `scripts/quick_check.sh` runs the same deterministic smoke subset as `make test-fast`.
+- Use `. .venv/bin/activate` before direct local `pytest` runs outside Make targets.
 
 **If ANY command fails:**
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test: ## Run pytest
 ## Fast tests (last failed)
 test-fast: ## Run only last failed tests
 	@echo "$(YELLOW)⚡ Быстрые тесты...$(NC)"
-	. .venv/bin/activate && pytest --lf --maxfail=3 -q
+	. .venv/bin/activate && pytest -q
 
 ## Coverage in terminal + XML (uses .coveragerc)
 cov: ## Run coverage with pytest (term + XML)

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ test: ## Run pytest
 	@echo "$(YELLOW)🧪 Запуск тестов...$(NC)"
 	. .venv/bin/activate && pytest -q
 
-## Fast tests (last failed)
-test-fast: ## Run only last failed tests
-	@echo "$(YELLOW)⚡ Быстрые тесты...$(NC)"
-	. .venv/bin/activate && pytest -q
+## Fast tests (deterministic smoke subset)
+test-fast: ## Run smoke tests (deterministic subset)
+	@echo "$(YELLOW)⚡ Smoke tests...$(NC)"
+	. .venv/bin/activate && pytest -q tests/edges tests/test_remaining_modules.py --maxfail=3
 
 ## Coverage in terminal + XML (uses .coveragerc)
 cov: ## Run coverage with pytest (term + XML)

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -14,7 +14,7 @@ echo -e "${BLUE}⚡ Быстрая проверка PulsePlate${NC}"
 
 # 1. Быстрые тесты (только измененные файлы)
 echo -e "${YELLOW}🧪 Запуск быстрых тестов...${NC}"
-if python -m pytest --lf --maxfail=1 -q; then
+if python -m pytest --maxfail=1 -q; then
     echo -e "${GREEN}✅ Быстрые тесты пройдены${NC}"
 else
     echo -e "${RED}❌ Быстрые тесты провалены${NC}"

--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -12,12 +12,12 @@ NC='\033[0m'
 
 echo -e "${BLUE}⚡ Быстрая проверка PulsePlate${NC}"
 
-# 1. Быстрые тесты (только измененные файлы)
-echo -e "${YELLOW}🧪 Запуск быстрых тестов...${NC}"
-if python -m pytest --maxfail=1 -q; then
-    echo -e "${GREEN}✅ Быстрые тесты пройдены${NC}"
+# 1. Smoke tests (детерминированный поднабор)
+echo -e "${YELLOW}🧪 Запуск smoke-тестов...${NC}"
+if python -m pytest -q tests/edges tests/test_remaining_modules.py --maxfail=1; then
+    echo -e "${GREEN}✅ Smoke-тесты пройдены${NC}"
 else
-    echo -e "${RED}❌ Быстрые тесты провалены${NC}"
+    echo -e "${RED}❌ Smoke-тесты провалены${NC}"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Remove `pytest --lf` dependency from automation.
- Keep quick feedback deterministic via smoke subset in `test-fast` and `scripts/quick_check.sh`.
- Add `docs(agents)` contract for tooling behavior.

## Scope
- `Makefile` target `test-fast` now runs deterministic smoke subset:
  - `tests/edges`
  - `tests/test_remaining_modules.py`
- `scripts/quick_check.sh` runs the same smoke subset with `--maxfail=1`.
- `AGENTS.md` documents deterministic tooling behavior and local `.venv` usage for direct `pytest` runs.

## Behavior Notes
- Full backend suite remains available via `make test` or direct `pytest -q`.
- No runtime API change. No CLI/UI product behavior change.

## Evidence
- `pre-commit run --all-files` PASS
- `make test-fast` PASS
- `bash scripts/quick_check.sh` PASS

## Risk & Impact
- Tooling-only change; low product risk.
- Improves determinism by removing `.pytest_cache`/`--lf` dependence from automated quick gates.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/765#discussion_r -> 95051758
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/765#discussion_r -> 6aaa7e30
- No actionable review comments

## Deferred / Follow-ups
- [x] Ledger item(s): None
- [x] GitHub issue(s): None