### PR TITLE
fix(tests): convert @patch to monkeypatch in test_food_store_coverage_boost.py

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1042,15 +1042,6 @@
         "line_number": 20
       }
     ],
-    "tests/test_food_store_coverage_boost.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_food_store_coverage_boost.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
     "tests/test_foods_router_coverage_boost.py": [
       {
         "type": "Secret Keyword",
@@ -1616,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-24T23:27:09Z"
+  "generated_at": "2026-02-25T07:31:40Z"
 }

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -155,9 +155,9 @@ Document supported zero-decimal currencies (currently: **JPY/KRW**) and define t
 
 Prefer modern typing syntax (Python 3.9+):
 
-* `tuple[int, str]`
-* `list[str]`
-* `dict[str, int]`
+- `tuple[int, str]`
+- `list[str]`
+- `dict[str, int]`
 
 ### Type hints for test fixtures
 

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -166,6 +166,71 @@ Prefer modern typing syntax (Python 3.9+):
 
 ---
 
+## 11) `@patch` decorator fails with `@contextmanager` under Python 3.12 + xdist (CRITICAL)
+
+### Problem
+
+`unittest.mock.patch` used as a **decorator** (`@patch("module._connect")`) does not
+correctly intercept `@contextmanager`-decorated functions when running under
+**Python 3.12 with pytest-xdist** (`-n 4 --dist=loadscope`).
+The mock is applied but the real function executes, causing tests to hit the
+real database and return unexpected results.
+
+### Symptoms
+
+- Tests pass locally (sequential, Python 3.13) but fail in CI (Python 3.12, xdist).
+- Assertions like `assert len(result) == 1` fail because the mock was bypassed
+  and the real DB returned all rows (e.g., 10 or 15 items).
+- Only tests using `@patch` on `@contextmanager` targets are affected; plain
+  function patches may still work.
+
+### Real incidents (PR #896, PR #897)
+
+- PR #896: 12 tests in `test_food_store_coverage.py` failed on Python 3.12 CI.
+- PR #897: 8 tests in `test_food_store_coverage_boost.py` — same root cause,
+  missed in PR #896 scope.
+
+### Fix
+
+Replace all `@patch(...)` decorators with `monkeypatch.setattr()`:
+
+```python
+# BEFORE (broken on 3.12 + xdist):
+@patch("app.services.food_store._connect")
+def test_search(self, mock_connect):
+    mock_con = MagicMock()
+    mock_connect.return_value = mock_con
+    ...
+
+# AFTER (works everywhere):
+def test_search(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_con = _MockConnection(fetchall_result=[...])
+    monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
+    ...
+```
+
+Also replace `os.environ` mutation in `setup_method()` with an autouse
+`monkeypatch.setenv()` fixture for proper test isolation.
+
+### Rule
+
+**Prefer `monkeypatch.setattr()` over `@patch` decorator for all new tests.**
+`monkeypatch` is pytest-native, version-safe, and properly scoped per test.
+
+### Prevention
+
+Before merging any PR that touches `food_store` tests (or any test using
+`@patch` on `@contextmanager` targets), run:
+
+```bash
+# Scan for remaining @patch on food_store targets
+git grep -n '@patch("app.services.food_store' -- tests/
+```
+
+If any matches remain, convert them to `monkeypatch.setattr()`.
+
+---
+
 ## Repo Commands Reference
 
 ```bash

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -188,7 +188,13 @@ real database and return unexpected results.
 
 - PR #896: 12 tests in `test_food_store_coverage.py` failed on Python 3.12 CI.
 - PR #897: 8 tests in `test_food_store_coverage_boost.py` — same root cause,
-  missed in PR #896 scope.
+  missed in the scope of PR #896.
+
+### Evidence (file:line)
+
+- `tests/test_food_store_coverage_boost.py:126-170` (monkeypatch migration for `_connect` targets)
+- `tests/test_food_store_coverage_boost.py:67-72` (autouse `monkeypatch.setenv` isolation)
+- `tests/AGENTS.md:21-25` (policy update for `@patch` vs `monkeypatch.setattr`)
 
 ### Fix
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,6 +18,11 @@
 - Never mock `builtins.__import__` or `builtins.float`.
 - Preserve xdist DB isolation: each worker gets its own SQLite path.
 - Prefer `monkeypatch` over global mutations; avoid real sleeps.
+- **Prefer `monkeypatch.setattr()` over `@patch` decorator** — `@patch` on `@contextmanager` targets
+  fails silently under Python 3.12 + xdist (see `docs/ENGINEERING_LESSONS.md` lesson 11).
+  Use autouse `monkeypatch.setenv()` fixtures instead of `os.environ` mutation in `setup_method()`.
+- **When fixing `@patch` tests, scan ALL sibling files** for the same pattern
+  (e.g., `_boost.py`, `_v2.py` variants). Fixing one file and missing its twin is a recurring incident.
 - Repo policy guards must not reference temporary/untracked files; AST scan path lists must filter by `.exists()`.
 - `ui_labels` is a required part of `WHOTargetsResponse` contract (SoT: `app/schemas/premium_contracts.py`); assert ES anchor string (`"Calorías diarias"`) in snapshot tests and do not feature-gate this contract after implementation.
 

--- a/tests/test_food_store_coverage_boost.py
+++ b/tests/test_food_store_coverage_boost.py
@@ -60,8 +60,8 @@ class _MockConnection:
         exc_type: Optional[type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
-    ) -> None:
-        return None
+    ) -> bool | None:
+        return False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_food_store_coverage_boost.py
+++ b/tests/test_food_store_coverage_boost.py
@@ -1,12 +1,14 @@
-import os
-
 # -*- coding: utf-8 -*-
 """
 RU: Тесты для повышения покрытия app/services/food_store.py
 EN: Coverage boost tests for app/services/food_store.py
+
+RU: Тесты используют monkeypatch вместо @patch для совместимости с Python 3.12+
+EN: Tests use monkeypatch instead of @patch for Python 3.12+ compatibility
 """
 
-from unittest.mock import MagicMock, patch
+from types import TracebackType
+from typing import Any, Callable, Dict, List, Optional
 
 import pytest
 
@@ -16,144 +18,180 @@ except ImportError as exc:
     pytest.skip(f"Import failed: {exc}", allow_module_level=True)
 
 
+class _MockCursor:
+    """Mock cursor for database operations."""
+
+    def __init__(
+        self,
+        fetchall_result: Optional[List[Dict[str, Any]]] = None,
+        fetchone_result: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._fetchall_result = fetchall_result or []
+        self._fetchone_result = fetchone_result
+
+    def fetchall(self) -> List[Dict[str, Any]]:
+        return self._fetchall_result
+
+    def fetchone(self) -> Optional[Dict[str, Any]]:
+        return self._fetchone_result
+
+
+class _MockConnection:
+    """Mock connection that tracks execute calls."""
+
+    def __init__(
+        self,
+        fetchall_result: Optional[List[Dict[str, Any]]] = None,
+        fetchone_result: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._fetchall_result = fetchall_result
+        self._fetchone_result = fetchone_result
+        self.execute_calls: List[tuple[str, Any]] = []
+
+    def execute(self, sql: str, params: Any = None) -> _MockCursor:
+        self.execute_calls.append((sql, params))
+        return _MockCursor(self._fetchall_result, self._fetchone_result)
+
+    def __enter__(self) -> "_MockConnection":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _set_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set test environment variables using monkeypatch for proper isolation."""
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
+
+
 class TestFoodStoreCoverage:
     """Test class for food_store coverage boost."""
 
-    def setup_method(self):
-        """Setup test environment"""
-        os.environ["API_KEY"] = "test_key"
-        os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
-
-    def test_expand_query_empty_string(self):
+    def test_expand_query_empty_string(self) -> None:
         """Test expand_query with empty string."""
         result = food_store.expand_query("")
         assert result == []
 
-    def test_expand_query_none(self):
+    def test_expand_query_none(self) -> None:
         """Test expand_query with None."""
-        result = food_store.expand_query(None)
+        # Intentional: testing None handling, not type conversion
+        result = food_store.expand_query(None)  # type: ignore[arg-type]
         assert result == []
 
-    def test_expand_query_whitespace(self):
+    def test_expand_query_whitespace(self) -> None:
         """Test expand_query with whitespace only."""
         result = food_store.expand_query("   ")
         assert result == []
 
-    def test_expand_query_basic_term(self):
+    def test_expand_query_basic_term(self) -> None:
         """Test expand_query with basic term."""
         result = food_store.expand_query("yogurt")
         assert "yogurt" in result
 
-    def test_expand_query_with_aliases(self):
+    def test_expand_query_with_aliases(self) -> None:
         """Test expand_query with aliases."""
         result = food_store.expand_query("йогурт")
         assert "йогурт" in result
         assert "yogurt" in result
         assert "yoghurt" in result
 
-    def test_expand_query_alias_variant(self):
+    def test_expand_query_alias_variant(self) -> None:
         """Test expand_query with alias variant."""
         result = food_store.expand_query("yoghurt")
         assert "yoghurt" in result
         assert "йогурт" in result
         assert "yogurt" in result
 
-    def test_expand_query_olive_oil(self):
+    def test_expand_query_olive_oil(self) -> None:
         """Test expand_query with olive oil."""
         result = food_store.expand_query("масло оливковое")
         assert "масло оливковое" in result
         assert "olive oil" in result
         assert "aceite de oliva" in result
 
-    def test_expand_query_cottage_cheese(self):
+    def test_expand_query_cottage_cheese(self) -> None:
         """Test expand_query with cottage cheese."""
         result = food_store.expand_query("творог")
         assert "творог" in result
         assert "cottage cheese" in result
         assert "queso cottage" in result
 
-    @patch("app.services.food_store._connect")
-    def test_search_foods_with_query(self, mock_connect):
+    def test_search_foods_with_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test search_foods with query."""
-        # Mock database connection and cursor
-        mock_con = MagicMock()
-        mock_con.__enter__.return_value = mock_con
-        mock_con.__exit__.return_value = None
-        mock_con.execute.return_value.fetchall.return_value = [
-            {
-                "id": "1",
-                "canonical_name": "apple",
-                "kcal": 52,
-                "protein_g": 0.3,
-                "fat_g": 0.2,
-                "carbs_g": 14.0,
-            }
-        ]
-        mock_connect.return_value = mock_con
+        mock_con = _MockConnection(
+            fetchall_result=[
+                {
+                    "id": "1",
+                    "canonical_name": "apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14.0,
+                }
+            ],
+        )
+        monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
 
         result = food_store.search_foods("apple", limit=10, offset=0)
 
         assert len(result) == 1
         assert result[0]["canonical_name"] == "apple"
-        mock_con.execute.assert_called_once()
+        assert len(mock_con.execute_calls) == 1
 
-    @patch("app.services.food_store._connect")
-    def test_search_foods_without_query(self, mock_connect):
+    def test_search_foods_without_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test search_foods without query."""
-        # Mock database connection and cursor
-        mock_con = MagicMock()
-        mock_con.__enter__.return_value = mock_con
-        mock_con.__exit__.return_value = None
-        mock_con.execute.return_value.fetchall.return_value = [
-            {
+        mock_con = _MockConnection(
+            fetchall_result=[
+                {
+                    "id": "1",
+                    "canonical_name": "apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14.0,
+                }
+            ],
+        )
+        monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
+
+        result = food_store.search_foods("", limit=10, offset=0)
+
+        assert len(result) == 1
+        assert result[0]["canonical_name"] == "apple"
+        assert len(mock_con.execute_calls) == 1
+
+    def test_search_foods_none_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test search_foods with None query."""
+        mock_con = _MockConnection(fetchall_result=[])
+        monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
+
+        # Intentional: testing None handling, not type conversion
+        result = food_store.search_foods(None, limit=10, offset=0)  # type: ignore[arg-type]
+
+        assert result == []
+        assert len(mock_con.execute_calls) == 1
+
+    def test_get_food_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test get_food when food is found."""
+        mock_con = _MockConnection(
+            fetchone_result={
                 "id": "1",
                 "canonical_name": "apple",
                 "kcal": 52,
                 "protein_g": 0.3,
                 "fat_g": 0.2,
                 "carbs_g": 14.0,
-            }
-        ]
-        mock_connect.return_value = mock_con
-
-        result = food_store.search_foods("", limit=10, offset=0)
-
-        assert len(result) == 1
-        assert result[0]["canonical_name"] == "apple"
-        mock_con.execute.assert_called_once()
-
-    @patch("app.services.food_store._connect")
-    def test_search_foods_none_query(self, mock_connect):
-        """Test search_foods with None query."""
-        # Mock database connection and cursor
-        mock_con = MagicMock()
-        mock_con.__enter__.return_value = mock_con
-        mock_con.__exit__.return_value = None
-        mock_con.execute.return_value.fetchall.return_value = []
-        mock_connect.return_value = mock_con
-
-        result = food_store.search_foods(None, limit=10, offset=0)
-
-        assert result == []
-        mock_con.execute.assert_called_once()
-
-    @patch("app.services.food_store._connect")
-    def test_get_food_found(self, mock_connect):
-        """Test get_food when food is found."""
-        # Mock database connection and cursor
-        mock_con = MagicMock()
-        mock_con.__enter__.return_value = mock_con
-        mock_con.__exit__.return_value = None
-        mock_con.execute.return_value.fetchone.return_value = {
-            "id": "1",
-            "canonical_name": "apple",
-            "kcal": 52,
-            "protein_g": 0.3,
-            "fat_g": 0.2,
-            "carbs_g": 14.0,
-            "per_g": 100.0,
-        }
-        mock_connect.return_value = mock_con
+                "per_g": 100.0,
+            },
+        )
+        monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
 
         result = food_store.get_food("1")
 
@@ -161,23 +199,19 @@ class TestFoodStoreCoverage:
         assert result["canonical_name"] == "apple"
         assert result["kcal"] == 52
 
-    @patch("app.services.food_store._connect")
-    def test_get_food_not_found(self, mock_connect):
+    def test_get_food_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test get_food when food is not found."""
-        # Mock database connection and cursor
-        mock_con = MagicMock()
-        mock_con.__enter__.return_value = mock_con
-        mock_con.__exit__.return_value = None
-        mock_con.execute.return_value.fetchone.return_value = None
-        mock_connect.return_value = mock_con
+        mock_con = _MockConnection(fetchone_result=None)
+        monkeypatch.setattr(food_store, "_connect", lambda: mock_con)
 
         result = food_store.get_food("999")
 
         assert result is None
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_empty_list(self, mock_get_food):
+    def test_nutrients_for_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with empty ingredients list."""
+        monkeypatch.setattr(food_store, "get_food", lambda food_id: None)
+
         result = food_store.nutrients_for([])
 
         expected_keys = [
@@ -198,10 +232,9 @@ class TestFoodStoreCoverage:
         for key in expected_keys:
             assert result[key] == 0.0
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_single_ingredient(self, mock_get_food):
+    def test_nutrients_for_single_ingredient(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with single ingredient."""
-        mock_get_food.return_value = {
+        mock_food: Dict[str, Any] = {
             "id": "1",
             "canonical_name": "apple",
             "kcal": 52,
@@ -218,6 +251,7 @@ class TestFoodStoreCoverage:
             "Iodine_ug": 0,
             "per_g": 100.0,
         }
+        monkeypatch.setattr(food_store, "get_food", lambda food_id: mock_food)
 
         ingredients = [{"food_id": "1", "grams": 200.0}]
         result = food_store.nutrients_for(ingredients)
@@ -228,11 +262,10 @@ class TestFoodStoreCoverage:
         assert result["fat_g"] == 0.4  # 0.2 * 2
         assert result["carbs_g"] == 28.0  # 14.0 * 2
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_multiple_ingredients(self, mock_get_food):
+    def test_nutrients_for_multiple_ingredients(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with multiple ingredients."""
 
-        def mock_get_food_side_effect(food_id):
+        def mock_get_food_side_effect(food_id: str) -> Optional[Dict[str, Any]]:
             if food_id == "1":
                 return {
                     "id": "1",
@@ -271,7 +304,7 @@ class TestFoodStoreCoverage:
                 }
             return None
 
-        mock_get_food.side_effect = mock_get_food_side_effect
+        monkeypatch.setattr(food_store, "get_food", mock_get_food_side_effect)
 
         ingredients = [
             {"food_id": "1", "grams": 100.0},  # 100g apple
@@ -285,10 +318,9 @@ class TestFoodStoreCoverage:
         assert result["protein_g"] == 0.3 + (1.1 * 1.5)  # 0.3 + 1.65 = 1.95
         assert result["fat_g"] == 0.2 + (0.3 * 1.5)  # 0.2 + 0.45 = 0.65
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_missing_food(self, mock_get_food):
+    def test_nutrients_for_missing_food(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with missing food."""
-        mock_get_food.return_value = None
+        monkeypatch.setattr(food_store, "get_food", lambda food_id: None)
 
         ingredients = [{"food_id": "999", "grams": 100.0}]
         result = food_store.nutrients_for(ingredients)
@@ -312,10 +344,9 @@ class TestFoodStoreCoverage:
         for key in expected_keys:
             assert result[key] == 0.0
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_custom_per_g(self, mock_get_food):
+    def test_nutrients_for_custom_per_g(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with custom per_g value."""
-        mock_get_food.return_value = {
+        mock_food: Dict[str, Any] = {
             "id": "1",
             "canonical_name": "apple",
             "kcal": 52,
@@ -332,6 +363,7 @@ class TestFoodStoreCoverage:
             "Iodine_ug": 0,
             "per_g": 50.0,  # Custom per_g value
         }
+        monkeypatch.setattr(food_store, "get_food", lambda food_id: mock_food)
 
         ingredients = [{"food_id": "1", "grams": 100.0}]
         result = food_store.nutrients_for(ingredients)
@@ -340,10 +372,9 @@ class TestFoodStoreCoverage:
         assert result["kcal"] == 104.0  # 52 * 2
         assert result["protein_g"] == 0.6  # 0.3 * 2
 
-    @patch("app.services.food_store.get_food")
-    def test_nutrients_for_missing_nutrient_values(self, mock_get_food):
+    def test_nutrients_for_missing_nutrient_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test nutrients_for with missing nutrient values."""
-        mock_get_food.return_value = {
+        mock_food: Dict[str, Any] = {
             "id": "1",
             "canonical_name": "apple",
             "kcal": 52,
@@ -353,6 +384,7 @@ class TestFoodStoreCoverage:
             # Missing some nutrient values
             "per_g": 100.0,
         }
+        monkeypatch.setattr(food_store, "get_food", lambda food_id: mock_food)
 
         ingredients = [{"food_id": "1", "grams": 100.0}]
         result = food_store.nutrients_for(ingredients)


### PR DESCRIPTION
## Summary

- Convert all 11 `@patch` decorators to `monkeypatch.setattr()` in `test_food_store_coverage_boost.py`
- Same root cause as PR #896: `@patch` on `@contextmanager` targets fails silently on Python 3.12 + xdist
- 8 tests failing in CI `test-main (3.12)` run [22386124335](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/22386124335/job/64797063249)

## Root cause

`unittest.mock.patch` as decorator does not intercept `@contextmanager`-decorated functions under Python 3.12 with pytest-xdist (`-n 4 --dist=loadscope`). The mock is applied but the real function executes, causing tests to hit the real database.

PR #896 fixed `test_food_store_coverage.py` but missed the `_boost` sibling file.

## Changes

| File | What |
|------|------|
| `tests/test_food_store_coverage_boost.py` | Replace 11 `@patch` → `monkeypatch.setattr()`; add `_MockCursor`/`_MockConnection` helpers; autouse `monkeypatch.setenv()` fixture; type hints |
| `docs/ENGINEERING_LESSONS.md` | Add lesson 11: `@patch` + `@contextmanager` + Python 3.12 incompatibility; fix markdownlint MD004; add file:line evidence |
| `tests/AGENTS.md` | Add monkeypatch-first rule + sibling-file scan rule |
| `.secrets.baseline` | Auto-updated by detect-secrets hook |

## Verification

- `pytest -q tests/test_food_store_coverage_boost.py` — 19/19 passed
- `pytest -q tests/test_food_store_coverage.py tests/test_food_store_coverage_boost.py` — 39/39 passed
- `pytest -q tests/test_repo_policy_guards.py` — 12/12 passed
- `make test-fast` — passed
- `make lint` — passed
- `mypy --no-incremental app core` — 215 files, no issues
- `pre-commit run --all-files` — passed

## Deferred / Follow-ups

- No deferred items; this PR completes the `@patch` → `monkeypatch` migration for all food_store test files
- Scan: `git grep -n '@patch("app.services.food_store' -- tests/` returns 0 matches after this PR

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/897#discussion_r2851357683 -> 40c5b3d9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/897#discussion_r2851392146 -> 40c5b3d9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/897#pullrequestreview-3852422225 -> 40c5b3d9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/897#pullrequestreview-3852456180 -> 40c5b3d9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/897#pullrequestreview-3852500228 -> cc4b0107

## Merge Readiness
- [x] CI green on latest run (test-pr 3.13.6 + coverage-pr + all gates)
- [x] Bot reviews resolved (CodeRabbit actionable, Sourcery suggestion, Cubic clean)
- [x] No unresolved threads