### PR TITLE
test(e2e): harden HPP Playwright smoke lane

### DIFF
--- a/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
+++ b/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
@@ -81,8 +81,8 @@ npm run storybook
 | ID | Flow | Start URL | Expected outcome | Artifacts |
 | --- | --- | --- | --- | --- |
 | `E2E-01` | Home smoke | `http://127.0.0.1:4173/` | App shell renders without fatal UI errors | Screenshot + snapshot log |
-| `E2E-02` | BMI route smoke | `http://127.0.0.1:4173/bmi` | BMI page opens and controls are interactable | Screenshot + step log |
-| `E2E-03` | Setup route smoke | `http://127.0.0.1:4173/setup` | Setup screen renders expected form flow | Screenshot + snapshot log |
+| `E2E-02` | Plate route smoke | `http://127.0.0.1:4173/plate` | Plate screen (or auth prompt) renders with deterministic shell checks | Screenshot + step log |
+| `E2E-03` | Progress route smoke | `http://127.0.0.1:4173/progress` | Progress screen (or auth prompt) renders with deterministic shell checks | Screenshot + snapshot log |
 | `E2E-04` | Pro paywall route smoke | `http://127.0.0.1:4173/pro` | Paywall page renders and primary CTA is visible | Screenshot + step log |
 
 ## Command pattern (CLI-first)
@@ -90,7 +90,7 @@ npm run storybook
 Use element references from the latest snapshot only. Do not hardcode `e*` ids.
 
 ```bash
-"$PWCLI" open http://127.0.0.1:4173/bmi --headed
+"$PWCLI" open http://127.0.0.1:4173/plate --headed
 "$PWCLI" snapshot
 "$PWCLI" click eX
 "$PWCLI" snapshot

--- a/frontend/e2e/hpp-smoke.spec.ts
+++ b/frontend/e2e/hpp-smoke.spec.ts
@@ -19,6 +19,8 @@ async function expectProtectedRouteOrAuthPrompt(routeHeading: Locator, authField
 test('home shell renders', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Configure Setup' })).toBeVisible();
+  await expect(page.getByRole('tablist', { name: 'Main tabs' })).toBeVisible();
 });
 
 test('plate route renders', async ({ page }) => {
@@ -27,6 +29,9 @@ test('plate route renders', async ({ page }) => {
     page.getByRole('heading', { name: 'Your Plate' }),
     page.locator('#api-key-input')
   );
+  if ((await page.getByRole('heading', { name: 'Your Plate' }).count()) > 0) {
+    await expect(page.getByRole('tablist', { name: 'Main tabs' })).toBeVisible();
+  }
 });
 
 test('progress route renders', async ({ page }) => {
@@ -35,9 +40,14 @@ test('progress route renders', async ({ page }) => {
     page.getByRole('heading', { name: 'Progress' }),
     page.locator('#api-key-input')
   );
+  if ((await page.getByRole('heading', { name: 'Progress' }).count()) > 0) {
+    await expect(page.getByRole('link', { name: 'Update setup parameters' })).toBeVisible();
+    await expect(page.getByRole('tablist', { name: 'Main tabs' })).toBeVisible();
+  }
 });
 
 test('pro paywall route renders', async ({ page }) => {
   await page.goto('/pro');
   await expect(page.getByTestId('paywall-cta')).toBeVisible();
+  await expect(page.getByTestId('paywall-cancel')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- aligns Playwright runbook scenario matrix to canonical HPP routes (`/`, `/plate`, `/progress`, `/pro`) and updates CLI example route
- strengthens `hpp-smoke` checks with deterministic shell/CTA assertions on home, protected routes, and pro paywall actions
- keeps smoke checks role/testid-based to reduce flakiness while improving regression detection

## Test plan
- [x] `pre-commit run --all-files`
- [x] `make verify`
- [x] `cd frontend && npm run test:e2e`

## Deferred / Follow-ups
- ledger close follow-up docs PR after merge for `HPP Web visual workflow: Playwright deterministic smoke lane`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Усилить смоук-тесты HPP Playwright и привести E2E runbook в соответствие с актуальными каноническими маршрутами и проверками.

Документация:
- Обновить матрицу сценариев и пример CLI в Playwright E2E runbook, чтобы использовать канонические маршруты HPP и описать новые ожидания для смоук-тестов.

Тесты:
- Расширить смоук-тесты HPP Playwright дополнительными детерминированными UI-проверками на маршрутах home, plate, progress и pro paywall.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen HPP Playwright smoke tests and align the E2E runbook with the current canonical routes and assertions.

Documentation:
- Update the Playwright E2E runbook scenario matrix and CLI example to use the canonical HPP routes and describe the new smoke expectations.

Tests:
- Enhance HPP Playwright smoke tests with additional deterministic UI assertions on home, plate, progress, and pro paywall routes.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Playwright smoke lane to canonical HPP routes and adds deterministic role/testid assertions to reduce flakiness and catch shell/paywall regressions.

- **Refactors**
  - Runbook: switches scenario matrix to `/`, `/plate`, `/progress`, `/pro`; updates CLI example to `/plate`.
  - Tests: adds stable checks for Home shell (Configure Setup link, Main tabs), Plate/Progress protected routes (heading or auth prompt), and Pro paywall (CTA and cancel).

<sup>Written for commit 50a146be0ca1dc594b07224810d6f67b1bf322e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test coverage with additional UI element validation across key application routes to improve test reliability and reduce false positives.

* **Documentation**
  * Updated testing runbook to align test scenarios and procedures with current application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->