### PR TITLE
feat(food-db): add W3 restaurant menus and moderated submissions foundation

### DIFF
--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "foods",
     "premium_week",
     "pro",
+    "restaurants",
     "recipes",
     "users",
     "vip",
@@ -31,6 +32,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from . import foods as foods  # noqa: F401
     from . import premium_week as premium_week  # noqa: F401
     from . import pro as pro  # noqa: F401
+    from . import restaurants as restaurants  # noqa: F401
     from . import recipes as recipes  # noqa: F401
     from . import users as users  # noqa: F401
     from . import vip as vip  # noqa: F401

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -93,8 +93,8 @@ def get_restaurant_store() -> RestaurantStore:
 @router.get("/api/v1/restaurants/search", response_model=list[RestaurantHit])
 def search_restaurants(
     query: str = Query("", max_length=128),
-    limit: int = 20,
-    offset: int = 0,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0, le=10000),
     store: RestaurantStore = Depends(get_restaurant_store),
 ) -> list[RestaurantHit]:
     if limit > 100 or limit < 1:

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.schemas.restaurants import (
+    RestaurantHit,
+    RestaurantMenuItem,
+    RestaurantSubmission,
+    RestaurantSubmissionCreate,
+    SubmissionReviewRequest,
+)
+from app.services import restaurant_store
+
+router = APIRouter(tags=["restaurants"])
+moderation_router = APIRouter(tags=["restaurants"])
+
+
+class RestaurantStore(Protocol):
+    def search_restaurants(
+        self, query: str, limit: int, offset: int
+    ) -> Sequence[Mapping[str, Any]]: ...
+
+    def get_restaurant_menu(self, chain_id: str, limit: int) -> Sequence[Mapping[str, Any]]: ...
+
+    def create_submission(
+        self,
+        *,
+        canonical_name: str,
+        payload: dict[str, Any],
+        barcode: str | None,
+        off_url: str | None,
+        entity_type: str,
+    ) -> Mapping[str, Any]: ...
+
+    def get_submission(self, submission_id: str) -> Mapping[str, Any] | None: ...
+
+    def review_submission(
+        self, submission_id: str, *, status: str, reviewer_notes: str | None
+    ) -> Mapping[str, Any] | None: ...
+
+
+class _RestaurantStoreCompat:
+    """Compatibility adapter around local restaurant service."""
+
+    def search_restaurants(
+        self, query: str, limit: int, offset: int
+    ) -> Sequence[Mapping[str, Any]]:
+        return restaurant_store.search_restaurants(query=query, limit=limit, offset=offset)
+
+    def get_restaurant_menu(self, chain_id: str, limit: int) -> Sequence[Mapping[str, Any]]:
+        return restaurant_store.get_restaurant_menu(chain_id=chain_id, limit=limit)
+
+    def create_submission(
+        self,
+        *,
+        canonical_name: str,
+        payload: dict[str, Any],
+        barcode: str | None,
+        off_url: str | None,
+        entity_type: str,
+    ) -> Mapping[str, Any]:
+        return restaurant_store.create_submission(
+            canonical_name=canonical_name,
+            payload=payload,
+            barcode=barcode,
+            off_url=off_url,
+            entity_type=entity_type,
+        )
+
+    def get_submission(self, submission_id: str) -> Mapping[str, Any] | None:
+        return restaurant_store.get_submission(submission_id)
+
+    def review_submission(
+        self, submission_id: str, *, status: str, reviewer_notes: str | None
+    ) -> Mapping[str, Any] | None:
+        return restaurant_store.review_submission(
+            submission_id,
+            status=status,
+            reviewer_notes=reviewer_notes,
+        )
+
+
+_STORE: RestaurantStore = _RestaurantStoreCompat()
+
+
+def get_restaurant_store() -> RestaurantStore:
+    return _STORE
+
+
+@router.get("/api/v1/restaurants/search", response_model=list[RestaurantHit])
+def search_restaurants(
+    query: str = Query("", max_length=128),
+    limit: int = 20,
+    offset: int = 0,
+    store: RestaurantStore = Depends(get_restaurant_store),
+) -> list[RestaurantHit]:
+    if limit > 100 or limit < 1:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="limit must be in [1,100]"
+        )
+    rows = store.search_restaurants(query, limit, offset)
+    return [RestaurantHit(**dict(row)) for row in rows]
+
+
+@router.get(
+    "/api/v1/restaurants/{chain_id}/menu",
+    response_model=list[RestaurantMenuItem],
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Restaurant menu not found"}},
+)
+def get_restaurant_menu(
+    chain_id: str,
+    limit: int = Query(200, ge=1, le=500),
+    store: RestaurantStore = Depends(get_restaurant_store),
+) -> list[RestaurantMenuItem]:
+    rows = store.get_restaurant_menu(chain_id, limit=limit)
+    if not rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Restaurant menu not found"
+        )
+    return [RestaurantMenuItem(**dict(row)) for row in rows]
+
+
+@router.post(
+    "/api/v1/restaurants/submissions",
+    response_model=RestaurantSubmission,
+    status_code=status.HTTP_201_CREATED,
+    responses={status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid submission"}},
+)
+def create_restaurant_submission(
+    payload: RestaurantSubmissionCreate,
+    store: RestaurantStore = Depends(get_restaurant_store),
+) -> RestaurantSubmission:
+    try:
+        created = store.create_submission(
+            canonical_name=payload.canonical_name,
+            payload=payload.payload,
+            barcode=payload.barcode,
+            off_url=payload.off_url,
+            entity_type="restaurant_menu",
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+        ) from exc
+    result: RestaurantSubmission = RestaurantSubmission.model_validate(created)
+    return result
+
+
+@router.get(
+    "/api/v1/restaurants/submissions/{submission_id}",
+    response_model=RestaurantSubmission,
+)
+def get_restaurant_submission(
+    submission_id: str,
+    store: RestaurantStore = Depends(get_restaurant_store),
+) -> RestaurantSubmission:
+    row = store.get_submission(submission_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
+    result: RestaurantSubmission = RestaurantSubmission.model_validate(row)
+    return result
+
+
+@moderation_router.patch(
+    "/api/v1/restaurants/submissions/{submission_id}/status",
+    response_model=RestaurantSubmission,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Submission not found"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid transition"},
+    },
+)
+def review_restaurant_submission(
+    submission_id: str,
+    payload: SubmissionReviewRequest,
+    store: RestaurantStore = Depends(get_restaurant_store),
+) -> RestaurantSubmission:
+    try:
+        row = store.review_submission(
+            submission_id,
+            status=payload.status.value,
+            reviewer_notes=payload.reviewer_notes,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+        ) from exc
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
+    result: RestaurantSubmission = RestaurantSubmission.model_validate(row)
+    return result

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -101,6 +101,10 @@ def search_restaurants(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="limit must be in [1,100]"
         )
+    if offset < 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="offset must be >= 0"
+        )
     rows = store.search_restaurants(query, limit, offset)
     return [RestaurantHit(**dict(row)) for row in rows]
 

--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -1,0 +1,90 @@
+"""
+Restaurant and moderated submission schemas.
+
+RU: Схемы ресторанов/меню и модерируемых пользовательских добавлений.
+EN: Schemas for restaurants/menus and moderated user submissions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SubmissionStatus(str, Enum):
+    """Moderation states for controlled submissions."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class RestaurantHit(BaseModel):
+    """Restaurant chain search hit."""
+
+    id: str
+    name: str
+    country: str | None = None
+    source: str
+
+
+class RestaurantMenuItem(BaseModel):
+    """Restaurant menu item payload."""
+
+    id: str
+    chain_id: str
+    item_name: str
+    category: str | None = None
+    serving_size_g: float | None = None
+    kcal: float | None = None
+    protein_g: float | None = None
+    fat_g: float | None = None
+    carbs_g: float | None = None
+    sodium_mg: float | None = None
+    source: str
+    source_id: str | None = None
+    is_active: bool = True
+
+
+class RestaurantSubmissionCreate(BaseModel):
+    """Create request for controlled submission queue."""
+
+    canonical_name: str = Field(..., min_length=1, max_length=256)
+    barcode: str | None = Field(default=None, max_length=64)
+    off_url: str | None = Field(default=None, max_length=1024)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class SubmissionAuditEntry(BaseModel):
+    """Single status transition for a submission."""
+
+    id: str
+    from_status: str | None = None
+    to_status: str
+    reviewer_notes: str | None = None
+    changed_at: str
+
+
+class RestaurantSubmission(BaseModel):
+    """Submission record returned by API."""
+
+    id: str
+    entity_type: str
+    canonical_name: str
+    barcode: str | None = None
+    off_url: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    status: SubmissionStatus
+    reviewer_notes: str | None = None
+    created_at: str
+    updated_at: str
+    audit: list[SubmissionAuditEntry] = Field(default_factory=list)
+
+
+class SubmissionReviewRequest(BaseModel):
+    """Request payload for moderation status update."""
+
+    status: SubmissionStatus
+    reviewer_notes: str | None = Field(default=None, max_length=1024)

--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class SubmissionStatus(str, Enum):
@@ -63,6 +64,17 @@ class RestaurantSubmissionCreate(BaseModel):
     barcode: str | None = Field(default=None, max_length=64)
     off_url: str | None = Field(default=None, max_length=1024)
     payload: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("off_url")
+    @classmethod
+    def validate_off_url(cls, value: str | None) -> str | None:
+        """Allow only valid HTTP(S) URLs for OFF references."""
+        if value is None:
+            return value
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("off_url must be a valid http/https URL")
+        return value
 
 
 class SubmissionAuditEntry(BaseModel):

--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -68,8 +68,8 @@ class SubmissionAuditEntry(BaseModel):
     """Single status transition for a submission."""
 
     id: str
-    from_status: str | None = None
-    to_status: str
+    from_status: SubmissionStatus | None = None
+    to_status: SubmissionStatus
     reviewer_notes: str | None = None
     changed_at: str
 

--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -7,6 +7,7 @@ EN: Schemas for restaurants/menus and moderated user submissions.
 
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -71,7 +72,7 @@ class SubmissionAuditEntry(BaseModel):
     from_status: SubmissionStatus | None = None
     to_status: SubmissionStatus
     reviewer_notes: str | None = None
-    changed_at: str
+    changed_at: datetime
 
 
 class RestaurantSubmission(BaseModel):
@@ -85,8 +86,8 @@ class RestaurantSubmission(BaseModel):
     payload: dict[str, Any] = Field(default_factory=dict)
     status: SubmissionStatus
     reviewer_notes: str | None = None
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime
     audit: list[SubmissionAuditEntry] = Field(default_factory=list)
 
 

--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -21,6 +21,13 @@ class SubmissionStatus(str, Enum):
     REJECTED = "rejected"
 
 
+class SubmissionReviewStatus(str, Enum):
+    """Allowed status values for moderation PATCH endpoint."""
+
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
 class RestaurantHit(BaseModel):
     """Restaurant chain search hit."""
 
@@ -86,5 +93,5 @@ class RestaurantSubmission(BaseModel):
 class SubmissionReviewRequest(BaseModel):
     """Request payload for moderation status update."""
 
-    status: SubmissionStatus
+    status: SubmissionReviewStatus
     reviewer_notes: str | None = Field(default=None, max_length=1024)

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -1,0 +1,404 @@
+# -*- coding: utf-8 -*-
+"""
+Restaurant menu store and controlled submission workflow.
+
+RU: Хранилище ресторанных меню и модерируемых пользовательских добавлений.
+EN: Restaurant menu storage and moderated submission workflow.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import sqlite3
+from typing import Any, Dict, Iterable, Iterator, Optional
+from uuid import uuid4
+
+# Keep food and restaurant data in the same SQLite file for local-first lookups.
+_env_db_path = os.getenv("FOOD_DB_PATH")
+DB_PATH: Path = Path(_env_db_path) if _env_db_path else Path("data/food.sqlite")
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+STATUS_PENDING = "pending"
+STATUS_APPROVED = "approved"
+STATUS_REJECTED = "rejected"
+_ALLOWED_REVIEW_STATUSES = {STATUS_APPROVED, STATUS_REJECTED}
+
+
+def _utc_now_iso() -> str:
+    """Return UTC timestamp in ISO format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slugify(value: str) -> str:
+    """Build deterministic IDs from external strings."""
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "unknown"
+
+
+def _as_float(value: Any) -> float | None:
+    """Best-effort numeric conversion for optional nutrient fields."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            return None
+    return None
+
+
+@contextmanager
+def _connect() -> Iterator[sqlite3.Connection]:
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    try:
+        _ensure_schema(con)
+        yield con
+    finally:
+        con.close()
+
+
+def _ensure_schema(con: sqlite3.Connection) -> None:
+    """Create W3 tables if absent.
+
+    RU: Создаёт минимальную схему W3 (идемпотентно).
+    EN: Ensures minimal W3 schema exists (idempotent).
+    """
+    con.executescript("""
+        CREATE TABLE IF NOT EXISTS restaurant_chains (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            country TEXT,
+            source TEXT NOT NULL,
+            source_id TEXT,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS restaurant_menu_items (
+            id TEXT PRIMARY KEY,
+            chain_id TEXT NOT NULL,
+            item_name TEXT NOT NULL,
+            category TEXT,
+            serving_size_g REAL,
+            kcal REAL,
+            protein_g REAL,
+            fat_g REAL,
+            carbs_g REAL,
+            sodium_mg REAL,
+            source TEXT NOT NULL,
+            source_id TEXT,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (chain_id) REFERENCES restaurant_chains(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS source_catalog (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            source_name TEXT NOT NULL,
+            source_record_id TEXT,
+            snapshot_date TEXT,
+            raw_data_json TEXT,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS user_submissions (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            canonical_name TEXT NOT NULL,
+            barcode TEXT,
+            off_url TEXT,
+            payload_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            reviewer_notes TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS submission_audit (
+            id TEXT PRIMARY KEY,
+            submission_id TEXT NOT NULL,
+            from_status TEXT,
+            to_status TEXT NOT NULL,
+            reviewer_notes TEXT,
+            changed_at TEXT NOT NULL,
+            FOREIGN KEY (submission_id) REFERENCES user_submissions(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_restaurant_chains_name
+            ON restaurant_chains(name);
+        CREATE INDEX IF NOT EXISTS idx_restaurant_menu_items_chain
+            ON restaurant_menu_items(chain_id);
+        CREATE INDEX IF NOT EXISTS idx_user_submissions_status
+            ON user_submissions(status);
+        CREATE INDEX IF NOT EXISTS idx_submission_audit_submission
+            ON submission_audit(submission_id);
+        """)
+    con.commit()
+
+
+def import_menustat_rows(
+    rows: Iterable[Dict[str, Any]],
+    *,
+    snapshot_date: str | None = None,
+    source_name: str = "menustat",
+) -> Dict[str, int]:
+    """
+    Import normalized MenuStat-like rows.
+
+    Expected keys:
+    - chain_name, item_name (required)
+    - category, serving_size_g, kcal, protein_g, fat_g, carbs_g, sodium_mg, source_id
+    """
+    snapshot = snapshot_date or datetime.now(timezone.utc).date().isoformat()
+    chains_upserted = 0
+    items_upserted = 0
+    with _connect() as con:
+        for row in rows:
+            chain_name = str(row.get("chain_name", "")).strip()
+            item_name = str(row.get("item_name", "")).strip()
+            if not chain_name or not item_name:
+                continue
+            chain_id = _slugify(chain_name)
+            now_iso = _utc_now_iso()
+            country = str(row.get("country", "US")).strip() or "US"
+            source_id = str(row.get("source_id", "")).strip() or None
+
+            con.execute(
+                """
+                INSERT INTO restaurant_chains (id, name, country, source, source_id, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name,
+                    country = excluded.country,
+                    source = excluded.source,
+                    source_id = excluded.source_id,
+                    updated_at = excluded.updated_at
+                """,
+                (chain_id, chain_name, country, source_name, source_id, now_iso),
+            )
+            chains_upserted += 1
+
+            menu_source_part = source_id or _slugify(item_name)
+            menu_id = f"{chain_id}:{menu_source_part}"
+            con.execute(
+                """
+                INSERT INTO restaurant_menu_items (
+                    id, chain_id, item_name, category, serving_size_g, kcal, protein_g,
+                    fat_g, carbs_g, sodium_mg, source, source_id, is_active, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    chain_id = excluded.chain_id,
+                    item_name = excluded.item_name,
+                    category = excluded.category,
+                    serving_size_g = excluded.serving_size_g,
+                    kcal = excluded.kcal,
+                    protein_g = excluded.protein_g,
+                    fat_g = excluded.fat_g,
+                    carbs_g = excluded.carbs_g,
+                    sodium_mg = excluded.sodium_mg,
+                    source = excluded.source,
+                    source_id = excluded.source_id,
+                    is_active = excluded.is_active,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    menu_id,
+                    chain_id,
+                    item_name,
+                    str(row.get("category", "")).strip() or None,
+                    _as_float(row.get("serving_size_g")),
+                    _as_float(row.get("kcal")),
+                    _as_float(row.get("protein_g")),
+                    _as_float(row.get("fat_g")),
+                    _as_float(row.get("carbs_g")),
+                    _as_float(row.get("sodium_mg")),
+                    source_name,
+                    source_id,
+                    now_iso,
+                ),
+            )
+            items_upserted += 1
+            con.execute(
+                """
+                INSERT INTO source_catalog (
+                    id, entity_type, entity_id, source_name, source_record_id,
+                    snapshot_date, raw_data_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(uuid4()),
+                    "restaurant_menu_item",
+                    menu_id,
+                    source_name,
+                    source_id,
+                    snapshot,
+                    json.dumps(row, ensure_ascii=True),
+                    now_iso,
+                ),
+            )
+        con.commit()
+    return {"chains_upserted": chains_upserted, "menu_items_upserted": items_upserted}
+
+
+def search_restaurants(query: str, limit: int = 20, offset: int = 0) -> list[Dict[str, Any]]:
+    """Search restaurant chains from local canonical DB."""
+    pattern = f"%{(query or '').strip().lower()}%"
+    with _connect() as con:
+        rows = con.execute(
+            """
+            SELECT id, name, country, source
+            FROM restaurant_chains
+            WHERE lower(name) LIKE ?
+            ORDER BY name ASC
+            LIMIT ? OFFSET ?
+            """,
+            (pattern, limit, offset),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def get_restaurant_menu(chain_id: str, limit: int = 200) -> list[Dict[str, Any]]:
+    """Return active menu rows for a restaurant chain."""
+    with _connect() as con:
+        rows = con.execute(
+            """
+            SELECT id, chain_id, item_name, category, serving_size_g, kcal, protein_g,
+                   fat_g, carbs_g, sodium_mg, source, source_id, is_active
+            FROM restaurant_menu_items
+            WHERE chain_id = ? AND is_active = 1
+            ORDER BY item_name ASC
+            LIMIT ?
+            """,
+            (chain_id, limit),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _normalize_submission_record(row: sqlite3.Row, audit_rows: list[sqlite3.Row]) -> Dict[str, Any]:
+    payload: dict[str, Any]
+    try:
+        payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+    except json.JSONDecodeError:
+        payload = {}
+    record = dict(row)
+    record["payload"] = payload
+    record.pop("payload_json", None)
+    record["audit"] = [dict(audit_row) for audit_row in audit_rows]
+    return record
+
+
+def create_submission(
+    *,
+    canonical_name: str,
+    payload: dict[str, Any] | None = None,
+    barcode: str | None = None,
+    off_url: str | None = None,
+    entity_type: str = "restaurant_menu",
+) -> Dict[str, Any]:
+    """Create a controlled submission in pending state."""
+    clean_name = canonical_name.strip()
+    if not clean_name:
+        raise ValueError("canonical_name is required")
+    payload_value = payload or {}
+    now_iso = _utc_now_iso()
+    submission_id = str(uuid4())
+    with _connect() as con:
+        con.execute(
+            """
+            INSERT INTO user_submissions (
+                id, entity_type, canonical_name, barcode, off_url, payload_json,
+                status, reviewer_notes, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+            """,
+            (
+                submission_id,
+                entity_type,
+                clean_name,
+                barcode,
+                off_url,
+                json.dumps(payload_value, ensure_ascii=True),
+                STATUS_PENDING,
+                now_iso,
+                now_iso,
+            ),
+        )
+        con.commit()
+    record = get_submission(submission_id)
+    if record is None:
+        raise RuntimeError("failed to persist submission")
+    return record
+
+
+def get_submission(submission_id: str) -> Optional[Dict[str, Any]]:
+    with _connect() as con:
+        row = con.execute(
+            """
+            SELECT id, entity_type, canonical_name, barcode, off_url, payload_json,
+                   status, reviewer_notes, created_at, updated_at
+            FROM user_submissions
+            WHERE id = ?
+            """,
+            (submission_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        audit_rows = con.execute(
+            """
+            SELECT id, from_status, to_status, reviewer_notes, changed_at
+            FROM submission_audit
+            WHERE submission_id = ?
+            ORDER BY changed_at ASC
+            """,
+            (submission_id,),
+        ).fetchall()
+    return _normalize_submission_record(row, list(audit_rows))
+
+
+def review_submission(
+    submission_id: str, *, status: str, reviewer_notes: str | None = None
+) -> Optional[Dict[str, Any]]:
+    """Move submission to approved/rejected and append audit transition."""
+    if status not in _ALLOWED_REVIEW_STATUSES:
+        raise ValueError("status must be one of: approved, rejected")
+
+    now_iso = _utc_now_iso()
+    with _connect() as con:
+        current = con.execute(
+            "SELECT id, status FROM user_submissions WHERE id = ?",
+            (submission_id,),
+        ).fetchone()
+        if current is None:
+            return None
+
+        from_status = str(current["status"])
+        con.execute(
+            """
+            UPDATE user_submissions
+            SET status = ?, reviewer_notes = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (status, reviewer_notes, now_iso, submission_id),
+        )
+        con.execute(
+            """
+            INSERT INTO submission_audit (
+                id, submission_id, from_status, to_status, reviewer_notes, changed_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (str(uuid4()), submission_id, from_status, status, reviewer_notes, now_iso),
+        )
+        con.commit()
+    return get_submission(submission_id)

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -55,6 +55,8 @@ def _as_float(value: Any) -> float | None:
     """Best-effort numeric conversion for optional nutrient fields."""
     if value is None:
         return None
+    if isinstance(value, bool):
+        return None
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -35,9 +36,19 @@ def _utc_now_iso() -> str:
 
 
 def _slugify(value: str) -> str:
-    """Build deterministic IDs from external strings."""
-    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-    return slug or "unknown"
+    """Build deterministic IDs from external strings.
+
+    RU: Для строк без ASCII-символов используем hash fallback вместо `unknown`,
+    чтобы избежать коллизий при upsert.
+    EN: For non-ASCII-only strings, use hash fallback instead of `unknown`
+    to prevent upsert collisions.
+    """
+    normalized = value.strip().casefold()
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized).strip("-")
+    if slug:
+        return slug
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"id-{digest}"
 
 
 def _as_float(value: Any) -> float | None:

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -28,6 +28,8 @@ STATUS_PENDING = "pending"
 STATUS_APPROVED = "approved"
 STATUS_REJECTED = "rejected"
 _ALLOWED_REVIEW_STATUSES = {STATUS_APPROVED, STATUS_REJECTED}
+MAX_RESTAURANT_SEARCH_LIMIT = 100
+MAX_RESTAURANT_MENU_LIMIT = 500
 
 
 def _utc_now_iso() -> str:
@@ -70,9 +72,21 @@ def _as_float(value: Any) -> float | None:
     return None
 
 
+def _validate_pagination(limit: int, offset: int, *, max_limit: int) -> tuple[int, int]:
+    """Validate pagination bounds for service-layer callers."""
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    if limit > max_limit:
+        raise ValueError(f"limit must be <= {max_limit}")
+    if offset < 0:
+        raise ValueError("offset must be >= 0")
+    return limit, offset
+
+
 @contextmanager
 def _connect() -> Iterator[sqlite3.Connection]:
     con = sqlite3.connect(DB_PATH)
+    con.execute("PRAGMA foreign_keys = ON")
     con.row_factory = sqlite3.Row
     try:
         _ensure_schema(con)
@@ -268,6 +282,11 @@ def import_menustat_rows(
 
 def search_restaurants(query: str, limit: int = 20, offset: int = 0) -> list[Dict[str, Any]]:
     """Search restaurant chains from local canonical DB."""
+    limit, offset = _validate_pagination(
+        limit=limit,
+        offset=offset,
+        max_limit=MAX_RESTAURANT_SEARCH_LIMIT,
+    )
     pattern = f"%{(query or '').strip().lower()}%"
     with _connect() as con:
         rows = con.execute(
@@ -285,6 +304,11 @@ def search_restaurants(query: str, limit: int = 20, offset: int = 0) -> list[Dic
 
 def get_restaurant_menu(chain_id: str, limit: int = 200) -> list[Dict[str, Any]]:
     """Return active menu rows for a restaurant chain."""
+    limit, _ = _validate_pagination(
+        limit=limit,
+        offset=0,
+        max_limit=MAX_RESTAURANT_MENU_LIMIT,
+    )
     with _connect() as con:
         rows = con.execute(
             """

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -66,8 +66,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W2-B
-  - Status: In Progress (W2-A merged in PR #891; W2-B barcode contract + tests)
+  - Target PR: PR #891, PR #893 (+ follow-up latency benchmark PR-TBD-FOOD-DB-W2-C)
+  - Status: In Progress (W2-A and W2-B merged; latency benchmark/report pending)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
@@ -86,8 +86,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3 — Restaurant menus + controlled user submissions
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W3
-  - Status: Planned
+  - Target PR: PR-TBD-FOOD-DB-W3-A
+  - Status: In Progress (W3-A foundation: restaurant schema/endpoints + moderated submissions)
   - Area: backend / data model / partner enablement
   - Finding Type: product coverage expansion
   - Reason: Product/restaurant database coverage and controlled data intake are required to reduce manual entry and support partner menu flows.
@@ -95,6 +95,9 @@ If it is not recorded here — it does not exist.
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/design/RESTAURANT_INTEGRATION_SPEC.md`
     - `docs/roadmap/BACKLOG_LEDGER.md` (P2 Vision: Restaurant/chef integration)
+    - `app/routers/restaurants.py`
+    - `app/services/restaurant_store.py`
+    - `app/schemas/restaurants.py`
   - DoD:
     - MenuStat baseline ingestion is operational
     - Restaurant menu schema and endpoints are documented

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -3979,6 +3979,7 @@
             "type": "string"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -4021,6 +4022,7 @@
             "$ref": "#/components/schemas/SubmissionStatus"
           },
           "updated_at": {
+            "format": "date-time",
             "title": "Updated At",
             "type": "string"
           }
@@ -5166,6 +5168,7 @@
         "description": "Single status transition for a submission.",
         "properties": {
           "changed_at": {
+            "format": "date-time",
             "title": "Changed At",
             "type": "string"
           },
@@ -8505,6 +8508,8 @@
             "required": false,
             "schema": {
               "default": 20,
+              "maximum": 100,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -8515,6 +8520,8 @@
             "required": false,
             "schema": {
               "default": 0,
+              "maximum": 10000,
+              "minimum": 0,
               "title": "Offset",
               "type": "integer"
             }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -3796,6 +3796,291 @@
         "title": "RecipeQueryHit",
         "type": "object"
       },
+      "RestaurantHit": {
+        "description": "Restaurant chain search hit.",
+        "properties": {
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "source"
+        ],
+        "title": "RestaurantHit",
+        "type": "object"
+      },
+      "RestaurantMenuItem": {
+        "description": "Restaurant menu item payload.",
+        "properties": {
+          "carbs_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Carbs G"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "chain_id": {
+            "title": "Chain Id",
+            "type": "string"
+          },
+          "fat_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fat G"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "is_active": {
+            "default": true,
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "item_name": {
+            "title": "Item Name",
+            "type": "string"
+          },
+          "kcal": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kcal"
+          },
+          "protein_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein G"
+          },
+          "serving_size_g": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Serving Size G"
+          },
+          "sodium_mg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sodium Mg"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "source_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Id"
+          }
+        },
+        "required": [
+          "id",
+          "chain_id",
+          "item_name",
+          "source"
+        ],
+        "title": "RestaurantMenuItem",
+        "type": "object"
+      },
+      "RestaurantSubmission": {
+        "description": "Submission record returned by API.",
+        "properties": {
+          "audit": {
+            "items": {
+              "$ref": "#/components/schemas/SubmissionAuditEntry"
+            },
+            "title": "Audit",
+            "type": "array"
+          },
+          "barcode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Barcode"
+          },
+          "canonical_name": {
+            "title": "Canonical Name",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "entity_type": {
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "off_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Off Url"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "reviewer_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewer Notes"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "entity_type",
+          "canonical_name",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "RestaurantSubmission",
+        "type": "object"
+      },
+      "RestaurantSubmissionCreate": {
+        "description": "Create request for controlled submission queue.",
+        "properties": {
+          "barcode": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Barcode"
+          },
+          "canonical_name": {
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Canonical Name",
+            "type": "string"
+          },
+          "off_url": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Off Url"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "canonical_name"
+        ],
+        "title": "RestaurantSubmissionCreate",
+        "type": "object"
+      },
       "ShopAisle": {
         "description": "Stable aisle/category for iOS (do not rename; only extend).\n\nRU: Категории для группировки списка покупок (не переименовывать).",
         "enum": [
@@ -4876,6 +5161,87 @@
         ],
         "title": "SoftPaywallMessage",
         "type": "object"
+      },
+      "SubmissionAuditEntry": {
+        "description": "Single status transition for a submission.",
+        "properties": {
+          "changed_at": {
+            "title": "Changed At",
+            "type": "string"
+          },
+          "from_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Status"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "reviewer_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewer Notes"
+          },
+          "to_status": {
+            "title": "To Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "to_status",
+          "changed_at"
+        ],
+        "title": "SubmissionAuditEntry",
+        "type": "object"
+      },
+      "SubmissionReviewRequest": {
+        "description": "Request payload for moderation status update.",
+        "properties": {
+          "reviewer_notes": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewer Notes"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "SubmissionReviewRequest",
+        "type": "object"
+      },
+      "SubmissionStatus": {
+        "description": "Moderation states for controlled submissions.",
+        "enum": [
+          "pending",
+          "approved",
+          "rejected"
+        ],
+        "title": "SubmissionStatus",
+        "type": "string"
       },
       "TargetsIn": {
         "description": "Nutrition targets input model.\n\nRU: Входная схема таргетов питания (используется в PRO/Premium эндпоинтах).\nEN: Input schema for nutrition targets (used by PRO/Premium endpoints).",
@@ -8108,6 +8474,264 @@
         "summary": "Get Recipe",
         "tags": [
           "recipes"
+        ]
+      }
+    },
+    "/api/v1/restaurants/search": {
+      "get": {
+        "operationId": "search_restaurants_api_v1_restaurants_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": {
+              "default": "",
+              "maxLength": 128,
+              "title": "Query",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RestaurantHit"
+                  },
+                  "title": "Response Search Restaurants Api V1 Restaurants Search Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Search Restaurants",
+        "tags": [
+          "restaurants"
+        ]
+      }
+    },
+    "/api/v1/restaurants/submissions": {
+      "post": {
+        "operationId": "create_restaurant_submission_api_v1_restaurants_submissions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestaurantSubmissionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestaurantSubmission"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Invalid submission"
+          }
+        },
+        "summary": "Create Restaurant Submission",
+        "tags": [
+          "restaurants"
+        ]
+      }
+    },
+    "/api/v1/restaurants/submissions/{submission_id}": {
+      "get": {
+        "operationId": "get_restaurant_submission_api_v1_restaurants_submissions__submission_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestaurantSubmission"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Restaurant Submission",
+        "tags": [
+          "restaurants"
+        ]
+      }
+    },
+    "/api/v1/restaurants/submissions/{submission_id}/status": {
+      "patch": {
+        "operationId": "review_restaurant_submission_api_v1_restaurants_submissions__submission_id__status_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "submission_id",
+            "required": true,
+            "schema": {
+              "title": "Submission Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmissionReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestaurantSubmission"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "Submission not found"
+          },
+          "422": {
+            "description": "Invalid transition"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Review Restaurant Submission",
+        "tags": [
+          "restaurants"
+        ]
+      }
+    },
+    "/api/v1/restaurants/{chain_id}/menu": {
+      "get": {
+        "operationId": "get_restaurant_menu_api_v1_restaurants__chain_id__menu_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "chain_id",
+            "required": true,
+            "schema": {
+              "title": "Chain Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RestaurantMenuItem"
+                  },
+                  "title": "Response Get Restaurant Menu Api V1 Restaurants  Chain Id  Menu Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "Restaurant menu not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Restaurant Menu",
+        "tags": [
+          "restaurants"
         ]
       }
     },

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5224,7 +5224,7 @@
             "title": "Reviewer Notes"
           },
           "status": {
-            "$ref": "#/components/schemas/SubmissionStatus"
+            "$ref": "#/components/schemas/SubmissionReviewStatus"
           }
         },
         "required": [
@@ -5232,6 +5232,15 @@
         ],
         "title": "SubmissionReviewRequest",
         "type": "object"
+      },
+      "SubmissionReviewStatus": {
+        "description": "Allowed status values for moderation PATCH endpoint.",
+        "enum": [
+          "approved",
+          "rejected"
+        ],
+        "title": "SubmissionReviewStatus",
+        "type": "string"
       },
       "SubmissionStatus": {
         "description": "Moderation states for controlled submissions.",

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5172,13 +5172,12 @@
           "from_status": {
             "anyOf": [
               {
-                "type": "string"
+                "$ref": "#/components/schemas/SubmissionStatus"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "From Status"
+            ]
           },
           "id": {
             "title": "Id",
@@ -5196,8 +5195,7 @@
             "title": "Reviewer Notes"
           },
           "to_status": {
-            "title": "To Status",
-            "type": "string"
+            "$ref": "#/components/schemas/SubmissionStatus"
           }
         },
         "required": [

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4879,14 +4879,12 @@ export interface components {
         SubmissionAuditEntry: {
             /** Changed At */
             changed_at: string;
-            /** From Status */
-            from_status?: string | null;
+            from_status?: components["schemas"]["SubmissionStatus"] | null;
             /** Id */
             id: string;
             /** Reviewer Notes */
             reviewer_notes?: string | null;
-            /** To Status */
-            to_status: string;
+            to_status: components["schemas"]["SubmissionStatus"];
         };
         /**
          * SubmissionReviewRequest

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1230,6 +1230,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/restaurants/{chain_id}/menu": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Restaurant Menu */
+        get: operations["get_restaurant_menu_api_v1_restaurants__chain_id__menu_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/restaurants/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Search Restaurants */
+        get: operations["search_restaurants_api_v1_restaurants_search_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/restaurants/submissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Restaurant Submission */
+        post: operations["create_restaurant_submission_api_v1_restaurants_submissions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/restaurants/submissions/{submission_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Restaurant Submission */
+        get: operations["get_restaurant_submission_api_v1_restaurants_submissions__submission_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/restaurants/submissions/{submission_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Review Restaurant Submission */
+        patch: operations["review_restaurant_submission_api_v1_restaurants_submissions__submission_id__status_patch"];
+        trace?: never;
+    };
     "/api/v1/shoplist": {
         parameters: {
             query?: never;
@@ -4073,6 +4158,100 @@ export interface components {
             title: string;
         };
         /**
+         * RestaurantHit
+         * @description Restaurant chain search hit.
+         */
+        RestaurantHit: {
+            /** Country */
+            country?: string | null;
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Source */
+            source: string;
+        };
+        /**
+         * RestaurantMenuItem
+         * @description Restaurant menu item payload.
+         */
+        RestaurantMenuItem: {
+            /** Carbs G */
+            carbs_g?: number | null;
+            /** Category */
+            category?: string | null;
+            /** Chain Id */
+            chain_id: string;
+            /** Fat G */
+            fat_g?: number | null;
+            /** Id */
+            id: string;
+            /**
+             * Is Active
+             * @default true
+             */
+            is_active: boolean;
+            /** Item Name */
+            item_name: string;
+            /** Kcal */
+            kcal?: number | null;
+            /** Protein G */
+            protein_g?: number | null;
+            /** Serving Size G */
+            serving_size_g?: number | null;
+            /** Sodium Mg */
+            sodium_mg?: number | null;
+            /** Source */
+            source: string;
+            /** Source Id */
+            source_id?: string | null;
+        };
+        /**
+         * RestaurantSubmission
+         * @description Submission record returned by API.
+         */
+        RestaurantSubmission: {
+            /** Audit */
+            audit?: components["schemas"]["SubmissionAuditEntry"][];
+            /** Barcode */
+            barcode?: string | null;
+            /** Canonical Name */
+            canonical_name: string;
+            /** Created At */
+            created_at: string;
+            /** Entity Type */
+            entity_type: string;
+            /** Id */
+            id: string;
+            /** Off Url */
+            off_url?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            };
+            /** Reviewer Notes */
+            reviewer_notes?: string | null;
+            status: components["schemas"]["SubmissionStatus"];
+            /** Updated At */
+            updated_at: string;
+        };
+        /**
+         * RestaurantSubmissionCreate
+         * @description Create request for controlled submission queue.
+         */
+        RestaurantSubmissionCreate: {
+            /** Barcode */
+            barcode?: string | null;
+            /** Canonical Name */
+            canonical_name: string;
+            /** Off Url */
+            off_url?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            };
+        };
+        /**
          * ShopAisle
          * @description Stable aisle/category for iOS (do not rename; only extend).
          *
@@ -4693,6 +4872,37 @@ export interface components {
              */
             title_key: string;
         };
+        /**
+         * SubmissionAuditEntry
+         * @description Single status transition for a submission.
+         */
+        SubmissionAuditEntry: {
+            /** Changed At */
+            changed_at: string;
+            /** From Status */
+            from_status?: string | null;
+            /** Id */
+            id: string;
+            /** Reviewer Notes */
+            reviewer_notes?: string | null;
+            /** To Status */
+            to_status: string;
+        };
+        /**
+         * SubmissionReviewRequest
+         * @description Request payload for moderation status update.
+         */
+        SubmissionReviewRequest: {
+            /** Reviewer Notes */
+            reviewer_notes?: string | null;
+            status: components["schemas"]["SubmissionStatus"];
+        };
+        /**
+         * SubmissionStatus
+         * @description Moderation states for controlled submissions.
+         * @enum {string}
+         */
+        SubmissionStatus: "pending" | "approved" | "rejected";
         /**
          * TargetsIn
          * @description Nutrition targets input model.
@@ -6714,6 +6924,181 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+        };
+    };
+    get_restaurant_menu_api_v1_restaurants__chain_id__menu_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                chain_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestaurantMenuItem"][];
+                };
+            };
+            /** @description Restaurant menu not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_restaurants_api_v1_restaurants_search_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                query?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestaurantHit"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_restaurant_submission_api_v1_restaurants_submissions_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RestaurantSubmissionCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestaurantSubmission"];
+                };
+            };
+            /** @description Invalid submission */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_restaurant_submission_api_v1_restaurants_submissions__submission_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                submission_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestaurantSubmission"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    review_restaurant_submission_api_v1_restaurants_submissions__submission_id__status_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                submission_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmissionReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestaurantSubmission"];
+                };
+            };
+            /** @description Submission not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid transition */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4895,8 +4895,14 @@ export interface components {
         SubmissionReviewRequest: {
             /** Reviewer Notes */
             reviewer_notes?: string | null;
-            status: components["schemas"]["SubmissionStatus"];
+            status: components["schemas"]["SubmissionReviewStatus"];
         };
+        /**
+         * SubmissionReviewStatus
+         * @description Allowed status values for moderation PATCH endpoint.
+         * @enum {string}
+         */
+        SubmissionReviewStatus: "approved" | "rejected";
         /**
          * SubmissionStatus
          * @description Moderation states for controlled submissions.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4217,7 +4217,10 @@ export interface components {
             barcode?: string | null;
             /** Canonical Name */
             canonical_name: string;
-            /** Created At */
+            /**
+             * Created At
+             * Format: date-time
+             */
             created_at: string;
             /** Entity Type */
             entity_type: string;
@@ -4232,7 +4235,10 @@ export interface components {
             /** Reviewer Notes */
             reviewer_notes?: string | null;
             status: components["schemas"]["SubmissionStatus"];
-            /** Updated At */
+            /**
+             * Updated At
+             * Format: date-time
+             */
             updated_at: string;
         };
         /**
@@ -4877,7 +4883,10 @@ export interface components {
          * @description Single status transition for a submission.
          */
         SubmissionAuditEntry: {
-            /** Changed At */
+            /**
+             * Changed At
+             * Format: date-time
+             */
             changed_at: string;
             from_status?: components["schemas"]["SubmissionStatus"] | null;
             /** Id */

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -54,6 +54,10 @@ from app.routers.foods import router as foods_router
 from app.routers.plan_export import export_router, plan_router
 from app.routers.pro_registration import register_pro_routes as _register_pro_routes
 from app.routers.recipes import router as recipes_router
+from app.routers.restaurants import (
+    moderation_router as restaurant_moderation_router,
+    router as restaurants_router,
+)
 from app.routers.shoplist_day import router as shoplist_day_router
 from app.routers.shopping_list_pro import router as shopping_list_pro_router
 from app.routers.shoplist_export import router as shoplist_router
@@ -834,9 +838,11 @@ async def admin_status() -> Dict[str, str]:
 protected_dependency = Depends(_get_api_key_dynamic)
 
 app.include_router(foods_router)
+app.include_router(restaurants_router)
 app.include_router(recipes_router)
 app.include_router(users_router)
 app.include_router(catalog_router)
+app.include_router(restaurant_moderation_router, dependencies=[protected_dependency])
 app.include_router(export_router, dependencies=[protected_dependency])
 app.include_router(plan_router, dependencies=[protected_dependency])
 app.include_router(shoplist_router, dependencies=[protected_dependency])

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -181,3 +181,29 @@ def test_import_menustat_rows_non_ascii_ids_do_not_collapse(
     chain_ids = [row["id"] for row in chain_rows]
     assert chain_ids[0] != chain_ids[1]
     assert all(chain_id.startswith("id-") for chain_id in chain_ids)
+
+
+def test_connect_enables_foreign_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    with restaurant_store._connect() as con:
+        row = con.execute("PRAGMA foreign_keys").fetchone()
+    assert row is not None
+    assert row[0] == 1
+
+
+def test_search_restaurants_rejects_invalid_pagination(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="offset must be >= 0"):
+        restaurant_store.search_restaurants("x", limit=10, offset=-1)
+    with pytest.raises(ValueError, match="limit must be <= 100"):
+        restaurant_store.search_restaurants("x", limit=101, offset=0)
+
+
+def test_get_restaurant_menu_rejects_invalid_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="limit must be <= 500"):
+        restaurant_store.get_restaurant_menu("any", limit=501)

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -159,3 +159,23 @@ def test_get_submission_missing_returns_none(
 ) -> None:
     _set_test_db(monkeypatch, tmp_path)
     assert restaurant_store.get_submission("no-such-submission") is None
+
+
+def test_import_menustat_rows_non_ascii_ids_do_not_collapse(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    stats = restaurant_store.import_menustat_rows(
+        [
+            {"chain_name": "Пицца Дом", "item_name": "Маргарита"},
+            {"chain_name": "Роллы Плюс", "item_name": "Филадельфия"},
+        ]
+    )
+    assert stats == {"chains_upserted": 2, "menu_items_upserted": 2}
+
+    with restaurant_store._connect() as con:
+        chain_rows = con.execute("SELECT id, name FROM restaurant_chains ORDER BY name").fetchall()
+    assert len(chain_rows) == 2
+    chain_ids = [row["id"] for row in chain_rows]
+    assert chain_ids[0] != chain_ids[1]
+    assert all(chain_id.startswith("id-") for chain_id in chain_ids)

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -88,6 +88,8 @@ def test_review_submission_missing_returns_none(
 
 def test_as_float_conversion_branches() -> None:
     assert restaurant_store._as_float(12) == 12.0
+    assert restaurant_store._as_float(True) is None
+    assert restaurant_store._as_float(False) is None
     assert restaurant_store._as_float("") is None
     assert restaurant_store._as_float("abc") is None
     assert restaurant_store._as_float(object()) is None

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -84,3 +84,78 @@ def test_review_submission_missing_returns_none(
 ) -> None:
     _set_test_db(monkeypatch, tmp_path)
     assert restaurant_store.review_submission("missing-id", status="approved") is None
+
+
+def test_as_float_conversion_branches() -> None:
+    assert restaurant_store._as_float(12) == 12.0
+    assert restaurant_store._as_float("") is None
+    assert restaurant_store._as_float("abc") is None
+    assert restaurant_store._as_float(object()) is None
+
+
+def test_import_menustat_rows_skips_invalid_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    stats = restaurant_store.import_menustat_rows(
+        [
+            {"chain_name": "", "item_name": "A"},
+            {"chain_name": "Chain", "item_name": ""},
+        ]
+    )
+    assert stats == {"chains_upserted": 0, "menu_items_upserted": 0}
+
+
+def test_get_submission_handles_invalid_payload_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    with restaurant_store._connect() as con:
+        con.execute(
+            """
+            INSERT INTO user_submissions (
+                id, entity_type, canonical_name, barcode, off_url, payload_json,
+                status, reviewer_notes, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+            """,
+            (
+                "s-bad-json",
+                "restaurant_menu",
+                "Bad payload",
+                None,
+                None,
+                "{bad",
+                "pending",
+                "a",
+                "b",
+            ),
+        )
+        con.commit()
+
+    row = restaurant_store.get_submission("s-bad-json")
+    assert row is not None
+    assert row["payload"] == {}
+
+
+def test_create_submission_requires_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="canonical_name is required"):
+        restaurant_store.create_submission(canonical_name="  ")
+
+
+def test_create_submission_runtime_error_when_lookup_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    original_get_submission = restaurant_store.get_submission
+    monkeypatch.setattr(restaurant_store, "get_submission", lambda _: None)
+    with pytest.raises(RuntimeError, match="failed to persist submission"):
+        restaurant_store.create_submission(canonical_name="X")
+    monkeypatch.setattr(restaurant_store, "get_submission", original_get_submission)
+
+
+def test_get_submission_missing_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    assert restaurant_store.get_submission("no-such-submission") is None

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,8 @@ from app.services import restaurant_store
 
 
 def _set_test_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    db_path = tmp_path / "restaurants_test.sqlite"
+    worker = os.getenv("PYTEST_XDIST_WORKER", "gw0")
+    db_path = tmp_path / f"restaurants_test_{worker}.sqlite"
     monkeypatch.setattr(restaurant_store, "DB_PATH", db_path)
     return db_path
 

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services import restaurant_store
+
+
+def _set_test_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    db_path = tmp_path / "restaurants_test.sqlite"
+    monkeypatch.setattr(restaurant_store, "DB_PATH", db_path)
+    return db_path
+
+
+def test_import_menustat_rows_and_query(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    stats = restaurant_store.import_menustat_rows(
+        [
+            {
+                "chain_name": "Test Chain",
+                "country": "US",
+                "item_name": "Protein Burger",
+                "category": "Burgers",
+                "kcal": "540",
+                "protein_g": "30",
+                "fat_g": "24",
+                "carbs_g": "50",
+                "sodium_mg": "910",
+                "source_id": "menu-001",
+            }
+        ],
+        snapshot_date="2026-02-24",
+    )
+    assert stats == {"chains_upserted": 1, "menu_items_upserted": 1}
+
+    chains = restaurant_store.search_restaurants("test", limit=10, offset=0)
+    assert len(chains) == 1
+    assert chains[0]["id"] == "test-chain"
+    assert chains[0]["source"] == "menustat"
+
+    menu = restaurant_store.get_restaurant_menu("test-chain", limit=10)
+    assert len(menu) == 1
+    assert menu[0]["item_name"] == "Protein Burger"
+    assert menu[0]["chain_id"] == "test-chain"
+    assert menu[0]["kcal"] == 540.0
+
+
+def test_submission_lifecycle_with_audit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+
+    created = restaurant_store.create_submission(
+        canonical_name="Protein Burger",
+        payload={"kcal": 540, "source_hint": "menustat"},
+        barcode="0123456789012",
+        off_url=None,
+    )
+    assert created["status"] == "pending"
+    assert created["audit"] == []
+
+    reviewed = restaurant_store.review_submission(
+        created["id"], status="approved", reviewer_notes="verified"
+    )
+    assert reviewed is not None
+    assert reviewed["status"] == "approved"
+    assert len(reviewed["audit"]) == 1
+    assert reviewed["audit"][0]["from_status"] == "pending"
+    assert reviewed["audit"][0]["to_status"] == "approved"
+
+
+def test_review_submission_invalid_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+
+    created = restaurant_store.create_submission(
+        canonical_name="Salad",
+        payload={"kcal": 120},
+    )
+    with pytest.raises(ValueError, match="status must be one of: approved, rejected"):
+        restaurant_store.review_submission(created["id"], status="pending")
+
+
+def test_review_submission_missing_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    assert restaurant_store.review_submission("missing-id", status="approved") is None

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -65,6 +65,13 @@ def test_search_restaurants_limit_validation() -> None:
     assert exc.value.detail == "limit must be in [1,100]"
 
 
+def test_search_restaurants_offset_validation() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restaurants.search_restaurants(query="x", limit=10, offset=-1, store=_StubStore())
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "offset must be >= 0"
+
+
 def test_get_restaurant_store_returns_singleton() -> None:
     assert restaurants.get_restaurant_store() is restaurants._STORE
 

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -261,3 +261,8 @@ def test_review_submission_not_found_maps_404() -> None:
 def test_review_payload_rejects_pending_status() -> None:
     with pytest.raises(ValidationError):
         SubmissionReviewRequest(status=SubmissionStatus.PENDING)
+
+
+def test_submission_create_rejects_invalid_off_url() -> None:
+    with pytest.raises(ValidationError):
+        RestaurantSubmissionCreate(canonical_name="X", off_url="not-a-url", payload={})

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -5,11 +5,13 @@ from typing import Any, Dict, Mapping, Sequence
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from app.routers import restaurants
 from app.schemas.restaurants import (
     RestaurantSubmissionCreate,
     SubmissionReviewRequest,
+    SubmissionReviewStatus,
     SubmissionStatus,
 )
 
@@ -223,7 +225,7 @@ def test_review_submission_maps_response() -> None:
             "audit": [],
         }
     )
-    payload = SubmissionReviewRequest(status=SubmissionStatus.APPROVED, reviewer_notes="ok")
+    payload = SubmissionReviewRequest(status=SubmissionReviewStatus.APPROVED, reviewer_notes="ok")
     result = restaurants.review_restaurant_submission("s1", payload, store=store)
     assert result.id == "s1"
     assert result.status == SubmissionStatus.APPROVED
@@ -231,14 +233,14 @@ def test_review_submission_maps_response() -> None:
 
 def test_review_submission_validation_error_maps_422() -> None:
     store = _StubStore(review_error=ValueError("status must be one of: approved, rejected"))
-    payload = SubmissionReviewRequest(status=SubmissionStatus.REJECTED)
+    payload = SubmissionReviewRequest(status=SubmissionReviewStatus.REJECTED)
     with pytest.raises(HTTPException) as exc:
         restaurants.review_restaurant_submission("s1", payload, store=store)
     assert exc.value.status_code == 422
 
 
 def test_review_submission_not_found_maps_404() -> None:
-    payload = SubmissionReviewRequest(status=SubmissionStatus.REJECTED)
+    payload = SubmissionReviewRequest(status=SubmissionReviewStatus.REJECTED)
     with pytest.raises(HTTPException) as exc:
         restaurants.review_restaurant_submission(
             "s1",
@@ -247,3 +249,8 @@ def test_review_submission_not_found_maps_404() -> None:
         )
     assert exc.value.status_code == 404
     assert exc.value.detail == "Submission not found"
+
+
+def test_review_payload_rejects_pending_status() -> None:
+    with pytest.raises(ValidationError):
+        SubmissionReviewRequest(status=SubmissionStatus.PENDING)

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Sequence
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import restaurants
+from app.schemas.restaurants import (
+    RestaurantSubmissionCreate,
+    SubmissionReviewRequest,
+    SubmissionStatus,
+)
+
+
+@dataclass
+class _StubStore:
+    search_rows: Sequence[Mapping[str, Any]] = field(default_factory=list)
+    menu_rows: Sequence[Mapping[str, Any]] = field(default_factory=list)
+    create_response: Mapping[str, Any] | None = None
+    get_response: Mapping[str, Any] | None = None
+    review_response: Mapping[str, Any] | None = None
+    create_error: Exception | None = None
+    review_error: Exception | None = None
+
+    def search_restaurants(
+        self, query: str, limit: int, offset: int
+    ) -> Sequence[Mapping[str, Any]]:
+        return self.search_rows
+
+    def get_restaurant_menu(self, chain_id: str, limit: int) -> Sequence[Mapping[str, Any]]:
+        return self.menu_rows
+
+    def create_submission(
+        self,
+        *,
+        canonical_name: str,
+        payload: Dict[str, Any],
+        barcode: str | None,
+        off_url: str | None,
+        entity_type: str,
+    ) -> Mapping[str, Any]:
+        if self.create_error is not None:
+            raise self.create_error
+        return self.create_response or {}
+
+    def get_submission(self, submission_id: str) -> Mapping[str, Any] | None:
+        return self.get_response
+
+    def review_submission(
+        self, submission_id: str, *, status: str, reviewer_notes: str | None
+    ) -> Mapping[str, Any] | None:
+        if self.review_error is not None:
+            raise self.review_error
+        return self.review_response
+
+
+def test_search_restaurants_limit_validation() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restaurants.search_restaurants(query="x", limit=0, offset=0, store=_StubStore())
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "limit must be in [1,100]"
+
+
+def test_search_restaurants_maps_hits() -> None:
+    store = _StubStore(
+        search_rows=[{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}]
+    )
+    result = restaurants.search_restaurants(query="chain", limit=10, offset=0, store=store)
+    assert len(result) == 1
+    assert result[0].id == "c1"
+    assert result[0].name == "Chain 1"
+
+
+def test_get_restaurant_menu_not_found() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restaurants.get_restaurant_menu("missing", limit=20, store=_StubStore(menu_rows=[]))
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Restaurant menu not found"
+
+
+def test_create_submission_validation_error_maps_422() -> None:
+    store = _StubStore(create_error=ValueError("canonical_name is required"))
+    payload = RestaurantSubmissionCreate(canonical_name="abc", payload={})
+    with pytest.raises(HTTPException) as exc:
+        restaurants.create_restaurant_submission(payload, store=store)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "canonical_name is required"
+
+
+def test_get_submission_not_found() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restaurants.get_restaurant_submission("missing", store=_StubStore(get_response=None))
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Submission not found"
+
+
+def test_review_submission_maps_response() -> None:
+    store = _StubStore(
+        review_response={
+            "id": "s1",
+            "entity_type": "restaurant_menu",
+            "canonical_name": "Protein Burger",
+            "barcode": None,
+            "off_url": None,
+            "payload": {"kcal": 540},
+            "status": "approved",
+            "reviewer_notes": "ok",
+            "created_at": "2026-02-24T00:00:00+00:00",
+            "updated_at": "2026-02-24T00:05:00+00:00",
+            "audit": [],
+        }
+    )
+    payload = SubmissionReviewRequest(status=SubmissionStatus.APPROVED, reviewer_notes="ok")
+    result = restaurants.review_restaurant_submission("s1", payload, store=store)
+    assert result.id == "s1"
+    assert result.status == SubmissionStatus.APPROVED
+
+
+def test_review_submission_validation_error_maps_422() -> None:
+    store = _StubStore(review_error=ValueError("status must be one of: approved, rejected"))
+    payload = SubmissionReviewRequest(status=SubmissionStatus.REJECTED)
+    with pytest.raises(HTTPException) as exc:
+        restaurants.review_restaurant_submission("s1", payload, store=store)
+    assert exc.value.status_code == 422
+
+
+def test_review_submission_not_found_maps_404() -> None:
+    payload = SubmissionReviewRequest(status=SubmissionStatus.REJECTED)
+    with pytest.raises(HTTPException) as exc:
+        restaurants.review_restaurant_submission(
+            "s1",
+            payload,
+            store=_StubStore(review_response=None),
+        )
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Submission not found"

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -63,6 +63,48 @@ def test_search_restaurants_limit_validation() -> None:
     assert exc.value.detail == "limit must be in [1,100]"
 
 
+def test_get_restaurant_store_returns_singleton() -> None:
+    assert restaurants.get_restaurant_store() is restaurants._STORE
+
+
+def test_compat_wrapper_delegates_to_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    compat = restaurants._RestaurantStoreCompat()
+    monkeypatch.setattr(
+        restaurants.restaurant_store, "search_restaurants", lambda **_: [{"id": "c1"}]
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "create_submission",
+        lambda **_: {"id": "s1"},
+    )
+    monkeypatch.setattr(restaurants.restaurant_store, "get_submission", lambda _sid: {"id": "s1"})
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "review_submission",
+        lambda _sid, **_: {"id": "s1"},
+    )
+
+    assert list(compat.search_restaurants("q", 1, 0))[0]["id"] == "c1"
+    assert list(compat.get_restaurant_menu("c1", 1))[0]["id"] == "m1"
+    assert (
+        compat.create_submission(
+            canonical_name="X",
+            payload={},
+            barcode=None,
+            off_url=None,
+            entity_type="restaurant_menu",
+        )["id"]
+        == "s1"
+    )
+    assert compat.get_submission("s1")["id"] == "s1"
+    assert compat.review_submission("s1", status="approved", reviewer_notes=None)["id"] == "s1"
+
+
 def test_search_restaurants_maps_hits() -> None:
     store = _StubStore(
         search_rows=[{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}]
@@ -80,6 +122,32 @@ def test_get_restaurant_menu_not_found() -> None:
     assert exc.value.detail == "Restaurant menu not found"
 
 
+def test_get_restaurant_menu_maps_rows() -> None:
+    store = _StubStore(
+        menu_rows=[
+            {
+                "id": "m1",
+                "chain_id": "c1",
+                "item_name": "Protein Burger",
+                "category": "Burgers",
+                "serving_size_g": 200.0,
+                "kcal": 540.0,
+                "protein_g": 30.0,
+                "fat_g": 24.0,
+                "carbs_g": 50.0,
+                "sodium_mg": 910.0,
+                "source": "menustat",
+                "source_id": "menu-001",
+                "is_active": 1,
+            }
+        ]
+    )
+    result = restaurants.get_restaurant_menu("c1", limit=20, store=store)
+    assert len(result) == 1
+    assert result[0].id == "m1"
+    assert result[0].item_name == "Protein Burger"
+
+
 def test_create_submission_validation_error_maps_422() -> None:
     store = _StubStore(create_error=ValueError("canonical_name is required"))
     payload = RestaurantSubmissionCreate(canonical_name="abc", payload={})
@@ -89,11 +157,54 @@ def test_create_submission_validation_error_maps_422() -> None:
     assert exc.value.detail == "canonical_name is required"
 
 
+def test_create_submission_success() -> None:
+    store = _StubStore(
+        create_response={
+            "id": "s1",
+            "entity_type": "restaurant_menu",
+            "canonical_name": "Protein Burger",
+            "barcode": None,
+            "off_url": None,
+            "payload": {"kcal": 540},
+            "status": "pending",
+            "reviewer_notes": None,
+            "created_at": "2026-02-24T00:00:00+00:00",
+            "updated_at": "2026-02-24T00:00:00+00:00",
+            "audit": [],
+        }
+    )
+    payload = RestaurantSubmissionCreate(canonical_name="Protein Burger", payload={"kcal": 540})
+    result = restaurants.create_restaurant_submission(payload, store=store)
+    assert result.id == "s1"
+    assert result.status == SubmissionStatus.PENDING
+
+
 def test_get_submission_not_found() -> None:
     with pytest.raises(HTTPException) as exc:
         restaurants.get_restaurant_submission("missing", store=_StubStore(get_response=None))
     assert exc.value.status_code == 404
     assert exc.value.detail == "Submission not found"
+
+
+def test_get_submission_success() -> None:
+    store = _StubStore(
+        get_response={
+            "id": "s1",
+            "entity_type": "restaurant_menu",
+            "canonical_name": "Protein Burger",
+            "barcode": None,
+            "off_url": None,
+            "payload": {"kcal": 540},
+            "status": "approved",
+            "reviewer_notes": "ok",
+            "created_at": "2026-02-24T00:00:00+00:00",
+            "updated_at": "2026-02-24T00:05:00+00:00",
+            "audit": [],
+        }
+    )
+    result = restaurants.get_restaurant_submission("s1", store=store)
+    assert result.id == "s1"
+    assert result.status == SubmissionStatus.APPROVED
 
 
 def test_review_submission_maps_response() -> None:


### PR DESCRIPTION
## Summary
- add non-breaking restaurant API slice for Wave 3:
  - `GET /api/v1/restaurants/search`
  - `GET /api/v1/restaurants/{chain_id}/menu`
- add controlled submissions workflow with moderation states (`pending/approved/rejected`) and submission audit trail:
  - `POST /api/v1/restaurants/submissions`
  - `GET /api/v1/restaurants/submissions/{submission_id}`
  - `PATCH /api/v1/restaurants/submissions/{submission_id}/status`
- add local SQLite-backed W3 foundation service and schema
- update canonical ledger status for W2/W3 carryover mapping

## Scope
- `app/routers/restaurants.py`
- `app/services/restaurant_store.py`
- `app/schemas/restaurants.py`
- `legacy_app.py`
- `app/routers/__init__.py`
- `tests/test_restaurant_store_service.py`
- `tests/test_restaurants_router.py`
- `docs/roadmap/BACKLOG_LEDGER.md`
- generated API sync artifacts:
  - `frontend/src/api/openapi.json`
  - `frontend/src/api/schema.ts`

## Compatibility
- existing `/api/v1/foods*` and current routers remain unchanged
- all new routes are additive and backward-compatible
- moderation mutation route is included with existing protected dependency in `legacy_app.py`

## Carryover
- W3 implementation starts after merged W1/W2 chain (PR #889, #891, #893)
- canonical backlog mapping updated in `docs/roadmap/BACKLOG_LEDGER.md`

## Test Plan
- `pre-commit run --all-files` ✅
- `make verify` ✅
  - lint ✅
  - typecheck ✅
  - test-fast ✅
  - diff-cover ✅ (100% on changed lines)

## Deferred / Follow-ups
- add MenuStat file ingestion CLI/scheduler integration (W3-B)
- wire moderation role/authz beyond existing API-key protection
- keep W2 latency benchmark carryover in ledger (`PR-TBD-FOOD-DB-W2-C`)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3850975248 -> `b500b628`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966740 -> `b500b628`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966746 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966747 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966750 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966756 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966760 -> `b500b628`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849966763 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849972048 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849972052 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849972056 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849972059 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2849972062 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3850980987 -> `2508fc88`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850013117 -> `0f3e252d`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850013125 -> `0f3e252d`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3851020776 -> `0f3e252d`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850027759 -> `837144a0`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850027763 -> `837144a0`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850027764 -> `837144a0`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3851035350 -> `837144a0`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850058841 -> `e45366ae`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3851065001 -> `e45366ae`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#pullrequestreview-3851115034 -> `d94a9872`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/895#discussion_r2850105656 -> `d94a9872`


## Merge Readiness
- [x] Scope is focused and non-breaking
- [x] Local quality gates passed (`pre-commit`, `make verify`)
- [x] Ledger carryover mapping updated for W2/W3
- [x] Ready for review/bot pass before merge

## Security Notes
- all writes remain local DB-only (no new external credential surface)
- controlled submissions never bypass moderated states
- status transitions are append-audited in `submission_audit`

## Marketing & GTM
- enables W3 positioning: verified restaurant menu coverage + controlled user contributions
- reduces manual entry friction via restaurant-specific search/menu flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Wave 3 foundation for restaurant menus and moderated submissions with new search/menu APIs, a local SQLite store, stricter validation, and tightened OpenAPI contracts reflected in frontend types.

- **New Features**
  - Endpoints: GET /api/v1/restaurants/search, GET /api/v1/restaurants/{chain_id}/menu; submissions POST/GET; moderation PATCH allows only approved/rejected and is API-key protected.
  - Local SQLite-backed store with a MenuStat import helper; non‑ASCII chain/item IDs use hashed slugs to prevent upsert collisions.
  - Router wiring: public restaurant routes added; moderation status PATCH moved to a protected router; limits validated with consistent 404/422; OpenAPI tightened with explicit enums/lengths/status codes and frontend types regenerated.

- **Bug Fixes**
  - Enforced SQLite foreign keys and added service-layer pagination guards (limit/offset) to block invalid access before hitting the DB.
  - Submission schema now validates off_url format (HTTP/HTTPS only).
  - Tests: isolate SQLite DB per pytest‑xdist worker to prevent cross-test collisions.

<sup>Written for commit d94a987248a67600fdc9d78adbbb524a0d75ce67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

- [x] Mapping baseline refreshed at 2026-02-24 22:58 UTC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public restaurant API: search, chain menu retrieval, submissions (create/get) and moderation (status review) with auditable status transitions and persisted store backing; routers exposed in app and frontend OpenAPI.

* **Documentation**
  * Roadmap updated to reflect restaurant feature progress, moderation requirements, and follow-up benchmarking.

* **Tests**
  * Added service and router tests covering ingestion, search, menus, submissions, moderation, validation, and audit trails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
