### PR TITLE
docs(agents): align token governance policy surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,11 +553,9 @@ Design exports without updating `docs/design/figma-manifest.json` are policy vio
 For icon lock artifacts, Figma source fields (`figma_design_url`, `figma_file_key`, `figma_node_id`)
 must reference `figma.com/design` nodes (Figma Make links are not SoT).
 
-Design token SoT for web is `frontend/src/styles/tokens.css` (single source).
-Token migrations must follow staged policy: PR-1 bridge aliases -> PR-2 palette switch -> PR-3 raw-hex guard.
-
-Raw hex values are forbidden in `frontend/src/**` runtime files.
-Allowlist only: `frontend/src/styles/tokens.css`, `frontend/src/styles/tokens.ts`, `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`.
+Design token governance policy is defined in `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
+(section `Web Token Governance`) and is authoritative for token SoT, migration stages,
+and raw-hex allowlist rules.
 
 ## Thin HTTP Adapter Policy (Hard Rule)
 

--- a/docs/design/TOKENS_SOT.md
+++ b/docs/design/TOKENS_SOT.md
@@ -2,6 +2,8 @@
 
 This document defines the canonical rule for PulsePlate design tokens.
 
+Policy location: `docs/sora/SORA_STYLE_QA_CHECKLIST.md` (section `Web Token Governance`).
+
 ### Canonical decision
 
 - `TOKEN_SOT`: `frontend/src/styles/tokens.css`

--- a/docs/sora/SORA_STYLE_QA_CHECKLIST.md
+++ b/docs/sora/SORA_STYLE_QA_CHECKLIST.md
@@ -5,6 +5,14 @@ Scope: PulsePlate HPP + Brand Core asset candidates (images + micro-motions)
 
 Use this checklist before approving any generated visual.
 
+## Web Token Governance
+
+- Token SoT for web: `frontend/src/styles/tokens.css` (single source).
+- Staged migration policy: PR-1 bridge aliases -> PR-2 palette switch -> PR-3 raw-hex guard.
+- Raw hex is forbidden in `frontend/src/**` runtime files.
+- Raw-hex allowlist: `frontend/src/styles/tokens.css`, `frontend/src/styles/tokens.ts`,
+ `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*`.
+
 ## Brand and Style
 
 - [ ] PASS if only canonical palette tokens are used


### PR DESCRIPTION
## Summary
- move full web token governance policy text to approved doc surface `docs/sora/SORA_STYLE_QA_CHECKLIST.md` (`Web Token Governance` section)
- replace duplicated hard-rule text in `AGENTS.md` with a short pointer to the approved policy location
- keep `docs/design/TOKENS_SOT.md` focused on token definitions/migration and add a pointer to policy location

## Test plan
- [x] `pre-commit run --all-files`
- [x] verify PR is docs-only (`AGENTS.md`, `docs/design/TOKENS_SOT.md`, `docs/sora/SORA_STYLE_QA_CHECKLIST.md`)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness (Mandatory)
- [x] PR is non-draft only when truly ready for merge
- [x] All required checks are green on latest commit (no pending/rerun required)
- [x] No unresolved review threads
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Why
- closes still-relevant docs feedback from PR #835 by removing policy duplication and making one authoritative policy surface easy to find.