### PR TITLE
feat(frontend): add HPP live indicator with fallback CTA telemetry

### DIFF
--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -1,3 +1,6 @@
+export function createWebSocketConnection(url: string): WebSocket {
+  return new WebSocket(url);
+}
 import { getApiBase } from "./client";
 
 export type WsConnectionState = "connecting" | "open" | "closed" | "error";

--- a/frontend/src/features/progress/LiveProgressIndicator.tsx
+++ b/frontend/src/features/progress/LiveProgressIndicator.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import { trackHppCtaClick, trackHppCtaImpression, trackHppLiveIndicatorImpression } from '../../lib/hppTelemetry';
+import { useHppLiveIndicator } from './useHppLiveIndicator';
+
+type HppIndicatorSource = 'home' | 'plate' | 'progress';
+
+interface LiveProgressIndicatorProps {
+  source: HppIndicatorSource;
+  ctaTo: string;
+  ctaLabel: string;
+}
+
+export default function LiveProgressIndicator({
+  source,
+  ctaTo,
+  ctaLabel,
+}: LiveProgressIndicatorProps) {
+  const { status, lastEventAt } = useHppLiveIndicator();
+  const trackedImpressionRef = useRef(false);
+
+  useEffect(() => {
+    if (trackedImpressionRef.current) {
+      return;
+    }
+    trackedImpressionRef.current = true;
+    trackHppLiveIndicatorImpression({ source, live_status: status });
+    trackHppCtaImpression({ source, live_status: status, cta_to: ctaTo });
+  }, [ctaTo, source, status]);
+
+  const statusLabel = status === 'live' ? 'Live updates on' : 'Static fallback';
+  const dotClass = status === 'live' ? 'bg-[var(--color-success)] animate-pulse' : 'bg-[var(--color-warning)]';
+
+  return (
+    <section
+      className="rounded-xl border p-4 space-y-3"
+      style={{ backgroundColor: 'var(--color-surface)', borderColor: 'var(--color-border)' }}
+      aria-label="Live progress indicator"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className={`h-2.5 w-2.5 rounded-full ${dotClass}`} aria-hidden="true" />
+          <p className="text-sm font-medium text-text">{statusLabel}</p>
+        </div>
+        {lastEventAt ? (
+          <p className="text-xs text-muted" aria-label="Live event timestamp">
+            {new Date(lastEventAt).toLocaleTimeString()}
+          </p>
+        ) : null}
+      </div>
+      <p className="text-xs text-muted">
+        If realtime is unavailable, PulsePlate stays usable and keeps CTA flow active.
+      </p>
+      <Link
+        to={ctaTo}
+        className="inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white"
+        onClick={() => trackHppCtaClick({ source, live_status: status, cta_to: ctaTo })}
+      >
+        {ctaLabel}
+      </Link>
+    </section>
+  );
+}

--- a/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
+++ b/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
@@ -1,0 +1,75 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import LiveProgressIndicator from '../LiveProgressIndicator';
+
+const mockTrackLiveIndicatorImpression = vi.fn();
+const mockTrackCtaImpression = vi.fn();
+const mockTrackCtaClick = vi.fn();
+
+vi.mock('../useHppLiveIndicator', () => ({
+  useHppLiveIndicator: vi.fn(),
+}));
+
+vi.mock('../../../lib/hppTelemetry', () => ({
+  trackHppLiveIndicatorImpression: (...args: unknown[]) => mockTrackLiveIndicatorImpression(...args),
+  trackHppCtaImpression: (...args: unknown[]) => mockTrackCtaImpression(...args),
+  trackHppCtaClick: (...args: unknown[]) => mockTrackCtaClick(...args),
+}));
+
+import { useHppLiveIndicator } from '../useHppLiveIndicator';
+
+describe('LiveProgressIndicator', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders static fallback and tracks impressions', () => {
+    vi.mocked(useHppLiveIndicator).mockReturnValue({
+      status: 'static',
+      lastEventAt: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <LiveProgressIndicator source="home" ctaTo="/progress" ctaLabel="Open progress live" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
+    expect(screen.getByText('Static fallback')).toBeInTheDocument();
+    expect(mockTrackLiveIndicatorImpression).toHaveBeenCalledWith({
+      source: 'home',
+      live_status: 'static',
+    });
+    expect(mockTrackCtaImpression).toHaveBeenCalledWith({
+      source: 'home',
+      live_status: 'static',
+      cta_to: '/progress',
+    });
+  });
+
+  it('renders live status and tracks click', () => {
+    vi.mocked(useHppLiveIndicator).mockReturnValue({
+      status: 'live',
+      lastEventAt: 1710000000000,
+    });
+
+    render(
+      <MemoryRouter>
+        <LiveProgressIndicator source="progress" ctaTo="/setup" ctaLabel="Refresh setup inputs" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Live updates on')).toBeInTheDocument();
+    expect(screen.getByLabelText('Live event timestamp')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Refresh setup inputs' }));
+
+    expect(mockTrackCtaClick).toHaveBeenCalledWith({
+      source: 'progress',
+      live_status: 'live',
+      cta_to: '/setup',
+    });
+  });
+});

--- a/frontend/src/features/progress/__tests__/useHppLiveIndicator.test.ts
+++ b/frontend/src/features/progress/__tests__/useHppLiveIndicator.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useHppLiveIndicator } from '../useHppLiveIndicator';
+
+type Listener = (event?: Event) => void;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(public readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, callback: Listener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)?.add(callback);
+  }
+
+  removeEventListener(type: string, callback: Listener): void {
+    this.listeners.get(type)?.delete(callback);
+  }
+
+  close(): void {
+    this.emit('close');
+  }
+
+  emit(type: string): void {
+    this.listeners.get(type)?.forEach((listener) => listener(new Event(type)));
+  }
+}
+
+describe('useHppLiveIndicator', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    MockWebSocket.instances = [];
+  });
+
+  it('uses static status when ws url is missing', () => {
+    const { result } = renderHook(() => useHppLiveIndicator(null));
+
+    expect(result.current.status).toBe('static');
+    expect(result.current.lastEventAt).toBeNull();
+  });
+
+  it('switches to live status on open and message', () => {
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+
+    const { result } = renderHook(() => useHppLiveIndicator('ws://localhost/live'));
+    const instance = MockWebSocket.instances[0];
+
+    expect(instance).toBeDefined();
+    expect(result.current.status).toBe('static');
+
+    act(() => {
+      instance.emit('open');
+    });
+
+    expect(result.current.status).toBe('live');
+    expect(result.current.lastEventAt).toBeTypeOf('number');
+
+    const firstTimestamp = result.current.lastEventAt;
+
+    act(() => {
+      instance.emit('message');
+    });
+
+    expect(result.current.status).toBe('live');
+    expect(result.current.lastEventAt).not.toBeNull();
+    expect(result.current.lastEventAt).toBeGreaterThanOrEqual(firstTimestamp ?? 0);
+  });
+
+  it('returns to static status after close', () => {
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+
+    const { result } = renderHook(() => useHppLiveIndicator('ws://localhost/live'));
+    const instance = MockWebSocket.instances[0];
+
+    act(() => {
+      instance.emit('open');
+    });
+
+    expect(result.current.status).toBe('live');
+
+    act(() => {
+      instance.emit('close');
+    });
+
+    expect(result.current.status).toBe('static');
+  });
+});

--- a/frontend/src/features/progress/useHppLiveIndicator.ts
+++ b/frontend/src/features/progress/useHppLiveIndicator.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export type HppLiveStatus = 'live' | 'static';
+
+interface UseHppLiveIndicatorResult {
+  status: HppLiveStatus;
+  lastEventAt: number | null;
+}
+
+const getConfiguredWsUrl = (): string | null => {
+  const value = ((import.meta as { env?: Record<string, string | undefined> }).env?.VITE_HPP_LIVE_WS_URL ?? '').trim();
+  return value.length > 0 ? value : null;
+};
+
+export function useHppLiveIndicator(overrideWsUrl?: string | null): UseHppLiveIndicatorResult {
+  const [status, setStatus] = useState<HppLiveStatus>('static');
+  const [lastEventAt, setLastEventAt] = useState<number | null>(null);
+
+  const wsUrl = useMemo(() => {
+    if (typeof overrideWsUrl === 'string') {
+      return overrideWsUrl.trim().length > 0 ? overrideWsUrl.trim() : null;
+    }
+    return overrideWsUrl === null ? null : getConfiguredWsUrl();
+  }, [overrideWsUrl]);
+
+  useEffect(() => {
+    if (!wsUrl || typeof WebSocket === 'undefined') {
+      setStatus('static');
+      setLastEventAt(null);
+      return;
+    }
+
+    const socket = new WebSocket(wsUrl);
+
+    const markLive = () => {
+      setStatus('live');
+      setLastEventAt(Date.now());
+    };
+
+    const markStatic = () => {
+      setStatus('static');
+    };
+
+    socket.addEventListener('open', markLive);
+    socket.addEventListener('message', markLive);
+    socket.addEventListener('error', markStatic);
+    socket.addEventListener('close', markStatic);
+
+    return () => {
+      socket.removeEventListener('open', markLive);
+      socket.removeEventListener('message', markLive);
+      socket.removeEventListener('error', markStatic);
+      socket.removeEventListener('close', markStatic);
+      socket.close();
+    };
+  }, [wsUrl]);
+
+  return { status, lastEventAt };
+}

--- a/frontend/src/features/progress/useHppLiveIndicator.ts
+++ b/frontend/src/features/progress/useHppLiveIndicator.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { createWebSocketConnection } from '../../api/wsClient';
 
 export type HppLiveStatus = 'live' | 'static';
 
@@ -30,7 +31,7 @@ export function useHppLiveIndicator(overrideWsUrl?: string | null): UseHppLiveIn
       return;
     }
 
-    const socket = new WebSocket(wsUrl);
+    const socket = createWebSocketConnection(wsUrl);
 
     const markLive = () => {
       setStatus('live');

--- a/frontend/src/lib/hppTelemetry.ts
+++ b/frontend/src/lib/hppTelemetry.ts
@@ -1,0 +1,31 @@
+import { log } from './analytics';
+
+type HppSource = 'home' | 'plate' | 'progress';
+type HppLiveStatus = 'live' | 'static';
+
+interface HppBasePayload extends Record<string, unknown> {
+  source: HppSource;
+  live_status: HppLiveStatus;
+}
+
+interface HppCtaPayload extends HppBasePayload {
+  cta_to: string;
+}
+
+export const HPP_EVENTS = {
+  LIVE_INDICATOR_IMPRESSION: 'hpp_live_indicator_impression',
+  CTA_IMPRESSION: 'hpp_cta_impression',
+  CTA_CLICK: 'hpp_cta_click',
+} as const;
+
+export function trackHppLiveIndicatorImpression(payload: HppBasePayload): void {
+  log(HPP_EVENTS.LIVE_INDICATOR_IMPRESSION, payload);
+}
+
+export function trackHppCtaImpression(payload: HppCtaPayload): void {
+  log(HPP_EVENTS.CTA_IMPRESSION, payload);
+}
+
+export function trackHppCtaClick(payload: HppCtaPayload): void {
+  log(HPP_EVENTS.CTA_CLICK, payload);
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { getStoredApiKey } from '../auth/storage';
 import { pageCardStyle } from '../components/ui/pageCardStyle';
+import LiveProgressIndicator from '../features/progress/LiveProgressIndicator';
 import { usePremium } from '../lib/usePremium';
 
 export default function Home() {
@@ -27,6 +28,8 @@ export default function Home() {
           </p>
         </article>
       </section>
+
+      <LiveProgressIndicator source="home" ctaTo="/progress" ctaLabel="Open progress live" />
 
       <section className="p-4 space-y-3" style={pageCardStyle}>
         <h2 className="text-base font-semibold text-text">Quick actions</h2>

--- a/frontend/src/pages/Plate.tsx
+++ b/frontend/src/pages/Plate.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import PremiumGate from "../components/PremiumGate";
 import { pageCardStyle } from "../components/ui/pageCardStyle";
+import LiveProgressIndicator from '../features/progress/LiveProgressIndicator';
 import { usePremium } from "../lib/usePremium";
 import { PREMIUM_GATE_SOURCES } from "../config/constants";
 
@@ -42,6 +43,7 @@ export default function Plate() {
             </Link>
           </div>
         </section>
+        <LiveProgressIndicator source="plate" ctaTo="/progress" ctaLabel="Open progress live" />
       </PremiumGate>
     </main>
   );

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -1,5 +1,6 @@
 import ProgressCharts from '../features/progress/ProgressCharts';
 import { pageCardStyle } from '../components/ui/pageCardStyle';
+import LiveProgressIndicator from '../features/progress/LiveProgressIndicator';
 
 export default function Progress() {
   return (
@@ -8,6 +9,7 @@ export default function Progress() {
         <h1 className="text-2xl font-bold text-text">Progress</h1>
         <p className="mt-2 text-sm text-muted">Daily and weekly trend surface for Home+Plate slice.</p>
       </section>
+      <LiveProgressIndicator source="progress" ctaTo="/setup" ctaLabel="Refresh setup inputs" />
       <ProgressCharts />
     </main>
   );

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -13,6 +13,8 @@ describe('Home', () => {
 
     expect(screen.getByRole('main')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open progress live' })).toHaveAttribute('href', '/progress');
     expect(screen.getByText('Quick actions')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open setup' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open plate' })).toHaveAttribute('href', '/plate');

--- a/frontend/src/pages/__tests__/Plate.test.tsx
+++ b/frontend/src/pages/__tests__/Plate.test.tsx
@@ -54,6 +54,8 @@ describe('Plate', () => {
     expect(screen.getByTestId('premium-gate')).toBeInTheDocument();
     expect(screen.getByText('PRO nutrition controls')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open setup' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open progress live' })).toHaveAttribute('href', '/progress');
   });
 
   it('passes correct isPremium prop to PremiumGate', () => {

--- a/frontend/src/pages/__tests__/Progress.test.tsx
+++ b/frontend/src/pages/__tests__/Progress.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Progress from '../Progress';
 
 // Mock ProgressCharts component
@@ -13,15 +14,25 @@ afterEach(() => {
 
 describe('Progress', () => {
   it('renders progress page with ProgressCharts', () => {
-    render(<Progress />);
+    render(
+      <MemoryRouter>
+        <Progress />
+      </MemoryRouter>
+    );
 
     expect(screen.getByRole('main')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: 'Progress' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Refresh setup inputs' })).toHaveAttribute('href', '/setup');
     expect(screen.getByTestId('progress-charts')).toBeInTheDocument();
   });
 
   it('has correct inline styles', () => {
-    render(<Progress />);
+    render(
+      <MemoryRouter>
+        <Progress />
+      </MemoryRouter>
+    );
 
     const main = screen.getByRole('main');
     expect(main).toHaveStyle({


### PR DESCRIPTION
## Summary
- add a new `LiveProgressIndicator` on Home, Plate, and Progress pages for a user-visible HPP live signal
- implement a WS-ready hook with strict static fallback (`ws unavailable/error -> static mode + CTA remains usable`)
- add HPP CTA instrumentation (`impression` + `click`) through a dedicated telemetry helper and deterministic tests

## Scope
### IN
- frontend-only HPP live indicator UI and hook
- CTA instrumentation for Home/Plate/Progress live blocks
- deterministic unit/page tests for fallback invariant and click telemetry

### OUT
- no backend websocket endpoint or new API perimeter
- no auth/rate-limit/transport changes
- no docs-heavy package in this PR

## Test plan
- [x] `npm test -- --run src/features/progress/__tests__/useHppLiveIndicator.test.ts src/features/progress/__tests__/LiveProgressIndicator.test.tsx src/pages/__tests__/Home.test.tsx src/pages/__tests__/Plate.test.tsx src/pages/__tests__/Progress.test.tsx`
- [x] `npm run build`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Risks / Mitigations
- Risk: realtime transport is not configured in current env
  - Mitigation: hook defaults to static fallback mode and never blocks CTA flow
- Risk: telemetry regressions via naming drift
  - Mitigation: centralized `hppTelemetry` helper + deterministic assertions in tests

## Deferred / Follow-ups
- If backend WS route is introduced later, set `VITE_HPP_LIVE_WS_URL` and reuse the same hook/indicator contract without UI refactor.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавлен переиспользуемый компонент индикатора живого прогресса с отказоустойчивым режимом, учитывающим WebSocket, для HPP и его интеграция в ключевые пользовательские страницы с телеметрией.

Новые возможности:
- Добавлен компонент `LiveProgressIndicator`, который отображает актуальный статус HPP и CTA на страницах Home, Plate и Progress.
- Добавлен хук `useHppLiveIndicator`, который определяет живой или статический статус HPP на основе необязательной конечной точки WebSocket с безопасным резервным режимом при недоступности работы в реальном времени.
- Добавлены централизованные помощники телеметрии HPP для показов живого индикатора и показов/кликов по CTA.

Тесты:
- Добавлены детерминированные модульные тесты для поведения `useHppLiveIndicator` с WebSocket и семантики резервного режима.
- Расширены тесты страниц Home, Plate и Progress для проверки рендеринга живого индикатора и корректных целей CTA.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a reusable live progress indicator component with websocket-aware fallback for HPP and integrate it into key user pages with telemetry.

New Features:
- Introduce a LiveProgressIndicator component that surfaces HPP live status and a CTA across Home, Plate, and Progress pages.
- Add a useHppLiveIndicator hook that derives live vs static HPP status from an optional websocket endpoint with safe fallback when realtime is unavailable.
- Add centralized HPP telemetry helpers for live indicator impressions and CTA impressions/clicks.

Tests:
- Add deterministic unit tests for useHppLiveIndicator websocket behavior and fallback semantics.
- Extend Home, Plate, and Progress page tests to cover rendering of the live indicator and correct CTA targets.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a reusable HPP live progress indicator to Home, Plate, and Progress with a safe static fallback when realtime isn’t available. Instrumented CTA impressions and clicks, and ensured the CTA always works.

- New Features
  - LiveProgressIndicator component showing live vs static status and last event time.
  - useHppLiveIndicator hook reads VITE_HPP_LIVE_WS_URL, opens sockets via wsClient adapter, and falls back to static on errors or absence.
  - Centralized hppTelemetry for indicator impressions and CTA impressions/clicks with deterministic tests.

- Migration
  - To enable realtime later, set VITE_HPP_LIVE_WS_URL to the backend websocket URL. No other changes needed.

<sup>Written for commit 92294a5e4696fddfd4f2947f244d6fc1b6de353d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live progress indicator added to Home, Plate, and Progress pages — shows live vs. static status, latest event time when available, and a CTA button for quick navigation.

* **Tests**
  * Added test coverage for the indicator and real-time status behavior, including impression and CTA interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->