### PR TITLE
docs(figma): mark missing node-id capture blockers

### DIFF
--- a/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
+++ b/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable MD013 -->
 # Figma Code Connect Mapping Candidates (H+P+Pr)
 
-**Date:** February 18, 2026
+**Date:** February 19, 2026
 **Scope:** 23 CTA IDs from `docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md`
-**Context version:** 2026-02-18 / commit `162ad6ef`
+**Context version:** 2026-02-19 / commit `5d05beae`
 
 Status policy for this revision: rows stay `blocked_by_design_url` when the Design file key is missing; once the Design URL exists but node IDs are missing, use `blocked_by_node_id_capture` (`missing_node_id`); rows with verified node capture are marked `validated`.
 
@@ -35,11 +35,11 @@ Status policy for this revision: rows stay `blocked_by_design_url` when the Desi
 
 ## Notes
 
-- Mapping coverage is complete for all 23 CTA IDs in H+P+Pr scope.
-- Candidate rows intentionally avoid fake node IDs.
-- 2026-02-19 browser capture validated `web.home.open_setup` as `1:72` in file `umcCk7TtO760DJ3N6M7mvh`; `Find (All pages)` returned no results for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, `ios.plate.issue_action_dynamic`.
-- Clear note: For `web.plate.premium_gate_cta`, `web.progress.export_pdf`, and `ios.plate.issue_action_dynamic`, the Design URL exists but node IDs are missing in the design file.
-- Activation starts after missing node IDs are added in Design and capture is completed.
+- Mapping coverage is complete for all 23 CTA IDs in H+P+Pr scope (evidence: `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md:12`).
+- Candidate rows intentionally avoid fake node IDs (evidence: `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md:13`).
+- 2026-02-19 browser capture validated `web.home.open_setup` as `1:72` in file `umcCk7TtO760DJ3N6M7mvh`; `Find (All pages)` returned no results for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, `ios.plate.issue_action_dynamic` (evidence: `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md:72`, `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md:77`).
+- Clear note: For `web.plate.premium_gate_cta`, `web.progress.export_pdf`, and `ios.plate.issue_action_dynamic`, the Design URL exists but node IDs are missing in the design file (evidence: `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md:79`).
+- Activation starts after missing node IDs are added in Design and capture is completed (evidence: `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md:83`).
 
 ## Next action for designer
 

--- a/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
+++ b/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
@@ -5,18 +5,18 @@
 **Scope:** 23 CTA IDs from `docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md`
 **Context version:** 2026-02-18 / commit `162ad6ef`
 
-Status policy for this revision: `blocked_by_design_url` until Design file key/node IDs are provided.
+Status policy for this revision: rows remain `blocked_by_node_id_capture` (`missing_node_id`) until node IDs are available in Design; rows with verified node capture are marked `validated`.
 
 | Button/CTA ID | Platform | Screen | Existing Site Surface (file:line) | Candidate Component/Entry | Code Connect Label | Design File Key | Node ID | Status | Gap/Refactor Needed | Owner |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `web.home.open_setup` | Web | Home | `frontend/src/pages/Home.tsx:34` | Inline `Link` in Home quick actions (`to="/setup"`) | React | TBD | TBD | blocked_by_design_url | Extract reusable quick-action CTA component for stable mapping | FE |
+| `web.home.open_setup` | Web | Home | `frontend/src/pages/Home.tsx:34` | Inline `Link` in Home quick actions (`to="/setup"`) | React | `umcCk7TtO760DJ3N6M7mvh` | `1:72` | validated | Extract reusable quick-action CTA component for stable mapping | FE |
 | `web.home.open_plate` | Web | Home | `frontend/src/pages/Home.tsx:37` | Inline `Link` in Home quick actions (`to="/plate"`) | React | TBD | TBD | blocked_by_design_url | Add lock-aware variant style and extract component | FE |
 | `web.home.open_progress` | Web | Home | `frontend/src/pages/Home.tsx:40` | Inline `Link` in Home quick actions (`to="/progress"`) | React | TBD | TBD | blocked_by_design_url | Consolidate auth-required CTA visual contract | FE |
 | `web.home.open_pro` | Web | Home | `frontend/src/pages/Home.tsx:43` | Inline `Link` in Home quick actions (`to="/pro"`) | React | TBD | TBD | blocked_by_design_url | Align with paywall CTA hierarchy and shared component | FE |
 | `web.plate.open_setup` | Web | Plate | `frontend/src/pages/Plate.tsx:37` | Inline `Link` inside premium-gated controls | React | TBD | TBD | blocked_by_design_url | Extract gated CTA pair component | FE |
 | `web.plate.open_progress` | Web | Plate | `frontend/src/pages/Plate.tsx:40` | Inline `Link` inside premium-gated controls | React | TBD | TBD | blocked_by_design_url | Same as above, shared secondary variant needed | FE |
-| `web.plate.premium_gate_cta` | Web | Plate | `frontend/src/components/PremiumGate.tsx:47` | PremiumGate unlock button entry | React | TBD | TBD | blocked_by_design_url | Real purchase hook still pending; map after stable CTA API | FE + Product |
-| `web.progress.export_pdf` | Web | Progress | `frontend/src/features/progress/ProgressCharts.tsx:120` | Export utility button in ProgressCharts | React | TBD | TBD | blocked_by_design_url | Refactor to shared utility button for consistent mapping | FE |
+| `web.plate.premium_gate_cta` | Web | Plate | `frontend/src/components/PremiumGate.tsx:47` | PremiumGate unlock button entry | React | `umcCk7TtO760DJ3N6M7mvh` | TBD | blocked_by_node_id_capture | Real purchase hook still pending; map after stable CTA API | FE + Product |
+| `web.progress.export_pdf` | Web | Progress | `frontend/src/features/progress/ProgressCharts.tsx:120` | Export utility button in ProgressCharts | React | `umcCk7TtO760DJ3N6M7mvh` | TBD | blocked_by_node_id_capture | Refactor to shared utility button for consistent mapping | FE |
 | `ios.home.bmi_calculator` | iOS | Home | `ios/PulsePlate/Views/HomeView.swift:57` | `NavigationLink` row entry to `BMICalculatorScreen()` | SwiftUI | TBD | TBD | blocked_by_design_url | Define reusable quick-action row component for iOS maps | iOS |
 | `ios.home.profile_setup` | iOS | Home | `ios/PulsePlate/Views/HomeView.swift:67` | `NavigationLink` row entry to `ProfileView()` | SwiftUI | TBD | TBD | blocked_by_design_url | Same quick-action row extraction as above | iOS |
 | `ios.home.open_plate` | iOS | Home | `ios/PulsePlate/Views/HomeView.swift:77` | `NavigationLink` row entry to `PlateViewPP()` | SwiftUI | TBD | TBD | blocked_by_design_url | Normalize row variants and states before mapping | iOS |
@@ -24,7 +24,7 @@ Status policy for this revision: `blocked_by_design_url` until Design file key/n
 | `ios.home.shopping_list_generator` | iOS | Home | `ios/PulsePlate/Views/HomeView.swift:106` | Flagged `NavigationLink` to shopping list screen | SwiftUI | TBD | TBD | blocked_by_design_url | Backend and release coupling incomplete | iOS |
 | `ios.plate.add_meal` | iOS | Plate | `ios/PulsePlate/Views/PlateView.swift:159` | Bottom bar button (`showMealEntry = true`) | SwiftUI | TBD | TBD | blocked_by_design_url | Destination placeholder; runtime completion required | iOS |
 | `ios.plate.view_details` | iOS | Plate | `ios/PulsePlate/Views/PlateView.swift:164` | Bottom bar button (`showNutritionDetails = true`) | SwiftUI | TBD | TBD | blocked_by_design_url | Destination placeholder; runtime completion required | iOS |
-| `ios.plate.issue_action_dynamic` | iOS | Plate | `ios/PulsePlate/Views/PlateView.swift:205` | Dynamic issue action button in `PlateIssueView` | SwiftUI | TBD | TBD | blocked_by_design_url | Need stable issue-action component abstraction | iOS |
+| `ios.plate.issue_action_dynamic` | iOS | Plate | `ios/PulsePlate/Views/PlateView.swift:205` | Dynamic issue action button in `PlateIssueView` | SwiftUI | `umcCk7TtO760DJ3N6M7mvh` | TBD | blocked_by_node_id_capture | Need stable issue-action component abstraction | iOS |
 | `ios.progress.refresh` | iOS | Progress | `ios/PulsePlate/Views/ProgressView.swift:50` | Refresh button in no-data state | SwiftUI | TBD | TBD | blocked_by_design_url | Promote shared recovery CTA style for mapping | iOS |
 | `ios.progress.issue_action_dynamic` | iOS | Progress | `ios/PulsePlate/Views/ProgressView.swift:182` | Dynamic issue action button by issue classifier | SwiftUI | TBD | TBD | blocked_by_design_url | Mirror Plate issue-action component contract | iOS |
 | `web.paywall.modal.cta` | Web (linked flow) | Paywall Modal | `frontend/src/components/Paywall/BeforeAfter.tsx:136` | Primary purchase CTA in modal | React | TBD | TBD | blocked_by_design_url | Purchase integration incomplete; keep status partial | FE + Product |
@@ -37,5 +37,15 @@ Status policy for this revision: `blocked_by_design_url` until Design file key/n
 
 - Mapping coverage is complete for all 23 CTA IDs in H+P+Pr scope.
 - Candidate rows intentionally avoid fake node IDs.
-- Activation starts after Design URL is provided and blocker is closed.
+- 2026-02-19 browser capture validated `web.home.open_setup` as `1:72` in file `umcCk7TtO760DJ3N6M7mvh`; `Find (All pages)` returned no results for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, `ios.plate.issue_action_dynamic`.
+- Clear note: Design URL exists, node IDs missing in design file.
+- Activation starts after missing node IDs are added in Design and capture is completed.
+
+## Next action for designer
+
+Provide node IDs (selection URLs) in Design file `umcCk7TtO760DJ3N6M7mvh` for:
+
+- `web.plate.premium_gate_cta`
+- `web.progress.export_pdf`
+- `ios.plate.issue_action_dynamic`
 <!-- markdownlint-enable MD013 -->

--- a/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
+++ b/docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md
@@ -5,7 +5,7 @@
 **Scope:** 23 CTA IDs from `docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md`
 **Context version:** 2026-02-18 / commit `162ad6ef`
 
-Status policy for this revision: rows remain `blocked_by_node_id_capture` (`missing_node_id`) until node IDs are available in Design; rows with verified node capture are marked `validated`.
+Status policy for this revision: rows stay `blocked_by_design_url` when the Design file key is missing; once the Design URL exists but node IDs are missing, use `blocked_by_node_id_capture` (`missing_node_id`); rows with verified node capture are marked `validated`.
 
 | Button/CTA ID | Platform | Screen | Existing Site Surface (file:line) | Candidate Component/Entry | Code Connect Label | Design File Key | Node ID | Status | Gap/Refactor Needed | Owner |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -38,7 +38,7 @@ Status policy for this revision: rows remain `blocked_by_node_id_capture` (`miss
 - Mapping coverage is complete for all 23 CTA IDs in H+P+Pr scope.
 - Candidate rows intentionally avoid fake node IDs.
 - 2026-02-19 browser capture validated `web.home.open_setup` as `1:72` in file `umcCk7TtO760DJ3N6M7mvh`; `Find (All pages)` returned no results for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, `ios.plate.issue_action_dynamic`.
-- Clear note: Design URL exists, node IDs missing in design file.
+- Clear note: For `web.plate.premium_gate_cta`, `web.progress.export_pdf`, and `ios.plate.issue_action_dynamic`, the Design URL exists but node IDs are missing in the design file.
 - Activation starts after missing node IDs are added in Design and capture is completed.
 
 ## Next action for designer

--- a/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
+++ b/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
@@ -70,9 +70,9 @@ If both succeed for all P0 rows, blocker is cleared and activation may proceed v
 | Button/CTA ID | Design URL | fileKey | nodeId | Captured by | Date | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | `web.home.open_setup` | `https://www.figma.com/design/umcCk7TtO760DJ3N6M7mvh/PulsePlate-Design-System?node-id=1-72` | `umcCk7TtO760DJ3N6M7mvh` | `1:72` | OpenClaw (browser capture) | 2026-02-19 | validated |
-| `web.plate.premium_gate_cta` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
-| `web.progress.export_pdf` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
-| `ios.plate.issue_action_dynamic` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+| `web.plate.premium_gate_cta` | `https://www.figma.com/design/umcCk7TtO760DJ3N6M7mvh/PulsePlate-Design-System` | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+| `web.progress.export_pdf` | `https://www.figma.com/design/umcCk7TtO760DJ3N6M7mvh/PulsePlate-Design-System` | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+| `ios.plate.issue_action_dynamic` | `https://www.figma.com/design/umcCk7TtO760DJ3N6M7mvh/PulsePlate-Design-System` | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
 
 **Capture note (2026-02-19):** in public browser session, `Find` with scope `All pages` returned `No results in this file` for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, and `ios.plate.issue_action_dynamic`; only `web.home.open_setup` resolved to `node-id=1-72`.
 

--- a/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
+++ b/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
@@ -69,10 +69,22 @@ If both succeed for all P0 rows, blocker is cleared and activation may proceed v
 
 | Button/CTA ID | Design URL | fileKey | nodeId | Captured by | Date | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| `web.home.open_setup` | TBD | TBD | TBD | TBD | TBD | blocked_by_design_url |
-| `web.plate.premium_gate_cta` | TBD | TBD | TBD | TBD | TBD | blocked_by_design_url |
-| `web.progress.export_pdf` | TBD | TBD | TBD | TBD | TBD | blocked_by_design_url |
-| `ios.plate.issue_action_dynamic` | TBD | TBD | TBD | TBD | TBD | blocked_by_design_url |
+| `web.home.open_setup` | `https://www.figma.com/design/umcCk7TtO760DJ3N6M7mvh/PulsePlate-Design-System?node-id=1-72` | `umcCk7TtO760DJ3N6M7mvh` | `1:72` | OpenClaw (browser capture) | 2026-02-19 | validated |
+| `web.plate.premium_gate_cta` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+| `web.progress.export_pdf` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+| `ios.plate.issue_action_dynamic` | TBD | `umcCk7TtO760DJ3N6M7mvh` | TBD | OpenClaw (browser search) | 2026-02-19 | blocked_by_node_id_capture |
+
+**Capture note (2026-02-19):** in public browser session, `Find` with scope `All pages` returned `No results in this file` for `web.plate.premium_gate_cta`, `web.progress.export_pdf`, and `ios.plate.issue_action_dynamic`; only `web.home.open_setup` resolved to `node-id=1-72`.
+
+**Clear note:** Design URL exists, node IDs missing in design file.
+
+## Next action for designer
+
+Add/restore the following node names in Design file `umcCk7TtO760DJ3N6M7mvh` and provide selection URLs with node IDs:
+
+- `web.plate.premium_gate_cta`
+- `web.progress.export_pdf`
+- `ios.plate.issue_action_dynamic`
 
 ## 5) Done Criteria
 
@@ -81,7 +93,7 @@ Dependency is considered closed only when:
 1. Design URL is recorded in repo docs.
 2. All four P0 rows have non-`TBD` `fileKey` and `nodeId`.
 3. MCP verification succeeds for all four rows.
-4. Mapping registry status is updated out of `blocked_by_design_url`.
+4. Mapping registry status is updated out of `blocked_by_node_id_capture` / `missing_node_id`.
 
 ## 6) Canonical links
 

--- a/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
+++ b/docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # Figma Design URL + Node ID Capture Protocol (H+P+Pr)
 
-**Date:** February 18, 2026
+**Date:** February 19, 2026
 **Scope:** unblock Code Connect activation for Home + Plate + Progress CTA mappings
 
 ## 1) Purpose

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -503,6 +503,33 @@ If it is not recorded here — it does not exist.
     - Matrix `Exists Now / Missing / Implement Needed` statuses are updated after remediation PR
     - `make verify` and required CI checks are green in remediation PR
 
+- [x] P1: Home/Plate/Progress Figma sync and Code Connect bridge docs package
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR #798 (`docs/figma-hpp-sync-package`)
+  - Status: ✅ Merged (PR #798, 2026-02-19)
+  - Merge SHA: 891a3fcaaac3da351c104a3ebb164c4c02a126c3
+  - Area: docs / design / orchestration
+  - Finding Type: documentation contract delivery
+  - Reason: Landed canonical H+P+Pr Figma sync protocols and Code Connect activation
+    bridge docs with evidence anchors, bot-review remediations, and policy-aligned
+    AGENTS updates; this closes the docs package while keeping Design URL/node ID
+    activation dependency explicitly tracked as a separate open ledger item.
+  - Links:
+    - PR #798
+    - `docs/figma/FIGMA_MAKE_SYNC_AUDIT_HPP.md`
+    - `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
+    - `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`
+    - `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
+    - `docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md`
+    - `AGENTS.md`
+  - DoD:
+    - Figma Make sync audit protocol committed with evidence anchors
+    - Code Connect activation blocker protocol and mapping candidate registry committed
+    - Design URL + node ID capture protocol committed
+    - Orchestration session artifacts committed for the sync package
+    - Root `AGENTS.md` updated with canonical Figma workflow protocol references
+
 - [x] P1: WebSocket foundation work-package (`/ws` secure baseline)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1


### PR DESCRIPTION
## Summary
- update H+P+Pr post-capture docs after validating design file key `umcCk7TtO760DJ3N6M7mvh`
- mark `web.home.open_setup` as validated (`nodeId=1:72`)
- reclassify remaining P0 rows to `blocked_by_node_id_capture` and add explicit note: Design URL exists, node IDs are missing in design file
- add "Next action for designer" block with required node names

## Files Changed
- `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
- `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`

## Validation
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified status policy and per-row behavior for design captures, introducing blocked_by_node_id_capture / missing_node_id semantics and validation rules.
  * Updated capture table: web.home.open_setup marked validated; three CTAs set to blocked_by_node_id_capture and listed as needing node IDs; capture dates and evidence notes updated.
  * Added capture/clear notes, “Next action for designer” list, and a backlog ledger entry tracking the Figma-to-code sync (duplicate entry noted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->