### PR TITLE
docs(analytics): P0 Growth telemetry canon Phase 1 — funnel, taxonomy, dashboard baseline

### DIFF
--- a/.github/pr_body_p0_growth_telemetry.md
+++ b/.github/pr_body_p0_growth_telemetry.md
@@ -1,0 +1,68 @@
+<!-- markdownlint-disable MD013 MD033 -->
+
+# Pull Request
+
+## Summary
+
+P0 Growth telemetry canon — Phase 1 (docs only): core funnel semantics, event taxonomy, new metrics (Soft paywall view rate, Trial start rate, Retention D7), and dashboard baseline requirements. No code changes; Phase 2 (eventRegistry.ts alignment) after PR #825 merge.
+
+- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
+- [x] Select one change type:
+  - [ ] Bug fix
+  - [ ] Feature
+  - [ ] Refactor
+  - [x] Docs
+- [x] Linked: BACKLOG_LEDGER P0 Growth telemetry canon and KPI dashboard baseline (lines 106–123)
+
+## Risk & Impact
+
+- [ ] User-facing change
+- [ ] Data model/migration
+- [ ] Security-sensitive
+- [ ] Performance-sensitive
+
+## Test Plan
+
+- [x] Existing analytics docs guards pass: `pytest tests/test_analytics_docs_guards.py`
+- [x] Manual: verify ANALYTICS_INDEX, METRICS_CATALOG, DASHBOARD_BASELINE_REQUIREMENTS structure and links
+
+## CI Gates
+
+- [ ] PR tests green (lint, type, unit)
+- [ ] Diff coverage ≥ 97% on changed lines (docs-only: no code lines in diff)
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness (Mandatory)
+
+- [ ] PR is non-draft only when truly ready for merge
+- [ ] All required checks are green on latest commit
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped
+- [ ] Wait-window completed after latest bot/review activity
+
+## Deferred / Follow-ups
+
+- [x] Ledger: [P0 Growth telemetry canon](docs/roadmap/BACKLOG_LEDGER.md) — Phase 2 (anchor event taxonomy in `frontend/src/lib/telemetry/eventRegistry.ts`) after PR #825 merge.
+- [ ] GitHub issue(s): —
+
+## Notes
+
+### For Simple Changes
+
+- [x] No database/schema/migration changes
+- [x] No public API contract changes
+- [x] Covered by existing tests (analytics docs guards)
+- [x] Docs-only (ANALYTICS_INDEX, METRICS_CATALOG, README, new DASHBOARD_BASELINE_REQUIREMENTS)
+- [x] No performance or security impact
+
+Rollback: revert commit; no feature flag.
+
+<!-- markdownlint-enable MD013 MD033 -->

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -131,6 +131,11 @@ Run before merge after latest commit and latest bot/review activity:
    - `## Merge Readiness`
 5. CI `Merge readiness gate` must be green on latest PR commit.
 
+**Phase2 PR body gates (CI):** To pass `check_pr_body_phase2_gates.py` and merge-readiness:
+- In PR description, under **Discussion Thread Pass**: check `[x] Discussion-thread pass completed` and `[x] Fixed in commit mapping completed`.
+- Under **### Fixed in Commit Mapping**: either list each bot comment as `- <comment-url> -> <commit-sha>`, or use exactly (no extra text): `- No actionable review comments`.
+- Local check (no API): `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"` (use the same body as on the PR).
+
 ## Agent Control Plane Security Ops (Wave 1 baseline)
 
 Use this checklist when operating agent automation or closing a token/secrets incident.

--- a/docs/analytics/ANALYTICS_INDEX.md
+++ b/docs/analytics/ANALYTICS_INDEX.md
@@ -6,6 +6,21 @@
 
 ---
 
+## Core funnel semantics
+
+Canonical funnel: **onboarding → paywall → conversion → retention**.
+
+| Stage | Owner | Update cadence | SoT |
+|-------|-------|-----------------|-----|
+| Onboarding | Product + Growth | Daily | `METRICS_CATALOG.md` (Onboarding completion rate) |
+| Paywall | Growth | Daily | `METRICS_CATALOG.md` (Soft paywall view rate, Trial start rate) |
+| Conversion | Growth + Finance | Daily | `METRICS_CATALOG.md` (Trial → Paid conversion) |
+| Retention | Product + Data | Daily / Weekly | `METRICS_CATALOG.md` (Retention D7, Retention D30) |
+
+Event taxonomy (names, required fields): `METRICS_CATALOG.md` → "Event taxonomy (growth funnel)".
+
+---
+
 ## Tracked Metrics
 
 | Metric | Definition (short) | Owner | Source of truth | Update frequency |
@@ -42,6 +57,8 @@ Notes:
 | Funnel dashboard | Vendor-agnostic BI | Product + Growth | Daily | onboarding -> paywall -> trial -> paid |
 | Retention dashboard | Vendor-agnostic BI | Product + Data | Daily | D1/D7/D30 by cohort |
 | Cost dashboard | Vendor-agnostic BI | Platform + Finance | Daily | LLM/API spend anomalies |
+
+Dashboard baseline requirements (goals, segments, data sources, KPI): `DASHBOARD_BASELINE_REQUIREMENTS.md`.
 
 ## Event Taxonomy Anchor (Wave 1)
 

--- a/docs/analytics/DASHBOARD_BASELINE_REQUIREMENTS.md
+++ b/docs/analytics/DASHBOARD_BASELINE_REQUIREMENTS.md
@@ -1,0 +1,60 @@
+# Dashboard Baseline Requirements (Wave 1)
+
+**Purpose:** Define baseline requirements for Wave 1 analytics dashboards so that goals, segments, data sources, and KPI are explicit and reviewable.
+
+**Status:** Canonical (docs-only). Vendor-agnostic.
+
+**Related:** `ANALYTICS_INDEX.md` (dashboard list), `METRICS_CATALOG.md` (metric definitions).
+
+---
+
+## Goals
+
+1. **Funnel visibility** — Product and Growth can monitor onboarding → paywall → trial → paid conversion in one place.
+2. **Retention visibility** — Product and Data can monitor D1/D7/D30 retention by cohort.
+3. **Cost visibility** — Platform and Finance can monitor LLM/API spend and cost per active user.
+
+---
+
+## Segments and dimensions
+
+| Segment / dimension | Use case | SoT / notes |
+|--------------------|----------|-------------|
+| Tier (FREE / PRO / VIP) | Funnel and retention by tier | Backend `app/middleware/api_tiers.py` |
+| Cohort (activation date) | Retention by cohort | First success / activation date |
+| Placement (paywall placement id) | Paywall performance by placement | Event property `placement` |
+| Source (entry point) | Attribution (onboarding, paywall, CTA) | Event property `source` |
+
+---
+
+## Data sources
+
+| Dashboard | Primary data | Secondary / derived |
+|-----------|--------------|----------------------|
+| Funnel | Client events (onboarding_*, paywall_*, trial_started), Billing (trial/paid) | Primary DB (users, subscriptions) for eligibility |
+| Retention | Client events (retention_heartbeat, activation), Primary DB (cohort definition) | — |
+| Cost | Platform spend (LLM/API), Primary DB or usage logs (active users) | — |
+
+Schema and field semantics: `DATA_CATALOG.md`. Event taxonomy: `METRICS_CATALOG.md` → "Event taxonomy (growth funnel)".
+
+---
+
+## KPI and update frequency
+
+| KPI | Owner | Update frequency | Definition |
+|-----|-------|------------------|------------|
+| Onboarding completion rate | Product + Growth | Daily | `METRICS_CATALOG.md` |
+| Activation (first_success) | Product + Data | Daily | `METRICS_CATALOG.md` |
+| Soft paywall view rate | Growth | Daily | `METRICS_CATALOG.md` |
+| Trial start rate | Growth | Daily | `METRICS_CATALOG.md` |
+| Trial → Paid conversion | Growth + Finance | Daily | `METRICS_CATALOG.md` |
+| Retention D7 | Product + Data | Daily | `METRICS_CATALOG.md` |
+| Retention D30 | Product + Data | Weekly | `METRICS_CATALOG.md` |
+| LLM cost per active user | Platform + Finance | Daily | `METRICS_CATALOG.md` |
+
+---
+
+## Guardrails and rollback
+
+- Dashboards must not expose raw PII (user_id only in trusted contexts; anonymize in exports).
+- Experiment guardrails (retention, churn, cost) are defined per experiment in `EXPERIMENT_REGISTRY.md`; dashboard alerts may reference those guardrail metrics for active experiments.

--- a/docs/analytics/DASHBOARD_BASELINE_REQUIREMENTS.md
+++ b/docs/analytics/DASHBOARD_BASELINE_REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Dashboard Baseline Requirements (Wave 1)
 
-**Purpose:** Define baseline requirements for Wave 1 analytics dashboards so that goals, segments, data sources, and KPI are explicit and reviewable.
+**Purpose:** Define baseline requirements for Wave 1 analytics dashboards so that goals, segments, data sources, and KPIs are explicit and reviewable.
 
 **Status:** Canonical (docs-only). Vendor-agnostic.
 

--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -170,3 +170,128 @@ Daily
 #### Change history
 
 - 2026-02-20: initial Wave 1 definition
+
+---
+
+## Soft paywall view rate
+
+#### Definition
+
+Percent of active users (within attribution window) who see the soft paywall trigger at least once.
+
+#### Formula
+
+```text
+soft_paywall_view_rate =
+  users_who_saw_soft_paywall / active_users_window
+```
+
+#### Owner
+
+Growth
+
+#### Update frequency
+
+Daily
+
+#### Change history
+
+- 2026-02-21: initial Wave 1 definition (P0 Growth telemetry canon)
+
+---
+
+## Trial start rate
+
+#### Definition
+
+Percent of users eligible for trial (e.g. saw paywall, not already subscribed) who start a trial within the attribution window.
+
+#### Formula
+
+```text
+trial_start_rate =
+  users_started_trial / users_eligible_for_trial
+```
+
+#### Owner
+
+Growth
+
+#### Update frequency
+
+Daily
+
+#### Change history
+
+- 2026-02-21: initial Wave 1 definition (P0 Growth telemetry canon)
+
+---
+
+## Retention D7
+
+#### Definition
+
+Percent of activated users who are active on day 7 after activation.
+
+#### Formula
+
+```text
+retention_d7 =
+  activated_users_active_on_day_7 / activated_users
+```
+
+#### Owner
+
+Product + Data
+
+#### Update frequency
+
+Daily
+
+#### Change history
+
+- 2026-02-21: initial Wave 1 definition (P0 Growth telemetry canon)
+
+---
+
+## Event taxonomy (growth funnel)
+
+Canonical event families and payload contracts for the growth funnel (onboarding → paywall → conversion → retention). Runtime implementation: `frontend/src/lib/telemetry/eventRegistry.ts`. This section is the doc SoT for semantics; code must stay aligned.
+
+### Funnel stages and owners
+
+| Stage | Owner | Cadence | Key events |
+|-------|-------|---------|------------|
+| Onboarding | Product + Growth | Daily | onboarding_started, onboarding_completed |
+| Paywall | Growth | Daily | paywall_viewed, paywall_cta_clicked, vip_paywall_* |
+| Conversion (trial) | Growth + Finance | Daily | trial_started |
+| Retention | Product + Data | Daily / Weekly | retention_heartbeat (d1/d7/d30) |
+
+### Growth funnel events (required fields)
+
+| Event | Required fields | Context |
+|-------|------------------|---------|
+| onboarding_started | source, variant | First-run entry |
+| onboarding_completed | source; optional: durationSec | Completion within session |
+| paywall_viewed | source, placement, tierContext (free/pro/vip) | Soft/hard paywall impression |
+| paywall_cta_clicked | source, ctaId, tierContext | CTA click for upgrade/trial |
+| trial_started | source, planType | User started trial |
+| retention_heartbeat | dayBucket (d1/d7/d30), source | Cohort activity signal |
+
+### VIP / paywall UX events (required fields)
+
+| Event | Required fields | Context |
+|-------|------------------|---------|
+| vip_module_viewed | source, vipEnabled | VIP module impression |
+| vip_feature_clicked | featureName, source, isVip | Feature click behind gate |
+| vip_paywall_viewed | source, context; optional: isRetry | VIP paywall view |
+| vip_paywall_dismissed | source, dismissMethod; optional: viewDuration | Dismiss without converting |
+| vip_upgrade_clicked | source, context; optional: isRetry | Upgrade CTA click |
+| vip_gate_interacted | featureName, interactionType, isVip | Gate interaction |
+| vip_badge_viewed | component, variant, isVip | Badge/upsell component view |
+
+### Base payload (optional on all events)
+
+- timestamp (number)
+- sessionId (string)
+- featureFlags (Record<string, boolean>)

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -14,9 +14,10 @@ Integrations and runtime telemetry changes must land in separate runtime PRs wit
 ## Files (canonical surfaces)
 
 - `ANALYTICS_INDEX.md` — catalog of metrics / dashboards / data sources (high-level, “what exists”)
-- `METRICS_CATALOG.md` — formal metric definitions (SoT for semantics)
+- `METRICS_CATALOG.md` — formal metric definitions and event taxonomy (SoT for semantics)
 - `DATA_CATALOG.md` — data source and schema semantics (SoT for fields/meaning)
 - `EXPERIMENT_REGISTRY.md` — active + completed experiments and decisions
+- `DASHBOARD_BASELINE_REQUIREMENTS.md` — Wave 1 dashboard goals, segments, data sources, KPI
 
 ---
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -98,8 +98,8 @@ If it is not recorded here — it does not exist.
 - [ ] P0: Growth telemetry canon and KPI dashboard baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-GROWTH-TELEMETRY-CANON
-  - Status: Planned (Wave 1 / 0-30 days)
+  - Target PR: PR #845 (Phase 1); Phase 2 (eventRegistry.ts) after PR #825 merge
+  - Status: In progress (Phase 1 in PR #845; Phase 2 deferred)
   - Area: analytics / frontend / growth
   - Finding Type: product optimization
   - Locations:
@@ -109,10 +109,11 @@ If it is not recorded here — it does not exist.
   - Reason: establish canonical funnel semantics and events for onboarding -> paywall -> conversion -> retention.
   - Links:
     - `docs/analytics/EXPERIMENT_REGISTRY.md`
+    - [PR #845](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/845) (Phase 1 docs)
   - DoD:
-    - Core funnel metrics defined with owner and update cadence
-    - Event taxonomy anchored in docs and frontend registry
-    - Dashboard baseline requirements documented
+    - Core funnel metrics defined with owner and update cadence (Phase 1 in PR #845)
+    - Event taxonomy anchored in docs and frontend registry (docs in PR #845; frontend in Phase 2)
+    - Dashboard baseline requirements documented (Phase 1 in PR #845)
 
 - [x] P0: Import determinism for app-level tests (remove skip fallback)
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

P0 Growth telemetry canon — Phase 1 (docs only): core funnel semantics, event taxonomy, new metrics (Soft paywall view rate, Trial start rate, Retention D7), and dashboard baseline requirements. No code changes; Phase 2 (eventRegistry.ts alignment) after PR #825 merge.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
- [x] Linked: BACKLOG_LEDGER P0 Growth telemetry canon and KPI dashboard baseline (lines 106–123)

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Existing analytics docs guards pass: `pytest tests/test_analytics_docs_guards.py`
- [x] Manual: verify ANALYTICS_INDEX, METRICS_CATALOG, DASHBOARD_BASELINE_REQUIREMENTS structure and links

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines (docs-only: no code lines in diff)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/845#discussion_r2836020008 -> 11e7f8ad4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/845#pullrequestreview-3835428698 -> 11e7f8ad4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/845#pullrequestreview-3835432388 -> 11e7f8ad4

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Wait-window completed after latest bot/review activity

## Deferred / Follow-ups

- [x] Ledger: [P0 Growth telemetry canon](docs/roadmap/BACKLOG_LEDGER.md) — Phase 2 (anchor event taxonomy in `frontend/src/lib/telemetry/eventRegistry.ts`) after PR #825 merge.
- [ ] GitHub issue(s): —

## Notes

### For Simple Changes

- [x] No database/schema/migration changes
- [x] No public API contract changes
- [x] Covered by existing tests (analytics docs guards)
- [x] Docs-only (ANALYTICS_INDEX, METRICS_CATALOG, README, new DASHBOARD_BASELINE_REQUIREMENTS)
- [x] No performance or security impact

Rollback: revert commit; no feature flag.

<!-- markdownlint-enable MD013 MD033 -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: Phase 1 of the Growth telemetry canon with core funnel semantics, event taxonomy, three new metrics, and dashboard baseline. Adds PR body template and runbook/backlog updates; runtime alignment lands in Phase 2.

- New Features
  - Core funnel semantics in ANALYTICS_INDEX
  - Event taxonomy (including VIP/paywall events) in METRICS_CATALOG
  - New metrics: Soft paywall view rate, Trial start rate, Retention D7
  - New DASHBOARD_BASELINE_REQUIREMENTS (goals, segments, data sources, KPIs)
  - README updated to reference new docs
  - BACKLOG_LEDGER linked to PR #845 and status updated; RUNBOOK_AGENT adds Phase 2 PR body gates; PR body template added

- Bug Fixes
  - Grammar: “KPI” -> “KPIs” in DASHBOARD_BASELINE_REQUIREMENTS

<sup>Written for commit 2d4d36cf665761642fa3d44387447363d1dc7e0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced analytics docs with core funnel semantics, a canonical funnel definition and 4-stage model (Onboarding, Paywall, Conversion, Retention)
  * Added Wave 1 dashboard baseline requirements: KPIs, segments/dimensions, data sources, guardrails, and review guidance
  * Expanded metrics catalog with new metrics (Soft paywall view rate, Trial start rate, Retention D7) and a growth event taxonomy
  * Updated README, runbook guidance, and backlog entry to reflect Phase 1 status and next steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
