### PR TITLE
chore(ci): enforce merge-readiness gate for non-draft PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,6 +48,14 @@
 - `<review-comment-url>` -> `<commit-sha>`
 - No actionable review comments
 
+## Merge Readiness (Mandatory)
+
+- [ ] PR is non-draft only when truly ready for merge
+- [ ] All required checks are green on latest commit (no pending/rerun required)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)
+
 ## Deferred / Follow-ups
 
 - [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches: [ main, feat/**, fix/** ]
   pull_request:
-    types: [ opened, synchronize, reopened, edited ]
+    types: [ opened, synchronize, reopened, edited, ready_for_review ]
     branches: [ main, feat/**, fix/** ]
 
 concurrency:
@@ -206,6 +206,30 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/ci/check_pr_body_phase2_gates.py --event-path "$GITHUB_EVENT_PATH"
+
+  merge_readiness_gate:
+    name: Merge readiness gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Setup Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: ${{ env.COVERAGE_PY }}
+
+      - name: Enforce merge readiness policy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/check_pr_merge_readiness.py --event-path "$GITHUB_EVENT_PATH"
 
   lint:
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 360
+        "line_number": 384
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1611,5 +1611,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-21T06:40:06Z"
+  "generated_at": "2026-02-21T07:29:12Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Or individually:
 - PR MUST NOT be merged while any bot comment contains actionable items.
 - Before merge, confirm CodeRabbit, Sourcery, and Cubic are explicitly PASS / no-actionables.
 - Required checks must be PASS with no pending required jobs.
+- Mandatory wait-window: after the latest bot/review activity, do one final check pass and wait at least one review cycle before merge (never merge on the first green tick).
+- Merge checklist is mandatory in PR body (`## Discussion Thread Pass`, `### Fixed in Commit Mapping`, and `## Merge Readiness`).
 - This gate applies to every non-draft PR before merge.
 
 **Pre-commit hook policy (mandatory before push):**

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -118,6 +118,18 @@ Run from repo root before any push/PR:
 4. `pre-commit run --all-files`
 5. `make verify`
 
+## Pre-merge readiness pass (mandatory for non-draft PRs)
+
+Run before merge after latest commit and latest bot/review activity:
+
+1. `gh pr checks <PR_NUMBER>` -> no failed/pending required checks
+2. `gh pr view <PR_NUMBER> --json mergeStateStatus,reviewDecision,isDraft`
+3. `gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments` -> no unresolved actionable bot comments
+4. Confirm PR body sections are complete:
+   - `## Discussion Thread Pass`
+   - `### Fixed in Commit Mapping`
+   - `## Merge Readiness`
+
 ## Agent Control Plane Security Ops (Wave 1 baseline)
 
 Use this checklist when operating agent automation or closing a token/secrets incident.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -129,6 +129,7 @@ Run before merge after latest commit and latest bot/review activity:
    - `## Discussion Thread Pass`
    - `### Fixed in Commit Mapping`
    - `## Merge Readiness`
+5. CI `Merge readiness gate` must be green on latest PR commit.
 
 ## Agent Control Plane Security Ops (Wave 1 baseline)
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1102,11 +1102,11 @@ If it is not recorded here — it does not exist.
   - Implemented keys (latest):
     - `shoplist_helpers` -> ✅ Merged (PR-764, 2026-02-16, `48c87f39`)
 
-- [ ] HPP Web visual workflow: Storybook bootstrap + first tokenized stories
+- [x] HPP Web visual workflow: Storybook bootstrap + first tokenized stories
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (frontend delivery accelerator)
-  - Target PR: PR/HPP-Storybook-Bootstrap
-  - Status: 📋 Planned
+  - Target PR: #828, #839
+  - Status: ✅ Merged (2026-02-21)
   - Area: frontend / HPP / design-system tooling
   - Finding Type: execution foundation
   - Reason: HPP UI currently lacks isolated component review. Adding Storybook enables deterministic visual
@@ -1143,11 +1143,11 @@ If it is not recorded here — it does not exist.
     - ✅ Plate chart raw hex replaced with token variables
     - ✅ Runtime raw-hex guard test merged with explicit allowlist
 
-- [ ] HPP Web visual workflow: Playwright deterministic smoke lane
+- [x] HPP Web visual workflow: Playwright deterministic smoke lane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (frontend quality guardrail)
-  - Target PR: PR/HPP-Playwright-Smoke-Lane
-  - Status: 📋 Planned
+  - Target PR: #828, #840
+  - Status: ✅ Merged (2026-02-21)
   - Area: frontend / HPP / e2e visual smoke
   - Finding Type: execution foundation
   - Reason: HPP route changes need deterministic browser smoke checks to catch critical UI regressions
@@ -1161,6 +1161,33 @@ If it is not recorded here — it does not exist.
     - `npm run test:e2e` and headed variant are available in `frontend/package.json`
     - Smoke checks run with deterministic local web server settings
     - Runbook contains npm-first execution commands
+
+- [x] Retro-audit PR window #838-#842: merge/comment timing + tail closure
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (process reliability)
+  - Target PR: #842, #843, #844
+  - Status: ✅ Completed (2026-02-21)
+  - Area: CI/process governance + docs follow-up
+  - Finding Type: post-merge audit + governance hardening
+  - Reason: Multiple PRs were merged before full bot/comment cycle completion; we needed deterministic evidence,
+    explicit tail closure, and technical merge-blocking controls.
+  - Findings:
+    - PR #838: only post-merge Codecov report (no actionables).
+    - PR #839: post-merge cubic "No issues found" + Codecov (no actionables).
+    - PR #840: post-merge review events (no actionable inline findings to apply).
+    - PR #841: post-merge Sourcery actionable found; fixed and merged via PR #842.
+    - PR #842: held until full green + bot pass; merged only after final CI completion.
+    - PR #833 doc comment tail: no longer relevant on current `main` (already reflected in `AGENTS.md`).
+    - PR #835 doc comment tail: still relevant; addressed via docs follow-up PR #843.
+  - Links:
+    - PR #842: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/842`
+    - PR #843: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/843`
+    - PR #844: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844`
+  - DoD:
+    - ✅ Retro-audit evidence recorded for each PR in scope
+    - ✅ Missed actionable from PR #841 remediated and merged
+    - ✅ Docs tail from PR #835 moved to follow-up PR (#843)
+    - ✅ Merge-readiness process hardened with CI policy gate PR (#844)
 
 - [ ] Cross-platform Design System: define tokens + UI primitives (Web + iOS)
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -1,3 +1,5 @@
+"""Merge-readiness CI gate: fail when non-draft PR has unresolved threads or unmapped bot comments."""
+
 from __future__ import annotations
 
 import argparse
@@ -5,7 +7,6 @@ import http.client
 import json
 import os
 import re
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -36,6 +37,8 @@ MAPPING_NO_ACTIONABLE_RE = re.compile(r"(?im)^\s*-\s*No actionable review commen
 
 @dataclass
 class ActionableItem:
+    """A single bot comment/review deemed actionable (needs mapping in PR body)."""
+
     author: str
     url: str
     created_at: str
@@ -43,11 +46,13 @@ class ActionableItem:
 
 
 def _strip_fenced_code_blocks(text: str) -> str:
+    """Remove ``` and ~~~ fenced code blocks from text so regex does not match inside them."""
     no_ticks = re.sub(r"(?s)```.*?```", "", text)
     return re.sub(r"(?s)~~~.*?~~~", "", no_ticks)
 
 
 def _extract_mapping_section(pr_body: str) -> str:
+    """Return the content of the last ### Fixed in Commit Mapping section in pr_body."""
     cleaned = _strip_fenced_code_blocks(pr_body)
     matches = list(MAPPING_HEADING_RE.finditer(cleaned))
     if not matches:
@@ -59,22 +64,27 @@ def _extract_mapping_section(pr_body: str) -> str:
 
 
 def _mapped_urls(pr_body: str) -> tuple[set[str], bool]:
+    """Parse PR body mapping section; return (set of mapped comment URLs, has_no_actionable_marker)."""
     section = _extract_mapping_section(pr_body)
     urls = {m.group(1).strip() for m in MAPPING_ENTRY_RE.finditer(section)}
     return urls, bool(MAPPING_NO_ACTIONABLE_RE.search(section))
 
 
 def _is_actionable(body: str) -> bool:
+    """True if body contains an actionable marker; False if non-actionable marker or neither."""
     if not body:
         return False
+    if any(marker.lower() in body.lower() for marker in ACTIONABLE_MARKERS):
+        return True
     if any(marker.lower() in body.lower() for marker in NON_ACTIONABLE_MARKERS):
         return False
-    return any(marker.lower() in body.lower() for marker in ACTIONABLE_MARKERS)
+    return False
 
 
 def _api_request(
     url: str, token: str, method: str = "GET", payload: dict[str, Any] | None = None
 ) -> Any:
+    """Perform a single GitHub API request (REST or GraphQL); raise HTTPError on 4xx/5xx."""
     data = None
     headers = {
         "Authorization": f"Bearer {token}",
@@ -111,12 +121,17 @@ def _api_request(
 
 
 def _graphql_unresolved_threads(repo: str, pr_number: int, token: str) -> int:
+    """Return count of unresolved review threads for the PR (paginated via GraphQL)."""
     owner, name = repo.split("/", maxsplit=1)
     query = """
-    query($owner: String!, $name: String!, $number: Int!) {
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
-          reviewThreads(first: 100) {
+          reviewThreads(first: 100, after: $cursor) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               isResolved
             }
@@ -125,27 +140,61 @@ def _graphql_unresolved_threads(repo: str, pr_number: int, token: str) -> int:
       }
     }
     """
-    payload = {"query": query, "variables": {"owner": owner, "name": name, "number": pr_number}}
-    resp = _api_request(
-        "https://api.github.com/graphql", token=token, method="POST", payload=payload
-    )
-    nodes = (
-        resp.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    )
-    return sum(1 for item in nodes if item and not item.get("isResolved", False))
+    total = 0
+    cursor: str | None = None
+    while True:
+        payload = {
+            "query": query,
+            "variables": {"owner": owner, "name": name, "number": pr_number, "cursor": cursor},
+        }
+        resp = _api_request(
+            "https://api.github.com/graphql", token=token, method="POST", payload=payload
+        )
+        threads = (
+            resp.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        nodes = threads.get("nodes", [])
+        total += sum(1 for item in nodes if item and not item.get("isResolved", False))
+        page_info = threads.get("pageInfo", {})
+        if not page_info.get("hasNextPage", False):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return total
+
+
+def _api_request_paginated_list(base_url: str, token: str) -> list[Any]:
+    """Fetch all pages of a GitHub REST list endpoint (per_page=100)."""
+    out: list[Any] = []
+    page = 1
+    while True:
+        sep = "&" if "?" in base_url else "?"
+        url = f"{base_url}{sep}page={page}" if page > 1 else base_url
+        data = _api_request(url, token=token)
+        if not isinstance(data, list):
+            return out
+        out.extend(data)
+        if len(data) < 100:
+            break
+        page += 1
+    return out
 
 
 def _collect_actionable_items(repo: str, pr_number: int, token: str) -> list[ActionableItem]:
+    """Fetch all issue comments, reviews, and review comments (paginated); return actionable bot items."""
     base = f"https://api.github.com/repos/{repo}"
     encoded = urllib.parse.quote(str(pr_number), safe="")
+    comments_url = f"{base}/issues/{encoded}/comments?per_page=100"
+    reviews_url = f"{base}/pulls/{encoded}/reviews?per_page=100"
+    review_comments_url = f"{base}/pulls/{encoded}/comments?per_page=100"
 
-    issue_comments = _api_request(f"{base}/issues/{encoded}/comments?per_page=100", token=token)
-    reviews = _api_request(f"{base}/pulls/{encoded}/reviews?per_page=100", token=token)
-    review_comments = _api_request(f"{base}/pulls/{encoded}/comments?per_page=100", token=token)
+    issue_comments = _api_request_paginated_list(comments_url, token=token)
+    reviews = _api_request_paginated_list(reviews_url, token=token)
+    review_comments = _api_request_paginated_list(review_comments_url, token=token)
 
     items: list[ActionableItem] = []
 
@@ -174,13 +223,12 @@ def _collect_actionable_items(repo: str, pr_number: int, token: str) -> list[Act
                 )
             )
 
-    unique: dict[str, ActionableItem] = {}
-    for item in items:
-        unique[item.url] = item
+    unique = {item.url: item for item in items}
     return sorted(unique.values(), key=lambda it: it.created_at)
 
 
 def _extract_pr_context(event_path: Path) -> tuple[int, str, bool, str]:
+    """Read GitHub event JSON; return (pr_number, repo, is_draft, pr_body)."""
     payload = json.loads(event_path.read_text(encoding="utf-8"))
     pr = payload.get("pull_request") or {}
     number = int(pr.get("number", 0))
@@ -191,6 +239,7 @@ def _extract_pr_context(event_path: Path) -> tuple[int, str, bool, str]:
 
 
 def main() -> int:
+    """Entry point: parse args, run merge-readiness checks, exit 0 on pass and 1 on fail."""
     parser = argparse.ArgumentParser(
         description="Fail CI when non-draft PR has unresolved review threads or unmapped actionable bot comments."
     )

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ACTIONABLE_MARKERS = (
+    "Actionable comments posted",
+    "Potential issue",
+    "Prompt for AI Agents",
+    "P0:",
+    "P1:",
+    "P2:",
+    "P3:",
+)
+
+NON_ACTIONABLE_MARKERS = (
+    "No actionable comments were generated",
+    "No issues found",
+    "look great",
+)
+
+MAPPING_HEADING_RE = re.compile(r"(?im)^\s*###\s+Fixed\s+in\s+Commit\s+Mapping\s*$")
+MAPPING_ENTRY_RE = re.compile(r"(?im)^\s*-\s*`?(https?://[^\s`]+)`?\s*->\s*`?[0-9a-f]{7,40}`?\s*$")
+MAPPING_NO_ACTIONABLE_RE = re.compile(r"(?im)^\s*-\s*No actionable review comments\s*$")
+
+
+@dataclass
+class ActionableItem:
+    author: str
+    url: str
+    created_at: str
+    kind: str
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    no_ticks = re.sub(r"(?s)```.*?```", "", text)
+    return re.sub(r"(?s)~~~.*?~~~", "", no_ticks)
+
+
+def _extract_mapping_section(pr_body: str) -> str:
+    cleaned = _strip_fenced_code_blocks(pr_body)
+    matches = list(MAPPING_HEADING_RE.finditer(cleaned))
+    if not matches:
+        return ""
+    start = matches[-1].end()
+    next_h2 = re.search(r"(?im)^\s*##\s+", cleaned[start:])
+    end = start + next_h2.start() if next_h2 else len(cleaned)
+    return cleaned[start:end]
+
+
+def _mapped_urls(pr_body: str) -> tuple[set[str], bool]:
+    section = _extract_mapping_section(pr_body)
+    urls = {m.group(1).strip() for m in MAPPING_ENTRY_RE.finditer(section)}
+    return urls, bool(MAPPING_NO_ACTIONABLE_RE.search(section))
+
+
+def _is_actionable(body: str) -> bool:
+    if not body:
+        return False
+    if any(marker.lower() in body.lower() for marker in NON_ACTIONABLE_MARKERS):
+        return False
+    return any(marker.lower() in body.lower() for marker in ACTIONABLE_MARKERS)
+
+
+def _api_request(
+    url: str, token: str, method: str = "GET", payload: dict[str, Any] | None = None
+) -> Any:
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pulseplate-merge-readiness-gate",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+        raise ValueError(f"Unsupported API URL: {url}")
+
+    path = parsed.path
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+    conn.request(method=method, url=path, body=data, headers=headers)
+    response = conn.getresponse()
+    body = response.read().decode("utf-8")
+    conn.close()
+
+    if response.status >= 400:
+        raise urllib.error.HTTPError(
+            url=url,
+            code=response.status,
+            msg=response.reason,
+            hdrs=response.headers,
+            fp=None,
+        )
+    return json.loads(body)
+
+
+def _graphql_unresolved_threads(repo: str, pr_number: int, token: str) -> int:
+    owner, name = repo.split("/", maxsplit=1)
+    query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+            }
+          }
+        }
+      }
+    }
+    """
+    payload = {"query": query, "variables": {"owner": owner, "name": name, "number": pr_number}}
+    resp = _api_request(
+        "https://api.github.com/graphql", token=token, method="POST", payload=payload
+    )
+    nodes = (
+        resp.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    return sum(1 for item in nodes if item and not item.get("isResolved", False))
+
+
+def _collect_actionable_items(repo: str, pr_number: int, token: str) -> list[ActionableItem]:
+    base = f"https://api.github.com/repos/{repo}"
+    encoded = urllib.parse.quote(str(pr_number), safe="")
+
+    issue_comments = _api_request(f"{base}/issues/{encoded}/comments?per_page=100", token=token)
+    reviews = _api_request(f"{base}/pulls/{encoded}/reviews?per_page=100", token=token)
+    review_comments = _api_request(f"{base}/pulls/{encoded}/comments?per_page=100", token=token)
+
+    items: list[ActionableItem] = []
+
+    for source, kind in (
+        (issue_comments, "issue_comment"),
+        (reviews, "review"),
+        (review_comments, "review_comment"),
+    ):
+        for row in source:
+            author = str((row.get("user") or {}).get("login", ""))
+            if not author.endswith("[bot]"):
+                continue
+            body = str(row.get("body") or "")
+            if not _is_actionable(body):
+                continue
+            url = str(row.get("html_url") or "")
+            created_at = str(row.get("created_at") or row.get("submitted_at") or "")
+            if not url:
+                continue
+            items.append(
+                ActionableItem(
+                    author=author,
+                    url=url,
+                    created_at=created_at,
+                    kind=kind,
+                )
+            )
+
+    unique: dict[str, ActionableItem] = {}
+    for item in items:
+        unique[item.url] = item
+    return sorted(unique.values(), key=lambda it: it.created_at)
+
+
+def _extract_pr_context(event_path: Path) -> tuple[int, str, bool, str]:
+    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    pr = payload.get("pull_request") or {}
+    number = int(pr.get("number", 0))
+    repo = str((payload.get("repository") or {}).get("full_name", ""))
+    is_draft = bool(pr.get("draft", False))
+    body = str(pr.get("body") or "")
+    return number, repo, is_draft, body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail CI when non-draft PR has unresolved review threads or unmapped actionable bot comments."
+    )
+    parser.add_argument(
+        "--event-path",
+        required=True,
+        help="Path to GitHub event payload JSON (e.g. $GITHUB_EVENT_PATH).",
+    )
+    args = parser.parse_args()
+
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    if not token:
+        print("ERROR: GITHUB_TOKEN is required for merge-readiness gate.")
+        return 1
+
+    try:
+        pr_number, repo, is_draft, pr_body = _extract_pr_context(Path(args.event_path))
+    except Exception as exc:  # noqa: BLE001 - fail closed for CI gate script
+        print(f"ERROR: failed to parse event payload: {exc}")
+        return 1
+
+    if not pr_number or not repo:
+        print("merge-readiness-gate: no PR context found; skipping.")
+        return 0
+
+    if is_draft:
+        print("merge-readiness-gate: PR is draft; skipping strict checks.")
+        return 0
+
+    errors: list[str] = []
+
+    try:
+        unresolved_threads = _graphql_unresolved_threads(
+            repo=repo, pr_number=pr_number, token=token
+        )
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: cannot query unresolved review threads: HTTP {exc.code}")
+        return 1
+
+    if unresolved_threads > 0:
+        errors.append(
+            f"Unresolved review threads: {unresolved_threads}. Resolve all threads before merge."
+        )
+
+    try:
+        actionable_items = _collect_actionable_items(repo=repo, pr_number=pr_number, token=token)
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: cannot query bot comments/reviews: HTTP {exc.code}")
+        return 1
+
+    mapped_urls, no_actionable_marker = _mapped_urls(pr_body=pr_body)
+
+    if actionable_items:
+        if no_actionable_marker:
+            errors.append(
+                "PR body claims `No actionable review comments` but actionable bot findings were detected."
+            )
+        unmapped = [item for item in actionable_items if item.url not in mapped_urls]
+        if unmapped:
+            errors.append(
+                "Unmapped actionable bot comments found in `### Fixed in Commit Mapping` "
+                "(add `<review-comment-url> -> <commit-sha>` entries)."
+            )
+            for item in unmapped:
+                print(f"UNMAPPED: {item.author} [{item.kind}] {item.url} ({item.created_at})")
+
+    if errors:
+        print("ERROR: merge-readiness gate failed:")
+        for line in errors:
+            print(f"- {line}")
+        return 1
+
+    print("merge-readiness-gate: passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from scripts.ci.check_pr_merge_readiness import _is_actionable, _mapped_urls
+
+
+def test_is_actionable_detects_known_markers() -> None:
+    body = "Actionable comments posted: 1\nPrompt for AI Agents"
+    assert _is_actionable(body) is True
+
+
+def test_is_actionable_ignores_explicit_no_actionables() -> None:
+    body = "No actionable comments were generated in the recent review."
+    assert _is_actionable(body) is False
+
+
+def test_mapped_urls_extracts_review_url_and_no_actionable_marker() -> None:
+    pr_body = """
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+- https://github.com/acme/repo/pull/1#discussion_r1 -> abc1234
+- No actionable review comments
+"""
+    urls, has_no_actionable = _mapped_urls(pr_body)
+    assert "https://github.com/acme/repo/pull/1#discussion_r1" in urls
+    assert has_no_actionable is True


### PR DESCRIPTION
## Summary
- add CI merge-readiness gate (`scripts/ci/check_pr_merge_readiness.py`) that fails non-draft PRs when review threads are unresolved or actionable bot comments are not mapped in `### Fixed in Commit Mapping`
- wire new `Merge readiness gate` job into `.github/workflows/ci.yml` and include `ready_for_review` trigger
- harden merge policy docs and templates: update `AGENTS.md`, `RUNBOOK_AGENT.md`, and `.github/pull_request_template.md` with mandatory merge checklist/wait-window guidance
- add unit tests for merge-readiness parser logic in `tests/test_pr_merge_readiness_gate.py`
- record retro-audit outcomes and closure links in `docs/roadmap/BACKLOG_LEDGER.md` (PR #838-#842 window)

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest -q tests/test_pr_merge_readiness_gate.py`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835948974 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835948975 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835950397 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835950399 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835950400 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#discussion_r2835950402 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#pullrequestreview-3835274226 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#pullrequestreview-3835280157 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#pullrequestreview-3835288044 -> 19c0c956
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/844#pullrequestreview-3835302001 -> 19c0c956

## Merge Readiness (Mandatory)
- [x] PR is non-draft only when truly ready for merge
- [x] All required checks are green on latest commit (no pending/rerun required)
- [x] No unresolved review threads
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups
- [x] Ledger item(s): updated in this PR (`docs/roadmap/BACKLOG_LEDGER.md`)
- [x] GitHub issue(s): None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mandatory "Merge Readiness" checklist to PRs and a CI gate that enforces merge readiness (checks for draft status, unresolved review threads, actionable bot comments mapping, and wait-window), and runs for ready_for_review events.

* **Documentation**
  * Updated docs and runbooks with merge readiness policy, required PR body sections, and mandatory wait-window guidance.

* **Tests**
  * Added unit tests covering merge-readiness detection and mapping logic.

* **Chores**
  * Updated CI secret baseline/timestamp reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
