### PR TITLE
fix(food-db): normalize barcode hit flags contract

### DIFF
--- a/app/schemas/food.py
+++ b/app/schemas/food.py
@@ -38,7 +38,7 @@ def _normalize_food_flags(value: object) -> List[str]:
             for parser in (json.loads, ast.literal_eval):
                 try:
                     parsed = parser(raw)
-                except (TypeError, ValueError, SyntaxError, json.JSONDecodeError):
+                except (TypeError, ValueError, SyntaxError):
                     continue
                 if isinstance(parsed, (list, tuple, set)):
                     return [str(item).strip() for item in parsed if str(item).strip()]

--- a/app/schemas/food.py
+++ b/app/schemas/food.py
@@ -7,9 +7,48 @@ EN: Base food model with nutrients, pricing and provenance.
 
 from __future__ import annotations
 
+import ast
+import json
+import re
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+def _normalize_food_flags(value: object) -> List[str]:
+    """
+    Normalize legacy flags payloads to canonical list[str].
+
+    RU: Нормализует legacy-представления flags в канонический список строк.
+    EN: Normalizes legacy flags payloads to canonical list of strings.
+    """
+    if value is None:
+        return []
+
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw or raw.lower() in {"null", "none"} or raw == "[]":
+            return []
+
+        # Attempt list-like payload parsing: JSON first, then Python literal style.
+        if raw.startswith("[") and raw.endswith("]"):
+            for parser in (json.loads, ast.literal_eval):
+                try:
+                    parsed = parser(raw)
+                except (TypeError, ValueError, SyntaxError, json.JSONDecodeError):
+                    continue
+                if isinstance(parsed, (list, tuple, set)):
+                    return [str(item).strip() for item in parsed if str(item).strip()]
+
+        # Fallback for "VEG,GF" / "VEG;GF" / "VEG|GF".
+        parts = [part.strip().strip("'\"") for part in re.split(r"[;,|]", raw)]
+        normalized = [part for part in parts if part]
+        return normalized if normalized else []
+
+    return []
 
 
 class FoodItem(BaseModel):
@@ -45,6 +84,17 @@ class FoodItem(BaseModel):
     source_priority: int = 0
     version_date: str
     price_per_100g: float = 0.0
+
+    @field_validator("flags", mode="before")
+    @classmethod
+    def _parse_legacy_flags(cls, value: object) -> List[str]:
+        """
+        Support backward-compatible flags parsing for DB-backed rows.
+
+        RU: Поддерживает backward-compatible парсинг flags для строк из БД.
+        EN: Supports backward-compatible flags parsing for DB-backed rows.
+        """
+        return _normalize_food_flags(value)
 
 
 class FoodHit(BaseModel):

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -67,7 +67,7 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #891, PR #893, PR #898
-  - Status: In Progress (W2-A and W2-B merged; W2-C latency benchmark/report prepared and pending merge)
+  - Status: In Progress (W2-A/W2-B/W2-C merged; barcode hit contract follow-up in progress)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
@@ -109,8 +109,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Food barcode hit contract normalization for canonical FoodItem response
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W2-HIT-CONTRACT
-  - Status: Planned
+  - Target PR: PR-TBD-FOOD-DB-W2-HIT-CONTRACT (`fix/food-barcode-hit-contract`)
+  - Status: In Progress
   - Area: backend / API contract / data normalization
   - Finding Type: correctness and reliability gap
   - Reason: `GET /api/v1/foods/barcode/{barcode}` can fail on hit-path serialization when persisted `flags` payload is string-encoded instead of list, causing non-deterministic hit-path behavior in benchmark and runtime.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -113,7 +113,7 @@ If it is not recorded here — it does not exist.
   - Status: In Progress
   - Area: backend / API contract / data normalization
   - Finding Type: correctness and reliability gap
-  - Reason: `GET /api/v1/foods/barcode/{barcode}` can fail on hit-path serialization when persisted `flags` payload is string-encoded instead of list, causing non-deterministic hit-path behavior in benchmark and runtime.
+  - Reason: `GET /api/v1/foods/barcode/{barcode}` can fail on hit-path serialization when persisted `flags` payload is string-encoded instead of a list, causing non-deterministic hit-path behavior in benchmark and runtime.
   - Links:
     - `app/routers/foods.py`
     - `app/schemas/food.py`

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -28,15 +28,26 @@ def _build_food_item_payload(flags: Any) -> dict[str, Any]:
         ('["VEG","GF"]', ["VEG", "GF"]),
         ("['VEG', 'GF']", ["VEG", "GF"]),
         ("VEG, GF", ["VEG", "GF"]),
+        ("VEG;GF", ["VEG", "GF"]),
+        ("VEG|GF", ["VEG", "GF"]),
+        ("VEG", ["VEG"]),
+        (" null ", []),
+        ("None", []),
+        (["VEG", "GF"], ["VEG", "GF"]),
+        (("VEG", "GF"), ["VEG", "GF"]),
+        ({"VEG", "GF"}, {"VEG", "GF"}),
         ("", []),
         ("[]", []),
         (None, []),
         (123, []),
     ],
 )
-def test_food_item_flags_normalization(raw_flags: Any, expected: list[str]) -> None:
+def test_food_item_flags_normalization(raw_flags: Any, expected: Any) -> None:
     item = FoodItem(**_build_food_item_payload(raw_flags))
-    assert item.flags == expected
+    if isinstance(expected, set):
+        assert set(item.flags) == expected
+    else:
+        assert item.flags == expected
 
 
 def test_list_foods_invalid_limit() -> None:
@@ -117,8 +128,13 @@ def test_get_food_by_barcode_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.id == "f1"
 
 
+@pytest.mark.parametrize(
+    "flags_value",
+    ['["VEG","GF"]', "['VEG', 'GF']", "VEG,GF", "VEG;GF", "VEG|GF"],
+)
 def test_get_food_by_barcode_success_normalizes_string_flags(
     monkeypatch: pytest.MonkeyPatch,
+    flags_value: str,
 ) -> None:
     row = {
         "id": "f1",
@@ -127,7 +143,7 @@ def test_get_food_by_barcode_success_normalizes_string_flags(
         "protein_g": 0.3,
         "fat_g": 0.2,
         "carbs_g": 14,
-        "flags": '["VEG","GF"]',
+        "flags": flags_value,
         "version_date": "2024-01-01",
     }
     monkeypatch.setattr(foods.food_store, "get_food_by_barcode", lambda *_: row)

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -9,6 +9,36 @@ from app.routers import foods
 from app.schemas.food import FoodHit, FoodItem
 
 
+def _build_food_item_payload(flags: Any) -> dict[str, Any]:
+    return {
+        "id": "f1",
+        "canonical_name": "Apple",
+        "kcal": 52,
+        "protein_g": 0.3,
+        "fat_g": 0.2,
+        "carbs_g": 14,
+        "flags": flags,
+        "version_date": "2024-01-01",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_flags", "expected"),
+    [
+        ('["VEG","GF"]', ["VEG", "GF"]),
+        ("['VEG', 'GF']", ["VEG", "GF"]),
+        ("VEG, GF", ["VEG", "GF"]),
+        ("", []),
+        ("[]", []),
+        (None, []),
+        (123, []),
+    ],
+)
+def test_food_item_flags_normalization(raw_flags: Any, expected: list[str]) -> None:
+    item = FoodItem(**_build_food_item_payload(raw_flags))
+    assert item.flags == expected
+
+
 def test_list_foods_invalid_limit() -> None:
     with pytest.raises(HTTPException):
         foods.list_foods(query="apple", limit=0, offset=0, store=foods.food_store)
@@ -85,6 +115,27 @@ def test_get_food_by_barcode_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert isinstance(result, FoodItem)
     assert result.id == "f1"
+
+
+def test_get_food_by_barcode_success_normalizes_string_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = {
+        "id": "f1",
+        "canonical_name": "Apple",
+        "kcal": 52,
+        "protein_g": 0.3,
+        "fat_g": 0.2,
+        "carbs_g": 14,
+        "flags": '["VEG","GF"]',
+        "version_date": "2024-01-01",
+    }
+    monkeypatch.setattr(foods.food_store, "get_food_by_barcode", lambda *_: row)
+
+    result = foods.get_food_by_barcode("0123456789012", store=foods.get_food_store())
+
+    assert isinstance(result, FoodItem)
+    assert result.flags == ["VEG", "GF"]
 
 
 def test_get_food_by_barcode_not_found(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- normalizes `FoodItem.flags` parsing to handle legacy DB payload shapes (`JSON string`, `python-literal string`, delimited string) without breaking API contract
- closes barcode hit-path serialization gap for `/api/v1/foods/barcode/{barcode}` where `flags` could be persisted as string
- adds deterministic tests for normalization and barcode hit behavior
- updates backlog status for W2 and this follow-up item

## Scope
- `app/schemas/food.py`
- `tests/test_foods_router_additional.py`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Carryover
- follow-up remediation from PR #898 benchmark findings (`PR_898_FOOD_DB_W2_C_LATENCY_BENCHMARK.md`) for barcode hit contract normalization

## Validation
- `pytest -q tests/test_food_store_service.py -k barcode` ✅
- `pytest -q tests/test_foods_router_additional.py -k barcode` ✅
- `pytest -q tests/test_foods_router_additional.py` ✅
- `pre-commit run --all-files` ✅
- `make verify` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/900#pullrequestreview-3853788532 -> 85e0a9ffcb8e5ef5f40ac8bc4e4e69e55207fddf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/900#discussion_r2852604879 -> 85e0a9ffcb8e5ef5f40ac8bc4e4e69e55207fddf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/900#discussion_r2852604898 -> 85e0a9ffcb8e5ef5f40ac8bc4e4e69e55207fddf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/900#discussion_r2852604907 -> 85e0a9ffcb8e5ef5f40ac8bc4e4e69e55207fddf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/900#pullrequestreview-3853843769 -> 85e0a9ffcb8e5ef5f40ac8bc4e4e69e55207fddf

## Merge Readiness
- [x] Required checks are passing
- [x] No unresolved review threads
- [x] No actionable bot comments from CodeRabbit/Sourcery/Cubic
- [x] Mandatory wait-window will be re-checked before merge

## Summary by Sourcery

Нормализовать обработку флагов `FoodItem`, чтобы гарантировать обратную совместимость ответов с штрих‑кодом и задокументировать прогресс по связанным задачам из бэклога.

Bug Fixes:
- Обеспечить, чтобы `FoodItem.flags` последовательно приводился к каноническому списку строк при разборе различных устаревших представлений в БД, включая строковые представления коллекций и строки с разделителями.
- Исправить ответы поиска по штрих‑коду, в которых строковое кодирование флагов ранее могло приводить к сбоям сериализации или возврату ненормализованных данных.

Documentation:
- Обновить реестр бэклога, чтобы отразить влитую работу W2 и текущую работу по нормализации контракта ответов поиска по штрих‑коду.

Tests:
- Добавить параметризованные тесты, проверяющие нормализацию флагов для устаревших форматов и поведение поиска по штрих‑коду для строк БД со строковым кодированием флагов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize FoodItem flags handling to ensure backward-compatible barcode responses and document progress on related backlog items.

Bug Fixes:
- Ensure FoodItem.flags is consistently parsed into a canonical string list from various legacy DB encodings, including stringified collections and delimited strings.
- Fix barcode lookup responses where string-encoded flags could previously break serialization or return non-normalized data.

Documentation:
- Update backlog ledger to reflect merged W2 work and in-progress barcode hit contract normalization effort.

Tests:
- Add parameterized tests validating flags normalization across legacy formats and barcode hit behavior for DB rows with string-encoded flags.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes FoodItem.flags to a canonical list and ensures barcode lookups always return flags as list[str]. This makes the API contract consistent for legacy DB rows and keeps barcode hits deterministic.

- **Bug Fixes**
  - Added a field validator with robust parsing: JSON first, then Python literal; supports comma/semicolon/pipe-delimited strings and lists/tuples/sets; "", "null"/"None", "[]", and non-iterables → [].
  - Ensured GET /api/v1/foods/barcode/{barcode} normalizes string-encoded flags; expanded tests to cover more legacy shapes and barcode responses.
  - Updated BACKLOG_LEDGER to reflect W2-C merged and this follow-up in progress.

<sup>Written for commit 85e0a9ffad0e63383a1d71beec7d5b8efa2d1f08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Food item flags now support multiple input formats (JSON strings, Python literals, comma-separated values) and are automatically normalized for consistency.

* **Bug Fixes**
  * Fixed default food source identifier to use a single standard value for improved data consistency.

* **Chores**
  * Updated project backlog tracking to reflect food database work progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

