### PR TITLE
fix(security): suppress code-scanning alert #542 (CVE-2026-27171)

### DIFF
--- a/docs/security/CVE-2026-27171-zlib1g.md
+++ b/docs/security/CVE-2026-27171-zlib1g.md
@@ -23,8 +23,8 @@ to keep code scanning signal actionable while tracking upstream fixes.
 
 ## Monitor / upstream status
 
-- **Debian Security Tracker**: https://security-tracker.debian.org/tracker/CVE-2026-27171
-- **NVD**: https://nvd.nist.gov/vuln/detail/CVE-2026-27171
+- **Debian Security Tracker**: <https://security-tracker.debian.org/tracker/CVE-2026-27171>
+- **NVD**: <https://nvd.nist.gov/vuln/detail/CVE-2026-27171>
 
 ## Removal condition
 

--- a/docs/security/CVE-2026-27171-zlib1g.md
+++ b/docs/security/CVE-2026-27171-zlib1g.md
@@ -1,0 +1,48 @@
+# CVE-2026-27171 — zlib1g (Debian bookworm) — Trivy code scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2026-27171
+- **Package**: `zlib1g`
+- **Installed version (observed)**: `1:1.2.13.dfsg-1`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: Low
+- **GitHub alert**: `security/code-scanning/542`
+
+This finding is reported by Trivy against an OS package in the Debian bookworm base image.
+At triage time, Trivy reports **no fixed version** for this package/version line.
+
+## Why we suppress (temporarily)
+
+- This is an **OS package** CVE, not an application-level Python/FastAPI vulnerability.
+- Repo-level code changes cannot patch distro zlib internals.
+- Trivy currently reports no actionable fixed version for this alert context.
+
+We therefore apply a **narrow suppression** (CVE + package + exact installed version + PkgID match)
+to keep code scanning signal actionable while tracking upstream fixes.
+
+## Monitor / upstream status
+
+- **Debian Security Tracker**: https://security-tracker.debian.org/tracker/CVE-2026-27171
+- **NVD**: https://nvd.nist.gov/vuln/detail/CVE-2026-27171
+
+## Removal condition
+
+Remove this suppression when either:
+
+1. Debian bookworm publishes a fixed `zlib1g` package for CVE-2026-27171, or
+2. Trivy metadata starts providing a `Fixed Version` for this package/CVE in our base image context.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Evidence anchors: `trivy/ignore-policy.rego:171`, `docs/security/CVE-2026-27171-zlib1g.md:38`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-27171"`
+  - `input.PkgName == "zlib1g"`
+  - `input.InstalledVersion == "1:1.2.13.dfsg-1"`
+  - `contains(input.PkgID, "zlib1g@1:1.2.13.dfsg-1")`
+
+## Review / expiry
+
+- **Review-by**: 2026-05-10 (shared policy-file expiry window)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,7 +10,7 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-10 (manual removal)
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2025-14831-gnutls.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-27171-zlib1g.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -166,4 +166,29 @@ ignore if {
 	input.PkgName == "libgnutls30"
 	cve_2025_14831_version_match
 	cve_2025_14831_pkgid_match
+}
+
+# CVE-2026-27171 (zlib1g) - upstream unfixed in Debian bookworm
+# Review-by: 2026-05-10 (manual removal)
+# Rationale: Unfixed distro CVE; no fixed version reported in Trivy metadata for bookworm at time of triage
+# Note: CI expiry is enforced once per policy file (see header); do not add another "Suppression expires:" line.
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-27171
+# Documented in: docs/security/CVE-2026-27171-zlib1g.md
+# Removal condition: Remove when Debian bookworm publishes a fixed zlib1g package or Trivy metadata includes Fixed Version
+
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_27171_version_match if {
+	input.InstalledVersion == "1:1.2.13.dfsg-1"
+}
+
+# Helper rule: check if PkgID matches observed zlib1g package
+cve_2026_27171_pkgid_match if {
+	contains(input.PkgID, "zlib1g@1:1.2.13.dfsg-1")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-27171"
+	input.PkgName == "zlib1g"
+	cve_2026_27171_version_match
+	cve_2026_27171_pkgid_match
 }


### PR DESCRIPTION
## Summary
- remediate GitHub code-scanning alert #542 (`CVE-2026-27171`, Trivy `OsPackageVulnerability`) with a narrow policy suppression for `zlib1g@1:1.2.13.dfsg-1`
- add security evidence note documenting rationale, monitor links, and explicit removal conditions
- keep scope strictly security-only (policy + docs evidence)

## Test plan
- [x] `pre-commit run --all-files`
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-27171-zlib1g.md`
- [x] `python scripts/ci/check_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego`
- [x] `make test-fast`

## Deferred / Follow-ups
- Remove suppression when Debian bookworm ships fixed `zlib1g` for CVE-2026-27171 or Trivy starts reporting a fixed version.
- Remaining security issue tracked separately: Dependabot alert #35 (`CVE-2025-14009` / `nltk`).

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить узкую политику подавления Trivy ignore для CVE-2026-27171, затрагивающей zlib1g в Debian bookworm, и задокументировать обоснование с точки зрения безопасности и условия удаления.

Исправления ошибок:
- Подавить шумное предупреждение Trivy OsPackageVulnerability для CVE-2026-27171 в отношении zlib1g, ограничив его наблюдаемой версией пакета Debian bookworm и PkgID.

Улучшения:
- Расширить метаданные политики Trivy ignore, добавив ссылку на новый документ с доказательствами по уязвимости zlib1g (CVE).
- Добавить документацию по безопасности, описывающую временное подавление для CVE-2026-27171, включая ссылки для мониторинга и явные критерии удаления.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a narrow Trivy ignore policy suppression for CVE-2026-27171 affecting zlib1g on Debian bookworm and document the security rationale and removal conditions.

Bug Fixes:
- Suppress the noisy Trivy OsPackageVulnerability alert for CVE-2026-27171 on zlib1g by scoping it to the observed Debian bookworm package version and PkgID.

Enhancements:
- Extend the Trivy ignore policy metadata to reference the new zlib1g CVE evidence document.
- Add security documentation detailing the temporary suppression for CVE-2026-27171, including monitoring links and explicit removal criteria.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses GitHub code-scanning alert #542 (CVE-2026-27171) by adding a tightly scoped Trivy ignore for zlib1g 1:1.2.13.dfsg-1 on Debian bookworm. Adds a security note with rationale, monitoring links, and clear removal conditions; no application code changes.

- **Bug Fixes**
  - Add narrow Trivy suppression (CVE + package + exact version + PkgID) for zlib1g 1:1.2.13.dfsg-1 on bookworm.
  - Add evidence doc with rationale, tracker links, and removal conditions; wrap monitor links in angle brackets to satisfy markdownlint MD034; includes review-by 2026-05-10 aligned with CI-enforced policy expiry.

<sup>Written for commit cc10c10ab0f67b4029a73cb1f99112a05c51557f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for CVE-2026-27171 (zlib1g), detailing observed details, mitigation entry, monitoring links, and review/expiry timeline.

* **Chores**
  * Updated vulnerability management policy to record handling for CVE-2026-27171 with narrow, reviewable criteria for targeted cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->