### PR TITLE
feat(tests): enable utils_pack feature key

### DIFF
--- a/core/time_utils.py
+++ b/core/time_utils.py
@@ -61,3 +61,152 @@ def local_date_today(tz_name: str) -> str:
     """Return today's date (YYYY-MM-DD) in the given timezone."""
 
     return local_now(tz_name).date().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Thin facades for utils_pack feature key (PR-880)
+# ---------------------------------------------------------------------------
+
+
+def parse_datetime(value: str) -> Optional[datetime]:
+    """Parse datetime string in various formats.
+
+    Args:
+        value: Datetime string to parse.
+
+    Returns:
+        Parsed datetime or None if parsing fails.
+    """
+    if not value:
+        return None
+    try:
+        return parse_iso8601(value)
+    except (ValueError, TypeError):
+        # Try common date-only format
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return None
+
+
+def format_datetime(dt: object, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:
+    """Format datetime object or string to specified format.
+
+    Args:
+        dt: Datetime object or ISO string.
+        fmt: Output format string.
+
+    Returns:
+        Formatted datetime string or None on error.
+    """
+    if dt is None:
+        return None
+    try:
+        if isinstance(dt, str):
+            parsed = parse_datetime(dt)
+            if parsed is None:
+                return None
+            return parsed.strftime(fmt)
+        if isinstance(dt, datetime):
+            return dt.strftime(fmt)
+        return None
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def get_timezone_offset(tz_name: str) -> Optional[float]:
+    """Get timezone offset in hours from UTC.
+
+    Args:
+        tz_name: Timezone name (e.g., 'UTC', 'US/Eastern').
+
+    Returns:
+        Offset in hours or None if timezone is invalid.
+    """
+    if not tz_name:
+        return None
+    if tz_name.upper() == "UTC":
+        return 0.0
+    if ZoneInfo is None:
+        return None
+    try:
+        tz = ZoneInfo(tz_name)
+        offset = datetime.now(tz).utcoffset()
+        if offset is None:
+            return None
+        return offset.total_seconds() / 3600
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def is_valid_date(value: str) -> bool:
+    """Check if string is a valid date.
+
+    Args:
+        value: Date string to validate.
+
+    Returns:
+        True if valid date, False otherwise.
+    """
+    if not value:
+        return False
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def format_time(t: object, fmt: str = "%H:%M:%S") -> Optional[str]:
+    """Format time object to specified format.
+
+    Args:
+        t: Time or datetime object.
+        fmt: Output format string.
+
+    Returns:
+        Formatted time string or None on error.
+    """
+    if t is None:
+        return None
+    try:
+        if isinstance(t, datetime):
+            return t.strftime(fmt)
+        if hasattr(t, "strftime"):
+            strftimeMethod = getattr(t, "strftime")
+            result = strftimeMethod(fmt)
+            return str(result) if result is not None else None
+        return None
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def human_delta(delta: object) -> str:
+    """Convert timedelta to human-readable string.
+
+    Args:
+        delta: Timedelta object or seconds as number.
+
+    Returns:
+        Human-readable duration string.
+    """
+    from datetime import timedelta
+
+    try:
+        if isinstance(delta, (int, float)):
+            delta = timedelta(seconds=delta)
+        if not isinstance(delta, timedelta):
+            return "0 seconds"
+        total_seconds = int(delta.total_seconds())
+        if total_seconds < 60:
+            return f"{total_seconds} second{'s' if total_seconds != 1 else ''}"
+        minutes = total_seconds // 60
+        if minutes < 60:
+            return f"{minutes} minute{'s' if minutes != 1 else ''}"
+        hours = minutes // 60
+        if hours < 24:
+            return f"{hours} hour{'s' if hours != 1 else ''}"
+        days = hours // 24
+        return f"{days} day{'s' if days != 1 else ''}"
+    except (ValueError, TypeError, AttributeError):
+        return "0 seconds"

--- a/core/time_utils.py
+++ b/core/time_utils.py
@@ -6,7 +6,7 @@ EN: Utilities for working with timezones and UTC-aware datetimes.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 try:  # Python 3.9+
@@ -190,8 +190,6 @@ def human_delta(delta: object) -> str:
     Returns:
         Human-readable duration string.
     """
-    from datetime import timedelta
-
     try:
         if isinstance(delta, (int, float)):
             delta = timedelta(seconds=delta)

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,13 +2,17 @@
 
 - get_activity_factor: unified mapping for activity multipliers.
 - resolve_attr: safe dynamic attribute resolver respecting test-time patches.
+- safe_float/safe_int/slugify: safe parsing and text utilities.
+- format_number/generate_id/sanitize_html/validate_email: formatting and validation.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import types
+import uuid
 from typing import Any, Iterable, Optional
 
 from core.bmr import PAL_FACTORS
@@ -153,3 +157,123 @@ def resolve_attr(name: str, local_default: Any, candidates: Optional[Iterable[An
 
 # Usage: add comment "# pragma: no cover" after lines that are difficult to test
 # when marking untestable edge cases in coverage reports
+
+
+# ---------------------------------------------------------------------------
+# Thin facades for utils_pack feature key (PR-880)
+# ---------------------------------------------------------------------------
+
+
+def safe_float(value: object, default: float | None = None) -> float | None:
+    """Safely convert value to float, returning default on failure.
+
+    Args:
+        value: Value to convert (string, number, or None).
+        default: Value to return if conversion fails.
+
+    Returns:
+        Converted float or default value.
+    """
+    if value is None:
+        return default
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return default
+
+
+def safe_int(value: object, default: int | None = None) -> int | None:
+    """Safely convert value to int, returning default on failure.
+
+    Args:
+        value: Value to convert (string, number, or None).
+        default: Value to return if conversion fails.
+
+    Returns:
+        Converted int or default value.
+    """
+    if value is None:
+        return default
+    try:
+        # Handle float strings like "123.45" by converting to float first
+        return int(float(value))  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return default
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(text: object) -> str:
+    """Convert text to URL-safe slug.
+
+    Args:
+        text: Text to convert (string or None).
+
+    Returns:
+        Lowercase slug with non-alphanumeric characters replaced by hyphens.
+    """
+    if text is None:
+        return ""
+    s = str(text).lower().strip()
+    s = _SLUG_RE.sub("-", s)
+    return s.strip("-")
+
+
+def format_number(value: object, decimals: int = 2) -> str:
+    """Format a number with specified decimal places.
+
+    Args:
+        value: Number to format.
+        decimals: Number of decimal places.
+
+    Returns:
+        Formatted string representation.
+    """
+    try:
+        return f"{float(value):.{decimals}f}"  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def generate_id() -> str:
+    """Generate a unique identifier string.
+
+    Returns:
+        UUID4 string without hyphens.
+    """
+    return uuid.uuid4().hex
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def sanitize_html(html: object) -> str:
+    """Remove HTML tags from input string.
+
+    Args:
+        html: HTML string to sanitize.
+
+    Returns:
+        Plain text with HTML tags removed.
+    """
+    if html is None:
+        return ""
+    return _HTML_TAG_RE.sub("", str(html))
+
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+
+def validate_email(email: object) -> bool:
+    """Validate email address format.
+
+    Args:
+        email: Email address to validate.
+
+    Returns:
+        True if valid email format, False otherwise.
+    """
+    if not email:
+        return False
+    return bool(_EMAIL_RE.match(str(email)))

--- a/core/utils.py
+++ b/core/utils.py
@@ -241,8 +241,14 @@ def format_number(value: object, decimals: int = 2) -> str:
         Formatted string representation.
     """
     try:
-        return f"{float(value):.{decimals}f}"  # type: ignore[arg-type]
-    except (ValueError, TypeError):
+        if isinstance(value, (int, float)):
+            num = float(value)
+        elif isinstance(value, (str, bytes, bytearray)):
+            num = float(value)
+        else:
+            num = float(str(value))
+        return f"{num:.{decimals}f}"
+    except (ValueError, TypeError, OverflowError):
         return str(value)
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -251,8 +251,13 @@ _HTML_TAG_RE = re.compile(r"<[^>]+>")
 def sanitize_html(html: object) -> str:
     """Remove HTML tags from input string.
 
+    Note: This is a simple tag-stripping utility, not a security-grade
+    sanitizer. For untrusted user input, use a dedicated library like
+    bleach or html-sanitizer.
+
     Args:
-        html: HTML string to sanitize.
+        html: HTML string to sanitize. Non-string inputs are coerced via str().
+              None returns empty string.
 
     Returns:
         Plain text with HTML tags removed.

--- a/core/utils.py
+++ b/core/utils.py
@@ -177,8 +177,12 @@ def safe_float(value: object, default: float | None = None) -> float | None:
     if value is None:
         return default
     try:
-        return float(value)  # type: ignore[arg-type]
-    except (ValueError, TypeError):
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, (str, bytes, bytearray)):
+            return float(value)
+        return float(str(value))
+    except (ValueError, TypeError, OverflowError):
         return default
 
 
@@ -196,8 +200,14 @@ def safe_int(value: object, default: int | None = None) -> int | None:
         return default
     try:
         # Handle float strings like "123.45" by converting to float first
-        return int(float(value))  # type: ignore[arg-type]
-    except (ValueError, TypeError):
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, (str, bytes, bytearray)):
+            return int(float(value))
+        return int(float(str(value)))
+    except (ValueError, TypeError, OverflowError):
         return default
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -283,7 +283,9 @@ def sanitize_html(html: object) -> str:
     return _HTML_TAG_RE.sub("", str(html))
 
 
-_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+_EMAIL_RE = re.compile(
+    r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$"
+)
 
 
 def validate_email(email: object) -> bool:

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -56,7 +56,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
         "planner_engines",
         "plate_day_micros",
         "premium_week_router_mocking",
-        "utils_pack",
         "weekly_plan_helpers",
         "exports_recipes_products",
         "sports_disclaimers_lifestage",

--- a/tests/test_core_coverage_97_final.py
+++ b/tests/test_core_coverage_97_final.py
@@ -116,19 +116,16 @@ class TestCoreCoverage97Final:
         if hasattr(targets, "calculate_targets"):
             assert callable(getattr(targets, "calculate_targets"))
 
-    def test_core_time_utils_functions(self):
+    def test_core_time_utils_functions(self) -> None:
         """Test core.time_utils functions."""
-        try:
-            import core.time_utils as tu
+        import core.time_utils as tu
 
-            assert tu is not None
-            # Test if module has expected functions
-            if hasattr(tu, "format_time"):
-                assert callable(getattr(tu, "format_time"))
-            if hasattr(tu, "human_delta"):
-                assert callable(getattr(tu, "human_delta"))
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        assert tu is not None
+        # Test if module has expected functions
+        assert hasattr(tu, "format_time")
+        assert callable(getattr(tu, "format_time"))
+        assert hasattr(tu, "human_delta")
+        assert callable(getattr(tu, "human_delta"))
 
     def test_core_region_catalog_functions(self):
         """Test core.region_catalog functions."""

--- a/tests/test_missing_coverage_97_final.py
+++ b/tests/test_missing_coverage_97_final.py
@@ -5,7 +5,6 @@ Final test coverage boost to reach 97%
 from contextlib import suppress
 
 import pytest
-from tests.feature_manifest import FEATURE_REASON, require_feature_or_raise
 
 
 class TestMissingCoverage97Final:
@@ -13,39 +12,27 @@ class TestMissingCoverage97Final:
 
     def test_fix_failing_tests_coverage(self) -> None:
         """Test fix_failing_tests.py coverage"""
-        try:
-            import fix_failing_tests
+        import fix_failing_tests
 
-            assert fix_failing_tests is not None
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        assert fix_failing_tests is not None
 
     def test_mcp_pulseplate_server_coverage(self) -> None:
         """Test mcp_pulseplate_server.py coverage"""
-        try:
-            import mcp_pulseplate_server
+        import mcp_pulseplate_server
 
-            assert mcp_pulseplate_server is not None
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        assert mcp_pulseplate_server is not None
 
     def test_setup_custom_mcp_coverage(self) -> None:
         """Test setup_custom_mcp.py coverage"""
-        try:
-            import setup_custom_mcp
+        import setup_custom_mcp
 
-            assert setup_custom_mcp is not None
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        assert setup_custom_mcp is not None
 
     def test_test_pro_access_coverage(self) -> None:
         """Test test_pro_access.py coverage"""
-        try:
-            import test_pro_access
+        import test_pro_access
 
-            assert test_pro_access is not None
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        assert test_pro_access is not None
 
     def test_app_import_coverage(self) -> None:
         """Test app/__init__.py coverage"""

--- a/tests/test_missing_coverage_97_final.py
+++ b/tests/test_missing_coverage_97_final.py
@@ -2,8 +2,6 @@
 Final test coverage boost to reach 97%
 """
 
-from contextlib import suppress
-
 import pytest
 
 

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -165,130 +165,112 @@ class TestWeeklyPlanModule:
 class TestUtilsModule:
     """Test core.utils module."""
 
-    def test_utils_comprehensive(self):
+    def test_utils_comprehensive(self) -> None:
         """Test utils functions comprehensively."""
-        try:
-            from core.utils import (
-                safe_float,
-                safe_int,
-                slugify,
-            )
+        from core.utils import (
+            safe_float,
+            safe_int,
+            slugify,
+        )
 
-            # Test safe_float with various inputs
-            assert safe_float("123.45") == 123.45 or safe_float("123.45") is None
-            assert safe_float("invalid") is None or isinstance(safe_float("invalid"), (int, float))
-            assert safe_float(None) is None or isinstance(safe_float(None), (int, float))
-            assert safe_float("") is None or isinstance(safe_float(""), (int, float))
-            assert safe_float("0") == 0.0 or safe_float("0") is None
-            assert safe_float("-123.45") == -123.45 or safe_float("-123.45") is None
+        # Test safe_float with various inputs
+        assert safe_float("123.45") == 123.45
+        assert safe_float("invalid") is None
+        assert safe_float(None) is None
+        assert safe_float("") is None
+        assert safe_float("0") == 0.0
+        assert safe_float("-123.45") == -123.45
 
-            # Test safe_int with various inputs
-            assert safe_int("123") == 123 or safe_int("123") is None
-            assert safe_int("invalid") is None or isinstance(safe_int("invalid"), int)
-            assert safe_int(None) is None or isinstance(safe_int(None), int)
-            assert safe_int("") is None or isinstance(safe_int(""), int)
-            assert safe_int("0") == 0 or safe_int("0") is None
-            assert safe_int("-123") == -123 or safe_int("-123") is None
+        # Test safe_int with various inputs
+        assert safe_int("123") == 123
+        assert safe_int("invalid") is None
+        assert safe_int(None) is None
+        assert safe_int("") is None
+        assert safe_int("0") == 0
+        assert safe_int("-123") == -123
 
-            # Test slugify with various inputs
-            slug = slugify("Test String With Spaces")
-            assert isinstance(slug, (str, type(None)))
+        # Test slugify with various inputs
+        slug = slugify("Test String With Spaces")
+        assert isinstance(slug, str)
 
-            slug = slugify("Special!@#$%Characters")
-            assert isinstance(slug, (str, type(None)))
+        slug = slugify("Special!@#$%Characters")
+        assert isinstance(slug, str)
 
-            slug = slugify("")
-            assert isinstance(slug, (str, type(None)))
+        slug = slugify("")
+        assert slug == ""
 
-            slug = slugify(None)
-            assert isinstance(slug, (str, type(None)))
+        slug = slugify(None)
+        assert slug == ""
 
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
-
-    def test_additional_utils(self):
+    def test_additional_utils(self) -> None:
         """Test additional utility functions."""
-        try:
-            from core.utils import (
-                format_number,
-                generate_id,
-                sanitize_html,
-                validate_email,
-            )
+        from core.utils import (
+            format_number,
+            generate_id,
+            sanitize_html,
+            validate_email,
+        )
 
-            # Test email validation
-            assert (
-                validate_email("test@example.com") is True
-                or validate_email("test@example.com") is None
-            )
-            assert (
-                validate_email("invalid-email") is False or validate_email("invalid-email") is None
-            )
-            assert validate_email("") is False or validate_email("") is None
-            assert validate_email(None) is False or validate_email(None) is None
+        # Test email validation
+        assert validate_email("test@example.com") is True
+        assert validate_email("invalid-email") is False
+        assert validate_email("") is False
+        assert validate_email(None) is False
 
-            # Test HTML sanitization
-            sanitized = sanitize_html("<script>alert('xss')</script>")
-            assert isinstance(sanitized, (str, type(None)))
+        # Test HTML sanitization
+        sanitized = sanitize_html("<script>alert('xss')</script>")
+        assert isinstance(sanitized, str)
+        assert "<script>" not in sanitized
 
-            sanitized = sanitize_html("<p>Valid HTML</p>")
-            assert isinstance(sanitized, (str, type(None)))
+        sanitized = sanitize_html("<p>Valid HTML</p>")
+        assert isinstance(sanitized, str)
 
-            # Test ID generation
-            id_val = generate_id()
-            assert isinstance(id_val, (str, type(None)))
+        # Test ID generation
+        idVal = generate_id()
+        assert isinstance(idVal, str)
+        assert len(idVal) == 32  # UUID hex without hyphens
 
-            # Test number formatting
-            formatted = format_number(1234.567)
-            assert isinstance(formatted, (str, type(None)))
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        # Test number formatting
+        formatted = format_number(1234.567)
+        assert isinstance(formatted, str)
 
 
 class TestTimeUtilsModule:
     """Test core.time_utils module for better coverage."""
 
-    def test_time_utils_comprehensive(self):
+    def test_time_utils_comprehensive(self) -> None:
         """Test time utilities comprehensively."""
-        try:
-            from core.time_utils import (
-                format_datetime,
-                get_timezone_offset,
-                is_valid_date,
-                parse_datetime,
-            )
+        from core.time_utils import (
+            format_datetime,
+            get_timezone_offset,
+            is_valid_date,
+            parse_datetime,
+        )
 
-            # Test datetime parsing
-            result = parse_datetime("2024-01-01T00:00:00")
-            assert result is not None or result is None
+        # Test datetime parsing
+        result = parse_datetime("2024-01-01T00:00:00")
+        assert result is not None
 
-            result = parse_datetime("2024-01-01")
-            assert result is not None or result is None
+        result = parse_datetime("2024-01-01")
+        assert result is not None
 
-            result = parse_datetime("invalid")
-            assert result is None or result is not None
+        result = parse_datetime("invalid")
+        assert result is None
 
-            result = parse_datetime("")
-            assert result is None or result is not None
+        result = parse_datetime("")
+        assert result is None
 
-            # Test datetime formatting
-            formatted = format_datetime("2024-01-01T00:00:00")
-            assert isinstance(formatted, (str, type(None)))
+        # Test datetime formatting
+        formatted = format_datetime("2024-01-01T00:00:00")
+        assert isinstance(formatted, str)
 
-            # Test timezone offset
-            offset = get_timezone_offset("UTC")
-            assert isinstance(offset, (int, float, type(None)))
+        # Test timezone offset
+        offset = get_timezone_offset("UTC")
+        assert offset == 0.0
 
-            offset = get_timezone_offset("US/Eastern")
-            assert isinstance(offset, (int, float, type(None)))
+        offset = get_timezone_offset("US/Eastern")
+        assert isinstance(offset, (int, float, type(None)))
 
-            # Test date validation
-            is_valid = is_valid_date("2024-01-01")
-            assert isinstance(is_valid, (bool, type(None)))
-
-            is_valid = is_valid_date("invalid")
-            assert isinstance(is_valid, (bool, type(None)))
-
-        except ImportError as exc:
-            require_feature_or_raise(exc, "utils_pack", reason=FEATURE_REASON)
+        # Test date validation
+        assert is_valid_date("2024-01-01") is True
+        assert is_valid_date("invalid") is False

--- a/tests/test_utils_pack_facades_coverage.py
+++ b/tests/test_utils_pack_facades_coverage.py
@@ -176,7 +176,7 @@ class TestCoreTimeUtilsFacades:
         """Test format_datetime with invalid type returns None."""
         from core.time_utils import format_datetime
 
-        assert format_datetime(12345) is None  # type: ignore[arg-type]
+        assert format_datetime(12345) is None
 
     def test_get_timezone_offset_utc(self) -> None:
         """Test get_timezone_offset with UTC."""

--- a/tests/test_utils_pack_facades_coverage.py
+++ b/tests/test_utils_pack_facades_coverage.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 
 class TestCoreUtilsFacades:
     """Test core.utils facade functions for coverage."""
@@ -300,20 +302,13 @@ class TestTimeUtilsEdgeCases:
         result = format_datetime(bad_dt)
         assert result is None
 
-    def test_get_timezone_offset_zoneinfo_none(self) -> None:
+    def test_get_timezone_offset_zoneinfo_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test get_timezone_offset when ZoneInfo unavailable."""
-        from unittest.mock import patch
-
         import core.time_utils as tu
 
-        # Temporarily set ZoneInfo to None
-        originalZoneInfo = tu.ZoneInfo
-        try:
-            tu.ZoneInfo = None  # type: ignore[assignment]
-            result = tu.get_timezone_offset("America/New_York")
-            assert result is None
-        finally:
-            tu.ZoneInfo = originalZoneInfo
+        monkeypatch.setattr(tu, "ZoneInfo", None)
+        result = tu.get_timezone_offset("America/New_York")
+        assert result is None
 
     def test_get_timezone_offset_invalid_timezone(self) -> None:
         """Test get_timezone_offset with invalid timezone names."""

--- a/tests/test_utils_pack_facades_coverage.py
+++ b/tests/test_utils_pack_facades_coverage.py
@@ -1,0 +1,281 @@
+"""Coverage tests for utils_pack facades (PR-880).
+
+Covers all new facade functions in core/utils.py and core/time_utils.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+class TestCoreUtilsFacades:
+    """Test core.utils facade functions for coverage."""
+
+    def test_safe_float_valid_inputs(self) -> None:
+        """Test safe_float with valid inputs."""
+        from core.utils import safe_float
+
+        assert safe_float("123.45") == 123.45
+        assert safe_float("0") == 0.0
+        assert safe_float("-123.45") == -123.45
+        assert safe_float(42) == 42.0
+        assert safe_float(3.14) == 3.14
+
+    def test_safe_float_invalid_inputs(self) -> None:
+        """Test safe_float with invalid inputs returns default."""
+        from core.utils import safe_float
+
+        assert safe_float("invalid") is None
+        assert safe_float("") is None
+        assert safe_float(None) is None
+        assert safe_float("invalid", default=0.0) == 0.0
+        assert safe_float(None, default=-1.0) == -1.0
+
+    def test_safe_int_valid_inputs(self) -> None:
+        """Test safe_int with valid inputs."""
+        from core.utils import safe_int
+
+        assert safe_int("123") == 123
+        assert safe_int("0") == 0
+        assert safe_int("-123") == -123
+        assert safe_int(42) == 42
+        assert safe_int("123.45") == 123  # truncates float string
+
+    def test_safe_int_invalid_inputs(self) -> None:
+        """Test safe_int with invalid inputs returns default."""
+        from core.utils import safe_int
+
+        assert safe_int("invalid") is None
+        assert safe_int("") is None
+        assert safe_int(None) is None
+        assert safe_int("invalid", default=0) == 0
+        assert safe_int(None, default=-1) == -1
+
+    def test_slugify_various_inputs(self) -> None:
+        """Test slugify with various inputs."""
+        from core.utils import slugify
+
+        assert slugify("Test String") == "test-string"
+        assert slugify("Special!@#$%Characters") == "special-characters"
+        assert slugify("") == ""
+        assert slugify(None) == ""
+        assert slugify("  Leading Trailing  ") == "leading-trailing"
+        assert slugify("multiple   spaces") == "multiple-spaces"
+
+    def test_format_number_valid(self) -> None:
+        """Test format_number with valid inputs."""
+        from core.utils import format_number
+
+        assert format_number(1234.567) == "1234.57"
+        assert format_number(1234.567, decimals=1) == "1234.6"
+        assert format_number(0) == "0.00"
+        assert format_number("42.1") == "42.10"
+
+    def test_format_number_invalid(self) -> None:
+        """Test format_number with invalid inputs returns str(value)."""
+        from core.utils import format_number
+
+        result = format_number("invalid")
+        assert result == "invalid"
+        result = format_number(None)
+        assert result == "None"
+
+    def test_generate_id(self) -> None:
+        """Test generate_id returns valid UUID hex."""
+        from core.utils import generate_id
+
+        idVal = generate_id()
+        assert isinstance(idVal, str)
+        assert len(idVal) == 32
+        # Should be unique
+        idVal2 = generate_id()
+        assert idVal != idVal2
+
+    def test_sanitize_html(self) -> None:
+        """Test sanitize_html removes tags."""
+        from core.utils import sanitize_html
+
+        assert sanitize_html("<script>alert('xss')</script>") == "alert('xss')"
+        assert sanitize_html("<p>Valid</p>") == "Valid"
+        assert sanitize_html("No tags") == "No tags"
+        assert sanitize_html("") == ""
+        assert sanitize_html(None) == ""
+
+    def test_validate_email(self) -> None:
+        """Test validate_email."""
+        from core.utils import validate_email
+
+        assert validate_email("test@example.com") is True
+        assert validate_email("user.name+tag@domain.co.uk") is True
+        assert validate_email("invalid-email") is False
+        assert validate_email("@nodomain.com") is False
+        assert validate_email("noat.com") is False
+        assert validate_email("") is False
+        assert validate_email(None) is False
+
+
+class TestCoreTimeUtilsFacades:
+    """Test core.time_utils facade functions for coverage."""
+
+    def test_parse_datetime_iso(self) -> None:
+        """Test parse_datetime with ISO format."""
+        from core.time_utils import parse_datetime
+
+        result = parse_datetime("2024-01-15T10:30:00")
+        assert result is not None
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_parse_datetime_date_only(self) -> None:
+        """Test parse_datetime with date-only format."""
+        from core.time_utils import parse_datetime
+
+        result = parse_datetime("2024-01-15")
+        assert result is not None
+        assert result.year == 2024
+
+    def test_parse_datetime_invalid(self) -> None:
+        """Test parse_datetime with invalid input."""
+        from core.time_utils import parse_datetime
+
+        assert parse_datetime("invalid") is None
+        assert parse_datetime("") is None
+        assert parse_datetime("not-a-date") is None
+
+    def test_format_datetime_from_string(self) -> None:
+        """Test format_datetime with string input."""
+        from core.time_utils import format_datetime
+
+        result = format_datetime("2024-01-15T10:30:00")
+        assert result is not None
+        assert "2024" in result
+
+    def test_format_datetime_from_datetime(self) -> None:
+        """Test format_datetime with datetime object."""
+        from core.time_utils import format_datetime
+
+        dt = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        result = format_datetime(dt)
+        assert result is not None
+        assert "2024" in result
+
+    def test_format_datetime_none(self) -> None:
+        """Test format_datetime with None."""
+        from core.time_utils import format_datetime
+
+        assert format_datetime(None) is None
+
+    def test_format_datetime_invalid_string(self) -> None:
+        """Test format_datetime with invalid string."""
+        from core.time_utils import format_datetime
+
+        assert format_datetime("invalid") is None
+
+    def test_format_datetime_invalid_type(self) -> None:
+        """Test format_datetime with invalid type returns None."""
+        from core.time_utils import format_datetime
+
+        assert format_datetime(12345) is None  # type: ignore[arg-type]
+
+    def test_get_timezone_offset_utc(self) -> None:
+        """Test get_timezone_offset with UTC."""
+        from core.time_utils import get_timezone_offset
+
+        assert get_timezone_offset("UTC") == 0.0
+
+    def test_get_timezone_offset_named(self) -> None:
+        """Test get_timezone_offset with named timezone."""
+        from core.time_utils import get_timezone_offset
+
+        # US/Eastern is either -5 or -4 depending on DST
+        offset = get_timezone_offset("US/Eastern")
+        assert offset is None or isinstance(offset, float)
+
+    def test_get_timezone_offset_empty(self) -> None:
+        """Test get_timezone_offset with empty string."""
+        from core.time_utils import get_timezone_offset
+
+        assert get_timezone_offset("") is None
+
+    def test_get_timezone_offset_invalid(self) -> None:
+        """Test get_timezone_offset with invalid timezone."""
+        from core.time_utils import get_timezone_offset
+
+        assert get_timezone_offset("Invalid/Timezone") is None
+
+    def test_is_valid_date(self) -> None:
+        """Test is_valid_date."""
+        from core.time_utils import is_valid_date
+
+        assert is_valid_date("2024-01-15") is True
+        assert is_valid_date("invalid") is False
+        assert is_valid_date("") is False
+        assert is_valid_date("2024-13-45") is False  # invalid month/day
+
+    def test_format_time_datetime(self) -> None:
+        """Test format_time with datetime object."""
+        from core.time_utils import format_time
+
+        dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+        result = format_time(dt)
+        assert result == "10:30:45"
+
+    def test_format_time_none(self) -> None:
+        """Test format_time with None."""
+        from core.time_utils import format_time
+
+        assert format_time(None) is None
+
+    def test_format_time_invalid(self) -> None:
+        """Test format_time with invalid type."""
+        from core.time_utils import format_time
+
+        assert format_time("not a time") is None
+        assert format_time(12345) is None
+
+    def test_human_delta_seconds(self) -> None:
+        """Test human_delta with seconds."""
+        from core.time_utils import human_delta
+
+        assert human_delta(30) == "30 seconds"
+        assert human_delta(1) == "1 second"
+        assert human_delta(0) == "0 seconds"
+
+    def test_human_delta_minutes(self) -> None:
+        """Test human_delta with minutes."""
+        from core.time_utils import human_delta
+
+        assert human_delta(60) == "1 minute"
+        assert human_delta(120) == "2 minutes"
+        assert human_delta(90) == "1 minute"  # rounds down
+
+    def test_human_delta_hours(self) -> None:
+        """Test human_delta with hours."""
+        from core.time_utils import human_delta
+
+        assert human_delta(3600) == "1 hour"
+        assert human_delta(7200) == "2 hours"
+
+    def test_human_delta_days(self) -> None:
+        """Test human_delta with days."""
+        from core.time_utils import human_delta
+
+        assert human_delta(86400) == "1 day"
+        assert human_delta(172800) == "2 days"
+
+    def test_human_delta_timedelta(self) -> None:
+        """Test human_delta with timedelta object."""
+        from core.time_utils import human_delta
+
+        assert human_delta(timedelta(seconds=30)) == "30 seconds"
+        assert human_delta(timedelta(minutes=5)) == "5 minutes"
+        assert human_delta(timedelta(hours=2)) == "2 hours"
+        assert human_delta(timedelta(days=3)) == "3 days"
+
+    def test_human_delta_invalid(self) -> None:
+        """Test human_delta with invalid input."""
+        from core.time_utils import human_delta
+
+        assert human_delta("invalid") == "0 seconds"
+        assert human_delta(None) == "0 seconds"

--- a/tests/test_utils_pack_facades_coverage.py
+++ b/tests/test_utils_pack_facades_coverage.py
@@ -279,3 +279,111 @@ class TestCoreTimeUtilsFacades:
 
         assert human_delta("invalid") == "0 seconds"
         assert human_delta(None) == "0 seconds"
+
+
+class TestTimeUtilsEdgeCases:
+    """Additional edge case tests for time_utils to reach 97% coverage."""
+
+    def test_format_datetime_exception_path(self) -> None:
+        """Test format_datetime exception handling with datetime subclass."""
+        from datetime import datetime
+
+        from core.time_utils import format_datetime
+
+        # Subclass of datetime that raises on strftime
+        class BadDatetime(datetime):
+            def strftime(self, fmt: str) -> str:
+                raise ValueError("bad format")
+
+        # Create instance that will pass isinstance check but raise on strftime
+        bad_dt = BadDatetime(2024, 1, 1, 12, 0, 0)
+        result = format_datetime(bad_dt)
+        assert result is None
+
+    def test_get_timezone_offset_zoneinfo_none(self) -> None:
+        """Test get_timezone_offset when ZoneInfo unavailable."""
+        from unittest.mock import patch
+
+        import core.time_utils as tu
+
+        # Temporarily set ZoneInfo to None
+        originalZoneInfo = tu.ZoneInfo
+        try:
+            tu.ZoneInfo = None  # type: ignore[assignment]
+            result = tu.get_timezone_offset("America/New_York")
+            assert result is None
+        finally:
+            tu.ZoneInfo = originalZoneInfo
+
+    def test_get_timezone_offset_invalid_timezone(self) -> None:
+        """Test get_timezone_offset with invalid timezone names."""
+        from core.time_utils import get_timezone_offset
+
+        # Invalid timezone names trigger KeyError path
+        assert get_timezone_offset("Invalid/Timezone") is None
+        assert get_timezone_offset("NotATimezone") is None
+        assert get_timezone_offset("Fake/Zone/Name") is None
+
+    def test_get_timezone_offset_utcoffset_returns_none(self) -> None:
+        """Test get_timezone_offset when utcoffset returns None."""
+        from unittest.mock import MagicMock, patch
+
+        import core.time_utils as tu
+
+        # Create a mock datetime that returns None for utcoffset
+        mock_dt = MagicMock()
+        mock_dt.utcoffset.return_value = None
+
+        # Patch the datetime class in the time_utils module
+        with patch.object(tu, "datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_dt
+            result = tu.get_timezone_offset("America/New_York")
+            assert result is None
+
+    def test_format_time_with_time_object(self) -> None:
+        """Test format_time with time object that has strftime."""
+        from datetime import time
+
+        from core.time_utils import format_time
+
+        t = time(10, 30, 45)
+        result = format_time(t)
+        assert result == "10:30:45"
+
+    def test_format_time_strftime_returns_none(self) -> None:
+        """Test format_time when strftime returns None."""
+        from core.time_utils import format_time
+
+        class WeirdTime:
+            def strftime(self, fmt: str) -> None:
+                return None
+
+        result = format_time(WeirdTime())
+        assert result is None
+
+    def test_format_time_strftime_raises(self) -> None:
+        """Test format_time when strftime raises."""
+        from core.time_utils import format_time
+
+        class BadTime:
+            def strftime(self, fmt: str) -> str:
+                raise TypeError("bad")
+
+        result = format_time(BadTime())
+        assert result is None
+
+    def test_human_delta_exception_in_total_seconds(self) -> None:
+        """Test human_delta exception path with timedelta subclass."""
+        from datetime import timedelta
+
+        from core.time_utils import human_delta
+
+        # Subclass of timedelta that raises on total_seconds
+        class BadDelta(timedelta):
+            def total_seconds(self) -> float:
+                raise ValueError("cannot compute total_seconds")
+
+        # Create instance that will pass isinstance check but raise on total_seconds
+        bad_delta = BadDelta(seconds=100)
+        result = human_delta(bad_delta)
+        assert result == "0 seconds"


### PR DESCRIPTION
## Summary
Add thin API facades to satisfy test imports, enabling the `utils_pack` feature key. This continues the pattern established in PR #877 and PR #879.

### Feature Key Enabled
- `utils_pack` — safe parsing utilities, formatting, and time utilities

## Changes

### core/utils.py facades (7 functions)
- `safe_float(value, default)`: Safe float conversion with default on failure
- `safe_int(value, default)`: Safe int conversion with default on failure
- `slugify(text)`: URL-safe slug generation from text
- `format_number(value, decimals)`: Number formatting with decimal places
- `generate_id()`: UUID4 hex generation (32 chars)
- `sanitize_html(html)`: HTML tag removal (note: not security-grade)
- `validate_email(email)`: Email format validation

### core/time_utils.py facades (6 functions)
- `parse_datetime(value)`: Parse ISO 8601 and date strings
- `format_datetime(dt, fmt)`: Format datetime objects or strings
- `get_timezone_offset(tz_name)`: Get timezone offset in hours from UTC
- `is_valid_date(value)`: Validate date string format
- `format_time(t, fmt)`: Format time objects
- `human_delta(delta)`: Human-readable timedelta strings

### Test Changes
- Removed `utils_pack` from `FEATURE_TODO_KEYS` in feature_manifest.py
- Removed feature gates from 4 test files
- Updated test assertions to use concrete expected values

## Test Plan
- [x] `pre-commit run --all-files` passes
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] diff-coverage >= 97%

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3839539892 -> fc63d1c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3839545992 -> fc63d1c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3839578290 -> fc63d1c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3839961881 -> fc63d1c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3846224836 -> 06d628b0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#pullrequestreview-3846316426 -> 7e00ccd6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2839487449 -> fc63d1c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2839834250 -> 1db5ec25
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2839834263 -> 1db5ec25
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2839834241 -> 1db5ec25
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2839834261 -> 1db5ec25
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2845532850 -> 06d628b0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/880#discussion_r2845619733 -> 7e00ccd6

## Merge Readiness
- [x] CodeRabbit: all threads resolved
- [x] Cubic: no issues found
- [x] Sourcery: summary only
- [ ] CI: pending re-run

## Deferred / Follow-ups
- Remaining feature keys tracked in BACKLOG_LEDGER.md (9 keys still gated)