### PR TITLE
docs(roadmap): close PR-786 item and queue ws observability P1

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -520,8 +520,9 @@ If it is not recorded here — it does not exist.
 - [ ] P1: WebSocket idle-timeout follow-up (capacity safeguard)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD (`feat/ws-idle-timeout-pr`)
-  - Status: 🟡 In progress (execution started 2026-02-16)
+  - Target PR: PR #786
+  - Status: ✅ Merged (PR #786, 2026-02-18, `a2e248cb`)
+  - Merge SHA: a2e248cb5feaa84608acc68491954476228751d4
   - Area: backend / realtime / capacity
   - Finding Type: deferred hardening / runtime safeguard
   - Reason: PR #783 intentionally shipped secure websocket foundation (`/ws`, auth, limits, versioned events) without idle timeout to avoid scope creep. Remaining risk is capacity/resource retention from idle connections (not a security bypass).
@@ -538,6 +539,39 @@ If it is not recorded here — it does not exist.
     - Add deterministic tests for idle-timeout behavior without `sleep()`-based flakiness
     - Keep existing websocket guardrails unchanged (fail-closed auth, burst limiter, connection cap)
     - Pass `make verify` and diff-coverage gates in follow-up PR
+
+- [ ] P1: WebSocket observability hardening (low-cardinality metrics + structured logs)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (`feat/ws-observability-hardening`)
+  - Status: 📋 Planned (next runtime package after PR #786)
+  - Area: backend / realtime / observability
+  - Finding Type: operational hardening / incident response readiness
+  - Reason: After deterministic idle-timeout delivery in PR #786, the remaining high-value runtime gap is operational visibility of `/ws` behavior under load. Without explicit websocket metrics and constrained structured logs, incident triage is slower and capacity regressions are harder to detect early.
+  - Worst-case scenario: high-volume idle/malformed websocket traffic degrades service while missing or high-cardinality observability obscures root cause and delays mitigation.
+  - Scope IN:
+    - Add low-cardinality counters for websocket connect result and close reasons.
+    - Add active websocket gauge aligned with tracker state.
+    - Add message counters by allowlisted event type (`ping`, `subscribe`) and outcome (`ok`/`closed`).
+    - Add structured logs for policy closes using non-sensitive fields only.
+  - Scope OUT:
+    - Product analytics, user-behavior funnels, and per-user telemetry.
+    - New websocket protocol features/channels.
+    - Frontend/iOS telemetry changes.
+  - Guardrails:
+    - Never log tokens, user IDs, raw payloads, or unbounded labels.
+    - Metrics labels must remain low-cardinality and enum-bound.
+  - Links:
+    - `app/routers/realtime_ws.py`
+    - `app/middleware/metrics.py`
+    - `docs/audit/PR_WS_IDLE_TIMEOUT_AUDIT.md`
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/786`
+  - DoD:
+    - `ws_connect_total{result,reason}` and `ws_messages_total{type,result}` are implemented with bounded labels.
+    - `ws_active_connections` gauge reflects tracker state without negative drift.
+    - Structured websocket logs include only safe, bounded fields (`reason`, `event_type`, `version`, `result`).
+    - Deterministic tests validate metric increments and no-`sleep()` time-based behavior.
+    - `make verify` and diff-coverage gates are green in observability PR.
 
 - [x] P1: Shoplist flow stabilization work-package (`plan -> shoplist`)
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -517,7 +517,7 @@ If it is not recorded here — it does not exist.
     - Add deterministic integration tests for expanded event flow
     - Keep `make verify` and diff-coverage gates green in expansion PR
 
-- [ ] P1: WebSocket idle-timeout follow-up (capacity safeguard)
+- [x] P1: WebSocket idle-timeout follow-up (capacity safeguard)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #786
@@ -527,7 +527,7 @@ If it is not recorded here — it does not exist.
   - Finding Type: deferred hardening / runtime safeguard
   - Reason: PR #783 intentionally shipped secure websocket foundation (`/ws`, auth, limits, versioned events) without idle timeout to avoid scope creep. Remaining risk is capacity/resource retention from idle connections (not a security bypass).
   - Links:
-    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/783`
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/786`
     - `docs/audit/PR_WS_REALTIME_EXPANSION_AUDIT.md`
     - `docs/plan/PR_WS_REALTIME_EXPANSION_PLAN.md`
     - `docs/plan/PR_WS_IDLE_TIMEOUT_PLAN.md`


### PR DESCRIPTION
## Summary
- Close backlog item for merged `PR #786` (websocket idle-timeout follow-up) with merge metadata.
- Add next runtime planned item: `P1 WebSocket observability hardening` with explicit Scope IN/OUT, worst-case scenario, guardrails, and DoD.

## Scope
### IN
- `docs/roadmap/BACKLOG_LEDGER.md` only

### OUT
- runtime code changes
- tests
- AGENTS changes

## Why
- Ledger hygiene: merged item must be closed promptly.
- Preserve momentum with a canon-aligned next P1 runtime package.

## Test plan
- [x] `pre-commit run --files docs/roadmap/BACKLOG_LEDGER.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Обновить реестр бэклога дорожной карты, чтобы зафиксировать мёрдж последующих работ по WebSocket idle-timeout и запланировать новый пакет по укреплению наблюдаемости WebSocket приоритетом P1.

Улучшения:
- Отметить последующий элемент работы по WebSocket idle-timeout как смёрженный с указанием связанного PR и метаданных коммита.
- Добавить новый запланированный элемент работы уровня P1 по укреплению наблюдаемости WebSocket с определёнными границами, ограничениями, ссылками и критериями готовности (definition of done).

Документация:
- Обновить реестр бэклога дорожной карты, чтобы отразить текущее состояние работ по WebSocket runtime и предстоящие усилия по улучшению наблюдаемости.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the roadmap backlog ledger to record the merge of the WebSocket idle-timeout follow-up work and to schedule a new P1 WebSocket observability hardening package.

Enhancements:
- Mark the WebSocket idle-timeout follow-up item as merged with associated PR and commit metadata.
- Add a new planned P1 work item for WebSocket observability hardening with defined scope, guardrails, links, and definition of done.

Documentation:
- Refresh the roadmap backlog ledger to reflect current WebSocket runtime work status and upcoming observability efforts.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Backlog updated: marked a WebSocket idle-timeout follow-up as merged and recorded merge details.
  * Added a new high-priority WebSocket observability hardening entry with owners, scope, acceptance criteria, and deterministic test guidance.
  * Adjusted related Shoplist flow stabilization notes and expanded audit/context links to align with the new observability work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->