### PR TITLE
docs(ledger): close Dialogue Visualization item after PR #796

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1733,15 +1733,17 @@ If it is not recorded here — it does not exist.
     - Minimal telemetry spec defined (what metrics, where recorded, retention)
     - Metrics collection does not affect runtime product behavior
 
-- [ ] Dialogue Visualization (interaction graph)
+- [x] Dialogue Visualization (interaction graph)
   - Owner: @katsiaryna_kavaleuskaya
-  - Target PR: PR-TBD (`docs/orchestration-dialogue-visualization`)
-  - Status: 🚧 In progress (started 2026-02-18)
+  - Target PR: PR #796
+  - Status: ✅ Merged (PR #796, 2026-02-18)
+  - Merge SHA: `fca3d6e7e2f2ab40a2cc4222e4330a30456e1a0b`
   - Priority: P2
   - Area: dev-process / orchestration
   - Finding Type: tooling
   - Reason: Multi-agent dialogue is hard to audit without a visual interaction graph.
   - Links:
+    - PR #796: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/796
     - docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md
     - docs/orchestration/workflow.md
     - docs/plan/PR_ORCHESTRATION_DIALOGUE_VISUALIZATION_TASK_ANALYSIS.md

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1743,7 +1743,7 @@ If it is not recorded here — it does not exist.
   - Finding Type: tooling
   - Reason: Multi-agent dialogue is hard to audit without a visual interaction graph.
   - Links:
-    - PR #796: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/796
+    - PR #796: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/796>
     - docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md
     - docs/orchestration/workflow.md
     - docs/plan/PR_ORCHESTRATION_DIALOGUE_VISUALIZATION_TASK_ANALYSIS.md


### PR DESCRIPTION
## Summary
- Close backlog item `Dialogue Visualization (interaction graph)` after successful merge of PR #796.
- Update `Target PR`, merged status, merge SHA, and add direct PR link in `docs/roadmap/BACKLOG_LEDGER.md`.
- Keep scope strictly docs-only and ledger-only.

## Scope
### IN
- `docs/roadmap/BACKLOG_LEDGER.md` status closure for Dialogue Visualization entry.

### OUT
- Runtime/backend/frontend/iOS code changes.
- CI/workflow behavior changes.
- Any additional backlog grooming unrelated to PR #796 closure.

## Risks / Mitigations
- Risk: metadata drift between merged PR and ledger entry.
- Mitigation: recorded exact merge SHA `fca3d6e7e2f2ab40a2cc4222e4330a30456e1a0b` and canonical PR URL.

## Test Plan
- `python scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md`
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project backlog to mark the Dialogue Visualization (interaction graph) item as merged; added the PR reference (PR #796), merge SHA, and PR link to the backlog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->