### PR TITLE
docs(agents): enforce post-merge worktree cleanup protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1129,7 +1129,7 @@ If the repo becomes multi-maintainer again, revisit this policy in a dedicated P
 - ✅ **Before resolving conflicts: check whether upstream PRs already landed; if branch becomes identical to main, close as duplicate.**
 - ✅ **Update PRs by adding new commits only.** If you need to undo something, use `git revert`.
 - ✅ **History cleanup happens only at merge time via GitHub "Squash and merge"**, not by rewriting branch history.
-- ✅ **After PR merge, clean local/remote branch and remove merged worktree in the same work session.**
+- ✅ **After PR merge, clean local branch, remote branch, and merged worktree in the same work session.**
 - ✅ **For every worktree-based PR, run cleanup commands after merge to avoid stale branch/worktree buildup.**
 - ✅ If CI is red → PR does not exist. Any work except fixing CI is forbidden.
 
@@ -1138,22 +1138,32 @@ If the repo becomes multi-maintainer again, revisit this policy in a dedicated P
 **Worktree cleanup protocol (mandatory after merge):**
 
 ```bash
-# 1) Sync main reference first
-git fetch origin
+# 1) Sync refs first
+git fetch --prune origin
 
 # 2) Remove merged local branch (if present)
 git branch --list <branch-name>
 # If listed, run:
 git branch -d <branch-name>
 
-# 3) Remove merged worktree
-git worktree remove worktrees/<worktree-name>
+# 3) Remove merged remote branch (if present)
+git ls-remote --heads origin <branch-name>
+# If listed, run:
+git push origin --delete <branch-name>
 
-# 4) Prune stale worktree metadata
+# 4) Discover the exact worktree path to remove
+git worktree list
+# Copy the exact path for <branch-name>; if this repo is your current directory,
+# switch to another worktree first.
+
+# 5) Remove merged worktree using the discovered path
+git worktree remove <worktree-path>
+
+# 6) Prune stale worktree metadata
 git worktree prune
 
-# 5) Ensure local repo sees the new main head
-git fetch origin && git rev-parse origin/main
+# 7) Ensure local repo sees the new main head
+git rev-parse origin/main
 ```
 
 **Incident response (if force-push to main occurred):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1129,9 +1129,32 @@ If the repo becomes multi-maintainer again, revisit this policy in a dedicated P
 - ✅ **Before resolving conflicts: check whether upstream PRs already landed; if branch becomes identical to main, close as duplicate.**
 - ✅ **Update PRs by adding new commits only.** If you need to undo something, use `git revert`.
 - ✅ **History cleanup happens only at merge time via GitHub "Squash and merge"**, not by rewriting branch history.
+- ✅ **After PR merge, clean local/remote branch and remove merged worktree in the same work session.**
+- ✅ **For every worktree-based PR, run cleanup commands after merge to avoid stale branch/worktree buildup.**
 - ✅ If CI is red → PR does not exist. Any work except fixing CI is forbidden.
 
 **Dependabot merges:** One-at-a-time; after each merge run `pre-commit run -a` and `pytest -q tests/test_repo_policy_guards.py` locally, then proceed to the next. Use squash + delete-branch. Do not extend dependabot PR scope — fix failures in a separate PR.
+
+**Worktree cleanup protocol (mandatory after merge):**
+
+```bash
+# 1) Sync main reference first
+git fetch origin
+
+# 2) Remove merged local branch (if present)
+git branch --list <branch-name>
+# If listed, run:
+git branch -d <branch-name>
+
+# 3) Remove merged worktree
+git worktree remove worktrees/<worktree-name>
+
+# 4) Prune stale worktree metadata
+git worktree prune
+
+# 5) Ensure local repo sees the new main head
+git fetch origin && git rev-parse origin/main
+```
 
 **Incident response (if force-push to main occurred):**
 


### PR DESCRIPTION
## Summary
- add explicit hard rules in `AGENTS.md` to clean merged worktree branches in the same work session
- add a mandatory 5-step post-merge worktree cleanup protocol (`fetch`, branch cleanup, worktree remove, prune, main sync check)
- codify this to prevent stale branch/worktree buildup and local repository clutter

## Test plan
- [x] `pre-commit run --files AGENTS.md`

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Задокументировать обязательный протокол очистки рабочей копии (worktree) после слияния PR, чтобы предотвратить «застаивание» веток и рабочих копий после слияний.

Документация:
- Обновить AGENTS.md с явными правилами, требующими очистки слитых веток и связанных с ними рабочих копий в рамках той же сессии.
- Добавить пошаговый протокол очистки рабочей копии (fetch, удаление ветки, удаление рабочей копии, prune, проверка синхронизации с main) в стандартные процедуры после слияния.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document a mandatory post-merge worktree cleanup protocol to prevent stale branches and worktrees after PR merges.

Documentation:
- Update AGENTS.md with explicit rules requiring same-session cleanup of merged branches and associated worktrees.
- Add a step-by-step worktree cleanup protocol (fetch, branch removal, worktree removal, prune, main sync verification) to standard post-merge procedures.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a mandatory post-merge worktree cleanup protocol in AGENTS.md. Requires same-session cleanup of local/remote branches and worktrees to prevent stale state and keep main in sync.

- **Migration**
  - After merging a worktree-based PR:
    - Fetch/prune refs: git fetch --prune origin
    - Delete local branch if present: git branch -d <branch-name>
    - Delete remote branch if present: git push origin --delete <branch-name>
    - Find worktree path: git worktree list
    - Remove worktree by path: git worktree remove <worktree-path>
    - Prune metadata: git worktree prune
    - Verify origin/main head: git rev-parse origin/main

<sup>Written for commit 5cfb1f52a4c0d5c0485c33246c5ee9568a45ebe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced post-merge operational hygiene with a new item to clean local/remote branches and merged worktrees in the same session.
  * Added a guideline requiring cleanup after worktree-based PRs and a detailed seven-step worktree cleanup protocol (sync, removal, prune, verify).
  * Introduced explicit incident response guidance for force-push or similar emergencies, including remediation steps and documentation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->