### PR TITLE
docs(ledger): mark shoplist_helpers merged and record PR-764 merge st…

### DIFF
--- a/docs/audit/PR_764_SHOPLIST_HELPERS_ENABLE_AUDIT.md
+++ b/docs/audit/PR_764_SHOPLIST_HELPERS_ENABLE_AUDIT.md
@@ -139,3 +139,8 @@ Note:
 
 - PR-764 scoped checks (`tests/test_remaining_modules.py` +
   skip-marker absence + pre-commit + mypy/lint) are green.
+
+## Merge status
+
+- Merged SHA: `48c87f39`
+- CI: required checks passed at merge time for PR-764.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -644,6 +644,8 @@ If it is not recorded here — it does not exist.
       `require_feature(...)` gate in tests.
     - Runtime `feature_disabled:<key>` skip count decreases as features land.
     - Ledger item is updated with merged PR references per implemented key.
+  - Implemented keys (latest):
+    - `shoplist_helpers` -> ✅ Merged (PR-764, 2026-02-16, `48c87f39`)
 
 - [ ] Cross-platform Design System: define tokens + UI primitives (Web + iOS)
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
- record post-merge status for PR-764 in audit/ledger docs only
- keep scope docs-only and preserve runtime behavior

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- [x] Ledger item(s): None
- [x] GitHub issue(s): None