### PR TITLE
fix(realtime): add deterministic websocket idle-timeout safeguard

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -188,6 +188,10 @@ curl -fsS https://.../metrics | grep http_requests_total
   - use `WS_MAX_CONNECTIONS` policy setting,
   - reject over-cap connections fail-closed with policy close (1008),
   - release tracker state in `finally` on every exit path.
+- Idle-timeout policy for `/ws` must remain deterministic:
+  - use `WS_IDLE_TIMEOUT_SECONDS` with default `0` (explicitly disabled),
+  - if timeout is enabled (`>0`), close idle connections fail-closed with policy close (1008),
+  - tests for timeout branches must not use `sleep()`; use deterministic timeout injection/mocking.
 - WebSocket response serialization should be deterministic (`sort_keys=True` where applicable)
   so tests and cross-runtime behavior remain stable.
 

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -255,7 +255,7 @@ async def _receive_frame_with_idle_timeout(
         if idle_timeout_seconds <= 0:
             return await ws.receive()
         return await asyncio.wait_for(ws.receive(), timeout=float(idle_timeout_seconds))
-    except TimeoutError:
+    except asyncio.TimeoutError:
         logger.info("ws_policy_close", extra={"reason": REASON_IDLE_TIMEOUT})
         await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_IDLE_TIMEOUT)
         return None

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import threading
 import time
 from collections import deque
+from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
 
@@ -20,6 +22,7 @@ DEFAULT_MAX_MESSAGE_BYTES: int = 4_096
 DEFAULT_WINDOW_SECONDS: int = 10
 DEFAULT_MAX_MESSAGES_PER_WINDOW: int = 20
 DEFAULT_MAX_CONNECTIONS: int = 200
+DEFAULT_IDLE_TIMEOUT_SECONDS: int = 0
 PROTOCOL_VERSION: str = "1"
 ALLOWED_EVENT_TYPES: frozenset[str] = frozenset({"ping", "subscribe"})
 ALLOWED_CHANNELS: frozenset[str] = frozenset({"progress"})
@@ -35,6 +38,7 @@ REASON_EVENT_TYPE_NOT_ALLOWED: str = "event_type_not_allowed"
 REASON_UNSUPPORTED_VERSION: str = "unsupported_version"
 REASON_CHANNEL_NOT_ALLOWED: str = "channel_not_allowed"
 REASON_TOO_MANY_CONNECTIONS: str = "too_many_connections"
+REASON_IDLE_TIMEOUT: str = "idle_timeout"
 
 
 class _ActiveConnectionsTracker:
@@ -79,6 +83,7 @@ class WsPolicy:
     window_seconds: int = DEFAULT_WINDOW_SECONDS
     max_messages_per_window: int = DEFAULT_MAX_MESSAGES_PER_WINDOW
     max_connections: int = DEFAULT_MAX_CONNECTIONS
+    idle_timeout_seconds: int = DEFAULT_IDLE_TIMEOUT_SECONDS
     protocol_version: str = PROTOCOL_VERSION
     allowed_event_types: frozenset[str] = field(default_factory=lambda: ALLOWED_EVENT_TYPES)
     allowed_channels: frozenset[str] = field(default_factory=lambda: ALLOWED_CHANNELS)
@@ -97,6 +102,16 @@ def _policy_from_env() -> WsPolicy:
             return default
         return value if value > 0 else default
 
+    def _get_non_negative_int(name: str, default: int) -> int:
+        raw = os.getenv(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            return default
+        return value if value >= 0 else default
+
     return WsPolicy(
         max_message_bytes=_get_positive_int("WS_MAX_MESSAGE_BYTES", DEFAULT_MAX_MESSAGE_BYTES),
         window_seconds=_get_positive_int("WS_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS),
@@ -104,6 +119,9 @@ def _policy_from_env() -> WsPolicy:
             "WS_MAX_MESSAGES_PER_WINDOW", DEFAULT_MAX_MESSAGES_PER_WINDOW
         ),
         max_connections=_get_positive_int("WS_MAX_CONNECTIONS", DEFAULT_MAX_CONNECTIONS),
+        idle_timeout_seconds=_get_non_negative_int(
+            "WS_IDLE_TIMEOUT_SECONDS", DEFAULT_IDLE_TIMEOUT_SECONDS
+        ),
         protocol_version=PROTOCOL_VERSION,
         allowed_event_types=ALLOWED_EVENT_TYPES,
         allowed_channels=ALLOWED_CHANNELS,
@@ -229,6 +247,20 @@ def _encode_event(event: dict[str, Any]) -> str:
     return json.dumps(event, separators=(",", ":"), sort_keys=True)
 
 
+async def _receive_frame_with_idle_timeout(
+    ws: WebSocket, idle_timeout_seconds: int
+) -> MutableMapping[str, Any] | None:
+    """Receive one frame, optionally enforcing idle timeout."""
+    try:
+        if idle_timeout_seconds <= 0:
+            return await ws.receive()
+        return await asyncio.wait_for(ws.receive(), timeout=float(idle_timeout_seconds))
+    except TimeoutError:
+        logger.info("ws_policy_close", extra={"reason": REASON_IDLE_TIMEOUT})
+        await ws.close(code=POLICY_CLOSE_CODE, reason=REASON_IDLE_TIMEOUT)
+        return None
+
+
 @router.websocket("/ws")
 async def ws_root(ws: WebSocket) -> None:
     """Secure and deterministic WebSocket endpoint."""
@@ -256,7 +288,12 @@ async def ws_root(ws: WebSocket) -> None:
         )
 
         while True:
-            frame = await ws.receive()
+            frame = await _receive_frame_with_idle_timeout(
+                ws,
+                policy.idle_timeout_seconds,
+            )
+            if frame is None:
+                return
             if frame.get("type") == "websocket.disconnect":
                 return
 

--- a/docs/audit/PR_WS_IDLE_TIMEOUT_AUDIT.md
+++ b/docs/audit/PR_WS_IDLE_TIMEOUT_AUDIT.md
@@ -1,0 +1,109 @@
+# PR-P1: WebSocket Idle Timeout Audit
+
+<!-- markdownlint-disable MD013 -->
+
+**Status:** In progress (runtime work-package)
+**Branch:** `feat/ws-idle-timeout-pr`
+**Date:** 2026-02-16
+
+---
+
+## Scope Validation
+
+### IN
+
+- Idle-timeout policy for existing `/ws` endpoint.
+- Deterministic timeout enforcement and tests.
+- Documentation updates for ledger and websocket invariants.
+
+### OUT
+
+- Heartbeat/ping scheduler design.
+- Frontend/iOS websocket contract changes.
+- New event catalog/channels.
+
+---
+
+## Architecture and Invariants
+
+| INV | Rule | Evidence |
+| --- | --- | --- |
+| INV-1 | `/ws` remains the only canonical realtime endpoint | `app/routers/realtime_ws.py:252` |
+| INV-2 | Connection cap remains fail-closed before auth | `app/routers/realtime_ws.py:263` |
+| INV-3 | Idle timeout is explicit policy with disabled default | `app/routers/realtime_ws.py:23`, `app/routers/realtime_ws.py:84`, `app/routers/realtime_ws.py:118` |
+| INV-4 | Timeout branch closes with policy semantics (`1008`) | `app/routers/realtime_ws.py:248` |
+| INV-5 | Existing deterministic event serialization is preserved | `app/routers/realtime_ws.py:234` |
+| INV-6 | Timeout tests avoid wall-clock sleeps | `tests/test_websocket_security_api.py:323`, `tests/test_websocket_security_api.py:343` |
+
+---
+
+## Threat Model (Worst-Case First)
+
+1. **Connection-slot starvation (capacity DoS):**
+   many authenticated but silent clients hold sockets, blocking active users.
+2. **Idle-timeout regression:**
+   timeout branch accidentally disabled due to parser/default mistakes.
+3. **Flaky tests from wall-clock timing:**
+   non-deterministic test behavior obscures real regressions.
+4. **Policy drift in close semantics:**
+   non-policy close code leaks behavior inconsistency across runtimes.
+5. **Guardrail regression under change pressure:**
+   cap/auth/limiter/version checks accidentally altered while adding timeout.
+
+Mitigations in PR:
+
+- Explicit `WS_IDLE_TIMEOUT_SECONDS` policy with disabled default.
+- Deterministic timeout branch via `asyncio.wait_for` and fail-closed `1008`.
+- Timeout tests use mocking (no `sleep()`).
+- Existing websocket guard paths retained and re-tested.
+
+---
+
+## Hidden Regression Checklist
+
+- [x] `WS_MAX_CONNECTIONS` behavior still enforced before auth.
+- [x] `ping -> pong` behavior remains stable when timeout disabled.
+- [x] Version/channel policy close paths remain unchanged.
+- [x] Tracker release remains in `finally`.
+- [x] Deterministic serialization (`sort_keys=True`) remains enabled.
+
+---
+
+## External Evidence Register
+
+- OWASP WebSocket Security Cheat Sheet:
+  DoS protections include connection limits + idle/dead-connection handling.
+  <https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html>
+- RFC 6455:
+  close-handshake/status code semantics for policy-driven closes.
+  <https://datatracker.ietf.org/doc/html/rfc6455>
+- Python `asyncio.wait_for` docs:
+  deterministic timeout behavior and `TimeoutError`.
+  <https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for>
+- Starlette websocket docs:
+  canonical `receive`/`close` mechanics for ASGI handlers.
+  <https://www.starlette.io/websockets/>
+
+---
+
+## Evidence Commands
+
+```bash
+pytest -q tests/test_websocket_security_api.py -v
+pytest -q tests/test_websocket_burst_limiter_unit.py -v
+pytest -q tests/test_main_ws_registration_guard.py -v
+rg -n "WS_IDLE_TIMEOUT_SECONDS|idle_timeout|_receive_frame_with_idle_timeout|@router.websocket\\(\"/ws\"\\)" app/routers/realtime_ws.py
+rg -n "idle timeout|WS_IDLE_TIMEOUT_SECONDS|wait_for" tests/test_websocket_security_api.py
+make test-fast
+make lint
+```
+
+---
+
+## DoD Checklist
+
+- [ ] Backlog item moved from deferred to execution-linked state with docs links.
+- [ ] Idle timeout implemented and tested deterministically.
+- [ ] Existing websocket security invariants unchanged.
+- [ ] No flaky time-based tests introduced.
+- [ ] Lint/test gates for changed scope pass.

--- a/docs/plan/PR_WS_IDLE_TIMEOUT_PLAN.md
+++ b/docs/plan/PR_WS_IDLE_TIMEOUT_PLAN.md
@@ -1,0 +1,119 @@
+# PR-P1: WebSocket Idle Timeout Work-Package Plan
+
+<!-- markdownlint-disable MD013 -->
+
+**Status:** Planned and executing in one runtime PR
+**Branch:** `feat/ws-idle-timeout-pr`
+**Date:** 2026-02-16
+
+---
+
+## Scope
+
+### IN
+
+- Add idle-timeout policy to `/ws` using `WS_IDLE_TIMEOUT_SECONDS`.
+- Keep default as explicit disabled mode (`0`) for backward compatibility.
+- When enabled (`>0`), close idle connections with policy close (`1008`, reason `idle_timeout`).
+- Keep existing connection cap, auth, message-size, and burst-limit invariants unchanged.
+- Add deterministic tests for timeout path without `sleep()`.
+- Update canonical docs (`BACKLOG_LEDGER`, websocket audit, `app/AGENTS.md`) with the new invariant.
+
+### OUT
+
+- Heartbeat scheduler or server-initiated ping loop.
+- Frontend/iOS behavior changes.
+- Any new websocket channels or protocol expansions.
+- Broker/fan-out/distributed realtime architecture work.
+
+---
+
+## Implementation Plan
+
+### Phase 1 - Backend policy extension
+
+1. Extend `WsPolicy` in `app/routers/realtime_ws.py` with:
+   - `idle_timeout_seconds` (default: `0`)
+2. Extend env loading with non-negative parser:
+   - `WS_IDLE_TIMEOUT_SECONDS` supports `0` (disabled) and positive values.
+3. Add receive helper with timeout branch:
+   - Wrap `ws.receive()` with `asyncio.wait_for(...)` when timeout enabled.
+   - On timeout: close with `1008` and reason `idle_timeout`.
+
+### Phase 2 - Deterministic testing
+
+1. Keep existing websocket happy/fail-closed tests green.
+2. Add timeout-path API test:
+   - Patch `asyncio.wait_for` to raise `TimeoutError` deterministically.
+   - Verify close behavior (`1008`) without wall-clock waits.
+3. Add disabled-mode test:
+   - `WS_IDLE_TIMEOUT_SECONDS=0` bypasses timeout wrapper and preserves `ping -> pong`.
+
+### Phase 3 - Documentation and quality gates
+
+1. Update `docs/roadmap/BACKLOG_LEDGER.md` with in-progress execution metadata and links.
+2. Add audit with file:line evidence and threat-model summary.
+3. Update `app/AGENTS.md` websocket invariant section.
+4. Run test/lint/coverage gates and prepare PR body mapping for review bots.
+
+---
+
+## Worst-Case Scenario Model
+
+### Scenario
+
+High volume of authenticated but silent websocket clients opens and holds `/ws` connections near max cap, starving active users. Under bursty load, this becomes capacity exhaustion and can cascade into degraded realtime service.
+
+### Consequences
+
+- Elevated connection rejection rate for legitimate clients.
+- Increased resource retention per worker/process.
+- Higher operational toil during incidents due to long-lived idle sockets.
+
+### Mitigation in this PR
+
+- Deterministic idle close policy (`1008`, `idle_timeout`) when timeout enabled.
+- Keep fail-closed semantics and current cap/limiter invariants unchanged.
+- Add explicit tests to guard against regressions in timeout and disabled modes.
+
+---
+
+## External Evidence Register
+
+- OWASP WebSocket Security Cheat Sheet:
+  - Recommends idle timeout and connection/resource limits for DoS resistance.
+  - <https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html>
+- RFC 6455:
+  - Defines close status codes and policy-violation semantics.
+  - <https://datatracker.ietf.org/doc/html/rfc6455>
+- Python asyncio docs:
+  - `asyncio.wait_for` timeout behavior for awaitables.
+  - <https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for>
+- Starlette WebSocket docs:
+  - Canonical receive/close behavior in ASGI websocket handlers.
+  - <https://www.starlette.io/websockets/>
+
+---
+
+## Deterministic Test Commands
+
+```bash
+pytest -q tests/test_websocket_burst_limiter_unit.py -v
+pytest -q tests/test_websocket_security_api.py -v
+pytest -q tests/test_main_ws_registration_guard.py -v
+pytest -q tests/test_repo_policy_guards.py -v
+make test-fast
+make lint
+```
+
+---
+
+## DoD Checklist
+
+- [ ] `WS_IDLE_TIMEOUT_SECONDS` is implemented with default disabled mode (`0`).
+- [ ] Enabled timeout closes idle `/ws` with deterministic policy close (`1008`, `idle_timeout`).
+- [ ] No regressions in existing `/ws` guardrails (auth, cap, limiter, versioned events).
+- [ ] Timeout test path is deterministic and uses no `sleep()`.
+- [ ] Audit includes file:line anchors and external evidence links.
+- [ ] `app/AGENTS.md` websocket invariants updated.
+- [ ] Quality gates pass for PR scope.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -520,8 +520,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: WebSocket idle-timeout follow-up (capacity safeguard)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-WS-IDLE-TIMEOUT (deferred from PR #783)
-  - Status: 🔜 Deferred
+  - Target PR: PR-TBD (`feat/ws-idle-timeout-pr`)
+  - Status: 🟡 In progress (execution started 2026-02-16)
   - Area: backend / realtime / capacity
   - Finding Type: deferred hardening / runtime safeguard
   - Reason: PR #783 intentionally shipped secure websocket foundation (`/ws`, auth, limits, versioned events) without idle timeout to avoid scope creep. Remaining risk is capacity/resource retention from idle connections (not a security bypass).
@@ -529,6 +529,8 @@ If it is not recorded here — it does not exist.
     - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783`
     - `docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md`
     - `docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md`
+    - `docs/plan/PR_WS_IDLE_TIMEOUT_PLAN.md`
+    - `docs/audit/PR_WS_IDLE_TIMEOUT_AUDIT.md`
     - `app/routers/realtime_ws.py`
   - DoD:
     - Add `WS_IDLE_TIMEOUT_SECONDS` with conservative default and explicit disable mode

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from fastapi import FastAPI
@@ -38,6 +38,7 @@ def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
     monkeypatch.delenv("WS_MAX_MESSAGE_BYTES", raising=False)
     monkeypatch.setenv("WS_WINDOW_SECONDS", "not-an-int")
     monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "0")
+    monkeypatch.setenv("WS_IDLE_TIMEOUT_SECONDS", "invalid")
 
     policy = realtime_ws._policy_from_env()
 
@@ -45,6 +46,7 @@ def test_policy_from_env_uses_defaults_for_missing_and_invalid_values(
     assert policy.window_seconds == realtime_ws.DEFAULT_WINDOW_SECONDS
     assert policy.max_messages_per_window == realtime_ws.DEFAULT_MAX_MESSAGES_PER_WINDOW
     assert policy.max_connections == realtime_ws.DEFAULT_MAX_CONNECTIONS
+    assert policy.idle_timeout_seconds == realtime_ws.DEFAULT_IDLE_TIMEOUT_SECONDS
     assert policy.protocol_version == realtime_ws.PROTOCOL_VERSION
 
 
@@ -317,6 +319,46 @@ def test_ws_over_cap_does_not_call_auth(
                 ws2.receive_text()
         assert exc.value.code == 1008
         assert called["auth"] == 0
+
+
+def test_ws_idle_timeout_closes_connection_without_sleep(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_IDLE_TIMEOUT_SECONDS", "5")
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+
+    async def _timeout(awaitable: Any, timeout: float) -> dict[str, Any]:
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise TimeoutError(f"idle timeout={timeout}")
+
+    monkeypatch.setattr(realtime_ws.asyncio, "wait_for", _timeout)
+
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_ws_idle_timeout_zero_disables_wait_for_branch(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WS_IDLE_TIMEOUT_SECONDS", "0")
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+
+    async def _wait_for_must_not_be_called(_awaitable: Any, _timeout: float) -> dict[str, Any]:
+        raise AssertionError("wait_for should not be called when idle timeout is disabled")
+
+    monkeypatch.setattr(realtime_ws.asyncio, "wait_for", _wait_for_must_not_be_called)
+
+    with ws_client.websocket_connect("/ws", headers={"Authorization": "Bearer valid-token"}) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+        response = json.loads(ws.receive_text())
+    assert response["version"] == "1"
+    assert response["type"] == "pong"
+    assert isinstance(response["server_time_ms"], int)
 
 
 def test_ws_rejects_subscribe_with_unknown_channel(


### PR DESCRIPTION
## Summary
- Implement `WS_IDLE_TIMEOUT_SECONDS` policy in `app/routers/realtime_ws.py` with explicit disabled mode (`0`) and fail-closed idle close (`1008`, `idle_timeout`) when enabled.
- Add deterministic no-sleep websocket tests for timeout and disabled branches in `tests/test_websocket_security_api.py`.
- Promote deferred backlog item to in-progress execution and add scoped plan/audit docs with risk model and external evidence links.

## Scope
### IN
- `/ws` idle-timeout follow-up only (capacity safeguard)
- deterministic timeout branch + tests
- backlog/plan/audit + websocket invariant docs updates

### OUT
- heartbeat scheduler
- new channels/events
- frontend/iOS websocket behavior changes
- broker/fan-out architecture changes

## Why
- Reduce capacity-risk from authenticated idle sockets occupying connection slots.
- Keep fail-closed semantics and deterministic tests under strict diff-coverage gates.

## Test plan
- [x] `pytest -q tests/test_websocket_burst_limiter_unit.py -v`
- [x] `pytest -q tests/test_websocket_security_api.py -v`
- [x] `pytest -q tests/test_main_ws_registration_guard.py -v`
- [x] `make lint`
- [x] `pre-commit run --files app/routers/realtime_ws.py tests/test_websocket_security_api.py app/AGENTS.md docs/roadmap/BACKLOG_LEDGER.md docs/plan/PR_WS_IDLE_TIMEOUT_PLAN.md docs/audit/PR_WS_IDLE_TIMEOUT_AUDIT.md`
- [x] `make verify`

## Risk model (worst-case)
- Slot retention / capacity starvation from idle authenticated sockets.
- Mitigation in this PR: deterministic idle close when policy is enabled; no change to existing auth/cap/limiter invariants.

## External evidence register
- OWASP WebSocket Security Cheat Sheet: <https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html>
- RFC 6455: <https://datatracker.ietf.org/doc/html/rfc6455>
- Python asyncio `wait_for`: <https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for>
- Starlette websockets: <https://www.starlette.io/websockets/>

## Deferred / Follow-ups
- Keep heartbeat scheduler as separate follow-up (explicitly out of this PR scope).
- Canonical tracking item: `docs/roadmap/BACKLOG_LEDGER.md` (`P1: WebSocket idle-timeout follow-up`).

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments