### PR TITLE
fix(security): remediate Dependabot alert #35 (CVE-2025-14009)

### DIFF
--- a/docs/security/CVE-2025-14009-nltk.md
+++ b/docs/security/CVE-2025-14009-nltk.md
@@ -1,0 +1,35 @@
+# CVE-2025-14009 — nltk (development dependency graph) — Dependabot #35 remediation
+
+## Summary
+
+- **CVE**: CVE-2025-14009
+- **Package**: `nltk`
+- **Alert type**: GitHub Dependabot alert
+- **GitHub alert**: `security/dependabot/35`
+- **Scope**: Development dependencies only (`requirements-dev.*`)
+
+Dependabot reported `nltk` in the dev dependency graph. In this repository, `nltk` was
+not a direct dependency and was pulled transitively through `safety`.
+
+## Remediation strategy
+
+- Remove `safety` from `requirements-dev.in` because it is not used by current CI/Make
+  security gates.
+- Regenerate `requirements-dev.txt` with `pip-compile` so the lock graph no longer includes
+  `safety` and transitive `nltk`.
+
+## Evidence anchors
+
+- `scripts/ci/check_docs_phase1_gates.py:8`
+- `docs/security/CVE-2025-14009-nltk.md:23`
+
+## Validation
+
+- `pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in`
+- `rg "nltk|safety" requirements-dev.txt` → no matches
+- `pre-commit run --all-files`
+
+## Notes
+
+This remediation removes the vulnerable transitive package from the repository dependency
+graph instead of suppressing the alert.

--- a/docs/security/CVE-2025-14009-nltk.md
+++ b/docs/security/CVE-2025-14009-nltk.md
@@ -21,7 +21,7 @@ not a direct dependency and was pulled transitively through `safety`.
 ## Evidence anchors
 
 - `scripts/ci/check_docs_phase1_gates.py:8`
-- `docs/security/CVE-2025-14009-nltk.md:23`
+- `tests/test_dependency_security_guard.py:22`
 
 ## Validation
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,6 @@
 -c requirements.txt
 # Use compatible release (~=) for stable dev tools to prevent breaking changes
-# Keep security tools (bandit, pip-audit, safety) with >= for latest vulnerability feeds
+# Keep security tools (bandit, pip-audit) with >= for latest vulnerability feeds
 pytest~=8.4.2
 pytest-cov~=7.0.0
 pytest-asyncio~=1.3.0
@@ -15,7 +15,6 @@ diff-cover~=10.2.0
 # Code quality tools: use compatible release for stability
 bandit>=1.8.6  # Security tool - keep >= for vulnerability updates
 pip-audit>=2.9.0  # Security tool - keep >= for vulnerability updates
-safety>=3.6.2  # Security tool - keep >= for vulnerability updates
 pre-commit~=4.5.1
 pip-tools~=7.5.3
 detect-secrets~=1.5.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -15,6 +15,7 @@ diff-cover~=10.2.0
 # Code quality tools: use compatible release for stability
 bandit>=1.8.6  # Security tool - keep >= for vulnerability updates
 pip-audit>=2.9.0  # Security tool - keep >= for vulnerability updates
+cryptography>=46.0.5  # Keep explicit dependency floor for dependency-security guard
 pre-commit~=4.5.1
 pip-tools~=7.5.3
 detect-secrets~=1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,16 +4,6 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
-annotated-types==0.7.0
-    # via
-    #   -c requirements.txt
-    #   pydantic
-anyio==4.12.0
-    # via
-    #   -c requirements.txt
-    #   httpx
-authlib==1.6.6
-    # via safety
 bandit==1.9.3
     # via -r requirements-dev.in
 black==26.1.0
@@ -29,13 +19,7 @@ cachecontrol[filecache]==0.14.4
 certifi==2026.1.4
     # via
     #   -c requirements.txt
-    #   httpcore
-    #   httpx
     #   requests
-cffi==2.0.0
-    # via
-    #   -c requirements.txt
-    #   cryptography
 cfgv==3.5.0
     # via pre-commit
 chardet==5.2.0
@@ -48,18 +32,11 @@ click==8.3.1
     # via
     #   -c requirements.txt
     #   black
-    #   nltk
     #   pip-tools
-    #   safety
-    #   typer
 coverage[toml]==7.13.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==46.0.5
-    # via
-    #   -c requirements.txt
-    #   authlib
 cyclonedx-python-lib==11.6.0
     # via pip-audit
 defusedxml==0.7.1
@@ -70,10 +47,6 @@ diff-cover==10.2.0
     # via -r requirements-dev.in
 distlib==0.4.0
     # via virtualenv
-dparse==0.6.4
-    # via
-    #   safety
-    #   safety-schemas
 execnet==2.1.2
     # via pytest-xdist
 faker==40.4.0
@@ -81,20 +54,7 @@ faker==40.4.0
 filelock==3.20.3
     # via
     #   cachecontrol
-    #   safety
     #   virtualenv
-h11==0.16.0
-    # via
-    #   -c requirements.txt
-    #   httpcore
-httpcore==1.0.9
-    # via
-    #   -c requirements.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -c requirements.txt
-    #   safety
 hypothesis==6.151.6
     # via -r requirements-dev.in
 identify==2.6.15
@@ -102,17 +62,11 @@ identify==2.6.15
 idna==3.11
     # via
     #   -c requirements.txt
-    #   anyio
-    #   httpx
     #   requests
 iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
-    # via
-    #   diff-cover
-    #   safety
-joblib==1.5.3
-    # via nltk
+    # via diff-cover
 librt==0.7.5
     # via mypy
 license-expression==30.4.4
@@ -123,8 +77,6 @@ markupsafe==3.0.3
     # via
     #   -c requirements.txt
     #   jinja2
-marshmallow==4.1.2
-    # via safety
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.2
@@ -139,8 +91,6 @@ nh3==0.3.2
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
-nltk==3.9.2
-    # via safety
 nodeenv==1.10.0
     # via pre-commit
 packageurl-python==0.17.6
@@ -150,12 +100,9 @@ packaging==25.0
     #   -c requirements.txt
     #   black
     #   build
-    #   dparse
     #   pip-audit
     #   pip-requirements-parser
     #   pytest
-    #   safety
-    #   safety-schemas
     #   wheel
 pathspec==1.0.3
     # via
@@ -184,19 +131,6 @@ pre-commit==4.5.1
     # via -r requirements-dev.in
 py-serializable==2.1.0
     # via cyclonedx-python-lib
-pycparser==2.23
-    # via
-    #   -c requirements.txt
-    #   cffi
-pydantic==2.12.5
-    # via
-    #   -c requirements.txt
-    #   safety
-    #   safety-schemas
-pydantic-core==2.41.5
-    # via
-    #   -c requirements.txt
-    #   pydantic
 pygments==2.19.2
     # via
     #   diff-cover
@@ -236,71 +170,33 @@ pyyaml==6.0.3
     #   detect-secrets
     #   pre-commit
     #   yamllint
-regex==2025.11.3
-    # via nltk
 requests==2.32.5
     # via
     #   cachecontrol
     #   detect-secrets
     #   pip-audit
-    #   safety
 rich==14.2.0
     # via
     #   bandit
     #   pip-audit
-    #   typer
-ruamel-yaml==0.18.17
-    # via
-    #   safety
-    #   safety-schemas
-ruamel-yaml-clib==0.2.15
-    # via ruamel-yaml
 ruff==0.15.1
     # via -r requirements-dev.in
-safety==3.7.0
-    # via -r requirements-dev.in
-safety-schemas==0.0.16
-    # via safety
-shellingham==1.5.4
-    # via typer
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   hypothesis
 stevedore==5.6.0
     # via bandit
-tenacity==9.1.2
-    # via
-    #   -c requirements.txt
-    #   safety
 tomli==2.3.0
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-tomlkit==0.13.3
-    # via safety
-tqdm==4.67.1
-    # via
-    #   -c requirements.txt
-    #   nltk
-typer==0.21.0
-    # via safety
 types-pyyaml==6.0.12.20250915
     # via -r requirements-dev.in
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
     #   mypy
-    #   pydantic
-    #   pydantic-core
-    #   safety
-    #   safety-schemas
-    #   typer
-    #   typing-inspection
-typing-inspection==0.4.2
-    # via
-    #   -c requirements.txt
-    #   pydantic
 urllib3==2.6.3
     # via requests
 virtualenv==20.36.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,10 @@ certifi==2026.1.4
     # via
     #   -c requirements.txt
     #   requests
+cffi==2.0.0
+    # via
+    #   -c requirements.txt
+    #   cryptography
 cfgv==3.5.0
     # via pre-commit
 chardet==5.2.0
@@ -37,6 +41,10 @@ coverage[toml]==7.13.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
+cryptography==46.0.5
+    # via
+    #   -c requirements.txt
+    #   -r requirements-dev.in
 cyclonedx-python-lib==11.6.0
     # via pip-audit
 defusedxml==0.7.1
@@ -131,6 +139,10 @@ pre-commit==4.5.1
     # via -r requirements-dev.in
 py-serializable==2.1.0
     # via cyclonedx-python-lib
+pycparser==2.23
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.19.2
     # via
     #   diff-cover


### PR DESCRIPTION
## Summary
- remediate Dependabot alert #35 by removing `safety` from dev requirements so transitive `nltk` is removed from the dependency graph
- regenerate `requirements-dev.txt` from `requirements-dev.in` with `pip-compile --allow-unsafe`
- add security evidence note documenting the remediation and validation for `CVE-2025-14009`

## Test plan
- [x] `pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in`
- [x] `rg "nltk|safety" requirements-dev.txt`
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2025-14009-nltk.md`
- [x] `pre-commit run --all-files`
- [x] `make test-fast`

## Deferred / Follow-ups
- If `safety` is reintroduced in the future, dependency security review must verify no vulnerable transitive re-entry for `nltk`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Удалить неиспользуемую dev-зависимость, чтобы устранить уязвимый транзитивный пакет, и задокументировать меры по обеспечению безопасности.

Bug Fixes:
- Удалить неиспользуемую dev-зависимость `safety`, чтобы транзитивная зависимость `nltk` (затронутая CVE-2025-14009) больше не присутствовала в графе зависимостей для разработки.

Documentation:
- Добавить документацию по подтверждению безопасности, описывающую шаги по устранению и проверке для оповещения Dependabot №35 (CVE-2025-14009), затрагивающего `nltk`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove an unused dev dependency to eliminate a vulnerable transitive package and document the security remediation.

Bug Fixes:
- Remove the unused `safety` dev dependency so transitive `nltk` (affected by CVE-2025-14009) is no longer present in the development dependency graph.

Documentation:
- Add security evidence documentation describing the remediation and validation steps for Dependabot alert #35 (CVE-2025-14009) affecting `nltk`.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused safety dev dependency to drop transitive nltk and resolve Dependabot alert #35 (CVE-2025-14009). Regenerated the dev lockfile, kept an explicit cryptography>=46.0.5 floor for the dependency-security guard, and updated the security evidence doc to reference the guard test.

- **Dependencies**
  - Removed safety from requirements-dev.in to eliminate transitive nltk and close Dependabot #35
  - Added cryptography>=46.0.5 to requirements-dev.in and recompiled requirements-dev.txt
  - Added docs/security/CVE-2025-14009-nltk.md and switched evidence anchors to the dependency-security guard test

<sup>Written for commit 188dda67235bbe98e714f318da0d34a8cfc09764. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security documentation for CVE-2025-14009 remediation, including vulnerability analysis, remediation guidance, and validation procedures for verification.

* **Security**
  * Resolved CVE-2025-14009 by removing the vulnerable transitive dependency from development environment and requirements.
  * Strengthened development environment security with enhanced cryptographic support and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->