### PR TITLE
docs(ledger): close PR #801 hpp live indicator item

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -530,6 +530,32 @@ If it is not recorded here — it does not exist.
     - Orchestration session artifacts committed for the sync package
     - Root `AGENTS.md` updated with canonical Figma workflow protocol references
 
+- [x] P1: Home/Plate/Progress live indicator + CTA instrumentation (web-first)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR #801 (`feat/hpp-live-indicator-cta`)
+  - Status: ✅ Merged (PR #801, 2026-02-19)
+  - Merge SHA: aec126d6b8757a7a413ebf051f5e7f8a917c3e42
+  - Area: frontend / product-metrics / HPP UX
+  - Finding Type: user-visible activation package
+  - Reason: Deliver one narrow user-facing package that adds a live progress signal on
+    Home/Plate/Progress, keeps strict static fallback when realtime transport is unavailable,
+    and instruments CTA impression/click events for conversion measurement.
+  - Links:
+    - PR #801
+    - `frontend/src/features/progress/LiveProgressIndicator.tsx`
+    - `frontend/src/features/progress/useHppLiveIndicator.ts`
+    - `frontend/src/lib/hppTelemetry.ts`
+    - `frontend/src/pages/Home.tsx`
+    - `frontend/src/pages/Plate.tsx`
+    - `frontend/src/pages/Progress.tsx`
+  - DoD:
+    - Live indicator renders on Home, Plate, and Progress surfaces
+    - Fallback invariant preserved (`ws unavailable/error -> static indicator + CTA works`)
+    - CTA telemetry events (`impression`, `click`) emitted through centralized helper
+    - Deterministic tests added for hook, indicator, and HPP page integration
+    - Thin-client websocket guard remains green (`src/api/wsClient.ts` adapter boundary)
+
 - [x] P1: WebSocket foundation work-package (`/ws` secure baseline)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1


### PR DESCRIPTION
## Summary
- record merged PR #801 as a completed ledger item in `docs/roadmap/BACKLOG_LEDGER.md`
- preserve repository policy of separate docs-only backlog closure after runtime/user-facing merge
- keep backlog traceability for HPP live indicator and CTA instrumentation package

## Test plan
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- none for this docs-only ledger closure PR

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Добавить проверенную запись в журнал, документирующую PR #801 для пакета телеметрии индикатора прогресса в реальном времени Home/Plate/Progress и CTA, включая владельца, статус, охват, обоснование, ссылки и определение готовности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a checked ledger entry documenting PR #801 for the Home/Plate/Progress live indicator and CTA telemetry package, including owner, status, scope, rationale, links, and definition of done.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded merged PR #801 in docs/roadmap/BACKLOG_LEDGER.md as a completed HPP live progress indicator and CTA telemetry package for Home, Plate, and Progress. This maintains our docs-only backlog closure policy and keeps clear traceability for the user-facing change.

<sup>Written for commit f59c8102a337c43ce2b2477b1b35b6dd73d013cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap ledger with two new high-priority backlog items, including delivery targets and completion criteria for planned features and infrastructure work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->