### PR TITLE
Docs ledger: close token hardening follow-up (#835/#837)

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1121,6 +1121,28 @@ If it is not recorded here — it does not exist.
     - Token usage guidelines page exists for HPP states (default/realtime/fallback/conversion)
     - Storybook build passes in local verification
 
+- [x] Web design-token hardening: Token SoT + palette switch + runtime raw-hex guard
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (frontend stability / drift prevention)
+  - Target PR: #835, #837
+  - Status: ✅ Merged (2026-02-21)
+  - Area: frontend / design-system governance
+  - Finding Type: policy hardening + runtime guard
+  - Reason: Token drift risk and hardcoded runtime colors were allowing visual inconsistency. We fixed
+    source-of-truth ownership, activated canonical palette tokens, and added deterministic guardrails
+    to prevent future raw-hex regressions in runtime UI paths.
+  - Links:
+    - `docs/design/TOKENS_SOT.md`
+    - `frontend/src/styles/tokens.css`
+    - `frontend/src/styles/tokens.ts`
+    - `tests/test_frontend_raw_hex_guard.py`
+    - PR #835, PR #837
+  - DoD:
+    - ✅ Token SoT documented and merged
+    - ✅ Canonical palette values active in web tokens
+    - ✅ Plate chart raw hex replaced with token variables
+    - ✅ Runtime raw-hex guard test merged with explicit allowlist
+
 - [ ] HPP Web visual workflow: Playwright deterministic smoke lane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (frontend quality guardrail)


### PR DESCRIPTION
## IN SCOPE
- Update `docs/roadmap/BACKLOG_LEDGER.md` with a completed entry for web token hardening work.
- Reference merged PRs #835 and #837 and capture DoD evidence.

## OUT OF SCOPE
- No runtime/frontend/backend code changes.
- No CI/workflow/config updates.

## Why
- Backlog policy requires deferred/completed work to be tracked and closed in ledger after merge.
- This docs-only PR records closure for the token SoT + palette switch + raw-hex guard package.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Test plan
- Pre-commit docs checks on commit ✅
- `git diff --name-only origin/main...HEAD` contains docs-only change ✅

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Добавить завершённую запись в реестр, документирующую инициативу по усилению безопасности веб-дизайн-токенов, включая область охвата, ответственное лицо, ссылки и определение готовности (definition of done).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a completed ledger entry documenting the web design-token hardening initiative, including scope, ownership, references, and definition of done.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close out the web design-token hardening effort in the backlog ledger. Adds a completed entry referencing PRs #835 and #837 and capturing DoD for Token SoT, palette switch, and a runtime raw-hex guard.

<sup>Written for commit 815ded7e2c5f7ae4dc53aea0f61737b6a72cd4c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog ledger with new design-token hardening initiative entry.
  * Removed completed visual workflow entry from backlog tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->