### PR TITLE
fix(ci): restore nightly security toolchain

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
+          # Nightly security step relies on Safety CLI; install explicitly to avoid runner drift.
+          python -m pip install safety
           pip list
 
       - name: Run linting

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -173,14 +173,14 @@
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 283
+        "line_number": 285
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 313
+        "line_number": 315
       }
     ],
     ".github/workflows/pr-coverage.yml": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-20T14:59:49Z"
+  "generated_at": "2026-02-21T06:35:00Z"
 }


### PR DESCRIPTION
## Summary
- fixes Nightly Tests failure on `main` where security step crashed with `safety: command not found`
- explicitly installs Safety CLI in nightly dependency setup to avoid runner drift
- includes mandatory pre-commit-generated `.secrets.baseline` refresh as a separate commit

## Test plan
- [x] `pre-commit run --all-files`

## Failure evidence
- Nightly run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/22249982159
- Failing job: `test (1)` https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/22249982159/job/64371556049
- Log lines:
  - `/home/runner/work/_temp/...sh: line 32: safety: command not found`
  - `##[error]Process completed with exit code 1.`

## Deferred / Follow-ups
- After merge, re-run Nightly Tests once to confirm shard-1 security step is green with Safety installed.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Обеспечить надежный запуск ночных проверок безопасности в CI за счет явной установки Safety CLI и обновления эталонного файла секретов.

Bug Fixes:
- Предотвратить сбой шага ночной проверки безопасности в CI из‑за отсутствия Safety CLI на раннере.

Enhancements:
- Явно добавить установку Safety CLI в настройку ночных зависимостей, чтобы защититься от расхождений конфигурации раннера.

CI:
- Обновить ночной workflow, чтобы устанавливать Safety как часть Python‑зависимостей для ночных запусков.

Chores:
- Обновить закоммиченный файл `.secrets.baseline`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure nightly CI security checks run reliably by explicitly installing the Safety CLI and refreshing the secrets baseline.

Bug Fixes:
- Prevent nightly CI security step from failing due to missing Safety CLI on the runner.

Enhancements:
- Explicitly add Safety CLI installation to the nightly dependency setup to guard against runner drift.

CI:
- Update nightly workflow to install Safety as part of the Python dependencies for nightly runs.

Chores:
- Refresh the checked-in .secrets.baseline file.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the nightly security step by explicitly installing the Safety CLI, fixing the “safety: command not found” failure. Refreshes the detect-secrets baseline so pre-commit and CI stay in sync.

- **Bug Fixes**
  - Add Safety install to nightly.yml (python -m pip install safety).
  - Update .secrets.baseline generated_at and line references from pre-commit.

<sup>Written for commit c89b7b1a3fca48c6e250c7faf597a71dd7e16f0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly workflow configuration to improve security tooling availability during automated checks.
  * Refreshed security baseline metadata and line number references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->