### PR TITLE
docs(ledger): close P0 Growth telemetry Phase 1 (PR #845 merged)

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -95,11 +95,11 @@ If it is not recorded here — it does not exist.
     - Security release gate conditions documented
     - Mandatory controls mapped to owner and verification evidence
 
-- [ ] P0: Growth telemetry canon and KPI dashboard baseline
+- [x] P0: Growth telemetry canon and KPI dashboard baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR #845 (Phase 1); Phase 2 (eventRegistry.ts) after PR #825 merge
-  - Status: In progress (Phase 1 in PR #845; Phase 2 deferred)
+  - Target PR: PR #845 (Phase 1 merged); Phase 2 (eventRegistry.ts) after PR #825 merge
+  - Status: Phase 1 ✅ Merged (PR #845, 2026-02-21); Phase 2 deferred
   - Area: analytics / frontend / growth
   - Finding Type: product optimization
   - Locations:


### PR DESCRIPTION
## Summary

Docs-only follow-up per AGENTS.md Backlog Ledger Policy: mark P0 Growth telemetry Phase 1 as closed after PR #845 merge.

- **File:** `docs/roadmap/BACKLOG_LEDGER.md`
- **Change:** Checkbox [x], Status «Phase 1 ✅ Merged (PR #845, 2026-02-21); Phase 2 deferred», Target PR text updated.
- **No code/runtime/CI changes.**

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/847#pullrequestreview-3835471744 -> 1e5d3a5850effd2cbbea5dd5f672b1448bffb7ab

## Merge Readiness
- [x] All required checks green
- [x] No unresolved threads

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить журнал бэклога, чтобы отметить выполнение пункта P0 Growth telemetry Phase 1 и зафиксировать его статус слияния и подробности целевого PR.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the backlog ledger to check off the P0 Growth telemetry Phase 1 item and record its merged status and target PR details.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark P0 Growth telemetry Phase 1 as complete in docs/roadmap/BACKLOG_LEDGER.md after PR #845 merged. Checkbox checked, status updated with merge date, and target PR text adjusted; no code, runtime, or CI changes.

<sup>Written for commit 1e5d3a5850effd2cbbea5dd5f672b1448bffb7ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project tracking documentation to reflect Phase 1 completion status of the telemetry baseline initiative, including merged state and timestamp; Phase 2 remains deferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->