### PR TITLE
feat(realtime): websocket v1 expansion work-package

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -176,6 +176,21 @@ curl -fsS https://.../metrics | grep http_requests_total
   fallback). `MISS` may fallback only during migration; plan DB-authoritative follow-up.
 - Never fail-open on tier checks.
 
+## WebSocket realtime hardening (PR-783 follow-up)
+
+- Any change to `/ws` message handling MUST include deterministic tests for:
+  - one success path (e.g. `ping` -> `pong`), and
+  - one fail-closed path (e.g. malformed version / disallowed event / policy close).
+- Protocol version rules are strict:
+  - if `version` key is present and not a string -> reject (policy close),
+  - legacy fallback is allowed only for explicitly supported legacy messages.
+- Per-process active connection cap is mandatory for `/ws`:
+  - use `WS_MAX_CONNECTIONS` policy setting,
+  - reject over-cap connections fail-closed with policy close (1008),
+  - release tracker state in `finally` on every exit path.
+- WebSocket response serialization should be deterministic (`sort_keys=True` where applicable)
+  so tests and cross-runtime behavior remain stable.
+
 ### Typing rule: Pydantic v2 `model_validate()` + mypy
 
 Pydantic v2 `BaseModel.model_validate()` is typed as returning `Any` for mypy in many cases.

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -256,7 +256,14 @@ async def ws_root(ws: WebSocket) -> None:
 
             version = _resolve_message_version(message, policy)
             if version != policy.protocol_version:
-                logger.info("ws_policy_close", extra={"reason": REASON_UNSUPPORTED_VERSION})
+                logger.info(
+                    "ws_policy_close",
+                    extra={
+                        "reason": REASON_UNSUPPORTED_VERSION,
+                        "version": version,
+                        "type": message_type,
+                    },
+                )
                 await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_UNSUPPORTED_VERSION)
                 return
 

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_MESSAGE_BYTES: int = 4_096
 DEFAULT_WINDOW_SECONDS: int = 10
 DEFAULT_MAX_MESSAGES_PER_WINDOW: int = 20
+DEFAULT_MAX_CONNECTIONS: int = 200
 PROTOCOL_VERSION: str = "1"
 ALLOWED_EVENT_TYPES: frozenset[str] = frozenset({"ping", "subscribe"})
 ALLOWED_CHANNELS: frozenset[str] = frozenset({"progress"})
@@ -32,6 +34,30 @@ REASON_INVALID_JSON: str = "invalid_json"
 REASON_EVENT_TYPE_NOT_ALLOWED: str = "event_type_not_allowed"
 REASON_UNSUPPORTED_VERSION: str = "unsupported_version"
 REASON_CHANNEL_NOT_ALLOWED: str = "channel_not_allowed"
+REASON_TOO_MANY_CONNECTIONS: str = "too_many_connections"
+
+
+class _ActiveConnectionsTracker:
+    """Thread-safe counter for per-process active websocket connections."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._count = 0
+
+    def try_acquire(self, limit: int) -> bool:
+        with self._lock:
+            if self._count >= limit:
+                return False
+            self._count += 1
+            return True
+
+    def release(self) -> None:
+        with self._lock:
+            if self._count > 0:
+                self._count -= 1
+
+
+_active_connections = _ActiveConnectionsTracker()
 
 
 def _is_ws_enabled() -> bool:
@@ -52,6 +78,7 @@ class WsPolicy:
     max_message_bytes: int = DEFAULT_MAX_MESSAGE_BYTES
     window_seconds: int = DEFAULT_WINDOW_SECONDS
     max_messages_per_window: int = DEFAULT_MAX_MESSAGES_PER_WINDOW
+    max_connections: int = DEFAULT_MAX_CONNECTIONS
     protocol_version: str = PROTOCOL_VERSION
     allowed_event_types: frozenset[str] = field(default_factory=lambda: ALLOWED_EVENT_TYPES)
     allowed_channels: frozenset[str] = field(default_factory=lambda: ALLOWED_CHANNELS)
@@ -76,6 +103,7 @@ def _policy_from_env() -> WsPolicy:
         max_messages_per_window=_get_positive_int(
             "WS_MAX_MESSAGES_PER_WINDOW", DEFAULT_MAX_MESSAGES_PER_WINDOW
         ),
+        max_connections=_get_positive_int("WS_MAX_CONNECTIONS", DEFAULT_MAX_CONNECTIONS),
         protocol_version=PROTOCOL_VERSION,
         allowed_event_types=ALLOWED_EVENT_TYPES,
         allowed_channels=ALLOWED_CHANNELS,
@@ -215,6 +243,12 @@ async def ws_root(ws: WebSocket) -> None:
         return
 
     policy = _policy_from_env()
+    connection_acquired = _active_connections.try_acquire(policy.max_connections)
+    if not connection_acquired:
+        logger.info("ws_policy_close", extra={"reason": REASON_TOO_MANY_CONNECTIONS})
+        await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_TOO_MANY_CONNECTIONS)
+        return
+
     limiter = _BurstLimiter(
         window_seconds=policy.window_seconds,
         max_events=policy.max_messages_per_window,
@@ -299,3 +333,6 @@ async def ws_root(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         logger.info("ws_disconnect", extra={"reason": "client_disconnected"})
         return
+    finally:
+        if connection_acquired:
+            _active_connections.release()

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_MESSAGE_BYTES: int = 4_096
 DEFAULT_WINDOW_SECONDS: int = 10
 DEFAULT_MAX_MESSAGES_PER_WINDOW: int = 20
-ALLOWED_EVENT_TYPES: frozenset[str] = frozenset({"ping"})
+PROTOCOL_VERSION: str = "1"
+ALLOWED_EVENT_TYPES: frozenset[str] = frozenset({"ping", "subscribe"})
+ALLOWED_CHANNELS: frozenset[str] = frozenset({"progress"})
 POLICY_CLOSE_CODE: int = 1008
 REASON_WS_DISABLED: str = "ws_disabled"
 REASON_AUTH_REQUIRED: str = "auth_required"
@@ -28,6 +30,8 @@ REASON_PAYLOAD_TOO_LARGE: str = "payload_too_large"
 REASON_RATE_LIMITED: str = "rate_limited"
 REASON_INVALID_JSON: str = "invalid_json"
 REASON_EVENT_TYPE_NOT_ALLOWED: str = "event_type_not_allowed"
+REASON_UNSUPPORTED_VERSION: str = "unsupported_version"
+REASON_CHANNEL_NOT_ALLOWED: str = "channel_not_allowed"
 
 
 def _is_ws_enabled() -> bool:
@@ -48,7 +52,9 @@ class WsPolicy:
     max_message_bytes: int = DEFAULT_MAX_MESSAGE_BYTES
     window_seconds: int = DEFAULT_WINDOW_SECONDS
     max_messages_per_window: int = DEFAULT_MAX_MESSAGES_PER_WINDOW
+    protocol_version: str = PROTOCOL_VERSION
     allowed_event_types: frozenset[str] = field(default_factory=lambda: ALLOWED_EVENT_TYPES)
+    allowed_channels: frozenset[str] = field(default_factory=lambda: ALLOWED_CHANNELS)
 
 
 def _policy_from_env() -> WsPolicy:
@@ -70,7 +76,9 @@ def _policy_from_env() -> WsPolicy:
         max_messages_per_window=_get_positive_int(
             "WS_MAX_MESSAGES_PER_WINDOW", DEFAULT_MAX_MESSAGES_PER_WINDOW
         ),
+        protocol_version=PROTOCOL_VERSION,
         allowed_event_types=ALLOWED_EVENT_TYPES,
+        allowed_channels=ALLOWED_CHANNELS,
     )
 
 
@@ -170,6 +178,29 @@ def _parse_message(text: str) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _resolve_message_version(message: dict[str, Any], policy: WsPolicy) -> str | None:
+    """Resolve protocol version with backward-compatible ping handling.
+
+    RU: Для ping разрешаем отсутствие version (legacy foundation behavior),
+    но нормализуем к v1 для ответа. Для остальных событий version обязателен.
+    EN: For ping we allow missing version (legacy foundation behavior) and
+    normalize to v1. For other events, version is required.
+    """
+    raw_version = message.get("version")
+    if isinstance(raw_version, str):
+        return raw_version
+
+    message_type = message.get("type")
+    if message_type == "ping":
+        return policy.protocol_version
+    return None
+
+
+def _encode_event(event: dict[str, Any]) -> str:
+    """Serialize websocket event deterministically."""
+    return json.dumps(event, separators=(",", ":"))
+
+
 @router.websocket("/ws")
 async def ws_root(ws: WebSocket) -> None:
     """Secure and deterministic WebSocket endpoint."""
@@ -223,8 +254,40 @@ async def ws_root(ws: WebSocket) -> None:
                 await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_EVENT_TYPE_NOT_ALLOWED)
                 return
 
+            version = _resolve_message_version(message, policy)
+            if version != policy.protocol_version:
+                logger.info("ws_policy_close", extra={"reason": REASON_UNSUPPORTED_VERSION})
+                await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_UNSUPPORTED_VERSION)
+                return
+
             if message_type == "ping":
-                await ws.send_text(json.dumps({"type": "pong"}))
+                await ws.send_text(
+                    _encode_event(
+                        {
+                            "version": policy.protocol_version,
+                            "type": "pong",
+                            "server_time_ms": int(time.time() * 1000),
+                        }
+                    )
+                )
+                continue
+
+            if message_type == "subscribe":
+                channel = message.get("channel")
+                if not isinstance(channel, str) or channel not in policy.allowed_channels:
+                    logger.info("ws_policy_close", extra={"reason": REASON_CHANNEL_NOT_ALLOWED})
+                    await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_CHANNEL_NOT_ALLOWED)
+                    return
+
+                await ws.send_text(
+                    _encode_event(
+                        {
+                            "version": policy.protocol_version,
+                            "type": "subscribed",
+                            "channel": channel,
+                        }
+                    )
+                )
                 continue
     except WebSocketDisconnect:
         logger.info("ws_disconnect", extra={"reason": "client_disconnected"})

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -187,8 +187,8 @@ def _resolve_message_version(message: dict[str, Any], policy: WsPolicy) -> str |
     normalize to v1. For other events, version is required.
     """
     raw_version = message.get("version")
-    if isinstance(raw_version, str):
-        return raw_version
+    if "version" in message:
+        return raw_version if isinstance(raw_version, str) else None
 
     message_type = message.get("type")
     if message_type == "ping":
@@ -198,7 +198,7 @@ def _resolve_message_version(message: dict[str, Any], policy: WsPolicy) -> str |
 
 def _encode_event(event: dict[str, Any]) -> str:
     """Serialize websocket event deterministically."""
-    return json.dumps(event, separators=(",", ":"))
+    return json.dumps(event, separators=(",", ":"), sort_keys=True)
 
 
 @router.websocket("/ws")

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -239,9 +239,6 @@ async def ws_root(ws: WebSocket) -> None:
         await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_WS_DISABLED)
         return
 
-    if not await _authenticate_or_close(ws):
-        return
-
     policy = _policy_from_env()
     connection_acquired = _active_connections.try_acquire(policy.max_connections)
     if not connection_acquired:
@@ -249,12 +246,15 @@ async def ws_root(ws: WebSocket) -> None:
         await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_TOO_MANY_CONNECTIONS)
         return
 
-    limiter = _BurstLimiter(
-        window_seconds=policy.window_seconds,
-        max_events=policy.max_messages_per_window,
-    )
-
     try:
+        if not await _authenticate_or_close(ws):
+            return
+
+        limiter = _BurstLimiter(
+            window_seconds=policy.window_seconds,
+            max_events=policy.max_messages_per_window,
+        )
+
         while True:
             frame = await ws.receive()
             if frame.get("type") == "websocket.disconnect":

--- a/docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md
+++ b/docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md
@@ -1,0 +1,113 @@
+# PR-P1: WebSocket Realtime Expansion Audit
+
+<!-- markdownlint-disable MD013 -->
+
+**Status:** In progress (runtime work-package)
+**Branch:** `feat/websocket-realtime-expansion`
+**Date:** 2026-02-16
+
+---
+
+## Scope
+
+### IN
+
+- Versioned WebSocket event contract on canonical `/ws`.
+- Controlled expansion from `ping`-only to `ping + subscribe(progress)`.
+- Deterministic policy closes for unsupported protocol version and unknown channel.
+- Thin frontend adapter for WebSocket transport only (`src/api/wsClient.ts`).
+- Frontend guard extension to keep raw `new WebSocket(...)` creation isolated to adapter.
+- Deterministic backend/frontend tests for the expanded contract.
+
+### OUT
+
+- iOS WebSocket consumer wiring.
+- Multi-room fan-out, broker/pub-sub, or distributed delivery guarantees.
+- CV/media streaming and sensor calibration logic.
+- AI/RAG streaming over WebSocket transport.
+
+---
+
+## Architectural Invariants
+
+| INV | Rule | Evidence anchor |
+| ----- | ------ | ----------------- |
+| INV-1 | `/ws` remains the canonical endpoint in router layer | `app/routers/realtime_ws.py:204` |
+| INV-2 | Request-time feature flag and policy loading remain deterministic | `app/routers/realtime_ws.py:33`, `app/routers/realtime_ws.py:58`, `app/routers/realtime_ws.py:69` |
+| INV-3 | Versioned contract is explicit (`PROTOCOL_VERSION="1"`) | `app/routers/realtime_ws.py:21`, `app/routers/realtime_ws.py:55`, `app/routers/realtime_ws.py:257` |
+| INV-4 | Allowed event surface is explicit and small (`ping`, `subscribe`) | `app/routers/realtime_ws.py:22`, `app/routers/realtime_ws.py:275` |
+| INV-5 | Allowed channels are explicit and constrained (`progress`) | `app/routers/realtime_ws.py:23`, `app/routers/realtime_ws.py:278` |
+| INV-6 | Frontend keeps transport-only thin adapter boundary for WS creation | `frontend/src/api/wsClient.ts:35`, `frontend/src/api/__tests__/thin-client-guards.test.ts:307` |
+
+---
+
+## Contract Delta (Foundation -> Expansion)
+
+### Endpoint
+
+`GET /ws` (WebSocket upgrade), unchanged as canonical transport endpoint.
+
+Evidence: `app/routers/realtime_ws.py:204`
+
+### Incoming event contract (v1)
+
+```json
+{"version":"1","type":"ping"}
+{"version":"1","type":"subscribe","channel":"progress"}
+```
+
+Legacy compatibility: `{"type":"ping"}` remains accepted and normalized to v1 response.
+
+Evidence: `app/routers/realtime_ws.py:181`, `app/routers/realtime_ws.py:194`, `app/routers/realtime_ws.py:263`, `tests/test_websocket_security_api.py:139`
+
+### Outgoing event contract (v1)
+
+```json
+{"version":"1","type":"pong","server_time_ms":1700000000000}
+{"version":"1","type":"subscribed","channel":"progress"}
+```
+
+Evidence: `app/routers/realtime_ws.py:267`, `app/routers/realtime_ws.py:287`, `tests/test_websocket_security_api.py:218`
+
+### New policy close reasons (1008)
+
+| Code | Reason | Trigger | Evidence |
+| ------ | -------- | --------- | ---------- |
+| 1008 | `unsupported_version` | message `version != "1"` or missing for non-legacy event | `app/routers/realtime_ws.py:259-261`, `tests/test_websocket_security_api.py:241` |
+| 1008 | `channel_not_allowed` | `subscribe` with unsupported channel | `app/routers/realtime_ws.py:278-280`, `tests/test_websocket_security_api.py:253` |
+
+---
+
+## Thin Adapter Evidence (Frontend)
+
+- Transport URL builder and socket creation are centralized in one adapter file.
+- Adapter exposes connection state callbacks and message parsing only (no business logic).
+- Guard test enforces policy that raw socket creation stays in the adapter file.
+
+Evidence: `frontend/src/api/wsClient.ts:26`, `frontend/src/api/wsClient.ts:35`, `frontend/src/api/__tests__/thin-client-guards.test.ts:176`, `frontend/src/api/__tests__/thin-client-guards.test.ts:307`
+
+---
+
+## Evidence Commands
+
+```bash
+pytest -q tests/test_websocket_burst_limiter_unit.py -v
+pytest -q tests/test_websocket_security_api.py -v
+cd frontend && npm test -- --run src/api/__tests__/wsClient.test.ts src/api/__tests__/thin-client-guards.test.ts
+rg -n "PROTOCOL_VERSION|ALLOWED_EVENT_TYPES|ALLOWED_CHANNELS|unsupported_version|channel_not_allowed|@router.websocket\\(\"/ws\"\\)" app/routers/realtime_ws.py
+rg -n "buildRealtimeWsUrl|connectRealtimeWs|new WebSocket" frontend/src/api/wsClient.ts frontend/src/api/__tests__/thin-client-guards.test.ts
+pre-commit run --all-files
+make verify
+```
+
+---
+
+## DoD Checklist
+
+- [ ] Versioned v1 contract implemented and tested (`ping`, `subscribe`).
+- [ ] Unsupported version and unknown channel are fail-closed with deterministic `1008`.
+- [ ] Legacy `ping` compatibility remains stable.
+- [ ] Frontend WebSocket adapter exists and remains thin.
+- [ ] Frontend guard enforces single socket-construction boundary.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] `make verify` passes.

--- a/docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md
+++ b/docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md
@@ -1,0 +1,113 @@
+# PR-P1: WebSocket Realtime Expansion Work-Package Plan
+
+<!-- markdownlint-disable MD013 -->
+
+**Status:** Planned and executing in one runtime PR
+**Branch:** `feat/websocket-realtime-expansion`
+**Date:** 2026-02-16
+
+---
+
+## Scope
+
+### IN
+
+- Expand `/ws` from foundation heartbeat to a small versioned realtime package.
+- Add explicit protocol version handling (`v1`) and policy close on unsupported versions.
+- Add `subscribe(progress)` event with explicit channel allowlist.
+- Keep auth/rate-limit/message-size fail-closed behavior from foundation.
+- Add frontend thin WebSocket adapter (`wsClient`) for transport-only integration scope.
+- Add deterministic backend and frontend tests; keep guard policies intact.
+
+### OUT
+
+- iOS consumer integration.
+- Multi-channel broker/fan-out architecture.
+- AI/RAG/CBT payload streaming and uncertainty policy wiring.
+- CV/image streaming, sensor calibration, and advanced telemetry rollout.
+
+---
+
+## Implementation Plan
+
+### Phase 1 - Backend protocol expansion
+
+1. Introduce protocol constants and policy fields:
+   - `PROTOCOL_VERSION`
+   - `ALLOWED_EVENT_TYPES` (`ping`, `subscribe`)
+   - `ALLOWED_CHANNELS` (`progress`)
+2. Add message version resolver:
+   - Require `version=="1"` for expanded events.
+   - Preserve legacy `ping` compatibility for smooth transition.
+3. Add event handlers:
+   - `ping` -> `pong` with `server_time_ms`
+   - `subscribe(progress)` -> `subscribed(progress)`
+4. Add deterministic close branches:
+   - `unsupported_version`
+   - `channel_not_allowed`
+
+### Phase 2 - Frontend thin adapter scope
+
+1. Create `frontend/src/api/wsClient.ts` transport adapter:
+   - URL builder (http->ws / https->wss)
+   - central socket creation
+   - optional callbacks for state and parsed messages
+2. Keep adapter transport-only:
+   - no BMI/risk/business logic
+   - no domain interpretation
+
+### Phase 3 - Guard and tests
+
+1. Backend tests (`tests/test_websocket_security_api.py`):
+   - `subscribe(progress)` happy path
+   - unsupported version reject
+   - unknown channel reject
+   - legacy ping compatibility
+2. Frontend tests (`frontend/src/api/__tests__/wsClient.test.ts`):
+   - URL conversion and token query behavior
+   - state transitions and message parsing
+3. Thin guard extension:
+   - prevent raw `new WebSocket(...)` outside adapter
+
+---
+
+## Deterministic Test Plan
+
+```bash
+pytest -q tests/test_websocket_burst_limiter_unit.py
+pytest -q tests/test_websocket_security_api.py
+cd frontend && npm test -- --run src/api/__tests__/wsClient.test.ts src/api/__tests__/thin-client-guards.test.ts
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+make verify
+```
+
+Determinism notes:
+
+- No sleeps for realtime assertions.
+- Stable event payload assertions for response type/version/channel.
+- `server_time_ms` validated as type (`int`), not exact wall-clock value.
+
+---
+
+## Risks and Mitigations
+
+- **Risk:** Contract break for existing simple ping clients.
+  **Mitigation:** Legacy `{"type":"ping"}` accepted and normalized to `v1` response.
+
+- **Risk:** Scope creep into heavy realtime features.
+  **Mitigation:** Strict allowlist (`progress` only), explicit OUT scope, no broker/pub-sub.
+
+- **Risk:** Thin-adapter drift on frontend.
+  **Mitigation:** Add guard to enforce socket creation only in `api/wsClient.ts`.
+
+---
+
+## Definition of Done
+
+- `/ws` supports versioned v1 messages for `ping` and `subscribe(progress)`.
+- Unsupported protocol versions and unknown channels are rejected deterministically.
+- Frontend has one transport-only WS adapter with tests.
+- Thin-client guard remains green with new websocket boundary checks.
+- Audit is updated with file:line evidence anchors.
+- `pre-commit run --all-files` and `make verify` pass.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -500,14 +500,16 @@ If it is not recorded here — it does not exist.
 - [ ] P1: WebSocket foundation follow-up (realtime expansion package)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-WS-EXPANSION (placeholder)
-  - Status: Planned
+  - Target PR: PR-WS-REALTIME-EXPANSION (in progress)
+  - Status: In progress (`feat/websocket-realtime-expansion`)
   - Area: backend / realtime / contracts
   - Finding Type: scope control / deferred enhancement
   - Reason: Current work-package intentionally delivers only secure websocket foundation (`/ws`, auth, limits, `ping -> pong`). Any expansion beyond foundation (event catalog, client consumers, rooms/fan-out) is deferred to avoid scope creep.
   - Links:
     - `docs/audit/PR_778_WEBSOCKET_FOUNDATION_AUDIT.md`
     - `docs/plan/PR_778_WEBSOCKET_FOUNDATION_PLAN.md`
+    - `docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md`
+    - `docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md`
   - DoD:
     - Define versioned event contract for realtime payloads
     - Add client integration scope (web/iOS) without violating thin-adapter policy

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -50,6 +50,17 @@ npm run build
 
 ---
 
+## Realtime WebSocket adapter policy
+
+- Raw `WebSocket(...)` construction is allowed only in `src/api/wsClient.ts`.
+- `src/api/__tests__/thin-client-guards.test.ts` must enforce this restriction and stay green.
+- Incoming realtime payloads MUST be minimally validated at runtime in adapter layer
+  before forwarding to UI callbacks (at least protocol `version` and event `type`).
+- WebSocket state and message callbacks in adapter code should use explicit function type
+  signatures to keep TypeScript guardrails clear in review and CI.
+
+---
+
 ## Contracts & Types policy (OpenAPI)
 
 **Canonical source:** See root `AGENTS.md` section "OpenAPI generation (determinism requirement)" for full policy.

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -306,7 +306,8 @@ describe('ThinClientGuards', () => {
 
   it('should create WebSocket connections only in api/wsClient.ts', () => {
     const violations: Array<{ file: string; line: number; content: string }> = [];
-    const websocketCtorPattern = /\bnew\s+WebSocket\s*\(/;
+    // Detect direct WebSocket usage forms to keep a single thin adapter boundary.
+    const websocketCtorPattern = /(?:\bnew\s+)?(?:window\.|globalThis\.)?WebSocket\s*\(/;
 
     for (const file of sourceFiles) {
       if (isAllowedWebSocketFile(file.relativePath)) {

--- a/frontend/src/api/__tests__/thin-client-guards.test.ts
+++ b/frontend/src/api/__tests__/thin-client-guards.test.ts
@@ -173,6 +173,11 @@ function isAllowedFetchFile(relativePath: string): boolean {
   return normalized === 'api/client.ts' || normalized.endsWith('/api/client.ts');
 }
 
+function isAllowedWebSocketFile(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, '/');
+  return normalized === 'api/wsClient.ts' || normalized.endsWith('/api/wsClient.ts');
+}
+
 describe('ThinClientGuards', () => {
   const srcDir = path.resolve(__dirname, '../..');
 
@@ -293,6 +298,58 @@ describe('ThinClientGuards', () => {
           `${report}\n\n` +
           `All HTTP calls must go through api() from src/api/client.ts.\n` +
           `Direct fetch() calls violate the thin client policy.`
+      );
+    }
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should create WebSocket connections only in api/wsClient.ts', () => {
+    const violations: Array<{ file: string; line: number; content: string }> = [];
+    const websocketCtorPattern = /\bnew\s+WebSocket\s*\(/;
+
+    for (const file of sourceFiles) {
+      if (isAllowedWebSocketFile(file.relativePath)) {
+        continue;
+      }
+
+      let inBlockComment = false;
+
+      for (let i = 0; i < file.lines.length; i++) {
+        const line = file.lines[i];
+        const commentCheck = isLineInComment(line, inBlockComment);
+        inBlockComment = commentCheck.newBlockCommentState;
+
+        if (commentCheck.skip) {
+          continue;
+        }
+
+        const candidate = stripInlineComments(line);
+        if (!candidate.trim()) {
+          continue;
+        }
+
+        if (websocketCtorPattern.test(candidate)) {
+          violations.push({
+            file: file.relativePath,
+            line: i + 1,
+            content: line.trim().substring(0, 100),
+          });
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const report = violations
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.content}`)
+        .join('\n');
+
+      expect.fail(
+        `Direct WebSocket usage detected!\n\n` +
+          `Found ${violations.length} violation(s):\n\n` +
+          `${report}\n\n` +
+          `WebSocket connections must be created only in src/api/wsClient.ts.\n` +
+          `Components/hooks should consume thin adapter abstractions only.`
       );
     }
 

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -95,4 +95,29 @@ describe("wsClient", () => {
 
     expect(states).toEqual(["connecting", "error"]);
   });
+
+  it("connectRealtimeWs emits error state for invalid envelope shape", () => {
+    setApiClientDependencies({
+      getStoredApiKey: () => null,
+      clearStoredApiKey: () => undefined,
+      apiBase: "http://localhost:8000/api/v1",
+    });
+
+    const states: WsConnectionState[] = [];
+    const fakeSocket = {
+      onopen: null as (() => void) | null,
+      onclose: null as (() => void) | null,
+      onerror: null as (() => void) | null,
+      onmessage: null as ((event: { data: string }) => void) | null,
+    };
+
+    vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
+
+    connectRealtimeWs({
+      onStateChange: (state) => states.push(state),
+    });
+    fakeSocket.onmessage?.({ data: '{"type":"pong"}' });
+
+    expect(states).toEqual(["connecting", "error"]);
+  });
 });

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -97,7 +97,10 @@ describe("wsClient", (): void => {
       onmessage: null as ((event: { data: string }) => void) | null,
     };
 
-    vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
+    vi.stubGlobal(
+      "WebSocket",
+      vi.fn((_: string): MockWebSocketHandlers => fakeSocket) as unknown as typeof WebSocket,
+    );
 
     connectRealtimeWs({
       onStateChange: (state: WsConnectionState): void => states.push(state),
@@ -123,7 +126,10 @@ describe("wsClient", (): void => {
       onmessage: null as ((event: { data: string }) => void) | null,
     };
 
-    vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
+    vi.stubGlobal(
+      "WebSocket",
+      vi.fn((_: string): MockWebSocketHandlers => fakeSocket) as unknown as typeof WebSocket,
+    );
 
     connectRealtimeWs({
       onStateChange: (state: WsConnectionState): void => states.push(state),

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -6,58 +6,68 @@ import {
   type RealtimeWsEnvelope,
   type WsConnectionState,
 } from "../wsClient";
-import { setApiClientDependencies } from "../client";
+import { setApiClientDependencies, type ApiClientDependencies } from "../client";
 
-describe("wsClient", () => {
-  afterEach(() => {
+type MockWebSocketHandlers = {
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((event: Event) => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+};
+
+describe("wsClient", (): void => {
+  afterEach((): void => {
     setApiClientDependencies(null);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("buildRealtimeWsUrl converts https API base to wss", () => {
-    setApiClientDependencies({
-      getStoredApiKey: () => null,
-      clearStoredApiKey: () => undefined,
+  it("buildRealtimeWsUrl converts https API base to wss", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
       apiBase: "https://api.example.com/api/v1",
-    });
+    };
+    setApiClientDependencies(deps);
 
     expect(buildRealtimeWsUrl("/ws")).toBe("wss://api.example.com/ws");
   });
 
-  it("buildRealtimeWsUrl appends token in query string", () => {
-    setApiClientDependencies({
-      getStoredApiKey: () => null,
-      clearStoredApiKey: () => undefined,
+  it("buildRealtimeWsUrl appends token in query string", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
       apiBase: "http://localhost:8000/api/v1",
-    });
+    };
+    setApiClientDependencies(deps);
 
     expect(buildRealtimeWsUrl("/ws", "abc123")).toBe("ws://localhost:8000/ws?token=abc123");
   });
 
-  it("connectRealtimeWs emits state transitions and parses messages", () => {
-    setApiClientDependencies({
-      getStoredApiKey: () => null,
-      clearStoredApiKey: () => undefined,
+  it("connectRealtimeWs emits state transitions and parses messages", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
       apiBase: "http://localhost:8000/api/v1",
-    });
+    };
+    setApiClientDependencies(deps);
 
     const states: WsConnectionState[] = [];
     const messages: RealtimeWsEnvelope[] = [];
 
-    const fakeSocket = {
+    const fakeSocket: MockWebSocketHandlers = {
       onopen: null as (() => void) | null,
       onclose: null as (() => void) | null,
-      onerror: null as (() => void) | null,
+      onerror: null as ((event: Event) => void) | null,
       onmessage: null as ((event: { data: string }) => void) | null,
     };
 
-    const wsCtor = vi.fn(() => fakeSocket);
+    const wsCtor = vi.fn((_: string): MockWebSocketHandlers => fakeSocket);
     vi.stubGlobal("WebSocket", wsCtor as unknown as typeof WebSocket);
 
     connectRealtimeWs({
-      onStateChange: (state) => states.push(state),
-      onMessage: (event) => messages.push(event),
+      onStateChange: (state: WsConnectionState): void => states.push(state),
+      onMessage: (event: RealtimeWsEnvelope): void => messages.push(event),
     });
 
     expect(states).toEqual(["connecting"]);
@@ -71,50 +81,52 @@ describe("wsClient", () => {
     expect(messages).toEqual([{ version: "1", type: "pong" }]);
   });
 
-  it("connectRealtimeWs emits error state for invalid JSON message", () => {
-    setApiClientDependencies({
-      getStoredApiKey: () => null,
-      clearStoredApiKey: () => undefined,
+  it("connectRealtimeWs emits error state for invalid JSON message", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
       apiBase: "http://localhost:8000/api/v1",
-    });
+    };
+    setApiClientDependencies(deps);
 
     const states: WsConnectionState[] = [];
-    const fakeSocket = {
+    const fakeSocket: MockWebSocketHandlers = {
       onopen: null as (() => void) | null,
       onclose: null as (() => void) | null,
-      onerror: null as (() => void) | null,
+      onerror: null as ((event: Event) => void) | null,
       onmessage: null as ((event: { data: string }) => void) | null,
     };
 
     vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
 
     connectRealtimeWs({
-      onStateChange: (state) => states.push(state),
+      onStateChange: (state: WsConnectionState): void => states.push(state),
     });
     fakeSocket.onmessage?.({ data: "not-json" });
 
     expect(states).toEqual(["connecting", "error"]);
   });
 
-  it("connectRealtimeWs emits error state for invalid envelope shape", () => {
-    setApiClientDependencies({
-      getStoredApiKey: () => null,
-      clearStoredApiKey: () => undefined,
+  it("connectRealtimeWs emits error state for invalid envelope shape", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
       apiBase: "http://localhost:8000/api/v1",
-    });
+    };
+    setApiClientDependencies(deps);
 
     const states: WsConnectionState[] = [];
-    const fakeSocket = {
+    const fakeSocket: MockWebSocketHandlers = {
       onopen: null as (() => void) | null,
       onclose: null as (() => void) | null,
-      onerror: null as (() => void) | null,
+      onerror: null as ((event: Event) => void) | null,
       onmessage: null as ((event: { data: string }) => void) | null,
     };
 
     vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
 
     connectRealtimeWs({
-      onStateChange: (state) => states.push(state),
+      onStateChange: (state: WsConnectionState): void => states.push(state),
     });
     fakeSocket.onmessage?.({ data: '{"type":"pong"}' });
 

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildRealtimeWsUrl,
+  connectRealtimeWs,
+  type RealtimeWsEnvelope,
+  type WsConnectionState,
+} from "../wsClient";
+import { setApiClientDependencies } from "../client";
+
+describe("wsClient", () => {
+  afterEach(() => {
+    setApiClientDependencies(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("buildRealtimeWsUrl converts https API base to wss", () => {
+    setApiClientDependencies({
+      getStoredApiKey: () => null,
+      clearStoredApiKey: () => undefined,
+      apiBase: "https://api.example.com/api/v1",
+    });
+
+    expect(buildRealtimeWsUrl("/ws")).toBe("wss://api.example.com/ws");
+  });
+
+  it("buildRealtimeWsUrl appends token in query string", () => {
+    setApiClientDependencies({
+      getStoredApiKey: () => null,
+      clearStoredApiKey: () => undefined,
+      apiBase: "http://localhost:8000/api/v1",
+    });
+
+    expect(buildRealtimeWsUrl("/ws", "abc123")).toBe("ws://localhost:8000/ws?token=abc123");
+  });
+
+  it("connectRealtimeWs emits state transitions and parses messages", () => {
+    setApiClientDependencies({
+      getStoredApiKey: () => null,
+      clearStoredApiKey: () => undefined,
+      apiBase: "http://localhost:8000/api/v1",
+    });
+
+    const states: WsConnectionState[] = [];
+    const messages: RealtimeWsEnvelope[] = [];
+
+    const fakeSocket = {
+      onopen: null as (() => void) | null,
+      onclose: null as (() => void) | null,
+      onerror: null as (() => void) | null,
+      onmessage: null as ((event: { data: string }) => void) | null,
+    };
+
+    const wsCtor = vi.fn(() => fakeSocket);
+    vi.stubGlobal("WebSocket", wsCtor as unknown as typeof WebSocket);
+
+    connectRealtimeWs({
+      onStateChange: (state) => states.push(state),
+      onMessage: (event) => messages.push(event),
+    });
+
+    expect(states).toEqual(["connecting"]);
+    expect(wsCtor).toHaveBeenCalledWith("ws://localhost:8000/ws");
+
+    fakeSocket.onopen?.();
+    fakeSocket.onmessage?.({ data: '{"version":"1","type":"pong"}' });
+    fakeSocket.onclose?.();
+
+    expect(states).toEqual(["connecting", "open", "closed"]);
+    expect(messages).toEqual([{ version: "1", type: "pong" }]);
+  });
+
+  it("connectRealtimeWs emits error state for invalid JSON message", () => {
+    setApiClientDependencies({
+      getStoredApiKey: () => null,
+      clearStoredApiKey: () => undefined,
+      apiBase: "http://localhost:8000/api/v1",
+    });
+
+    const states: WsConnectionState[] = [];
+    const fakeSocket = {
+      onopen: null as (() => void) | null,
+      onclose: null as (() => void) | null,
+      onerror: null as (() => void) | null,
+      onmessage: null as ((event: { data: string }) => void) | null,
+    };
+
+    vi.stubGlobal("WebSocket", vi.fn(() => fakeSocket) as unknown as typeof WebSocket);
+
+    connectRealtimeWs({
+      onStateChange: (state) => states.push(state),
+    });
+    fakeSocket.onmessage?.({ data: "not-json" });
+
+    expect(states).toEqual(["connecting", "error"]);
+  });
+});

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -1,0 +1,63 @@
+import { getApiBase } from "./client";
+
+export type WsConnectionState = "connecting" | "open" | "closing" | "closed" | "error";
+
+export interface RealtimeWsEnvelope {
+  version: "1";
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface RealtimeWsConnectOptions {
+  path?: string;
+  token?: string;
+  onMessage?: (event: RealtimeWsEnvelope) => void;
+  onStateChange?: (state: WsConnectionState) => void;
+}
+
+const DEFAULT_WS_PATH = "/ws";
+
+function toWsBaseUrl(apiBase: string): string {
+  const parsed = new URL(apiBase);
+  const protocol = parsed.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${parsed.host}`;
+}
+
+export function buildRealtimeWsUrl(path: string = DEFAULT_WS_PATH, token?: string): string {
+  const wsBase = toWsBaseUrl(getApiBase());
+  const url = new URL(path, wsBase);
+  if (token) {
+    url.searchParams.set("token", token);
+  }
+  return url.toString();
+}
+
+export function connectRealtimeWs(options: RealtimeWsConnectOptions = {}): WebSocket {
+  const url = buildRealtimeWsUrl(options.path ?? DEFAULT_WS_PATH, options.token);
+  const socket = new WebSocket(url);
+
+  options.onStateChange?.("connecting");
+
+  socket.onopen = () => {
+    options.onStateChange?.("open");
+  };
+
+  socket.onclose = () => {
+    options.onStateChange?.("closed");
+  };
+
+  socket.onerror = () => {
+    options.onStateChange?.("error");
+  };
+
+  socket.onmessage = (event: MessageEvent<string>) => {
+    try {
+      const parsed = JSON.parse(event.data) as RealtimeWsEnvelope;
+      options.onMessage?.(parsed);
+    } catch {
+      options.onStateChange?.("error");
+    }
+  };
+
+  return socket;
+}

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -47,19 +47,19 @@ export function connectRealtimeWs(options: RealtimeWsConnectOptions = {}): WebSo
 
   options.onStateChange?.("connecting");
 
-  socket.onopen = () => {
+  socket.onopen = (): void => {
     options.onStateChange?.("open");
   };
 
-  socket.onclose = () => {
+  socket.onclose = (): void => {
     options.onStateChange?.("closed");
   };
 
-  socket.onerror = () => {
+  socket.onerror = (): void => {
     options.onStateChange?.("error");
   };
 
-  socket.onmessage = (event: MessageEvent<string>) => {
+  socket.onmessage = (event: MessageEvent<string>): void => {
     try {
       const parsed: unknown = JSON.parse(event.data);
       if (!isRealtimeWsEnvelope(parsed)) {

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -1,6 +1,6 @@
 import { getApiBase } from "./client";
 
-export type WsConnectionState = "connecting" | "open" | "closing" | "closed" | "error";
+export type WsConnectionState = "connecting" | "open" | "closed" | "error";
 
 export interface RealtimeWsEnvelope {
   version: "1";
@@ -32,6 +32,15 @@ export function buildRealtimeWsUrl(path: string = DEFAULT_WS_PATH, token?: strin
   return url.toString();
 }
 
+function isRealtimeWsEnvelope(value: unknown): value is RealtimeWsEnvelope {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const maybeEnvelope = value as { version?: unknown; type?: unknown };
+  return maybeEnvelope.version === "1" && typeof maybeEnvelope.type === "string";
+}
+
 export function connectRealtimeWs(options: RealtimeWsConnectOptions = {}): WebSocket {
   const url = buildRealtimeWsUrl(options.path ?? DEFAULT_WS_PATH, options.token);
   const socket = new WebSocket(url);
@@ -52,7 +61,11 @@ export function connectRealtimeWs(options: RealtimeWsConnectOptions = {}): WebSo
 
   socket.onmessage = (event: MessageEvent<string>) => {
     try {
-      const parsed = JSON.parse(event.data) as RealtimeWsEnvelope;
+      const parsed: unknown = JSON.parse(event.data);
+      if (!isRealtimeWsEnvelope(parsed)) {
+        options.onStateChange?.("error");
+        return;
+      }
       options.onMessage?.(parsed);
     } catch {
       options.onStateChange?.("error");

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,14 +23,7 @@
 
 ### WebSocket/realtime test invariants
 
-- Any PR touching `app/routers/realtime_ws.py` must include deterministic tests for both:
-  - a success path, and
-  - a policy-close/failure path.
-- Coverage for websocket guardrails should include at least one over-limit scenario
-  (message burst and/or active connection cap).
-- For connection-cap tests, keep the first connection open while opening the second one
-  (nested websocket context managers) so concurrency behavior is actually validated.
-- Avoid time-based flakiness in realtime tests: do not rely on arbitrary sleeps for assertions.
+- See canonical WebSocket/realtime invariants in root `AGENTS.md`.
 
 ### Module purge / reload invariant (xdist stability)
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -21,6 +21,17 @@
 - Repo policy guards must not reference temporary/untracked files; AST scan path lists must filter by `.exists()`.
 - `ui_labels` is a required part of `WHOTargetsResponse` contract (SoT: `app/schemas/premium_contracts.py`); assert ES anchor string (`"Calorías diarias"`) in snapshot tests and do not feature-gate this contract after implementation.
 
+### WebSocket/realtime test invariants
+
+- Any PR touching `app/routers/realtime_ws.py` must include deterministic tests for both:
+  - a success path, and
+  - a policy-close/failure path.
+- Coverage for websocket guardrails should include at least one over-limit scenario
+  (message burst and/or active connection cap).
+- For connection-cap tests, keep the first connection open while opening the second one
+  (nested websocket context managers) so concurrency behavior is actually validated.
+- Avoid time-based flakiness in realtime tests: do not rely on arbitrary sleeps for assertions.
+
 ### Module purge / reload invariant (xdist stability)
 
 Some tests intentionally purge/reload modules (e.g., via `module_purge.purge_modules(...)` or

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -287,6 +287,38 @@ def test_ws_rejects_connection_when_over_max_connections(
         assert exc.value.code == 1008
 
 
+def test_ws_over_cap_does_not_call_auth(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_MAX_CONNECTIONS", "1")
+
+    called = {"auth": 0}
+
+    def _spy(_token: str) -> object:
+        called["auth"] += 1
+        return {"sub": "ws-user"}
+
+    monkeypatch.setattr("app.middleware.api_tiers.require_pro_tier", _spy)
+
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+        response = json.loads(ws.receive_text())
+        assert response["version"] == "1"
+        assert response["type"] == "pong"
+        assert isinstance(response["server_time_ms"], int)
+        assert called["auth"] == 1
+
+        called["auth"] = 0
+        with ws_client.websocket_connect(
+            "/ws", headers={"Authorization": "Bearer valid-token"}
+        ) as ws2:
+            with pytest.raises(WebSocketDisconnect) as exc:
+                ws2.receive_text()
+        assert exc.value.code == 1008
+        assert called["auth"] == 0
+
+
 def test_ws_rejects_subscribe_with_unknown_channel(
     ws_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -44,6 +44,7 @@ def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
     assert policy.max_message_bytes == realtime_ws.DEFAULT_MAX_MESSAGE_BYTES
     assert policy.window_seconds == realtime_ws.DEFAULT_WINDOW_SECONDS
     assert policy.max_messages_per_window == realtime_ws.DEFAULT_MAX_MESSAGES_PER_WINDOW
+    assert policy.max_connections == realtime_ws.DEFAULT_MAX_CONNECTIONS
     assert policy.protocol_version == realtime_ws.PROTOCOL_VERSION
 
 
@@ -262,6 +263,28 @@ def test_ws_rejects_ping_with_non_string_version(
         with pytest.raises(WebSocketDisconnect) as exc:
             ws.receive_text()
     assert exc.value.code == 1008
+
+
+def test_ws_rejects_connection_when_over_max_connections(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_MAX_CONNECTIONS", "1")
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+        response = json.loads(ws.receive_text())
+        assert response["version"] == "1"
+        assert response["type"] == "pong"
+        assert isinstance(response["server_time_ms"], int)
+
+        with ws_client.websocket_connect(
+            "/ws", headers={"Authorization": "Bearer valid-token"}
+        ) as ws2:
+            with pytest.raises(WebSocketDisconnect) as exc:
+                ws2.receive_text()
+        assert exc.value.code == 1008
 
 
 def test_ws_rejects_subscribe_with_unknown_channel(

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from typing import cast
 
 import pytest
 from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi import WebSocket
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -250,6 +252,18 @@ def test_ws_rejects_unsupported_protocol_version(
     assert exc.value.code == 1008
 
 
+def test_ws_rejects_ping_with_non_string_version(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": 1, "type": "ping"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
 def test_ws_rejects_subscribe_with_unknown_channel(
     ws_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -326,4 +340,4 @@ async def test_ws_handles_websocket_disconnect_exception(
     monkeypatch.setattr(realtime_ws, "_is_ws_enabled", lambda: True)
     monkeypatch.setattr(realtime_ws, "_authenticate_or_close", _auth_ok)
 
-    await realtime_ws.ws_root(_DummyWebSocket())
+    await realtime_ws.ws_root(cast(WebSocket, _DummyWebSocket()))

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -42,6 +42,7 @@ def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
     assert policy.max_message_bytes == realtime_ws.DEFAULT_MAX_MESSAGE_BYTES
     assert policy.window_seconds == realtime_ws.DEFAULT_WINDOW_SECONDS
     assert policy.max_messages_per_window == realtime_ws.DEFAULT_MAX_MESSAGES_PER_WINDOW
+    assert policy.protocol_version == realtime_ws.PROTOCOL_VERSION
 
 
 def test_token_verifier_accepts_valid_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,9 +114,11 @@ def test_ws_accepts_valid_token_and_responds_pong(
 ) -> None:
     monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
     with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
-        ws.send_text(json.dumps({"type": "ping"}))
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
         response = json.loads(ws.receive_text())
-    assert response == {"type": "pong"}
+    assert response["version"] == "1"
+    assert response["type"] == "pong"
+    assert isinstance(response["server_time_ms"], int)
 
 
 def test_ws_accepts_token_via_query_param_and_responds_pong(
@@ -126,9 +129,24 @@ def test_ws_accepts_token_via_query_param_and_responds_pong(
         "app.middleware.api_tiers.require_pro_tier", lambda _token: {"sub": "ws-user"}
     )
     with ws_client.websocket_connect("/ws?token=valid-token") as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+        response = json.loads(ws.receive_text())
+    assert response["version"] == "1"
+    assert response["type"] == "pong"
+    assert isinstance(response["server_time_ms"], int)
+
+
+def test_ws_legacy_ping_without_version_is_still_supported(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
         ws.send_text(json.dumps({"type": "ping"}))
         response = json.loads(ws.receive_text())
-    assert response == {"type": "pong"}
+    assert response["version"] == "1"
+    assert response["type"] == "pong"
+    assert isinstance(response["server_time_ms"], int)
 
 
 @pytest.mark.parametrize(
@@ -173,10 +191,13 @@ def test_ws_rate_limit_closes_after_burst(
     limit = 3
     with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
         for _ in range(limit):
-            ws.send_text(json.dumps({"type": "ping"}))
-            assert json.loads(ws.receive_text()) == {"type": "pong"}
+            ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+            response = json.loads(ws.receive_text())
+            assert response["version"] == "1"
+            assert response["type"] == "pong"
+            assert isinstance(response["server_time_ms"], int)
 
-        ws.send_text(json.dumps({"type": "ping"}))
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
         with pytest.raises(WebSocketDisconnect) as exc:
             ws.receive_text()
     assert exc.value.code == 1008
@@ -188,7 +209,54 @@ def test_ws_rejects_unknown_event_type(
 ) -> None:
     monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
     with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
-        ws.send_text(json.dumps({"type": "subscribe", "channel": "bmi"}))
+        ws.send_text(json.dumps({"version": "1", "type": "unknown", "channel": "bmi"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_subscribe_progress_channel_returns_ack(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "subscribe", "channel": "progress"}))
+        response = json.loads(ws.receive_text())
+    assert response == {"version": "1", "type": "subscribed", "channel": "progress"}
+
+
+def test_ws_rejects_subscribe_without_version(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"type": "subscribe", "channel": "progress"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_unsupported_protocol_version(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "2", "type": "ping"}))
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_rejects_subscribe_with_unknown_channel(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "subscribe", "channel": "bmi"}))
         with pytest.raises(WebSocketDisconnect) as exc:
             ws.receive_text()
     assert exc.value.code == 1008


### PR DESCRIPTION
## Summary
- Expand canonical `/ws` from foundation ping-only behavior to a versioned v1 realtime contract with controlled `subscribe(progress)` support.
- Preserve fail-closed websocket policy with deterministic closes for unsupported protocol version and unknown channel, while keeping legacy `ping` compatibility.
- Add a thin frontend WebSocket adapter (`frontend/src/api/wsClient.ts`) and guard enforcement so raw socket creation stays isolated to transport layer.
- Add audit/plan artifacts and link this in-progress package from `BACKLOG_LEDGER` for scope and DoD traceability.

## Test plan
- [x] `pytest -q tests/test_websocket_burst_limiter_unit.py tests/test_websocket_security_api.py`
- [x] `cd frontend && npm test -- --run src/api/__tests__/wsClient.test.ts src/api/__tests__/thin-client-guards.test.ts`
- [x] `python3 -m py_compile app/routers/realtime_ws.py tests/test_websocket_security_api.py`
- [ ] `make verify` *(blocked in this worktree: missing `.venv/bin/activate` in local environment)*

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783#discussion_r2818880121 -> 709579b6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783#discussion_r2818880123 -> 709579b6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783#discussion_r2818880126 -> 709579b6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783#discussion_r2818880128 -> 709579b6

## Deferred / Follow-ups
- iOS websocket consumer integration remains out-of-scope for this PR and will be tracked as a separate follow-up item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Versioned WebSocket protocol (v1) with subscribe support for a progress channel, versioned ping/pong including server timestamp, and per-process connection limits; frontend adds a dedicated realtime WebSocket client with URL building, lifecycle states, message validation, and typed envelopes.

* **Bug Fixes**
  * Deterministic rejection and explicit close reasons for unsupported versions, disallowed channels, oversized/invalid messages, binary frames, and excess connections.

* **Documentation**
  * Added expansion plan, audit, roadmap, and agent guidelines.

* **Tests**
  * Backend and frontend tests for protocol/versioning, channel rules, guards, message validity, and connection limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Fixed in commit 8d322534: added per-process active WS connection cap (WS_MAX_CONNECTIONS) with fail-closed policy close and deterministic test coverage.
- Fixed in commit cb23b53c: added explicit typed signatures for remaining WebSocket vi.fn mocks in wsClient tests to satisfy type-hint policy and CodeRabbit finding.
- Fixed in commit 32b403d4: acquire WS connection slot before auth to reduce load under cap; dedupe websocket invariants in tests/AGENTS.md via canonical link; added deterministic test that over-cap does not call auth.
