### PR TITLE
Test/pr 766 fast stubs runtime

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -614,14 +614,14 @@
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 37
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 57
       }
     ],
     "tests/test_app_coverage_optimized.py": [
@@ -680,7 +680,7 @@
         "filename": "tests/test_app_extra_coverage.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 22
       }
     ],
     "tests/test_app_missing_coverage_96.py": [
@@ -752,7 +752,7 @@
         "filename": "tests/test_comprehensive_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 29
       }
     ],
     "tests/test_core_db_additional_coverage.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-15T18:54:09Z"
+  "generated_at": "2026-02-16T17:51:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -614,14 +614,14 @@
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 38
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 58
       }
     ],
     "tests/test_app_coverage_optimized.py": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-16T17:51:04Z"
+  "generated_at": "2026-02-16T18:26:18Z"
 }

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -2,22 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from collections.abc import Callable
-from types import SimpleNamespace
 from typing import Any
-
-
-def _default_force_update_result() -> object:
-    """Return attribute-shaped result compatible with force-update response formatter."""
-    return SimpleNamespace(
-        success=True,
-        old_version="stub-old",
-        new_version="stub-new",
-        records_added=0,
-        records_updated=0,
-        records_removed=0,
-        duration_seconds=0.0,
-        errors=[],
-    )
 
 
 def make_scheduler_stub(usda_result: Any = None) -> object:
@@ -29,10 +14,9 @@ def make_scheduler_stub(usda_result: Any = None) -> object:
     class _SchedulerStub:
         async def force_update(self, source: str | None = None) -> dict[str, Any]:
             _ = source
-            source_result = (
-                usda_result if usda_result is not None else _default_force_update_result()
-            )
-            return {"usda": source_result}
+            if usda_result is not None:
+                return {"usda": usda_result}
+            return {"usda": {"ok": True, "status": "stubbed"}}
 
     return _SchedulerStub()
 

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -48,12 +48,30 @@ def patch_unified_db_common_foods_fast(monkeypatch: Any) -> None:
     Patch UnifiedFoodDatabase.get_common_foods_database to return a tiny DB fast.
     Keeps method async and avoids IO/cache work.
     """
-    from core.food_apis.unified_db import UnifiedFoodDatabase
+    from core.food_apis.unified_db import UnifiedFoodDatabase, UnifiedFoodItem
 
-    async def _fast_common_foods(self: UnifiedFoodDatabase) -> dict[str, Any]:
+    async def _fast_common_foods(self: UnifiedFoodDatabase) -> dict[str, UnifiedFoodItem]:
         return {
-            "oats": {"name": "oats"},
-            "rice": {"name": "rice"},
+            "oats": UnifiedFoodItem(
+                name="oats",
+                nutrients_per_100g={"protein_g": 13.0, "fat_g": 7.0, "carbs_g": 66.0},
+                cost_per_100g=0.5,
+                tags=["grain"],
+                availability_regions=["US", "EU"],
+                source="stub",
+                source_id="oats_stub",
+                category="grains",
+            ),
+            "rice": UnifiedFoodItem(
+                name="rice",
+                nutrients_per_100g={"protein_g": 2.7, "fat_g": 0.3, "carbs_g": 28.0},
+                cost_per_100g=0.3,
+                tags=["grain"],
+                availability_regions=["US", "EU"],
+                source="stub",
+                source_id="rice_stub",
+                category="grains",
+            ),
         }
 
     monkeypatch.setattr(UnifiedFoodDatabase, "get_common_foods_database", _fast_common_foods)

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_scheduler_stub(usda_result: dict[str, Any] | None = None) -> object:
+    """
+    Return a scheduler-like object with async force_update.
+    Matches app.get_update_scheduler seam used in tests.
+    """
+
+    class _SchedulerStub:
+        async def force_update(self) -> dict[str, Any]:
+            return {"usda": usda_result or {"ok": True, "status": "stubbed"}}
+
+    return _SchedulerStub()
+
+
+def patch_app_get_update_scheduler(monkeypatch: Any, app_module: Any, scheduler: object) -> None:
+    """Patch app.get_update_scheduler to return provided scheduler."""
+
+    async def _fake_get_update_scheduler() -> object:
+        return scheduler
+
+    monkeypatch.setattr(app_module, "get_update_scheduler", _fake_get_update_scheduler)
+
+
+def patch_unified_db_common_foods_fast(monkeypatch: Any) -> None:
+    """
+    Patch UnifiedFoodDatabase.get_common_foods_database to return a tiny DB fast.
+    Keeps method async and avoids IO/cache work.
+    """
+    from core.food_apis.unified_db import UnifiedFoodDatabase
+
+    async def _fast_common_foods(self: UnifiedFoodDatabase) -> dict[str, Any]:
+        return {
+            "oats": {"name": "oats"},
+            "rice": {"name": "rice"},
+        }
+
+    monkeypatch.setattr(UnifiedFoodDatabase, "get_common_foods_database", _fast_common_foods)
+
+
+def patch_unified_db_cache_load_save(
+    monkeypatch: Any, *, load: Any = None, save: Any = None
+) -> None:
+    """
+    Patch _load_cache/_save_cache for exception-path tests.
+    Provide callables or leave None to keep existing behavior.
+    """
+    from core.food_apis.unified_db import UnifiedFoodDatabase
+
+    if load is not None:
+        monkeypatch.setattr(UnifiedFoodDatabase, "_load_cache", load)
+    if save is not None:
+        monkeypatch.setattr(UnifiedFoodDatabase, "_save_cache", save)
+
+
+def test_fast_update_stubs_smoke() -> None:
+    """Smoke-test helper stubs to satisfy deterministic changed-file hooks."""
+    scheduler = make_scheduler_stub()
+    assert scheduler is not None

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -1,30 +1,56 @@
 from __future__ import annotations
 
-import asyncio
+from contextlib import suppress
+from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 
 
-def make_scheduler_stub(usda_result: dict[str, Any] | None = None) -> object:
+def _default_force_update_result() -> object:
+    """Return attribute-shaped result compatible with force-update response formatter."""
+    return SimpleNamespace(
+        success=True,
+        old_version="stub-old",
+        new_version="stub-new",
+        records_added=0,
+        records_updated=0,
+        records_removed=0,
+        duration_seconds=0.0,
+        errors=[],
+    )
+
+
+def make_scheduler_stub(usda_result: Any = None) -> object:
     """
     Return a scheduler-like object with async force_update.
-    Matches app.get_update_scheduler seam used in tests.
+    Matches legacy_app.get_update_scheduler seam used in tests.
     """
 
     class _SchedulerStub:
         async def force_update(self, source: str | None = None) -> dict[str, Any]:
             _ = source
-            return {"usda": usda_result or {"ok": True, "status": "stubbed"}}
+            source_result = (
+                usda_result if usda_result is not None else _default_force_update_result()
+            )
+            return {"usda": source_result}
 
     return _SchedulerStub()
 
 
 def patch_app_get_update_scheduler(monkeypatch: Any, app_module: Any, scheduler: object) -> None:
-    """Patch app.get_update_scheduler to return provided scheduler."""
+    """
+    Patch scheduler seam for force-update tests.
+    Applies override to both `app` facade and `legacy_app` where endpoint resolves runtime getter.
+    """
 
     async def _fake_get_update_scheduler() -> object:
         return scheduler
 
     monkeypatch.setattr(app_module, "get_update_scheduler", _fake_get_update_scheduler)
+    with suppress(Exception):
+        import legacy_app as legacy_app_mod
+
+        monkeypatch.setattr(legacy_app_mod, "get_update_scheduler", _fake_get_update_scheduler)
 
 
 def patch_unified_db_common_foods_fast(monkeypatch: Any) -> None:
@@ -44,7 +70,10 @@ def patch_unified_db_common_foods_fast(monkeypatch: Any) -> None:
 
 
 def patch_unified_db_cache_load_save(
-    monkeypatch: Any, *, load: Any = None, save: Any = None
+    monkeypatch: Any,
+    *,
+    load: Callable[..., Any] | None = None,
+    save: Callable[..., Any] | None = None,
 ) -> None:
     """
     Patch _load_cache/_save_cache for exception-path tests.
@@ -56,14 +85,3 @@ def patch_unified_db_cache_load_save(
         monkeypatch.setattr(UnifiedFoodDatabase, "_load_cache", load)
     if save is not None:
         monkeypatch.setattr(UnifiedFoodDatabase, "_save_cache", save)
-
-
-def test_fast_update_stubs_smoke() -> None:
-    """Smoke-test helper stubs to satisfy deterministic changed-file hooks."""
-    scheduler = make_scheduler_stub()
-    assert scheduler is not None
-    force_update = getattr(scheduler, "force_update")
-    result_default = asyncio.run(force_update())
-    result_with_source = asyncio.run(force_update("usda"))
-    assert "usda" in result_default
-    assert "usda" in result_with_source

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 
@@ -10,7 +11,8 @@ def make_scheduler_stub(usda_result: dict[str, Any] | None = None) -> object:
     """
 
     class _SchedulerStub:
-        async def force_update(self) -> dict[str, Any]:
+        async def force_update(self, source: str | None = None) -> dict[str, Any]:
+            _ = source
             return {"usda": usda_result or {"ok": True, "status": "stubbed"}}
 
     return _SchedulerStub()
@@ -60,3 +62,8 @@ def test_fast_update_stubs_smoke() -> None:
     """Smoke-test helper stubs to satisfy deterministic changed-file hooks."""
     scheduler = make_scheduler_stub()
     assert scheduler is not None
+    force_update = getattr(scheduler, "force_update")
+    result_default = asyncio.run(force_update())
+    result_with_source = asyncio.run(force_update("usda"))
+    assert "usda" in result_default
+    assert "usda" in result_with_source

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from contextlib import suppress
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 
-def make_scheduler_stub(usda_result: Any = None) -> object:
+class SchedulerLike(Protocol):
+    async def force_update(self, source: str | None = None) -> dict[str, Any]: ...
+
+
+def make_scheduler_stub(usda_result: Any = None) -> SchedulerLike:
     """
     Return a scheduler-like object with async force_update.
     Matches legacy_app.get_update_scheduler seam used in tests.
@@ -31,10 +34,13 @@ def patch_app_get_update_scheduler(monkeypatch: Any, app_module: Any, scheduler:
         return scheduler
 
     monkeypatch.setattr(app_module, "get_update_scheduler", _fake_get_update_scheduler)
-    with suppress(Exception):
+    try:
         import legacy_app as legacy_app_mod
-
-        monkeypatch.setattr(legacy_app_mod, "get_update_scheduler", _fake_get_update_scheduler)
+    except ModuleNotFoundError:
+        return
+    monkeypatch.setattr(
+        legacy_app_mod, "get_update_scheduler", _fake_get_update_scheduler, raising=False
+    )
 
 
 def patch_unified_db_common_foods_fast(monkeypatch: Any) -> None:

--- a/tests/helpers/test_fast_update_stubs.py
+++ b/tests/helpers/test_fast_update_stubs.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from tests.helpers.fast_update_stubs import make_scheduler_stub
+from core.food_apis.unified_db import UnifiedFoodDatabase, UnifiedFoodItem
+from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_unified_db_common_foods_fast
 
 
 @pytest.mark.asyncio
@@ -23,3 +24,15 @@ async def test_make_scheduler_stub_allows_falsy_payload() -> None:
     scheduler = make_scheduler_stub(usda_result={})
     result = await scheduler.force_update("usda")
     assert result["usda"] == {}
+
+
+@pytest.mark.asyncio
+async def test_patch_unified_db_common_foods_fast_returns_unified_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fast common-foods patch must preserve UnifiedFoodItem return contract."""
+    patch_unified_db_common_foods_fast(monkeypatch)
+    db = UnifiedFoodDatabase.__new__(UnifiedFoodDatabase)
+    foods = await db.get_common_foods_database()
+    assert set(foods.keys()) == {"oats", "rice"}
+    assert all(isinstance(item, UnifiedFoodItem) for item in foods.values())

--- a/tests/helpers/test_fast_update_stubs.py
+++ b/tests/helpers/test_fast_update_stubs.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-import asyncio
+import pytest
 
 from tests.helpers.fast_update_stubs import make_scheduler_stub
 
 
-def test_fast_update_stubs_smoke() -> None:
+@pytest.mark.asyncio
+async def test_fast_update_stubs_smoke() -> None:
     """Smoke-test helper stubs in a dedicated test module."""
     scheduler = make_scheduler_stub()
-    force_update = getattr(scheduler, "force_update")
-    result_default = asyncio.run(force_update())
-    result_with_source = asyncio.run(force_update("usda"))
+    result_default = await scheduler.force_update()
+    result_with_source = await scheduler.force_update("usda")
     assert "usda" in result_default
     assert "usda" in result_with_source
     assert result_default["usda"] == {"ok": True, "status": "stubbed"}
     assert result_with_source["usda"] == {"ok": True, "status": "stubbed"}
 
 
-def test_make_scheduler_stub_allows_falsy_payload() -> None:
+@pytest.mark.asyncio
+async def test_make_scheduler_stub_allows_falsy_payload() -> None:
     """Explicit falsy payload must not be replaced by default stub."""
     scheduler = make_scheduler_stub(usda_result={})
-    force_update = getattr(scheduler, "force_update")
-    result = asyncio.run(force_update("usda"))
+    result = await scheduler.force_update("usda")
     assert result["usda"] == {}

--- a/tests/helpers/test_fast_update_stubs.py
+++ b/tests/helpers/test_fast_update_stubs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import asyncio
+
+from tests.helpers.fast_update_stubs import make_scheduler_stub
+
+
+def test_fast_update_stubs_smoke() -> None:
+    """Smoke-test helper stubs in a dedicated test module."""
+    scheduler = make_scheduler_stub()
+    force_update = getattr(scheduler, "force_update")
+    result_default = asyncio.run(force_update())
+    result_with_source = asyncio.run(force_update("usda"))
+    assert "usda" in result_default
+    assert "usda" in result_with_source
+    source_result = result_default["usda"]
+    assert hasattr(source_result, "success")
+    assert hasattr(source_result, "old_version")

--- a/tests/helpers/test_fast_update_stubs.py
+++ b/tests/helpers/test_fast_update_stubs.py
@@ -13,6 +13,13 @@ def test_fast_update_stubs_smoke() -> None:
     result_with_source = asyncio.run(force_update("usda"))
     assert "usda" in result_default
     assert "usda" in result_with_source
-    source_result = result_default["usda"]
-    assert hasattr(source_result, "success")
-    assert hasattr(source_result, "old_version")
+    assert result_default["usda"] == {"ok": True, "status": "stubbed"}
+    assert result_with_source["usda"] == {"ok": True, "status": "stubbed"}
+
+
+def test_make_scheduler_stub_allows_falsy_payload() -> None:
+    """Explicit falsy payload must not be replaced by default stub."""
+    scheduler = make_scheduler_stub(usda_result={})
+    force_update = getattr(scheduler, "force_update")
+    result = asyncio.run(force_update("usda"))
+    assert result["usda"] == {}

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -12,12 +12,13 @@
 
 import os
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import app as app_mod
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
+from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 
 @pytest.fixture
@@ -34,6 +35,8 @@ class TestAdminEndpoints:
     ) -> None:
         """Тест /api/v1/admin/force-update (блок 1566-1595)"""
         monkeypatch.setenv("API_KEY", "test_key")
+        scheduler = make_scheduler_stub()
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 
         response = client.post(
             "/api/v1/admin/force-update",
@@ -82,6 +85,8 @@ class TestAdminEndpoints:
     ) -> None:
         """Test admin endpoints with real behavior"""
         monkeypatch.setenv("API_KEY", "test_key")
+        scheduler = make_scheduler_stub()
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 
         # Test force-update (real request, no invasive sys.modules patching)
         response = client.post(

--- a/tests/test_app_coverage_missing_lines.py
+++ b/tests/test_app_coverage_missing_lines.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import app as app_mod
+from fastapi.testclient import TestClient
 from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 
@@ -256,7 +257,9 @@ class TestAppMissingLinesCoverage:
             503,
         ], f"Unexpected status code: {response.status_code}\nResponse: {response.json()}"
 
-    def test_force_database_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_force_database_update_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test force database update endpoint."""
         client = client
         scheduler = make_scheduler_stub()

--- a/tests/test_app_coverage_missing_lines.py
+++ b/tests/test_app_coverage_missing_lines.py
@@ -261,7 +261,6 @@ class TestAppMissingLinesCoverage:
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test force database update endpoint."""
-        client = client
         scheduler = make_scheduler_stub()
         patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 

--- a/tests/test_app_coverage_missing_lines.py
+++ b/tests/test_app_coverage_missing_lines.py
@@ -6,6 +6,8 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+import app as app_mod
+from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 
 class TestAppMissingLinesCoverage:
@@ -254,9 +256,11 @@ class TestAppMissingLinesCoverage:
             503,
         ], f"Unexpected status code: {response.status_code}\nResponse: {response.json()}"
 
-    def test_force_database_update_endpoint(self, client):
+    def test_force_database_update_endpoint(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test force database update endpoint."""
         client = client
+        scheduler = make_scheduler_stub()
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 
         response = client.post(
             "/api/v1/admin/force-update",

--- a/tests/test_app_extra_coverage.py
+++ b/tests/test_app_extra_coverage.py
@@ -8,9 +8,11 @@ import os
 from unittest.mock import Mock
 from tests._client import get_client
 
+import pytest
 from fastapi.testclient import TestClient
 
 import app as app_module
+from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 
 class TestAppHelperFunctions:
@@ -136,7 +138,7 @@ class TestEndpointsAndValidation:
         }
         assert self.client.post("/bmi", json=bad_enum).status_code == 422
 
-    def test_admin_and_debug_endpoints(self):
+    def test_admin_and_debug_endpoints(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Debug page is defined in main.py; tolerate environments where it might be restricted
         r = self.client.get("/debug_env")
         assert r.status_code in [200, 404, 405]
@@ -144,5 +146,7 @@ class TestEndpointsAndValidation:
         # Admin endpoints (provided by routers) may be up or return 500/503 when backends are unavailable
         r1 = self.client.get("/api/v1/admin/db-status", headers={"X-API-Key": "test-key"})
         assert r1.status_code in [200, 500, 503]
+        scheduler = make_scheduler_stub()
+        patch_app_get_update_scheduler(monkeypatch, app_module, scheduler)
         r2 = self.client.post("/api/v1/admin/force-update", headers={"X-API-Key": "test-key"})
         assert r2.status_code in [200, 500, 503]

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -15,6 +15,10 @@ from typing import cast
 
 import app as app_mod
 from app import app
+from tests.helpers.fast_update_stubs import (
+    make_scheduler_stub,
+    patch_app_get_update_scheduler,
+)
 
 
 class TestComprehensiveCoverage:
@@ -108,56 +112,50 @@ class TestComprehensiveCoverage:
         data = response.json()
         assert "detail" in data
 
-    def test_force_update_endpoint_success(self) -> None:
+    def test_force_update_endpoint_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test force update endpoint success case with deterministic status."""
-        with patch("app.get_update_scheduler", new_callable=AsyncMock) as mock_get_scheduler:
-            mock_scheduler = AsyncMock()
-            mock_result = MagicMock()
-            mock_result.success = True
-            mock_result.old_version = "1.0"
-            mock_result.new_version = "1.1"
-            mock_result.records_added = 10
-            mock_result.records_updated = 5
-            mock_result.records_removed = 0
-            mock_result.duration_seconds = 1.0
-            mock_result.errors = []
-            mock_scheduler.force_update = AsyncMock(return_value={"usda": mock_result})
-            mock_get_scheduler.return_value = mock_scheduler
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.old_version = "1.0"
+        mock_result.new_version = "1.1"
+        mock_result.records_added = 10
+        mock_result.records_updated = 5
+        mock_result.records_removed = 0
+        mock_result.duration_seconds = 1.0
+        mock_result.errors = []
+        scheduler = make_scheduler_stub(usda_result=mock_result)
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 
-            response = self.client.post(
-                "/api/v1/admin/force-update", headers={"X-API-Key": "test_key"}
-            )
-            # With successful mock, expect deterministic 200
-            assert response.status_code == 200
-            data = response.json()
-            assert "message" in data
-            assert "results" in data
+        response = self.client.post("/api/v1/admin/force-update", headers={"X-API-Key": "test_key"})
+        # With successful mock, expect deterministic 200
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "results" in data
 
-    def test_force_update_endpoint_with_source(self) -> None:
+    def test_force_update_endpoint_with_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test force update endpoint with specific source - deterministic success."""
-        with patch("app.get_update_scheduler", new_callable=AsyncMock) as mock_get_scheduler:
-            mock_scheduler = AsyncMock()
-            mock_result = MagicMock()
-            mock_result.success = True
-            mock_result.old_version = "1.0"
-            mock_result.new_version = "1.1"
-            mock_result.records_added = 5
-            mock_result.records_updated = 3
-            mock_result.records_removed = 1
-            mock_result.duration_seconds = 0.5
-            mock_result.errors = []
-            mock_scheduler.force_update = AsyncMock(return_value={"usda": mock_result})
-            mock_get_scheduler.return_value = mock_scheduler
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.old_version = "1.0"
+        mock_result.new_version = "1.1"
+        mock_result.records_added = 5
+        mock_result.records_updated = 3
+        mock_result.records_removed = 1
+        mock_result.duration_seconds = 0.5
+        mock_result.errors = []
+        scheduler = make_scheduler_stub(usda_result=mock_result)
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
 
-            response = self.client.post(
-                "/api/v1/admin/force-update?source=usda",
-                headers={"X-API-Key": "test_key"},
-            )
-            # With successful mock, expect deterministic 200
-            assert response.status_code == 200
-            data = response.json()
-            assert "message" in data
-            assert "results" in data
+        response = self.client.post(
+            "/api/v1/admin/force-update?source=usda",
+            headers={"X-API-Key": "test_key"},
+        )
+        # With successful mock, expect deterministic 200
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "results" in data
 
     def test_force_update_endpoint_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test force update endpoint exception handling - deterministic.

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -7,8 +7,10 @@ from unittest.mock import MagicMock, patch
 from tests._client import get_client
 
 import pytest
+import app as app_mod
 from fastapi.testclient import TestClient
 from tests.feature_manifest import FEATURE_REASON, require_feature
+from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 # Setup environment before importing
 os.environ.setdefault("API_KEY", "test-key")
@@ -296,7 +298,9 @@ class TestAppAdminEndpoints:
         response = client.get("/api/v1/admin/db-status", headers={"X-API-Key": "test_key"})
         assert response.status_code in [200, 404, 500, 503]
 
-    def test_admin_force_update(self, client):
+    def test_admin_force_update(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test admin force update."""
+        scheduler = make_scheduler_stub()
+        patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)
         response = client.post("/api/v1/admin/force-update", headers={"X-API-Key": "test_key"})
         assert response.status_code in [200, 404, 500, 503]

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -298,7 +298,7 @@ class TestAppAdminEndpoints:
         response = client.get("/api/v1/admin/db-status", headers={"X-API-Key": "test_key"})
         assert response.status_code in [200, 404, 500, 503]
 
-    def test_admin_force_update(self, client, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_admin_force_update(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test admin force update."""
         scheduler = make_scheduler_stub()
         patch_app_get_update_scheduler(monkeypatch, app_mod, scheduler)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `<review-comment-url>` -> `<commit-sha>`
- No actionable review comments

## Deferred / Follow-ups

- [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

<!-- markdownlint-enable MD013 MD033 -->

## Summary by Sourcery

Ввести общие быстрые вспомогательные заглушки для планировщика обновлений и единой базы данных продуктов, чтобы упростить и ускорить тесты, связанные с админкой и обновлениями.

Улучшения:
- Добавлен многократно используемый модуль вспомогательных функций, предоставляющий быстрые заглушки для поведения планировщика обновлений и единой базы данных продуктов, используемых в тестах.

Тесты:
- Рефакторинг множества тестов эндпоинтов админки и принудительного обновления для использования общих вспомогательных заглушек планировщика через monkeypatching вместо встроенного patching с AsyncMock.
- Расширено покрытие тестов эндпоинтов admin/debug с опорой на лёгкие заглушки планировщика для детерминированного поведения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce shared fast stub helpers for update scheduling and unified food database to simplify and speed up admin/update-related tests.

Enhancements:
- Add reusable helper module providing fast stubs for update scheduler and unified food database behaviors used in tests.

Tests:
- Refactor multiple admin and force-update endpoint tests to use shared scheduler stub helpers via monkeypatching instead of inline AsyncMock patching.
- Extend admin/debug endpoint coverage tests to rely on lightweight scheduler stubs for deterministic behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test helpers to stub and patch the update scheduler for faster, deterministic admin-update testing; updated multiple tests to use these helpers/monkeypatch fixtures and added unit tests validating stub behavior.
* **Chores**
  * Updated secret baseline line references and regenerated the metadata timestamp to reflect the new references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->