### PR TITLE
feat(food-db): close W3-B MenuStat provenance gaps

### DIFF
--- a/app/schemas/restaurants.py
+++ b/app/schemas/restaurants.py
@@ -55,6 +55,9 @@ class RestaurantMenuItem(BaseModel):
     source: str
     source_id: str | None = None
     is_active: bool = True
+    snapshot_date: str | None = None
+    provenance_source: str | None = None
+    provenance_record_id: str | None = None
 
 
 class RestaurantSubmissionCreate(BaseModel):

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -171,6 +171,8 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             ON user_submissions(status);
         CREATE INDEX IF NOT EXISTS idx_submission_audit_submission
             ON submission_audit(submission_id);
+        CREATE INDEX IF NOT EXISTS idx_source_catalog_entity
+            ON source_catalog(entity_type, entity_id, created_at);
         """)
     con.commit()
 
@@ -312,11 +314,35 @@ def get_restaurant_menu(chain_id: str, limit: int = 200) -> list[Dict[str, Any]]
     with _connect() as con:
         rows = con.execute(
             """
-            SELECT id, chain_id, item_name, category, serving_size_g, kcal, protein_g,
-                   fat_g, carbs_g, sodium_mg, source, source_id, is_active
-            FROM restaurant_menu_items
-            WHERE chain_id = ? AND is_active = 1
-            ORDER BY item_name ASC
+            SELECT
+                m.id,
+                m.chain_id,
+                m.item_name,
+                m.category,
+                m.serving_size_g,
+                m.kcal,
+                m.protein_g,
+                m.fat_g,
+                m.carbs_g,
+                m.sodium_mg,
+                m.source,
+                m.source_id,
+                m.is_active,
+                sc.snapshot_date AS snapshot_date,
+                sc.source_name AS provenance_source,
+                sc.source_record_id AS provenance_record_id
+            FROM restaurant_menu_items AS m
+            LEFT JOIN source_catalog AS sc
+                ON sc.id = (
+                    SELECT latest.id
+                    FROM source_catalog AS latest
+                    WHERE latest.entity_type = 'restaurant_menu_item'
+                      AND latest.entity_id = m.id
+                    ORDER BY latest.created_at DESC, latest.id DESC
+                    LIMIT 1
+                )
+            WHERE m.chain_id = ? AND m.is_active = 1
+            ORDER BY m.item_name ASC
             LIMIT ?
             """,
             (chain_id, limit),
@@ -429,13 +455,39 @@ def review_submission(
             """,
             (status, reviewer_notes, now_iso, submission_id),
         )
+        audit_id = str(uuid4())
         con.execute(
             """
             INSERT INTO submission_audit (
                 id, submission_id, from_status, to_status, reviewer_notes, changed_at
             ) VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (str(uuid4()), submission_id, from_status, status, reviewer_notes, now_iso),
+            (audit_id, submission_id, from_status, status, reviewer_notes, now_iso),
+        )
+        con.execute(
+            """
+            INSERT INTO source_catalog (
+                id, entity_type, entity_id, source_name, source_record_id,
+                snapshot_date, raw_data_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid4()),
+                "user_submission",
+                submission_id,
+                "moderation",
+                audit_id,
+                now_iso.split("T", maxsplit=1)[0],
+                json.dumps(
+                    {
+                        "from_status": from_status,
+                        "to_status": status,
+                        "reviewer_notes": reviewer_notes,
+                    },
+                    ensure_ascii=True,
+                ),
+                now_iso,
+            ),
         )
         con.commit()
     return get_submission(submission_id)

--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -172,7 +172,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_submission_audit_submission
             ON submission_audit(submission_id);
         CREATE INDEX IF NOT EXISTS idx_source_catalog_entity
-            ON source_catalog(entity_type, entity_id, created_at);
+            ON source_catalog(entity_type, entity_id, created_at, id);
         """)
     con.commit()
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -89,7 +89,7 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #895 (+ follow-up PR #901, `feat/food-db-w3b-menustat-provenance-closure`)
-  - Status: In Progress (W3-A foundation merged in PR #895; W3-B MenuStat ingestion/provenance closure in progress)
+  - Status: In Progress (W3-A foundation merged in PR #895; W3-B closure tracked in PR #901 and is finalized on merge)
   - Area: backend / data model / partner enablement
   - Finding Type: product coverage expansion
   - Reason: Product/restaurant database coverage and controlled data intake are required to reduce manual entry and support partner menu flows.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -63,11 +63,11 @@ If it is not recorded here — it does not exist.
     - Deterministic OFF delta ingestion is in place
     - Existing `/api/v1/foods*` behavior remains compatible
 
-- [ ] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
+- [x] P1: Execution Wave 2 — Search modernization (Meili/TypeSense) + API compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #891, PR #893, PR #898
-  - Status: In Progress (W2-A/W2-B/W2-C merged; barcode hit contract follow-up in progress)
+  - Target PR: PR #891, PR #893, PR #898, PR #900
+  - Status: ✅ Merged (W2-A/W2-B/W2-C + barcode hit contract in PR #900, 2026-02-25)
   - Area: backend / search / API
   - Finding Type: performance and UX improvement
   - Reason: Local-first indexed search is required for predictable low latency and better discoverability while preserving client compatibility.
@@ -88,8 +88,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3 — Restaurant menus + controlled user submissions
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #895 (+ follow-up PR-TBD-FOOD-DB-W3-B)
-  - Status: In Progress (W3-A foundation merged in PR #895; MenuStat ingestion/provenance closure pending)
+  - Target PR: PR #895 (+ follow-up PR-TBD-FOOD-DB-W3-B, `feat/food-db-w3b-menustat-provenance-closure`)
+  - Status: In Progress (W3-A foundation merged in PR #895; W3-B MenuStat ingestion/provenance closure in progress)
   - Area: backend / data model / partner enablement
   - Finding Type: product coverage expansion
   - Reason: Product/restaurant database coverage and controlled data intake are required to reduce manual entry and support partner menu flows.
@@ -106,11 +106,11 @@ If it is not recorded here — it does not exist.
     - Moderated user submission workflow is implemented (`pending/approved/rejected`)
     - Source audit trail persists provenance for imported and moderated records
 
-- [ ] P1: Food barcode hit contract normalization for canonical FoodItem response
+- [x] P1: Food barcode hit contract normalization for canonical FoodItem response
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W2-HIT-CONTRACT (`fix/food-barcode-hit-contract`)
-  - Status: In Progress
+  - Target PR: PR #900 (`fix/food-barcode-hit-contract`)
+  - Status: ✅ Merged (PR #900, 2026-02-25)
   - Area: backend / API contract / data normalization
   - Finding Type: correctness and reliability gap
   - Reason: `GET /api/v1/foods/barcode/{barcode}` can fail on hit-path serialization when persisted `flags` payload is string-encoded instead of a list, causing non-deterministic hit-path behavior in benchmark and runtime.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -88,7 +88,7 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3 — Restaurant menus + controlled user submissions
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #895 (+ follow-up PR-TBD-FOOD-DB-W3-B, `feat/food-db-w3b-menustat-provenance-closure`)
+  - Target PR: PR #895 (+ follow-up PR #901, `feat/food-db-w3b-menustat-provenance-closure`)
   - Status: In Progress (W3-A foundation merged in PR #895; W3-B MenuStat ingestion/provenance closure in progress)
   - Area: backend / data model / partner enablement
   - Finding Type: product coverage expansion

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -3906,6 +3906,28 @@
             ],
             "title": "Protein G"
           },
+          "provenance_record_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provenance Record Id"
+          },
+          "provenance_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provenance Source"
+          },
           "serving_size_g": {
             "anyOf": [
               {
@@ -3916,6 +3938,17 @@
               }
             ],
             "title": "Serving Size G"
+          },
+          "snapshot_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Date"
           },
           "sodium_mg": {
             "anyOf": [

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4197,8 +4197,14 @@ export interface components {
             kcal?: number | null;
             /** Protein G */
             protein_g?: number | null;
+            /** Provenance Record Id */
+            provenance_record_id?: string | null;
+            /** Provenance Source */
+            provenance_source?: string | null;
             /** Serving Size G */
             serving_size_g?: number | null;
+            /** Snapshot Date */
+            snapshot_date?: string | null;
             /** Sodium Mg */
             sodium_mg?: number | null;
             /** Source */

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -46,6 +47,9 @@ def test_import_menustat_rows_and_query(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert menu[0]["item_name"] == "Protein Burger"
     assert menu[0]["chain_id"] == "test-chain"
     assert menu[0]["kcal"] == 540.0
+    assert menu[0]["snapshot_date"] == "2026-02-24"
+    assert menu[0]["provenance_source"] == "menustat"
+    assert menu[0]["provenance_record_id"] == "menu-001"
 
 
 def test_submission_lifecycle_with_audit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -68,6 +72,26 @@ def test_submission_lifecycle_with_audit(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert len(reviewed["audit"]) == 1
     assert reviewed["audit"][0]["from_status"] == "pending"
     assert reviewed["audit"][0]["to_status"] == "approved"
+
+    with restaurant_store._connect() as con:
+        source_row = con.execute(
+            """
+            SELECT entity_type, source_name, source_record_id, snapshot_date, raw_data_json
+            FROM source_catalog
+            WHERE entity_type = 'user_submission' AND entity_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (created["id"],),
+        ).fetchone()
+    assert source_row is not None
+    assert source_row["entity_type"] == "user_submission"
+    assert source_row["source_name"] == "moderation"
+    assert source_row["snapshot_date"]
+    source_payload = json.loads(source_row["raw_data_json"])
+    assert source_payload["from_status"] == "pending"
+    assert source_payload["to_status"] == "approved"
+    assert source_payload["reviewer_notes"] == "verified"
 
 
 def test_review_submission_invalid_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -183,6 +207,49 @@ def test_import_menustat_rows_non_ascii_ids_do_not_collapse(
     chain_ids = [row["id"] for row in chain_rows]
     assert chain_ids[0] != chain_ids[1]
     assert all(chain_id.startswith("id-") for chain_id in chain_ids)
+
+
+def test_get_restaurant_menu_uses_latest_provenance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    timestamps = iter(
+        [
+            "2026-02-24T00:00:00+00:00",
+            "2026-02-25T00:00:00+00:00",
+        ]
+    )
+    monkeypatch.setattr(restaurant_store, "_utc_now_iso", lambda: next(timestamps))
+
+    restaurant_store.import_menustat_rows(
+        [
+            {
+                "chain_name": "Test Chain",
+                "item_name": "Protein Burger",
+                "kcal": 500,
+                "source_id": "menu-001",
+            }
+        ],
+        snapshot_date="2026-02-24",
+    )
+    restaurant_store.import_menustat_rows(
+        [
+            {
+                "chain_name": "Test Chain",
+                "item_name": "Protein Burger",
+                "kcal": 550,
+                "source_id": "menu-001",
+            }
+        ],
+        snapshot_date="2026-02-25",
+    )
+
+    menu = restaurant_store.get_restaurant_menu("test-chain", limit=10)
+    assert len(menu) == 1
+    assert menu[0]["kcal"] == 550.0
+    assert menu[0]["snapshot_date"] == "2026-02-25"
+    assert menu[0]["provenance_source"] == "menustat"
+    assert menu[0]["provenance_record_id"] == "menu-001"
 
 
 def test_connect_enables_foreign_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -148,6 +148,9 @@ def test_get_restaurant_menu_maps_rows() -> None:
                 "source": "menustat",
                 "source_id": "menu-001",
                 "is_active": 1,
+                "snapshot_date": "2026-02-24",
+                "provenance_source": "menustat",
+                "provenance_record_id": "menu-001",
             }
         ]
     )
@@ -155,6 +158,9 @@ def test_get_restaurant_menu_maps_rows() -> None:
     assert len(result) == 1
     assert result[0].id == "m1"
     assert result[0].item_name == "Protein Burger"
+    assert result[0].snapshot_date == "2026-02-24"
+    assert result[0].provenance_source == "menustat"
+    assert result[0].provenance_record_id == "menu-001"
 
 
 def test_create_submission_validation_error_maps_422() -> None:

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -163,6 +163,34 @@ def test_get_restaurant_menu_maps_rows() -> None:
     assert result[0].provenance_record_id == "menu-001"
 
 
+def test_get_restaurant_menu_maps_rows_without_provenance() -> None:
+    store = _StubStore(
+        menu_rows=[
+            {
+                "id": "m1",
+                "chain_id": "c1",
+                "item_name": "Protein Burger",
+                "category": "Burgers",
+                "serving_size_g": 200.0,
+                "kcal": 540.0,
+                "protein_g": 30.0,
+                "fat_g": 24.0,
+                "carbs_g": 50.0,
+                "sodium_mg": 910.0,
+                "source": "menustat",
+                "source_id": "menu-001",
+                "is_active": 1,
+            }
+        ]
+    )
+    result = restaurants.get_restaurant_menu("c1", limit=20, store=store)
+    assert len(result) == 1
+    assert result[0].id == "m1"
+    assert result[0].snapshot_date is None
+    assert result[0].provenance_source is None
+    assert result[0].provenance_record_id is None
+
+
 def test_create_submission_validation_error_maps_422() -> None:
     store = _StubStore(create_error=ValueError("canonical_name is required"))
     payload = RestaurantSubmissionCreate(canonical_name="abc", payload={})


### PR DESCRIPTION
## Summary
- close W3-B provenance gap for restaurant menu and moderation flows
- expose import provenance metadata on `/api/v1/restaurants/{chain_id}/menu` via non-breaking optional fields
- persist moderation transitions in `source_catalog` so imported and moderated records share audit provenance
- update backlog ledger state after PR #900 merge and W3-B kickoff

## Scope
- `app/services/restaurant_store.py`
- `app/schemas/restaurants.py`
- `tests/test_restaurant_store_service.py`
- `tests/test_restaurants_router.py`
- `docs/roadmap/BACKLOG_LEDGER.md`
- generated OpenAPI artifacts

## Carryover
- follow-up to PR #895 (W3-A foundation) to complete pending MenuStat/provenance closure tracked in `docs/roadmap/BACKLOG_LEDGER.md`

## Validation
- `pytest -q tests/test_restaurant_store_service.py tests/test_restaurants_router.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- `6e862e42` — service/schema/tests/ledger implementation for W3-B provenance closure
- `2b9bebfb` — `chore(pre-commit): sync OpenAPI artifacts`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/901#pullrequestreview-3854004594 -> c30dca52
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/901#pullrequestreview-3854070992 -> 9f498469
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/901#discussion_r2852868619 -> 9f498469
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/901#pullrequestreview-3854180987 -> 1994f593
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/901#discussion_r2852966597 -> 1994f593

## Merge Readiness
- [x] pre-commit run --all-files
- [x] make verify
- [x] zero unresolved threads required before merge
- [x] actionable bot comments must be mapped before merge

## Summary by Sourcery

Открыть метаданные происхождения (provenance) для пунктов ресторанного меню и сохранять события модерации в общий каталог источников (shared source catalog), чтобы закрыть пробелы в происхождении для импортов из MenuStat и пользовательских отправок.

Новые функции:
- Добавить необязательные поля `snapshot_date`, `provenance_source` и `provenance_record_id` в API/схему ресторанного меню и фронтенд-клиент OpenAPI для пунктов меню.

Улучшения:
- Объединять пункты ресторанного меню с `source_catalog`, чтобы запросы меню возвращали актуальные метаданные происхождения для каждого пункта.
- Записывать переходы состояний модерации пользовательских отправок в `source_catalog` со структурированными payload'ами, чтобы согласовать журналы аудита для импортированных и модераторских изменений.
- Индексировать `source_catalog` по типу сущности и её идентификатору для эффективного поиска последних записей о происхождении.
- Расширить тесты хранилища ресторанов и роутера, чтобы покрыть поля происхождения и поведение выбора последнего snapshot'а.
- Обновить записи в backlog ledger, чтобы отразить завершение работ по модернизации поиска и контракту по barcode hit, а также прогресс по закрытию разрывов в происхождении W3-B MenuStat.

Документация:
- Переработать записи дорожной карты в `BACKLOG_LEDGER`, чтобы отметить соответствующие волны выполнения как объединённые (merged) и задокументировать работу по закрытию разрывов в происхождении W3-B MenuStat.

Тесты:
- Добавить тесты, проверяющие поля происхождения для импортированных пунктов меню MenuStat и гарантирующие, что `get_restaurant_menu` использует последний snapshot происхождения.
- Добавить тесты, валидирующие сохранение и структуру payload'ов событий модерации в `source_catalog`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose provenance metadata for restaurant menu items and persist moderation events into the shared source catalog to close provenance gaps for MenuStat imports and user submissions.

New Features:
- Add optional snapshot_date, provenance_source, and provenance_record_id fields to restaurant menu API/schema and frontend OpenAPI client for menu items.

Enhancements:
- Join restaurant menu items with source_catalog so menu queries return the latest provenance metadata for each item.
- Record moderation transitions for user submissions in source_catalog with structured payloads to align imported and moderated audit trails.
- Index source_catalog by entity type and id to support efficient lookup of latest provenance records.
- Extend restaurant store and router tests to cover provenance fields and latest-snapshot selection behavior.
- Update backlog ledger entries to reflect completion of search modernization and barcode hit contract work and progress of W3-B MenuStat provenance closure.

Documentation:
- Revise BACKLOG_LEDGER roadmap entries to mark related execution waves as merged and to document W3-B MenuStat provenance closure work.

Tests:
- Add tests verifying provenance fields on imported MenuStat menu items and ensuring get_restaurant_menu uses the latest provenance snapshot.
- Add tests validating persistence and payload shape of moderation events in source_catalog.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes W3‑B MenuStat provenance gaps for restaurant menus and moderation. Adds optional provenance fields to the menu API and persists moderation transitions so imports and moderated items share a single audit trail.

- **New Features**
  - API: GET /api/v1/restaurants/{chain_id}/menu returns optional snapshot_date, provenance_source, and provenance_record_id (non-breaking). OpenAPI and frontend types updated.
  - Data: Menu queries join the latest source_catalog record per item; composite index added on source_catalog(entity_type, entity_id, created_at, id).
  - Moderation: review_submission writes a source_catalog record with source_name=moderation, links to submission_audit id, and stores snapshot_date.

- **Bug Fixes**
  - Deterministic latest provenance selection via ORDER BY created_at DESC, id DESC.
  - Router maps missing provenance fields to null.
  - Tests cover latest-wins selection and moderation payload shape.
  - BACKLOG_LEDGER: mark search modernization and barcode hit contract as merged; clarify W3‑B closure timing and track in PR #901.

<sup>Written for commit 1994f593539e41ddcbeda51259159805aed01756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restaurant menu items now include optional provenance metadata: snapshot date, provenance source, and provenance record ID.
  * User submission auditing added to record moderation events and link them to provenance entries.
* **Public API**
  * Frontend schema exposes the new optional provenance fields for menu items.
* **Tests**
  * Tests updated/added to validate provenance behavior and latest-provenance selection.
* **Documentation**
  * Roadmap/backlog entries updated to reflect progress and follow-up work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

