### PR TITLE
docs(runbook): add Figma MCP live activation protocol

### DIFF
--- a/docs/runbooks/FIGMA_MCP_LIVE_ACTIVATION.md
+++ b/docs/runbooks/FIGMA_MCP_LIVE_ACTIVATION.md
@@ -1,0 +1,97 @@
+# Figma MCP Live Activation (Code -> Canvas)
+
+<!-- markdownlint-disable MD013 -->
+
+This runbook is a practical execution protocol for the first real
+`local prototype -> Figma canvas` session after setup.
+
+## Goal
+
+- Verify Figma MCP is reachable in the active IDE session.
+- Verify token and region settings are valid.
+- Execute one real push cycle from local prototype to Figma.
+- Capture reproducible evidence for future sessions.
+
+## Preconditions
+
+- `docs/runbooks/FIGMA_MCP_CODEX.md` already completed.
+- `FIGMA_OAUTH_TOKEN` exists in the environment that launches IDE/Codex.
+- Figma MCP server is connected in runtime tools list.
+- You have one target Figma file/frame URL for variant placement.
+
+## Step-by-Step Session Protocol
+
+### Step 1: Environment sanity
+
+Run locally:
+
+```bash
+test -n "$FIGMA_OAUTH_TOKEN" && echo "FIGMA_OAUTH_TOKEN is set"
+printf "FIGMA_OAUTH_TOKEN length: %s\n" "${#FIGMA_OAUTH_TOKEN}"
+```
+
+Expected:
+
+- both commands succeed,
+- length > 0.
+
+### Step 2: MCP visibility check
+
+In IDE/Codex MCP panel:
+
+- confirm `figma` server exists,
+- confirm Figma tools are callable (context/screenshot/metadata-like tools).
+
+### Step 3: Pick one source route/frame
+
+- open a concrete local screen variant (example: Home/Progress card state),
+- define one canonical target frame in Figma,
+- prepare a single variant label (for example: `v1_compact_live`).
+
+### Step 4: Push first variant
+
+- request MCP flow: fetch context -> screenshot -> push variant to canvas,
+- avoid parallel variant pushes in first session,
+- record returned frame/node references.
+
+### Step 5: Validate in Figma
+
+- visual parity check (layout/text/spacing),
+- node naming sanity (`variant_id`, `source_route`, `date`),
+- no duplicate unnamed layers.
+
+### Step 6: Capture evidence
+
+Store in `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md`:
+
+- source route,
+- target Figma URL,
+- created node/frame IDs,
+- success/failure notes,
+- next action.
+
+## Failure Modes and Fast Recovery
+
+1. **Token missing**
+   - Re-export token and fully restart IDE session.
+2. **Figma server not listed**
+   - Re-check plugin/config and restart MCP runtime.
+3. **Region/header mismatch**
+   - Remove header temporarily, then re-add confirmed region.
+4. **Push succeeded but wrong frame**
+   - verify exact target URL/node before push; retry with strict mapping.
+5. **Visual mismatch**
+   - keep same node and iterate variant naming (`v2`, `v3`) with diffs logged.
+
+## Security Notes
+
+- Never paste raw token into logs, comments, or PR text.
+- Evidence must include token presence/length only, never token value.
+- If accidental leak happens, rotate token immediately.
+
+## Definition of Done (Live Activation)
+
+- [ ] one variant is pushed from local prototype to Figma canvas,
+- [ ] node/frame references are captured in evidence template,
+- [ ] no secrets leaked in commands/logs/comments,
+- [ ] first iteration loop (`v1 -> v2`) is reproducible by another teammate.

--- a/docs/runbooks/FIGMA_MCP_LIVE_ACTIVATION.md
+++ b/docs/runbooks/FIGMA_MCP_LIVE_ACTIVATION.md
@@ -62,7 +62,12 @@ In IDE/Codex MCP panel:
 
 ### Step 6: Capture evidence
 
-Store in `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md`:
+Do not edit `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md` directly.
+For each live session, copy it to a session file under:
+
+- `docs/runbooks/sessions/FIGMA_MCP_SESSION_<YYYY-MM-DD>_<slug>.md`
+
+Then store:
 
 - source route,
 - target Figma URL,

--- a/docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md
+++ b/docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md
@@ -1,0 +1,59 @@
+# Figma MCP Session Evidence Template
+
+Use this template after each live `code -> Figma` session.
+
+## Session Metadata
+
+- Date:
+- Operator:
+- Branch:
+- Local source route:
+- Target Figma file URL:
+- Target node/frame URL:
+
+## Preconditions Check
+
+- `FIGMA_OAUTH_TOKEN` present: yes/no
+- Token length check passed: yes/no
+- Figma MCP server visible in runtime: yes/no
+- Figma tools callable: yes/no
+
+## Execution
+
+### Request
+
+- Prompt used:
+- Variant label:
+
+### Result
+
+- Created/updated Figma node ID:
+- Created/updated frame ID:
+- Push status: success/failure
+
+## Validation
+
+- Visual parity status: pass/fail
+- Naming convention status: pass/fail
+- Layer hygiene status: pass/fail
+
+## Security Check
+
+- Token value leaked: yes/no
+- Sensitive data in logs/comments: yes/no
+
+## Raw Evidence
+
+- Command 1:
+- Output lines:
+- Exit code:
+
+- Command 2:
+- Output lines:
+- Exit code:
+
+## Follow-ups
+
+- Next iteration variant:
+- Blockers:
+- Owner:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,10 @@ operational tasks.
 - [`FRONTEND_CI_PR_NOTES.md`](FRONTEND_CI_PR_NOTES.md)
 - [`FIGMA_MCP_CODEX.md`](FIGMA_MCP_CODEX.md) — Figma MCP setup and
   code-to-canvas flow for Codex/Claude
+- [`FIGMA_MCP_LIVE_ACTIVATION.md`](FIGMA_MCP_LIVE_ACTIVATION.md) —
+  first-session live activation protocol
+- [`Session evidence template`](FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md) —
+  reproducible code-to-canvas evidence capture checklist
 
 ## Project maintenance
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -34,7 +34,7 @@ operational tasks.
   code-to-canvas flow for Codex/Claude
 - [`FIGMA_MCP_LIVE_ACTIVATION.md`](FIGMA_MCP_LIVE_ACTIVATION.md) —
   first-session live activation protocol
-- [`Session evidence template`](FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md) —
+- [Figma Session Evidence Template](FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md) —
   reproducible code-to-canvas evidence capture checklist
 
 ## Project maintenance


### PR DESCRIPTION
## Summary
- add a first-session live activation protocol for Figma MCP (`code -> canvas`) with clear preconditions and failure recovery
- add a reusable session evidence template for deterministic capture of route/url/node/push results
- update runbooks index to include activation and evidence documents

## Test plan
- [x] `npx --yes markdownlint-cli2 docs/runbooks/FIGMA_MCP_LIVE_ACTIVATION.md docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md docs/runbooks/README.md`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- first real live push session should attach one filled evidence template entry with concrete Figma node/frame IDs.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Задокументировать протокол live-активации первой сессии Figma MCP и внедрить переиспользуемый шаблон свидетельств сессии для запусков code-to-canvas.

Документация:
- Добавить runbook, описывающий пошаговый процесс live-активации для первой Figma MCP code-to-canvas сессии, включая предусловия, валидацию, режимы отказа и примечания по безопасности.
- Ввести стандартизированный шаблон свидетельств сессии Figma MCP для последовательного фиксирования метаданных сессии, результатов и деталей валидации.
- Обновить индекс runbook'ов, чтобы добавить ссылки на новые документы по live-активации Figma MCP и свидетельствам сессии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the Figma MCP first-session live activation protocol and introduce a reusable session evidence template for code-to-canvas runs.

Documentation:
- Add a runbook describing the step-by-step live activation flow for the first Figma MCP code-to-canvas session, including preconditions, validation, failure modes, and security notes.
- Introduce a standardized Figma MCP session evidence template for consistently capturing session metadata, results, and validation details.
- Update the runbooks index to reference the new Figma MCP live activation and session evidence documents.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added runbook detailing live activation protocol for Figma MCP
  * Added template for capturing and documenting session evidence
  * Updated documentation index with new runbook references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->