### PR TITLE
docs(audit): add CP3 no-op audit and execution plan

### DIFF
--- a/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
+++ b/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
@@ -1,0 +1,75 @@
+# CP3 Skip-Heavy A1 Audit Memo (No-Op)
+
+## Scope
+
+- In scope:
+  - `tests/test_remaining_modules.py`
+  - `tests/test_zero_coverage_modules.py`
+- Out of scope:
+  - Runtime modules (`app/`, `core/`)
+  - Other test suites
+  - Ledger/process updates outside CP3 planning
+
+## Finding
+
+A1 found no skip-protocol drift in the two scoped files.
+
+- All current skip-gating callsites use `require_feature_or_raise(...)`.
+- No ad-hoc `pytest.skip(...)` calls were found.
+- Skip reasons are emitted via canonical `feature_disabled:<key>`.
+
+## Evidence
+
+Command:
+
+```bash
+pytest -q -rs tests/test_remaining_modules.py tests/test_zero_coverage_modules.py | rg -n "SKIPPED|feature_disabled:"
+```
+
+Observed output lines:
+
+- `SKIPPED [1] ... feature_disabled:weekly_plan_helpers ...`
+- `SKIPPED [3] ... feature_disabled:utils_pack ...`
+- `SKIPPED [3] ... feature_disabled:sports_disclaimers_lifestage ...`
+- `SKIPPED [5] ... feature_disabled:exports_recipes_products ...`
+
+Command:
+
+```bash
+rg -n "require_feature\\(|require_feature_or_raise\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+```
+
+Observed output lines:
+
+- `tests/test_remaining_modules.py:40` (and subsequent matches) -> `require_feature_or_raise(...)`
+- `tests/test_zero_coverage_modules.py:47` (and subsequent matches) -> `require_feature_or_raise(...)`
+
+Command:
+
+```bash
+rg -n "pytest\\.skip|skip\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+```
+
+Observed output lines:
+
+- no matches
+
+## File:line anchors
+
+- `tests/test_remaining_modules.py:40`
+- `tests/test_remaining_modules.py:116`
+- `tests/test_remaining_modules.py:219`
+- `tests/test_zero_coverage_modules.py:47`
+- `tests/test_zero_coverage_modules.py:92`
+- `tests/test_zero_coverage_modules.py:315`
+
+## Decision
+
+- A1 remediation in the current narrow scope is a no-op.
+- Do not force synthetic rewrites in these two files.
+- Move to CP3 plan hardening with explicit hypotheses, KPI baselines, and next-scope stop/go rules before opening any code-changing execution PR.
+
+## Risk notes
+
+- Main risk is false progress (rewriting already-canonical code).
+- Main control is evidence-first progression: only promote to execution PR if expanded audit finds non-canonical skips or contract drift.

--- a/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
+++ b/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
@@ -45,12 +45,14 @@ rg -n "require_feature\\(|require_feature_or_raise\\(" \
 Observed output lines:
 
 - `tests/test_remaining_modules.py:40` (and subsequent matches) -> `require_feature_or_raise(...)`
-- `tests/test_zero_coverage_modules.py:47` (and subsequent matches) -> `require_feature_or_raise(...)`
+- `tests/test_zero_coverage_modules.py:47` (and subsequent matches) ->
+  `require_feature_or_raise(...)`
 
 Command:
 
 ```bash
-rg -n "pytest\\.skip|skip\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+rg -n "pytest\\.skip|skip\\(" tests/test_remaining_modules.py \
+  tests/test_zero_coverage_modules.py
 ```
 
 Observed output lines:

--- a/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
+++ b/docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md
@@ -23,7 +23,9 @@ A1 found no skip-protocol drift in the two scoped files.
 Command:
 
 ```bash
-pytest -q -rs tests/test_remaining_modules.py tests/test_zero_coverage_modules.py | rg -n "SKIPPED|feature_disabled:"
+pytest -q -rs tests/test_remaining_modules.py \
+  tests/test_zero_coverage_modules.py | \
+  rg -n "SKIPPED|feature_disabled:"
 ```
 
 Observed output lines:
@@ -36,7 +38,8 @@ Observed output lines:
 Command:
 
 ```bash
-rg -n "require_feature\\(|require_feature_or_raise\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+rg -n "require_feature\\(|require_feature_or_raise\\(" \
+  tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
 ```
 
 Observed output lines:
@@ -67,9 +70,12 @@ Observed output lines:
 
 - A1 remediation in the current narrow scope is a no-op.
 - Do not force synthetic rewrites in these two files.
-- Move to CP3 plan hardening with explicit hypotheses, KPI baselines, and next-scope stop/go rules before opening any code-changing execution PR.
+- Move to CP3 plan hardening with explicit hypotheses, KPI baselines,
+  and next-scope stop/go rules before opening any code-changing
+  execution PR.
 
 ## Risk notes
 
 - Main risk is false progress (rewriting already-canonical code).
-- Main control is evidence-first progression: only promote to execution PR if expanded audit finds non-canonical skips or contract drift.
+- Main control is evidence-first progression: only promote to execution
+  PR if expanded audit finds non-canonical skips or contract drift.

--- a/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
+++ b/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
@@ -10,9 +10,9 @@ Convert CP3 from "cleanup by assumption" to evidence-driven execution.
 ## Scope guard (hard)
 
 - This plan is docs-and-audit only.
-- No runtime code changes.
-- No test behavior rewrites without new evidence.
-- No new skip mechanics beyond canonical protocol.
+- Runtime code changes are out of scope.
+- Test behavior rewrites require new evidence.
+- Only the canonical skip protocol is permitted (no new mechanics).
 
 ## A1 summary (input state)
 
@@ -29,7 +29,8 @@ Reference: `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
 ## Falsifiable hypotheses (next audit stage)
 
 1. Expanded CP3 scope still contains only canonical skip protocol usage.
-2. Any non-canonical skip in expanded scope is attributable to a concrete file and line and can be fixed without runtime edits.
+2. Any non-canonical skip in expanded scope is attributable to a
+   concrete file and line and can be fixed without runtime edits.
 3. "No-op" remains true for scoped files unless a new test drift is introduced.
 
 ### Promotion criteria to execution PR
@@ -55,8 +56,9 @@ Otherwise, keep CP3 as a no-op with documented evidence.
 
 ### KPI Baseline Update Protocol
 
-The baseline skip counts are snapshot values from the latest completed audit pass.
-They must be updated after each CP3 audit cycle, or when skip delta exceeds plus or minus 3 across tracked keys.
+The baseline skip counts are snapshot values from the latest completed
+audit pass. They must be updated after each CP3 audit cycle, or when
+skip delta exceeds plus or minus 3 across tracked keys.
 
 Update sequence:
 
@@ -69,12 +71,14 @@ Update sequence:
 
 - Canonical skip compliance: `100%` required.
 - Ad-hoc skip strings: `0` allowed.
-- Protocol regressions (`require_feature_or_raise` missing where required): `0` allowed.
+- Protocol regressions (`require_feature_or_raise` missing where
+  required): `0` allowed.
 
 ## Uncertainty and stop/degrade policy
 
 - Confidence labels for findings: High / Medium / Low.
-- Stop expansion if evidence quality is Low and cannot be improved by one additional audit pass.
+- Stop expansion if evidence quality is Low and cannot be improved
+  by one additional audit pass.
 - Degrade behavior under low evidence:
   - reduce to smallest reproducible file slice
   - avoid speculative rewrites
@@ -102,7 +106,8 @@ Canonical SoT for verification commands and evidence format:
 
 Plan-level requirement:
 
-- Each CP3 phase must reference canonical evidence from the audit SoT and record the decision (`no-op` or `actionable`) in this plan.
+- Each CP3 phase must reference canonical evidence from the audit SoT
+  and record the decision (`no-op` or `actionable`) in this plan.
 
 ## Stakeholder framing
 

--- a/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
+++ b/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
@@ -26,12 +26,32 @@ Convert CP3 from "cleanup by assumption" to evidence-driven execution.
 
 Reference: `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
 
+Evidence anchors:
+
+- `tests/test_remaining_modules.py:40` and
+  `tests/test_zero_coverage_modules.py:47` show
+  `require_feature_or_raise(...)` usage.
+- `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md:53` and
+  `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md:58` record
+  no ad-hoc `pytest.skip(...)` matches.
+- `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md:33` and
+  `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md:36` record
+  observed `feature_disabled:<key>` output.
+
 ## Falsifiable hypotheses (next audit stage)
 
 1. Expanded CP3 scope still contains only canonical skip protocol usage.
 2. Any non-canonical skip in expanded scope is attributable to a
    concrete file and line and can be fixed without runtime edits.
 3. "No-op" remains true for scoped files unless a new test drift is introduced.
+
+Hypothesis evidence anchors:
+
+- Canonical baseline for these hypotheses is captured in
+  `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md:31`-`36`,
+  plus file-level anchors at
+  `tests/test_remaining_modules.py:40` and
+  `tests/test_zero_coverage_modules.py:47`.
 
 ### Promotion criteria to execution PR
 
@@ -111,5 +131,7 @@ Plan-level requirement:
 
 ## Stakeholder framing
 
-- This phase optimizes delivery predictability and trust by avoiding cosmetic rewrites.
-- Value is risk reduction and audit precision, not artificial code churn.
+- This phase optimizes delivery predictability and trust by avoiding
+  cosmetic rewrites.
+- Value is risk reduction and audit precision, not artificial code
+  churn.

--- a/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
+++ b/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
@@ -4,7 +4,7 @@
 
 Convert CP3 from "cleanup by assumption" to evidence-driven execution.
 
-- A1 in narrow scope is no-op (already canonical).
+- A1 in narrow scope is a no-op (already canonical).
 - Next step is controlled audit expansion with strict scope guards.
 
 ## Scope guard (hard)
@@ -40,7 +40,7 @@ Promote only if at least one of the following is true:
 - Missing `require_feature_or_raise(...)` in an ImportError gating path.
 - Contract drift found between skip reason key and ledger key.
 
-Otherwise, keep CP3 as no-op with documented evidence.
+Otherwise, keep CP3 as a no-op with documented evidence.
 
 ## KPI baseline and thresholds
 
@@ -52,6 +52,18 @@ Otherwise, keep CP3 as no-op with documented evidence.
 | `utils_pack` | 3 |
 | `sports_disclaimers_lifestage` | 3 |
 | `exports_recipes_products` | 5 |
+
+### KPI Baseline Update Protocol
+
+The baseline skip counts are snapshot values from the latest completed audit pass.
+They must be updated after each CP3 audit cycle, or when skip delta exceeds plus or minus 3 across tracked keys.
+
+Update sequence:
+
+1. Re-run the canonical command block from the audit SoT document.
+2. Attach 1-3 raw evidence lines with exit code.
+3. Update the baseline table in this plan.
+4. Add a short status note in `docs/roadmap/BACKLOG_LEDGER.md`.
 
 ### Thresholds
 
@@ -84,21 +96,13 @@ Otherwise, keep CP3 as no-op with documented evidence.
 
 ## Evidence and traceability format
 
-For each CP3 phase:
+Canonical SoT for verification commands and evidence format:
 
-1. exact command
-2. 1-3 raw output lines
-3. exit code
-4. file:line anchors
-5. decision (no-op / actionable)
+- `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
 
-## Verification commands (for CP3 docs and audits)
+Plan-level requirement:
 
-```bash
-pytest -q -rs tests/test_remaining_modules.py tests/test_zero_coverage_modules.py | rg -n "SKIPPED|feature_disabled:"
-rg -n "require_feature\\(|require_feature_or_raise\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
-rg -n "pytest\\.skip|skip\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
-```
+- Each CP3 phase must reference canonical evidence from the audit SoT and record the decision (`no-op` or `actionable`) in this plan.
 
 ## Stakeholder framing
 

--- a/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
+++ b/docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md
@@ -1,0 +1,106 @@
+# CP3 Plan: Skip-Heavy Coverage Drift Follow-Up
+
+## Goal
+
+Convert CP3 from "cleanup by assumption" to evidence-driven execution.
+
+- A1 in narrow scope is no-op (already canonical).
+- Next step is controlled audit expansion with strict scope guards.
+
+## Scope guard (hard)
+
+- This plan is docs-and-audit only.
+- No runtime code changes.
+- No test behavior rewrites without new evidence.
+- No new skip mechanics beyond canonical protocol.
+
+## A1 summary (input state)
+
+- A1 files:
+  - `tests/test_remaining_modules.py`
+  - `tests/test_zero_coverage_modules.py`
+- Outcome:
+  - canonical `require_feature_or_raise(...)` usage
+  - no ad-hoc `pytest.skip(...)`
+  - canonical `feature_disabled:<key>` reasons only
+
+Reference: `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
+
+## Falsifiable hypotheses (next audit stage)
+
+1. Expanded CP3 scope still contains only canonical skip protocol usage.
+2. Any non-canonical skip in expanded scope is attributable to a concrete file and line and can be fixed without runtime edits.
+3. "No-op" remains true for scoped files unless a new test drift is introduced.
+
+### Promotion criteria to execution PR
+
+Promote only if at least one of the following is true:
+
+- Non-canonical skip pattern found in expanded scope.
+- Missing `require_feature_or_raise(...)` in an ImportError gating path.
+- Contract drift found between skip reason key and ledger key.
+
+Otherwise, keep CP3 as no-op with documented evidence.
+
+## KPI baseline and thresholds
+
+### Baseline (A1 scoped files)
+
+| Key | Current skipped count |
+| --- | --- |
+| `weekly_plan_helpers` | 1 |
+| `utils_pack` | 3 |
+| `sports_disclaimers_lifestage` | 3 |
+| `exports_recipes_products` | 5 |
+
+### Thresholds
+
+- Canonical skip compliance: `100%` required.
+- Ad-hoc skip strings: `0` allowed.
+- Protocol regressions (`require_feature_or_raise` missing where required): `0` allowed.
+
+## Uncertainty and stop/degrade policy
+
+- Confidence labels for findings: High / Medium / Low.
+- Stop expansion if evidence quality is Low and cannot be improved by one additional audit pass.
+- Degrade behavior under low evidence:
+  - reduce to smallest reproducible file slice
+  - avoid speculative rewrites
+  - create/update ledger follow-up instead of forcing code churn
+
+## Logic and architecture invariants
+
+- Skip protocol SoT remains canonical and singular.
+- No policy-guard weakening.
+- No runtime path changes in CP3.
+- Matrix-style negative checks remain status-only where applicable.
+
+## Security and bug-risk controls
+
+- Prevent false-green outcomes:
+  - no hidden failures via ad-hoc skips
+  - no mask patterns (`|| true`, broad skip wrappers) in CP3 changes
+- Every deferred finding must map to a backlog item with owner and DoD.
+
+## Evidence and traceability format
+
+For each CP3 phase:
+
+1. exact command
+2. 1-3 raw output lines
+3. exit code
+4. file:line anchors
+5. decision (no-op / actionable)
+
+## Verification commands (for CP3 docs and audits)
+
+```bash
+pytest -q -rs tests/test_remaining_modules.py tests/test_zero_coverage_modules.py | rg -n "SKIPPED|feature_disabled:"
+rg -n "require_feature\\(|require_feature_or_raise\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+rg -n "pytest\\.skip|skip\\(" tests/test_remaining_modules.py tests/test_zero_coverage_modules.py
+```
+
+## Stakeholder framing
+
+- This phase optimizes delivery predictability and trust by avoiding cosmetic rewrites.
+- Value is risk reduction and audit precision, not artificial code churn.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -579,7 +579,7 @@ If it is not recorded here — it does not exist.
 - [ ] P1: CP3 follow-up for skip-heavy coverage drift cleanup
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD (CP3 follow-up)
+  - Target PR: PR-TBD (CP3 execution follow-up)
   - Status: 📋 Planned (deferred from PR-773)
   - Area: backend / tests / contracts
   - Finding Type: drift / contract mismatch
@@ -593,6 +593,8 @@ If it is not recorded here — it does not exist.
   - Links:
     - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/773`
     - `docs/audit/SKIPPED_TESTS_CLASSIFICATION_AUDIT_2026-02-13.md`
+    - `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
+    - `docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md`
     - `core/food_apis/unified_db.py:265`
   - DoD:
     - CP3 buckets are implemented in a dedicated follow-up PR with explicit mapping by test file.


### PR DESCRIPTION
## Scope (IN)
- `docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md`
- `docs/plan/CP3_SKIP_COVERAGE_DRIFT_PLAN.md`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Scope (OUT)
- runtime/app/core changes
- test logic changes
- CI/workflow/infra changes

## Summary
- Record A1 CP3 no-op audit evidence for skip-heavy scope in two test files.
- Add CP3 execution plan with hypotheses, KPI baseline, stop/degrade criteria, and verification commands.
- Link both artifacts from the existing CP3 backlog item for traceable follow-up.

## Evidence (local)
- `pre-commit run --all-files` ✅
- `python scripts/ci/check_docs_phase1_gates.py --files docs/audit/CP3_SKIP_HEAVY_A1_NOOP_AUDIT_2026-02-16.md docs/roadmap/BACKLOG_LEDGER.md` ✅
- docs-only guard for non-md changes ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- CP3 execution remains a separate code PR, promoted only by evidence from expanded audit scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed audit memo documenting scope, findings, evidence, anchors, decisions, and risk notes for the recent CP3 assessment.
  * Added a comprehensive CP3 plan specifying strict scope guards, execution constraints, promotion criteria, KPIs, evidence/traceability requirements, thresholds, and controls.
  * Updated backlog semantics and appended links to the new audit memo and CP3 plan for follow-up tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->