### PR TITLE
Design Tokens: switch canonical palette and tokenize PlateChart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,6 +553,12 @@ Design exports without updating `docs/design/figma-manifest.json` are policy vio
 For icon lock artifacts, Figma source fields (`figma_design_url`, `figma_file_key`, `figma_node_id`)
 must reference `figma.com/design` nodes (Figma Make links are not SoT).
 
+Design token SoT for web is `frontend/src/styles/tokens.css` (single source).
+Token migrations must follow staged policy: PR-1 bridge aliases -> PR-2 palette switch -> PR-3 raw-hex guard.
+
+Raw hex values are forbidden in `frontend/src/**` runtime files.
+Allowlist only: `frontend/src/styles/tokens.css`, `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`.
+
 ## Thin HTTP Adapter Policy (Hard Rule)
 
 **Invariant:** Clients (iOS/Web) must be **thin adapters only** — zero business logic, only transport/contract/UX.

--- a/docs/design/TOKENS_SOT.md
+++ b/docs/design/TOKENS_SOT.md
@@ -1,0 +1,29 @@
+# Tokens Source Of Truth
+
+This document defines the canonical rule for PulsePlate design tokens.
+
+### Canonical decision
+
+- `TOKEN_SOT`: `frontend/src/styles/tokens.css`
+- `GOLD`: approved as premium/accent semantic token
+
+### Migration policy
+
+- PR-1 (bridge): introduce canonical `--pp-*` brand tokens and keep legacy aliases.
+- PR-2 (palette switch): update canonical token values to Guidelines palette.
+- PR-3 (guard): ban raw hex in frontend runtime paths with explicit allowlist.
+
+### Canonical brand tokens
+
+- `--pp-navy`
+- `--pp-blue`
+- `--pp-green`
+- `--pp-red`
+- `--pp-gold`
+
+### Legacy aliases (temporary)
+
+- `--pp-primary` -> `--pp-blue`
+- `--pp-accent` -> `--pp-green`
+
+Legacy aliases are kept only for soft migration and should not be used in new code.

--- a/frontend/src/pages/NutritionSetup/PlateChart.tsx
+++ b/frontend/src/pages/NutritionSetup/PlateChart.tsx
@@ -55,7 +55,7 @@ export default function PlateChart({ carbsPct, proteinPct, fatPct }: PlateChartP
           cy="55"
           r={radius}
           fill="none"
-          stroke="#f3f4f6"
+          stroke="var(--color-gray-100)"
           strokeWidth="8"
         />
 
@@ -65,7 +65,7 @@ export default function PlateChart({ carbsPct, proteinPct, fatPct }: PlateChartP
           cy="55"
           r={radius}
           fill="none"
-          stroke="#3b82f6"
+          stroke="var(--pp-blue)"
           strokeWidth="8"
           strokeDasharray={`${carbsDash} ${circumference}`}
           strokeDashoffset={circumference * 0.25}
@@ -78,7 +78,7 @@ export default function PlateChart({ carbsPct, proteinPct, fatPct }: PlateChartP
           cy="55"
           r={radius}
           fill="none"
-          stroke="#10b981"
+          stroke="var(--pp-green)"
           strokeWidth="8"
           strokeDasharray={`${proteinDash} ${circumference}`}
           strokeDashoffset={circumference * 0.25 + carbsDash}
@@ -91,7 +91,7 @@ export default function PlateChart({ carbsPct, proteinPct, fatPct }: PlateChartP
           cy="55"
           r={radius}
           fill="none"
-          stroke="#ef4444"
+          stroke="var(--pp-red)"
           strokeWidth="8"
           strokeDasharray={`${fatDash} ${circumference}`}
           strokeDashoffset={circumference * 0.25 + carbsDash + proteinDash}
@@ -102,16 +102,16 @@ export default function PlateChart({ carbsPct, proteinPct, fatPct }: PlateChartP
       {/* Legend */}
       <div className="mt-4 space-y-2 text-sm">
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-blue-500"></div>
-          <span className="text-text">{t('nutrition.macros.carbs')}: {Math.round(carbsPct)}%</span>
+          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: 'var(--pp-blue)' }}></div>
+          <span className="text-text">{t('nutrition.macros.carbs')}: {Math.round(safeCarbsPct)}%</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-green-500"></div>
-          <span className="text-text">{t('nutrition.macros.protein')}: {Math.round(proteinPct)}%</span>
+          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: 'var(--pp-green)' }}></div>
+          <span className="text-text">{t('nutrition.macros.protein')}: {Math.round(safeProteinPct)}%</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-red-500"></div>
-          <span className="text-text">{t('nutrition.macros.fat')}: {Math.round(fatPct)}%</span>
+          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: 'var(--pp-red)' }}></div>
+          <span className="text-text">{t('nutrition.macros.fat')}: {Math.round(safeFatPct)}%</span>
         </div>
       </div>
     </div>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -12,6 +12,13 @@
      COLOR VARIABLES
      ============================================================================ */
 
+  /* Canonical PulsePlate brand tokens (bridge phase: no visual change) */
+  --pp-navy: #102a43;
+  --pp-blue: #3b82f6;
+  --pp-green: #22c55e;
+  --pp-red: #ef4444;
+  --pp-gold: #d4af37;
+
   /* Navy theme */
   --color-navy-50: #f0f4f8;
   --color-navy-100: #d9e2ec;
@@ -73,29 +80,27 @@
   --color-gray-900: #111827;
 
   /* Base UI semantic tokens */
-  --color-primary: var(--color-blue-600);
+  --color-primary: var(--pp-blue);
   --color-primary-foreground: #fff;
   --color-bg: #fff;
   --color-surface: var(--color-navy-50);
   --color-surface-muted: var(--color-navy-100);
   --color-border: var(--color-navy-200);
-  --color-text: var(--color-navy-900);
+  --color-text: var(--pp-navy);
   --color-text-muted: var(--color-navy-500);
 
   /* Status semantic colors */
-  --color-success: var(--color-green-500);
+  --color-success: var(--pp-green);
   --color-warning: #f59e0b;
-  --color-error: var(--color-heart-500);
-  --color-info: var(--color-blue-500);
-  --color-focus: var(--color-blue-500);
+  --color-error: var(--pp-red);
+  --color-info: var(--pp-blue);
+  --color-focus: var(--pp-blue);
   --color-focus-rgb: 59, 130, 246;
   --color-focus-shadow: rgba(var(--color-focus-rgb), 0.1);
 
-  /* Legacy aliases (deprecated) */
-  --pp-navy: var(--color-navy-900);
-  --pp-primary: var(--color-primary);
-  --pp-gold: #D4AF37;
-  --pp-accent: #20C997;
+  /* Legacy aliases (deprecated, keep until PR-2 migration) */
+  --pp-primary: var(--pp-blue);
+  --pp-accent: var(--pp-green);
   --pp-text: var(--color-text);
   --pp-muted: var(--color-text-muted);
   --pp-radius-xl: 1.25rem;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -13,10 +13,10 @@
      ============================================================================ */
 
   /* Canonical PulsePlate brand tokens (bridge phase: no visual change) */
-  --pp-navy: #102a43;
-  --pp-blue: #3b82f6;
-  --pp-green: #22c55e;
-  --pp-red: #ef4444;
+  --pp-navy: #0f172a;
+  --pp-blue: #339fff;
+  --pp-green: #20c997;
+  --pp-red: #ff5d5d;
   --pp-gold: #d4af37;
 
   /* Navy theme */
@@ -95,7 +95,7 @@
   --color-error: var(--pp-red);
   --color-info: var(--pp-blue);
   --color-focus: var(--pp-blue);
-  --color-focus-rgb: 59, 130, 246;
+  --color-focus-rgb: 51, 159, 255;
   --color-focus-shadow: rgba(var(--color-focus-rgb), 0.1);
 
   /* Legacy aliases (deprecated, keep until PR-2 migration) */

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -10,10 +10,10 @@
  * Bridge phase uses current runtime values to avoid visual drift in PR-1.
  */
 export const canonicalBrand = {
-  navy: '#102a43',
-  blue: '#3b82f6',
-  green: '#22c55e',
-  red: '#ef4444',
+  navy: '#0f172a',
+  blue: '#339fff',
+  green: '#20c997',
+  red: '#ff5d5d',
   gold: '#d4af37',
 } as const;
 

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -5,6 +5,27 @@
  * Provides type-safe access to colors, spacing, typography, and other design values.
  */
 
+/**
+ * Canonical PulsePlate brand tokens.
+ * Bridge phase uses current runtime values to avoid visual drift in PR-1.
+ */
+export const canonicalBrand = {
+  navy: '#102a43',
+  blue: '#3b82f6',
+  green: '#22c55e',
+  red: '#ef4444',
+  gold: '#d4af37',
+} as const;
+
+/**
+ * @deprecated Use canonicalBrand.* directly in new code.
+ * Kept only for soft migration compatibility.
+ */
+export const legacyBrandAliases = {
+  primary: canonicalBrand.blue,
+  accent: canonicalBrand.green,
+} as const;
+
 // ============================================================================
 // COLOR TOKENS
 // ============================================================================
@@ -85,10 +106,10 @@ export const colors = {
 
   // Semantic colors
   semantic: {
-    success: '#22c55e',
+    success: canonicalBrand.green,
     warning: '#f59e0b',
-    error: '#ef4444',
-    info: '#3b82f6',
+    error: canonicalBrand.red,
+    info: canonicalBrand.blue,
   },
 } as const;
 


### PR DESCRIPTION
## IN SCOPE
- Switch canonical `--pp-*` palette values in `frontend/src/styles/tokens.css`:
  - `--pp-navy: #0F172A`
  - `--pp-blue: #339FFF`
  - `--pp-green: #20C997`
  - `--pp-red: #FF5D5D`
  - `--pp-gold: #D4AF37`
- Align `--color-focus-rgb` with canonical blue (`51, 159, 255`).
- Update `canonicalBrand` values in `frontend/src/styles/tokens.ts`.
- Tokenize `frontend/src/pages/NutritionSetup/PlateChart.tsx` (remove raw hex; use token vars).

## OUT OF SCOPE
- No changes to legacy tonal scale tokens (`--color-*-50..900`).
- No raw-hex CI guard implementation (PR-3).
- No broad component refactors outside PlateChart.

## Why
- Complete PR-2 migration phase by activating approved brand palette at canonical token layer.
- Remove runtime raw-hex usage in PlateChart and keep chart visuals aligned with token SoT.

## Test plan
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `cd frontend && npm run build` ✅
- Targeted tests:
  - `npm run test -- src/pages/NutritionSetup/__tests__/ResultView.test.tsx src/features/progress/__tests__/ProgressCharts.test.tsx` ✅

## Live preview
- Dev server run: `http://127.0.0.1:4173/`.
- Visual smoke check confirms tokenized chart colors are wired correctly.
- Non-blocking observation: mock response currently lacks macro data on setup result path, so chart can show 0% segments in mock mode (`Plate response missing macronutrient data`).

## Risk
- Medium-low: intentional visual palette update at canonical token layer.
- Chart rendering path is tokenized and tested.

## Deferred
- PR-3: enforce frontend raw-hex ban with allowlist (`tokens.css`, tests/spec/stories).

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## DoD
- Canonical palette switched.
- PlateChart raw hex removed.
- Full local quality gates green.