### PR TITLE
test(ws): add deterministic websocket security checks

### DIFF
--- a/tests/test_realtime_ws_security.py
+++ b/tests/test_realtime_ws_security.py
@@ -45,4 +45,5 @@ def test_ws_rate_limit_closes_connection(
         websocket.send_text(json.dumps({"type": "ping", "version": "1"}))
         with pytest.raises(WebSocketDisconnect) as exc_info:
             websocket.receive_text()
+        # 1008 is the canonical close code our server uses for rate-limit violations.
         assert exc_info.value.code == 1008

--- a/tests/test_realtime_ws_security.py
+++ b/tests/test_realtime_ws_security.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+
+def test_ws_rejects_connection_without_token_when_enabled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "true")
+    with client.websocket_connect("/ws") as websocket:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            websocket.receive_text()
+        assert exc_info.value.code == 1008
+
+
+def test_ws_accepts_pro_token_and_replies_with_pong(
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "true")
+    token = pro_headers["X-API-Key"]
+    with client.websocket_connect(f"/ws?token={token}") as websocket:
+        websocket.send_text(json.dumps({"type": "ping", "version": "1"}))
+        payload = json.loads(websocket.receive_text())
+        assert payload["type"] == "pong"
+        assert payload["version"] == "1"
+        assert "server_time_ms" in payload
+
+
+def test_ws_rate_limit_closes_connection(
+    client: TestClient, pro_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FEATURE_WEBSOCKET_ENABLED", "true")
+    monkeypatch.setenv("WS_MAX_MESSAGES_PER_WINDOW", "1")
+    monkeypatch.setenv("WS_WINDOW_SECONDS", "30")
+
+    token = pro_headers["X-API-Key"]
+    with client.websocket_connect(f"/ws?token={token}") as websocket:
+        websocket.send_text(json.dumps({"type": "ping", "version": "1"}))
+        json.loads(websocket.receive_text())
+
+        websocket.send_text(json.dumps({"type": "ping", "version": "1"}))
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            websocket.receive_text()
+        assert exc_info.value.code == 1008


### PR DESCRIPTION
## Summary
- Add deterministic websocket integration tests for `/ws` security behavior.
- Cover fail-closed unauthenticated connect path, valid PRO token ping/pong path, and rate-limit close path.
- Keep scope narrow to tests-only for the first P1 websocket security milestone.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- 58cafe96 -> add websocket auth/rate-limit deterministic tests
- No actionable review comments

## Test plan
- [x] `pytest -q tests/test_realtime_ws_security.py`
- [ ] CI: `tests` job passes
- [ ] CI: `test-pr (3.13.6)` + `coverage-pr` pass
- [ ] CI: `diff-coverage` stays green

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md`: P1 WebSocket implementation item remains open for runtime/contract expansion beyond this tests-first scope.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить детерминированные интеграционные тесты, покрывающие поведение безопасности WebSocket.

Тесты:
- Добавить тесты, чтобы убедиться, что неаутентифицированные WebSocket-подключения отклоняются, когда функция включена.
- Добавить тесты, проверяющие, что WebSocket-подключения с PRO-токеном получают ping/pong-ответы с метаданными.
- Добавить тесты, проверяющие, что WebSocket-подключения закрываются при превышении настроенных лимитов скорости.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add deterministic integration tests covering WebSocket security behavior.

Tests:
- Add tests to ensure unauthenticated WebSocket connections are rejected when the feature is enabled.
- Add tests verifying PRO-token WebSocket connections receive ping/pong responses with metadata.
- Add tests verifying WebSocket connections are closed when exceeding configured rate limits.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic integration tests for /ws security and documents 1008 as the canonical rate-limit close code. Refreshes CI checks.

- **New Tests**
  - Rejects unauthenticated connections with close code 1008 when the websocket feature flag is enabled.
  - Accepts PRO token via query param and replies to ping with pong, echoing version and server_time_ms.
  - Enforces rate limits via WS_MAX_MESSAGES_PER_WINDOW and WS_WINDOW_SECONDS; closes with 1008 (canonical policy) when exceeded.

<sup>Written for commit 908ab52b9b1e28888a742027b74b30c57144e7a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for real-time WebSocket behavior: verifies connections are rejected when authentication is required and no token is provided, verifies valid token-based connections respond to pings with matching version and server time, and verifies rate-limiting closes connections after exceeding allowed message rate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->