### PR TITLE
fix(ci): pin nightly safety via managed dependencies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,8 +45,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
-          # Nightly security step relies on Safety CLI; install explicitly to avoid runner drift.
-          python -m pip install safety
           pip list
 
       - name: Run linting

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -173,14 +173,14 @@
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 283
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 313
       }
     ],
     ".github/workflows/pr-coverage.yml": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-21T06:35:00Z"
+  "generated_at": "2026-02-21T06:40:06Z"
 }

--- a/constraints.txt
+++ b/constraints.txt
@@ -20,7 +20,7 @@ ruff>=0.14.7  # Primary linter (replaces flake8)
 
 # Security - allow patch updates for vulnerability fixes
 bandit>=1.8.6
-safety==3.7.0
+safety>=3.7.0
 
 # Dev tools - allow minor updates
 pre-commit>=4.3.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -20,7 +20,7 @@ ruff>=0.14.7  # Primary linter (replaces flake8)
 
 # Security - allow patch updates for vulnerability fixes
 bandit>=1.8.6
-# safety>=3.6.2  # Match requirements-dev.txt if needed
+safety>=3.6.2
 
 # Dev tools - allow minor updates
 pre-commit>=4.3.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -20,7 +20,7 @@ ruff>=0.14.7  # Primary linter (replaces flake8)
 
 # Security - allow patch updates for vulnerability fixes
 bandit>=1.8.6
-safety>=3.6.2
+safety==3.7.0
 
 # Dev tools - allow minor updates
 pre-commit>=4.3.0

--- a/frontend/src/features/progress/ProgressCharts.tsx
+++ b/frontend/src/features/progress/ProgressCharts.tsx
@@ -144,7 +144,7 @@ export default function ProgressCharts({ windowRange = 'MONTH' }: ProgressCharts
         <button
           onClick={handleExportToPdf}
           className="flex items-center gap-2 px-4 py-2 rounded-lg transition-colors hover:opacity-90"
-          style={{ backgroundColor: chartTokens.primary, color: '#fff' }}
+          style={{ backgroundColor: chartTokens.primary, color: chartTokens.surface }}
           aria-label="Export progress report as PDF"
         >
           <Download className="w-4 h-4" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,7 +16,7 @@ body {
 
 /* Utilities */
 .bg-pp-primary { background: var(--pp-primary); }
-.text-white { color: #fff; }
+.text-white { color: var(--color-surface); }
 .sr-only {
   position: absolute;
   width: 1px;

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -16,6 +16,7 @@ diff-cover~=10.2.0
 bandit>=1.8.6  # Security tool - keep >= for vulnerability updates
 safety>=3.6.2  # Security tool - keep >= for vulnerability updates
 pip-audit>=2.9.0  # Security tool - keep >= for vulnerability updates
+marshmallow>=4.1.2  # Explicit floor to keep CVE fix independent of transitive deps
 cryptography>=46.0.5  # Keep explicit dependency floor for dependency-security guard
 pre-commit~=4.5.1
 pip-tools~=7.5.3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,6 +14,7 @@ coverage~=7.13.4
 diff-cover~=10.2.0
 # Code quality tools: use compatible release for stability
 bandit>=1.8.6  # Security tool - keep >= for vulnerability updates
+safety>=3.6.2  # Security tool - keep >= for vulnerability updates
 pip-audit>=2.9.0  # Security tool - keep >= for vulnerability updates
 cryptography>=46.0.5  # Keep explicit dependency floor for dependency-security guard
 pre-commit~=4.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,20 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
+annotated-doc==0.0.4
+    # via
+    #   -c requirements.txt
+    #   typer
+annotated-types==0.7.0
+    # via
+    #   -c requirements.txt
+    #   pydantic
+anyio==4.12.0
+    # via
+    #   -c requirements.txt
+    #   httpx
+authlib==1.6.8
+    # via safety
 bandit==1.9.3
     # via -r requirements-dev.in
 black==26.1.0
@@ -19,6 +33,8 @@ cachecontrol[filecache]==0.14.4
 certifi==2026.1.4
     # via
     #   -c requirements.txt
+    #   httpcore
+    #   httpx
     #   requests
 cffi==2.0.0
     # via
@@ -36,7 +52,10 @@ click==8.3.1
     # via
     #   -c requirements.txt
     #   black
+    #   nltk
     #   pip-tools
+    #   safety
+    #   typer
 coverage[toml]==7.13.4
     # via
     #   -r requirements-dev.in
@@ -45,6 +64,7 @@ cryptography==46.0.5
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
+    #   authlib
 cyclonedx-python-lib==11.6.0
     # via pip-audit
 defusedxml==0.7.1
@@ -55,6 +75,10 @@ diff-cover==10.2.0
     # via -r requirements-dev.in
 distlib==0.4.0
     # via virtualenv
+dparse==0.6.4
+    # via
+    #   safety
+    #   safety-schemas
 execnet==2.1.2
     # via pytest-xdist
 faker==40.4.0
@@ -62,7 +86,20 @@ faker==40.4.0
 filelock==3.20.3
     # via
     #   cachecontrol
+    #   safety
     #   virtualenv
+h11==0.16.0
+    # via
+    #   -c requirements.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -c requirements.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -c requirements.txt
+    #   safety
 hypothesis==6.151.6
     # via -r requirements-dev.in
 identify==2.6.15
@@ -70,11 +107,17 @@ identify==2.6.15
 idna==3.11
     # via
     #   -c requirements.txt
+    #   anyio
+    #   httpx
     #   requests
 iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
-    # via diff-cover
+    # via
+    #   diff-cover
+    #   safety
+joblib==1.5.3
+    # via nltk
 librt==0.7.5
     # via mypy
 license-expression==30.4.4
@@ -85,6 +128,8 @@ markupsafe==3.0.3
     # via
     #   -c requirements.txt
     #   jinja2
+marshmallow==4.2.2
+    # via safety
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.2
@@ -99,6 +144,8 @@ nh3==0.3.2
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
+nltk==3.9.2
+    # via safety
 nodeenv==1.10.0
     # via pre-commit
 packageurl-python==0.17.6
@@ -108,9 +155,12 @@ packaging==25.0
     #   -c requirements.txt
     #   black
     #   build
+    #   dparse
     #   pip-audit
     #   pip-requirements-parser
     #   pytest
+    #   safety
+    #   safety-schemas
     #   wheel
 pathspec==1.0.3
     # via
@@ -143,6 +193,15 @@ pycparser==2.23
     # via
     #   -c requirements.txt
     #   cffi
+pydantic==2.12.5
+    # via
+    #   -c requirements.txt
+    #   safety
+    #   safety-schemas
+pydantic-core==2.41.5
+    # via
+    #   -c requirements.txt
+    #   pydantic
 pygments==2.19.2
     # via
     #   diff-cover
@@ -182,33 +241,68 @@ pyyaml==6.0.3
     #   detect-secrets
     #   pre-commit
     #   yamllint
+regex==2026.2.19
+    # via nltk
 requests==2.32.5
     # via
     #   cachecontrol
     #   detect-secrets
     #   pip-audit
+    #   safety
 rich==14.2.0
     # via
     #   bandit
     #   pip-audit
+    #   typer
+ruamel-yaml==0.19.1
+    # via
+    #   safety
+    #   safety-schemas
 ruff==0.15.1
     # via -r requirements-dev.in
+safety==3.7.0
+    # via -r requirements-dev.in
+safety-schemas==0.0.16
+    # via safety
+shellingham==1.5.4
+    # via typer
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   hypothesis
 stevedore==5.6.0
     # via bandit
+tenacity==9.1.2
+    # via
+    #   -c requirements.txt
+    #   safety
 tomli==2.3.0
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
+tomlkit==0.14.0
+    # via safety
+tqdm==4.67.1
+    # via
+    #   -c requirements.txt
+    #   nltk
+typer==0.24.0
+    # via safety
 types-pyyaml==6.0.12.20250915
     # via -r requirements-dev.in
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
     #   mypy
+    #   pydantic
+    #   pydantic-core
+    #   safety
+    #   safety-schemas
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   -c requirements.txt
+    #   pydantic
 urllib3==2.6.3
     # via requests
 virtualenv==20.36.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -129,7 +129,9 @@ markupsafe==3.0.3
     #   -c requirements.txt
     #   jinja2
 marshmallow==4.2.2
-    # via safety
+    # via
+    #   -r requirements-dev.in
+    #   safety
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.2

--- a/tests/test_frontend_raw_hex_guard.py
+++ b/tests/test_frontend_raw_hex_guard.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
-HEX_RE = re.compile(r"#[0-9a-fA-F]{6}\b")
+# Match valid CSS hex forms: RGB, RGBA, RRGGBB, RRGGBBAA.
+HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b")
 
 # Explicit allowlist for token definition files and non-runtime test/story files.
 ALLOWLIST_FILES = {
@@ -22,6 +23,20 @@ def _is_allowlisted(path: Path) -> bool:
     return any(part in path.name for part in ALLOWLIST_NAME_PARTS)
 
 
+def _hex_matches_in_line(line: str) -> list[str]:
+    return [match.group(0) for match in HEX_RE.finditer(line)]
+
+
+def test_hex_match_detects_multiple_and_extended_forms() -> None:
+    line = "colors: #fff #abcd #123456 #11223344; border: #00f;"
+    assert _hex_matches_in_line(line) == ["#fff", "#abcd", "#123456", "#11223344", "#00f"]
+
+
+def test_hex_match_ignores_invalid_lengths() -> None:
+    line = "invalid: #12 #12345 #1234567 #123456789;"
+    assert _hex_matches_in_line(line) == []
+
+
 def test_frontend_runtime_has_no_raw_hex_outside_allowlist() -> None:
     violations: list[str] = []
 
@@ -33,9 +48,10 @@ def test_frontend_runtime_has_no_raw_hex_outside_allowlist() -> None:
 
         text = file_path.read_text(encoding="utf-8")
         for line_no, line in enumerate(text.splitlines(), start=1):
-            match = HEX_RE.search(line)
-            if match:
+            matches = _hex_matches_in_line(line)
+            if matches:
                 rel_path = file_path.relative_to(REPO_ROOT)
-                violations.append(f"{rel_path}:{line_no}:{match.group(0)}")
+                for match in matches:
+                    violations.append(f"{rel_path}:{line_no}:{match}")
 
     assert not violations, "Raw hex colors found outside allowlist:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- addresses post-merge Sourcery actionable feedback from #841 by moving Safety into managed dependency files
- adds explicit `marshmallow>=4.1.2` floor in `requirements-dev.in` and keeps `safety>=3.7.0` in `constraints.txt`
- regenerates `requirements-dev.txt` and keeps the follow-up raw-hex guard fixes from #837 in this branch

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest -q tests/test_frontend_raw_hex_guard.py`
- [x] `npm run test -- --run src/features/progress/__tests__/ProgressCharts.test.tsx`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/842#discussion_r2835916657 -> 6eb73553
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/842#discussion_r2835920260 -> a6e2d63a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/842#discussion_r2835921757 -> a6e2d63a

## Context
- Follow-up cleanup for missed feedback that arrived after merge in #837 and #841.