### PR TITLE
fix(web): step3 P0-A action card UX remediation

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -47,16 +47,16 @@ export default function Home() {
       <section className="p-4 space-y-3" style={pageCardStyle}>
         <h2 className="text-base font-semibold text-text">Quick actions</h2>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <Link className="rounded-full bg-primary px-4 py-3 text-center text-sm font-semibold text-white" to="/setup">
+          <Link className="rounded-full bg-primary px-4 py-3 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90" to="/setup">
             Open setup
           </Link>
-          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/plate">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text transition-colors hover:bg-[var(--color-border)]" to="/plate">
             Open plate
           </Link>
-          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/progress">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text transition-colors hover:bg-[var(--color-border)]" to="/progress">
             Open progress
           </Link>
-          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text" to="/pro">
+          <Link className="rounded-full bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text transition-colors hover:bg-[var(--color-border)]" to="/pro">
             Open Pro
           </Link>
         </div>

--- a/frontend/src/pages/Plate.tsx
+++ b/frontend/src/pages/Plate.tsx
@@ -35,10 +35,10 @@ export default function Plate() {
             Use setup to refresh targets, then open progress for trend tracking.
           </p>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            <Link className="rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white" to="/setup">
+            <Link className="rounded-lg bg-primary px-4 py-3 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90" to="/setup">
               Open setup
             </Link>
-            <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-sm font-semibold text-text" to="/progress">
+            <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text transition-colors hover:bg-[var(--color-border)]" to="/progress">
               Open progress
             </Link>
           </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -22,10 +22,10 @@ export default function Profile() {
       <section className="p-4 space-y-3" style={pageCardStyle}>
         <h2 className="text-base font-semibold text-text">Actions</h2>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <Link className="rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white" to="/enter-key">
+          <Link className="rounded-lg bg-primary px-4 py-3 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90" to="/enter-key">
             Configure API key
           </Link>
-          <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-sm font-semibold text-text" to="/setup">
+          <Link className="rounded-lg bg-[var(--color-surface-muted)] px-4 py-3 text-center text-sm font-semibold text-text transition-colors hover:bg-[var(--color-border)]" to="/setup">
             Open nutrition setup
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- apply step-3 P0-A remediation polish for Home/Plate/Profile action surfaces
- unify CTA affordance and interaction feedback (text centering + hover transitions)
- keep scope strictly presentation-layer without API/contract changes

## Test plan
- [x] `npm run test -- src/pages/__tests__/Home.test.tsx src/pages/__tests__/Plate.test.tsx src/pages/__tests__/Profile.test.tsx`
- [x] `npm run build`

## Deferred / Follow-ups
- user-device-specific iOS open symptom verification remains tracked under P0-A ledger item in `#819`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments