### PR TITLE
feat(frontend): apply figma MCP matrix UI refinements

### DIFF
--- a/docs/runbooks/FIGMA_MCP_DESIGN_SYSTEM_RULES.md
+++ b/docs/runbooks/FIGMA_MCP_DESIGN_SYSTEM_RULES.md
@@ -1,0 +1,198 @@
+# Figma MCP Design System Rules (PulsePlate Frontend)
+
+## Scope
+
+This document is the implementation-facing ruleset for translating Figma MCP
+design context into production code in `frontend/`.
+
+Use this with:
+
+- `get_design_context(fileKey,nodeId)`
+- `get_metadata(fileKey,nodeId)` for large trees
+- `get_screenshot(fileKey,nodeId)` when supported by file type/runtime
+
+## 1) Token Definitions
+
+### Source of truth
+
+- Type-safe tokens: `frontend/src/styles/tokens.ts`
+- Runtime CSS variables: `frontend/src/styles/tokens.css`
+- Tailwind mapping to legacy aliases: `frontend/tailwind.config.ts`
+
+### Token structure
+
+- Typed object exports (`colors`, `spacing`, `typography`, `borderRadius`, etc.)
+- CSS custom properties (`--color-*`, `--spacing-*`, `--font-*`)
+- Semantic tokens (`--color-primary`, `--color-surface`, `--color-text`)
+- Legacy aliases kept for compatibility (`--pp-*`)
+
+```ts
+// frontend/src/styles/tokens.ts
+export const colors = {
+  navy: { 50: "#f0f4f8", 900: "#102a43" },
+  blue: { 500: "#3b82f6", 600: "#2563eb" },
+  semantic: { success: "#22c55e", warning: "#f59e0b" },
+} as const;
+```
+
+```css
+/* frontend/src/styles/tokens.css */
+:root {
+  --color-primary: var(--color-blue-600);
+  --color-surface: var(--color-navy-50);
+  --color-text: var(--color-navy-900);
+  --pp-primary: var(--color-primary); /* compatibility alias */
+}
+```
+
+### Transformation systems
+
+- No separate token build pipeline found.
+- Mapping is done by importing CSS variables and extending Tailwind theme.
+
+## 2) Component Library
+
+### Locations
+
+- Shared components: `frontend/src/components/`
+- UI primitives: `frontend/src/components/ui/`
+- Feature-specific components: nested folders (for example `Paywall/`)
+- Barrel export: `frontend/src/components/index.ts`
+
+### Architecture
+
+- Function components + TypeScript props interfaces
+- Composition and route-level assembly via `frontend/src/App.tsx`
+- Feature pages in `frontend/src/pages/` consume shared components
+
+### Documentation and storybook
+
+- No Storybook configuration detected in `frontend/`.
+- Component behavior is validated primarily through Vitest + RTL tests under
+  `__tests__/`.
+
+## 3) Frameworks and Libraries
+
+### UI stack
+
+- React 18 + TypeScript
+- Routing: `react-router-dom`
+- Forms: `react-hook-form`, `zod`
+- Charts: `recharts`
+- Icons: `lucide-react`
+
+### Styling stack
+
+- Tailwind CSS + custom utility classes
+- CSS variables from `tokens.css`
+- App-level CSS in `index.css` and `styles/utilities.css`
+
+### Build and test
+
+- Bundler/build tool: Vite (`frontend/vite.config.ts`)
+- Tests: Vitest + jsdom + Testing Library
+
+```json
+// frontend/package.json (scripts excerpt)
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest"
+  }
+}
+```
+
+## 4) Asset Management
+
+### Storage and references
+
+- Static/public mocks under `frontend/public/`
+- No dedicated image asset folder in `frontend/src/` found
+- SVGs are commonly inline in TSX or icon components
+
+### Optimization
+
+- Vite handles bundling and minification
+- Current production build warns for large chunks (monitor split points)
+
+### CDN
+
+- No frontend CDN-specific configuration found in Vite config for assets
+
+## 5) Icon System
+
+### Sources
+
+- Primary icon library: `lucide-react`
+- Secondary: inline SVG in component markup where needed
+
+### Usage pattern
+
+```tsx
+import { Download, TrendingUp } from "lucide-react";
+```
+
+### Naming convention
+
+- Use semantic component names matching UI meaning (`Download`, `TrendingUp`)
+- For custom inline SVGs, keep usage local to the component context
+
+## 6) Styling Approach
+
+### Methodology
+
+- Utility-first classes + CSS variable tokens
+- Minimal inline styles used only for dynamic token combinations and gradients
+
+### Global styles
+
+- `frontend/src/main.tsx` imports:
+  - `styles/tokens.css`
+  - `index.css`
+- Global baseline includes reduced-motion handling and focus-visible behavior
+
+```tsx
+// frontend/src/main.tsx
+import "./styles/tokens.css";
+import "./index.css";
+```
+
+### Responsive design
+
+- Tailwind responsive breakpoints (`sm`, `md`, `lg`) in class names
+- Tokenized breakpoint values also exist in `tokens.css`
+
+## 7) Project Structure
+
+### High-level organization
+
+- `frontend/src/pages/` -> route surfaces
+- `frontend/src/components/` -> reusable UI and feature components
+- `frontend/src/features/` -> feature modules (for example progress)
+- `frontend/src/api/` -> thin API adapter + generated OpenAPI schema
+- `frontend/src/styles/` -> design tokens + utilities
+
+### Feature pattern
+
+- Route component composes feature components and shared UI
+- Tests are colocated in `__tests__/` near page/component modules
+
+## Figma MCP Translation Rules (Project-Specific)
+
+1. Start from `get_design_context`, not assumptions.
+2. Map Figma colors/spacing to semantic tokens first (`--color-*`).
+3. Reuse existing primitives in `frontend/src/components/ui/` before creating
+   new ones.
+4. Keep business logic unchanged in design-only passes.
+5. Validate with targeted tests and `npm run build`.
+6. If runtime/file type does not support screenshot, proceed with context +
+   metadata and document the limitation.
+
+## Quick Validation Checklist
+
+- [ ] Layout hierarchy matches Figma node intent
+- [ ] Colors map to project tokens (no random hardcoded palette)
+- [ ] Touch targets are at least 44px where interactive
+- [ ] Existing routes/state/analytics contracts remain intact
+- [ ] Related tests pass + frontend build succeeds

--- a/docs/runbooks/FIGMA_MCP_DESIGN_SYSTEM_RULES.md
+++ b/docs/runbooks/FIGMA_MCP_DESIGN_SYSTEM_RULES.md
@@ -65,7 +65,7 @@ export const colors = {
 - Composition and route-level assembly via `frontend/src/App.tsx`
 - Feature pages in `frontend/src/pages/` consume shared components
 
-### Documentation and storybook
+### Documentation and Storybook
 
 - No Storybook configuration detected in `frontend/`.
 - Component behavior is validated primarily through Vitest + RTL tests under

--- a/docs/runbooks/FIGMA_TERMINAL_CLAWBOT_MCP.md
+++ b/docs/runbooks/FIGMA_TERMINAL_CLAWBOT_MCP.md
@@ -1,0 +1,140 @@
+# Figma Terminal Clawbot MCP Runbook
+
+## Purpose
+
+Define a deterministic setup for `terminal -> Figma MCP -> design iteration`,
+with optional Clawbot orchestration for repetitive flows.
+
+## Direct Answer: Is Figma MCP Already Connected On The Site?
+
+No. Figma MCP is not "enabled on the website" as a global site switch.
+It is connected per client runtime (Cursor, Claude Code, or other MCP client)
+via MCP config + OAuth/auth session.
+
+- If `whoami` works in your MCP client, runtime connection is active.
+- Website access alone does not mean MCP tools are active in terminal.
+
+## Current PulsePlate Baseline
+
+- Workspace MCP config exists: `.cursor/mcp.json`
+- Active remote endpoint: `https://mcp.figma.com/mcp`
+- Verified tools in this runtime include:
+  - `whoami`
+  - `get_design_context`
+  - `generate_diagram`
+  - `get_screenshot` (not supported for Figma Make files)
+
+## Scope
+
+### In
+
+- Terminal-to-Figma Make context extraction.
+- Design iteration loop with node targeting and variant comparison.
+- Optional Clawbot role as orchestrator.
+- Security-safe operational practices.
+
+### Out
+
+- Auto-deploying frontend to production from Figma.
+- Storing secrets in repository files.
+- Forcing `generate_figma_design` in runtimes where tool is unavailable.
+
+## Required Agents (Coordinator-First)
+
+- `agent-coordinator`: routing, quality gates, synthesis.
+- `architecture-specialist`: integration contracts and failure modes.
+- `creative-designer`: variant and UX iteration strategy.
+- `frontend-engineer`: implementation diffs and component mapping.
+- `security-auditor`: token/redaction policy.
+- `bug-hunter` or `qa`: deterministic verification and regressions.
+
+## Integration Contracts
+
+### Contract A: Runtime Capability
+
+- `whoami` must succeed before any design-context call.
+- `get_design_context(fileKey,nodeId)` is required for Make flow.
+- `get_screenshot` is unsupported for Make in this runtime; do not block on it.
+
+### Contract B: Input Format
+
+- Figma Make URL:
+  - `https://www.figma.com/make/<FILE_KEY>/<NAME>?...`
+- Required parsing:
+  - `fileKey = <FILE_KEY>`
+  - default `nodeId = 0:1` when root-level context is intended
+
+### Contract C: Output Artifacts
+
+- One short execution log per session.
+- One implementation action list linked to frontend paths.
+- One risk and rollback note for UI changes.
+
+## Full Implementation Plan
+
+1. Verify runtime auth with `whoami`.
+2. Parse Make URL and extract `fileKey`.
+3. Pull context with `get_design_context(fileKey, nodeId)`.
+4. Select target component set for iteration (hero, cards, CTA, etc.).
+5. Create 2 variants (A/B) and record decision criteria.
+6. Map variant to concrete frontend file edits.
+7. Validate with deterministic tests/lint for touched files.
+8. Log evidence and next actions.
+
+## Optional Clawbot Bridge
+
+Use Clawbot only as an orchestration layer, not as a source of truth.
+
+- Clawbot responsibilities:
+  - invoke MCP sequence in the correct order
+  - enforce required fields (`fileKey`, `nodeId`)
+  - store session summary in docs
+- Clawbot must not:
+  - write secrets to repo
+  - bypass agent-coordinator routing
+  - claim unavailable MCP tools are available
+
+## Deterministic Session Template
+
+1. Input:
+   - Figma URL
+   - `nodeId` (or `0:1`)
+2. Calls:
+   - `whoami`
+   - `get_design_context`
+   - `generate_diagram` (optional for flow visualization)
+3. Output:
+   - target files list
+   - minimal diff plan
+   - verification checklist
+
+## Verification Checklist
+
+- MCP auth pass (`whoami` returns user).
+- Design context pass (`get_design_context` returns resources).
+- Expected runtime limits acknowledged (for Make screenshot constraints).
+- No secrets committed in git diff.
+- Frontend changes validated by tests/lint when code is modified.
+
+## Security Notes
+
+- Never commit OAuth tokens or API keys.
+- Redact user email, file keys, and URLs with sensitive parameters in docs.
+- Store only minimal operational evidence needed for audit.
+- If token leakage is suspected:
+  - rotate token immediately
+  - invalidate active sessions
+  - document incident and remediation in `docs/security/`
+
+## Marketing And GTM Notes
+
+- Fast code-to-design loop reduces time-to-iteration for paywall/onboarding.
+- Use variant comparison in each cycle to improve conversion experiments.
+- Keep assets and messaging synchronized with product tiers (FREE/PRO/VIP).
+
+## Next Actions For This Workspace
+
+1. Continue using the current Figma MCP runtime for Make context extraction.
+2. For direct `code -> Figma Design` push, use a client runtime that exposes
+   `generate_figma_design`.
+3. Keep this runbook as single operational reference for the terminal bridge.

--- a/docs/runbooks/PR_CANONICAL_MATRIX_CHECKLIST.md
+++ b/docs/runbooks/PR_CANONICAL_MATRIX_CHECKLIST.md
@@ -1,0 +1,51 @@
+# PR Canonical Matrix Checklist
+
+## Purpose
+
+Single operational checklist so context is never lost during PR execution.
+
+## Canonical Flow (Strict Order)
+
+1. Matrix and scope lock
+   - Define IN/OUT scope.
+   - Confirm work package type (runtime/docs/security/etc.).
+   - Start with coordinator-first routing.
+2. Audit and brainstorming
+   - Quick audit of touched surfaces and risks.
+   - Brainstorm alternatives, choose one path, record rationale.
+3. Plan and implementation
+   - Create concrete step plan.
+   - Implement in narrow scope only.
+4. Local quality gates
+   - Run relevant tests/lint/build for changed scope.
+   - Fix failures before commit.
+5. Commits and PR creation
+   - Logical commits with canonical messages.
+   - Open PR with required body sections and mapping.
+6. Online CI watch
+   - Monitor checks until stable pass.
+   - Rerun only when transient failures are confirmed.
+7. Bot and review loop
+   - Answer all actionable bot comments (CodeRabbit/Sourcery/etc.).
+   - Resolve all review threads.
+8. Merge gate
+   - Merge only when:
+     - required CI is green,
+     - no unresolved review threads,
+     - no actionable bot comments remain.
+9. Post-merge closure
+   - Update backlog ledger for deferred/completed items.
+   - Add follow-up docs-only ledger closure PR when policy requires.
+
+## Hard Merge Conditions
+
+- No unresolved review threads.
+- Required checks are PASS.
+- No unaddressed actionable bot comments.
+- PR scope stays within declared matrix.
+
+## Operator Notes
+
+- Never skip matrix/audit/plan stages.
+- Never mark "ready" before full gate closure.
+- If context drifts, return to this checklist and restart at step 1.

--- a/frontend/src/components/Paywall/BeforeAfter.tsx
+++ b/frontend/src/components/Paywall/BeforeAfter.tsx
@@ -14,6 +14,24 @@ type Props = {
   via?: string;
 };
 
+const beforeItems = [
+  "paywall.items.before.random_plate",
+  "paywall.items.before.macros_only",
+  "paywall.items.before.manual_shopping",
+] as const;
+
+const afterItems = [
+  "paywall.items.after.personal_plate",
+  "paywall.items.after.micro_balance",
+  "paywall.items.after.auto_shopping_list",
+] as const;
+
+const plans = [
+  { name: "Free", subtitle: "Basics", highlighted: false },
+  { name: "Pro", subtitle: "Best value", highlighted: true },
+  { name: "VIP", subtitle: "Advanced", highlighted: false },
+] as const;
+
 /**
  * Renders a modal paywall dialog showing before/after feature lists with primary purchase and cancel actions.
  *
@@ -104,97 +122,125 @@ export default function BeforeAfter({
       className="fixed inset-0 grid place-items-center bg-black/60 p-4"
       onKeyDown={handleKeyDown}
     >
-      <div ref={dialogRef} className="w-full max-w-md rounded-xl bg-white text-black p-5">
-        <h2 id="paywall-title" className="text-2xl mb-1">
-          {t("paywall.title")}
-        </h2>
-        <p className="text-sm text-gray-600 mb-4">{t("paywall.subtitle")}</p>
+      <div
+        ref={dialogRef}
+        className="flex w-full max-w-md max-h-[85vh] flex-col overflow-hidden rounded-2xl bg-white text-black shadow-xl"
+      >
+        <div className="overflow-y-auto p-5">
+          <div className="mb-4 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-muted)] p-4">
+            <div className="mb-2 inline-flex items-center rounded-full bg-[var(--color-surface)] px-3 py-1 text-xs font-semibold text-[var(--color-primary)]">
+              PRO
+            </div>
+            <h2 id="paywall-title" className="text-2xl mb-1">
+              {t("paywall.title")}
+            </h2>
+            <p className="text-sm text-gray-600">{t("paywall.subtitle")}</p>
+          </div>
 
-        <div className="grid grid-cols-2 gap-3 mb-4">
-          <div className="border rounded-lg p-3">
-            <div className="text-xs uppercase text-gray-500">{t("paywall.before.label")}</div>
-            <ul className="text-sm list-disc list-inside">
-              {[
-                "paywall.items.before.random_plate",
-                "paywall.items.before.macros_only",
-                "paywall.items.before.manual_shopping",
-              ].map((key) => (
-                <li key={key}>{t(key)}</li>
-              ))}
-            </ul>
+          <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-[var(--color-border)] p-3">
+              <div className="text-xs uppercase text-gray-500">{t("paywall.before.label")}</div>
+              <ul className="mt-2 text-sm list-disc list-inside space-y-1">
+                {beforeItems.map((key) => (
+                  <li key={key}>{t(key)}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-xl border border-[var(--pp-gold)] bg-[var(--color-surface-muted)] p-3">
+              <div className="text-xs uppercase text-gray-500">{t("paywall.after.label")}</div>
+              <ul className="mt-2 text-sm list-disc list-inside space-y-1">
+                {afterItems.map((key) => (
+                  <li key={key}>{t(key)}</li>
+                ))}
+              </ul>
+            </div>
           </div>
-          <div className="border rounded-lg p-3 border-[var(--pp-gold)]">
-            <div className="text-xs uppercase text-gray-500">{t("paywall.after.label")}</div>
-            <ul className="text-sm list-disc list-inside">
-              {[
-                "paywall.items.after.personal_plate",
-                "paywall.items.after.micro_balance",
-                "paywall.items.after.auto_shopping_list",
-              ].map((key) => (
-                <li key={key}>{t(key)}</li>
-              ))}
-            </ul>
+
+          <div className="mb-4 grid grid-cols-3 gap-2 text-center text-xs">
+            {plans.map((plan) => (
+              <div
+                key={plan.name}
+                className={`rounded-lg p-2 ${
+                  plan.highlighted
+                    ? "border border-[var(--color-primary)] bg-[var(--color-surface-muted)]"
+                    : "border border-[var(--color-border)]"
+                }`}
+              >
+                <div
+                  className={`font-semibold ${
+                    plan.highlighted ? "text-[var(--color-primary)]" : "text-gray-700"
+                  }`}
+                >
+                  {plan.name}
+                </div>
+                <div className={plan.highlighted ? "text-gray-600" : "text-gray-500"}>
+                  {plan.subtitle}
+                </div>
+              </div>
+            ))}
           </div>
+
+          <p className="text-xs text-gray-500">{t("paywall.legal")}</p>
         </div>
 
-        <button
-          type="button"
-          ref={primaryButtonRef}
-          className="w-full py-3 rounded-xl bg-pp-primary text-white disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{ minHeight: 44 }}
-          data-testid="paywall-cta"
-          disabled={purchaseDisabled || isPurchasing}
-          aria-disabled={purchaseDisabled || isPurchasing}
-          onClick={async () => {
-            if (purchaseDisabled || isPurchasing) return;
-            setPurchaseError(null);
-            // Fire-and-forget analytics before invoking callback
-            try {
-              log(Events.PURCHASE_ATTEMPT, { source, via });
-            } catch {
-              // Ignore analytics errors
-            }
-            try {
-              setIsPurchasing(true);
-              await onPurchase?.();
-            } catch (error) {
-              const message = error instanceof Error ? error.message : t("common.tryAgain");
-              setPurchaseError(message);
-            } finally {
-              setIsPurchasing(false);
-            }
-          }}
-        >
-          {isPurchasing
-            ? (processingLabel ?? purchaseLabel ?? t("common.retrying"))
-            : (purchaseLabel ?? t("paywall.cta"))}
-        </button>
+        <div className="border-t border-[var(--color-border)] bg-white p-4">
+          <button
+            type="button"
+            ref={primaryButtonRef}
+            className="w-full rounded-xl bg-pp-primary py-3 text-white disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ minHeight: 44 }}
+            data-testid="paywall-cta"
+            disabled={purchaseDisabled || isPurchasing}
+            aria-disabled={purchaseDisabled || isPurchasing}
+            onClick={async () => {
+              if (purchaseDisabled || isPurchasing) return;
+              setPurchaseError(null);
+              // Fire-and-forget analytics before invoking callback
+              try {
+                log(Events.PURCHASE_ATTEMPT, { source, via });
+              } catch {
+                // Ignore analytics errors
+              }
+              try {
+                setIsPurchasing(true);
+                await onPurchase?.();
+              } catch (error) {
+                const message = error instanceof Error ? error.message : t("common.tryAgain");
+                setPurchaseError(message);
+              } finally {
+                setIsPurchasing(false);
+              }
+            }}
+          >
+            {isPurchasing
+              ? (processingLabel ?? purchaseLabel ?? t("common.retrying"))
+              : (purchaseLabel ?? t("paywall.cta"))}
+          </button>
 
-        {purchaseError && (
-          <p className="mt-2 text-xs text-red-600" data-testid="paywall-purchase-error">
-            {purchaseError}
-          </p>
-        )}
+          {purchaseError && (
+            <p className="mt-2 text-xs text-red-600" data-testid="paywall-purchase-error">
+              {purchaseError}
+            </p>
+          )}
 
-        <button
-          type="button"
-          ref={cancelButtonRef}
-          className="w-full py-2 mt-2 rounded-xl"
-          style={{ minHeight: 44 }}
-          data-testid="paywall-cancel"
-          onClick={() => {
-            try {
-              log(Events.PURCHASE_CANCEL, { source, via });
-            } catch {
-              // Ignore analytics errors
-            }
-            onClose();
-          }}
-        >
-          {t("common.cancel")}
-        </button>
-
-        <p className="mt-3 text-xs text-gray-500">{t("paywall.legal")}</p>
+          <button
+            type="button"
+            ref={cancelButtonRef}
+            className="mt-2 w-full rounded-xl py-2 text-sm text-gray-700"
+            style={{ minHeight: 44 }}
+            data-testid="paywall-cancel"
+            onClick={() => {
+              try {
+                log(Events.PURCHASE_CANCEL, { source, via });
+              } catch {
+                // Ignore analytics errors
+              }
+              onClose();
+            }}
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -43,17 +43,27 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
   };
 
   return (
-    <div className="bg-white rounded-xl p-6 shadow-sm border border-primary/20">
-      <h3 className="text-lg font-semibold text-text mb-2">
+    <div
+      className="rounded-2xl border p-6 shadow-sm"
+      style={{
+        background:
+          'linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-muted) 100%)',
+        borderColor: 'var(--color-border)',
+      }}
+    >
+      <div className="mb-3 inline-flex items-center rounded-full bg-[var(--color-surface)] px-3 py-1 text-xs font-semibold text-[var(--color-primary)]">
+        PRO Insights
+      </div>
+      <h3 className="mb-2 text-lg font-semibold text-text">
         {hook.message.default_title}
       </h3>
-      <p className="text-muted mb-4">
+      <p className="mb-5 text-muted">
         {hook.message.default_body}
       </p>
       <button
         type="button"
         onClick={handleClick}
-        className="px-4 py-2 bg-primary text-navy rounded-lg hover:bg-primary/90 transition-colors font-medium"
+        className="min-h-[44px] rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90"
         data-testid="soft-paywall-cta"
       >
         {hook.message.default_cta}

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -51,9 +51,6 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
         borderColor: 'var(--color-border)',
       }}
     >
-      <div className="mb-3 inline-flex items-center rounded-full bg-[var(--color-surface)] px-3 py-1 text-xs font-semibold text-[var(--color-primary)]">
-        PRO Insights
-      </div>
       <h3 className="mb-2 text-lg font-semibold text-text">
         {hook.message.default_title}
       </h3>

--- a/frontend/src/components/ui/SegmentedControl.tsx
+++ b/frontend/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,40 @@
+import type { JSX } from 'react';
+
+interface SegmentedControlProps<T extends string> {
+  options: readonly T[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}
+
+export default function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: SegmentedControlProps<T>): JSX.Element {
+  return (
+    <div
+      className="inline-flex items-center rounded-full border p-1"
+      style={{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-surface-muted)' }}
+      role="group"
+      aria-label={ariaLabel}
+    >
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onChange(option)}
+          className="min-h-[36px] rounded-full px-3 py-1 text-xs font-semibold transition-colors"
+          style={{
+            backgroundColor: value === option ? 'var(--color-surface)' : 'transparent',
+            color: 'var(--color-text)',
+          }}
+          aria-pressed={value === option}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/progress/ProgressCharts.tsx
+++ b/frontend/src/features/progress/ProgressCharts.tsx
@@ -198,8 +198,8 @@ export default function ProgressCharts({ windowRange = '30D' }: ProgressChartsPr
           <ResponsiveContainer width="100%" height={250}>
             <PieChart>
               <Pie data={macroData} cx="50%" cy="50%" outerRadius={80} dataKey="value" label={({ name, percentage }) => `${name}: ${percentage}%`}>
-                {macroData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
+                {macroData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
                 ))}
               </Pie>
               <Tooltip contentStyle={tooltipStyle} />
@@ -210,8 +210,8 @@ export default function ProgressCharts({ windowRange = '30D' }: ProgressChartsPr
         <div className="rounded-lg p-6 shadow-sm" style={{ backgroundColor: chartTokens.surface, border: `1px solid ${chartTokens.border}` }}>
           <h3 className="mb-4 text-lg font-semibold" style={{ color: chartTokens.text }}>Nutrient Breakdown</h3>
           <div className="space-y-3">
-            {macroData.map((nutrient, index) => (
-              <div key={index} className="flex items-center justify-between">
+            {macroData.map((nutrient) => (
+              <div key={nutrient.name} className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-4 h-4 rounded" style={{ backgroundColor: nutrient.color }} />
                   <span style={{ color: chartTokens.text }}>{nutrient.name}</span>

--- a/frontend/src/features/progress/ProgressCharts.tsx
+++ b/frontend/src/features/progress/ProgressCharts.tsx
@@ -12,6 +12,7 @@ import {
   BarChart,
   Bar
 } from 'recharts';
+import { useMemo, useCallback } from 'react';
 import { Download, TrendingUp, TrendingDown } from 'lucide-react';
 import { showError } from '../../components/ui';
 
@@ -28,7 +29,6 @@ const chartTokens = {
   tooltipBackground: 'var(--color-bg)',
 };
 
-// Mock data for progress tracking
 const weightData = [
   { date: '2024-01-01', weight: 75.2, bmi: 24.1 },
   { date: '2024-01-08', weight: 74.8, bmi: 23.9 },
@@ -57,12 +57,25 @@ const macroData = [
   { name: 'Other', value: 70, color: chartTokens.info, percentage: 15 },
 ];
 
+const beforeAfterShadow = '0 4px 6px -1px rgba(0, 0, 0, 0.1)';
+
+type ProgressWindow = '7D' | '30D' | '90D';
+
+interface ProgressChartsProps {
+  windowRange?: ProgressWindow;
+}
+
+const filterByWindow = <T,>(data: T[], windowRange: ProgressWindow): T[] => {
+  if (windowRange === '7D') return data.slice(-3);
+  if (windowRange === '30D') return data.slice(-5);
+  return data;
+};
+
 const formatDate = (dateStr: string): string => {
   return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 };
 
 const exportToPDF = async (): Promise<void> => {
-  // Simple PDF export using html2canvas + jspdf
   try {
     const html2canvas = await import('html2canvas');
     const { jsPDF } = await import('jspdf');
@@ -84,7 +97,6 @@ const exportToPDF = async (): Promise<void> => {
     let heightLeft = imgHeight;
 
     let position = 0;
-
     pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
     heightLeft -= pageHeight;
 
@@ -99,45 +111,48 @@ const exportToPDF = async (): Promise<void> => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     showError(`Failed to export PDF: ${message}`);
-    return;
   }
 };
 
-export default function ProgressCharts(): JSX.Element {
-  const latestWeight = weightData[weightData.length - 1];
-  const previousWeight = weightData[weightData.length - 2];
+export default function ProgressCharts({ windowRange = '30D' }: ProgressChartsProps): JSX.Element {
+  const scopedWeightData = useMemo(() => filterByWindow(weightData, windowRange), [windowRange]);
+  const scopedCalorieData = useMemo(() => filterByWindow(calorieData, windowRange), [windowRange]);
+  const latestWeight = scopedWeightData[scopedWeightData.length - 1];
+  const previousWeight = scopedWeightData[Math.max(0, scopedWeightData.length - 2)];
   const weightChange = latestWeight.weight - previousWeight.weight;
   const isWeightLoss = weightChange < 0;
+  const tooltipStyle = useMemo(
+    () => ({
+      backgroundColor: chartTokens.tooltipBackground,
+      border: `1px solid ${chartTokens.border}`,
+      borderRadius: '8px',
+      boxShadow: beforeAfterShadow,
+    }),
+    []
+  );
+  const handleExportToPdf = useCallback(() => {
+    void exportToPDF();
+  }, []);
 
   return (
     <div id="progress-charts" className="space-y-6 p-4">
-      {/* Header with Export Button */}
       <div className="flex justify-between items-center">
         <div>
           <h2 className="text-2xl font-bold" style={{ color: chartTokens.text }}>Progress Tracking</h2>
-          <p style={{ color: chartTokens.muted }}>Monitor your health journey</p>
+          <p style={{ color: chartTokens.muted }}>Monitor your health journey ({windowRange})</p>
         </div>
         <button
-          onClick={exportToPDF}
+          onClick={handleExportToPdf}
           className="flex items-center gap-2 px-4 py-2 rounded-lg transition-colors hover:opacity-90"
-          style={{
-            backgroundColor: chartTokens.primary,
-            color: chartTokens.text
-          }}
+          style={{ backgroundColor: chartTokens.primary, color: '#fff' }}
+          aria-label="Export progress report as PDF"
         >
           <Download className="w-4 h-4" />
           Export PDF
         </button>
       </div>
 
-      {/* Weight Progress Chart */}
-      <div
-        className="rounded-lg p-6 shadow-sm"
-        style={{
-          backgroundColor: chartTokens.surface,
-          border: `1px solid ${chartTokens.border}`
-        }}
-      >
+      <div className="rounded-lg p-6 shadow-sm" style={{ backgroundColor: chartTokens.surface, border: `1px solid ${chartTokens.border}` }}>
         <div className="mb-4 flex items-center justify-between">
           <h3 className="text-lg font-semibold" style={{ color: chartTokens.text }}>Weight & BMI Progress</h3>
           <div className="flex items-center gap-2">
@@ -146,138 +161,59 @@ export default function ProgressCharts(): JSX.Element {
             ) : (
               <TrendingUp className="h-5 w-5" style={{ color: chartTokens.error }} />
             )}
-            <span
-              className="text-sm font-medium"
-              style={{ color: isWeightLoss ? chartTokens.success : chartTokens.error }}
-            >
+            <span className="text-sm font-medium" style={{ color: isWeightLoss ? chartTokens.success : chartTokens.error }}>
               {Math.abs(weightChange).toFixed(1)} kg {isWeightLoss ? 'lost' : 'gained'}
             </span>
           </div>
         </div>
         <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={weightData}>
+          <LineChart data={scopedWeightData}>
             <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
-            <XAxis
-              dataKey="date"
-              tickFormatter={formatDate}
-              className="text-gray-600 dark:text-gray-400"
-            />
+            <XAxis dataKey="date" tickFormatter={formatDate} className="text-gray-600 dark:text-gray-400" />
             <YAxis className="text-gray-600 dark:text-gray-400" />
-            <Tooltip
-              labelFormatter={(value) => formatDate(value)}
-              contentStyle={{
-                backgroundColor: chartTokens.tooltipBackground,
-                border: `1px solid ${chartTokens.border}`,
-                borderRadius: '8px',
-                boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-              }}
-            />
-            <Line
-              type="monotone"
-              dataKey="weight"
-              stroke={chartTokens.primary}
-              strokeWidth={3}
-              dot={{ fill: chartTokens.primary, strokeWidth: 2, r: 4 }}
-              name="Weight (kg)"
-            />
-            <Line
-              type="monotone"
-              dataKey="bmi"
-              stroke={chartTokens.success}
-              strokeWidth={2}
-              strokeDasharray="5 5"
-              dot={{ fill: chartTokens.success, strokeWidth: 2, r: 3 }}
-              name="BMI"
-            />
+            <Tooltip labelFormatter={(value) => formatDate(value)} contentStyle={tooltipStyle} />
+            <Line type="monotone" dataKey="weight" stroke={chartTokens.primary} strokeWidth={3} dot={{ fill: chartTokens.primary, strokeWidth: 2, r: 4 }} name="Weight (kg)" />
+            <Line type="monotone" dataKey="bmi" stroke={chartTokens.success} strokeWidth={2} strokeDasharray="5 5" dot={{ fill: chartTokens.success, strokeWidth: 2, r: 3 }} name="BMI" />
           </LineChart>
         </ResponsiveContainer>
       </div>
 
-      {/* Calorie Balance Chart */}
-      <div
-        className="rounded-lg p-6 shadow-sm"
-        style={{
-          backgroundColor: chartTokens.surface,
-          border: `1px solid ${chartTokens.border}`
-        }}
-      >
+      <div className="rounded-lg p-6 shadow-sm" style={{ backgroundColor: chartTokens.surface, border: `1px solid ${chartTokens.border}` }}>
         <h3 className="mb-4 text-lg font-semibold" style={{ color: chartTokens.text }}>Calorie Balance</h3>
         <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={calorieData}>
+          <BarChart data={scopedCalorieData}>
             <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
-            <XAxis
-              dataKey="date"
-              tickFormatter={formatDate}
-              className="text-gray-600 dark:text-gray-400"
-            />
+            <XAxis dataKey="date" tickFormatter={formatDate} className="text-gray-600 dark:text-gray-400" />
             <YAxis className="text-gray-600 dark:text-gray-400" />
-            <Tooltip
-              labelFormatter={(value) => formatDate(value)}
-              contentStyle={{
-                backgroundColor: chartTokens.tooltipBackground,
-                border: `1px solid ${chartTokens.border}`,
-                borderRadius: '8px',
-                boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-              }}
-            />
+            <Tooltip labelFormatter={(value) => formatDate(value)} contentStyle={tooltipStyle} />
             <Bar dataKey="consumed" fill={chartTokens.error} name="Consumed" />
             <Bar dataKey="burned" fill={chartTokens.success} name="Burned" />
           </BarChart>
         </ResponsiveContainer>
       </div>
 
-      {/* Macronutrient Distribution */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div
-          className="rounded-lg p-6 shadow-sm"
-          style={{
-            backgroundColor: chartTokens.surface,
-            border: `1px solid ${chartTokens.border}`
-          }}
-        >
+        <div className="rounded-lg p-6 shadow-sm" style={{ backgroundColor: chartTokens.surface, border: `1px solid ${chartTokens.border}` }}>
           <h3 className="mb-4 text-lg font-semibold" style={{ color: chartTokens.text }}>Macronutrient Distribution</h3>
           <ResponsiveContainer width="100%" height={250}>
             <PieChart>
-              <Pie
-                data={macroData}
-                cx="50%"
-                cy="50%"
-                outerRadius={80}
-                dataKey="value"
-                label={({ name, percentage }) => `${name}: ${percentage}%`}
-              >
-                {macroData.map((entry) => (
-                  <Cell key={`cell-${entry.name}`} fill={entry.color} />
+              <Pie data={macroData} cx="50%" cy="50%" outerRadius={80} dataKey="value" label={({ name, percentage }) => `${name}: ${percentage}%`}>
+                {macroData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: chartTokens.tooltipBackground,
-                  border: `1px solid ${chartTokens.border}`,
-                  borderRadius: '8px',
-                  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-                }}
-              />
+              <Tooltip contentStyle={tooltipStyle} />
             </PieChart>
           </ResponsiveContainer>
         </div>
 
-        <div
-          className="rounded-lg p-6 shadow-sm"
-          style={{
-            backgroundColor: chartTokens.surface,
-            border: `1px solid ${chartTokens.border}`
-          }}
-        >
+        <div className="rounded-lg p-6 shadow-sm" style={{ backgroundColor: chartTokens.surface, border: `1px solid ${chartTokens.border}` }}>
           <h3 className="mb-4 text-lg font-semibold" style={{ color: chartTokens.text }}>Nutrient Breakdown</h3>
           <div className="space-y-3">
-            {macroData.map((nutrient) => (
-              <div key={nutrient.name} className="flex items-center justify-between">
+            {macroData.map((nutrient, index) => (
+              <div key={index} className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                    <div
-                      className="w-4 h-4 rounded"
-                      style={{ backgroundColor: nutrient.color }}
-                    />
+                  <div className="w-4 h-4 rounded" style={{ backgroundColor: nutrient.color }} />
                   <span style={{ color: chartTokens.text }}>{nutrient.name}</span>
                 </div>
                 <div className="text-right">

--- a/frontend/src/features/progress/__tests__/ProgressCharts.test.tsx
+++ b/frontend/src/features/progress/__tests__/ProgressCharts.test.tsx
@@ -35,7 +35,7 @@ describe('ProgressCharts', () => {
     render(<ProgressCharts />);
 
     expect(screen.getByText('Progress Tracking')).toBeInTheDocument();
-    expect(screen.getByText('Monitor your health journey')).toBeInTheDocument();
+    expect(screen.getByText('Monitor your health journey (30D)')).toBeInTheDocument();
   });
 
   it('renders export PDF button', () => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,25 +7,38 @@ import { usePremium } from '../lib/usePremium';
 export default function Home() {
   const isPremium = usePremium();
   const hasApiKey = getStoredApiKey() !== null;
+  const premiumLabel = isPremium === undefined ? 'Checking…' : isPremium ? 'Active' : 'Inactive';
+  const statusTone = isPremium === true ? 'text-[var(--color-success)]' : 'text-text';
 
   return (
     <main className="p-4 pb-24 space-y-4">
-      <section className="p-5" style={pageCardStyle}>
-        <h1 className="text-2xl font-bold text-text">Home</h1>
-        <p className="mt-2 text-sm text-muted">PulsePlate command center for Home, Plate, and Progress.</p>
+      <section className="p-6" style={pageCardStyle}>
+        <p className="text-xs uppercase tracking-wide text-muted">Today</p>
+        <h1 className="mt-2 text-2xl font-bold text-text">Home</h1>
+        <p className="mt-2 text-sm text-muted">
+          Your wellness control panel with quick access to setup, plate, and progress.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <span className="rounded-full bg-[var(--color-surface-muted)] px-3 py-1 text-xs font-medium text-text">
+            API {hasApiKey ? 'Connected' : 'Missing'}
+          </span>
+          <span className={`rounded-full bg-[var(--color-surface-muted)] px-3 py-1 text-xs font-medium ${statusTone}`}>
+            Premium {premiumLabel}
+          </span>
+        </div>
       </section>
 
       <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <article className="p-4" style={pageCardStyle}>
           <p className="text-xs uppercase tracking-wide text-muted">API key</p>
           <p className="mt-2 text-lg font-semibold text-text">{hasApiKey ? 'Connected' : 'Not configured'}</p>
+          <p className="mt-2 text-sm text-muted">Setup unlocks personalized guidance and sync.</p>
         </article>
 
         <article className="p-4" style={pageCardStyle}>
           <p className="text-xs uppercase tracking-wide text-muted">Premium</p>
-          <p className="mt-2 text-lg font-semibold text-text">
-            {isPremium === undefined ? 'Checking…' : isPremium ? 'Active' : 'Inactive'}
-          </p>
+          <p className="mt-2 text-lg font-semibold text-text">{premiumLabel}</p>
+          <p className="mt-2 text-sm text-muted">Pro enables advanced insights and premium planning views.</p>
         </article>
       </section>
 
@@ -34,16 +47,16 @@ export default function Home() {
       <section className="p-4 space-y-3" style={pageCardStyle}>
         <h2 className="text-base font-semibold text-text">Quick actions</h2>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <Link className="rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white" to="/setup">
+          <Link className="rounded-full bg-primary px-4 py-3 text-center text-sm font-semibold text-white" to="/setup">
             Open setup
           </Link>
-          <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-sm font-semibold text-text" to="/plate">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/plate">
             Open plate
           </Link>
-          <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-sm font-semibold text-text" to="/progress">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/progress">
             Open progress
           </Link>
-          <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-sm font-semibold text-text" to="/pro">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/pro">
             Open Pro
           </Link>
         </div>

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -1,16 +1,32 @@
 import ProgressCharts from '../features/progress/ProgressCharts';
 import { pageCardStyle } from '../components/ui/pageCardStyle';
 import LiveProgressIndicator from '../features/progress/LiveProgressIndicator';
+import { useState } from 'react';
+import SegmentedControl from '../components/ui/SegmentedControl';
+
+type ProgressWindow = '7D' | '30D' | '90D';
 
 export default function Progress() {
+  const [windowRange, setWindowRange] = useState<ProgressWindow>('30D');
+
   return (
     <main className="p-4 pb-24 space-y-4" style={{ backgroundColor: 'var(--pp-navy)', minHeight: '100vh' }}>
       <section className="p-4" style={pageCardStyle}>
-        <h1 className="text-2xl font-bold text-text">Progress</h1>
-        <p className="mt-2 text-sm text-muted">Daily and weekly trend surface for Home+Plate slice.</p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-text">Progress</h1>
+            <p className="mt-2 text-sm text-muted">Daily and weekly trend surface for Home+Plate slice.</p>
+          </div>
+          <SegmentedControl
+            options={['7D', '30D', '90D'] as const}
+            value={windowRange}
+            onChange={setWindowRange}
+            ariaLabel="Progress date range"
+          />
+        </div>
       </section>
       <LiveProgressIndicator source="progress" ctaTo="/setup" ctaLabel="Refresh setup inputs" />
-      <ProgressCharts />
+      <ProgressCharts windowRange={windowRange} />
     </main>
   );
 }

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -6,7 +6,7 @@ import SegmentedControl from '../components/ui/SegmentedControl';
 
 type ProgressWindow = '7D' | '30D' | '90D';
 
-export default function Progress() {
+export default function Progress(): JSX.Element {
   const [windowRange, setWindowRange] = useState<ProgressWindow>('30D');
 
   return (

--- a/frontend/src/pages/__tests__/Progress.test.tsx
+++ b/frontend/src/pages/__tests__/Progress.test.tsx
@@ -24,6 +24,9 @@ describe('Progress', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Progress' })).toBeInTheDocument();
     expect(screen.getByLabelText('Live progress indicator')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Refresh setup inputs' })).toHaveAttribute('href', '/setup');
+    expect(screen.getByRole('button', { name: '7D' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '30D' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '90D' })).toBeInTheDocument();
     expect(screen.getByTestId('progress-charts')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- implement P0-P2 frontend refinements for Home, Progress, and Paywall flows from the Figma MCP session while preserving existing route and analytics contracts
- add reusable `SegmentedControl` and wire progress window filtering + memoized chart rendering/export handlers
- add runbooks for Figma MCP workflow and PR canonical matrix checklist to keep execution deterministic

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Test plan
- [x] `frontend: npm run build`
- [x] `pre-commit run --all-files`
- [x] `frontend vitest` (via pre-commit)

## Deferred / Follow-ups
- None.

<!-- phase2-refresh -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 7D/30D/90D time-range filters with a new SegmentedControl and updated ProgressCharts to accept the windowRange prop
  * Redesigned paywall modal into a responsive, scrollable dialog with plan comparison cards
  * Added premium status indicators and API connectivity badges on Home

* **Style**
  * Updated SoftPaywallHook visuals and CTA styling for a rounded, bordered presentation

* **Documentation**
  * Added three runbooks: design system rules, Figma MCP/Clawbot runbook, and PR canonical checklist

* **Tests**
  * Updated tests for range buttons and header label (30D)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->