### PR TITLE
feat(food-db): add Wave 1 snapshot manager and OFF delta contracts

### DIFF
--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -1,0 +1,152 @@
+"""
+Open Food Facts snapshot source with deterministic weekly delta ingestion.
+
+RU: Источник OFF со snapshot-first контрактом и детерминированным delta-слиянием.
+EN: OFF source implementing snapshot-first and deterministic delta merge.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Callable, Iterable, Protocol
+
+import httpx
+
+from .snapshot_manager import SnapshotIntegrityError, SnapshotMeta, sha256_file
+
+OFF_DELTA_URL = "https://static.openfoodfacts.org/data/delta/{year}-{month:02d}-{day:02d}.jsonl.gz"
+OFF_FULL_URL = "https://static.openfoodfacts.org/data/openfoodfacts-products.jsonl.gz"
+
+
+class OFFTransport(Protocol):
+    """Transport abstraction to keep ingestion testable and deterministic."""
+
+    def fetch(self, url: str, timeout_seconds: int) -> bytes | None:
+        """Return raw payload bytes for URL, or None for non-existing resources."""
+
+    def iter_bytes(self, url: str, timeout_seconds: int, chunk_size: int) -> Iterable[bytes]:
+        """Stream payload bytes for URL."""
+
+
+class HttpxOFFTransport:
+    """Default transport using httpx."""
+
+    def fetch(self, url: str, timeout_seconds: int) -> bytes | None:
+        response = httpx.get(url, timeout=timeout_seconds, follow_redirects=True)
+        if response.status_code == 200:
+            return response.content
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return None
+
+    def iter_bytes(self, url: str, timeout_seconds: int, chunk_size: int) -> Iterable[bytes]:
+        with httpx.stream("GET", url, timeout=timeout_seconds, follow_redirects=True) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes(chunk_size=chunk_size):
+                yield chunk
+
+
+class OpenFoodFactsDeltaSource:
+    """OFF source implementation for SnapshotManager protocol."""
+
+    name = "off"
+
+    def __init__(
+        self,
+        *,
+        transport: OFFTransport | None = None,
+        today_provider: Callable[[], date] | None = None,
+        full_url: str = OFF_FULL_URL,
+        delta_url_template: str = OFF_DELTA_URL,
+    ) -> None:
+        self.transport = transport or HttpxOFFTransport()
+        self._today_provider = today_provider or date.today
+        self.full_url = full_url
+        self.delta_url_template = delta_url_template
+
+    def _today(self) -> date:
+        return self._today_provider()
+
+    def has_updates_since(self, last_snapshot: date) -> bool:
+        """OFF policy: sync delta weekly or later."""
+        return (self._today() - last_snapshot).days >= 7
+
+    def _iter_delta_days(self, since: date) -> Iterable[date]:
+        current = since + timedelta(days=1)
+        while current <= self._today():
+            yield current
+            current = current + timedelta(days=1)
+
+    def _decode_delta_payload(self, payload: bytes, source_url: str) -> bytes:
+        try:
+            with gzip.GzipFile(fileobj=io.BytesIO(payload), mode="rb") as gzip_file:
+                return gzip_file.read()
+        except OSError as exc:
+            raise SnapshotIntegrityError(f"Malformed OFF delta payload: {source_url}") from exc
+
+    def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
+        """Download and merge daily OFF delta payloads into one deterministic gzip snapshot."""
+        dest.mkdir(parents=True, exist_ok=True)
+        output_path = dest / "openfoodfacts-delta.jsonl.gz"
+
+        record_count = 0
+        with open(output_path, "wb") as output_file:
+            # mtime=0 keeps gzip output deterministic across runs for identical input.
+            with gzip.GzipFile(fileobj=output_file, mode="wb", mtime=0) as gzip_out:
+                for day in self._iter_delta_days(since):
+                    url = self.delta_url_template.format(
+                        year=day.year,
+                        month=day.month,
+                        day=day.day,
+                    )
+                    payload = self.transport.fetch(url=url, timeout_seconds=120)
+                    if payload is None:
+                        continue
+                    decoded = self._decode_delta_payload(payload=payload, source_url=url)
+                    if decoded and not decoded.endswith(b"\n"):
+                        decoded += b"\n"
+                    record_count += decoded.count(b"\n")
+                    gzip_out.write(decoded)
+
+        checksum = sha256_file(output_path)
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=self._today(),
+            file_path=output_path,
+            checksum_sha256=checksum,
+            record_count=record_count,
+            size_bytes=output_path.stat().st_size,
+            mode="delta",
+        )
+
+    def download_full(self, dest: Path) -> SnapshotMeta:
+        """Download full OFF dump snapshot."""
+        dest.mkdir(parents=True, exist_ok=True)
+        output_path = dest / "openfoodfacts-products.jsonl.gz"
+
+        with open(output_path, "wb") as output_file:
+            for chunk in self.transport.iter_bytes(
+                url=self.full_url, timeout_seconds=3600, chunk_size=1024 * 1024
+            ):
+                output_file.write(chunk)
+
+        try:
+            with gzip.open(output_path, "rb") as gzip_file:
+                record_count = sum(1 for _ in gzip_file)
+        except OSError as exc:
+            raise SnapshotIntegrityError(f"Malformed OFF full snapshot: {output_path}") from exc
+
+        checksum = sha256_file(output_path)
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=self._today(),
+            file_path=output_path,
+            checksum_sha256=checksum,
+            record_count=record_count,
+            size_bytes=output_path.stat().st_size,
+            mode="full",
+        )

--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -85,7 +85,7 @@ class OpenFoodFactsDeltaSource:
         try:
             with gzip.GzipFile(fileobj=io.BytesIO(payload), mode="rb") as gzip_file:
                 return gzip_file.read()
-        except OSError as exc:
+        except (OSError, EOFError) as exc:
             raise SnapshotIntegrityError(f"Malformed OFF delta payload: {source_url}") from exc
 
     def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
@@ -137,7 +137,7 @@ class OpenFoodFactsDeltaSource:
         try:
             with gzip.open(output_path, "rb") as gzip_file:
                 record_count = sum(1 for _ in gzip_file)
-        except OSError as exc:
+        except (OSError, EOFError) as exc:
             raise SnapshotIntegrityError(f"Malformed OFF full snapshot: {output_path}") from exc
 
         checksum = sha256_file(output_path)

--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import gzip
 import io
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Protocol
 
@@ -55,6 +55,11 @@ class OpenFoodFactsDeltaSource:
 
     name = "off"
 
+    @staticmethod
+    def _utc_today() -> date:
+        """Return UTC calendar date to avoid local-time drift."""
+        return datetime.now(timezone.utc).date()
+
     def __init__(
         self,
         *,
@@ -64,7 +69,7 @@ class OpenFoodFactsDeltaSource:
         delta_url_template: str = OFF_DELTA_URL,
     ) -> None:
         self.transport = transport or HttpxOFFTransport()
-        self._today_provider = today_provider or date.today
+        self._today_provider = today_provider or self._utc_today
         self.full_url = full_url
         self.delta_url_template = delta_url_template
 

--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -37,7 +37,7 @@ class HttpxOFFTransport:
 
     def fetch(self, url: str, timeout_seconds: int) -> bytes | None:
         response = httpx.get(url, timeout=timeout_seconds, follow_redirects=True)
-        if response.status_code == 200:
+        if 200 <= response.status_code < 300:
             return response.content
         if response.status_code == 404:
             return None

--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import gzip
 import io
+import zlib
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Protocol
@@ -91,7 +92,7 @@ class OpenFoodFactsDeltaSource:
         try:
             with gzip.GzipFile(fileobj=io.BytesIO(payload), mode="rb") as gzip_file:
                 return gzip_file.read()
-        except (OSError, EOFError) as exc:
+        except (OSError, EOFError, zlib.error) as exc:
             raise SnapshotIntegrityError(f"Malformed OFF delta payload: {source_url}") from exc
 
     def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
@@ -143,7 +144,7 @@ class OpenFoodFactsDeltaSource:
         try:
             with gzip.open(output_path, "rb") as gzip_file:
                 record_count = sum(1 for _ in gzip_file)
-        except (OSError, EOFError) as exc:
+        except (OSError, EOFError, zlib.error) as exc:
             raise SnapshotIntegrityError(f"Malformed OFF full snapshot: {output_path}") from exc
 
         checksum = sha256_file(output_path)

--- a/core/food_sources/off_delta.py
+++ b/core/food_sources/off_delta.py
@@ -77,7 +77,8 @@ class OpenFoodFactsDeltaSource:
 
     def _iter_delta_days(self, since: date) -> Iterable[date]:
         current = since + timedelta(days=1)
-        while current <= self._today():
+        end_date = self._today()
+        while current <= end_date:
             yield current
             current = current + timedelta(days=1)
 

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -12,7 +12,25 @@ import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Protocol, cast
+from typing import Callable, Protocol, TypedDict
+
+
+class ManifestSnapshotEntry(TypedDict):
+    """Typed manifest entry for a single snapshot."""
+
+    date: str
+    file: str
+    checksum: str
+    records: int
+    bytes: int
+    mode: str
+
+
+class ManifestData(TypedDict):
+    """Typed manifest payload stored per source."""
+
+    source: str
+    snapshots: list[ManifestSnapshotEntry]
 
 
 def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
@@ -39,7 +57,7 @@ class SnapshotMeta:
     size_bytes: int
     mode: str = "full"
 
-    def to_manifest_entry(self) -> dict[str, Any]:
+    def to_manifest_entry(self) -> ManifestSnapshotEntry:
         """Convert to a serializable manifest entry."""
         return {
             "date": self.snapshot_date.isoformat(),
@@ -93,7 +111,7 @@ class SnapshotManager:
     def _manifest_path(self, source: str) -> Path:
         return self.base_path / source / self.MANIFEST_FILE
 
-    def _load_manifest(self, source: str) -> dict[str, Any]:
+    def _load_manifest(self, source: str) -> ManifestData:
         manifest_path = self._manifest_path(source)
         if not manifest_path.exists():
             return {"source": source, "snapshots": []}
@@ -103,9 +121,8 @@ class SnapshotManager:
             raise SnapshotIntegrityError(
                 f"Invalid manifest schema for source={source}: root object must be a dict"
             )
-        data = cast(dict[str, Any], loaded)
 
-        manifest_source = data.get("source")
+        manifest_source = loaded.get("source")
         if not isinstance(manifest_source, str):
             raise SnapshotIntegrityError(
                 f"Invalid manifest schema for source={source}: missing string 'source' key"
@@ -116,16 +133,17 @@ class SnapshotManager:
                 f"{source}: source mismatch '{manifest_source}'"
             )
 
-        if "snapshots" not in data:
+        if "snapshots" not in loaded:
             raise SnapshotIntegrityError(
                 f"Invalid manifest schema for source={source}: missing 'snapshots' key"
             )
-        snapshots = data["snapshots"]
-        if not isinstance(snapshots, list):
+        snapshots_obj = loaded["snapshots"]
+        if not isinstance(snapshots_obj, list):
             raise SnapshotIntegrityError(
                 f"Invalid manifest schema for source={source}: snapshots must be a list"
             )
-        for index, snapshot in enumerate(snapshots):
+        validated: list[ManifestSnapshotEntry] = []
+        for index, snapshot in enumerate(snapshots_obj):
             if not isinstance(snapshot, dict):
                 raise SnapshotIntegrityError(
                     f"Invalid manifest schema for source={source}: snapshots[{index}] must be a dict"
@@ -137,12 +155,40 @@ class SnapshotManager:
                         f"Invalid manifest schema for source={source}: "
                         f"snapshots[{index}]['{key}'] must be a string"
                     )
-        return data
+            checksum = snapshot.get("checksum")
+            if not isinstance(checksum, str):
+                raise SnapshotIntegrityError(
+                    f"Invalid manifest schema for source={source}: "
+                    f"snapshots[{index}]['checksum'] must be a string"
+                )
+            records = snapshot.get("records")
+            if not isinstance(records, int):
+                raise SnapshotIntegrityError(
+                    f"Invalid manifest schema for source={source}: "
+                    f"snapshots[{index}]['records'] must be an int"
+                )
+            bytes_count = snapshot.get("bytes")
+            if not isinstance(bytes_count, int):
+                raise SnapshotIntegrityError(
+                    f"Invalid manifest schema for source={source}: "
+                    f"snapshots[{index}]['bytes'] must be an int"
+                )
+            validated.append(
+                {
+                    "date": snapshot["date"],
+                    "file": snapshot["file"],
+                    "checksum": checksum,
+                    "records": records,
+                    "bytes": bytes_count,
+                    "mode": snapshot["mode"],
+                }
+            )
+        return {"source": manifest_source, "snapshots": validated}
 
     def get_last_snapshot_date(self, source: str) -> date | None:
         """Return date of latest recorded snapshot for a source."""
         data = self._load_manifest(source)
-        snapshots = data.get("snapshots", [])
+        snapshots = data["snapshots"]
         if not snapshots:
             return None
         try:
@@ -170,17 +216,15 @@ class SnapshotManager:
         manifest_path = self._manifest_path(meta.source)
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         data = self._load_manifest(meta.source)
-
-        snapshots = data.setdefault("snapshots", [])
         entry = meta.to_manifest_entry()
-
-        filtered = [
+        snapshots = data["snapshots"]
+        filtered: list[ManifestSnapshotEntry] = [
             snapshot
             for snapshot in snapshots
             if not (
-                snapshot.get("date") == entry["date"]
-                and snapshot.get("file") == entry["file"]
-                and snapshot.get("mode") == entry["mode"]
+                snapshot["date"] == entry["date"]
+                and snapshot["file"] == entry["file"]
+                and snapshot["mode"] == entry["mode"]
             )
         ]
         filtered.append(entry)
@@ -206,6 +250,11 @@ class SnapshotManager:
         elif force or source.has_updates_since(last_snapshot):
             meta = source.download_delta(last_snapshot, destination)
         else:
+            return None
+
+        if meta.mode == "delta" and meta.record_count == 0:
+            if meta.file_path.exists():
+                meta.file_path.unlink()
             return None
 
         self.record_snapshot(meta)

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Callable, Protocol, TypedDict
 
@@ -98,12 +98,17 @@ class SnapshotManager:
 
     MANIFEST_FILE = "manifest.json"
 
+    @staticmethod
+    def _utc_today() -> date:
+        """Return UTC calendar date to avoid local-time drift."""
+        return datetime.now(timezone.utc).date()
+
     def __init__(
         self, base_path: Path | str, *, today_provider: Callable[[], date] | None = None
     ) -> None:
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
-        self._today_provider = today_provider or date.today
+        self._today_provider = today_provider or self._utc_today
 
     def _today(self) -> date:
         return self._today_provider()
@@ -242,12 +247,14 @@ class SnapshotManager:
         Subsequent runs pull delta only when updates are available or force=True.
         """
         last_snapshot = self.get_last_snapshot_date(source.name)
-        destination = self.base_path / source.name / self._today().isoformat()
-        destination.mkdir(parents=True, exist_ok=True)
 
         if last_snapshot is None:
+            destination = self.base_path / source.name / self._today().isoformat()
+            destination.mkdir(parents=True, exist_ok=True)
             meta = source.download_full(destination)
         elif force or source.has_updates_since(last_snapshot):
+            destination = self.base_path / source.name / self._today().isoformat()
+            destination.mkdir(parents=True, exist_ok=True)
             meta = source.download_delta(last_snapshot, destination)
         else:
             return None

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -1,0 +1,182 @@
+"""
+Snapshot manager contracts for snapshot-first food source ingestion.
+
+RU: Контракты и менеджер снапшотов для snapshot-first пайплайна.
+EN: Snapshot contracts and manager for snapshot-first ingestion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+
+def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    """Return SHA-256 checksum for a file."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as file_obj:
+        while True:
+            chunk = file_obj.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class SnapshotMeta:
+    """Metadata about a synchronized snapshot."""
+
+    source: str
+    snapshot_date: date
+    file_path: Path
+    checksum_sha256: str
+    record_count: int
+    size_bytes: int
+    mode: str = "full"
+
+    def to_manifest_entry(self) -> dict[str, Any]:
+        """Convert to a serializable manifest entry."""
+        return {
+            "date": self.snapshot_date.isoformat(),
+            "file": str(self.file_path),
+            "checksum": self.checksum_sha256,
+            "records": self.record_count,
+            "bytes": self.size_bytes,
+            "mode": self.mode,
+        }
+
+
+class SnapshotSource(Protocol):
+    """Protocol for snapshot-capable food data sources."""
+
+    name: str
+
+    def has_updates_since(self, last_snapshot: date) -> bool:
+        """Return True when source has updates since last snapshot."""
+
+    def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
+        """Download a delta snapshot into destination path."""
+
+    def download_full(self, dest: Path) -> SnapshotMeta:
+        """Download a full snapshot into destination path."""
+
+
+class SnapshotIntegrityError(RuntimeError):
+    """Raised when snapshot integrity checks fail."""
+
+
+class SnapshotManager:
+    """
+    Local snapshot manager with immutable storage and manifest tracking.
+
+    RU: Локальный менеджер снапшотов с манифестом и fail-closed валидацией.
+    EN: Local snapshot manager with manifest tracking and fail-closed validation.
+    """
+
+    MANIFEST_FILE = "manifest.json"
+
+    def __init__(self, base_path: Path | str, *, today_provider: Any | None = None) -> None:
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self._today_provider = today_provider or date.today
+
+    def _today(self) -> date:
+        return self._today_provider()
+
+    def _manifest_path(self, source: str) -> Path:
+        return self.base_path / source / self.MANIFEST_FILE
+
+    def _load_manifest(self, source: str) -> dict[str, Any]:
+        manifest_path = self._manifest_path(source)
+        if not manifest_path.exists():
+            return {"source": source, "snapshots": []}
+        with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+            loaded = json.load(manifest_file)
+        if not isinstance(loaded, dict):
+            raise SnapshotIntegrityError(
+                f"Invalid manifest schema for source={source}: root object must be a dict"
+            )
+        data = cast(dict[str, Any], loaded)
+        snapshots = data.get("snapshots")
+        if not isinstance(snapshots, list):
+            raise SnapshotIntegrityError(
+                f"Invalid manifest schema for source={source}: snapshots must be a list"
+            )
+        return data
+
+    def get_last_snapshot_date(self, source: str) -> date | None:
+        """Return date of latest recorded snapshot for a source."""
+        data = self._load_manifest(source)
+        snapshots = data.get("snapshots", [])
+        if not snapshots:
+            return None
+        try:
+            return date.fromisoformat(snapshots[-1]["date"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise SnapshotIntegrityError(
+                f"Invalid latest snapshot date for source={source}"
+            ) from exc
+
+    def validate_snapshot(self, meta: SnapshotMeta) -> None:
+        """Fail-closed integrity validation before manifest update."""
+        if not meta.file_path.exists():
+            raise SnapshotIntegrityError(f"Snapshot file does not exist: {meta.file_path}")
+        actual_checksum = sha256_file(meta.file_path)
+        if actual_checksum != meta.checksum_sha256:
+            raise SnapshotIntegrityError(
+                "Checksum mismatch for snapshot "
+                f"{meta.file_path}: expected={meta.checksum_sha256} actual={actual_checksum}"
+            )
+
+    def record_snapshot(self, meta: SnapshotMeta) -> None:
+        """Persist snapshot metadata entry into source manifest."""
+        self.validate_snapshot(meta)
+
+        manifest_path = self._manifest_path(meta.source)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        data = self._load_manifest(meta.source)
+
+        snapshots = data.setdefault("snapshots", [])
+        entry = meta.to_manifest_entry()
+
+        filtered = [
+            snapshot
+            for snapshot in snapshots
+            if not (
+                snapshot.get("date") == entry["date"]
+                and snapshot.get("file") == entry["file"]
+                and snapshot.get("mode") == entry["mode"]
+            )
+        ]
+        filtered.append(entry)
+        filtered.sort(key=lambda snapshot: (snapshot["date"], snapshot["file"], snapshot["mode"]))
+        data["snapshots"] = filtered
+
+        with open(manifest_path, "w", encoding="utf-8") as manifest_file:
+            json.dump(data, manifest_file, indent=2)
+
+    def sync_if_needed(self, source: SnapshotSource, force: bool = False) -> SnapshotMeta | None:
+        """
+        Sync a source snapshot if required.
+
+        First run pulls full snapshot.
+        Subsequent runs pull delta only when updates are available or force=True.
+        """
+        last_snapshot = self.get_last_snapshot_date(source.name)
+        destination = self.base_path / source.name / self._today().isoformat()
+        destination.mkdir(parents=True, exist_ok=True)
+
+        if last_snapshot is None:
+            meta = source.download_full(destination)
+        elif force or source.has_updates_since(last_snapshot):
+            meta = source.download_delta(last_snapshot, destination)
+        else:
+            return None
+
+        self.record_snapshot(meta)
+        return meta

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -12,7 +12,7 @@ import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Callable, Protocol, cast
 
 
 def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
@@ -80,7 +80,9 @@ class SnapshotManager:
 
     MANIFEST_FILE = "manifest.json"
 
-    def __init__(self, base_path: Path | str, *, today_provider: Any | None = None) -> None:
+    def __init__(
+        self, base_path: Path | str, *, today_provider: Callable[[], date] | None = None
+    ) -> None:
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
         self._today_provider = today_provider or date.today
@@ -102,11 +104,39 @@ class SnapshotManager:
                 f"Invalid manifest schema for source={source}: root object must be a dict"
             )
         data = cast(dict[str, Any], loaded)
-        snapshots = data.get("snapshots")
+
+        manifest_source = data.get("source")
+        if not isinstance(manifest_source, str):
+            raise SnapshotIntegrityError(
+                f"Invalid manifest schema for source={source}: missing string 'source' key"
+            )
+        if manifest_source != source:
+            raise SnapshotIntegrityError(
+                "Invalid manifest schema for source="
+                f"{source}: source mismatch '{manifest_source}'"
+            )
+
+        if "snapshots" not in data:
+            raise SnapshotIntegrityError(
+                f"Invalid manifest schema for source={source}: missing 'snapshots' key"
+            )
+        snapshots = data["snapshots"]
         if not isinstance(snapshots, list):
             raise SnapshotIntegrityError(
                 f"Invalid manifest schema for source={source}: snapshots must be a list"
             )
+        for index, snapshot in enumerate(snapshots):
+            if not isinstance(snapshot, dict):
+                raise SnapshotIntegrityError(
+                    f"Invalid manifest schema for source={source}: snapshots[{index}] must be a dict"
+                )
+            for key in ("date", "file", "mode"):
+                value = snapshot.get(key)
+                if not isinstance(value, str):
+                    raise SnapshotIntegrityError(
+                        f"Invalid manifest schema for source={source}: "
+                        f"snapshots[{index}]['{key}'] must be a string"
+                    )
         return data
 
     def get_last_snapshot_date(self, source: str) -> date | None:

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_food_sources_off_delta.py
+++ b/tests/test_food_sources_off_delta.py
@@ -1,0 +1,186 @@
+"""Tests for OFF snapshot delta source contracts."""
+
+from __future__ import annotations
+
+import gzip
+import io
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from core.food_sources.off_delta import HttpxOFFTransport, OpenFoodFactsDeltaSource
+from core.food_sources.snapshot_manager import SnapshotIntegrityError
+
+
+def _gzip_payload(text: str) -> bytes:
+    raw_buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=raw_buffer, mode="wb", mtime=0) as gzip_file:
+        gzip_file.write(text.encode("utf-8"))
+    return raw_buffer.getvalue()
+
+
+class _StubTransport:
+    def __init__(
+        self,
+        *,
+        payload_map: dict[str, bytes] | None = None,
+        full_chunks: list[bytes] | None = None,
+    ) -> None:
+        self.payload_map = payload_map or {}
+        self.full_chunks = full_chunks or []
+
+    def fetch(self, url: str, timeout_seconds: int) -> bytes | None:
+        _ = timeout_seconds
+        return self.payload_map.get(url)
+
+    def iter_bytes(self, url: str, timeout_seconds: int, chunk_size: int) -> list[bytes]:
+        _ = (url, timeout_seconds, chunk_size)
+        return self.full_chunks
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
+        self._raise_called = False
+
+    def raise_for_status(self) -> None:
+        self._raise_called = True
+        raise RuntimeError("boom")
+
+
+class _FakeStreamResponse:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def __enter__(self) -> "_FakeStreamResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        _ = (exc_type, exc, tb)
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self, chunk_size: int) -> list[bytes]:
+        _ = chunk_size
+        return self._chunks
+
+
+def test_off_delta_is_deterministic_and_counts_records(tmp_path: Path) -> None:
+    day_21 = "https://static.openfoodfacts.org/data/delta/2026-02-21.jsonl.gz"
+    day_22 = "https://static.openfoodfacts.org/data/delta/2026-02-22.jsonl.gz"
+    transport = _StubTransport(
+        payload_map={
+            day_21: _gzip_payload('{"code":"1"}\n{"code":"2"}\n'),
+            day_22: _gzip_payload('{"code":"3"}'),
+        }
+    )
+
+    source = OpenFoodFactsDeltaSource(
+        transport=transport,
+        today_provider=lambda: date(2026, 2, 22),
+    )
+
+    meta_1 = source.download_delta(since=date(2026, 2, 20), dest=tmp_path / "run1")
+    meta_2 = source.download_delta(since=date(2026, 2, 20), dest=tmp_path / "run2")
+
+    assert meta_1.record_count == 3
+    assert meta_2.record_count == 3
+    assert meta_1.checksum_sha256 == meta_2.checksum_sha256
+
+    with gzip.open(meta_1.file_path, "rt", encoding="utf-8") as gzip_file:
+        lines = [line.strip() for line in gzip_file if line.strip()]
+    assert lines == ['{"code":"1"}', '{"code":"2"}', '{"code":"3"}']
+
+
+def test_off_delta_ignores_missing_day_payload(tmp_path: Path) -> None:
+    day_21 = "https://static.openfoodfacts.org/data/delta/2026-02-21.jsonl.gz"
+    transport = _StubTransport(payload_map={day_21: _gzip_payload('{"code":"1"}\n')})
+
+    source = OpenFoodFactsDeltaSource(
+        transport=transport,
+        today_provider=lambda: date(2026, 2, 22),
+    )
+    meta = source.download_delta(since=date(2026, 2, 20), dest=tmp_path)
+
+    assert meta.record_count == 1
+
+
+def test_off_delta_malformed_payload_fails_closed(tmp_path: Path) -> None:
+    day_21 = "https://static.openfoodfacts.org/data/delta/2026-02-21.jsonl.gz"
+    transport = _StubTransport(payload_map={day_21: b"not-a-gzip-stream"})
+
+    source = OpenFoodFactsDeltaSource(
+        transport=transport,
+        today_provider=lambda: date(2026, 2, 21),
+    )
+
+    with pytest.raises(SnapshotIntegrityError):
+        source.download_delta(since=date(2026, 2, 20), dest=tmp_path)
+
+
+def test_off_delta_update_policy_weekly_threshold() -> None:
+    source = OpenFoodFactsDeltaSource(today_provider=lambda: date(2026, 2, 24))
+    assert source.has_updates_since(date(2026, 2, 16)) is True
+    assert source.has_updates_since(date(2026, 2, 18)) is False
+
+
+def test_off_full_download_counts_records(tmp_path: Path) -> None:
+    full_payload = _gzip_payload('{"code":"1"}\n{"code":"2"}\n')
+    transport = _StubTransport(full_chunks=[full_payload])
+
+    source = OpenFoodFactsDeltaSource(
+        transport=transport,
+        today_provider=lambda: date(2026, 2, 24),
+    )
+
+    meta = source.download_full(dest=tmp_path)
+    assert meta.mode == "full"
+    assert meta.record_count == 2
+    assert meta.file_path.exists()
+
+
+def test_off_full_malformed_payload_fails_closed(tmp_path: Path) -> None:
+    transport = _StubTransport(full_chunks=[b"not-a-gzip-stream"])
+    source = OpenFoodFactsDeltaSource(
+        transport=transport,
+        today_provider=lambda: date(2026, 2, 24),
+    )
+
+    with pytest.raises(SnapshotIntegrityError):
+        source.download_full(dest=tmp_path)
+
+
+def test_httpx_transport_fetch_and_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = HttpxOFFTransport()
+
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.get",
+        lambda url, timeout, follow_redirects: _FakeResponse(200, b"ok"),  # type: ignore[arg-type]
+    )
+    assert transport.fetch("https://example.com", timeout_seconds=1) == b"ok"
+
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.get",
+        lambda url, timeout, follow_redirects: _FakeResponse(404),  # type: ignore[arg-type]
+    )
+    assert transport.fetch("https://example.com", timeout_seconds=1) is None
+
+    failing_response = _FakeResponse(500)
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.get",
+        lambda url, timeout, follow_redirects: failing_response,  # type: ignore[arg-type]
+    )
+    with pytest.raises(RuntimeError):
+        transport.fetch("https://example.com", timeout_seconds=1)
+    assert failing_response._raise_called is True
+
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.stream",
+        lambda method, url, timeout, follow_redirects: _FakeStreamResponse([b"a", b"b"]),  # type: ignore[arg-type]
+    )
+    chunks = list(transport.iter_bytes("https://example.com", timeout_seconds=1, chunk_size=2))
+    assert chunks == [b"a", b"b"]

--- a/tests/test_food_sources_off_delta.py
+++ b/tests/test_food_sources_off_delta.py
@@ -173,6 +173,16 @@ def test_httpx_transport_fetch_and_stream(monkeypatch: pytest.MonkeyPatch) -> No
     )
     assert transport.fetch("https://example.com", timeout_seconds=1) == b"ok"
 
+    def _httpx_get_created(url: str, timeout: int, follow_redirects: bool) -> _FakeResponse:
+        _ = (url, timeout, follow_redirects)
+        return _FakeResponse(201, b"created")
+
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.get",
+        _httpx_get_created,
+    )
+    assert transport.fetch("https://example.com", timeout_seconds=1) == b"created"
+
     def _httpx_get_404(url: str, timeout: int, follow_redirects: bool) -> _FakeResponse:
         _ = (url, timeout, follow_redirects)
         return _FakeResponse(404)

--- a/tests/test_food_sources_off_delta.py
+++ b/tests/test_food_sources_off_delta.py
@@ -6,6 +6,7 @@ import gzip
 import io
 from datetime import date
 from pathlib import Path
+from types import TracebackType
 
 import pytest
 
@@ -57,7 +58,12 @@ class _FakeStreamResponse:
     def __enter__(self) -> "_FakeStreamResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         _ = (exc_type, exc, tb)
         return None
 
@@ -157,30 +163,49 @@ def test_off_full_malformed_payload_fails_closed(tmp_path: Path) -> None:
 def test_httpx_transport_fetch_and_stream(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = HttpxOFFTransport()
 
-    monkeypatch.setattr(
-        "core.food_sources.off_delta.httpx.get",
-        lambda url, timeout, follow_redirects: _FakeResponse(200, b"ok"),  # type: ignore[arg-type]
-    )
-    assert transport.fetch("https://example.com", timeout_seconds=1) == b"ok"
+    def _httpx_get_ok(url: str, timeout: int, follow_redirects: bool) -> _FakeResponse:
+        _ = (url, timeout, follow_redirects)
+        return _FakeResponse(200, b"ok")
 
     monkeypatch.setattr(
         "core.food_sources.off_delta.httpx.get",
-        lambda url, timeout, follow_redirects: _FakeResponse(404),  # type: ignore[arg-type]
+        _httpx_get_ok,
+    )
+    assert transport.fetch("https://example.com", timeout_seconds=1) == b"ok"
+
+    def _httpx_get_404(url: str, timeout: int, follow_redirects: bool) -> _FakeResponse:
+        _ = (url, timeout, follow_redirects)
+        return _FakeResponse(404)
+
+    monkeypatch.setattr(
+        "core.food_sources.off_delta.httpx.get",
+        _httpx_get_404,
     )
     assert transport.fetch("https://example.com", timeout_seconds=1) is None
 
     failing_response = _FakeResponse(500)
+
+    def _httpx_get_500(url: str, timeout: int, follow_redirects: bool) -> _FakeResponse:
+        _ = (url, timeout, follow_redirects)
+        return failing_response
+
     monkeypatch.setattr(
         "core.food_sources.off_delta.httpx.get",
-        lambda url, timeout, follow_redirects: failing_response,  # type: ignore[arg-type]
+        _httpx_get_500,
     )
     with pytest.raises(RuntimeError):
         transport.fetch("https://example.com", timeout_seconds=1)
     assert failing_response._raise_called is True
 
+    def _httpx_stream_ok(
+        method: str, url: str, timeout: int, follow_redirects: bool
+    ) -> _FakeStreamResponse:
+        _ = (method, url, timeout, follow_redirects)
+        return _FakeStreamResponse([b"a", b"b"])
+
     monkeypatch.setattr(
         "core.food_sources.off_delta.httpx.stream",
-        lambda method, url, timeout, follow_redirects: _FakeStreamResponse([b"a", b"b"]),  # type: ignore[arg-type]
+        _httpx_stream_ok,
     )
     chunks = list(transport.iter_bytes("https://example.com", timeout_seconds=1, chunk_size=2))
     assert chunks == [b"a", b"b"]

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -57,6 +57,19 @@ class _DummySource:
 
 
 @dataclass
+class _AdvancingToday:
+    first: date
+    second: date
+    calls: int = 0
+
+    def __call__(self) -> date:
+        self.calls += 1
+        if self.calls == 1:
+            return self.first
+        return self.second
+
+
+@dataclass
 class _EmptyDeltaSource:
     name: str
     updates_available: bool = True
@@ -117,6 +130,17 @@ def test_snapshot_manager_skips_when_no_updates(tmp_path: Path) -> None:
 
     source.updates_available = False
     assert manager.sync_if_needed(source) is None
+
+
+def test_snapshot_manager_noop_sync_does_not_create_empty_date_dir(tmp_path: Path) -> None:
+    today_provider = _AdvancingToday(first=date(2026, 2, 23), second=date(2026, 2, 24))
+    manager = SnapshotManager(tmp_path, today_provider=today_provider)
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+
+    source.updates_available = False
+    assert manager.sync_if_needed(source) is None
+    assert not (tmp_path / "dummy" / "2026-02-24").exists()
 
 
 def test_snapshot_manager_syncs_delta_after_initial_snapshot(tmp_path: Path) -> None:

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -278,7 +278,7 @@ def test_snapshot_manager_manifest_schema_errors(tmp_path: Path) -> None:
         manager.get_last_snapshot_date("broken-source")
 
     manifest_path.write_text(
-        '{"source":"broken-source","snapshots":[{"date":"not-a-date"}]}',
+        '{"source":"broken-source","snapshots":[{"date":"not-a-date","file":"f","mode":"delta","checksum":"x","records":1,"bytes":1}]}',
         encoding="utf-8",
     )
     with pytest.raises(SnapshotIntegrityError):

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -92,6 +93,17 @@ def test_snapshot_manager_syncs_delta_after_initial_snapshot(tmp_path: Path) -> 
     assert meta.mode == "delta"
 
 
+def test_snapshot_manager_force_sync_uses_delta_even_without_updates(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+
+    source.updates_available = False
+    meta = manager.sync_if_needed(source, force=True)
+    assert meta is not None
+    assert meta.mode == "delta"
+
+
 def test_snapshot_manager_checksum_mismatch_fails_closed(tmp_path: Path) -> None:
     manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
     snapshot_file = tmp_path / "bad-source" / "2026-02-24" / "bad.bin"
@@ -139,7 +151,33 @@ def test_snapshot_manager_manifest_schema_errors(tmp_path: Path) -> None:
     with pytest.raises(SnapshotIntegrityError):
         manager.get_last_snapshot_date("broken-source")
 
+    manifest_path.write_text('{"snapshots":[]}', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text('{"source":"other-source","snapshots":[]}', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
     manifest_path.write_text('{"source":"broken-source","snapshots":"bad"}', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text('{"source":"broken-source","snapshots":[1]}', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f"}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f","mode":1}]}',
+        encoding="utf-8",
+    )
     with pytest.raises(SnapshotIntegrityError):
         manager.get_last_snapshot_date("broken-source")
 
@@ -149,3 +187,65 @@ def test_snapshot_manager_manifest_schema_errors(tmp_path: Path) -> None:
     )
     with pytest.raises(SnapshotIntegrityError):
         manager.get_last_snapshot_date("broken-source")
+
+
+def test_snapshot_manager_record_snapshot_dedup_and_ordering(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_dir = tmp_path / "dummy" / "2026-02-24"
+    source_dir.mkdir(parents=True, exist_ok=True)
+
+    file_a = source_dir / "a.bin"
+    file_b = source_dir / "b.bin"
+    file_c = source_dir / "c.bin"
+    for file_path in (file_a, file_b, file_c):
+        file_path.write_bytes(file_path.name.encode("utf-8"))
+
+    meta_a = SnapshotMeta(
+        source="dummy",
+        snapshot_date=date(2026, 2, 24),
+        file_path=file_a,
+        checksum_sha256=sha256_file(file_a),
+        record_count=1,
+        size_bytes=file_a.stat().st_size,
+        mode="full",
+    )
+    meta_a_dup = SnapshotMeta(
+        source="dummy",
+        snapshot_date=date(2026, 2, 24),
+        file_path=file_a,
+        checksum_sha256=sha256_file(file_a),
+        record_count=1,
+        size_bytes=file_a.stat().st_size,
+        mode="full",
+    )
+    meta_b = SnapshotMeta(
+        source="dummy",
+        snapshot_date=date(2026, 2, 25),
+        file_path=file_b,
+        checksum_sha256=sha256_file(file_b),
+        record_count=1,
+        size_bytes=file_b.stat().st_size,
+        mode="delta",
+    )
+    meta_c = SnapshotMeta(
+        source="dummy",
+        snapshot_date=date(2026, 2, 24),
+        file_path=file_c,
+        checksum_sha256=sha256_file(file_c),
+        record_count=1,
+        size_bytes=file_c.stat().st_size,
+        mode="delta",
+    )
+
+    manager.record_snapshot(meta_a)
+    manager.record_snapshot(meta_a_dup)
+    manager.record_snapshot(meta_b)
+    manager.record_snapshot(meta_c)
+
+    manifest_path = tmp_path / "dummy" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    snapshots = manifest["snapshots"]
+
+    assert len(snapshots) == 3
+    keys = [(row["date"], row["file"], row["mode"]) for row in snapshots]
+    assert keys == sorted(keys)

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -56,6 +56,43 @@ class _DummySource:
         )
 
 
+@dataclass
+class _EmptyDeltaSource:
+    name: str
+    updates_available: bool = True
+
+    def has_updates_since(self, last_snapshot: date) -> bool:
+        _ = last_snapshot
+        return self.updates_available
+
+    def download_full(self, dest: Path) -> SnapshotMeta:
+        output_path = dest / "full.bin"
+        output_path.write_bytes(b"full")
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=date(2026, 2, 23),
+            file_path=output_path,
+            checksum_sha256=sha256_file(output_path),
+            record_count=1,
+            size_bytes=output_path.stat().st_size,
+            mode="full",
+        )
+
+    def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
+        _ = since
+        output_path = dest / "delta.bin"
+        output_path.write_bytes(b"")
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=date(2026, 2, 24),
+            file_path=output_path,
+            checksum_sha256=sha256_file(output_path),
+            record_count=0,
+            size_bytes=output_path.stat().st_size,
+            mode="delta",
+        )
+
+
 def test_snapshot_manager_first_sync_and_manifest_integrity(tmp_path: Path) -> None:
     manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
     source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
@@ -91,6 +128,20 @@ def test_snapshot_manager_syncs_delta_after_initial_snapshot(tmp_path: Path) -> 
     meta = manager.sync_if_needed(source)
     assert meta is not None
     assert meta.mode == "delta"
+
+
+def test_snapshot_manager_skips_empty_delta_without_advancing_manifest(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _EmptyDeltaSource(name="dummy")
+
+    first_meta = manager.sync_if_needed(source)
+    assert first_meta is not None
+    assert manager.get_last_snapshot_date("dummy") == date(2026, 2, 23)
+
+    second_meta = manager.sync_if_needed(source)
+    assert second_meta is None
+    assert manager.get_last_snapshot_date("dummy") == date(2026, 2, 23)
+    assert not (tmp_path / "dummy" / "2026-02-24" / "delta.bin").exists()
 
 
 def test_snapshot_manager_force_sync_uses_delta_even_without_updates(tmp_path: Path) -> None:
@@ -176,6 +227,27 @@ def test_snapshot_manager_manifest_schema_errors(tmp_path: Path) -> None:
 
     manifest_path.write_text(
         '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f","mode":1}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f","mode":"delta","checksum":1,"records":1,"bytes":1}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f","mode":"delta","checksum":"x","records":"1","bytes":1}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"2026-02-24","file":"f","mode":"delta","checksum":"x","records":1,"bytes":"1"}]}',
         encoding="utf-8",
     )
     with pytest.raises(SnapshotIntegrityError):

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -1,0 +1,151 @@
+"""Tests for snapshot manager contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from core.food_sources.snapshot_manager import (
+    SnapshotIntegrityError,
+    SnapshotManager,
+    SnapshotMeta,
+    sha256_file,
+)
+
+
+@dataclass
+class _DummySource:
+    name: str
+    full_payload: bytes
+    delta_payload: bytes
+    updates_available: bool = True
+
+    def has_updates_since(self, last_snapshot: date) -> bool:
+        _ = last_snapshot
+        return self.updates_available
+
+    def download_full(self, dest: Path) -> SnapshotMeta:
+        output_path = dest / "full.bin"
+        output_path.write_bytes(self.full_payload)
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=date(2026, 2, 24),
+            file_path=output_path,
+            checksum_sha256=sha256_file(output_path),
+            record_count=1,
+            size_bytes=output_path.stat().st_size,
+            mode="full",
+        )
+
+    def download_delta(self, since: date, dest: Path) -> SnapshotMeta:
+        _ = since
+        output_path = dest / "delta.bin"
+        output_path.write_bytes(self.delta_payload)
+        return SnapshotMeta(
+            source=self.name,
+            snapshot_date=date(2026, 2, 24),
+            file_path=output_path,
+            checksum_sha256=sha256_file(output_path),
+            record_count=1,
+            size_bytes=output_path.stat().st_size,
+            mode="delta",
+        )
+
+
+def test_snapshot_manager_first_sync_and_manifest_integrity(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+
+    meta = manager.sync_if_needed(source)
+    assert meta is not None
+    assert meta.mode == "full"
+
+    manifest_path = tmp_path / "dummy" / "manifest.json"
+    assert manifest_path.exists()
+
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    assert '"source": "dummy"' in manifest_text
+    assert '"mode": "full"' in manifest_text
+    assert manager.get_last_snapshot_date("dummy") == date(2026, 2, 24)
+
+
+def test_snapshot_manager_skips_when_no_updates(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+
+    source.updates_available = False
+    assert manager.sync_if_needed(source) is None
+
+
+def test_snapshot_manager_syncs_delta_after_initial_snapshot(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+
+    source.updates_available = True
+    meta = manager.sync_if_needed(source)
+    assert meta is not None
+    assert meta.mode == "delta"
+
+
+def test_snapshot_manager_checksum_mismatch_fails_closed(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snapshot_file = tmp_path / "bad-source" / "2026-02-24" / "bad.bin"
+    snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_file.write_bytes(b"payload")
+
+    bad_meta = SnapshotMeta(
+        source="bad-source",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snapshot_file,
+        checksum_sha256="0" * 64,
+        record_count=1,
+        size_bytes=snapshot_file.stat().st_size,
+        mode="full",
+    )
+
+    with pytest.raises(SnapshotIntegrityError):
+        manager.record_snapshot(bad_meta)
+
+    assert not (tmp_path / "bad-source" / "manifest.json").exists()
+
+
+def test_snapshot_manager_missing_snapshot_file_fails_closed(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    missing_meta = SnapshotMeta(
+        source="missing-source",
+        snapshot_date=date(2026, 2, 24),
+        file_path=tmp_path / "missing-source" / "2026-02-24" / "missing.bin",
+        checksum_sha256="0" * 64,
+        record_count=0,
+        size_bytes=0,
+        mode="full",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.validate_snapshot(missing_meta)
+
+
+def test_snapshot_manager_manifest_schema_errors(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_dir = tmp_path / "broken-source"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = source_dir / "manifest.json"
+
+    manifest_path.write_text('["not", "an", "object"]', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text('{"source":"broken-source","snapshots":"bad"}', encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")
+
+    manifest_path.write_text(
+        '{"source":"broken-source","snapshots":[{"date":"not-a-date"}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError):
+        manager.get_last_snapshot_date("broken-source")


### PR DESCRIPTION
## Summary
- Add snapshot-first foundation contracts for Food Data Wave 1:
  - `SnapshotMeta` / `SnapshotSource` / `SnapshotManager`
  - fail-closed checksum + manifest integrity validation
  - deterministic OFF delta ingestion source (`OpenFoodFactsDeltaSource`)
- Add focused tests for manifest integrity, checksum mismatch, deterministic delta behavior, malformed payload handling, dedup/order, `force=True`, empty-delta skip semantics, and no-op sync directory behavior.
- Apply a small lint hygiene fix in `scripts/design/generate_figma_instructions.py` (remove unused imports) required for `make verify` on current `main`.

## Scope
- `core/food_sources/snapshot_manager.py` (new)
- `core/food_sources/off_delta.py` (new)
- `tests/test_food_sources_snapshot_manager.py` (new)
- `tests/test_food_sources_off_delta.py` (new)
- `scripts/design/generate_figma_instructions.py` (lint-only cleanup)

## Compatibility
- No request/response changes in existing API routes.
- No changes to current runtime food endpoints behavior.
- New contracts are additive and isolated for Wave 1 ingestion track.

## Test Plan
- [x] `pytest -q tests/test_food_sources_snapshot_manager.py tests/test_food_sources_off_delta.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3848799092 -> f67e8e99
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3848828849 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2847987130 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2847987140 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2847987153 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2847987158 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3848873487 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848024444 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848024455 -> 27026ab0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3848966728 -> c9c5e371
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848101359 -> c9c5e371
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848101378 -> c9c5e371
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848101386 -> c9c5e371
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3849074450 -> 5ffcb07a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848199961 -> 5ffcb07a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848199972 -> 5ffcb07a

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#pullrequestreview-3849145161 -> 700d5335

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/889#discussion_r2848265637 -> 700d5335

## Merge Readiness
- [x] Non-draft PR, scoped runtime changes only for Wave 1 contracts
- [x] `pre-commit run --all-files` green
- [x] `make verify` green (lint + typecheck + test-fast + diff-cov)
- [x] Bot actionables addressed across `f67e8e99`, `27026ab0`, `c9c5e371`, `5ffcb07a`

## Security Notes
- Snapshot import path is fail-closed on checksum mismatch.
- OFF malformed gzip payloads fail with explicit integrity error.
- Manifest schema violations fail closed (invalid root/source/snapshots/entry keys and typed fields).

## Carryover
- This PR introduces Wave 1 foundation only; scheduler wiring, live sync orchestration, and API exposure remain for subsequent execution wave PRs per strategy SoT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot manager with local manifests, integrity checks, deterministic full vs incremental syncs and manifest recording.
  * Deterministic Open Food Facts ingestion supporting merged daily deltas, full dump downloads, and robust error handling.

* **Tests**
  * Comprehensive tests covering snapshot manager and OFF ingestion: delta/full flows, integrity failures, update detection, deduplication, and streaming behavior.

* **Chores**
  * Minor import cleanup in a helper script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
