### PR TITLE
feat(realtime): add secure websocket foundation with fail-closed auth

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,10 +14,25 @@ from legacy_app import app as _legacy_app  # re-export FastAPI instance from leg
 # This must be done here, not in legacy_app.py, to keep legacy as a thin proxy
 from app.bootstrap.metrics import register_metrics
 from app.bootstrap.pro_contracts import register_pro_contract_routes
+import app.routers.realtime_ws as realtime_ws
 
 app: FastAPI = _legacy_app
 
 register_metrics(app)
 register_pro_contract_routes(app)
+
+
+def _assert_no_duplicate_ws_route() -> None:
+    """Fail fast if /ws is already registered elsewhere."""
+    existing_paths = {getattr(route, "path", None) for route in app.routes}
+    if "/ws" in existing_paths:
+        raise RuntimeError(
+            "Duplicate /ws route detected. "
+            "Check legacy_app.py or other router registration points."
+        )
+
+
+_assert_no_duplicate_ws_route()
+app.include_router(realtime_ws.router)
 
 __all__ = ["app"]

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -82,8 +82,6 @@ def _get_token_verifier() -> TokenVerifier:
     def _verify(token: str) -> object:
         try:
             return require_pro_tier(token)
-        except HTTPException as exc:
-            raise PermissionError("auth_invalid") from exc
         except Exception as exc:
             raise PermissionError("auth_invalid") from exc
 
@@ -185,7 +183,7 @@ async def ws_root(ws: WebSocket) -> None:
 
             text = frame.get("text")
             if text is None:
-                await ws.close(code=1008, reason="invalid_json")
+                await ws.close(code=1008, reason="text_frame_required")
                 return
 
             if not _is_within_size_limit(text, policy.max_message_bytes):

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -83,8 +83,6 @@ def _get_token_verifier() -> TokenVerifier:
         try:
             return require_pro_tier(token)
         except HTTPException as exc:
-            if exc.status_code in (401, 403):
-                raise PermissionError("auth_invalid") from exc
             raise PermissionError("auth_invalid") from exc
         except Exception as exc:
             raise PermissionError("auth_invalid") from exc

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
 
 from fastapi import APIRouter, HTTPException, WebSocket
+from starlette.concurrency import run_in_threadpool
 from starlette.websockets import WebSocketDisconnect
 
 router = APIRouter(tags=["realtime"])
@@ -113,7 +114,7 @@ async def _authenticate_or_close(ws: WebSocket) -> bool:
 
     try:
         verifier = _get_token_verifier()
-        verifier(token)
+        await run_in_threadpool(verifier, token)
         return True
     except Exception:
         await ws.close(code=1008, reason="auth_invalid")
@@ -180,7 +181,14 @@ async def ws_root(ws: WebSocket) -> None:
 
     try:
         while True:
-            text = await ws.receive_text()
+            frame = await ws.receive()
+            if frame.get("type") == "websocket.disconnect":
+                return
+
+            text = frame.get("text")
+            if text is None:
+                await ws.close(code=1008, reason="invalid_json")
+                return
 
             if not _is_within_size_limit(text, policy.max_message_bytes):
                 await ws.close(code=1008, reason="payload_too_large")

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -7,7 +7,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
 
-from fastapi import APIRouter, HTTPException, WebSocket
+from fastapi import APIRouter, WebSocket
 from starlette.concurrency import run_in_threadpool
 from starlette.websockets import WebSocketDisconnect
 
@@ -72,9 +72,9 @@ class TokenVerifier(Protocol):
 def _get_token_verifier() -> TokenVerifier:
     """Wire canonical PRO auth verifier via existing api_tiers stack.
 
-    RU: Явно маппим HTTPException в PermissionError, чтобы websocket auth
+    RU: Любую ошибку в verifier маппим в PermissionError, чтобы websocket auth
     оставался единообразно fail-closed.
-    EN: Explicitly map HTTPException to PermissionError to keep websocket auth
+    EN: Map any verifier error to PermissionError to keep websocket auth
     behavior uniformly fail-closed.
     """
     from app.middleware.api_tiers import require_pro_tier

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+from fastapi import APIRouter, HTTPException, WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+router = APIRouter(tags=["realtime"])
+
+DEFAULT_MAX_MESSAGE_BYTES: int = 4_096
+DEFAULT_WINDOW_SECONDS: int = 10
+DEFAULT_MAX_MESSAGES_PER_WINDOW: int = 20
+ALLOWED_EVENT_TYPES: frozenset[str] = frozenset({"ping"})
+
+
+def _is_ws_enabled() -> bool:
+    """Read WebSocket feature flag at call-time.
+
+    RU: Флаг читается при каждом запросе, чтобы monkeypatch.setenv в тестах
+    работал детерминированно и без import-time freeze.
+    EN: Read feature flag on each request to keep tests deterministic and avoid
+    import-time freeze issues.
+    """
+    return os.getenv("FEATURE_WEBSOCKET_ENABLED", "false").lower() == "true"
+
+
+@dataclass(frozen=True)
+class WsPolicy:
+    """Immutable policy for WebSocket guardrails."""
+
+    max_message_bytes: int = DEFAULT_MAX_MESSAGE_BYTES
+    window_seconds: int = DEFAULT_WINDOW_SECONDS
+    max_messages_per_window: int = DEFAULT_MAX_MESSAGES_PER_WINDOW
+    allowed_event_types: frozenset[str] = field(default_factory=lambda: ALLOWED_EVENT_TYPES)
+
+
+def _policy_from_env() -> WsPolicy:
+    """Load policy from env at call-time."""
+
+    def _get_positive_int(name: str, default: int) -> int:
+        raw = os.getenv(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            return default
+        return value if value > 0 else default
+
+    return WsPolicy(
+        max_message_bytes=_get_positive_int("WS_MAX_MESSAGE_BYTES", DEFAULT_MAX_MESSAGE_BYTES),
+        window_seconds=_get_positive_int("WS_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS),
+        max_messages_per_window=_get_positive_int(
+            "WS_MAX_MESSAGES_PER_WINDOW", DEFAULT_MAX_MESSAGES_PER_WINDOW
+        ),
+        allowed_event_types=ALLOWED_EVENT_TYPES,
+    )
+
+
+class TokenVerifier(Protocol):
+    """Callable protocol for token/API-key verification."""
+
+    def __call__(self, token: str) -> object: ...
+
+
+def _get_token_verifier() -> TokenVerifier:
+    """Wire canonical PRO auth verifier via existing api_tiers stack.
+
+    RU: Явно маппим HTTPException в PermissionError, чтобы websocket auth
+    оставался единообразно fail-closed.
+    EN: Explicitly map HTTPException to PermissionError to keep websocket auth
+    behavior uniformly fail-closed.
+    """
+    from app.middleware.api_tiers import require_pro_tier
+
+    def _verify(token: str) -> object:
+        try:
+            return require_pro_tier(token)
+        except HTTPException as exc:
+            raise PermissionError("auth_invalid") from exc
+        except Exception as exc:
+            raise PermissionError("auth_invalid") from exc
+
+    return _verify
+
+
+def _extract_bearer_token(ws: WebSocket) -> str | None:
+    """Extract token from Authorization header or query parameter."""
+    auth = ws.headers.get("authorization", "")
+    parts = auth.split()
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        token = parts[1].strip()
+        if token:
+            return token
+
+    token = ws.query_params.get("token", "").strip()
+    return token if token else None
+
+
+async def _authenticate_or_close(ws: WebSocket) -> bool:
+    """Authenticate websocket and close with policy code on failure."""
+    token = _extract_bearer_token(ws)
+    if not token:
+        await ws.close(code=1008, reason="auth_required")
+        return False
+
+    try:
+        verifier = _get_token_verifier()
+        verifier(token)
+        return True
+    except Exception:
+        await ws.close(code=1008, reason="auth_invalid")
+        return False
+
+
+class _BurstLimiter:
+    """Per-connection sliding-window limiter."""
+
+    def __init__(
+        self,
+        window_seconds: int,
+        max_events: int,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._window = window_seconds
+        self._max = max_events
+        self._clock = clock
+        self._events: deque[float] = deque()
+
+    def allow(self) -> bool:
+        now = self._clock()
+        cutoff = now - self._window
+
+        while self._events and self._events[0] < cutoff:
+            self._events.popleft()
+
+        if len(self._events) >= self._max:
+            return False
+
+        self._events.append(now)
+        return True
+
+
+def _is_within_size_limit(text: str, max_bytes: int) -> bool:
+    return len(text.encode("utf-8")) <= max_bytes
+
+
+def _parse_message(text: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+@router.websocket("/ws")
+async def ws_root(ws: WebSocket) -> None:
+    """Secure and deterministic WebSocket endpoint."""
+    await ws.accept()
+
+    if not _is_ws_enabled():
+        await ws.close(code=1008, reason="ws_disabled")
+        return
+
+    if not await _authenticate_or_close(ws):
+        return
+
+    policy = _policy_from_env()
+    limiter = _BurstLimiter(
+        window_seconds=policy.window_seconds,
+        max_events=policy.max_messages_per_window,
+    )
+
+    try:
+        while True:
+            text = await ws.receive_text()
+
+            if not _is_within_size_limit(text, policy.max_message_bytes):
+                await ws.close(code=1008, reason="payload_too_large")
+                return
+
+            if not limiter.allow():
+                await ws.close(code=1008, reason="rate_limited")
+                return
+
+            message = _parse_message(text)
+            if message is None:
+                await ws.close(code=1008, reason="invalid_json")
+                return
+
+            message_type = message.get("type")
+            if not isinstance(message_type, str) or message_type not in policy.allowed_event_types:
+                await ws.close(code=1008, reason="event_type_not_allowed")
+                return
+
+            if message_type == "ping":
+                await ws.send_text(json.dumps({"type": "pong"}))
+                continue
+
+            await ws.close(code=1008, reason="handler_not_implemented")
+            return
+    except WebSocketDisconnect:
+        return

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -82,6 +82,8 @@ def _get_token_verifier() -> TokenVerifier:
         try:
             return require_pro_tier(token)
         except HTTPException as exc:
+            if exc.status_code in (401, 403):
+                raise PermissionError("auth_invalid") from exc
             raise PermissionError("auth_invalid") from exc
         except Exception as exc:
             raise PermissionError("auth_invalid") from exc
@@ -99,7 +101,7 @@ def _extract_bearer_token(ws: WebSocket) -> str | None:
             return token
 
     token = ws.query_params.get("token", "").strip()
-    return token if token else None
+    return token or None
 
 
 async def _authenticate_or_close(ws: WebSocket) -> bool:
@@ -201,8 +203,5 @@ async def ws_root(ws: WebSocket) -> None:
             if message_type == "ping":
                 await ws.send_text(json.dumps({"type": "pong"}))
                 continue
-
-            await ws.close(code=1008, reason="handler_not_implemented")
-            return
     except WebSocketDisconnect:
         return

--- a/docs/audit/PR_XXX_WEBSOCKET_FOUNDATION_AUDIT.md
+++ b/docs/audit/PR_XXX_WEBSOCKET_FOUNDATION_AUDIT.md
@@ -1,0 +1,106 @@
+# PR-P1: WebSocket Foundation Audit
+
+**Status:** Pre-merge evidence checklist
+**Branch:** `feat/p1-secure-websocket-foundation`
+**Date:** 2026-02-16
+
+---
+
+## Scope
+
+### IN
+
+- Runtime WebSocket endpoint `/ws` with mandatory auth.
+- Server-side guardrails: rate limit, message size limit, event allowlist.
+- Deterministic tests: auth reject/accept, rate limit, size limit, event allowlist.
+- Audit evidence and DoD checklist.
+
+### OUT
+
+- Frontend and iOS integration.
+- Business event expansion beyond `ping -> pong`.
+- Legacy app broad refactors.
+- Bayesian/CBT/RAG feature expansion.
+
+---
+
+## Architectural Invariants
+
+| INV | Rule | Evidence anchor |
+|-----|------|-----------------|
+| INV-1 | Route registration is unconditional; feature flag checked at request time | `app/main.py:40`, `app/routers/realtime_ws.py:153` |
+| INV-2 | `ws.accept()` runs before any `ws.close()` branch | `app/routers/realtime_ws.py:151` |
+| INV-3 | Verifier is not a WS handler argument | `app/routers/realtime_ws.py:150` |
+| INV-4 | WebSocket env values are read call-time (no import freeze) | `app/routers/realtime_ws.py:22`, `app/routers/realtime_ws.py:43` |
+| INV-5 | `_BurstLimiter` supports injectable clock for deterministic tests | `app/routers/realtime_ws.py:114` |
+
+---
+
+## Contract
+
+### Endpoint
+
+`GET /ws` (WebSocket upgrade)
+
+### Auth
+
+- `Authorization: Bearer <token>` preferred.
+- `?token=<value>` fallback.
+- Missing token -> close `1008` with `auth_required`.
+- Invalid token -> close `1008` with `auth_invalid`.
+
+### Message format
+
+```json
+{"type":"<event_type>","payload":{}}
+```
+
+### Allowed events (v1)
+
+- `ping` -> `{"type":"pong"}`
+
+### Close codes
+
+| Code | Reason | Trigger |
+|------|--------|---------|
+| 1008 | `ws_disabled` | `FEATURE_WEBSOCKET_ENABLED != true` |
+| 1008 | `auth_required` | token missing |
+| 1008 | `auth_invalid` | verifier rejected token |
+| 1008 | `payload_too_large` | message bytes > policy limit |
+| 1008 | `rate_limited` | burst over policy window |
+| 1008 | `invalid_json` | non-JSON or non-object message |
+| 1008 | `event_type_not_allowed` | event type not on allowlist |
+
+### Policy defaults
+
+| Variable | Default |
+|----------|---------|
+| `FEATURE_WEBSOCKET_ENABLED` | `false` |
+| `WS_MAX_MESSAGE_BYTES` | `4096` |
+| `WS_WINDOW_SECONDS` | `10` |
+| `WS_MAX_MESSAGES_PER_WINDOW` | `20` |
+
+---
+
+## Evidence Commands
+
+```bash
+pytest -q tests/test_websocket_burst_limiter_unit.py -v
+pytest -q tests/test_websocket_security_api.py -v
+rg -n 'websocket\("/ws"\)|\.websocket\("/ws"\)' app tests
+rg -n 'FEATURE_WEBSOCKET_ENABLED|WS_MAX_MESSAGE_BYTES|WS_WINDOW_SECONDS|WS_MAX_MESSAGES_PER_WINDOW' app/routers/realtime_ws.py
+pre-commit run --all-files
+make verify
+```
+
+---
+
+## DoD Checklist
+
+- [ ] `/ws` endpoint exists and is authenticated.
+- [ ] Unauthenticated access is fail-closed.
+- [ ] Deterministic limiter tests pass.
+- [ ] Deterministic websocket security tests pass.
+- [ ] No runtime scope expansion beyond `/ws` foundation.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] `make verify` passes.

--- a/docs/audit/PR_XXX_WEBSOCKET_FOUNDATION_AUDIT.md
+++ b/docs/audit/PR_XXX_WEBSOCKET_FOUNDATION_AUDIT.md
@@ -1,5 +1,7 @@
 # PR-P1: WebSocket Foundation Audit
 
+<!-- markdownlint-disable MD013 -->
+
 **Status:** Pre-merge evidence checklist
 **Branch:** `feat/p1-secure-websocket-foundation`
 **Date:** 2026-02-16
@@ -27,7 +29,7 @@
 ## Architectural Invariants
 
 | INV | Rule | Evidence anchor |
-|-----|------|-----------------|
+| ----- | ------ | ----------------- |
 | INV-1 | Route registration is unconditional; feature flag checked at request time | `app/main.py:40`, `app/routers/realtime_ws.py:153` |
 | INV-2 | `ws.accept()` runs before any `ws.close()` branch | `app/routers/realtime_ws.py:151` |
 | INV-3 | Verifier is not a WS handler argument | `app/routers/realtime_ws.py:150` |
@@ -62,7 +64,7 @@
 ### Close codes
 
 | Code | Reason | Trigger |
-|------|--------|---------|
+| ------ | -------- | --------- |
 | 1008 | `ws_disabled` | `FEATURE_WEBSOCKET_ENABLED != true` |
 | 1008 | `auth_required` | token missing |
 | 1008 | `auth_invalid` | verifier rejected token |
@@ -74,7 +76,7 @@
 ### Policy defaults
 
 | Variable | Default |
-|----------|---------|
+| ---------- | --------- |
 | `FEATURE_WEBSOCKET_ENABLED` | `false` |
 | `WS_MAX_MESSAGE_BYTES` | `4096` |
 | `WS_WINDOW_SECONDS` | `10` |

--- a/tests/test_main_ws_registration_guard.py
+++ b/tests/test_main_ws_registration_guard.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_ws_duplicate_registration_guard_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Duplicate /ws path must fail fast to prevent silent route shadowing."""
+    import app.main as main_module
+
+    fake_app = SimpleNamespace(
+        routes=[
+            SimpleNamespace(path="/health"),
+            SimpleNamespace(path="/ws"),
+        ]
+    )
+    monkeypatch.setattr(main_module, "app", fake_app)
+    guard = getattr(main_module, "_assert_no_duplicate_ws_route")
+
+    with pytest.raises(RuntimeError, match="Duplicate /ws route detected"):
+        guard()

--- a/tests/test_main_ws_registration_guard.py
+++ b/tests/test_main_ws_registration_guard.py
@@ -20,3 +20,20 @@ def test_ws_duplicate_registration_guard_raises(monkeypatch: pytest.MonkeyPatch)
 
     with pytest.raises(RuntimeError, match="Duplicate /ws route detected"):
         guard()
+
+
+def test_ws_duplicate_registration_guard_passes_without_ws_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.main as main_module
+
+    fake_app = SimpleNamespace(
+        routes=[
+            SimpleNamespace(path="/health"),
+            SimpleNamespace(path="/metrics"),
+        ]
+    )
+    monkeypatch.setattr(main_module, "app", fake_app)
+    guard = getattr(main_module, "_assert_no_duplicate_ws_route")
+
+    guard()

--- a/tests/test_websocket_burst_limiter_unit.py
+++ b/tests/test_websocket_burst_limiter_unit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from app.routers.realtime_ws import _BurstLimiter
+
+
+def test_limiter_allows_up_to_max_then_denies() -> None:
+    """Exactly max_events are allowed; next event is denied."""
+    t = 0.0
+    limiter = _BurstLimiter(window_seconds=10, max_events=3, clock=lambda: t)
+
+    assert limiter.allow() is True
+    assert limiter.allow() is True
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+
+def test_limiter_resets_after_full_window_passes() -> None:
+    """Limiter allows events again after full-window eviction."""
+    t = 0.0
+    limiter = _BurstLimiter(window_seconds=10, max_events=2, clock=lambda: t)
+
+    assert limiter.allow() is True
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+    t = 100.0
+    assert limiter.allow() is True
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+
+def test_limiter_sliding_window_not_tumbling() -> None:
+    """Sliding window evicts old events individually."""
+    t = 0.0
+    limiter = _BurstLimiter(window_seconds=10, max_events=2, clock=lambda: t)
+
+    assert limiter.allow() is True
+    t = 5.0
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+    t = 11.0
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+
+def test_limiter_single_event_max() -> None:
+    """Single-slot limiter denies until event leaves window."""
+    t = 0.0
+    limiter = _BurstLimiter(window_seconds=10, max_events=1, clock=lambda: t)
+
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+    t = 10.5
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+
+def test_limiter_events_expire_exactly_at_boundary() -> None:
+    """Boundary behavior must be deterministic around cutoff."""
+    t = 0.0
+    limiter = _BurstLimiter(window_seconds=10, max_events=1, clock=lambda: t)
+
+    assert limiter.allow() is True
+    t = 10.0
+    assert limiter.allow() is False
+
+    t = 10.001
+    assert limiter.allow() is True
+
+
+def test_limiter_instances_are_independent() -> None:
+    """Separate websocket connections must not share limiter state."""
+    t = 0.0
+    clock = lambda: t  # noqa: E731
+    limiter_a = _BurstLimiter(window_seconds=10, max_events=2, clock=clock)
+    limiter_b = _BurstLimiter(window_seconds=10, max_events=2, clock=clock)
+
+    assert limiter_a.allow() is True
+    assert limiter_a.allow() is True
+    assert limiter_a.allow() is False
+
+    assert limiter_b.allow() is True
+    assert limiter_b.allow() is True
+    assert limiter_b.allow() is False

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import pytest
 from fastapi import FastAPI
@@ -142,7 +142,7 @@ def test_ws_accepts_token_via_query_param_and_responds_pong(
 def test_ws_maps_require_pro_tier_exceptions_to_auth_invalid(
     ws_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
-    exception_factory,
+    exception_factory: Callable[[], BaseException],
 ) -> None:
     def _raise(_token: str) -> object:
         raise exception_factory()

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.routers import realtime_ws
+
+
+def _accept_stub(token: str) -> object:
+    return {"sub": "ws-user", "token": token}
+
+
+def _deny_stub(token: str) -> object:
+    raise PermissionError(f"denied token={token!r}")
+
+
+@pytest.fixture()
+def ws_client(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Client configured for deterministic websocket policy tests."""
+    monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "true")
+    monkeypatch.setenv("WS_WINDOW_SECONDS", "9999")
+    monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "3")
+    monkeypatch.setenv("WS_MAX_MESSAGE_BYTES", "128")
+    return TestClient(app)
+
+
+def test_ws_disabled_returns_1008(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "false")
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws") as ws:
+            with pytest.raises(WebSocketDisconnect) as exc:
+                ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_missing_token(ws_client: TestClient) -> None:
+    with ws_client.websocket_connect("/ws") as ws:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_invalid_token(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _deny_stub)
+    with ws_client.websocket_connect(
+        "/ws", headers={"Authorization": "Bearer invalid-token"}
+    ) as ws:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_accepts_valid_token_and_responds_pong(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"type": "ping"}))
+        response = json.loads(ws.receive_text())
+    assert response == {"type": "pong"}
+
+
+def test_ws_rejects_oversized_payload(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text("x" * 500)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rate_limit_closes_after_burst(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    limit = 3
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        for _ in range(limit):
+            ws.send_text(json.dumps({"type": "ping"}))
+            assert json.loads(ws.receive_text()) == {"type": "pong"}
+
+        ws.send_text(json.dumps({"type": "ping"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_unknown_event_type(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"type": "subscribe", "channel": "bmi"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_non_json_message(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text("not-json")
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_json_array_message(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps(["ping"]))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from fastapi import FastAPI
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -26,6 +27,54 @@ def ws_client(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "3")
     monkeypatch.setenv("WS_MAX_MESSAGE_BYTES", "128")
     return TestClient(app)
+
+
+def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WS_MAX_MESSAGE_BYTES", raising=False)
+    monkeypatch.setenv("WS_WINDOW_SECONDS", "not-an-int")
+    monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "0")
+
+    policy = realtime_ws._policy_from_env()
+
+    assert policy.max_message_bytes == realtime_ws.DEFAULT_MAX_MESSAGE_BYTES
+    assert policy.window_seconds == realtime_ws.DEFAULT_WINDOW_SECONDS
+    assert policy.max_messages_per_window == realtime_ws.DEFAULT_MAX_MESSAGES_PER_WINDOW
+
+
+def test_token_verifier_accepts_valid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _require_pro_tier_stub(token: str) -> object:
+        return {"token": token}
+
+    monkeypatch.setattr("app.middleware.api_tiers.require_pro_tier", _require_pro_tier_stub)
+    verifier = realtime_ws._get_token_verifier()
+    result = verifier("valid-token")
+    assert result == {"token": "valid-token"}
+
+
+def test_token_verifier_maps_http_exception_to_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_http_exception(_token: str) -> object:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    monkeypatch.setattr("app.middleware.api_tiers.require_pro_tier", _raise_http_exception)
+    verifier = realtime_ws._get_token_verifier()
+    with pytest.raises(PermissionError, match="auth_invalid"):
+        verifier("bad-token")
+
+
+def test_token_verifier_maps_unexpected_exception_to_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_unexpected(_token: str) -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.middleware.api_tiers.require_pro_tier", _raise_unexpected)
+    verifier = realtime_ws._get_token_verifier()
+    with pytest.raises(PermissionError, match="auth_invalid"):
+        verifier("bad-token")
 
 
 def test_ws_disabled_returns_1008(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 
 import pytest
 from fastapi import FastAPI
@@ -20,13 +21,14 @@ def _deny_stub(token: str) -> object:
 
 
 @pytest.fixture()
-def ws_client(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def ws_client(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Client configured for deterministic websocket policy tests."""
     monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "true")
     monkeypatch.setenv("WS_WINDOW_SECONDS", "9999")
     monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "3")
     monkeypatch.setenv("WS_MAX_MESSAGE_BYTES", "128")
-    return TestClient(app)
+    with TestClient(app) as client:
+        yield client
 
 
 def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
@@ -117,6 +119,41 @@ def test_ws_accepts_valid_token_and_responds_pong(
     assert response == {"type": "pong"}
 
 
+def test_ws_accepts_token_via_query_param_and_responds_pong(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.middleware.api_tiers.require_pro_tier", lambda _token: {"sub": "ws-user"}
+    )
+    with ws_client.websocket_connect("/ws?token=valid-token") as ws:
+        ws.send_text(json.dumps({"type": "ping"}))
+        response = json.loads(ws.receive_text())
+    assert response == {"type": "pong"}
+
+
+@pytest.mark.parametrize(
+    "exception_factory",
+    [
+        lambda: HTTPException(status_code=403, detail="forbidden"),
+        lambda: Exception("boom"),
+    ],
+)
+def test_ws_maps_require_pro_tier_exceptions_to_auth_invalid(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_factory,
+) -> None:
+    def _raise(_token: str) -> object:
+        raise exception_factory()
+
+    monkeypatch.setattr("app.middleware.api_tiers.require_pro_tier", _raise)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer some-token"}) as ws:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
 def test_ws_rejects_oversized_payload(
     ws_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -177,6 +214,18 @@ def test_ws_rejects_json_array_message(
     monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
     with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
         ws.send_text(json.dumps(["ping"]))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_binary_frame_with_policy_close(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_bytes(b"\x00\x01\x02")
         with pytest.raises(WebSocketDisconnect) as exc:
             ws.receive_text()
     assert exc.value.code == 1008


### PR DESCRIPTION
## Summary
- Add secure `/ws` websocket foundation with call-time feature flag and policy guardrails (size/rate/allowlist).
- Wire canonical auth through `require_pro_tier` with explicit fail-closed mapping to `auth_invalid`.
- Add deterministic websocket tests (security matrix + burst limiter + duplicate route guard) and audit evidence doc.

## Scope
### IN
- `app/main.py`
- `app/routers/realtime_ws.py`
- `tests/test_websocket_security_api.py`
- `tests/test_websocket_burst_limiter_unit.py`
- `tests/test_main_ws_registration_guard.py`
- `docs/audit/PR_XXX_WEBSOCKET_FOUNDATION_AUDIT.md`

### OUT
- Frontend/iOS integration
- Business event expansion beyond `ping -> pong`
- Legacy broad refactors
- Bayesian/CBT/RAG expansion

## Security Notes
- Feature is disabled by default (`FEATURE_WEBSOCKET_ENABLED=false`).
- Missing/invalid auth is fail-closed (`1008`, `auth_required`/`auth_invalid`).
- Unexpected verifier failures are mapped to `auth_invalid` to avoid leaking HTTP details.
- No `sys.modules` mutation patterns were introduced in tests.

## Validation
- `pytest -q tests/test_websocket_security_api.py -v`
- `pytest -q tests/test_websocket_burst_limiter_unit.py -v`
- `pytest -q tests/test_main_ws_registration_guard.py -v`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a secure, fail-closed WebSocket endpoint at /ws with per-request checks for auth, size, rate, and event allowlist. Feature is off by default; token verification runs in a threadpool; non-text frames close with 1008/text_frame_required.

- **New Features**
  - Secure /ws router with fail-closed auth (require_pro_tier); tokens via Authorization or ?token; all verifier errors map to auth_invalid.
  - Guardrails: size limit, sliding-window rate limit, event allowlist (ping -> pong); explicit close reasons for violations.
  - Call-time env reads for feature flag and policy; duplicate /ws route guard in app/main.py.
  - Tests cover policy fallback, exception mapping, query-token path, limiter, non-text frames, and registration guard; audit doc.

- **Refactors**
  - Simplified verifier exception mapping and removed unused HTTPException import.

<sup>Written for commit e3fa9c699825d3edbc3dc93e64465180794cd55f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time WebSocket endpoint with authentication, per-connection rate limiting, configurable message size limits, deterministic close reasons, and event-type validation.
  * Startup guard to prevent duplicate WebSocket route registration.

* **Documentation**
  * Added WebSocket audit/specification documenting endpoint contract, policy defaults, close semantics, and test evidence.

* **Tests**
  * Added comprehensive tests for the registration guard, auth flows, payload validation, rate limiting, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->