### PR TITLE
test(skips): normalize feature_disabled gating in skip-heavy coverage suites

### DIFF
--- a/tests/test_database_apis_coverage.py
+++ b/tests/test_database_apis_coverage.py
@@ -130,7 +130,10 @@ class TestCoreDatabaseCoverage:
 
     def test_update_manager_coverage(self) -> None:
         """Test current update manager API surface."""
-        from core.food_apis.update_manager import DatabaseUpdateManager, DatabaseVersion
+        try:
+            from core.food_apis.update_manager import DatabaseUpdateManager, DatabaseVersion
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
 
         # Test database version
         version = DatabaseVersion(

--- a/tests/test_final_coverage_97_boost.py
+++ b/tests/test_final_coverage_97_boost.py
@@ -9,7 +9,7 @@ from tests._client import get_client
 import pytest
 import app as app_mod
 from fastapi.testclient import TestClient
-from tests.feature_manifest import FEATURE_REASON, require_feature
+from tests.feature_manifest import FEATURE_REASON, require_feature, require_feature_or_raise
 from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
 # Setup environment before importing
@@ -72,8 +72,8 @@ class TestMenuEngineNewCoverage:
             from core import menu_engine_new
 
             assert menu_engine_new is not None
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_menu_engine_new_with_functions(self) -> None:
         """Test menu_engine_new functions."""
@@ -86,8 +86,8 @@ class TestMenuEngineNewCoverage:
             # Test available functions
             if hasattr(menu_engine_new, "make_weekly_menu"):
                 assert callable(menu_engine_new.make_weekly_menu)
-        except ImportError:
-            require_feature("planner_engines", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
 
 class TestRecommendationsCoverage:
@@ -138,13 +138,16 @@ class TestUnifiedDbCoverage:
             # Test with special characters
             result = await search_unified_food("тест !@#")
             assert result is not None
-        except ImportError:
-            require_feature("unified_db", reason=FEATURE_REASON)
+        except ImportError as exc:
+            require_feature_or_raise(exc, "unified_db", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_unified_db_language_support(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test unified_db language normalization contract."""
-        from core.food_apis import unified_db as unified_db_mod
+        try:
+            from core.food_apis import unified_db as unified_db_mod
+        except ImportError as exc:
+            require_feature_or_raise(exc, "unified_db", reason=FEATURE_REASON)
 
         async def _fake_search(
             query: str, max_results: int = 5

--- a/tests/test_quick_coverage_boost.py
+++ b/tests/test_quick_coverage_boost.py
@@ -305,7 +305,7 @@ class TestQuickCoverageBoost:
             require_feature_or_raise(
                 exc,
                 "food_apis",
-                reason=f"{FEATURE_REASON} Missing optional module: core.food_apis.update_manager.",
+                reason=FEATURE_REASON,
             )
 
         manager = DatabaseUpdateManager(update_interval_hours=1)


### PR DESCRIPTION
## Scope (IN)
- `tests/test_final_coverage_97_boost.py` (CP1)
- `tests/test_database_apis_coverage.py` (CP2)
- `tests/test_quick_coverage_boost.py` (CP2)

## Scope (OUT)
- runtime / OpenAPI / iOS-web / infra / security configs / refactors

## Problem
Inconsistent skip-gating and ad-hoc skip reasons caused drift and noise.

## Fix summary
- CP1: unified_db gating drift fixed (`require_feature_or_raise` everywhere; import wrapped)
- CP2: update_manager imports gated under `food_apis`; removed ad-hoc skip reason

## Evidence (local)
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `pytest -q -rs tests/test_database_apis_coverage.py tests/test_quick_coverage_boost.py` ✅

## Skip policy
- 0 skip reasons outside `feature_disabled:*`

## Deferred / Follow-ups
- CP3 buckets (`exports_recipes_products`, `sports_disclaimers_lifestage`, `weekly_plan_helpers`, `utils_pack`, `nutrient_recommendations`) — separate PR

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments
- `9683cd8b` — CP1: unified_db gating drift fix in final coverage suite
- `53068715` — CP2: gate update_manager coverage under food_apis
- `cb3afbe2` — CP2: remove ad-hoc skip reason in update_manager async coverage