### PR TITLE
Frontend guard: ban raw hex outside token/test allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,7 +557,7 @@ Design token SoT for web is `frontend/src/styles/tokens.css` (single source).
 Token migrations must follow staged policy: PR-1 bridge aliases -> PR-2 palette switch -> PR-3 raw-hex guard.
 
 Raw hex values are forbidden in `frontend/src/**` runtime files.
-Allowlist only: `frontend/src/styles/tokens.css`, `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`.
+Allowlist only: `frontend/src/styles/tokens.css`, `frontend/src/styles/tokens.ts`, `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`.
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/tests/test_frontend_raw_hex_guard.py
+++ b/tests/test_frontend_raw_hex_guard.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
+HEX_RE = re.compile(r"#[0-9a-fA-F]{6}\b")
+
+# Explicit allowlist for token definition files and non-runtime test/story files.
+ALLOWLIST_FILES = {
+    FRONTEND_SRC / "styles" / "tokens.css",
+    FRONTEND_SRC / "styles" / "tokens.ts",
+}
+ALLOWLIST_NAME_PARTS = (".test.", ".spec.", ".stories.")
+SCAN_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".css"}
+
+
+def _is_allowlisted(path: Path) -> bool:
+    if path in ALLOWLIST_FILES:
+        return True
+    return any(part in path.name for part in ALLOWLIST_NAME_PARTS)
+
+
+def test_frontend_runtime_has_no_raw_hex_outside_allowlist() -> None:
+    violations: list[str] = []
+
+    for file_path in FRONTEND_SRC.rglob("*"):
+        if not file_path.is_file() or file_path.suffix not in SCAN_EXTENSIONS:
+            continue
+        if _is_allowlisted(file_path):
+            continue
+
+        text = file_path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            match = HEX_RE.search(line)
+            if match:
+                rel_path = file_path.relative_to(REPO_ROOT)
+                violations.append(f"{rel_path}:{line_no}:{match.group(0)}")
+
+    assert not violations, "Raw hex colors found outside allowlist:\n" + "\n".join(violations)


### PR DESCRIPTION
## IN SCOPE
- Add deterministic guard test: `tests/test_frontend_raw_hex_guard.py`.
- Enforce no raw hex colors in `frontend/src/**` runtime files.
- Keep explicit allowlist for:
  - `frontend/src/styles/tokens.css`
  - `frontend/src/styles/tokens.ts`
  - `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`
- Align root `AGENTS.md` policy line with implemented allowlist.

## OUT OF SCOPE
- No token palette changes.
- No UI component refactors.
- No workflow/CI YAML changes.

## Why
- Lock PR-3 migration stage with a deterministic guard to prevent token drift and future raw-hex regressions in runtime code.

## Test plan
- `pytest -q tests/test_frontend_raw_hex_guard.py` ✅
- Pre-commit hook run during commit ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## DoD
- Guard test exists and fails on non-allowlisted raw hex.
- Current frontend runtime passes guard.
- Policy text in `AGENTS.md` matches actual guard allowlist.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить защиту, предотвращающую использование «сырых» шестнадцатеричных цветов в runtime-коде фронтенда, и привести документацию в соответствие с применяемым разрешающим списком.

Документация:
- Обновить `AGENTS.md`, чтобы задокументировать расширенный разрешающий список «сырых» hex-значений, включая файл с токенами TypeScript.

Тесты:
- Добавить детерминированный тест на уровне репозитория, который сканирует исходные файлы фронтенда и падает при обнаружении неразрешённых литералов «сырых» шестнадцатеричных цветов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a guard to prevent raw hex color usage in frontend runtime code and align documentation with the enforced allowlist.

Documentation:
- Update AGENTS.md to document the expanded raw-hex allowlist, including the TypeScript tokens file.

Tests:
- Add a deterministic repo-level test that scans frontend source files and fails on non-allowlisted raw hex color literals.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guard test that blocks raw hex colors in frontend runtime code to prevent token drift. Aligns AGENTS.md policy with the allowlist.

- New Features
  - Added tests/test_frontend_raw_hex_guard.py to scan frontend/src for raw hex (#RRGGBB) and fail on violations.
  - Allowlist: frontend/src/styles/tokens.css, frontend/src/styles/tokens.ts, and any *.test.*, *.spec.*, *.stories.* files.

<sup>Written for commit 0743a3948cf2a1058933afde3ccab54fd6d14ce6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

