### PR TITLE
docs(ledger): close PR #783 realtime item

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -517,6 +517,26 @@ If it is not recorded here — it does not exist.
     - Add deterministic integration tests for expanded event flow
     - Keep `make verify` and diff-coverage gates green in expansion PR
 
+- [ ] P1: WebSocket idle-timeout follow-up (capacity safeguard)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-WS-IDLE-TIMEOUT (deferred from PR #783)
+  - Status: 🔜 Deferred
+  - Area: backend / realtime / capacity
+  - Finding Type: deferred hardening / runtime safeguard
+  - Reason: PR #783 intentionally shipped secure websocket foundation (`/ws`, auth, limits, versioned events) without idle timeout to avoid scope creep. Remaining risk is capacity/resource retention from idle connections (not a security bypass).
+  - Links:
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783`
+    - `docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md`
+    - `docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md`
+    - `app/routers/realtime_ws.py`
+  - DoD:
+    - Add `WS_IDLE_TIMEOUT_SECONDS` with conservative default and explicit disable mode
+    - Close idle websocket connections with deterministic policy close semantics
+    - Add deterministic tests for idle-timeout behavior without `sleep()`-based flakiness
+    - Keep existing websocket guardrails unchanged (fail-closed auth, burst limiter, connection cap)
+    - Pass `make verify` and diff-coverage gates in follow-up PR
+
 - [x] P1: Shoplist flow stabilization work-package (`plan -> shoplist`)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -497,11 +497,12 @@ If it is not recorded here — it does not exist.
     - Governance/docs are synchronized in AGENTS + audit + plan
     - CI gates for PR #778 are green before merge
 
-- [ ] P1: WebSocket foundation follow-up (realtime expansion package)
+- [x] P1: WebSocket foundation follow-up (realtime expansion package)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-WS-REALTIME-EXPANSION (in progress)
-  - Status: In progress (`feat/websocket-realtime-expansion`)
+  - Target PR: PR #783
+  - Status: ✅ Merged (PR #783, 2026-02-17, `a78040a0`)
+  - Merge SHA: a78040a0d8a191876f702b426b98ae82ae9460cc
   - Area: backend / realtime / contracts
   - Finding Type: scope control / deferred enhancement
   - Reason: Current work-package intentionally delivers only secure websocket foundation (`/ws`, auth, limits, `ping -> pong`). Any expansion beyond foundation (event catalog, client consumers, rooms/fan-out) is deferred to avoid scope creep.


### PR DESCRIPTION
## Summary
- Mark P1 \"WebSocket foundation follow-up (realtime expansion package)\" as merged in `docs/roadmap/BACKLOG_LEDGER.md`
- Replace in-progress markers with canonical merge metadata for PR #783 (`a78040a0`)
- Add separate deferred idle-timeout follow-up item with owner/priority/links/DoD per Backlog Ledger Policy

## Test plan
- [x] Docs-only diff (`docs/roadmap/BACKLOG_LEDGER.md`)
- [x] Pre-commit hooks pass on changed files
- [x] Validate ledger entries now include merged PR #783 metadata and deferred idle-timeout follow-up

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments
- Fixed in commit 65ae6a19: marked P1 websocket realtime expansion item as merged (PR #783 + merge SHA)
- Fixed in commit eeef9123: added deferred backlog item for websocket idle-timeout follow-up from PR #783 with owner/priority/links/DoD

## Deferred / Follow-ups
- Runtime implementation of idle-timeout remains deferred by design and tracked in `docs/roadmap/BACKLOG_LEDGER.md` as separate follow-up scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Backlog ledger updated: WebSocket foundation follow-up marked completed/merged.
  * Added a new deferred follow-up entry for WebSocket idle-timeout (capacity safeguard) with owner, priority, and DoD details.
  * Kept the Shoplist flow stabilization entry intact with no substantive changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->