### PR TITLE
feat(food-db): add W2-A search compatibility adapter

### DIFF
--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -17,12 +17,22 @@ class FoodStore(Protocol):
     def get_food(self, food_id: str) -> Mapping[str, Any] | None: ...
 
 
+class _FoodStoreCompat:
+    """Compatibility wrapper that keeps router contract stable while allowing backend switching."""
+
+    def search_foods(self, query: str, limit: int, offset: int) -> Sequence[Mapping[str, Any]]:
+        backend = food_store.get_search_backend()
+        return backend.search_foods(query=query, limit=limit, offset=offset)
+
+    def get_food(self, food_id: str) -> Mapping[str, Any] | None:
+        return food_store.get_food(food_id)
+
+
+_FOOD_STORE_COMPAT: FoodStore = _FoodStoreCompat()
+
+
 def get_food_store() -> FoodStore:
-    # With pre-push mypy (--follow-imports=skip), imported modules are treated as Any. Assigning to
-    # a typed local ensures the router's DI surface stays type-safe in CI and doesn't trip
-    # no-any-return locally.
-    store: FoodStore = food_store
-    return store
+    return _FOOD_STORE_COMPAT
 
 
 @router.get("/api/v1/foods", response_model=list[FoodHit])

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -279,7 +279,7 @@ class FoodSearchBackend(Protocol):
 
     def search_foods(
         self, query: str, limit: int | str = 20, offset: int | str = 0
-    ) -> List[Dict[str, Any]]: ...
+    ) -> Sequence[Mapping[str, Any]]: ...
 
 
 class _LegacyFoodSearchBackend:
@@ -287,7 +287,7 @@ class _LegacyFoodSearchBackend:
 
     def search_foods(
         self, query: str, limit: int | str = 20, offset: int | str = 0
-    ) -> List[Dict[str, Any]]:
+    ) -> Sequence[Mapping[str, Any]]:
         return search_foods(query, limit=limit, offset=offset)
 
 

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -11,7 +11,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import os
-from typing import Any, Dict, Iterator, List, Optional, Mapping, Sequence, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Mapping, Protocol, Sequence, Tuple
 import threading
 from collections import defaultdict
 
@@ -40,6 +40,7 @@ except OSError as exc:  # pragma: no cover - extremely rare filesystem errors
 ALIASES_CSV_PATH: Path = Path(os.getenv("FOOD_ALIASES_CSV", "data/food_aliases.csv"))
 MAX_LIMIT: int = 100
 DEFAULT_PER_G: float = 100.0
+FEATURE_FOOD_SEARCH_COMPAT_ENABLED = "FEATURE_FOOD_SEARCH_COMPAT_ENABLED"
 
 DEFAULT_ALIASES: Dict[str, List[str]] = {
     # RU/EN/ES базовые соответствия; расширяй из своего alias CSV
@@ -271,6 +272,63 @@ _ALIASES_LOCK = threading.Lock()
 _MISSING_FOOD_COUNTER: Dict[str, int] = defaultdict(int)
 _MISSING_FOOD_LOCK = threading.Lock()
 _MISSING_FOOD_REPORT_THRESHOLD = int(os.getenv("MISSING_FOOD_REPORT_THRESHOLD", "100"))
+
+
+class FoodSearchBackend(Protocol):
+    """Search backend contract used by API compatibility layer."""
+
+    def search_foods(
+        self, query: str, limit: int | str = 20, offset: int | str = 0
+    ) -> List[Dict[str, Any]]: ...
+
+
+class _LegacyFoodSearchBackend:
+    """Default backend that keeps existing SQLite/FTS behavior."""
+
+    def search_foods(
+        self, query: str, limit: int | str = 20, offset: int | str = 0
+    ) -> List[Dict[str, Any]]:
+        return search_foods(query, limit=limit, offset=offset)
+
+
+_LEGACY_SEARCH_BACKEND: FoodSearchBackend = _LegacyFoodSearchBackend()
+_COMPAT_SEARCH_BACKEND: FoodSearchBackend | None = None
+_SEARCH_BACKEND_LOCK = threading.Lock()
+
+
+def _is_truthy_env(value: str | None) -> bool:
+    """Parse common truthy env representations."""
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _use_compat_search_backend() -> bool:
+    """Return True when compatibility adapter path is explicitly enabled."""
+    return _is_truthy_env(os.getenv(FEATURE_FOOD_SEARCH_COMPAT_ENABLED))
+
+
+def register_search_backend_adapter(adapter: FoodSearchBackend | None) -> None:
+    """Register optional compatibility search backend adapter."""
+    global _COMPAT_SEARCH_BACKEND
+    with _SEARCH_BACKEND_LOCK:
+        _COMPAT_SEARCH_BACKEND = adapter
+
+
+def reset_search_backend_adapter() -> None:
+    """Reset compatibility search backend adapter to legacy-only state."""
+    register_search_backend_adapter(None)
+
+
+def get_search_backend() -> FoodSearchBackend:
+    """
+    Resolve active search backend.
+
+    Legacy SQLite backend remains default unless feature flag is enabled and adapter is registered.
+    """
+    with _SEARCH_BACKEND_LOCK:
+        compat_backend = _COMPAT_SEARCH_BACKEND
+    if _use_compat_search_backend() and compat_backend is not None:
+        return compat_backend
+    return _LEGACY_SEARCH_BACKEND
 
 
 def _log_missing_food(food_id: str) -> None:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -24,11 +24,11 @@ If it is not recorded here — it does not exist.
 
 ## P0 — Next (Must happen)
 
-- [ ] P0: Food Data Platform Foundation (snapshot-first, multi-source, low-API-cost)
+- [x] P0: Food Data Platform Foundation (snapshot-first, multi-source, low-API-cost)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-FOOD-DB-STRATEGY-DOCS
-  - Status: Planned
+  - Target PR: PR #886
+  - Status: ✅ Merged (PR #886, 2026-02-24)
   - Area: architecture / data platform / product database
   - Finding Type: financial + architecture gap closure
   - Reason: The largest current financial and architecture gap is food/menus data quality and coverage. USDA+OFF foundations exist, but snapshot governance, canonical confidence/provenance policy, and structured execution waves are not yet locked as a canonical strategy.
@@ -44,11 +44,11 @@ If it is not recorded here — it does not exist.
     - Execution is split into wave PRs with clear ownership
     - Carryover/deferred mapping is documented in this ledger
 
-- [ ] P0: Execution Wave 1 — Snapshot manager + OFF delta + canonical merge contract
+- [x] P0: Execution Wave 1 — Snapshot manager + OFF delta + canonical merge contract
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-FOOD-DB-W1
-  - Status: Planned
+  - Target PR: PR #889
+  - Status: ✅ Merged (PR #889, 2026-02-24)
   - Area: backend / data ingestion
   - Finding Type: runtime foundation
   - Reason: Runtime needs deterministic snapshot lifecycle and incremental OFF updates before expansion to search and restaurants.
@@ -66,8 +66,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W2
-  - Status: Planned
+  - Target PR: PR-TBD-FOOD-DB-W2-A
+  - Status: In Progress (W2-A compatibility adapter)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -126,6 +126,52 @@ def test_search_foods_parameter_normalization(monkeypatch: pytest.MonkeyPatch) -
     assert dummy.last_params[-2:] == [5, 1]
 
 
+def test_get_search_backend_defaults_to_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: dict[str, tuple[Any, Any, Any]] = {}
+
+    def fake_legacy_search(query: str, limit: Any = 20, offset: Any = 0) -> List[Dict[str, Any]]:
+        called["params"] = (query, limit, offset)
+        return [{"id": "legacy"}]
+
+    monkeypatch.delenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", raising=False)
+    monkeypatch.setattr(food_store, "search_foods", fake_legacy_search)
+    food_store.reset_search_backend_adapter()
+
+    backend = food_store.get_search_backend()
+    rows = backend.search_foods("apple", limit=7, offset=3)
+
+    assert rows == [{"id": "legacy"}]
+    assert called["params"] == ("apple", 7, 3)
+
+
+def test_get_search_backend_uses_registered_adapter_when_flag_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _StubBackend:
+        def __init__(self) -> None:
+            self.calls: List[tuple[str, Any, Any]] = []
+
+        def search_foods(
+            self, query: str, limit: Any = 20, offset: Any = 0
+        ) -> List[Dict[str, Any]]:
+            self.calls.append((query, limit, offset))
+            return [{"id": "compat"}]
+
+    stub = _StubBackend()
+    monkeypatch.setenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", "true")
+    food_store.register_search_backend_adapter(stub)
+    try:
+        backend = food_store.get_search_backend()
+        rows = backend.search_foods("banana", limit=5, offset=1)
+        assert rows == [{"id": "compat"}]
+        assert stub.calls == [("banana", 5, 1)]
+    finally:
+        food_store.reset_search_backend_adapter()
+        monkeypatch.delenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", raising=False)
+
+
 @pytest.mark.parametrize(
     "limit,offset,expected_message",
     [

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -67,3 +67,64 @@ def test_get_food_success(monkeypatch: pytest.MonkeyPatch) -> None:
     result = foods.get_food("f1", store=foods.food_store)
     assert isinstance(result, FoodItem)
     assert result.id == "f1"
+
+
+def test_list_foods_compat_backend_via_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _CompatBackend:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int, int]] = []
+
+        def search_foods(
+            self, query: str, limit: int = 20, offset: int = 0
+        ) -> list[dict[str, Any]]:
+            self.calls.append((query, limit, offset))
+            return [
+                {
+                    "id": "compat-1",
+                    "canonical_name": "Compat Apple",
+                    "kcal": 77,
+                    "protein_g": 1.0,
+                    "fat_g": 0.5,
+                    "carbs_g": 18.0,
+                }
+            ]
+
+    compat_backend = _CompatBackend()
+    monkeypatch.setenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", "true")
+    foods.food_store.register_search_backend_adapter(compat_backend)
+    try:
+        store = foods.get_food_store()
+        result = foods.list_foods(query="apple", limit=10, offset=0, store=store)
+        assert result[0].id == "compat-1"
+        assert compat_backend.calls == [("apple", 10, 0)]
+    finally:
+        foods.food_store.reset_search_backend_adapter()
+        monkeypatch.delenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", raising=False)
+
+
+def test_list_foods_compat_flag_without_adapter_falls_back_to_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: dict[str, tuple[Any, ...]] = {}
+
+    def fake_legacy_search(query: str, limit: int = 20, offset: int = 0) -> list[dict[str, Any]]:
+        called["params"] = (query, limit, offset)
+        return [
+            {
+                "id": "legacy-1",
+                "canonical_name": "Legacy Apple",
+                "kcal": 52,
+                "protein_g": 0.3,
+                "fat_g": 0.2,
+                "carbs_g": 14.0,
+            }
+        ]
+
+    monkeypatch.setenv("FEATURE_FOOD_SEARCH_COMPAT_ENABLED", "true")
+    foods.food_store.reset_search_backend_adapter()
+    monkeypatch.setattr(foods.food_store, "search_foods", fake_legacy_search)
+
+    store = foods.get_food_store()
+    result = foods.list_foods(query="apple", limit=10, offset=0, store=store)
+    assert result[0].id == "legacy-1"
+    assert called["params"] == ("apple", 10, 0)


### PR DESCRIPTION
## Summary
- Add W2-A search compatibility adapter for `/api/v1/foods*` while preserving the existing API contract.
- Keep legacy SQLite/FTS search as default path and add feature-flagged backend switching via `FEATURE_FOOD_SEARCH_COMPAT_ENABLED`.
- Update canonical ledger status for Food Data strategy/W1 completion and W2-A in-progress tracking.

## Scope
- `app/services/food_store.py`
- `app/routers/foods.py`
- `tests/test_food_store_service.py`
- `tests/test_foods_router_additional.py`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Compatibility
- Existing endpoints unchanged:
  - `/api/v1/foods`
  - `/api/v1/foods/search`
  - `/api/v1/foods/{food_id}`
- Request/response shapes remain unchanged.
- Default runtime path remains legacy `food_store.search_foods` unless compat flag is enabled and adapter is registered.

## Test Plan
- [x] `pytest -q tests/test_food_store_service.py tests/test_foods_router_additional.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Deferred / Follow-ups
- Canonical follow-ups tracked in `docs/roadmap/BACKLOG_LEDGER.md`:
  - P1 Execution Wave 2 full modernization (`PR-TBD-FOOD-DB-W2` track split through W2-A)
  - P1 Execution Wave 3 (restaurant menus + moderated submissions)
  - P2 Execution Wave 4 (semantic retrieval)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/891#pullrequestreview-3850060530 -> 128e082c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/891#discussion_r2849105945 -> 128e082c

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/891#pullrequestreview-3850091333 -> 128e082c

## Merge Readiness
- [x] Non-draft PR, scoped to W2-A compatibility layer + ledger sync
- [x] `pre-commit run --all-files` green
- [x] `make verify` green (lint + typecheck + test-fast + diff-cov)
- [x] Legacy `/api/v1/foods*` contract preserved

## Security Notes
- New behavior is feature-flag-gated (`FEATURE_FOOD_SEARCH_COMPAT_ENABLED`) and defaults to legacy path.
- No secrets/tokens introduced; no new external exposure.
- No auth/permission contract changes.

## Carryover
- Body gate sync refresh: 2026-02-24
- This PR intentionally carries over only roadmap status transitions after merged PRs #886 and #889 and starts W2-A adapter track without runtime API breaks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a search compatibility adapter for /api/v1/foods* to enable backend switching via a feature flag while keeping the existing API and default legacy search. Supports Wave 2 search modernization without breaking clients.

- **New Features**
  - Compatibility layer with adapter registration and backend resolver in food_store.
  - Router uses a compatibility wrapper to route search calls through the selected backend.
  - Feature flag FEATURE_FOOD_SEARCH_COMPAT_ENABLED controls switching; defaults to SQLite/FTS.
  - Relaxed adapter return typing to Sequence[Mapping] for easier integration and test coverage.

- **Migration**
  - To enable a new backend: set FEATURE_FOOD_SEARCH_COMPAT_ENABLED=true and call register_search_backend_adapter(adapter).
  - If the flag is off or no adapter is registered, it falls back to legacy automatically.

<sup>Written for commit 128e082c1fcbde5f161208125683338f78e92e3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for pluggable search backend selection, adapter registration, flag-driven behavior, and fallback to legacy search.

* **Chores**
  * Refactored food search to support a feature-flag-driven, pluggable backend while preserving existing behavior by default.

* **Documentation**
  * Updated roadmap backlog entries to reflect merged/in-progress statuses and PR references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


