### PR TITLE
feat(food-db): add W2-C latency benchmark report

### DIFF
--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -235,6 +235,34 @@ git grep -n '@patch("app.services.food_store' -- tests/
 
 If any matches remain, convert them to `monkeypatch.setattr()`.
 
+## 12) API schema types must match persisted row types (barcode hit contract)
+
+### Problem
+Endpoint handlers that construct `FoodItem(**row)` can fail at runtime if DB columns store
+string-encoded payloads for fields typed as structured types (example: `flags` expected as `List[str]`).
+
+### Real incident (W2-C benchmark, 2026-02-25)
+During latency benchmark for `/api/v1/foods/barcode/{barcode}`, hit-path requests raised
+Pydantic validation errors because `app/schemas/food.py` defines:
+
+- `flags: List[str]` (`app/schemas/food.py:40`)
+
+but seeded DB rows may contain string values (e.g. `"[]"`), and router returns:
+
+- `return FoodItem(**row)` (`app/routers/foods.py:105`)
+
+### Rule
+Before exposing DB rows directly through strict Pydantic models:
+
+1. Normalize row payload types in repository/service layer
+2. Add deterministic tests for hit/miss/malformed paths
+3. Treat benchmark "scenario disabled" as tracked debt in `BACKLOG_LEDGER.md`
+
+### Use instead
+- Parse/normalize structured columns (`flags`) before model construction
+- Keep migration/seed contracts aligned with API schema types
+- Verify with endpoint-level tests, not only unit repository tests
+
 ---
 
 ## Repo Commands Reference

--- a/docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
+++ b/docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
@@ -1,4 +1,4 @@
-# PR-TBD — Food DB Wave 2-C Latency Benchmark Report
+# PR-898 — Food DB Wave 2-C Latency Benchmark Report
 
 ## Scope
 
@@ -23,7 +23,7 @@
 
 ## Method
 
-Run command (UTC run timestamp: `2026-02-25 07:17:06 UTC`):
+Run command (UTC run timestamp: `2026-02-25 07:53:58 UTC`):
 
 ```bash
 SERVER_SALT=bench-salt \
@@ -33,23 +33,24 @@ PYTHONPATH=. \
 python scripts/benchmarks/food_api_latency_benchmark.py \
   --iterations 120 \
   --warmup 20 \
+  --db-path data/food.sqlite \
   --output-json docs/audit/artifacts/food_w2c_latency_benchmark.json
 ```
 
 Artifact checksum:
 
 - `sha256 docs/audit/artifacts/food_w2c_latency_benchmark.json`
-- `e2f3487f6617ca38d82c192a560781fb7cd65fa0500d033db579313be56d15d7`
+- `90331d10b53daf2ac8096f374f5851883fee4c904d7f384440f0b5af5ebe53f0`
 
 ## Results
 
 | Scenario | Endpoint | Expected status | p50 (ms) | p95 (ms) | p99 (ms) |
 |---|---|---:|---:|---:|---:|
-| foods_list_hit | `/api/v1/foods?query=chickenbreast&limit=20&offset=0` | 200 | 0.9003 | 1.0863 | 1.1860 |
-| foods_search_alias_hit | `/api/v1/foods/search?query=chickenbreast&limit=20&offset=0` | 200 | 0.9071 | 1.1134 | 1.4968 |
-| foods_list_no_results | `/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0` | 200 | 0.8841 | 0.9657 | 1.1416 |
-| barcode_miss | `/api/v1/foods/barcode/9999999999999` | 404 | 0.7903 | 1.0003 | 1.0481 |
-| barcode_malformed | `/api/v1/foods/barcode/abc` | 422 | 0.6924 | 0.8920 | 0.9466 |
+| foods_list_hit | `/api/v1/foods?query=chicken&limit=20&offset=0` | 200 | 0.8991 | 1.0875 | 1.1198 |
+| foods_search_alias_hit | `/api/v1/foods/search?query=chicken&limit=20&offset=0` | 200 | 0.8900 | 1.0288 | 1.1326 |
+| foods_list_no_results | `/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0` | 200 | 0.8796 | 1.0901 | 1.3637 |
+| barcode_miss | `/api/v1/foods/barcode/9999999999999` | 404 | 0.7822 | 0.9978 | 1.0959 |
+| barcode_malformed | `/api/v1/foods/barcode/abc` | 422 | 0.6859 | 0.8576 | 0.9255 |
 
 ## Conclusion
 

--- a/docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
+++ b/docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
@@ -23,7 +23,7 @@
 
 ## Method
 
-Run command (UTC run timestamp: `2026-02-25 07:53:58 UTC`):
+Run command (UTC run timestamp: `2026-02-25 10:23:27 UTC`):
 
 ```bash
 SERVER_SALT=bench-salt \
@@ -40,17 +40,17 @@ python scripts/benchmarks/food_api_latency_benchmark.py \
 Artifact checksum:
 
 - `sha256 docs/audit/artifacts/food_w2c_latency_benchmark.json`
-- `90331d10b53daf2ac8096f374f5851883fee4c904d7f384440f0b5af5ebe53f0`
+- `a30153edae00c2648e5a4e03d7ec655e2703bf33ad893ff735c23ed7d2820cba`
 
 ## Results
 
 | Scenario | Endpoint | Expected status | p50 (ms) | p95 (ms) | p99 (ms) |
 |---|---|---:|---:|---:|---:|
-| foods_list_hit | `/api/v1/foods?query=chicken&limit=20&offset=0` | 200 | 0.8991 | 1.0875 | 1.1198 |
-| foods_search_alias_hit | `/api/v1/foods/search?query=chicken&limit=20&offset=0` | 200 | 0.8900 | 1.0288 | 1.1326 |
-| foods_list_no_results | `/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0` | 200 | 0.8796 | 1.0901 | 1.3637 |
-| barcode_miss | `/api/v1/foods/barcode/9999999999999` | 404 | 0.7822 | 0.9978 | 1.0959 |
-| barcode_malformed | `/api/v1/foods/barcode/abc` | 422 | 0.6859 | 0.8576 | 0.9255 |
+| foods_list_hit | `/api/v1/foods?query=chicken&limit=20&offset=0` | 200 | 0.8724 | 0.9525 | 1.0481 |
+| foods_search_alias_hit | `/api/v1/foods/search?query=chicken&limit=20&offset=0` | 200 | 0.8802 | 0.9665 | 1.0846 |
+| foods_list_no_results | `/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0` | 200 | 0.8720 | 0.9013 | 1.0540 |
+| barcode_miss | `/api/v1/foods/barcode/9999999999999` | 404 | 0.7772 | 0.9819 | 0.9938 |
+| barcode_malformed | `/api/v1/foods/barcode/abc` | 422 | 0.6848 | 0.8616 | 0.9002 |
 
 ## Conclusion
 

--- a/docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
+++ b/docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md
@@ -1,0 +1,64 @@
+# PR-TBD — Food DB Wave 2-C Latency Benchmark Report
+
+## Scope
+
+- Program wave: W2-C (search modernization follow-up benchmark/report).
+- Goal: measure local-first latency for the existing food API surface and barcode error paths.
+- Runtime behavior changes: none (benchmark/report only).
+
+## Evidence Anchors
+
+- Router contract:
+  - `app/routers/foods.py:43` (`GET /api/v1/foods`)
+  - `app/routers/foods.py:67` (`GET /api/v1/foods/search` alias)
+  - `app/routers/foods.py:88` (`GET /api/v1/foods/barcode/{barcode}`)
+- Search/barcode service paths:
+  - `app/services/food_store.py:478` (`search_foods`)
+  - `app/services/food_store.py:518` (`_normalize_barcode`)
+  - `app/services/food_store.py:533` (`get_food_by_barcode`)
+- Benchmark harness:
+  - `scripts/benchmarks/food_api_latency_benchmark.py`
+- Raw artifact:
+  - `docs/audit/artifacts/food_w2c_latency_benchmark.json`
+
+## Method
+
+Run command (UTC run timestamp: `2026-02-25 07:17:06 UTC`):
+
+```bash
+SERVER_SALT=bench-salt \
+TESTING=true \
+RATE_LIMITING_IN_TESTS=false \
+PYTHONPATH=. \
+python scripts/benchmarks/food_api_latency_benchmark.py \
+  --iterations 120 \
+  --warmup 20 \
+  --output-json docs/audit/artifacts/food_w2c_latency_benchmark.json
+```
+
+Artifact checksum:
+
+- `sha256 docs/audit/artifacts/food_w2c_latency_benchmark.json`
+- `e2f3487f6617ca38d82c192a560781fb7cd65fa0500d033db579313be56d15d7`
+
+## Results
+
+| Scenario | Endpoint | Expected status | p50 (ms) | p95 (ms) | p99 (ms) |
+|---|---|---:|---:|---:|---:|
+| foods_list_hit | `/api/v1/foods?query=chickenbreast&limit=20&offset=0` | 200 | 0.9003 | 1.0863 | 1.1860 |
+| foods_search_alias_hit | `/api/v1/foods/search?query=chickenbreast&limit=20&offset=0` | 200 | 0.9071 | 1.1134 | 1.4968 |
+| foods_list_no_results | `/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0` | 200 | 0.8841 | 0.9657 | 1.1416 |
+| barcode_miss | `/api/v1/foods/barcode/9999999999999` | 404 | 0.7903 | 1.0003 | 1.0481 |
+| barcode_malformed | `/api/v1/foods/barcode/abc` | 422 | 0.6924 | 0.8920 | 0.9466 |
+
+## Conclusion
+
+- W2 latency budget objective (`<50ms p50`) is satisfied for measured local-first paths by a wide margin.
+- Alias route (`/api/v1/foods/search`) shows parity with `/api/v1/foods` under the same query/load settings.
+- Barcode validation/miss paths are fast and deterministic for current contract behavior (422/404).
+
+## Open Issue (Tracked)
+
+- Optional `barcode_hit` scenario remains disabled by default in the benchmark harness.
+- Reason: on seeded local DB rows, response serialization can fail at `app/routers/foods.py:105` because `FoodItem.flags` expects `List[str]` (`app/schemas/food.py:40`) while stored value may be stringified.
+- Follow-up is tracked in backlog for contract normalization before enabling `--include-barcode-hit` as default gate.

--- a/docs/audit/artifacts/food_w2c_latency_benchmark.json
+++ b/docs/audit/artifacts/food_w2c_latency_benchmark.json
@@ -1,46 +1,47 @@
 {
   "iterations": 120,
   "warmup": 20,
+  "db_path": "data/food.sqlite",
   "results": [
     {
       "name": "foods_list_hit",
-      "endpoint": "/api/v1/foods?query=chickenbreast&limit=20&offset=0",
+      "endpoint": "/api/v1/foods?query=chicken&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.9003,
-      "p95_ms": 1.0863,
-      "p99_ms": 1.186
+      "p50_ms": 0.8991,
+      "p95_ms": 1.0875,
+      "p99_ms": 1.1198
     },
     {
       "name": "foods_search_alias_hit",
-      "endpoint": "/api/v1/foods/search?query=chickenbreast&limit=20&offset=0",
+      "endpoint": "/api/v1/foods/search?query=chicken&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.9071,
-      "p95_ms": 1.1134,
-      "p99_ms": 1.4968
+      "p50_ms": 0.89,
+      "p95_ms": 1.0288,
+      "p99_ms": 1.1326
     },
     {
       "name": "foods_list_no_results",
       "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.8841,
-      "p95_ms": 0.9657,
-      "p99_ms": 1.1416
+      "p50_ms": 0.8796,
+      "p95_ms": 1.0901,
+      "p99_ms": 1.3637
     },
     {
       "name": "barcode_miss",
       "endpoint": "/api/v1/foods/barcode/9999999999999",
       "expected_status": 404,
-      "p50_ms": 0.7903,
-      "p95_ms": 1.0003,
-      "p99_ms": 1.0481
+      "p50_ms": 0.7822,
+      "p95_ms": 0.9978,
+      "p99_ms": 1.0959
     },
     {
       "name": "barcode_malformed",
       "endpoint": "/api/v1/foods/barcode/abc",
       "expected_status": 422,
-      "p50_ms": 0.6924,
-      "p95_ms": 0.892,
-      "p99_ms": 0.9466
+      "p50_ms": 0.6859,
+      "p95_ms": 0.8576,
+      "p99_ms": 0.9255
     }
   ]
 }

--- a/docs/audit/artifacts/food_w2c_latency_benchmark.json
+++ b/docs/audit/artifacts/food_w2c_latency_benchmark.json
@@ -7,41 +7,41 @@
       "name": "foods_list_hit",
       "endpoint": "/api/v1/foods?query=chicken&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.8991,
-      "p95_ms": 1.0875,
-      "p99_ms": 1.1198
+      "p50_ms": 0.8724,
+      "p95_ms": 0.9525,
+      "p99_ms": 1.0481
     },
     {
       "name": "foods_search_alias_hit",
       "endpoint": "/api/v1/foods/search?query=chicken&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.89,
-      "p95_ms": 1.0288,
-      "p99_ms": 1.1326
+      "p50_ms": 0.8802,
+      "p95_ms": 0.9665,
+      "p99_ms": 1.0846
     },
     {
       "name": "foods_list_no_results",
       "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
       "expected_status": 200,
-      "p50_ms": 0.8796,
-      "p95_ms": 1.0901,
-      "p99_ms": 1.3637
+      "p50_ms": 0.872,
+      "p95_ms": 0.9013,
+      "p99_ms": 1.054
     },
     {
       "name": "barcode_miss",
       "endpoint": "/api/v1/foods/barcode/9999999999999",
       "expected_status": 404,
-      "p50_ms": 0.7822,
-      "p95_ms": 0.9978,
-      "p99_ms": 1.0959
+      "p50_ms": 0.7772,
+      "p95_ms": 0.9819,
+      "p99_ms": 0.9938
     },
     {
       "name": "barcode_malformed",
       "endpoint": "/api/v1/foods/barcode/abc",
       "expected_status": 422,
-      "p50_ms": 0.6859,
-      "p95_ms": 0.8576,
-      "p99_ms": 0.9255
+      "p50_ms": 0.6848,
+      "p95_ms": 0.8616,
+      "p99_ms": 0.9002
     }
   ]
 }

--- a/docs/audit/artifacts/food_w2c_latency_benchmark.json
+++ b/docs/audit/artifacts/food_w2c_latency_benchmark.json
@@ -1,0 +1,46 @@
+{
+  "iterations": 120,
+  "warmup": 20,
+  "results": [
+    {
+      "name": "foods_list_hit",
+      "endpoint": "/api/v1/foods?query=chickenbreast&limit=20&offset=0",
+      "expected_status": 200,
+      "p50_ms": 0.9003,
+      "p95_ms": 1.0863,
+      "p99_ms": 1.186
+    },
+    {
+      "name": "foods_search_alias_hit",
+      "endpoint": "/api/v1/foods/search?query=chickenbreast&limit=20&offset=0",
+      "expected_status": 200,
+      "p50_ms": 0.9071,
+      "p95_ms": 1.1134,
+      "p99_ms": 1.4968
+    },
+    {
+      "name": "foods_list_no_results",
+      "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
+      "expected_status": 200,
+      "p50_ms": 0.8841,
+      "p95_ms": 0.9657,
+      "p99_ms": 1.1416
+    },
+    {
+      "name": "barcode_miss",
+      "endpoint": "/api/v1/foods/barcode/9999999999999",
+      "expected_status": 404,
+      "p50_ms": 0.7903,
+      "p95_ms": 1.0003,
+      "p99_ms": 1.0481
+    },
+    {
+      "name": "barcode_malformed",
+      "endpoint": "/api/v1/foods/barcode/abc",
+      "expected_status": 422,
+      "p50_ms": 0.6924,
+      "p95_ms": 0.892,
+      "p99_ms": 0.9466
+    }
+  ]
+}

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -66,14 +66,14 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #891, PR #893, PR-TBD-FOOD-DB-W2-C
+  - Target PR: PR #891, PR #893, PR #898
   - Status: In Progress (W2-A and W2-B merged; W2-C latency benchmark/report prepared and pending merge)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
   - Links:
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
-    - `docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
+    - `docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
     - `scripts/benchmarks/food_api_latency_benchmark.py`
     - `app/routers/foods.py`
     - `app/services/food_store.py`
@@ -117,7 +117,7 @@ If it is not recorded here — it does not exist.
   - Links:
     - `app/routers/foods.py`
     - `app/schemas/food.py`
-    - `docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
+    - `docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
   - DoD:
     - Barcode hit path returns `200` with valid `FoodItem` serialization on canonical seeded DB
     - `flags` storage/parse contract is normalized and backward-compatible

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -66,13 +66,15 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #891, PR #893 (+ follow-up latency benchmark PR-TBD-FOOD-DB-W2-C)
-  - Status: In Progress (W2-A and W2-B merged; latency benchmark/report pending)
+  - Target PR: PR #891, PR #893, PR-TBD-FOOD-DB-W2-C
+  - Status: In Progress (W2-A and W2-B merged; W2-C latency benchmark/report prepared and pending merge)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
   - Links:
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
+    - `docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
+    - `scripts/benchmarks/food_api_latency_benchmark.py`
     - `app/routers/foods.py`
     - `app/services/food_store.py`
     - `tests/test_food_store_service.py`
@@ -86,8 +88,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3 — Restaurant menus + controlled user submissions
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W3-A
-  - Status: In Progress (W3-A foundation: restaurant schema/endpoints + moderated submissions)
+  - Target PR: PR #895 (+ follow-up PR-TBD-FOOD-DB-W3-B)
+  - Status: In Progress (W3-A foundation merged in PR #895; MenuStat ingestion/provenance closure pending)
   - Area: backend / data model / partner enablement
   - Finding Type: product coverage expansion
   - Reason: Product/restaurant database coverage and controlled data intake are required to reduce manual entry and support partner menu flows.
@@ -103,6 +105,23 @@ If it is not recorded here — it does not exist.
     - Restaurant menu schema and endpoints are documented
     - Moderated user submission workflow is implemented (`pending/approved/rejected`)
     - Source audit trail persists provenance for imported and moderated records
+
+- [ ] P1: Food barcode hit contract normalization for canonical FoodItem response
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOOD-DB-W2-HIT-CONTRACT
+  - Status: Planned
+  - Area: backend / API contract / data normalization
+  - Finding Type: correctness and reliability gap
+  - Reason: `GET /api/v1/foods/barcode/{barcode}` can fail on hit-path serialization when persisted `flags` payload is string-encoded instead of list, causing non-deterministic hit-path behavior in benchmark and runtime.
+  - Links:
+    - `app/routers/foods.py`
+    - `app/schemas/food.py`
+    - `docs/audit/PR_TBD_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`
+  - DoD:
+    - Barcode hit path returns `200` with valid `FoodItem` serialization on canonical seeded DB
+    - `flags` storage/parse contract is normalized and backward-compatible
+    - Deterministic tests cover hit/miss/malformed barcode paths
 
 - [ ] P2: Execution Wave 4 — Semantic retrieval (pgvector + multilingual embeddings)
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/benchmarks/food_api_latency_benchmark.py
+++ b/scripts/benchmarks/food_api_latency_benchmark.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Latency benchmark for Wave 2-C food endpoints.
+
+RU: Бенчмарк latency для food endpoint'ов Wave 2-C.
+EN: Latency benchmark for Wave 2-C food endpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+import tempfile
+import time
+from typing import Any
+
+DEFAULT_BENCH_BARCODE = "0123456789012"
+DEFAULT_MISS_BARCODE = "9999999999999"
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    endpoint: str
+    expected_status: int
+    samples_ms: list[float]
+
+    @property
+    def p50(self) -> float:
+        return _percentile(self.samples_ms, 50)
+
+    @property
+    def p95(self) -> float:
+        return _percentile(self.samples_ms, 95)
+
+    @property
+    def p99(self) -> float:
+        return _percentile(self.samples_ms, 99)
+
+
+def _percentile(values: list[float], percentile: int) -> float:
+    """Return percentile value for already measured latencies."""
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    sorted_values = sorted(values)
+    index = (len(sorted_values) - 1) * (percentile / 100)
+    lower = int(index)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = index - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def _create_temp_food_db(src_db: Path, injected_barcode: str) -> tuple[Path, str]:
+    """Create temporary benchmark DB and inject one deterministic barcode hit row."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="food-bench-"))
+    tmp_db = tmp_dir / "food.sqlite"
+    shutil.copy2(src_db, tmp_db)
+
+    with sqlite3.connect(tmp_db) as con:
+        row = con.execute("SELECT id, canonical_name FROM foods ORDER BY id ASC LIMIT 1").fetchone()
+        if row is None:
+            raise RuntimeError("foods table is empty; cannot run benchmark")
+        row_id = row[0]
+        canonical_name = str(row[1] or "")
+        con.execute("UPDATE foods SET gtin = ? WHERE id = ?", (injected_barcode, row_id))
+        con.commit()
+
+    token = canonical_name.split()[0] if canonical_name.strip() else ""
+    query_term = re.sub(r"[^A-Za-z0-9]+", "", token).lower() or "apple"
+    return tmp_db, query_term
+
+
+def _run_scenario(
+    *,
+    client: Any,
+    name: str,
+    endpoint: str,
+    expected_status: int,
+    warmup: int,
+    iterations: int,
+) -> ScenarioResult:
+    """Run warmup + measured requests for one endpoint scenario."""
+    for _ in range(warmup):
+        response = client.get(endpoint)
+        if response.status_code != expected_status:
+            raise RuntimeError(
+                f"warmup status mismatch for {name}: expected={expected_status} got={response.status_code}"
+            )
+
+    samples_ms: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        response = client.get(endpoint)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        if response.status_code != expected_status:
+            raise RuntimeError(
+                f"status mismatch for {name}: expected={expected_status} got={response.status_code}"
+            )
+        samples_ms.append(elapsed_ms)
+
+    return ScenarioResult(
+        name=name,
+        endpoint=endpoint,
+        expected_status=expected_status,
+        samples_ms=samples_ms,
+    )
+
+
+def _format_results(results: list[ScenarioResult]) -> str:
+    lines = [
+        "Scenario | Endpoint | Status | p50 (ms) | p95 (ms) | p99 (ms)",
+        "--- | --- | ---: | ---: | ---: | ---:",
+    ]
+    for result in results:
+        lines.append(
+            f"{result.name} | `{result.endpoint}` | {result.expected_status} | "
+            f"{result.p50:.2f} | {result.p95:.2f} | {result.p99:.2f}"
+        )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Wave 2-C latency benchmark for food APIs")
+    parser.add_argument("--iterations", type=int, default=150)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--bench-barcode", default=DEFAULT_BENCH_BARCODE)
+    parser.add_argument("--miss-barcode", default=DEFAULT_MISS_BARCODE)
+    parser.add_argument("--include-barcode-hit", action="store_true")
+    parser.add_argument("--output-json", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.iterations < 1:
+        raise ValueError("iterations must be >= 1")
+    if args.warmup < 0:
+        raise ValueError("warmup must be >= 0")
+
+    src_db = Path("data/food.sqlite")
+    if not src_db.exists():
+        raise FileNotFoundError(f"food db not found: {src_db}")
+
+    tmp_db, query_term = _create_temp_food_db(src_db=src_db, injected_barcode=args.bench_barcode)
+    os.environ["FOOD_DB_PATH"] = str(tmp_db)
+
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    scenarios = [
+        {
+            "name": "foods_list_hit",
+            "endpoint": f"/api/v1/foods?query={query_term}&limit=20&offset=0",
+            "expected_status": 200,
+        },
+        {
+            "name": "foods_search_alias_hit",
+            "endpoint": f"/api/v1/foods/search?query={query_term}&limit=20&offset=0",
+            "expected_status": 200,
+        },
+        {
+            "name": "foods_list_no_results",
+            "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
+            "expected_status": 200,
+        },
+        {
+            "name": "barcode_miss",
+            "endpoint": f"/api/v1/foods/barcode/{args.miss_barcode}",
+            "expected_status": 404,
+        },
+        {
+            "name": "barcode_malformed",
+            "endpoint": "/api/v1/foods/barcode/abc",
+            "expected_status": 422,
+        },
+    ]
+    if args.include_barcode_hit:
+        scenarios.insert(
+            3,
+            {
+                "name": "barcode_hit",
+                "endpoint": f"/api/v1/foods/barcode/{args.bench_barcode}",
+                "expected_status": 200,
+            },
+        )
+
+    results: list[ScenarioResult] = []
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        for scenario in scenarios:
+            results.append(
+                _run_scenario(
+                    client=client,
+                    name=scenario["name"],
+                    endpoint=scenario["endpoint"],
+                    expected_status=scenario["expected_status"],
+                    warmup=args.warmup,
+                    iterations=args.iterations,
+                )
+            )
+
+    print(_format_results(results))
+
+    if args.output_json is not None:
+        payload = {
+            "iterations": args.iterations,
+            "warmup": args.warmup,
+            "results": [
+                {
+                    "name": item.name,
+                    "endpoint": item.endpoint,
+                    "expected_status": item.expected_status,
+                    "p50_ms": round(item.p50, 4),
+                    "p95_ms": round(item.p95, 4),
+                    "p99_ms": round(item.p99, 4),
+                }
+                for item in results
+            ],
+        }
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/food_api_latency_benchmark.py
+++ b/scripts/benchmarks/food_api_latency_benchmark.py
@@ -14,14 +14,14 @@ import logging
 import os
 from pathlib import Path
 import re
-import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Any
+from typing import Any, Callable
 
 DEFAULT_BENCH_BARCODE = "0123456789012"
 DEFAULT_MISS_BARCODE = "9999999999999"
+ResponseValidator = Callable[[Any], None]
 
 
 @dataclass
@@ -58,11 +58,10 @@ def _percentile(values: list[float], percentile: int) -> float:
     return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
 
 
-def _create_temp_food_db(src_db: Path, injected_barcode: str) -> tuple[Path, str]:
+def _create_temp_food_db(src_db: Path, injected_barcode: str, tmp_dir: Path) -> tuple[Path, str]:
     """Create temporary benchmark DB and inject one deterministic barcode hit row."""
-    tmp_dir = Path(tempfile.mkdtemp(prefix="food-bench-"))
     tmp_db = tmp_dir / "food.sqlite"
-    shutil.copy2(src_db, tmp_db)
+    tmp_db.write_bytes(src_db.read_bytes())
 
     with sqlite3.connect(tmp_db) as con:
         row = con.execute("SELECT id, canonical_name FROM foods ORDER BY id ASC LIMIT 1").fetchone()
@@ -73,9 +72,42 @@ def _create_temp_food_db(src_db: Path, injected_barcode: str) -> tuple[Path, str
         con.execute("UPDATE foods SET gtin = ? WHERE id = ?", (injected_barcode, row_id))
         con.commit()
 
-    token = canonical_name.split()[0] if canonical_name.strip() else ""
-    query_term = re.sub(r"[^A-Za-z0-9]+", "", token).lower() or "apple"
+    token_match = re.search(r"[A-Za-z]{3,}", canonical_name or "")
+    query_term = token_match.group(0).lower() if token_match else "apple"
     return tmp_db, query_term
+
+
+def _expect_non_empty_list(response: Any) -> None:
+    payload = response.json()
+    if not isinstance(payload, list) or len(payload) == 0:
+        raise ValueError("expected non-empty list payload")
+
+
+def _expect_empty_list(response: Any) -> None:
+    payload = response.json()
+    if not isinstance(payload, list) or len(payload) != 0:
+        raise ValueError("expected empty list payload")
+
+
+def _expect_detail_contains(expected_fragment: str) -> ResponseValidator:
+    def _validator(response: Any) -> None:
+        payload = response.json()
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        if not isinstance(detail, str) or expected_fragment not in detail:
+            raise ValueError(f"expected error detail containing '{expected_fragment}'")
+
+    return _validator
+
+
+def _validate_response(
+    *, name: str, phase: str, response: Any, validator: ResponseValidator | None
+) -> None:
+    if validator is None:
+        return
+    try:
+        validator(response)
+    except Exception as exc:  # pragma: no cover - defensive error wrapping
+        raise RuntimeError(f"{phase} validation failed for {name}: {exc}") from exc
 
 
 def _run_scenario(
@@ -84,6 +116,7 @@ def _run_scenario(
     name: str,
     endpoint: str,
     expected_status: int,
+    validator: ResponseValidator | None,
     warmup: int,
     iterations: int,
 ) -> ScenarioResult:
@@ -94,6 +127,7 @@ def _run_scenario(
             raise RuntimeError(
                 f"warmup status mismatch for {name}: expected={expected_status} got={response.status_code}"
             )
+        _validate_response(name=name, phase="warmup", response=response, validator=validator)
 
     samples_ms: list[float] = []
     for _ in range(iterations):
@@ -104,6 +138,7 @@ def _run_scenario(
             raise RuntimeError(
                 f"status mismatch for {name}: expected={expected_status} got={response.status_code}"
             )
+        _validate_response(name=name, phase="measure", response=response, validator=validator)
         samples_ms.append(elapsed_ms)
 
     return ScenarioResult(
@@ -131,6 +166,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Wave 2-C latency benchmark for food APIs")
     parser.add_argument("--iterations", type=int, default=150)
     parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--db-path", type=Path, default=Path("data/food.sqlite"))
     parser.add_argument("--bench-barcode", default=DEFAULT_BENCH_BARCODE)
     parser.add_argument("--miss-barcode", default=DEFAULT_MISS_BARCODE)
     parser.add_argument("--include-barcode-hit", action="store_true")
@@ -145,67 +181,87 @@ def main() -> int:
     if args.warmup < 0:
         raise ValueError("warmup must be >= 0")
 
-    src_db = Path("data/food.sqlite")
+    src_db = args.db_path
     if not src_db.exists():
         raise FileNotFoundError(f"food db not found: {src_db}")
 
-    tmp_db, query_term = _create_temp_food_db(src_db=src_db, injected_barcode=args.bench_barcode)
-    os.environ["FOOD_DB_PATH"] = str(tmp_db)
-
-    from fastapi.testclient import TestClient
-    from app.main import app
-
-    scenarios = [
-        {
-            "name": "foods_list_hit",
-            "endpoint": f"/api/v1/foods?query={query_term}&limit=20&offset=0",
-            "expected_status": 200,
-        },
-        {
-            "name": "foods_search_alias_hit",
-            "endpoint": f"/api/v1/foods/search?query={query_term}&limit=20&offset=0",
-            "expected_status": 200,
-        },
-        {
-            "name": "foods_list_no_results",
-            "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
-            "expected_status": 200,
-        },
-        {
-            "name": "barcode_miss",
-            "endpoint": f"/api/v1/foods/barcode/{args.miss_barcode}",
-            "expected_status": 404,
-        },
-        {
-            "name": "barcode_malformed",
-            "endpoint": "/api/v1/foods/barcode/abc",
-            "expected_status": 422,
-        },
-    ]
-    if args.include_barcode_hit:
-        scenarios.insert(
-            3,
-            {
-                "name": "barcode_hit",
-                "endpoint": f"/api/v1/foods/barcode/{args.bench_barcode}",
-                "expected_status": 200,
-            },
-        )
-
+    original_food_db_path = os.environ.get("FOOD_DB_PATH")
     results: list[ScenarioResult] = []
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    with TestClient(app, raise_server_exceptions=False) as client:
-        for scenario in scenarios:
-            results.append(
-                _run_scenario(
-                    client=client,
-                    name=scenario["name"],
-                    endpoint=scenario["endpoint"],
-                    expected_status=scenario["expected_status"],
-                    warmup=args.warmup,
-                    iterations=args.iterations,
+
+    with tempfile.TemporaryDirectory(prefix="food-bench-") as tmp_dir_raw:
+        tmp_db, query_term = _create_temp_food_db(
+            src_db=src_db,
+            injected_barcode=args.bench_barcode,
+            tmp_dir=Path(tmp_dir_raw),
+        )
+        os.environ["FOOD_DB_PATH"] = str(tmp_db)
+
+        try:
+            from fastapi.testclient import TestClient
+            from app.main import app
+
+            scenarios = [
+                {
+                    "name": "foods_list_hit",
+                    "endpoint": f"/api/v1/foods?query={query_term}&limit=20&offset=0",
+                    "expected_status": 200,
+                    "validator": _expect_non_empty_list,
+                },
+                {
+                    "name": "foods_search_alias_hit",
+                    "endpoint": f"/api/v1/foods/search?query={query_term}&limit=20&offset=0",
+                    "expected_status": 200,
+                    "validator": _expect_non_empty_list,
+                },
+                {
+                    "name": "foods_list_no_results",
+                    "endpoint": "/api/v1/foods?query=zzzzzzzzzz&limit=20&offset=0",
+                    "expected_status": 200,
+                    "validator": _expect_empty_list,
+                },
+                {
+                    "name": "barcode_miss",
+                    "endpoint": f"/api/v1/foods/barcode/{args.miss_barcode}",
+                    "expected_status": 404,
+                    "validator": _expect_detail_contains("Food not found"),
+                },
+                {
+                    "name": "barcode_malformed",
+                    "endpoint": "/api/v1/foods/barcode/abc",
+                    "expected_status": 422,
+                    "validator": _expect_detail_contains("at least one digit"),
+                },
+            ]
+            if args.include_barcode_hit:
+                scenarios.insert(
+                    3,
+                    {
+                        "name": "barcode_hit",
+                        "endpoint": f"/api/v1/foods/barcode/{args.bench_barcode}",
+                        "expected_status": 200,
+                        "validator": None,
+                    },
                 )
-            )
+
+            logging.getLogger("httpx").setLevel(logging.WARNING)
+            with TestClient(app, raise_server_exceptions=False) as client:
+                for scenario in scenarios:
+                    results.append(
+                        _run_scenario(
+                            client=client,
+                            name=scenario["name"],
+                            endpoint=scenario["endpoint"],
+                            expected_status=scenario["expected_status"],
+                            validator=scenario["validator"],
+                            warmup=args.warmup,
+                            iterations=args.iterations,
+                        )
+                    )
+        finally:
+            if original_food_db_path is None:
+                os.environ.pop("FOOD_DB_PATH", None)
+            else:
+                os.environ["FOOD_DB_PATH"] = original_food_db_path
 
     print(_format_results(results))
 
@@ -213,6 +269,7 @@ def main() -> int:
         payload = {
             "iterations": args.iterations,
             "warmup": args.warmup,
+            "db_path": str(args.db_path),
             "results": [
                 {
                     "name": item.name,

--- a/scripts/benchmarks/food_api_latency_benchmark.py
+++ b/scripts/benchmarks/food_api_latency_benchmark.py
@@ -13,11 +13,11 @@ import json
 import logging
 import os
 from pathlib import Path
-import re
 import sqlite3
 import tempfile
 import time
 from typing import Any, Callable
+from urllib.parse import quote_plus
 
 DEFAULT_BENCH_BARCODE = "0123456789012"
 DEFAULT_MISS_BARCODE = "9999999999999"
@@ -72,9 +72,24 @@ def _create_temp_food_db(src_db: Path, injected_barcode: str, tmp_dir: Path) -> 
         con.execute("UPDATE foods SET gtin = ? WHERE id = ?", (injected_barcode, row_id))
         con.commit()
 
-    token_match = re.search(r"[A-Za-z]{3,}", canonical_name or "")
-    query_term = token_match.group(0).lower() if token_match else "apple"
+    query_term = _extract_query_term(canonical_name)
     return tmp_db, query_term
+
+
+def _extract_query_term(canonical_name: str | None) -> str:
+    """Pick the first alpha token (unicode-aware) with length >= 3."""
+    text = canonical_name or ""
+    buffer: list[str] = []
+    for char in text:
+        if char.isalpha():
+            buffer.append(char)
+            continue
+        if len(buffer) >= 3:
+            return "".join(buffer).lower()
+        buffer.clear()
+    if len(buffer) >= 3:
+        return "".join(buffer).lower()
+    return "apple"
 
 
 def _expect_non_empty_list(response: Any) -> None:
@@ -203,13 +218,15 @@ def main() -> int:
             scenarios = [
                 {
                     "name": "foods_list_hit",
-                    "endpoint": f"/api/v1/foods?query={query_term}&limit=20&offset=0",
+                    "endpoint": f"/api/v1/foods?query={quote_plus(query_term)}&limit=20&offset=0",
                     "expected_status": 200,
                     "validator": _expect_non_empty_list,
                 },
                 {
                     "name": "foods_search_alias_hit",
-                    "endpoint": f"/api/v1/foods/search?query={query_term}&limit=20&offset=0",
+                    "endpoint": (
+                        f"/api/v1/foods/search?query={quote_plus(query_term)}&limit=20&offset=0"
+                    ),
                     "expected_status": 200,
                     "validator": _expect_non_empty_list,
                 },


### PR DESCRIPTION
## Summary
- adds a reproducible Wave 2-C latency benchmark harness for food endpoints (`scripts/benchmarks/food_api_latency_benchmark.py`)
- adds measured benchmark artifact and audit report (`docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`, `docs/audit/artifacts/food_w2c_latency_benchmark.json`)
- updates execution tracking in backlog for W2/W3 and records follow-up for barcode hit contract normalization (`docs/roadmap/BACKLOG_LEDGER.md`)
- promotes a new engineering lesson from this cycle (`docs/ENGINEERING_LESSONS.md`)

## Scope
- benchmark/report and governance updates only
- no runtime behavior changes in app/core production paths

## Validation
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `python scripts/ci/check_docs_phase1_gates.py --files docs/audit/PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#pullrequestreview-3852437472 -> 9a8413ab18002cad27d3a3357c012f171e66b2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#discussion_r2851403760 -> 9a8413ab18002cad27d3a3357c012f171e66b2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#discussion_r2851403761 -> 9a8413ab18002cad27d3a3357c012f171e66b2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#discussion_r2851403772 -> 9a8413ab18002cad27d3a3357c012f171e66b2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#pullrequestreview-3852467933 -> 9a8413ab18002cad27d3a3357c012f171e66b2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#discussion_r2851508066 -> 066c5b3c3f98211efb21a7e3dd042a71fe44d20c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/898#pullrequestreview-3852573165 -> 066c5b3c3f98211efb21a7e3dd042a71fe44d20c

## Merge Readiness
- [x] Required checks are passing
- [x] No unresolved review threads
- [x] No actionable bot comments from CodeRabbit/Sourcery/Cubic
- [x] Mandatory wait-window will be re-checked before merge

