### PR TITLE
feat(food-db): add W2-B barcode lookup endpoint and tests

### DIFF
--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -16,6 +16,8 @@ class FoodStore(Protocol):
 
     def get_food(self, food_id: str) -> Mapping[str, Any] | None: ...
 
+    def get_food_by_barcode(self, barcode: str) -> Mapping[str, Any] | None: ...
+
 
 class _FoodStoreCompat:
     """Compatibility wrapper that keeps router contract stable while allowing backend switching."""
@@ -26,6 +28,9 @@ class _FoodStoreCompat:
 
     def get_food(self, food_id: str) -> Mapping[str, Any] | None:
         return food_store.get_food(food_id)
+
+    def get_food_by_barcode(self, barcode: str) -> Mapping[str, Any] | None:
+        return food_store.get_food_by_barcode(barcode)
 
 
 _FOOD_STORE_COMPAT: FoodStore = _FoodStoreCompat()
@@ -75,6 +80,17 @@ def list_foods_search(
 @router.get("/api/v1/foods/{food_id}", response_model=FoodItem)
 def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
     row = store.get_food(food_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Food not found")
+    return FoodItem(**row)
+
+
+@router.get("/api/v1/foods/barcode/{barcode}", response_model=FoodItem)
+def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
+    try:
+        row = store.get_food_by_barcode(barcode)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     if not row:
         raise HTTPException(status_code=404, detail="Food not found")
     return FoodItem(**row)

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -85,7 +85,13 @@ def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodIt
     return FoodItem(**row)
 
 
-@router.get("/api/v1/foods/barcode/{barcode}", response_model=FoodItem)
+@router.get(
+    "/api/v1/foods/barcode/{barcode}",
+    response_model=FoodItem,
+    responses={
+        404: {"description": "Food not found"},
+    },
+)
 def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
     try:
         row = store.get_food_by_barcode(barcode)

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.schemas.food import FoodHit, FoodItem
 from app.services import food_store
@@ -81,7 +81,7 @@ def list_foods_search(
 def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
     row = store.get_food(food_id)
     if not row:
-        raise HTTPException(status_code=404, detail="Food not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Food not found")
     return FoodItem(**row)
 
 
@@ -96,7 +96,9 @@ def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)
     try:
         row = store.get_food_by_barcode(barcode)
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+        ) from exc
     if not row:
-        raise HTTPException(status_code=404, detail="Food not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Food not found")
     return FoodItem(**row)

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -89,8 +89,8 @@ def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodIt
     "/api/v1/foods/barcode/{barcode}",
     response_model=FoodItem,
     responses={
-        422: {"description": "Malformed barcode"},
-        404: {"description": "Food not found"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Malformed barcode"},
+        status.HTTP_404_NOT_FOUND: {"description": "Food not found"},
     },
 )
 def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -89,6 +89,7 @@ def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodIt
     "/api/v1/foods/barcode/{barcode}",
     response_model=FoodItem,
     responses={
+        422: {"description": "Malformed barcode"},
         404: {"description": "Food not found"},
     },
 )

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -11,6 +11,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import os
+import re
 from typing import Any, Dict, Iterator, List, Optional, Mapping, Protocol, Sequence, Tuple
 import threading
 from collections import defaultdict
@@ -41,6 +42,8 @@ ALIASES_CSV_PATH: Path = Path(os.getenv("FOOD_ALIASES_CSV", "data/food_aliases.c
 MAX_LIMIT: int = 100
 DEFAULT_PER_G: float = 100.0
 FEATURE_FOOD_SEARCH_COMPAT_ENABLED = "FEATURE_FOOD_SEARCH_COMPAT_ENABLED"
+BARCODE_MIN_LEN = 8
+BARCODE_MAX_LEN = 14
 
 DEFAULT_ALIASES: Dict[str, List[str]] = {
     # RU/EN/ES базовые соответствия; расширяй из своего alias CSV
@@ -494,6 +497,43 @@ def get_food(food_id: str) -> Optional[Dict[str, Any]]:
     with _connect() as con:
         row = con.execute("SELECT * FROM foods WHERE id = ?", (food_id,)).fetchone()
     return dict(row) if row else None
+
+
+def _normalize_barcode(barcode: str) -> str:
+    """
+    Normalize and validate barcode value.
+
+    RU: Нормализует и валидирует barcode.
+    EN: Normalizes and validates barcode.
+    """
+    normalized = re.sub(r"\D+", "", (barcode or "").strip())
+    if not normalized:
+        raise ValueError("barcode must contain at least one digit")
+    if not (BARCODE_MIN_LEN <= len(normalized) <= BARCODE_MAX_LEN):
+        raise ValueError(f"barcode must have length in [{BARCODE_MIN_LEN},{BARCODE_MAX_LEN}]")
+    return normalized
+
+
+def get_food_by_barcode(barcode: str) -> Optional[Dict[str, Any]]:
+    """
+    Return a single food by barcode (GTIN/EAN/UPC) or None when not found.
+
+    RU: Возвращает продукт по штрихкоду (GTIN/EAN/UPC) или None, если не найден.
+    EN: Returns a food by barcode (GTIN/EAN/UPC) or None if not found.
+    """
+    normalized = _normalize_barcode(barcode)
+    with _connect() as con:
+        row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (normalized,)).fetchone()
+        if row:
+            return dict(row)
+
+        # Some sources store GTIN without leading zeros; keep lookup deterministic with one fallback.
+        fallback = normalized.lstrip("0")
+        if fallback and fallback != normalized:
+            row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (fallback,)).fetchone()
+            if row:
+                return dict(row)
+    return None
 
 
 def _validate_ingredient_mapping(ing: Mapping[str, Any]) -> Optional[Tuple[str, float]]:

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -540,10 +540,17 @@ def get_food_by_barcode(barcode: str) -> Optional[Dict[str, Any]]:
     if row:
         return row
 
-    # Some sources store GTIN without a single left-pad zero.
-    # Drop only one leading zero to avoid changing significant digits.
-    fallback = normalized[1:] if normalized.startswith("0") else ""
-    if fallback:
+    fallback_candidates: list[str] = []
+    if normalized.startswith("0"):
+        # First fallback: remove only one padding zero.
+        fallback_candidates.append(normalized[1:])
+
+    # Second fallback: strip all left-padding zeros for GTIN-14 -> GTIN-12 cases.
+    fully_stripped = normalized.lstrip("0")
+    if fully_stripped and fully_stripped not in {normalized, *fallback_candidates}:
+        fallback_candidates.append(fully_stripped)
+
+    for fallback in fallback_candidates:
         row = FoodRepository.get_by_gtin(fallback)
         if row:
             return row

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -311,7 +311,9 @@ class FoodRepository:
     @staticmethod
     def get_by_gtin(gtin: str) -> Optional[Dict[str, Any]]:
         with _connect() as con:
-            row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (gtin,)).fetchone()
+            row = con.execute(
+                "SELECT * FROM foods WHERE gtin = ? ORDER BY id ASC LIMIT 1", (gtin,)
+            ).fetchone()
         return dict(row) if row else None
 
 
@@ -543,11 +545,17 @@ def get_food_by_barcode(barcode: str) -> Optional[Dict[str, Any]]:
     fallback_candidates: list[str] = []
     if normalized.startswith("0"):
         # First fallback: remove only one padding zero.
-        fallback_candidates.append(normalized[1:])
+        one_zero = normalized[1:]
+        if len(one_zero) >= BARCODE_MIN_LEN:
+            fallback_candidates.append(one_zero)
 
     # Second fallback: strip all left-padding zeros for GTIN-14 -> GTIN-12 cases.
     fully_stripped = normalized.lstrip("0")
-    if fully_stripped and fully_stripped not in {normalized, *fallback_candidates}:
+    if (
+        fully_stripped
+        and len(fully_stripped) >= BARCODE_MIN_LEN
+        and fully_stripped not in {normalized, *fallback_candidates}
+    ):
         fallback_candidates.append(fully_stripped)
 
     for fallback in fallback_candidates:

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -527,9 +527,10 @@ def get_food_by_barcode(barcode: str) -> Optional[Dict[str, Any]]:
         if row:
             return dict(row)
 
-        # Some sources store GTIN without leading zeros; keep lookup deterministic with one fallback.
-        fallback = normalized.lstrip("0")
-        if fallback and fallback != normalized:
+        # Some sources store GTIN without a single left-pad zero.
+        # Drop only one leading zero to avoid changing significant digits.
+        fallback = normalized[1:] if normalized.startswith("0") else ""
+        if fallback:
             row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (fallback,)).fetchone()
             if row:
                 return dict(row)

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -299,6 +299,22 @@ _COMPAT_SEARCH_BACKEND: FoodSearchBackend | None = None
 _SEARCH_BACKEND_LOCK = threading.Lock()
 
 
+class FoodRepository:
+    """Repository wrapper for food lookups against the local SQLite store."""
+
+    @staticmethod
+    def get_by_id(food_id: str) -> Optional[Dict[str, Any]]:
+        with _connect() as con:
+            row = con.execute("SELECT * FROM foods WHERE id = ?", (food_id,)).fetchone()
+        return dict(row) if row else None
+
+    @staticmethod
+    def get_by_gtin(gtin: str) -> Optional[Dict[str, Any]]:
+        with _connect() as con:
+            row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (gtin,)).fetchone()
+        return dict(row) if row else None
+
+
 def _is_truthy_env(value: str | None) -> bool:
     """Parse common truthy env representations."""
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
@@ -494,9 +510,7 @@ def search_foods(query: str, limit: int | str = 20, offset: int | str = 0) -> Li
 
 def get_food(food_id: str) -> Optional[Dict[str, Any]]:
     """Return a single food by id or None if not found."""
-    with _connect() as con:
-        row = con.execute("SELECT * FROM foods WHERE id = ?", (food_id,)).fetchone()
-    return dict(row) if row else None
+    return FoodRepository.get_by_id(food_id)
 
 
 def _normalize_barcode(barcode: str) -> str:
@@ -522,18 +536,17 @@ def get_food_by_barcode(barcode: str) -> Optional[Dict[str, Any]]:
     EN: Returns a food by barcode (GTIN/EAN/UPC) or None if not found.
     """
     normalized = _normalize_barcode(barcode)
-    with _connect() as con:
-        row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (normalized,)).fetchone()
-        if row:
-            return dict(row)
+    row = FoodRepository.get_by_gtin(normalized)
+    if row:
+        return row
 
-        # Some sources store GTIN without a single left-pad zero.
-        # Drop only one leading zero to avoid changing significant digits.
-        fallback = normalized[1:] if normalized.startswith("0") else ""
-        if fallback:
-            row = con.execute("SELECT * FROM foods WHERE gtin = ? LIMIT 1", (fallback,)).fetchone()
-            if row:
-                return dict(row)
+    # Some sources store GTIN without a single left-pad zero.
+    # Drop only one leading zero to avoid changing significant digits.
+    fallback = normalized[1:] if normalized.startswith("0") else ""
+    if fallback:
+        row = FoodRepository.get_by_gtin(fallback)
+        if row:
+            return row
     return None
 
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -66,8 +66,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W2-A
-  - Status: In Progress (W2-A compatibility adapter)
+  - Target PR: PR-TBD-FOOD-DB-W2-B
+  - Status: In Progress (W2-A merged in PR #891; W2-B barcode contract + tests)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
@@ -75,6 +75,8 @@ If it is not recorded here — it does not exist.
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `app/routers/foods.py`
     - `app/services/food_store.py`
+    - `tests/test_food_store_service.py`
+    - `tests/test_foods_router_additional.py`
   - DoD:
     - Existing `/api/v1/foods` contracts remain stable
     - New search backend is integrated behind compatibility layer

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -6489,6 +6489,48 @@
         ]
       }
     },
+    "/api/v1/foods/barcode/{barcode}": {
+      "get": {
+        "operationId": "get_food_by_barcode_api_v1_foods_barcode__barcode__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "barcode",
+            "required": true,
+            "schema": {
+              "title": "Barcode",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Food By Barcode",
+        "tags": [
+          "foods"
+        ]
+      }
+    },
     "/api/v1/foods/search": {
       "get": {
         "operationId": "list_foods_search_api_v1_foods_search_get",

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -6514,6 +6514,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Food not found"
+          },
           "422": {
             "content": {
               "application/json": {

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -6518,14 +6518,7 @@
             "description": "Food not found"
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
+            "description": "Malformed barcode"
           }
         },
         "summary": "Get Food By Barcode",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -5708,14 +5708,12 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
+            /** @description Malformed barcode */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -534,6 +534,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/foods/barcode/{barcode}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Food By Barcode */
+        get: operations["get_food_by_barcode_api_v1_foods_barcode__barcode__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/foods/search": {
         parameters: {
             query?: never;
@@ -5639,6 +5656,37 @@ export interface operations {
             header?: never;
             path: {
                 food_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoodItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_food_by_barcode_api_v1_foods_barcode__barcode__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                barcode: string;
             };
             cookie?: never;
         };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -5701,6 +5701,13 @@ export interface operations {
                     "application/json": components["schemas"]["FoodItem"];
                 };
             };
+            /** @description Food not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -117,6 +117,32 @@ class _DummyConn:
         return None
 
 
+class _DummyBarcodeCursor:
+    def __init__(self, row: Dict[str, Any] | None) -> None:
+        self._row = row
+
+    def fetchone(self) -> Dict[str, Any] | None:
+        return self._row
+
+
+class _DummyBarcodeConn:
+    def __init__(self, rows_by_barcode: Dict[str, Dict[str, Any] | None]) -> None:
+        self.rows_by_barcode = rows_by_barcode
+        self.calls: List[str] = []
+
+    def execute(self, sql: str, params: tuple[str]) -> _DummyBarcodeCursor:
+        assert "WHERE gtin = ?" in sql
+        barcode = params[0]
+        self.calls.append(barcode)
+        return _DummyBarcodeCursor(self.rows_by_barcode.get(barcode))
+
+    def __enter__(self) -> "_DummyBarcodeConn":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
 def test_search_foods_parameter_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy = _DummyConn()
     monkeypatch.setattr(food_store, "_connect", lambda: dummy)
@@ -124,6 +150,55 @@ def test_search_foods_parameter_normalization(monkeypatch: pytest.MonkeyPatch) -
     rows = food_store.search_foods("apple", limit="5", offset="1")
     assert rows and rows[0]["canonical_name"] == "apple"
     assert dummy.last_params[-2:] == [5, 1]
+
+
+def test_get_food_by_barcode_returns_row_with_normalized_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _DummyBarcodeConn(
+        rows_by_barcode={"00012345678905": {"id": "f1", "canonical_name": "apple"}}
+    )
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode(" 00012345678905 ")
+
+    assert result == {"id": "f1", "canonical_name": "apple"}
+    assert conn.calls == ["00012345678905"]
+
+
+def test_get_food_by_barcode_uses_leading_zero_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _DummyBarcodeConn(
+        rows_by_barcode={
+            "0123456789012": None,
+            "123456789012": {"id": "f2", "canonical_name": "banana"},
+        }
+    )
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode("0123456789012")
+
+    assert result == {"id": "f2", "canonical_name": "banana"}
+    assert conn.calls == ["0123456789012", "123456789012"]
+
+
+def test_get_food_by_barcode_validation_error() -> None:
+    with pytest.raises(ValueError, match=r"barcode must have length in \[8,14\]"):
+        food_store.get_food_by_barcode("123")
+
+
+def test_get_food_by_barcode_validation_error_when_no_digits() -> None:
+    with pytest.raises(ValueError, match="barcode must contain at least one digit"):
+        food_store.get_food_by_barcode("abc-def")
+
+
+def test_get_food_by_barcode_returns_none_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _DummyBarcodeConn(rows_by_barcode={})
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode("1234567890123")
+
+    assert result is None
+    assert conn.calls == ["1234567890123"]
 
 
 def test_get_search_backend_defaults_to_legacy(

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -196,6 +196,24 @@ def test_get_food_by_barcode_drops_only_one_leading_zero(monkeypatch: pytest.Mon
     assert conn.calls == ["0012345678905", "012345678905"]
 
 
+def test_get_food_by_barcode_uses_full_strip_fallback_as_last_resort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _DummyBarcodeConn(
+        rows_by_barcode={
+            "0012345678905": None,
+            "012345678905": None,
+            "12345678905": {"id": "f4", "canonical_name": "orange"},
+        }
+    )
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode("0012345678905")
+
+    assert result == {"id": "f4", "canonical_name": "orange"}
+    assert conn.calls == ["0012345678905", "012345678905", "12345678905"]
+
+
 def test_get_food_by_barcode_validation_error() -> None:
     with pytest.raises(ValueError, match=r"barcode must have length in \[8,14\]"):
         food_store.get_food_by_barcode("123")

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -181,6 +181,21 @@ def test_get_food_by_barcode_uses_leading_zero_fallback(monkeypatch: pytest.Monk
     assert conn.calls == ["0123456789012", "123456789012"]
 
 
+def test_get_food_by_barcode_drops_only_one_leading_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _DummyBarcodeConn(
+        rows_by_barcode={
+            "0012345678905": None,
+            "012345678905": {"id": "f3", "canonical_name": "pear"},
+        }
+    )
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode("0012345678905")
+
+    assert result == {"id": "f3", "canonical_name": "pear"}
+    assert conn.calls == ["0012345678905", "012345678905"]
+
+
 def test_get_food_by_barcode_validation_error() -> None:
     with pytest.raises(ValueError, match=r"barcode must have length in \[8,14\]"):
         food_store.get_food_by_barcode("123")

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 from pathlib import Path
+from types import TracebackType
 from typing import Any, Dict, List
 
 import pytest
@@ -113,7 +114,12 @@ class _DummyConn:
     def __enter__(self) -> "_DummyConn":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         return None
 
 
@@ -139,7 +145,12 @@ class _DummyBarcodeConn:
     def __enter__(self) -> "_DummyBarcodeConn":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         return None
 
 

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -214,6 +214,18 @@ def test_get_food_by_barcode_uses_full_strip_fallback_as_last_resort(
     assert conn.calls == ["0012345678905", "012345678905", "12345678905"]
 
 
+def test_get_food_by_barcode_skips_short_fallback_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _DummyBarcodeConn(rows_by_barcode={"01234567": None})
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+
+    result = food_store.get_food_by_barcode("01234567")
+
+    assert result is None
+    assert conn.calls == ["01234567"]
+
+
 def test_get_food_by_barcode_validation_error() -> None:
     with pytest.raises(ValueError, match=r"barcode must have length in \[8,14\]"):
         food_store.get_food_by_barcode("123")

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -109,6 +109,15 @@ def test_get_food_by_barcode_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc.value.detail == "barcode must have length in [8,14]"
 
 
+def test_get_food_by_barcode_route_documents_404() -> None:
+    route = next(
+        r
+        for r in foods.router.routes
+        if getattr(r, "path", "") == "/api/v1/foods/barcode/{barcode}"
+    )
+    assert 404 in route.responses
+
+
 def test_list_foods_compat_backend_via_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
     class _CompatBackend:
         def __init__(self) -> None:

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -115,6 +115,7 @@ def test_get_food_by_barcode_route_documents_404() -> None:
         for r in foods.router.routes
         if getattr(r, "path", "") == "/api/v1/foods/barcode/{barcode}"
     )
+    assert 422 in route.responses
     assert 404 in route.responses
 
 

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -69,6 +69,46 @@ def test_get_food_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.id == "f1"
 
 
+def test_get_food_by_barcode_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    row = {
+        "id": "f1",
+        "canonical_name": "Apple",
+        "kcal": 52,
+        "protein_g": 0.3,
+        "fat_g": 0.2,
+        "carbs_g": 14,
+        "version_date": "2024-01-01",
+    }
+    monkeypatch.setattr(foods.food_store, "get_food_by_barcode", lambda *_: row)
+
+    result = foods.get_food_by_barcode("0123456789012", store=foods.get_food_store())
+
+    assert isinstance(result, FoodItem)
+    assert result.id == "f1"
+
+
+def test_get_food_by_barcode_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(foods.food_store, "get_food_by_barcode", lambda *_: None)
+
+    with pytest.raises(HTTPException) as exc:
+        foods.get_food_by_barcode("0123456789012", store=foods.get_food_store())
+
+    assert exc.value.status_code == 404
+
+
+def test_get_food_by_barcode_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_invalid(_: str) -> None:
+        raise ValueError("barcode must have length in [8,14]")
+
+    monkeypatch.setattr(foods.food_store, "get_food_by_barcode", _raise_invalid)
+
+    with pytest.raises(HTTPException) as exc:
+        foods.get_food_by_barcode("123", store=foods.get_food_store())
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "barcode must have length in [8,14]"
+
+
 def test_list_foods_compat_backend_via_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
     class _CompatBackend:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- add non-breaking `/api/v1/foods/barcode/{barcode}` endpoint for local-first barcode lookup
- add barcode normalization/validation and deterministic GTIN fallback in `food_store`
- keep existing `/api/v1/foods`, `/api/v1/foods/search`, `/api/v1/foods/{food_id}` contracts unchanged
- update W2 ledger tracking to W2-B carryover (`PR-TBD-FOOD-DB-W2-B`)

## Scope
- `app/routers/foods.py`
- `app/services/food_store.py`
- `tests/test_food_store_service.py`
- `tests/test_foods_router_additional.py`
- `docs/roadmap/BACKLOG_LEDGER.md`
- generated API sync artifacts:
  - `frontend/src/api/openapi.json`
  - `frontend/src/api/schema.ts`

## Compatibility
- existing foods routes remain backward compatible
- new barcode endpoint is additive only
- invalid barcode shape returns explicit `422`; missing record returns `404`

## Carryover
- carryover from W2-A (`PR #891`) to complete next Wave-2 contract slice (barcode lookup path)
- canonical backlog link: `docs/roadmap/BACKLOG_LEDGER.md` (P1 Wave 2 updated)

## Test Plan
- `pre-commit run --all-files` ✅
- `make verify` ✅
  - lint ✅
  - typecheck ✅
  - test-fast ✅
  - diff-cover ✅ (100% on changed lines)

## Deferred / Follow-ups
- keep W2 open for search engine modernization (Meili/TypeSense) and latency measurements (<50ms p50)
- tracked in `docs/roadmap/BACKLOG_LEDGER.md` (P1 Wave 2)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850328256 -> f61243ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849385587 -> a71ddf3d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849385588 -> a71ddf3d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850349751 -> a71ddf3d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850421130 -> ba587d78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849453712 -> ba587d78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850422431 -> ba587d78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849454794 -> ba587d78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849513417 -> 9b1f3d07
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849513426 -> 9b1f3d07
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850489806 -> 9b1f3d07
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849588170 -> 561589eb
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850572914 -> 561589eb
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#discussion_r2849632436 -> 9473e7f0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/893#pullrequestreview-3850627817 -> 9473e7f0

## Merge Readiness
- [x] Scope is focused and non-breaking
- [x] Local quality gates passed (`pre-commit`, `make verify`)
- [x] Ledger carryover mapping updated for W2-B
- [x] Ready for review/bot pass before merge

## Security Notes
- barcode lookup is local DB-first only (no secrets or outbound API calls)
- input validation is fail-closed (`422`) for malformed barcode values
- SQL access remains parameterized (`?` placeholders)

## Summary by Sourcery

Добавлен новый путь поиска продуктов по штрихкоду и его интеграция в сервис, роутер и схему API при сохранении обратной совместимости существующих эндпоинтов для продуктов.

Новые возможности:
- Добавлен метод сервиса FoodStore для поиска продуктов по нормализованному штрихкоду с детерминированным добавлением ведущих нулей при необходимости.
- Добавлен новый эндпоинт `GET /api/v1/foods/barcode/{barcode}`, который возвращает один продукт по штрихкоду, с кодом 404 при отсутствии записи и 422 при некорректном штрихкоде.

Улучшения:
- Добавлены многоразовые хелперы нормализации и валидации штрихкодов с настраиваемыми ограничениями по длине в сервисе хранилища продуктов.
- Расширен совместимый обёрточный слой и типизация хранилища продуктов для поддержки поиска по штрихкоду.
- Обновлён реестр дорожной карты Wave 2, чтобы отразить срез контракта W2-B по штрихкодам и новое покрытие тестами.

Документация:
- Обновлён backlog-реестр с упоминанием W2-B и описанием новых файлов, связанных с работой по штрихкодам во Wave 2.

Тесты:
- Добавлены модульные тесты для нормализации и валидации штрихкодов, поведения с fallback’ом и обработки случаев «не найдено» в сервисе хранилища продуктов.
- Добавлены тесты для роутера, покрывающие успешные ответы, ответы «не найдено» и ошибки валидации для нового эндпоинта поиска по штрихкоду.

Рутины:
- Перегенерирована фронтенд-схема OpenAPI и типы клиента TypeScript для включения нового эндпоинта поиска по штрихкоду.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new barcode-based food lookup path and wire it through the service, router, and API schema while keeping existing food endpoints backward compatible.

New Features:
- Introduce a FoodStore service method for looking up foods by normalized barcode with deterministic leading-zero fallback.
- Expose a new GET /api/v1/foods/barcode/{barcode} endpoint that returns a single food item by barcode with 404 for missing records and 422 for invalid barcodes.

Enhancements:
- Add reusable barcode normalization and validation helpers with configurable length constraints in the food store service.
- Extend the food store compatibility wrapper and typing to support barcode-based lookups.
- Update the Wave 2 roadmap ledger to reflect the W2-B barcode contract slice and new test coverage.

Documentation:
- Refresh the backlog ledger to reference W2-B and document the new files involved in the Wave 2 barcode work.

Tests:
- Add unit tests for barcode normalization, validation, fallback behavior, and not-found handling in the food store service.
- Add router tests to cover success, not-found, and validation-error responses for the new barcode endpoint.

Chores:
- Regenerate the frontend OpenAPI schema and TypeScript client types to include the new barcode lookup endpoint.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added GET /api/v1/foods/barcode/{barcode} for local barcode lookups with deterministic GTIN fallback and strict input validation. Existing food routes stay unchanged; OpenAPI/TS client and W2-B ledger updated.

- **New Features**
  - Normalizes input (strips non-digits), validates 8–14 digits; returns 422 for invalid input.
  - Deterministic fallback: remove one leading zero, then all leading zeros; skip short/duplicate candidates; return 404 when not found.
  - OpenAPI and TypeScript client updated with 404/422; tests cover normalization, fallback order, not-found, validation errors, and route docs.

- **Refactors**
  - Introduced FoodRepository for ID and GTIN lookups in the local store.
  - Aligned 404/422 responses with FastAPI status constants.
  - Added typed context-manager signatures in test helpers.

<sup>Written for commit 9473e7f0f414a318b735f4c800393dbe81b223a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a barcode lookup endpoint to fetch food items by 8–14 digit GTIN/EAN/UPC with input normalization and leading-zero fallback; returns item or 404/422 as appropriate.
  * Frontend API/OpenAPI updated to expose the barcode route.

* **Documentation**
  * Roadmap updated to reflect the barcode endpoint, tests, and acceptance criteria.

* **Tests**
  * Added tests for success, not-found, invalid input, normalization, fallback, and route documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


- [x] Mapping sync refreshed at 2026-02-24 21:50 UTC
