### PR TITLE
docs(agents): implement figma-clawbot systematization P0-P2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,9 @@ A **task** is any unit of work that:
 - Figma Make sync and blocker audit protocol: `docs/figma/FIGMA_MAKE_SYNC_AUDIT_HPP.md`
 - Figma Code Connect activation and blocker protocol: `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
 - Design URL + node-id capture protocol for Code Connect activation: `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
+- Figma/OpenClaw operating model and evidence contract: `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+- Sandbox design-agent specification and HITL gates: `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+- Sora prompt pack and QA rubric for HPP visuals: `docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md`, `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
 - Dialogue visualization contract (Mermaid): `docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md` (section `Визуализация диалога`)
 
 **Full workflow:** See `docs/orchestration/workflow.md`

--- a/docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md
+++ b/docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md
@@ -1,0 +1,122 @@
+# Figma + Clawbot Operating Model (H+P+Pr)
+
+Date: 2026-02-19
+Scope: Home + Plate + Progress (`H+P+Pr`) for Web + iOS
+Mode: process/systematization only (no runtime perimeter expansion)
+
+## 1) Purpose
+
+Define one canonical operating model for:
+- `figma.com/make` ideation and reconciliation
+- `figma.com/design` node-level mapping and Code Connect activation
+- OpenClaw/Clawbat terminal execution with deterministic evidence
+
+This file is the operational SoT for execution discipline. Domain behavior and
+style constraints remain in existing SoT docs under `docs/figma/`, `docs/design/`,
+and `docs/sora/`.
+
+## 2) Source-of-Truth Lock
+
+- `figma.com/make/...`:
+  - Allowed: iteration, exploration, draft structure, drift audits
+  - Forbidden: final node-level Code Connect activation claims
+- `figma.com/design/...`:
+  - Allowed: canonical layer selection, fileKey/nodeId capture, Code Connect activation
+  - Required for: `get_code_connect_suggestions`, `get_code_connect_map`, final mapping evidence
+
+If only Make is available, status must remain `blocked_by_design_url` in mapping docs.
+
+## 3) Command Contract (OpenClaw/Clawbat)
+
+Every terminal run must capture:
+- exact command line
+- working directory
+- session id
+- start/end timestamp
+- exit code
+- evidence snippet (1-3 raw lines) and pointer links
+
+Forbidden:
+- hidden skips (`|| true`, silent continue)
+- manual paraphrase without raw evidence
+- fabricated node ids or design keys
+
+## 4) Session-ID Discipline
+
+Session format:
+- `figma-hpp-<YYYYMMDD>-<HHMMSS>`
+
+Rules:
+- One session id per run
+- Same id across logs, evidence, and output docs
+- No cross-session evidence reuse without explicit note
+
+## 5) Artifact Capture Contract
+
+Minimum artifact set per run:
+- command block
+- output block
+- exit code
+- affected docs/files
+- blocker state (`none`, `blocked_by_design_url`, `blocked_by_node_id_capture`, `stale`)
+
+Required fields in evidence summaries:
+- `context_version` (date + commit)
+- `fileKey` (if design-known)
+- `nodeId` (if design-known)
+- mapping status transition (`candidate -> validated -> active` when applicable)
+
+## 6) Failure Triage Protocol
+
+When run fails:
+1. Copy first failing raw line(s)
+2. Classify failure:
+   - auth/token
+   - missing design URL/node id
+   - mapping mismatch
+   - infra/transient (cache/network/service)
+3. State impact:
+   - no-op
+   - partial update
+   - rollback needed
+4. Log next deterministic command for retry
+
+Do not mark activation complete unless verification command succeeds.
+
+## 7) Canonical Flow
+
+```mermaid
+flowchart TD
+  makeSource[FigmaMakeSource] --> reconcile[MakeGitReconciliation]
+  reconcile --> designCapture[FigmaDesignUrlNodeCapture]
+  designCapture --> opsRun[OpenClawClawbatRun]
+  opsRun --> mapping[CodeConnectMapping]
+  mapping --> evidence[EvidenceAndStatusUpdate]
+  evidence --> qa[QAAndSafetyGate]
+```
+
+## 8) Execution Checklist (per task)
+
+- Read:
+  - `docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md`
+  - `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
+  - `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
+- Run with session id and capture evidence
+- Update mapping status and blocker state
+- Run QA checklist:
+  - `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+
+## 9) Non-negotiable Safety Rules
+
+- No secrets/internal URLs in prompts or evidence
+- No medical claims or diagnosis framing
+- No palette drift outside canonical tokens without explicit approved exception
+- No replacing canonical route/auth behavior with design-only assumptions
+
+## 10) Related Canonical Docs
+
+- `docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md`
+- `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
+- `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
+- `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`
+- `docs/sora/SORA_STYLE_QA_CHECKLIST.md`

--- a/docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md
+++ b/docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Figma + Clawbot Operating Model (H+P+Pr)
 
 Date: 2026-02-19
@@ -7,6 +8,7 @@ Mode: process/systematization only (no runtime perimeter expansion)
 ## 1) Purpose
 
 Define one canonical operating model for:
+
 - `figma.com/make` ideation and reconciliation
 - `figma.com/design` node-level mapping and Code Connect activation
 - OpenClaw/Clawbat terminal execution with deterministic evidence
@@ -29,6 +31,7 @@ If only Make is available, status must remain `blocked_by_design_url` in mapping
 ## 3) Command Contract (OpenClaw/Clawbat)
 
 Every terminal run must capture:
+
 - exact command line
 - working directory
 - session id
@@ -37,6 +40,7 @@ Every terminal run must capture:
 - evidence snippet (1-3 raw lines) and pointer links
 
 Forbidden:
+
 - hidden skips (`|| true`, silent continue)
 - manual paraphrase without raw evidence
 - fabricated node ids or design keys
@@ -44,9 +48,11 @@ Forbidden:
 ## 4) Session-ID Discipline
 
 Session format:
+
 - `figma-hpp-<YYYYMMDD>-<HHMMSS>`
 
 Rules:
+
 - One session id per run
 - Same id across logs, evidence, and output docs
 - No cross-session evidence reuse without explicit note
@@ -54,6 +60,7 @@ Rules:
 ## 5) Artifact Capture Contract
 
 Minimum artifact set per run:
+
 - command block
 - output block
 - exit code
@@ -61,6 +68,7 @@ Minimum artifact set per run:
 - blocker state (`none`, `blocked_by_design_url`, `blocked_by_node_id_capture`, `stale`)
 
 Required fields in evidence summaries:
+
 - `context_version` (date + commit)
 - `fileKey` (if design-known)
 - `nodeId` (if design-known)
@@ -69,6 +77,7 @@ Required fields in evidence summaries:
 ## 6) Failure Triage Protocol
 
 When run fails:
+
 1. Copy first failing raw line(s)
 2. Classify failure:
    - auth/token

--- a/docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md
+++ b/docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md
@@ -28,6 +28,11 @@ Read in this order for every new Figma task:
 10. `docs/design/PULSEPLATE_LUXURY_WEB_IOS_VISUAL_GUIDELINES.md`
 11. `docs/design/LUXURY_UI_REVIEW_CHECKLIST.md`
 12. `docs/sora/PULSEPLATE_SORA_PROMPT_ENGINEERING_PLAYBOOK.md`
+13. `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+14. `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+15. `docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md`
+16. `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+17. `docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md`
 
 ## 3) Git Packs to Read by Intent
 
@@ -78,6 +83,13 @@ Use when conflicts appear or when acceptance criteria are unclear.
 - `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`
 
 Use when translating Figma nodes to existing site components and tracking map status.
+
+### 3.8 Clawbot/OpenClaw operating model and sandbox agent spec
+
+- `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+- `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+
+Use when running terminal automation, evidence capture, and human-gated design-agent tasks.
 
 ## 4) Implementation Lookup Matrix
 
@@ -199,6 +211,11 @@ Before any brainstorm session in `docs/figma/orchestration/`:
 - `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
 - `docs/figma/FIGMA_DESIGN_URL_NODEID_CAPTURE_HPP.md`
 - `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`
+- `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+- `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+- `docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md`
+- `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+- `docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md`
 - `docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md`
 - `docs/design/PULSEPLATE_LUXURY_WEB_IOS_VISUAL_GUIDELINES.md`
 - `docs/design/LUXURY_UI_REVIEW_CHECKLIST.md`

--- a/docs/figma/README.md
+++ b/docs/figma/README.md
@@ -16,7 +16,12 @@ Purpose: single Git folder for everything you pass to Figma AI.
 9. `docs/design/PULSEPLATE_BUTTON_VISUAL_SYSTEM_TRENDS_AND_FORECAST.md`
 10. `docs/figma/FIGMA_AI_HANDOFF_CHECKLIST.md`
 11. `docs/figma/FIGMA_AI_INBOX_TEMPLATE.md`
-12. `docs/figma/orchestration/README.md`
+12. `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+13. `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+14. `docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md`
+15. `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+16. `docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md`
+17. `docs/figma/orchestration/README.md`
 
 ## Files
 
@@ -40,8 +45,19 @@ Purpose: single Git folder for everything you pass to Figma AI.
   - What to verify before sending and after receiving outputs.
 - `docs/figma/FIGMA_AI_INBOX_TEMPLATE.md`
   - Template for adding new requests in a stable format.
+- `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+  - Canonical operating model for Make vs Design source-of-truth lock and
+    OpenClaw/Clawbat terminal workflow contract.
+- `docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md`
+  - P1 specification for sandbox design-agent contracts, safety gates, and DoD.
 - `docs/figma/orchestration/README.md`
   - How to run Figma-focused multi-agent sessions with canonical constraints.
+- `docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md`
+  - P2 prompt templates and controlled variations for Home/Plate/Progress assets.
+- `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+  - Release-ready QA rubric (pass/fail) for prompt outputs.
+- `docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md`
+  - Throughput measurement and GTM matrix for visual experiments.
 
 ## Recommended workflow
 
@@ -53,8 +69,10 @@ Purpose: single Git folder for everything you pass to Figma AI.
 5. Update CTA map candidates in `docs/figma/FIGMA_CODE_CONNECT_MAPPING_CANDIDATES_HPP.md`.
 6. Add request via `docs/figma/FIGMA_AI_INBOX_TEMPLATE.md`.
 7. Align request with `docs/figma/PULSEPLATE_FIGMA_AI_GOVERNANCE_INDEX.md`.
-8. Validate output via `docs/figma/FIGMA_AI_HANDOFF_CHECKLIST.md`.
-9. If session is complex, record decisions in `docs/figma/orchestration/sessions/`.
+8. Validate ops evidence via `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`.
+9. Validate output via `docs/figma/FIGMA_AI_HANDOFF_CHECKLIST.md`.
+10. Run QA pass/fail checks in `docs/sora/SORA_STYLE_QA_CHECKLIST.md`.
+11. If session is complex, record decisions in `docs/figma/orchestration/sessions/`.
 
 ## Canonical project links
 

--- a/docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md
+++ b/docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md
@@ -1,0 +1,117 @@
+# Sandbox Design-Agent Specification (P1)
+
+Date: 2026-02-19
+Status: Spec only (implementation deferred to dedicated PoC PR)
+Scope: Home + Plate + Progress (`H+P+Pr`)
+
+## 1) Mission
+
+Provide a deterministic assistant lane that transforms approved design tasks into:
+- structured design/mapping outputs
+- reproducible evidence artifacts
+- implementation-ready constraints for FE/iOS teams
+
+without direct runtime code changes.
+
+## 2) In/Out Scope
+
+In scope:
+- Figma Make reconciliation support
+- Design URL + node-id capture workflow
+- Code Connect mapping proposal/verification workflow
+- prompt governance pack generation for approved asset families
+
+Out of scope:
+- direct backend/frontend runtime mutations
+- auto-merge or auto-release actions
+- bypassing human approval gates
+
+## 3) IO Contracts
+
+## Input Contract
+- `task_id`
+- `session_id`
+- `context_version`
+- `surface`: `web` | `ios` | `both`
+- `source_mode`: `make_only` | `design_available`
+- `objective`: free text
+- `constraints`: list
+- `allowed_tools`: explicit allowlist
+
+## Output Contract
+- `result_status`: `done` | `partial` | `blocked`
+- `decision_log`: ordered bullets
+- `evidence`: command/output/exit records
+- `mapping_updates`: optional list with (`cta_id`, `fileKey`, `nodeId`, `status`)
+- `risk_flags`: optional list
+- `next_actions`: ordered list
+
+## 4) Tool Allowlist
+
+Allowed:
+- read/search/docs operations
+- bounded browser lookup for design capture
+- deterministic terminal commands for evidence capture
+
+Forbidden:
+- destructive git actions
+- secret exfiltration or token logging
+- direct runtime file mutation in this agent lane
+
+## 5) Human-in-the-Loop Gates
+
+Gate A (task start):
+- Coordinator approves objective, scope, and constraints
+
+Gate B (mapping activation):
+- Design + FE confirm node-level match before `active` status
+
+Gate C (handoff completion):
+- Coordinator signs DoD and records backlog status
+
+No gate bypass is allowed.
+
+## 6) Risk and UQ Policy
+
+## UQ Levels
+- `low`: evidence complete, mapping verified
+- `medium`: partial evidence, pending validation
+- `high`: missing design URL/node id, ambiguous mapping, or drift conflicts
+
+## Degrade Behavior
+- If UQ is `high`, output must be `blocked` or `partial` with explicit blocker.
+- Agent must not assert readiness/activation under high uncertainty.
+
+## 7) Rollback / Kill-Switch
+
+Rollback trigger conditions:
+- repeated contradictory mapping outputs
+- evidence contract violations
+- unresolved safety violations
+
+Kill-switch:
+- set task state to `halted`
+- require coordinator restart with revised constraints
+
+## 8) Acceptance Criteria (DoD)
+
+- Input/output contracts are documented and testable as checklist items
+- All gates (A/B/C) are explicit and role-owned
+- UQ policy and degrade behavior are explicit
+- rollback and kill-switch conditions are explicit
+- references to canonical SoT docs are complete
+
+## 9) Implementation Hand-off (future PoC PR)
+
+PoC must include:
+- command/session/evidence schema validator
+- one deterministic happy-path scenario
+- one blocked-path scenario (`blocked_by_design_url`)
+- no runtime perimeter expansion
+
+## 10) Canonical References
+
+- `docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md`
+- `docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md`
+- `docs/figma/FIGMA_CODE_CONNECT_BRIDGE_HPP.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`

--- a/docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md
+++ b/docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md
@@ -7,6 +7,7 @@ Scope: Home + Plate + Progress (`H+P+Pr`)
 ## 1) Mission
 
 Provide a deterministic assistant lane that transforms approved design tasks into:
+
 - structured design/mapping outputs
 - reproducible evidence artifacts
 - implementation-ready constraints for FE/iOS teams
@@ -16,12 +17,14 @@ without direct runtime code changes.
 ## 2) In/Out Scope
 
 In scope:
+
 - Figma Make reconciliation support
 - Design URL + node-id capture workflow
 - Code Connect mapping proposal/verification workflow
 - prompt governance pack generation for approved asset families
 
 Out of scope:
+
 - direct backend/frontend runtime mutations
 - auto-merge or auto-release actions
 - bypassing human approval gates
@@ -29,6 +32,7 @@ Out of scope:
 ## 3) IO Contracts
 
 ## Input Contract
+
 - `task_id`
 - `session_id`
 - `context_version`
@@ -39,6 +43,7 @@ Out of scope:
 - `allowed_tools`: explicit allowlist
 
 ## Output Contract
+
 - `result_status`: `done` | `partial` | `blocked`
 - `decision_log`: ordered bullets
 - `evidence`: command/output/exit records
@@ -49,11 +54,13 @@ Out of scope:
 ## 4) Tool Allowlist
 
 Allowed:
+
 - read/search/docs operations
 - bounded browser lookup for design capture
 - deterministic terminal commands for evidence capture
 
 Forbidden:
+
 - destructive git actions
 - secret exfiltration or token logging
 - direct runtime file mutation in this agent lane
@@ -61,12 +68,15 @@ Forbidden:
 ## 5) Human-in-the-Loop Gates
 
 Gate A (task start):
+
 - Coordinator approves objective, scope, and constraints
 
 Gate B (mapping activation):
+
 - Design + FE confirm node-level match before `active` status
 
 Gate C (handoff completion):
+
 - Coordinator signs DoD and records backlog status
 
 No gate bypass is allowed.
@@ -74,22 +84,26 @@ No gate bypass is allowed.
 ## 6) Risk and UQ Policy
 
 ## UQ Levels
+
 - `low`: evidence complete, mapping verified
 - `medium`: partial evidence, pending validation
 - `high`: missing design URL/node id, ambiguous mapping, or drift conflicts
 
 ## Degrade Behavior
+
 - If UQ is `high`, output must be `blocked` or `partial` with explicit blocker.
 - Agent must not assert readiness/activation under high uncertainty.
 
 ## 7) Rollback / Kill-Switch
 
 Rollback trigger conditions:
+
 - repeated contradictory mapping outputs
 - evidence contract violations
 - unresolved safety violations
 
 Kill-switch:
+
 - set task state to `halted`
 - require coordinator restart with revised constraints
 
@@ -104,6 +118,7 @@ Kill-switch:
 ## 9) Implementation Hand-off (future PoC PR)
 
 PoC must include:
+
 - command/session/evidence schema validator
 - one deterministic happy-path scenario
 - one blocked-path scenario (`blocked_by_design_url`)

--- a/docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md
+++ b/docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Brand Throughput Metrics + GTM Matrix (P2)
 
 Date: 2026-02-19
@@ -6,6 +7,7 @@ Scope: HPP visual workflow acceleration
 ## 1) Throughput Metrics
 
 Track weekly:
+
 - Lead time (brief -> approved visual)
 - Iteration count per approved asset
 - Reject rate by failure tag
@@ -42,6 +44,7 @@ Track weekly:
 ## 6) Reporting Template
 
 For each reporting cycle:
+
 - what shipped
 - throughput numbers
 - quality failures by tag

--- a/docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md
+++ b/docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md
@@ -1,0 +1,49 @@
+# Brand Throughput Metrics + GTM Matrix (P2)
+
+Date: 2026-02-19
+Scope: HPP visual workflow acceleration
+
+## 1) Throughput Metrics
+
+Track weekly:
+- Lead time (brief -> approved visual)
+- Iteration count per approved asset
+- Reject rate by failure tag
+- Rework rate after FE/iOS handoff
+
+## 2) Quality Metrics
+
+- QA pass rate on first review
+- Token drift incidents per sprint
+- Accessibility rejection rate
+- Mapping blockage rate (`blocked_by_design_url`, `blocked_by_node_id_capture`)
+
+## 3) Product/Growth Metrics (where applicable)
+
+- `hpp_live_cta_click_rate_by_variant`
+- `paywall_open_from_live_by_variant`
+- CTR uplift of updated visual treatments vs baseline
+
+## 4) GTM Channels and Experiments
+
+| Channel | Asset family | Primary metric | Cadence |
+| --- | --- | --- | --- |
+| App store screenshots | onboarding/paywall visuals | install-to-open uplift proxy | per release |
+| Product Hunt / launch posts | hero + social cards | click-through rate | per campaign |
+| Social short-form | mascot + CTA cards | engagement rate | weekly |
+| In-app surfaces | home/plate/progress cards | CTA click rate | continuous |
+
+## 5) Decision Gates
+
+- Promote only assets that pass `SORA_STYLE_QA_CHECKLIST.md`
+- Block rollout if safety/compliance checks fail
+- Require coordinator sign-off for cross-channel release packs
+
+## 6) Reporting Template
+
+For each reporting cycle:
+- what shipped
+- throughput numbers
+- quality failures by tag
+- growth deltas vs baseline
+- next corrective action

--- a/docs/sora/SORA_STYLE_QA_CHECKLIST.md
+++ b/docs/sora/SORA_STYLE_QA_CHECKLIST.md
@@ -1,0 +1,49 @@
+# Sora Style QA Checklist (Pass/Fail)
+
+Version: v1.0
+Scope: PulsePlate HPP asset candidates
+
+Use this checklist before approving any generated visual.
+
+## Brand and Style
+
+- [ ] PASS if only canonical palette tokens are used
+- [ ] PASS if hierarchy is clear (primary action > metric > decoration)
+- [ ] PASS if FitChef style remains consistent and non-clinical
+- [ ] FAIL if visual drifts into generic AI aesthetics (neon/cyberpunk/purple-gold)
+
+## Safety and Compliance
+
+- [ ] PASS if no medical diagnosis/cure implication appears
+- [ ] PASS if tone is wellness-safe and trust-first
+- [ ] FAIL if fear/shame manipulation is present
+- [ ] FAIL if internal secrets/URLs appear in text overlays or metadata
+
+## Usability and Accessibility
+
+- [ ] PASS if CTA region is visually readable at small-size preview
+- [ ] PASS if contrast appears sufficient for core text/CTA
+- [ ] FAIL if micro-detail makes information unreadable in app contexts
+- [ ] FAIL if key affordances are visually ambiguous
+
+## Variation Control
+
+- [ ] PASS if fixed elements remain fixed across A/B/C variants
+- [ ] PASS if only declared variation axes changed
+- [ ] FAIL if variant introduces undocumented style or token drift
+
+## Evidence and Decision
+
+- [ ] PASS if prompt id and version are recorded
+- [ ] PASS if decision rationale is captured (`approved` / `rejected`)
+- [ ] PASS if rejected artifacts include failure reason tags
+
+## Failure Reason Tags
+
+Use one or more:
+- `palette_drift`
+- `mascot_drift`
+- `safety_violation`
+- `readability_failure`
+- `hierarchy_failure`
+- `undocumented_variation`

--- a/docs/sora/SORA_STYLE_QA_CHECKLIST.md
+++ b/docs/sora/SORA_STYLE_QA_CHECKLIST.md
@@ -41,6 +41,7 @@ Use this checklist before approving any generated visual.
 ## Failure Reason Tags
 
 Use one or more:
+
 - `palette_drift`
 - `mascot_drift`
 - `safety_violation`

--- a/docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md
+++ b/docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # PulsePlate HPP Prompt Pack (P2)
 
 Version: v1.0
@@ -18,7 +19,7 @@ Scope: Home + Plate + Progress visual assets
 
 Use this for release candidates:
 
-```
+```text
 Create a PulsePlate visual for {surface} in a minimalist iOS-first wellness style.
 Keep strict palette tokens: Navy #0F172A, Blue #339FFF, Accent Green #20C997,
 Heart Red #FF5D5D as accent only. The mood is cozy, intelligent, and premium-clean.
@@ -32,13 +33,13 @@ Output ratio: {ratio}. Focus: {goal}. Keep text-safe regions and no micro-detail
 
 Use this for rapid iteration:
 
-```
+```text
 PulsePlate {surface}, minimalist cozy wellness, palette-locked (#0F172A #339FFF #20C997 #FF5D5D accent), flat + soft shadow, premium-clean hierarchy, FitChef non-clinical.
 ```
 
 ## 4) Negative Prompt (mandatory)
 
-```
+```text
 No neon cyberpunk, no purple-gold luxury drift, no medical diagnosis imagery,
 no hospital devices, no fear/shame framing, no unreadable micro-textures,
 no inconsistent mascot style.
@@ -47,29 +48,34 @@ no inconsistent mascot style.
 ## 5) Controlled Variations
 
 What stays fixed:
+
 - palette tokens
 - hierarchy and tone
 - safety constraints
 
 What changes:
+
 - composition density
 - CTA emphasis
 - background texture level
 
 ### Variation A: Compact Utility
-```
+
+```text
 Create a compact utility-focused card visual for {surface}, with minimal decorative
 noise, strong CTA readability, and calm metric support.
 ```
 
 ### Variation B: Emphasized Conversion
-```
+
+```text
 Create an emphasized conversion-oriented visual for {surface}, where primary action
 is visually dominant and metric context remains secondary but clear.
 ```
 
 ### Variation C: Balanced Trust
-```
+
+```text
 Create a balanced trust-oriented visual for {surface}, blending calm data context
 with a gentle premium feel and accessible CTA prominence.
 ```
@@ -77,4 +83,5 @@ with a gentle premium feel and accessible CTA prominence.
 ## 6) Required QA Link
 
 Before release, validate output with:
+
 - `docs/sora/SORA_STYLE_QA_CHECKLIST.md`

--- a/docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md
+++ b/docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md
@@ -1,0 +1,80 @@
+# PulsePlate HPP Prompt Pack (P2)
+
+Version: v1.0
+Scope: Home + Plate + Progress visual assets
+
+## 1) Style Lock (fixed across variants)
+
+- Mood: minimal + cozy + intelligent + luxury-clean
+- Palette:
+  - Navy `#0F172A`
+  - Blue `#339FFF`
+  - Accent Green `#20C997`
+  - Heart Red `#FF5D5D` (accent only)
+- Mascot: FitChef is lifestyle-friendly, non-clinical
+- Rendering: flat + soft shadow + subtle gradient
+
+## 2) Master Prompt Template
+
+Use this for release candidates:
+
+```
+Create a PulsePlate visual for {surface} in a minimalist iOS-first wellness style.
+Keep strict palette tokens: Navy #0F172A, Blue #339FFF, Accent Green #20C997,
+Heart Red #FF5D5D as accent only. The mood is cozy, intelligent, and premium-clean.
+Use flat forms, soft shadows, and subtle gradients. Preserve clear visual hierarchy:
+primary action first, supporting metric second, background calm and low-noise.
+FitChef mascot, if present, must appear friendly and lifestyle-oriented, never clinical.
+Output ratio: {ratio}. Focus: {goal}. Keep text-safe regions and no micro-details.
+```
+
+## 3) Nano Prompt Template
+
+Use this for rapid iteration:
+
+```
+PulsePlate {surface}, minimalist cozy wellness, palette-locked (#0F172A #339FFF #20C997 #FF5D5D accent), flat + soft shadow, premium-clean hierarchy, FitChef non-clinical.
+```
+
+## 4) Negative Prompt (mandatory)
+
+```
+No neon cyberpunk, no purple-gold luxury drift, no medical diagnosis imagery,
+no hospital devices, no fear/shame framing, no unreadable micro-textures,
+no inconsistent mascot style.
+```
+
+## 5) Controlled Variations
+
+What stays fixed:
+- palette tokens
+- hierarchy and tone
+- safety constraints
+
+What changes:
+- composition density
+- CTA emphasis
+- background texture level
+
+### Variation A: Compact Utility
+```
+Create a compact utility-focused card visual for {surface}, with minimal decorative
+noise, strong CTA readability, and calm metric support.
+```
+
+### Variation B: Emphasized Conversion
+```
+Create an emphasized conversion-oriented visual for {surface}, where primary action
+is visually dominant and metric context remains secondary but clear.
+```
+
+### Variation C: Balanced Trust
+```
+Create a balanced trust-oriented visual for {surface}, blending calm data context
+with a gentle premium feel and accessible CTA prominence.
+```
+
+## 6) Required QA Link
+
+Before release, validate output with:
+- `docs/sora/SORA_STYLE_QA_CHECKLIST.md`


### PR DESCRIPTION
## Summary
- add canonical Figma/OpenClaw operating model with source-of-truth lock (`make` vs `design`) and deterministic command/session/evidence rules
- add sandbox design-agent specification (IO contracts, HITL gates, UQ/degrade policy, rollback/kill-switch)
- add P2 enablement pack (master+nano prompts, QA checklist, throughput + GTM metrics) and wire references in figma runbook/README/AGENTS

## Test plan
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md docs/sora/SORA_STYLE_QA_CHECKLIST.md docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md`
- [x] `npx --yes markdownlint-cli2 "docs/figma/FIGMA_CLAWBOT_OPERATING_MODEL.md" "docs/figma/SANDBOX_DESIGN_AGENT_SPEC.md" "docs/sora/BRAND_THROUGHPUT_METRICS_GTM_MATRIX.md" "docs/sora/SORA_STYLE_QA_CHECKLIST.md" "docs/sora/prompts/hpp/MASTER_NANO_PROMPT_PACK.md" "docs/figma/README.md" "docs/figma/FIGMA_IMPLEMENTATION_RUNBOOK.md"`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- PR-D implementation PoC is intentionally deferred; open dedicated runtime PR only after this spec package is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Figma-Clawbot integration operating model documentation and sandbox design-agent specification with HITL gates guidance.
  * Added Sora visual QA checklist and style guidelines for brand consistency across visual assets.
  * Added PulsePlate HPP prompt pack with constrained templates and variation definitions.
  * Added brand throughput metrics and GTM governance framework documentation.
  * Updated implementation runbook with new references and updated workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->