### PR TITLE
docs(runbook): add Figma MCP live smoke session evidence

### DIFF
--- a/docs/runbooks/FIGMA_MCP_CODEX.md
+++ b/docs/runbooks/FIGMA_MCP_CODEX.md
@@ -79,6 +79,8 @@ Restart Codex/Cursor after config changes.
 - Figma tools are callable (metadata/context/screenshot/export tools).
 - No auth errors in first tool call.
 - Region header matches your Figma org region.
+- Runtime capability expectations are confirmed against
+  [`FIGMA_MCP_RUNTIME_MATRIX.md`](FIGMA_MCP_RUNTIME_MATRIX.md).
 
 ## Canonical code-to-Figma flow
 

--- a/docs/runbooks/FIGMA_MCP_RUNTIME_MATRIX.md
+++ b/docs/runbooks/FIGMA_MCP_RUNTIME_MATRIX.md
@@ -1,0 +1,61 @@
+# Figma MCP Runtime Matrix
+
+<!-- markdownlint-disable MD013 -->
+
+This runbook clarifies which Figma MCP capabilities are available by runtime.
+It is the canonical "why it works here and not there" reference.
+
+## Scope
+
+### IN
+
+- Runtime capability matrix for Figma MCP tools.
+- Exact path to enable `generate_figma_design`.
+- Fast verification checklist.
+
+### OUT
+
+- Product design decisions.
+- App runtime changes.
+- Figma org governance details.
+
+## Capability Matrix
+
+| Runtime | Remote MCP auth (`whoami`) | Make context (`get_design_context`) | Diagram write (`generate_diagram`) | Design push (`generate_figma_design`) |
+| --- | --- | --- | --- | --- |
+| Cursor/Codex (this workspace MCP bridge) | Yes | Yes | Yes | No (tool not exposed) |
+| Claude Code + remote Figma MCP | Yes | Yes | Yes | Yes (supported path) |
+
+## Hard Rule
+
+If the active tool list does not include `generate_figma_design`, direct
+`code -> Figma Design` push is not possible in that runtime.
+
+Do not treat this as a bug in project code. It is a client capability gap.
+
+## Canonical Enablement Path (`generate_figma_design`)
+
+1. Use Claude Code runtime.
+2. Configure remote Figma MCP endpoint:
+   - `https://mcp.figma.com/mcp`
+3. Run OAuth flow in Claude Code (`/mcp` -> `figma` -> `Authenticate`).
+4. Start local app server for the target page.
+5. Prompt with explicit target:
+   - `Start a local server for my app and capture the UI in <Figma Design file URL>.`
+6. In capture toolbar, use:
+   - `Entire screen` for full-page state.
+   - `Select element` for focused state captures.
+7. Save generated output and record evidence in session runbook.
+
+## Quick Verification
+
+- `whoami` returns identity payload.
+- `get_design_context(fileKey,nodeId)` returns context/resources.
+- `generate_figma_design` appears in tool list.
+- One capture to Figma Design file succeeds.
+
+## Security Notes
+
+- Never store OAuth token in repository files.
+- Keep only minimal evidence in docs (redacted identifiers, no raw secrets).
+- Prefer canonical Figma URLs without tracking query params in long-lived docs.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,8 @@ operational tasks.
 - [`FRONTEND_CI_PR_NOTES.md`](FRONTEND_CI_PR_NOTES.md)
 - [`FIGMA_MCP_CODEX.md`](FIGMA_MCP_CODEX.md) — Figma MCP setup and
   code-to-canvas flow for Codex/Claude
+- [`FIGMA_MCP_RUNTIME_MATRIX.md`](FIGMA_MCP_RUNTIME_MATRIX.md) — runtime
+  capability matrix (`generate_figma_design` availability by client)
 - [`FIGMA_MCP_LIVE_ACTIVATION.md`](FIGMA_MCP_LIVE_ACTIVATION.md) —
   first-session live activation protocol
 - [Figma Session Evidence Template](FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md) —

--- a/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
+++ b/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
@@ -44,15 +44,15 @@
   - `mermaidSyntax` simple `code -> canvas -> iteration` flow
 - Result:
   - diagram created successfully in FigJam
-  - URL:
-    [PulsePlate code-to-figma smoke](https://www.figma.com/online-whiteboard/create-diagram/580b99ea-ef7b-47b6-bf64-4f0283765f2c)
+  - URL: `<REDACTED_FIGJAM_URL>`
 
 ## Validation
 
 - MCP auth status: pass
 - Make context fetch status: pass
 - Write operation to Figma (FigJam): pass
-- Direct Make screenshot operation: fail (tool unsupported for Make in this runtime)
+- Direct Make screenshot operation: fail (`get_screenshot` unsupported for
+  Figma Make in this runtime)
 
 ## Security Check
 

--- a/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
+++ b/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
@@ -5,8 +5,8 @@
 - Date: 2026-02-19
 - Operator: Codex agent + user session
 - Branch: `docs/figma-mcp-session-smoke-evidence`
-- Local source route: N/A (Make-source smoke focus)
-- Target Figma source URL: `https://www.figma.com/make/MrztJU3CQtxhADBbtAsWJ6/PulsePlate_Web`
+- Local source root: N/A (Make-source smoke focus)
+- Target Figma source URL: `https://www.figma.com/make/<REDACTED_FILE_KEY>/PulsePlate_Web`
 - Target node/frame: Make root node (`0:1`) and FigJam output canvas
 
 ## Preconditions Check
@@ -22,15 +22,15 @@
 
 - Tool: `plugin-figma-figma.whoami`
 - Result:
-  - email: `lexakm532@gmail.com`
-  - handle: `Katsiaryna Kavaleuskaya`
-  - plan: `Катерина's team` (`pro`, seat `Full`)
+  - email: `l***@g***.com` (redacted)
+  - handle: `K*** K***` (redacted)
+  - plan: `Team (redacted)` (`pro`, seat `Full`)
 
 ### Request 2 (Make context extraction)
 
 - Tool: `plugin-figma-figma.get_design_context`
 - Arguments:
-  - `fileKey=MrztJU3CQtxhADBbtAsWJ6`
+  - `fileKey=<REDACTED_FILE_KEY>`
   - `nodeId=0:1`
 - Result:
   - returned Make source resources (including `src/app/App.tsx`)
@@ -44,7 +44,8 @@
   - `mermaidSyntax` simple `code -> canvas -> iteration` flow
 - Result:
   - diagram created successfully in FigJam
-  - URL: [PulsePlate code-to-figma smoke](https://www.figma.com/online-whiteboard/create-diagram/580b99ea-ef7b-47b6-bf64-4f0283765f2c?utm_source=other&utm_content=edit_in_figjam&oai_id=&request_id=dc3224b6-5130-48d3-ab9f-e9c30bbcc58d)
+  - URL:
+    [PulsePlate code-to-figma smoke](https://www.figma.com/online-whiteboard/create-diagram/580b99ea-ef7b-47b6-bf64-4f0283765f2c)
 
 ## Validation
 
@@ -64,7 +65,7 @@
   - Output line: user identity payload returned
   - Exit: success
 
-- Call: `get_design_context(fileKey=MrztJU3CQtxhADBbtAsWJ6,nodeId=0:1)`
+- Call: `get_design_context(fileKey=<REDACTED_FILE_KEY>,nodeId=0:1)`
   - Output line:
     "This contains the resource links for all the source files in the
     Figma Make."

--- a/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
+++ b/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md
@@ -1,0 +1,89 @@
+# Figma MCP Session Evidence
+
+## Session Metadata
+
+- Date: 2026-02-19
+- Operator: Codex agent + user session
+- Branch: `docs/figma-mcp-session-smoke-evidence`
+- Local source route: N/A (Make-source smoke focus)
+- Target Figma source URL: `https://www.figma.com/make/MrztJU3CQtxhADBbtAsWJ6/PulsePlate_Web`
+- Target node/frame: Make root node (`0:1`) and FigJam output canvas
+
+## Preconditions Check
+
+- `FIGMA_OAUTH_TOKEN` present: yes (authenticated `whoami` response)
+- Token length check passed: not logged in this evidence file (security-safe policy)
+- Figma MCP server visible in runtime: yes
+- Figma tools callable: yes
+
+## Execution
+
+### Request 1 (identity/auth)
+
+- Tool: `plugin-figma-figma.whoami`
+- Result:
+  - email: `lexakm532@gmail.com`
+  - handle: `Katsiaryna Kavaleuskaya`
+  - plan: `Катерина's team` (`pro`, seat `Full`)
+
+### Request 2 (Make context extraction)
+
+- Tool: `plugin-figma-figma.get_design_context`
+- Arguments:
+  - `fileKey=MrztJU3CQtxhADBbtAsWJ6`
+  - `nodeId=0:1`
+- Result:
+  - returned Make source resources (including `src/app/App.tsx`)
+  - confirmed live access to Make-backed code assets via MCP resource URIs
+
+### Request 3 (diagram write smoke)
+
+- Tool: `plugin-figma-figma.generate_diagram`
+- Arguments:
+  - `name="PulsePlate code-to-figma smoke"`
+  - `mermaidSyntax` simple `code -> canvas -> iteration` flow
+- Result:
+  - diagram created successfully in FigJam
+  - URL: [PulsePlate code-to-figma smoke](https://www.figma.com/online-whiteboard/create-diagram/580b99ea-ef7b-47b6-bf64-4f0283765f2c?utm_source=other&utm_content=edit_in_figjam&oai_id=&request_id=dc3224b6-5130-48d3-ab9f-e9c30bbcc58d)
+
+## Validation
+
+- MCP auth status: pass
+- Make context fetch status: pass
+- Write operation to Figma (FigJam): pass
+- Direct Make screenshot operation: fail (tool unsupported for Make in this runtime)
+
+## Security Check
+
+- Token value leaked: no
+- Sensitive data in logs/comments: no
+
+## Raw Evidence
+
+- Call: `whoami`
+  - Output line: user identity payload returned
+  - Exit: success
+
+- Call: `get_design_context(fileKey=MrztJU3CQtxhADBbtAsWJ6,nodeId=0:1)`
+  - Output line:
+    "This contains the resource links for all the source files in the
+    Figma Make."
+  - Exit: success
+
+- Call: `generate_diagram(name,mermaidSyntax)`
+  - Output line: returned FigJam diagram URL
+  - Exit: success
+
+## Known Limits / Next Action
+
+- `generate_figma_design` (Claude Code to Figma Design push) is not currently exposed
+  in this client tool list.
+- For full "local web page -> Figma Design file" capture, next step is to run
+  from a client/runtime where `generate_figma_design` is available and bind
+  that output to this same evidence format.
+
+## Follow-ups
+
+- Next iteration variant: `design-file push smoke` (not only FigJam)
+- Blockers: client capability mismatch for `generate_figma_design`
+- Owner: current workspace operator


### PR DESCRIPTION
## Summary
- add first live Figma MCP session evidence for PulsePlate Make file (`MrztJU3CQtxhADBbtAsWJ6`)
- document successful auth (`whoami`), make-context retrieval (`get_design_context`), and FigJam write smoke (`generate_diagram`)
- capture current runtime limitation for full design-file push (`generate_figma_design` not exposed in this client tool list)

## Test plan
- [x] `npx --yes markdownlint-cli2 docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-02-19_make-pulseplate-smoke.md`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- execute a second session from a runtime where `generate_figma_design` is available to complete true design-file `code -> canvas` capture and append evidence.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Задокументировать первую сессионную проверку (smoke session) Figma MCP для файла PulsePlate Make и ввести матрицу возможностей времени выполнения (runtime capability matrix), ссылающуюся на существующие runbook'и.

Документация:
- Добавить подробный runbook с доказательствами сессии, фиксирующий smoke-тест Figma MCP PulsePlate Make от 2026-02-19, включая аутентификацию, получение контекста, запись в FigJam и известные ограничения.
- Ввести матрицу возможностей Figma MCP во время выполнения (runtime capability matrix), документирующую, какие инструменты (включая `generate_figma_design`) доступны для каждого клиента/среды выполнения и как включить полноценную отправку дизайна (full design push), а также добавить ссылку на неё из Codex runbook и README для runbook'ов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the first Figma MCP smoke session for the PulsePlate Make file and introduce a runtime capability matrix referenced from existing runbooks.

Documentation:
- Add a detailed session evidence runbook capturing the 2026-02-19 Figma MCP PulsePlate Make smoke test, including auth, context retrieval, FigJam write, and known limitations.
- Introduce a Figma MCP runtime capability matrix documenting which tools (including `generate_figma_design`) are available per client/runtime and how to enable full design push, and link it from the Codex runbook and runbook README.

</details>

Документация:
- Добавить подробный регламент (runbook), фиксирующий пробную сессию Figma MCP от 2026-02-19, включая проверку авторизации, получение контекста Make, создание диаграммы FigJam и известные ограничения при отправке данных в файл дизайна.
- Ввести матрицу возможностей среды выполнения Figma MCP, объясняющую, какие инструменты доступны в каждом клиенте и как включить `generate_figma_design`, а также добавить на неё ссылку из Codex runbook и README для runbook.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Задокументировать первую сессионную проверку (smoke session) Figma MCP для файла PulsePlate Make и ввести матрицу возможностей времени выполнения (runtime capability matrix), ссылающуюся на существующие runbook'и.

Документация:
- Добавить подробный runbook с доказательствами сессии, фиксирующий smoke-тест Figma MCP PulsePlate Make от 2026-02-19, включая аутентификацию, получение контекста, запись в FigJam и известные ограничения.
- Ввести матрицу возможностей Figma MCP во время выполнения (runtime capability matrix), документирующую, какие инструменты (включая `generate_figma_design`) доступны для каждого клиента/среды выполнения и как включить полноценную отправку дизайна (full design push), а также добавить ссылку на неё из Codex runbook и README для runbook'ов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the first Figma MCP smoke session for the PulsePlate Make file and introduce a runtime capability matrix referenced from existing runbooks.

Documentation:
- Add a detailed session evidence runbook capturing the 2026-02-19 Figma MCP PulsePlate Make smoke test, including auth, context retrieval, FigJam write, and known limitations.
- Introduce a Figma MCP runtime capability matrix documenting which tools (including `generate_figma_design`) are available per client/runtime and how to enable full design push, and link it from the Codex runbook and runbook README.

</details>

</details>
- Задокументировать первую live smoke-сессию Figma MCP для файла PulsePlate Make, включая проверку авторизации, получение контекста, создание диаграммы в FigJam и текущие ограничения рантайма.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Задокументировать первую сессионную проверку (smoke session) Figma MCP для файла PulsePlate Make и ввести матрицу возможностей времени выполнения (runtime capability matrix), ссылающуюся на существующие runbook'и.

Документация:
- Добавить подробный runbook с доказательствами сессии, фиксирующий smoke-тест Figma MCP PulsePlate Make от 2026-02-19, включая аутентификацию, получение контекста, запись в FigJam и известные ограничения.
- Ввести матрицу возможностей Figma MCP во время выполнения (runtime capability matrix), документирующую, какие инструменты (включая `generate_figma_design`) доступны для каждого клиента/среды выполнения и как включить полноценную отправку дизайна (full design push), а также добавить ссылку на неё из Codex runbook и README для runbook'ов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the first Figma MCP smoke session for the PulsePlate Make file and introduce a runtime capability matrix referenced from existing runbooks.

Documentation:
- Add a detailed session evidence runbook capturing the 2026-02-19 Figma MCP PulsePlate Make smoke test, including auth, context retrieval, FigJam write, and known limitations.
- Introduce a Figma MCP runtime capability matrix documenting which tools (including `generate_figma_design`) are available per client/runtime and how to enable full design push, and link it from the Codex runbook and runbook README.

</details>

Документация:
- Добавить подробный регламент (runbook), фиксирующий пробную сессию Figma MCP от 2026-02-19, включая проверку авторизации, получение контекста Make, создание диаграммы FigJam и известные ограничения при отправке данных в файл дизайна.
- Ввести матрицу возможностей среды выполнения Figma MCP, объясняющую, какие инструменты доступны в каждом клиенте и как включить `generate_figma_design`, а также добавить на неё ссылку из Codex runbook и README для runbook.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Задокументировать первую сессионную проверку (smoke session) Figma MCP для файла PulsePlate Make и ввести матрицу возможностей времени выполнения (runtime capability matrix), ссылающуюся на существующие runbook'и.

Документация:
- Добавить подробный runbook с доказательствами сессии, фиксирующий smoke-тест Figma MCP PulsePlate Make от 2026-02-19, включая аутентификацию, получение контекста, запись в FigJam и известные ограничения.
- Ввести матрицу возможностей Figma MCP во время выполнения (runtime capability matrix), документирующую, какие инструменты (включая `generate_figma_design`) доступны для каждого клиента/среды выполнения и как включить полноценную отправку дизайна (full design push), а также добавить ссылку на неё из Codex runbook и README для runbook'ов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the first Figma MCP smoke session for the PulsePlate Make file and introduce a runtime capability matrix referenced from existing runbooks.

Documentation:
- Add a detailed session evidence runbook capturing the 2026-02-19 Figma MCP PulsePlate Make smoke test, including auth, context retrieval, FigJam write, and known limitations.
- Introduce a Figma MCP runtime capability matrix documenting which tools (including `generate_figma_design`) are available per client/runtime and how to enable full design push, and link it from the Codex runbook and runbook README.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a runbook for the first live Figma MCP smoke session (auth, design context, FigJam diagram), with hardened redaction (FigJam URL and identifiers removed) and an explicit note that Make screenshots fail in this runtime. Added a runtime capability matrix and links in Codex/README to explain why generate_figma_design isn’t available here and how to enable it in supported clients.

<sup>Written for commit 39045c873e5dddc3704d5d86cbb926edbf534057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PulsePlate Figma MCP session runbook covering metadata, preconditions, three-step execution, validation results, security checks, raw evidence, known limits, next actions, follow-ups, and ownership.
  * Introduced a Figma MCP runtime capability matrix with scope, availability rules for design generation, verification checklist, and security notes.
  * Added a verification checklist entry linking the runtime matrix into the runbooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->