### PR TITLE
docs(audit): lock parallel ownership seams for shoplist runtime

### DIFF
--- a/docs/audit/PR_SHOPLIST_FLOW_STABILIZATION_WORK_PACKAGE_PLAN.md
+++ b/docs/audit/PR_SHOPLIST_FLOW_STABILIZATION_WORK_PACKAGE_PLAN.md
@@ -160,10 +160,10 @@ Next (separate package):
 ```bash
 # 1) confirm docs-only delta for this governance PR
 git diff --name-only origin/main...HEAD \
-  | rg -v '\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$'
+  | rg -v '^docs/.*\.md$'
 
 # 2) show files touching shoplist runtime surface (must be empty in parallel docs PR)
-git diff --name-only origin/main...HEAD | rg -n 'shoplist|shopping_list|core/shoplist'
+git diff --name-only origin/main...HEAD | rg 'shoplist|shopping_list|core/shoplist'
 
 # 3) prove branch cleanliness before moving back to runtime work
 git status --short

--- a/docs/audit/PR_SHOPLIST_FLOW_STABILIZATION_WORK_PACKAGE_PLAN.md
+++ b/docs/audit/PR_SHOPLIST_FLOW_STABILIZATION_WORK_PACKAGE_PLAN.md
@@ -134,6 +134,41 @@ Now (this package):
 Next (separate package):
 - Deferred items only, recorded in `docs/roadmap/BACKLOG_LEDGER.md` with owner/DoD/target PR.
 
+## Parallel ownership seams (conflict-avoidance contract)
+
+### Shoplist owner (primary)
+
+- `core/shoplist.py`
+- `app/core/shopping_list/*`
+- `tests/*shoplist*`, `tests/*shopping_list*`
+- shoplist flow contract/integration tests and related audit notes
+
+### Parallel track (safe while shoplist is in progress)
+
+- `tests/helpers/*` and non-shoplist tests
+- CI/gates updates and docs-only governance updates
+- security hardening outside shoplist paths (`app/security/*`, guard tests not tied to shoplist)
+
+### Do-not-touch list for parallel track
+
+- router/schema/service connection points that expose shoplist runtime surface
+- shoplist API DTO/response contract files
+- shoplist route registration points
+
+### Evidence commands (pre-push)
+
+```bash
+# 1) confirm docs-only delta for this governance PR
+git diff --name-only origin/main...HEAD \
+  | rg -v '\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$'
+
+# 2) show files touching shoplist runtime surface (must be empty in parallel docs PR)
+git diff --name-only origin/main...HEAD | rg -n 'shoplist|shopping_list|core/shoplist'
+
+# 3) prove branch cleanliness before moving back to runtime work
+git status --short
+```
+
 ## Task matrix with checkpoints (A/B/C/D)
 
 | Phase | Objective | Responsible | Checkpoint (objective evidence) | Hard gate |


### PR DESCRIPTION
## Summary
- add explicit ownership seams for parallel `shoplist` delivery to prevent branch conflicts
- document do-not-touch runtime surfaces and low-conflict parallel tracks
- add evidence commands for docs-only scope verification before push

## Test plan
- [x] `git diff --name-only origin/main...HEAD | rg -v '\.md$|README\.md$|AGENTS\.md$|RUNBOOK_AGENT\.md$|DEPLOYMENT\.md$'` (empty)
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/audit/PR_SHOPLIST_FLOW_STABILIZATION_WORK_PACKAGE_PLAN.md`
- [x] `python scripts/ci/check_pr_body_phase2_gates.py --body "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n- [x] Fixed in commit mapping completed\n### Fixed in Commit Mapping\n- No actionable review comments"`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- [x] Ledger item(s): None
- [x] GitHub issue(s): None

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Задокументировать правила управления для параллельной работы над runtime списка покупок и определить границы избежания конфликтов при одновременных изменениях.

Документация:
- Добавить явные границы владения и рекомендации по предотвращению конфликтов для параллельной работы, связанной со списком покупок.
- Задокументировать допустимые параллельные направления работ, «запрещённые» runtime-области, а также команды для подтверждения того, что изменения затрагивают только документацию, перед отправкой.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document governance for parallel shoplist runtime work and define conflict-avoidance boundaries for concurrent changes.

Documentation:
- Add explicit ownership seams and conflict-avoidance guidelines for parallel shoplist-related work.
- Document allowed parallel tracks, do-not-touch runtime surfaces, and supporting evidence commands for verifying docs-only scope before push.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies parallel ownership seams for the shoplist runtime to enable conflict-free parallel work. Refines pre-push evidence commands to simplify shoplist surface detection and future-proof docs-only checks.

- **New Features**
  - Enumerates primary owner paths: core/shoplist.py, app/core/shopping_list/*, and related tests.
  - Defines safe parallel tracks and a do-not-touch list: router/service connection points, DTOs, route registration.
  - Updates evidence commands with a docs-path filter and a simpler shoplist grep to keep docs-only and runtime changes separated.

<sup>Written for commit 75c9b574b54811da6128b8b8f8ab9322a5203cc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new subsection explaining a "Parallel ownership seams (conflict-avoidance contract)" approach, with guidance on roles and workflow.
  * Documents four focused areas: Shoplist owner, Parallel track, Do-not-touch list, and Evidence commands.
  * Includes procedural guidance and example pre-push commands to support adoption and stabilization of the flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->