### PR TITLE
feat(frontend): add HPP live indicator A/B variants with telemetry

### DIFF
--- a/frontend/src/features/progress/LiveProgressIndicator.tsx
+++ b/frontend/src/features/progress/LiveProgressIndicator.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import {
   trackHppCtaClick,
@@ -25,8 +25,15 @@ export default function LiveProgressIndicator({
 }: LiveProgressIndicatorProps) {
   const { status, lastEventAt, variant: assignedVariant } = useHppLiveIndicator();
   const resolvedVariant = variant ?? assignedVariant;
+  const lastImpressionKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const impressionKey = `${source}|${ctaTo}|${resolvedVariant}|${status}`;
+    if (lastImpressionKeyRef.current === impressionKey) {
+      return;
+    }
+    lastImpressionKeyRef.current = impressionKey;
+
     const basePayload = {
       source: 'hpp_live_indicator' as const,
       placement: source,
@@ -45,7 +52,8 @@ export default function LiveProgressIndicator({
     resolvedVariant === 'emphasized'
       ? 'inline-flex rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white'
       : 'inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white';
-  const isPaywallCta = ctaTo.includes('/pro') || ctaTo.includes('/paywall');
+  const path = ctaTo.split('?')[0];
+  const isPaywallCta = /^\/pro(?:\/|$)/.test(path) || /^\/paywall(?:\/|$)/.test(path);
 
   return (
     <section

--- a/frontend/src/features/progress/LiveProgressIndicator.tsx
+++ b/frontend/src/features/progress/LiveProgressIndicator.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { trackHppCtaClick, trackHppCtaImpression, trackHppLiveIndicatorImpression } from '../../lib/hppTelemetry';
-import { useHppLiveIndicator } from './useHppLiveIndicator';
+import {
+  trackHppCtaClick,
+  trackHppCtaImpression,
+  trackHppLiveIndicatorImpression,
+  trackHppPaywallOpenFromLive,
+} from '../../lib/hppTelemetry';
+import { type HppLiveVariant, useHppLiveIndicator } from './useHppLiveIndicator';
 
 type HppIndicatorSource = 'home' | 'plate' | 'progress';
 
@@ -9,33 +14,45 @@ interface LiveProgressIndicatorProps {
   source: HppIndicatorSource;
   ctaTo: string;
   ctaLabel: string;
+  variant?: HppLiveVariant;
 }
 
 export default function LiveProgressIndicator({
   source,
   ctaTo,
   ctaLabel,
+  variant,
 }: LiveProgressIndicatorProps) {
-  const { status, lastEventAt } = useHppLiveIndicator();
-  const trackedImpressionRef = useRef(false);
+  const { status, lastEventAt, variant: assignedVariant } = useHppLiveIndicator();
+  const resolvedVariant = variant ?? assignedVariant;
 
   useEffect(() => {
-    if (trackedImpressionRef.current) {
-      return;
-    }
-    trackedImpressionRef.current = true;
-    trackHppLiveIndicatorImpression({ source, live_status: status });
-    trackHppCtaImpression({ source, live_status: status, cta_to: ctaTo });
-  }, [ctaTo, source, status]);
+    const basePayload = {
+      source: 'hpp_live_indicator' as const,
+      placement: source,
+      live_status: status,
+      variant: resolvedVariant,
+    };
+    trackHppLiveIndicatorImpression(basePayload);
+    trackHppCtaImpression({ ...basePayload, cta_to: ctaTo });
+  }, [ctaTo, resolvedVariant, source, status]);
 
   const statusLabel = status === 'live' ? 'Live updates on' : 'Static fallback';
   const dotClass = status === 'live' ? 'bg-[var(--color-success)] animate-pulse' : 'bg-[var(--color-warning)]';
+  const containerClass =
+    resolvedVariant === 'emphasized' ? 'rounded-xl border p-5 space-y-3 shadow-sm' : 'rounded-xl border p-4 space-y-3';
+  const ctaClass =
+    resolvedVariant === 'emphasized'
+      ? 'inline-flex rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white'
+      : 'inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white';
+  const isPaywallCta = ctaTo.includes('/pro') || ctaTo.includes('/paywall');
 
   return (
     <section
-      className="rounded-xl border p-4 space-y-3"
+      className={containerClass}
       style={{ backgroundColor: 'var(--color-surface)', borderColor: 'var(--color-border)' }}
       aria-label="Live progress indicator"
+      data-variant={resolvedVariant}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -53,8 +70,20 @@ export default function LiveProgressIndicator({
       </p>
       <Link
         to={ctaTo}
-        className="inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white"
-        onClick={() => trackHppCtaClick({ source, live_status: status, cta_to: ctaTo })}
+        className={ctaClass}
+        onClick={() => {
+          const basePayload = {
+            source: 'hpp_live_indicator' as const,
+            placement: source,
+            live_status: status,
+            variant: resolvedVariant,
+            cta_to: ctaTo,
+          };
+          trackHppCtaClick(basePayload);
+          if (isPaywallCta) {
+            trackHppPaywallOpenFromLive(basePayload);
+          }
+        }}
       >
         {ctaLabel}
       </Link>

--- a/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
+++ b/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
@@ -6,6 +6,7 @@ import LiveProgressIndicator from '../LiveProgressIndicator';
 const mockTrackLiveIndicatorImpression = vi.fn();
 const mockTrackCtaImpression = vi.fn();
 const mockTrackCtaClick = vi.fn();
+const mockTrackPaywallOpen = vi.fn();
 
 vi.mock('../useHppLiveIndicator', () => ({
   useHppLiveIndicator: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock('../../../lib/hppTelemetry', () => ({
   trackHppLiveIndicatorImpression: (...args: unknown[]) => mockTrackLiveIndicatorImpression(...args),
   trackHppCtaImpression: (...args: unknown[]) => mockTrackCtaImpression(...args),
   trackHppCtaClick: (...args: unknown[]) => mockTrackCtaClick(...args),
+  trackHppPaywallOpenFromLive: (...args: unknown[]) => mockTrackPaywallOpen(...args),
 }));
 
 import { useHppLiveIndicator } from '../useHppLiveIndicator';
@@ -28,9 +30,10 @@ describe('LiveProgressIndicator', () => {
     vi.mocked(useHppLiveIndicator).mockReturnValue({
       status: 'static',
       lastEventAt: null,
+      variant: 'compact',
     });
 
-    render(
+    const { container } = render(
       <MemoryRouter>
         <LiveProgressIndicator source="home" ctaTo="/progress" ctaLabel="Open progress live" />
       </MemoryRouter>
@@ -39,23 +42,31 @@ describe('LiveProgressIndicator', () => {
     expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
     expect(screen.getByText('Static fallback')).toBeInTheDocument();
     expect(mockTrackLiveIndicatorImpression).toHaveBeenCalledWith({
-      source: 'home',
+      source: 'hpp_live_indicator',
+      placement: 'home',
       live_status: 'static',
+      variant: 'compact',
     });
     expect(mockTrackCtaImpression).toHaveBeenCalledWith({
-      source: 'home',
+      source: 'hpp_live_indicator',
+      placement: 'home',
       live_status: 'static',
+      variant: 'compact',
       cta_to: '/progress',
     });
+
+    expect(screen.getByLabelText('Live progress indicator')).toHaveAttribute('data-variant', 'compact');
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders live status and tracks click', () => {
+  it('renders live status and tracks click with enriched payload', () => {
     vi.mocked(useHppLiveIndicator).mockReturnValue({
       status: 'live',
       lastEventAt: 1710000000000,
+      variant: 'emphasized',
     });
 
-    render(
+    const { container } = render(
       <MemoryRouter>
         <LiveProgressIndicator source="progress" ctaTo="/setup" ctaLabel="Refresh setup inputs" />
       </MemoryRouter>
@@ -67,9 +78,38 @@ describe('LiveProgressIndicator', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Refresh setup inputs' }));
 
     expect(mockTrackCtaClick).toHaveBeenCalledWith({
-      source: 'progress',
+      source: 'hpp_live_indicator',
+      placement: 'progress',
       live_status: 'live',
+      variant: 'emphasized',
       cta_to: '/setup',
+    });
+    expect(mockTrackPaywallOpen).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Live progress indicator')).toHaveAttribute('data-variant', 'emphasized');
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('tracks paywall open event for paywall-targeted cta', () => {
+    vi.mocked(useHppLiveIndicator).mockReturnValue({
+      status: 'live',
+      lastEventAt: 1710000000000,
+      variant: 'compact',
+    });
+
+    render(
+      <MemoryRouter>
+        <LiveProgressIndicator source="plate" ctaTo="/pro" ctaLabel="Open Pro" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open Pro' }));
+
+    expect(mockTrackPaywallOpen).toHaveBeenCalledWith({
+      source: 'hpp_live_indicator',
+      placement: 'plate',
+      live_status: 'live',
+      variant: 'compact',
+      cta_to: '/pro',
     });
   });
 });

--- a/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
+++ b/frontend/src/features/progress/__tests__/LiveProgressIndicator.test.tsx
@@ -60,6 +60,7 @@ describe('LiveProgressIndicator', () => {
   });
 
   it('renders live status and tracks click with enriched payload', () => {
+    const timeSpy = vi.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('7:00:00 PM');
     vi.mocked(useHppLiveIndicator).mockReturnValue({
       status: 'live',
       lastEventAt: 1710000000000,
@@ -87,6 +88,7 @@ describe('LiveProgressIndicator', () => {
     expect(mockTrackPaywallOpen).not.toHaveBeenCalled();
     expect(screen.getByLabelText('Live progress indicator')).toHaveAttribute('data-variant', 'emphasized');
     expect(container.firstChild).toMatchSnapshot();
+    timeSpy.mockRestore();
   });
 
   it('tracks paywall open event for paywall-targeted cta', () => {
@@ -109,6 +111,62 @@ describe('LiveProgressIndicator', () => {
       placement: 'plate',
       live_status: 'live',
       variant: 'compact',
+      cta_to: '/pro',
+    });
+  });
+
+  it('tracks paywall open event for /paywall-targeted cta', () => {
+    vi.mocked(useHppLiveIndicator).mockReturnValue({
+      status: 'live',
+      lastEventAt: 1710000000000,
+      variant: 'compact',
+    });
+
+    render(
+      <MemoryRouter>
+        <LiveProgressIndicator source="plate" ctaTo="/paywall?plan=pro" ctaLabel="Open Pro Paywall" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open Pro Paywall' }));
+
+    expect(mockTrackPaywallOpen).toHaveBeenCalledWith({
+      source: 'hpp_live_indicator',
+      placement: 'plate',
+      live_status: 'live',
+      variant: 'compact',
+      cta_to: '/paywall?plan=pro',
+    });
+  });
+
+  it('uses explicit variant prop over hook variant for telemetry and DOM', () => {
+    vi.mocked(useHppLiveIndicator).mockReturnValue({
+      status: 'live',
+      lastEventAt: 1710000000000,
+      variant: 'compact',
+    });
+
+    render(
+      <MemoryRouter>
+        <LiveProgressIndicator source="progress" variant="emphasized" ctaTo="/pro" ctaLabel="Open Pro" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText('Live progress indicator')).toHaveAttribute('data-variant', 'emphasized');
+    expect(mockTrackLiveIndicatorImpression).toHaveBeenCalledWith({
+      source: 'hpp_live_indicator',
+      placement: 'progress',
+      live_status: 'live',
+      variant: 'emphasized',
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open Pro' }));
+
+    expect(mockTrackPaywallOpen).toHaveBeenCalledWith({
+      source: 'hpp_live_indicator',
+      placement: 'progress',
+      live_status: 'live',
+      variant: 'emphasized',
       cta_to: '/pro',
     });
   });

--- a/frontend/src/features/progress/__tests__/__snapshots__/LiveProgressIndicator.test.tsx.snap
+++ b/frontend/src/features/progress/__tests__/__snapshots__/LiveProgressIndicator.test.tsx.snap
@@ -1,0 +1,85 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`LiveProgressIndicator > renders live status and tracks click with enriched payload 1`] = `
+<section
+  aria-label="Live progress indicator"
+  class="rounded-xl border p-5 space-y-3 shadow-sm"
+  data-variant="emphasized"
+  style="background-color: var(--color-surface); border-color: var(--color-border);"
+>
+  <div
+    class="flex items-center justify-between gap-3"
+  >
+    <div
+      class="flex items-center gap-2"
+    >
+      <span
+        aria-hidden="true"
+        class="h-2.5 w-2.5 rounded-full bg-[var(--color-success)] animate-pulse"
+      />
+      <p
+        class="text-sm font-medium text-text"
+      >
+        Live updates on
+      </p>
+    </div>
+    <p
+      aria-label="Live event timestamp"
+      class="text-xs text-muted"
+    >
+      7:00:00 PM
+    </p>
+  </div>
+  <p
+    class="text-xs text-muted"
+  >
+    If realtime is unavailable, PulsePlate stays usable and keeps CTA flow active.
+  </p>
+  <a
+    class="inline-flex rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white"
+    data-discover="true"
+    href="/setup"
+  >
+    Refresh setup inputs
+  </a>
+</section>
+`;
+
+exports[`LiveProgressIndicator > renders static fallback and tracks impressions 1`] = `
+<section
+  aria-label="Live progress indicator"
+  class="rounded-xl border p-4 space-y-3"
+  data-variant="compact"
+  style="background-color: var(--color-surface); border-color: var(--color-border);"
+>
+  <div
+    class="flex items-center justify-between gap-3"
+  >
+    <div
+      class="flex items-center gap-2"
+    >
+      <span
+        aria-hidden="true"
+        class="h-2.5 w-2.5 rounded-full bg-[var(--color-warning)]"
+      />
+      <p
+        class="text-sm font-medium text-text"
+      >
+        Static fallback
+      </p>
+    </div>
+  </div>
+  <p
+    class="text-xs text-muted"
+  >
+    If realtime is unavailable, PulsePlate stays usable and keeps CTA flow active.
+  </p>
+  <a
+    class="inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white"
+    data-discover="true"
+    href="/progress"
+  >
+    Open progress live
+  </a>
+</section>
+`;

--- a/frontend/src/features/progress/__tests__/hppTelemetry.test.ts
+++ b/frontend/src/features/progress/__tests__/hppTelemetry.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  HPP_EVENTS,
+  trackHppCtaClick,
+  trackHppCtaImpression,
+  trackHppLiveIndicatorImpression,
+  trackHppPaywallOpenFromLive,
+} from '../../../lib/hppTelemetry';
+
+const mockLog = vi.fn();
+
+vi.mock('../../../lib/analytics', () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+describe('hppTelemetry', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs impression and cta events with stable payload shape', () => {
+    const payload = {
+      source: 'hpp_live_indicator' as const,
+      placement: 'home' as const,
+      live_status: 'static' as const,
+      variant: 'compact' as const,
+      cta_to: '/progress',
+    };
+
+    trackHppLiveIndicatorImpression({
+      source: payload.source,
+      placement: payload.placement,
+      live_status: payload.live_status,
+      variant: payload.variant,
+    });
+    trackHppCtaImpression(payload);
+    trackHppCtaClick(payload);
+    trackHppPaywallOpenFromLive(payload);
+
+    expect(mockLog).toHaveBeenNthCalledWith(1, HPP_EVENTS.LIVE_INDICATOR_IMPRESSION, {
+      source: 'hpp_live_indicator',
+      placement: 'home',
+      live_status: 'static',
+      variant: 'compact',
+    });
+    expect(mockLog).toHaveBeenNthCalledWith(2, HPP_EVENTS.CTA_IMPRESSION, payload);
+    expect(mockLog).toHaveBeenNthCalledWith(3, HPP_EVENTS.CTA_CLICK, payload);
+    expect(mockLog).toHaveBeenNthCalledWith(4, HPP_EVENTS.PAYWALL_OPEN_FROM_LIVE, payload);
+  });
+});

--- a/frontend/src/features/progress/__tests__/useHppLiveIndicator.test.ts
+++ b/frontend/src/features/progress/__tests__/useHppLiveIndicator.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useHppLiveIndicator } from '../useHppLiveIndicator';
+import { assignHppLiveVariant, useHppLiveIndicator } from '../useHppLiveIndicator';
 
 type Listener = (event?: Event) => void;
 
@@ -44,6 +44,7 @@ describe('useHppLiveIndicator', () => {
 
     expect(result.current.status).toBe('static');
     expect(result.current.lastEventAt).toBeNull();
+    expect(result.current.variant).toBe('compact');
   });
 
   it('switches to live status on open and message', () => {
@@ -90,5 +91,16 @@ describe('useHppLiveIndicator', () => {
     });
 
     expect(result.current.status).toBe('static');
+  });
+
+  it('assigns deterministic variant by user id hash', () => {
+    expect(assignHppLiveVariant('user_alpha')).toBe(assignHppLiveVariant('user_alpha'));
+    expect(assignHppLiveVariant(null)).toBe('compact');
+
+    const variantA = assignHppLiveVariant('a');
+    const variantB = assignHppLiveVariant('b');
+    expect(['compact', 'emphasized']).toContain(variantA);
+    expect(['compact', 'emphasized']).toContain(variantB);
+    expect(variantA).not.toBe(variantB);
   });
 });

--- a/frontend/src/features/progress/useHppLiveIndicator.ts
+++ b/frontend/src/features/progress/useHppLiveIndicator.ts
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { createWebSocketConnection } from '../../api/wsClient';
 
 export type HppLiveStatus = 'live' | 'static';
+export type HppLiveVariant = 'compact' | 'emphasized';
 
 interface UseHppLiveIndicatorResult {
   status: HppLiveStatus;
   lastEventAt: number | null;
+  variant: HppLiveVariant;
 }
 
 const getConfiguredWsUrl = (): string | null => {
@@ -13,7 +15,33 @@ const getConfiguredWsUrl = (): string | null => {
   return value.length > 0 ? value : null;
 };
 
-export function useHppLiveIndicator(overrideWsUrl?: string | null): UseHppLiveIndicatorResult {
+const HPP_USER_ID_STORAGE_KEY = 'pp_user_id';
+
+const getStoredUserId = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return localStorage.getItem(HPP_USER_ID_STORAGE_KEY) || sessionStorage.getItem(HPP_USER_ID_STORAGE_KEY);
+};
+
+export function assignHppLiveVariant(userId: string | null | undefined): HppLiveVariant {
+  if (!userId) {
+    return 'compact';
+  }
+
+  // Deterministic hash for stable user-to-variant assignment.
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+
+  return hash % 2 === 0 ? 'compact' : 'emphasized';
+}
+
+export function useHppLiveIndicator(
+  overrideWsUrl?: string | null,
+  overrideUserId?: string | null
+): UseHppLiveIndicatorResult {
   const [status, setStatus] = useState<HppLiveStatus>('static');
   const [lastEventAt, setLastEventAt] = useState<number | null>(null);
 
@@ -23,6 +51,11 @@ export function useHppLiveIndicator(overrideWsUrl?: string | null): UseHppLiveIn
     }
     return overrideWsUrl === null ? null : getConfiguredWsUrl();
   }, [overrideWsUrl]);
+
+  const variant = useMemo(() => {
+    const userId = overrideUserId !== undefined ? overrideUserId : getStoredUserId();
+    return assignHppLiveVariant(userId);
+  }, [overrideUserId]);
 
   useEffect(() => {
     if (!wsUrl || typeof WebSocket === 'undefined') {
@@ -56,5 +89,5 @@ export function useHppLiveIndicator(overrideWsUrl?: string | null): UseHppLiveIn
     };
   }, [wsUrl]);
 
-  return { status, lastEventAt };
+  return { status, lastEventAt, variant };
 }

--- a/frontend/src/features/progress/useHppLiveIndicator.ts
+++ b/frontend/src/features/progress/useHppLiveIndicator.ts
@@ -21,7 +21,11 @@ const getStoredUserId = (): string | null => {
   if (typeof window === 'undefined') {
     return null;
   }
-  return localStorage.getItem(HPP_USER_ID_STORAGE_KEY) || sessionStorage.getItem(HPP_USER_ID_STORAGE_KEY);
+  try {
+    return localStorage.getItem(HPP_USER_ID_STORAGE_KEY) || sessionStorage.getItem(HPP_USER_ID_STORAGE_KEY);
+  } catch {
+    return null;
+  }
 };
 
 export function assignHppLiveVariant(userId: string | null | undefined): HppLiveVariant {
@@ -52,7 +56,7 @@ export function useHppLiveIndicator(
     return overrideWsUrl === null ? null : getConfiguredWsUrl();
   }, [overrideWsUrl]);
 
-  const variant = useMemo(() => {
+  const variant = useMemo((): HppLiveVariant => {
     const userId = overrideUserId !== undefined ? overrideUserId : getStoredUserId();
     return assignHppLiveVariant(userId);
   }, [overrideUserId]);

--- a/frontend/src/lib/hppTelemetry.ts
+++ b/frontend/src/lib/hppTelemetry.ts
@@ -1,11 +1,14 @@
 import { log } from './analytics';
+import type { HppLiveVariant } from '../features/progress/useHppLiveIndicator';
 
 type HppSource = 'home' | 'plate' | 'progress';
 type HppLiveStatus = 'live' | 'static';
 
 interface HppBasePayload extends Record<string, unknown> {
-  source: HppSource;
+  source: 'hpp_live_indicator';
+  placement: HppSource;
   live_status: HppLiveStatus;
+  variant: HppLiveVariant;
 }
 
 interface HppCtaPayload extends HppBasePayload {
@@ -16,6 +19,7 @@ export const HPP_EVENTS = {
   LIVE_INDICATOR_IMPRESSION: 'hpp_live_indicator_impression',
   CTA_IMPRESSION: 'hpp_cta_impression',
   CTA_CLICK: 'hpp_cta_click',
+  PAYWALL_OPEN_FROM_LIVE: 'hpp_paywall_open_from_live',
 } as const;
 
 export function trackHppLiveIndicatorImpression(payload: HppBasePayload): void {
@@ -28,4 +32,8 @@ export function trackHppCtaImpression(payload: HppCtaPayload): void {
 
 export function trackHppCtaClick(payload: HppCtaPayload): void {
   log(HPP_EVENTS.CTA_CLICK, payload);
+}
+
+export function trackHppPaywallOpenFromLive(payload: HppCtaPayload): void {
+  log(HPP_EVENTS.PAYWALL_OPEN_FROM_LIVE, payload);
 }


### PR DESCRIPTION
## Summary
- add deterministic A/B assignment for HPP live indicator variants (`compact` / `emphasized`) using `userId hash % 2` with fallback to `compact`
- enrich HPP telemetry payloads with `variant`, `placement`, and a new `hpp_paywall_open_from_live` event
- update live indicator rendering to support two visual modes and keep scope frontend-only (no transport/backend changes)

## Scope
### IN
- deterministic variant contract in `useHppLiveIndicator`
- variant-aware UI in `LiveProgressIndicator`
- telemetry enrichment in `hppTelemetry`
- deterministic tests: assignment, payload shape, and snapshots for compact/emphasized

### OUT
- no websocket transport changes
- no backend API changes
- no docs-heavy package in this PR

## Test plan
- [x] `cd frontend && npm test -- --run src/features/progress/__tests__/useHppLiveIndicator.test.ts src/features/progress/__tests__/LiveProgressIndicator.test.tsx src/features/progress/__tests__/hppTelemetry.test.ts src/pages/__tests__/Home.test.tsx src/pages/__tests__/Plate.test.tsx src/pages/__tests__/Progress.test.tsx`
- [x] `cd frontend && npm run build`
- [x] `pre-commit run --all-files`

## KPI/Experiment Contract
- Primary: `hpp_live_cta_click_rate_by_variant`
- Secondary: `paywall_open_from_live_by_variant`
- Guardrails: no JS runtime error increase, no layout shift regression

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- docs-only ledger closure PR after merge (experiment window + result tracking note)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ввести A/B‑варианты для индикатора прямого эфира в HPP и подключить телеметрию, учитывающую вариант, для показов, кликов и открытий paywall.

New Features:
- Добавить детерминированные варианты индикатора прямого эфира HPP (компактный и подчёркнутый), доступные через `useHppLiveIndicator` и `LiveProgressIndicator`.
- Отслеживать открытия paywall, инициированные CTA индикатора прямого эфира HPP, с помощью отдельного события телеметрии.

Enhancements:
- Обогатить полезную нагрузку телеметрии HPP единообразными полями source, placement, live status и variant для показов и кликов и прокинуть их через `LiveProgressIndicator`.
- Обновить UI `LiveProgressIndicator`, чтобы отображать компактный или подчёркнутый визуальный вариант в зависимости от назначенного или переопределённого варианта.

Tests:
- Расширить тесты функционала прогресса, чтобы покрыть назначение варианта, структуру полезной нагрузки телеметрии и snapshot‑покрытие для компактного и подчёркнутого вариантов индикатора.
- Добавить отдельные тесты телеметрии для проверки логирования всех HPP‑событий, включая новое событие открытия paywall.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce A/B variants for the HPP live indicator and wire variant-aware telemetry for impressions, clicks, and paywall opens.

New Features:
- Add deterministic user-assigned HPP live indicator variants (compact vs emphasized) exposed via useHppLiveIndicator and LiveProgressIndicator.
- Track paywall opens originating from the HPP live indicator CTA with a dedicated telemetry event.

Enhancements:
- Enrich HPP telemetry payloads with a consistent source, placement, live status, and variant for impressions and clicks and propagate through LiveProgressIndicator.
- Update LiveProgressIndicator UI to render compact or emphasized visual treatments based on the assigned or overridden variant.

Tests:
- Extend progress feature tests to cover variant assignment, telemetry payload shape, and snapshot coverage for compact and emphasized indicator variants.
- Add dedicated telemetry tests to assert logging of all HPP events, including the new paywall-open event.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic A/B variants (compact and emphasized) to the HPP live indicator and enriches telemetry with variant and placement. Hardens paywall CTA detection and storage safety; no backend or transport changes.

- New Features
  - Deterministic user assignment via userId hash % 2 (fallback: compact); LiveProgressIndicator renders compact/emphasized and accepts an optional variant override.
  - Telemetry uses source=hpp_live_indicator and placement, includes variant, and logs paywall_open_from_live for paywall-targeted CTAs.

- Bug Fixes
  - Stricter paywall CTA detection (/pro and /paywall) and guarded storage access for userId.
  - Impression de-dupe across source/cta/variant/status; deterministic snapshots and added telemetry tests.

<sup>Written for commit 191a71c3433bad74d785868c4987992020564be7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live progress indicator now supports configurable visual variants (compact and emphasized) enabling flexible UI presentation options.
  * Enhanced tracking to monitor paywall open events when users interact with paywall actions from the progress indicator.

* **Tests**
  * Expanded test coverage to validate variant functionality and paywall event telemetry logging across user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->