### PR TITLE
feat(tests): audit and enable feature keys — 2 modules enabled, 22 ad-hoc skips migrated

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1270,7 +1270,7 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-748
-  - Status: 📋 Planned (seeded by PR-747 protocol cleanup)
+  - Status: 🔄 In progress (PR-748 audit pass: 2 keys enabled, 22 ad-hoc skips migrated)
   - Area: backend / tests / feature debt management
   - Finding Type: product feature debt / runtime skip protocol
   - Reason for deferral: Runtime skip reasons are now standardized via
@@ -1288,7 +1288,17 @@ If it is not recorded here — it does not exist.
     - Runtime `feature_disabled:<key>` skip count decreases as features land.
     - Ledger item is updated with merged PR references per implemented key.
   - Implemented keys (latest):
-    - `shoplist_helpers` -> ✅ Merged (PR-764, 2026-02-16, `48c87f39`)
+    - `shoplist_helpers` -> ✅ Merged (PR-764, 2026-02-16, `48c87f39`); gate removed in PR-748
+    - `aliases_module` -> ✅ Enabled (PR-748); core/aliases.py fully implemented
+  - Keys still gated (module exists but tested API surface incomplete):
+    - `utils_pack`: core/utils.py exists but safe_float/safe_int/slugify not implemented
+    - `weekly_plan_helpers`: core/weekly_plan.py exists but calculate_weekly_nutrition/optimize_weekly_variety/validate_weekly_plan not implemented
+    - `core_db`: core/db.py exists but get_db not exported
+    - `food_apis`: core/food_apis/ exists but search_food/get_food_details not implemented
+    - `unified_db`: core/food_apis/unified_db.py exists but import chain issues
+  - Ad-hoc skip migration (PR-748):
+    - 22 ad-hoc pytest.skip() calls migrated to require_feature() in 3 test files
+    - 2 new feature keys added: `plate_day_micros`, `aliases_module` (then enabled)
 
 - [x] HPP Web visual workflow: Storybook bootstrap + first tokenized stories
   - Owner: @katsiaryna_kavaleuskaya

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -65,7 +65,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "targets_fixture_data",
         "utils_pack",
         "weekly_plan_helpers",
-        "shoplist_helpers",
         "exports_recipes_products",
         "sports_disclaimers_lifestage",
         "legacy_bmi_removed",

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -52,7 +52,6 @@ class FeatureManifest:
 # Canonical feature TODO keys (must match BACKLOG_LEDGER item; one-to-one mapping).
 FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
     {
-        "aliases_module",
         "core_db",
         "food_apis",
         "food_apis_error_injection",

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -52,11 +52,13 @@ class FeatureManifest:
 # Canonical feature TODO keys (must match BACKLOG_LEDGER item; one-to-one mapping).
 FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
     {
+        "aliases_module",
         "core_db",
         "food_apis",
         "food_apis_error_injection",
         "unified_db",
         "planner_engines",
+        "plate_day_micros",
         "premium_week_router_mocking",
         "i18n_advanced",
         "rag",

--- a/tests/test_plate_targets_micro_coverage.py
+++ b/tests/test_plate_targets_micro_coverage.py
@@ -10,6 +10,7 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.feature_manifest import FEATURE_REASON, require_feature
 from tests.test_helpers import skip_if_no_plate_micros
 
 try:
@@ -108,8 +109,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            # day_micros not implemented yet - skip this test
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check that plate micronutrients meet minimum thresholds
         target_micros = targets_data["priority_micros"]
@@ -151,7 +151,7 @@ class TestPlateTargetsMicroCoverage:
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
             # day_micros not implemented yet - skip this test
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check iron coverage
         target_iron = targets_data["priority_micros"].get("iron_mg", 0)
@@ -184,7 +184,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check calcium coverage
         target_calcium = targets_data["priority_micros"].get("calcium_mg", 0)
@@ -217,7 +217,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check magnesium coverage
         target_magnesium = targets_data["priority_micros"].get("magnesium_mg", 0)
@@ -250,7 +250,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check potassium coverage
         target_potassium = targets_data["priority_micros"].get("potassium_mg", 0)
@@ -283,7 +283,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check vitamin D coverage
         target_vitd = targets_data["priority_micros"].get("vitamin_d_iu", 0)
@@ -316,7 +316,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check B12 coverage
         target_b12 = targets_data["priority_micros"].get("b12_ug", 0)
@@ -349,7 +349,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check folate coverage
         target_folate = targets_data["priority_micros"].get("folate_ug", 0)
@@ -382,7 +382,7 @@ class TestPlateTargetsMicroCoverage:
 
         # Check if day_micros is implemented
         if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-            pytest.skip("day_micros not implemented in plate endpoint yet")
+            require_feature("plate_day_micros", reason=FEATURE_REASON)
 
         # Check iodine coverage
         target_iodine = targets_data["priority_micros"].get("iodine_ug", 0)
@@ -430,7 +430,7 @@ class TestPlateTargetsMicroCoverage:
 
             # Check if day_micros is implemented
             if "day_micros" not in plate_data or plate_data["day_micros"] is None:
-                pytest.skip("day_micros not implemented in plate endpoint yet")
+                require_feature("plate_day_micros", reason=FEATURE_REASON)
 
             # Verify micronutrient keys are consistent
             target_micros = set(targets_data["priority_micros"].keys())

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -20,77 +20,65 @@ class TestShoplistModule:
 
     def test_packaging_rule_class(self):
         """Test PackagingRule dataclass."""
-        try:
-            from core.shoplist import PackagingRule
+        from core.shoplist import PackagingRule
 
-            # Test creating packaging rule
-            rule = PackagingRule(
-                category="grains",
-                unit="g",
-                typical_packages=[100, 250, 500, 1000],
-                rounding_strategy="up",
-            )
+        # Test creating packaging rule
+        rule = PackagingRule(
+            category="grains",
+            unit="g",
+            typical_packages=[100, 250, 500, 1000],
+            rounding_strategy="up",
+        )
 
-            assert rule.category == "grains"
-            assert rule.unit == "g"
-            assert rule.typical_packages == [100, 250, 500, 1000]
-            assert rule.rounding_strategy == "up"
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
+        assert rule.category == "grains"
+        assert rule.unit == "g"
+        assert rule.typical_packages == [100, 250, 500, 1000]
+        assert rule.rounding_strategy == "up"
 
     def test_shopping_item_class(self):
         """Test ShoppingItem dataclass."""
-        try:
-            from core.shoplist import ShoppingItem
+        from core.shoplist import ShoppingItem
 
-            # Test creating shopping item
-            item = ShoppingItem(name="chicken breast", quantity=500.0, unit="g", category="meat")
+        # Test creating shopping item
+        item = ShoppingItem(name="chicken breast", quantity=500.0, unit="g", category="meat")
 
-            assert item.name == "chicken breast"
-            assert item.quantity == 500.0
-            assert item.unit == "g"
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
+        assert item.name == "chicken breast"
+        assert item.quantity == 500.0
+        assert item.unit == "g"
 
     def test_shoplist_functions(self):
         """Test shoplist utility functions."""
-        try:
-            from core.shoplist import (
-                create_shopping_list,
-                group_by_category,
-                optimize_packaging,
-            )
+        from core.shoplist import (
+            create_shopping_list,
+            group_by_category,
+            optimize_packaging,
+        )
 
-            # Test with mock meal plan
-            meal_plan = {
-                "day1": {
-                    "breakfast": [{"name": "oats", "amount": 50, "unit": "g"}],
-                    "lunch": [{"name": "chicken", "amount": 150, "unit": "g"}],
-                    "dinner": [{"name": "rice", "amount": 100, "unit": "g"}],
-                }
+        # Test with mock meal plan
+        meal_plan = {
+            "day1": {
+                "breakfast": [{"name": "oats", "amount": 50, "unit": "g"}],
+                "lunch": [{"name": "chicken", "amount": 150, "unit": "g"}],
+                "dinner": [{"name": "rice", "amount": 100, "unit": "g"}],
             }
+        }
 
-            # Test shopping list creation
-            shopping_list = create_shopping_list(meal_plan)
-            assert isinstance(shopping_list, (list, dict, type(None)))
+        # Test shopping list creation
+        shopping_list = create_shopping_list(meal_plan)
+        assert isinstance(shopping_list, (list, dict, type(None)))
 
-            # Test packaging optimization
-            items = [
-                {"name": "flour", "quantity": 350, "unit": "g"},
-                {"name": "sugar", "quantity": 150, "unit": "g"},
-            ]
+        # Test packaging optimization
+        items = [
+            {"name": "flour", "quantity": 350, "unit": "g"},
+            {"name": "sugar", "quantity": 150, "unit": "g"},
+        ]
 
-            optimized = optimize_packaging(items)
-            assert isinstance(optimized, (list, dict, type(None)))
+        optimized = optimize_packaging(items)
+        assert isinstance(optimized, (list, dict, type(None)))
 
-            # Test category grouping
-            grouped = group_by_category(items)
-            assert isinstance(grouped, (dict, type(None)))
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "shoplist_helpers", reason=FEATURE_REASON)
+        # Test category grouping
+        grouped = group_by_category(items)
+        assert isinstance(grouped, (dict, type(None)))
 
 
 class TestWeeklyPlanModule:

--- a/tests/test_simple_coverage_fixed.py
+++ b/tests/test_simple_coverage_fixed.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
+
 
 class TestSimpleCoverageBoost:
     """Простые тесты для увеличения покрытия модулей"""
@@ -63,8 +65,8 @@ class TestSimpleCoverageBoost:
             )
             assert coverage.nutrient_name == "protein"
 
-        except ImportError:
-            pytest.skip("targets module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "targets_fixture_data", reason=FEATURE_REASON)
 
     def test_i18n_module_coverage(self):
         """Покрытие core/i18n.py (83% -> 95%+)"""
@@ -102,8 +104,8 @@ class TestSimpleCoverageBoost:
                 normalized = i18n_module.normalize_lang(None)
                 assert normalized in ["en", "ru", "es"]
 
-        except ImportError:
-            pytest.skip("i18n module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "i18n_advanced", reason=FEATURE_REASON)
 
     def test_rag_simple_module_coverage(self):
         """Покрытие core/rag/simple_rag.py (77% -> 90%+)"""
@@ -182,8 +184,8 @@ class TestSimpleCoverageBoost:
                 index = rag_module._get_index()
                 assert isinstance(index, list)
 
-        except ImportError:
-            pytest.skip("rag.simple_rag module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "rag", reason=FEATURE_REASON)
 
     def test_food_sources_coverage(self):
         """Покрытие core/food_sources/ модулей"""
@@ -251,8 +253,8 @@ class TestSimpleCoverageBoost:
             if hasattr(base_module, "FoodRecord"):
                 assert base_module.FoodRecord is not None
 
-        except ImportError:
-            pytest.skip("food_sources modules not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)
 
     def test_other_core_modules(self):
         """Покрытие остальных core модулей"""
@@ -466,8 +468,8 @@ class TestSimpleCoverageBoost:
 
             assert region_catalog_module is not None
 
-        except ImportError:
-            pytest.skip("Some core modules not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     @pytest.mark.asyncio
     async def test_unified_db_module_coverage(self) -> None:
@@ -489,8 +491,8 @@ class TestSimpleCoverageBoost:
                 result = await unified_db_module.get_unified_food_db()
                 assert result is mock_db
 
-        except ImportError:
-            pytest.skip("unified_db module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "unified_db", reason=FEATURE_REASON)
 
     def test_update_manager_module_coverage(self):
         """Покрытие core/food_apis/update_manager.py (95% -> 97%+)"""
@@ -504,5 +506,5 @@ class TestSimpleCoverageBoost:
             manager = update_manager_module.DatabaseUpdateManager(update_interval_hours=1)
             assert manager is not None
 
-        except ImportError:
-            pytest.skip("update_manager module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "food_apis", reason=FEATURE_REASON)

--- a/tests/test_specific_core_modules.py
+++ b/tests/test_specific_core_modules.py
@@ -38,7 +38,7 @@ class TestAliasesModule:
         with patch("builtins.open", mock_open(read_data=csv_content)):
             result = _load_aliases("mock_path.csv")
             assert isinstance(result, dict)
-            assert "apple" in result or len(result) >= 0
+            assert "apple" in result
 
     def test_map_to_canonical(self):
         """Test canonical name mapping."""
@@ -82,7 +82,7 @@ class TestAliasesModule:
 
             with open(temp_path, "r") as f:
                 content = f.read()
-                assert "test_alias" in content or len(content) >= 0
+                assert "test_alias" in content
 
         finally:
             if os.path.exists(temp_path):

--- a/tests/test_specific_core_modules.py
+++ b/tests/test_specific_core_modules.py
@@ -21,88 +21,72 @@ class TestAliasesModule:
 
     def test_aliases_load_empty(self):
         """Test loading aliases with non-existent file."""
-        try:
-            from core.aliases import _load_aliases
+        from core.aliases import _load_aliases
 
-            # Test with non-existent file
-            result = _load_aliases("/non/existent/path.csv")
-            assert isinstance(result, dict)
-            assert len(result) == 0
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
+        # Test with non-existent file
+        result = _load_aliases("/non/existent/path.csv")
+        assert isinstance(result, dict)
+        assert len(result) == 0
 
     def test_aliases_load_with_data(self):
         """Test loading aliases with mock CSV data."""
-        try:
-            from core.aliases import _load_aliases
+        from core.aliases import _load_aliases
 
-            # Mock CSV data
-            csv_content = "alias,canonical\napple,fruit_apple\nbanana,fruit_banana\n"
+        # Mock CSV data
+        csv_content = "alias,canonical\napple,fruit_apple\nbanana,fruit_banana\n"
 
-            with patch("builtins.open", mock_open(read_data=csv_content)):
-                result = _load_aliases("mock_path.csv")
-                assert isinstance(result, dict)
-                assert "apple" in result or len(result) >= 0
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
+        with patch("builtins.open", mock_open(read_data=csv_content)):
+            result = _load_aliases("mock_path.csv")
+            assert isinstance(result, dict)
+            assert "apple" in result or len(result) >= 0
 
     def test_map_to_canonical(self):
         """Test canonical name mapping."""
-        try:
-            from core.aliases import map_to_canonical
+        from core.aliases import map_to_canonical
 
-            # Test empty input
-            result = map_to_canonical("")
-            assert result == "unknown"
+        # Test empty input
+        result = map_to_canonical("")
+        assert result == "unknown"
 
-            # Test None input
-            result = map_to_canonical(cast(Any, None))
-            assert result == "unknown"
+        # Test None input
+        result = map_to_canonical(cast(Any, None))
+        assert result == "unknown"
 
-            # Test normal input
-            result = map_to_canonical("Apple Fruit")
-            assert isinstance(result, str)
-            assert len(result) > 0
+        # Test normal input
+        result = map_to_canonical("Apple Fruit")
+        assert isinstance(result, str)
+        assert len(result) > 0
 
-            # Test special characters
-            result = map_to_canonical("Apple & Banana!")
-            assert isinstance(result, str)
+        # Test special characters
+        result = map_to_canonical("Apple & Banana!")
+        assert isinstance(result, str)
 
-            # Test spaces and hyphens
-            result = map_to_canonical("Green-Apple Fruit")
-            assert isinstance(result, str)
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
+        # Test spaces and hyphens
+        result = map_to_canonical("Green-Apple Fruit")
+        assert isinstance(result, str)
 
     def test_add_alias(self):
         """Test adding new aliases."""
+        from core.aliases import add_alias
+
+        # Test with temporary file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            temp_path = f.name
+
         try:
-            from core.aliases import add_alias
+            # Add alias to new file
+            add_alias("test_alias", "test_canonical", temp_path)
 
-            # Test with temporary file
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-                temp_path = f.name
+            # Verify file was created and contains data
+            assert os.path.exists(temp_path)
 
-            try:
-                # Add alias to new file
-                add_alias("test_alias", "test_canonical", temp_path)
+            with open(temp_path, "r") as f:
+                content = f.read()
+                assert "test_alias" in content or len(content) >= 0
 
-                # Verify file was created and contains data
-                assert os.path.exists(temp_path)
-
-                with open(temp_path, "r") as f:
-                    content = f.read()
-                    assert "test_alias" in content or len(content) >= 0
-
-            finally:
-                if os.path.exists(temp_path):
-                    os.unlink(temp_path)
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
 
 
 class TestTargetsModule:

--- a/tests/test_specific_core_modules.py
+++ b/tests/test_specific_core_modules.py
@@ -13,6 +13,8 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
+from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
+
 
 class TestAliasesModule:
     """Test core.aliases module specifically."""
@@ -27,8 +29,8 @@ class TestAliasesModule:
             assert isinstance(result, dict)
             assert len(result) == 0
 
-        except ImportError:
-            pytest.skip("aliases module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
 
     def test_aliases_load_with_data(self):
         """Test loading aliases with mock CSV data."""
@@ -43,8 +45,8 @@ class TestAliasesModule:
                 assert isinstance(result, dict)
                 assert "apple" in result or len(result) >= 0
 
-        except ImportError:
-            pytest.skip("aliases module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
 
     def test_map_to_canonical(self):
         """Test canonical name mapping."""
@@ -72,8 +74,8 @@ class TestAliasesModule:
             result = map_to_canonical("Green-Apple Fruit")
             assert isinstance(result, str)
 
-        except ImportError:
-            pytest.skip("aliases module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
 
     def test_add_alias(self):
         """Test adding new aliases."""
@@ -99,8 +101,8 @@ class TestAliasesModule:
                 if os.path.exists(temp_path):
                     os.unlink(temp_path)
 
-        except ImportError:
-            pytest.skip("aliases module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "aliases_module", reason=FEATURE_REASON)
 
 
 class TestTargetsModule:
@@ -248,8 +250,8 @@ class TestMenuEngineModule:
 
             assert isinstance(result, WeekMenu)
 
-        except ImportError:
-            pytest.skip("menu_engine module not available")
+        except ImportError as exc:
+            require_feature_or_raise(exc, "planner_engines", reason=FEATURE_REASON)
 
     def test_nutrition_totals(self):
         """Test nutrition totals calculation."""


### PR DESCRIPTION
## Summary

- **Audit** all 18 `FEATURE_TODO_KEYS` in `tests/feature_manifest.py` to determine which modules are fully implemented and can have their gates removed.
- **Enable 2 modules** (`shoplist_helpers`, `aliases_module`) — try/except gates removed, direct imports verified.
- **Migrate 22 ad-hoc `pytest.skip()` calls** to canonical `require_feature()` / `require_feature_or_raise()` pattern across 3 test files, ensuring all runtime skips emit standardized `feature_disabled:<key>` reason strings.
- **Document 5 keys that remain gated** with specific reasons (module exists but tested API surface incomplete).
- **Add 1 new feature key** (`plate_day_micros`) for day-level micronutrient coverage tests.

### Scope

| Area | What changed |
|------|-------------|
| `tests/feature_manifest.py` | `FEATURE_TODO_KEYS`: removed `shoplist_helpers` + `aliases_module`; added `plate_day_micros` (net: 17 → 16 keys) |
| `tests/test_simple_coverage_fixed.py` | 7 ad-hoc skips → `require_feature_or_raise()` |
| `tests/test_specific_core_modules.py` | 5 ad-hoc skips migrated; 4 `aliases_module` try/except gates removed |
| `tests/test_plate_targets_micro_coverage.py` | 10 ad-hoc skips → `require_feature("plate_day_micros")` |
| `tests/test_remaining_modules.py` | 3 `shoplist_helpers` try/except gates removed |
| `docs/roadmap/BACKLOG_LEDGER.md` | Ledger updated: status, enabled keys, gated keys with reasons, migration summary |

### Keys enabled (gates removed)

1. **`shoplist_helpers`** — `core.shoplist_helpers` fully implements `PackagingRule`, `ShoppingItem`, tested functions. Gate removed from `TestShoplistModule` (3 tests).
2. **`aliases_module`** — `core.aliases` fully implements `load_aliases`, `map_to_canonical`, `add_alias`. Gate removed from `TestAliasesModule` (4 tests).

### Keys still gated (documented in ledger)

| Key | Reason |
|-----|--------|
| `utils_pack` | `safe_float`/`safe_int`/`slugify` not in `core.utils` |
| `weekly_plan_helpers` | `calculate_weekly_nutrition`/`optimize_weekly_variety`/`validate_weekly_plan` not in `core.weekly_plan` |
| `core_db` | `get_db` not exported from `core.db` |
| `food_apis` | `search_food`/`get_food_details` not implemented |
| `unified_db` | import chain issues |

### Verification

- `pre-commit run --all-files` — PASS
- `make test-fast` — PASS (4 skips = expected feature-gated tests)
- `make lint` — PASS
- `make typecheck` — PASS

## Deferred / Follow-ups

- Remaining 16 feature keys stay gated — tracked in `docs/roadmap/BACKLOG_LEDGER.md` (P1, PR-748 entry).
- API surface completion for gated keys is out of scope for this PR (per plan: "Do NOT fix bugs in this PR").

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#discussion_r2837840330 -> 1b3cf317
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#discussion_r2837840326 -> 1b3cf317
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#discussion_r2837856097 -> 1b3cf317
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#discussion_r2837856098 -> 1b3cf317
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#pullrequestreview-3837712915 -> 1b3cf317
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/873#pullrequestreview-3837729554 -> 1b3cf317

**Commit summary:**

- `29e6e93a` — Phase 1: migrate 22 ad-hoc `pytest.skip()` → `require_feature()` + add `plate_day_micros` key
- `6a5a327c` — Phase 2a: enable `shoplist_helpers` — remove 3 try/except gates
- `cde74032` — Phase 2b: enable `aliases_module` — remove 4 try/except gates
- `78e436e8` — Phase 3: update `BACKLOG_LEDGER.md` with full audit results
- `1b3cf317` — Fix tautological assertions in aliases tests (CodeRabbit review)

**Note:** CodeRabbit comments about camelCase naming (PEP 8 Python uses snake_case), return type hints (out of scope for test refactor), and `Any` typing (acceptable in test cast usage) were resolved as non-actionable for this PR.

## Merge Readiness

- [x] `pre-commit run --all-files` green
- [x] `make test-fast` green
- [x] `make lint` green
- [x] `make typecheck` green
- [ ] CI green
- [ ] CodeRabbit / Sourcery / Cubic — no actionables
- [x] Review threads resolved
- [ ] Mandatory wait-window observed

🤖 Generated with [Qoder][https://qoder.com]