### PR TITLE
feat(tests): enable premium_week_router_mocking feature key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1304,7 +1304,7 @@
         "filename": "tests/test_premium_week_app_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 34
       }
     ],
     "tests/test_premium_week_endpoint_96.py": [
@@ -1634,5 +1634,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T15:33:13Z"
+  "generated_at": "2026-02-24T15:36:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1298,15 +1298,6 @@
         "line_number": 22
       }
     ],
-    "tests/test_premium_week_app_coverage.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_premium_week_app_coverage.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 36
-      }
-    ],
     "tests/test_premium_week_endpoint_96.py": [
       {
         "type": "Secret Keyword",
@@ -1634,5 +1625,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T15:55:40Z"
+  "generated_at": "2026-02-24T16:32:17Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1304,7 +1304,7 @@
         "filename": "tests/test_premium_week_app_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 36
       }
     ],
     "tests/test_premium_week_endpoint_96.py": [
@@ -1634,5 +1634,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T15:46:41Z"
+  "generated_at": "2026-02-24T15:55:40Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1304,7 +1304,7 @@
         "filename": "tests/test_premium_week_app_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 22
       }
     ],
     "tests/test_premium_week_endpoint_96.py": [
@@ -1634,5 +1634,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T10:56:19Z"
+  "generated_at": "2026-02-24T15:33:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1304,7 +1304,7 @@
         "filename": "tests/test_premium_week_app_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 35
       }
     ],
     "tests/test_premium_week_endpoint_96.py": [
@@ -1634,5 +1634,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T15:36:30Z"
+  "generated_at": "2026-02-24T15:46:41Z"
 }

--- a/tests/feature_manifest.py
+++ b/tests/feature_manifest.py
@@ -54,7 +54,6 @@ FEATURE_TODO_KEYS: FrozenSet[str] = frozenset(
     {
         "planner_engines",
         "plate_day_micros",
-        "premium_week_router_mocking",
         "exports_recipes_products",
         "sports_disclaimers_lifestage",
         "legacy_bmi_removed",

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -6,14 +6,12 @@ RU: Простые тесты для покрытия эндпоинта premium
 EN: Simple tests for premium week endpoint coverage in main.py
 """
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 import legacy_app
-from app import app
 
 # Common test payload for weekly menu tests (DRY)
 _BASE_WEEKLY_PAYLOAD: dict = {
@@ -31,18 +29,20 @@ _BASE_WEEKLY_PAYLOAD: dict = {
 class TestPremiumWeekAppCoverage:
     """Test suite for premium week endpoint coverage in main.py."""
 
-    def setup_method(self):
-        """Set up test client."""
-        os.environ["API_KEY"] = "test_key"
-        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
-        self.client = TestClient(app)
+    @pytest.fixture(autouse=True)
+    def _env_and_client(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client: TestClient,
+    ) -> None:
+        """Set up test client and env with automatic cleanup."""
+        monkeypatch.setenv("API_KEY", "test_key")
+        monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
+        self.client = client
 
-    def teardown_method(self):
-        """Clean up test environment."""
-        os.environ.pop("API_KEY", None)
-        os.environ.pop("FEATURE_PREMIUM_NUTRITION", None)
-
-    def test_api_weekly_menu_make_weekly_menu_not_available(self, monkeypatch: pytest.MonkeyPatch):
+    def test_api_weekly_menu_make_weekly_menu_not_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test when make_weekly_menu is not available (503 error).
 
         The endpoint resolves make_weekly_menu via two paths (legacy_app.py L4277-4282):
@@ -66,11 +66,12 @@ class TestPremiumWeekAppCoverage:
             headers={"X-API-Key": "test_key"},
         )
         assert response.status_code == 503
+        assert response.headers["content-type"].startswith("application/json")
         data = response.json()
         assert "detail" in data
         assert "not available" in data["detail"].lower()
 
-    def test_api_weekly_menu_success(self):
+    def test_api_weekly_menu_success(self) -> None:
         """Test successful weekly menu generation."""
         # Mock make_weekly_menu to return a valid WeekMenu
         mock_week_menu = MagicMock()
@@ -85,13 +86,14 @@ class TestPremiumWeekAppCoverage:
                 headers={"X-API-Key": "test_key"},
             )
             assert response.status_code == 200
+            assert response.headers["content-type"].startswith("application/json")
             data = response.json()
             assert "week_summary" in data
             assert "daily_menus" in data
             assert "weekly_coverage" in data
             assert "shopping_list" in data
 
-    def test_api_weekly_menu_exception_handling(self, monkeypatch: pytest.MonkeyPatch):
+    def test_api_weekly_menu_exception_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test exception handling in weekly menu generation."""
 
         # Mock make_weekly_menu to raise an exception
@@ -108,11 +110,12 @@ class TestPremiumWeekAppCoverage:
             headers={"X-API-Key": "test_key"},
         )
         assert response.status_code == 500
+        assert response.headers["content-type"].startswith("application/json")
         data = response.json()
         assert "detail" in data
         assert "Weekly menu generation failed" in data["detail"]
 
-    def test_api_weekly_menu_with_optional_fields(self):
+    def test_api_weekly_menu_with_optional_fields(self) -> None:
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""
         payload = {
             **_BASE_WEEKLY_PAYLOAD,
@@ -136,6 +139,7 @@ class TestPremiumWeekAppCoverage:
                 headers={"X-API-Key": "test_key"},
             )
             assert response.status_code == 200
+            assert response.headers["content-type"].startswith("application/json")
             data = response.json()
             assert "week_summary" in data
             assert "daily_menus" in data

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import legacy_app
+from app import app
 
 # Common test payload for weekly menu tests (DRY)
 _BASE_WEEKLY_PAYLOAD: dict = {
@@ -30,15 +31,11 @@ class TestPremiumWeekAppCoverage:
     """Test suite for premium week endpoint coverage in main.py."""
 
     @pytest.fixture(autouse=True)
-    def _env_and_client(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        client: TestClient,
-    ) -> None:
+    def _env_and_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Set up test client and env with automatic cleanup."""
         monkeypatch.setenv("API_KEY", "test_key")
         monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
-        self.client = client
+        self.client = TestClient(app)
 
     def test_api_weekly_menu_make_weekly_menu_not_available(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+import legacy_app
 from app import app
 
 # Common test payload for weekly menu tests (DRY)
@@ -43,12 +44,16 @@ class TestPremiumWeekAppCoverage:
     def test_api_weekly_menu_make_weekly_menu_not_available(self):
         """Test when make_weekly_menu is not available (503 error).
 
-        The endpoint checks both app.make_weekly_menu and legacy_app globals,
+        The endpoint checks both app.make_weekly_menu and legacy_app globals(),
         so we need to ensure both return None to trigger the 503 response.
+        Using patch.dict to directly modify legacy_app.__dict__ ensures globals()
+        sees the patched value.
         """
-        # Mock make_weekly_menu to be None (not available) in both locations
-        # The endpoint checks app.make_weekly_menu first, then falls back to globals
-        with patch("app.make_weekly_menu", None), patch("legacy_app.make_weekly_menu", None):
+        # Use patch.dict to directly modify module's __dict__ for reliable globals() patching
+        with (
+            patch("app.make_weekly_menu", None),
+            patch.dict(legacy_app.__dict__, {"make_weekly_menu": None}),
+        ):
             response = self.client.post(
                 "/api/v1/premium/plan/week",
                 json=_BASE_WEEKLY_PAYLOAD,
@@ -83,13 +88,14 @@ class TestPremiumWeekAppCoverage:
     def test_api_weekly_menu_exception_handling(self):
         """Test exception handling in weekly menu generation."""
 
-        # Mock make_weekly_menu to raise an exception in both locations for consistency
+        # Mock make_weekly_menu to raise an exception
         def raise_exception(*args, **kwargs):
             raise RuntimeError("Test exception: menu engine failure")
 
+        # Use patch.dict for legacy_app to ensure globals() sees the mock
         with (
             patch("app.make_weekly_menu", side_effect=raise_exception),
-            patch("legacy_app.make_weekly_menu", side_effect=raise_exception),
+            patch.dict(legacy_app.__dict__, {"make_weekly_menu": raise_exception}),
         ):
             response = self.client.post(
                 "/api/v1/premium/plan/week",

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -7,12 +7,9 @@ EN: Simple tests for premium week endpoint coverage in main.py
 """
 
 import os
-import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
-from tests.feature_manifest import FEATURE_REASON, fail_feature_gated_test, require_feature
 
 from app import app
 
@@ -21,13 +18,9 @@ class TestPremiumWeekAppCoverage:
     """Test suite for premium week endpoint coverage in main.py."""
 
     def setup_method(self):
-        """Setup test environment"""
-        os.environ["API_KEY"] = "test_key"
-        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
-
-    def setup_method(self):
         """Set up test client."""
         os.environ["API_KEY"] = "test_key"
+        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
         self.client = TestClient(app)
 
     def teardown_method(self):
@@ -36,14 +29,34 @@ class TestPremiumWeekAppCoverage:
             del os.environ["API_KEY"]
 
     def test_api_weekly_menu_make_weekly_menu_not_available(self):
-        """Test when make_weekly_menu is not available (503 error)."""
-        # Skip this test for now - mocking is complex with FastAPI
-        # The function is imported at module level and hard to mock
-        require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
-        fail_feature_gated_test(
-            "premium_week_router_mocking",
-            reason="Weekly menu missing-handler assertions are not implemented yet.",
-        )
+        """Test when make_weekly_menu is not available (503 error).
+
+        The endpoint checks both app.make_weekly_menu and legacy_app globals,
+        so we need to ensure both return None to trigger the 503 response.
+        """
+        payload = {
+            "sex": "female",
+            "age": 30,
+            "height_cm": 165.0,
+            "weight_kg": 60.0,
+            "activity": "moderate",
+            "goal": "maintain",
+            "diet_flags": [],
+            "lang": "en",
+        }
+
+        # Mock make_weekly_menu to be None (not available) in both locations
+        # The endpoint checks app.make_weekly_menu first, then falls back to globals
+        with patch("app.make_weekly_menu", None), patch("legacy_app.make_weekly_menu", None):
+            response = self.client.post(
+                "/api/v1/premium/plan/week",
+                json=payload,
+                headers={"X-API-Key": "test_key"},
+            )
+            assert response.status_code == 503
+            data = response.json()
+            assert "detail" in data
+            assert "not available" in data["detail"].lower()
 
     def test_api_weekly_menu_success(self):
         """Test successful weekly menu generation."""
@@ -87,13 +100,31 @@ class TestPremiumWeekAppCoverage:
 
     def test_api_weekly_menu_exception_handling(self):
         """Test exception handling in weekly menu generation."""
-        # Skip this test for now - mocking is complex with FastAPI
-        # The function is imported at module level and hard to mock
-        require_feature("premium_week_router_mocking", reason=FEATURE_REASON)
-        fail_feature_gated_test(
-            "premium_week_router_mocking",
-            reason="Weekly menu exception-handling assertions are not implemented yet.",
-        )
+        payload = {
+            "sex": "female",
+            "age": 30,
+            "height_cm": 165.0,
+            "weight_kg": 60.0,
+            "activity": "moderate",
+            "goal": "maintain",
+            "diet_flags": [],
+            "lang": "en",
+        }
+
+        # Mock make_weekly_menu to raise an exception
+        def raise_exception(*args, **kwargs):
+            raise RuntimeError("Test exception: menu engine failure")
+
+        with patch("app.make_weekly_menu", side_effect=raise_exception):
+            response = self.client.post(
+                "/api/v1/premium/plan/week",
+                json=payload,
+                headers={"X-API-Key": "test_key"},
+            )
+            assert response.status_code == 500
+            data = response.json()
+            assert "detail" in data
+            assert "Weekly menu generation failed" in data["detail"]
 
     def test_api_weekly_menu_with_optional_fields(self):
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -45,24 +45,19 @@ class TestPremiumWeekAppCoverage:
     def test_api_weekly_menu_make_weekly_menu_not_available(self, monkeypatch: pytest.MonkeyPatch):
         """Test when make_weekly_menu is not available (503 error).
 
-        The endpoint checks both app.make_weekly_menu (via PEP 562 __getattr__) and
-        legacy_app globals(), so we need to ensure both return None.
+        The endpoint resolves make_weekly_menu via two paths (legacy_app.py L4277-4282):
+          1. getattr(sys.modules["app"], "make_weekly_menu", None)  — app module dict
+          2. globals().get("make_weekly_menu")                       — legacy_app namespace
 
-        We remove 'make_weekly_menu' from app._LOCAL_EXPORTS and set
-        legacy_app.make_weekly_menu to None directly.
+        Previous tests using ``patch("app.make_weekly_menu", ...)`` leave the real
+        function in ``app.__dict__`` after cleanup (patch restores via setattr).
+        We must set BOTH to None so neither path resolves a callable.
         """
         import app as app_module
 
-        # Remove 'make_weekly_menu' from app's lazy exports so __getattr__ falls back to legacy_app
-        original_exports = app_module._LOCAL_EXPORTS.copy()
-        monkeypatch.setattr(
-            app_module,
-            "_LOCAL_EXPORTS",
-            {k: v for k, v in original_exports.items() if k != "make_weekly_menu"},
-        )
-
-        # Set make_weekly_menu to None in legacy_app so getattr returns None
-        # and globals().get() also returns None
+        # Null out the app-level attribute (covers path 1: app.__dict__ lookup)
+        monkeypatch.setattr(app_module, "make_weekly_menu", None)
+        # Null out the legacy_app-level attribute (covers path 2: globals() fallback)
         monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
 
         response = self.client.post(

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -13,6 +13,18 @@ from fastapi.testclient import TestClient
 
 from app import app
 
+# Common test payload for weekly menu tests (DRY)
+_BASE_WEEKLY_PAYLOAD: dict = {
+    "sex": "female",
+    "age": 30,
+    "height_cm": 165.0,
+    "weight_kg": 60.0,
+    "activity": "moderate",
+    "goal": "maintain",
+    "diet_flags": [],
+    "lang": "en",
+}
+
 
 class TestPremiumWeekAppCoverage:
     """Test suite for premium week endpoint coverage in main.py."""
@@ -25,8 +37,8 @@ class TestPremiumWeekAppCoverage:
 
     def teardown_method(self):
         """Clean up test environment."""
-        if "API_KEY" in os.environ:
-            del os.environ["API_KEY"]
+        os.environ.pop("API_KEY", None)
+        os.environ.pop("FEATURE_PREMIUM_NUTRITION", None)
 
     def test_api_weekly_menu_make_weekly_menu_not_available(self):
         """Test when make_weekly_menu is not available (503 error).
@@ -34,23 +46,12 @@ class TestPremiumWeekAppCoverage:
         The endpoint checks both app.make_weekly_menu and legacy_app globals,
         so we need to ensure both return None to trigger the 503 response.
         """
-        payload = {
-            "sex": "female",
-            "age": 30,
-            "height_cm": 165.0,
-            "weight_kg": 60.0,
-            "activity": "moderate",
-            "goal": "maintain",
-            "diet_flags": [],
-            "lang": "en",
-        }
-
         # Mock make_weekly_menu to be None (not available) in both locations
         # The endpoint checks app.make_weekly_menu first, then falls back to globals
         with patch("app.make_weekly_menu", None), patch("legacy_app.make_weekly_menu", None):
             response = self.client.post(
                 "/api/v1/premium/plan/week",
-                json=payload,
+                json=_BASE_WEEKLY_PAYLOAD,
                 headers={"X-API-Key": "test_key"},
             )
             assert response.status_code == 503
@@ -60,35 +61,16 @@ class TestPremiumWeekAppCoverage:
 
     def test_api_weekly_menu_success(self):
         """Test successful weekly menu generation."""
-        payload = {
-            "sex": "female",
-            "age": 30,
-            "height_cm": 165.0,
-            "weight_kg": 60.0,
-            "activity": "moderate",
-            "goal": "maintain",
-            "diet_flags": [],
-            "lang": "en",
-        }
-
         # Mock make_weekly_menu to return a valid WeekMenu
         mock_week_menu = MagicMock()
         mock_week_menu.week_start = "2024-01-01"
-        mock_week_menu.daily_menus = [
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-        ]
+        mock_week_menu.daily_menus = [MagicMock() for _ in range(7)]
         mock_week_menu.total_cost = 105.0
 
         with patch("app.make_weekly_menu", return_value=mock_week_menu):
             response = self.client.post(
                 "/api/v1/premium/plan/week",
-                json=payload,
+                json=_BASE_WEEKLY_PAYLOAD,
                 headers={"X-API-Key": "test_key"},
             )
             assert response.status_code == 200
@@ -100,25 +82,18 @@ class TestPremiumWeekAppCoverage:
 
     def test_api_weekly_menu_exception_handling(self):
         """Test exception handling in weekly menu generation."""
-        payload = {
-            "sex": "female",
-            "age": 30,
-            "height_cm": 165.0,
-            "weight_kg": 60.0,
-            "activity": "moderate",
-            "goal": "maintain",
-            "diet_flags": [],
-            "lang": "en",
-        }
 
-        # Mock make_weekly_menu to raise an exception
+        # Mock make_weekly_menu to raise an exception in both locations for consistency
         def raise_exception(*args, **kwargs):
             raise RuntimeError("Test exception: menu engine failure")
 
-        with patch("app.make_weekly_menu", side_effect=raise_exception):
+        with (
+            patch("app.make_weekly_menu", side_effect=raise_exception),
+            patch("legacy_app.make_weekly_menu", side_effect=raise_exception),
+        ):
             response = self.client.post(
                 "/api/v1/premium/plan/week",
-                json=payload,
+                json=_BASE_WEEKLY_PAYLOAD,
                 headers={"X-API-Key": "test_key"},
             )
             assert response.status_code == 500
@@ -129,18 +104,12 @@ class TestPremiumWeekAppCoverage:
     def test_api_weekly_menu_with_optional_fields(self):
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""
         payload = {
-            "sex": "female",
-            "age": 30,
-            "height_cm": 165.0,
-            "weight_kg": 60.0,
-            "activity": "moderate",
-            "goal": "maintain",
+            **_BASE_WEEKLY_PAYLOAD,
             "deficit_pct": 10.0,
             "surplus_pct": 5.0,
             "bodyfat": 20.0,
             "life_stage": "adult",
             "diet_flags": ["VEG"],
-            "lang": "en",
         }
 
         # Mock make_weekly_menu to return a valid WeekMenu

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -9,6 +9,7 @@ EN: Simple tests for premium week endpoint coverage in main.py
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 import legacy_app
@@ -41,28 +42,40 @@ class TestPremiumWeekAppCoverage:
         os.environ.pop("API_KEY", None)
         os.environ.pop("FEATURE_PREMIUM_NUTRITION", None)
 
-    def test_api_weekly_menu_make_weekly_menu_not_available(self):
+    def test_api_weekly_menu_make_weekly_menu_not_available(self, monkeypatch: pytest.MonkeyPatch):
         """Test when make_weekly_menu is not available (503 error).
 
-        The endpoint checks both app.make_weekly_menu and legacy_app globals(),
-        so we need to ensure both return None to trigger the 503 response.
-        Using patch.dict to directly modify legacy_app.__dict__ ensures globals()
-        sees the patched value.
+        The endpoint checks both app.make_weekly_menu (via PEP 562 __getattr__) and
+        legacy_app globals(), so we need to ensure both return None.
+
+        We mock app._LOCAL_EXPORTS to remove 'make_weekly_menu' and delete from legacy_app.
         """
-        # Use patch.dict to directly modify module's __dict__ for reliable globals() patching
-        with (
-            patch("app.make_weekly_menu", None),
-            patch.dict(legacy_app.__dict__, {"make_weekly_menu": None}),
-        ):
-            response = self.client.post(
-                "/api/v1/premium/plan/week",
-                json=_BASE_WEEKLY_PAYLOAD,
-                headers={"X-API-Key": "test_key"},
-            )
-            assert response.status_code == 503
-            data = response.json()
-            assert "detail" in data
-            assert "not available" in data["detail"].lower()
+        import app as app_module
+
+        # Remove 'make_weekly_menu' from app's lazy exports so __getattr__ won't find it
+        original_exports = app_module._LOCAL_EXPORTS.copy()
+        monkeypatch.setattr(
+            app_module,
+            "_LOCAL_EXPORTS",
+            {k: v for k, v in original_exports.items() if k != "make_weekly_menu"},
+        )
+
+        # Also need to handle the fallback to legacy_app in __getattr__
+        # And delete from legacy_app globals
+        try:
+            monkeypatch.delattr(legacy_app, "make_weekly_menu")
+        except AttributeError:
+            pass
+
+        response = self.client.post(
+            "/api/v1/premium/plan/week",
+            json=_BASE_WEEKLY_PAYLOAD,
+            headers={"X-API-Key": "test_key"},
+        )
+        assert response.status_code == 503
+        data = response.json()
+        assert "detail" in data
+        assert "not available" in data["detail"].lower()
 
     def test_api_weekly_menu_success(self):
         """Test successful weekly menu generation."""
@@ -85,27 +98,26 @@ class TestPremiumWeekAppCoverage:
             assert "weekly_coverage" in data
             assert "shopping_list" in data
 
-    def test_api_weekly_menu_exception_handling(self):
+    def test_api_weekly_menu_exception_handling(self, monkeypatch: pytest.MonkeyPatch):
         """Test exception handling in weekly menu generation."""
 
         # Mock make_weekly_menu to raise an exception
         def raise_exception(*args, **kwargs):
             raise RuntimeError("Test exception: menu engine failure")
 
-        # Use patch.dict for legacy_app to ensure globals() sees the mock
-        with (
-            patch("app.make_weekly_menu", side_effect=raise_exception),
-            patch.dict(legacy_app.__dict__, {"make_weekly_menu": raise_exception}),
-        ):
-            response = self.client.post(
-                "/api/v1/premium/plan/week",
-                json=_BASE_WEEKLY_PAYLOAD,
-                headers={"X-API-Key": "test_key"},
-            )
-            assert response.status_code == 500
-            data = response.json()
-            assert "detail" in data
-            assert "Weekly menu generation failed" in data["detail"]
+        # Use monkeypatch.setattr for both modules to ensure globals() sees the mock
+        monkeypatch.setattr("app.make_weekly_menu", raise_exception)
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", raise_exception)
+
+        response = self.client.post(
+            "/api/v1/premium/plan/week",
+            json=_BASE_WEEKLY_PAYLOAD,
+            headers={"X-API-Key": "test_key"},
+        )
+        assert response.status_code == 500
+        data = response.json()
+        assert "detail" in data
+        assert "Weekly menu generation failed" in data["detail"]
 
     def test_api_weekly_menu_with_optional_fields(self):
         """Test with optional fields like deficit_pct, surplus_pct, bodyfat, life_stage."""

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -48,11 +48,12 @@ class TestPremiumWeekAppCoverage:
         The endpoint checks both app.make_weekly_menu (via PEP 562 __getattr__) and
         legacy_app globals(), so we need to ensure both return None.
 
-        We mock app._LOCAL_EXPORTS to remove 'make_weekly_menu' and delete from legacy_app.
+        We remove 'make_weekly_menu' from app._LOCAL_EXPORTS and set
+        legacy_app.make_weekly_menu to None directly.
         """
         import app as app_module
 
-        # Remove 'make_weekly_menu' from app's lazy exports so __getattr__ won't find it
+        # Remove 'make_weekly_menu' from app's lazy exports so __getattr__ falls back to legacy_app
         original_exports = app_module._LOCAL_EXPORTS.copy()
         monkeypatch.setattr(
             app_module,
@@ -60,12 +61,9 @@ class TestPremiumWeekAppCoverage:
             {k: v for k, v in original_exports.items() if k != "make_weekly_menu"},
         )
 
-        # Also need to handle the fallback to legacy_app in __getattr__
-        # And delete from legacy_app globals
-        try:
-            monkeypatch.delattr(legacy_app, "make_weekly_menu")
-        except AttributeError:
-            pass
+        # Set make_weekly_menu to None in legacy_app so getattr returns None
+        # and globals().get() also returns None
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
 
         response = self.client.post(
             "/api/v1/premium/plan/week",


### PR DESCRIPTION
## Summary
- Implement `test_api_weekly_menu_make_weekly_menu_not_available` test (503 error when `make_weekly_menu` unavailable)
- Implement `test_api_weekly_menu_exception_handling` test (500 error when `make_weekly_menu` raises exception)
- Remove `premium_week_router_mocking` from `FEATURE_TODO_KEYS` (6 keys remaining)

## Test plan
- [x] `pytest tests/test_premium_week_app_coverage.py -v` passes (4/4 tests)
- [x] `pytest -q tests/edges tests/test_remaining_modules.py` passes (test-fast equivalent)
- [x] Pre-commit hooks pass
- [x] Ruff lint passes
- [x] CI green (test-feature, test-pr, coverage-feature, coverage-pr all pass)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-2686369590 -> bf12e208
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2847901283 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848732470 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848756959 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2847924210 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2847924307 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848757156 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2847974698 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848813551 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848880838 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2848082475 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3848942252 -> 9faa3f80
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3849097226 -> da006926
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#discussion_r2848356235 -> da006926
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/888#pullrequestreview-3849241551 -> da006926

## Merge Readiness
- [x] CI green
- [x] Bot comments addressed to zero

## Deferred / Follow-ups
- 6 feature keys remaining: `planner_engines`, `plate_day_micros`, `exports_recipes_products`, `sports_disclaimers_lifestage`, `legacy_bmi_removed`, `nutrient_recommendations`

🤖 Generated with [Qoder][https://qoder.com]