### PR TITLE
refactor(p1): extract and cache import-safe ORM model helper

### DIFF
--- a/app/openapi/orm_imports.py
+++ b/app/openapi/orm_imports.py
@@ -22,9 +22,9 @@ _NUTRITION_EVENT_KEY: Final[str] = "nutrition_event_model"
 
 
 def clear_orm_import_cache() -> None:
-    """Clear cached ORM imports (test helper).
+    """Test-only helper. Do not use in runtime code.
 
-    RU: Сбрасывает кэш import-safe ORM-резолвера. Используется только в тестах,
+    RU: Только для тестов. Сбрасывает кэш import-safe ORM-резолвера,
     чтобы избежать зависимостей от порядка импортов.
     """
     _ORM_IMPORT_CACHE.clear()
@@ -47,6 +47,9 @@ def get_nutrition_event_model() -> object:
     ORM на этапе импорта роутеров.
     EN: Returns NutritionEvent ORM model lazily to avoid ORM registration at
     router module import time.
+
+    Note: cache writes are intentionally lock-free; concurrent cold starts may do
+    redundant imports/assignments, but importlib import is idempotent and this is harmless.
     """
     cached = _ORM_IMPORT_CACHE.get(_NUTRITION_EVENT_KEY)
     if cached is not None:

--- a/app/openapi/orm_imports.py
+++ b/app/openapi/orm_imports.py
@@ -10,18 +10,48 @@ ORM side effects.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Type
+import importlib
+from typing import Final
 
-if TYPE_CHECKING:  # pragma: no cover
-    from app.models import NutritionEvent  # noqa: F401
+# Import-safe cache: values are model classes or other resolved objects.
+# We intentionally avoid `Any` in core/openapi logic.
+_ORM_IMPORT_CACHE: dict[str, object] = {}
+
+# Canonical cache keys (stable string literals).
+_NUTRITION_EVENT_KEY: Final[str] = "nutrition_event_model"
 
 
-def get_nutrition_event_model() -> Type["NutritionEvent"]:
-    """Return NutritionEvent ORM model via runtime import.
+def clear_orm_import_cache() -> None:
+    """Clear cached ORM imports (test helper).
 
-    RU: runtime import, чтобы избежать import-time side effects.
-    EN: runtime import to avoid import-time side effects.
+    RU: Сбрасывает кэш import-safe ORM-резолвера. Используется только в тестах,
+    чтобы избежать зависимостей от порядка импортов.
     """
-    from app.models import NutritionEvent
+    _ORM_IMPORT_CACHE.clear()
 
-    return NutritionEvent
+
+def _lazy_import_attr(module_path: str, attr_name: str) -> object:
+    """Import `module_path` lazily and return `attr_name`.
+
+    RU: Ленивый импорт без side effects на уровне модуля. ORM-модели не должны
+    импортироваться при генерации OpenAPI / schema-only режимах.
+    """
+    module = importlib.import_module(module_path)
+    return getattr(module, attr_name)
+
+
+def get_nutrition_event_model() -> object:
+    """Return the NutritionEvent ORM model class (import-safe).
+
+    RU: Возвращает ORM-модель NutritionEvent лениво, чтобы не регистрировать
+    ORM на этапе импорта роутеров.
+    EN: Returns NutritionEvent ORM model lazily to avoid ORM registration at
+    router module import time.
+    """
+    cached = _ORM_IMPORT_CACHE.get(_NUTRITION_EVENT_KEY)
+    if cached is not None:
+        return cached
+
+    model = _lazy_import_attr("app.models", "NutritionEvent")
+    _ORM_IMPORT_CACHE[_NUTRITION_EVENT_KEY] = model
+    return model

--- a/app/routers/nutrition_log.py
+++ b/app/routers/nutrition_log.py
@@ -7,7 +7,7 @@ EN: PRO nutrition logging endpoints that feed the adherence micro-model.
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
@@ -38,13 +38,13 @@ router = APIRouter(
 IDEMP_CONSTRAINT = "uq_nutrition_events_idempotency"
 
 
-def _nutrition_event_model() -> object:
+def _nutrition_event_model() -> "type[NutritionEventModel]":
     """Resolve NutritionEvent ORM model lazily (OpenAPI import-safe).
 
     RU: Ленивое получение ORM-модели, чтобы не тянуть ORM при импорте роутера
     (важно для OpenAPI/schema-only путей).
     """
-    return get_nutrition_event_model()
+    return cast("type[NutritionEventModel]", get_nutrition_event_model())
 
 
 def _is_idempotency_violation(err: IntegrityError) -> bool:

--- a/app/routers/nutrition_log.py
+++ b/app/routers/nutrition_log.py
@@ -38,6 +38,15 @@ router = APIRouter(
 IDEMP_CONSTRAINT = "uq_nutrition_events_idempotency"
 
 
+def _nutrition_event_model() -> object:
+    """Resolve NutritionEvent ORM model lazily (OpenAPI import-safe).
+
+    RU: Ленивое получение ORM-модели, чтобы не тянуть ORM при импорте роутера
+    (важно для OpenAPI/schema-only путей).
+    """
+    return get_nutrition_event_model()
+
+
 def _is_idempotency_violation(err: IntegrityError) -> bool:
     """Check if IntegrityError is specifically an idempotency constraint violation.
 
@@ -69,8 +78,7 @@ def _is_idempotency_violation(err: IntegrityError) -> bool:
 def _fetch_existing_event(
     session: Session, subject_id: int, day: date, source: str, client_event_id: str
 ) -> "NutritionEventModel" | None:
-    # Lazy import: avoid ORM model import at module import time (OpenAPI generation path).
-    NutritionEventModel = get_nutrition_event_model()
+    NutritionEventModel = _nutrition_event_model()
 
     stmt = (
         select(NutritionEventModel)
@@ -172,7 +180,7 @@ async def log_meal(
 
     # Write event to append-only log (idempotent if client_event_id provided)
     event_record: "NutritionEventModel" | None = None
-    NutritionEventModel = get_nutrition_event_model()
+    NutritionEventModel = _nutrition_event_model()
 
     event_payload = {
         "log_type": payload.log_type,
@@ -240,7 +248,7 @@ async def close_day(
 
     # Write day_closed event to append-only log (idempotent)
     event_record: "NutritionEventModel" | None = None
-    NutritionEventModel = get_nutrition_event_model()
+    NutritionEventModel = _nutrition_event_model()
 
     try:
         event_record = NutritionEventModel(

--- a/tests/test_openapi_import_safe_orm_guard.py
+++ b/tests/test_openapi_import_safe_orm_guard.py
@@ -38,3 +38,29 @@ def test_fetch_existing_event_uses_runtime_helper(monkeypatch: pytest.MonkeyPatc
     session_dummy: Any = None
     with pytest.raises(RuntimeError, match="helper-called"):
         module._fetch_existing_event(session_dummy, 1, date.today(), "meal_log", "evt-1")
+
+
+def test_orm_import_cache_clear_and_refill(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache must short-circuit repeated resolution and be clearable for tests."""
+    orm_imports = importlib.import_module("app.openapi.orm_imports")
+    orm_imports.clear_orm_import_cache()
+
+    call_count = 0
+    real_import_module = orm_imports.importlib.import_module
+
+    def _spy_import(module_name: str) -> object:
+        nonlocal call_count
+        call_count += 1
+        return real_import_module(module_name)
+
+    monkeypatch.setattr(orm_imports.importlib, "import_module", _spy_import)
+
+    first = orm_imports.get_nutrition_event_model()
+    second = orm_imports.get_nutrition_event_model()
+    assert first is second
+    assert call_count == 1
+
+    orm_imports.clear_orm_import_cache()
+    third = orm_imports.get_nutrition_event_model()
+    assert third is first
+    assert call_count == 2


### PR DESCRIPTION
## Summary
- introduce cached import-safe ORM resolver in `app/openapi/orm_imports.py`
- standardize NutritionEvent model resolution in `app/routers/nutrition_log.py` via a single local resolver wrapper
- preserve runtime behavior (no schema/contract/auth/guard changes)
- extend OpenAPI import-safe guard test to cover cache clear/refill branch

## Scope
- IN:
  - `app/openapi/orm_imports.py`
  - `app/routers/nutrition_log.py`
  - `tests/test_openapi_import_safe_orm_guard.py`
- OUT:
  - schema/contract changes
  - iOS/web
  - OpenAPI mode/tooling changes
  - skip-heavy cleanup

## Behavior
- no API/validation/auth guard changes
- import-safe semantics preserved
- ORM model resolution cached per process

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Test plan
- [x] `pytest -q tests/test_openapi_import_safe_orm_guard.py`
- [x] `pytest -q tests/test_nutrition_log_api.py tests/test_nutrition_log_idempotency.py`
- [x] `make verify`
- [x] diff-cover 100% on changed lines

## Risks
- Low: refactor-only, no route contract changes

## Rollback
- Revert PR (no migrations/state changes)

## Deferred / Follow-ups
- Next planned item (separate PR): P1 skip-heavy drift cleanup, after post-merge sanity window


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ввести кешируемый, безопасный при импорте механизм разрешения ORM-модели для `NutritionEvent` и стандартизировать его использование в роутере журнала питания, сохранив существующее поведение.

Улучшения:
- Кешировать безопасное при импорте разрешение ORM-модели для `NutritionEvent`, чтобы избежать повторных импортов во время выполнения.
- Добавить локальный вспомогательный резолвер модели `NutritionEvent` в роутере журнала питания для централизации ленивого доступа к ORM.

Тесты:
- Расширить тесты защитного механизма безопасного при импорте ORM для OpenAPI, чтобы покрыть очистку кеша импорта и поведение его повторного заполнения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a cached, import-safe ORM model resolver for NutritionEvent and standardize its usage in the nutrition log router while preserving existing behavior.

Enhancements:
- Cache import-safe ORM model resolution for NutritionEvent to avoid repeated runtime imports.
- Add a local NutritionEvent model resolver helper in the nutrition log router to centralize lazy ORM access.

Tests:
- Extend OpenAPI import-safe ORM guard tests to cover import cache clear and refill behavior.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a cached, import-safe ORM model resolver and standardized NutritionEvent loading in nutrition_log. Behavior is unchanged; OpenAPI imports stay safe and model resolution is cached per process.

- **Refactors**
  - Added import-safe cache and clear_orm_import_cache in app/openapi/orm_imports.py; lazy resolves via importlib and caches by key.
  - Introduced _nutrition_event_model() in nutrition_log with explicit typing; replaced direct resolver calls.
  - Clarified docs: lock-free cache writes are safe; cache reset is test-only.

- **Tests**
  - Added coverage for cache clear/refill and kept the OpenAPI import-safe guard.

<sup>Written for commit 40fe4bcc118240737501108fdc8a7c1c8603c881. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved import-safe, cache-backed lazy loading of ORM models to avoid import-time side effects and reduce initialization overhead.
  * Added a test-friendly mechanism to clear and refresh the model resolution cache.

* **Tests**
  * New tests ensure the import cache short-circuits repeated resolutions, can be cleared, and refills correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->