### PR TITLE
feat(food-db): add W3-C MenuStat bootstrap importer

### DIFF
--- a/data/restaurant_menu_sample.csv
+++ b/data/restaurant_menu_sample.csv
@@ -1,0 +1,4 @@
+restaurant,item_name,category,serving_size_g,calories,protein,total_fat,total_carbohydrate,sodium,source_id,country
+Pulse Grill,Protein Burger,Burgers,220,540,30,24,50,910,pulse-001,US
+Pulse Grill,Green Salad,Salads,180,180,6,8,18,320,pulse-002,US
+Fit Brew,Vanilla Protein Latte,Drinks,350,260,20,7,30,180,fit-010,US

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -281,6 +281,19 @@ Once PR state is `MERGED`:
 - `gh pr view <N> --json state,mergeCommit,mergedAt`
 - if `state=MERGED`, do not push further commits to that branch
 
+## 14) Local-first ingest scripts must fail-closed on empty normalized payload
+
+### Problem
+CSV ingestion can report "success" even when alias mapping drops required fields,
+resulting in zero imported rows and empty API results.
+
+### Rule
+For operational import scripts (MenuStat-style and similar):
+1. normalize column aliases to canonical contract keys
+2. require non-empty mandatory keys (`chain_name`, `item_name`) per row
+3. fail with non-zero exit code when no valid rows remain after normalization
+4. keep a deterministic sample CSV + end-to-end script test in-repo
+
 ---
 
 ## Repo Commands Reference

--- a/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
+++ b/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
@@ -156,7 +156,7 @@ Deliverables:
 
 Operational bootstrap (local-first, deterministic):
 
-- run `python scripts/import_restaurant_menu.py --input data/restaurant_menu_sample.csv --snapshot-date 2026-02-25 --db-path data/food.sqlite`
+- run `python -m scripts.import_restaurant_menu --input data/restaurant_menu_sample.csv --snapshot-date 2026-02-25 --db-path data/food.sqlite`
 - this command performs MenuStat-style CSV normalization and writes to `restaurant_chains`, `restaurant_menu_items`, and `source_catalog` via `app/services/restaurant_store.py`
 - use sample CSV for deterministic local bootstrap; production snapshots should keep immutable raw files under `data/raw/menustat/*` and run checksum validation before import
 

--- a/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
+++ b/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
@@ -154,6 +154,12 @@ Deliverables:
 - restaurant menu schema and endpoints
 - moderated user submissions (`pending/approved/rejected`) with audit trail
 
+Operational bootstrap (local-first, deterministic):
+
+- run `python scripts/import_restaurant_menu.py --input data/restaurant_menu_sample.csv --snapshot-date 2026-02-25 --db-path data/food.sqlite`
+- this command performs MenuStat-style CSV normalization and writes to `restaurant_chains`, `restaurant_menu_items`, and `source_catalog` via `app/services/restaurant_store.py`
+- use sample CSV for deterministic local bootstrap; production snapshots should keep immutable raw files under `data/raw/menustat/*` and run checksum validation before import
+
 ## W4 (P2): Optional semantic retrieval
 
 Deliverables:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -109,7 +109,7 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3-C — operational MenuStat bootstrap importer
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W3-C (`feat/food-db-w3d-menustat-importer`)
+  - Target PR: PR #904 (`feat/food-db-w3d-menustat-importer`)
   - Status: In Progress
   - Area: backend / ingestion operations / restaurant coverage
   - Finding Type: operational gap closure

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -106,6 +106,26 @@ If it is not recorded here — it does not exist.
     - Moderated user submission workflow is implemented (`pending/approved/rejected`)
     - Source audit trail persists provenance for imported and moderated records
 
+- [ ] P1: Execution Wave 3-C — operational MenuStat bootstrap importer
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOOD-DB-W3-C (`feat/food-db-w3d-menustat-importer`)
+  - Status: In Progress
+  - Area: backend / ingestion operations / restaurant coverage
+  - Finding Type: operational gap closure
+  - Reason: Restaurant endpoints and storage contracts exist, but local environments need a deterministic, repeatable import command to seed menu data from MenuStat-style snapshots without manual DB editing.
+  - Links:
+    - `scripts/import_restaurant_menu.py`
+    - `data/restaurant_menu_sample.csv`
+    - `tests/test_import_restaurant_menu_script.py`
+    - `app/services/restaurant_store.py`
+    - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
+  - DoD:
+    - CLI importer loads MenuStat-style CSV with alias mapping into canonical restaurant tables
+    - Importer supports explicit snapshot date and source name for provenance
+    - Deterministic sample dataset exists for local bootstrap and tests
+    - End-to-end test verifies import command populates searchable chain/menu records
+
 - [x] P1: Food barcode hit contract normalization for canonical FoodItem response
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -11,6 +11,7 @@ import argparse
 import csv
 import json
 import sys
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,16 @@ def _has_required_header_aliases(fieldnames: list[str] | None) -> bool:
     chain_aliases = set(_FIELD_ALIASES["chain_name"])
     item_aliases = set(_FIELD_ALIASES["item_name"])
     return bool(headers.intersection(chain_aliases)) and bool(headers.intersection(item_aliases))
+
+
+def _parse_snapshot_date(value: str) -> str:
+    """Validate CLI snapshot date and return canonical YYYY-MM-DD."""
+    try:
+        return date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"snapshot-date must be YYYY-MM-DD, got: {value!r}"
+        ) from exc
 
 
 def _first_present_value(row: dict[str, Any], aliases: tuple[str, ...]) -> str | None:
@@ -71,8 +82,14 @@ def load_menu_rows(csv_path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
         reader = csv.DictReader(handle)
-        if not _has_required_header_aliases(reader.fieldnames):
+        if reader.fieldnames is None:
             raise ValueError("input CSV has no header row")
+        if not _has_required_header_aliases(reader.fieldnames):
+            raise ValueError(
+                "input CSV missing required columns/aliases: "
+                f"one of {list(_FIELD_ALIASES['chain_name'])} and "
+                f"one of {list(_FIELD_ALIASES['item_name'])}"
+            )
         for raw_row in reader:
             normalized = normalize_row(raw_row)
             if not normalized.get("chain_name") or not normalized.get("item_name"):
@@ -130,6 +147,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--snapshot-date",
         default=None,
+        type=_parse_snapshot_date,
         help="Snapshot date (YYYY-MM-DD). Defaults to today's UTC date.",
     )
     parser.add_argument(

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import re
 import sys
 from datetime import date
 from pathlib import Path
@@ -30,6 +31,7 @@ _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
     "sodium_mg": ("sodium_mg", "sodium"),
     "source_id": ("source_id", "menu_item_id", "id"),
 }
+_DATE_YYYY_MM_DD = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _has_required_header_aliases(fieldnames: list[str] | None) -> bool:
@@ -44,6 +46,8 @@ def _has_required_header_aliases(fieldnames: list[str] | None) -> bool:
 
 def _parse_snapshot_date(value: str) -> str:
     """Validate CLI snapshot date and return canonical YYYY-MM-DD."""
+    if not _DATE_YYYY_MM_DD.fullmatch(value):
+        raise argparse.ArgumentTypeError(f"snapshot-date must be YYYY-MM-DD, got: {value!r}")
     try:
         return date.fromisoformat(value).isoformat()
     except ValueError as exc:

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -82,6 +82,8 @@ def load_menu_rows(csv_path: Path) -> list[dict[str, Any]]:
     """Load and normalize valid rows from CSV file."""
     if not csv_path.exists():
         raise FileNotFoundError(f"input file does not exist: {csv_path}")
+    if not csv_path.is_file():
+        raise ValueError(f"input path is not a file: {csv_path}")
 
     rows: list[dict[str, Any]] = []
     with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
@@ -95,7 +97,10 @@ def load_menu_rows(csv_path: Path) -> list[dict[str, Any]]:
                 f"one of {list(_FIELD_ALIASES['item_name'])}"
             )
         for raw_row in reader:
-            normalized = normalize_row(raw_row)
+            normalized_input = {
+                str(key).strip(): value for key, value in raw_row.items() if key is not None
+            }
+            normalized = normalize_row(normalized_input)
             if not normalized.get("chain_name") or not normalized.get("item_name"):
                 continue
             rows.append(normalized)

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+RU: CLI-импорт MenuStat-совместимого CSV в локальный restaurant store.
+EN: CLI import of MenuStat-compatible CSV into local restaurant store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from app.services import restaurant_store
+
+_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "chain_name": ("chain_name", "restaurant", "restaurant_name", "chain"),
+    "item_name": ("item_name", "menu_item", "name"),
+    "category": ("category", "menu_category"),
+    "country": ("country",),
+    "serving_size_g": ("serving_size_g", "serving_size_grams"),
+    "kcal": ("kcal", "calories"),
+    "protein_g": ("protein_g", "protein"),
+    "fat_g": ("fat_g", "total_fat"),
+    "carbs_g": ("carbs_g", "total_carbohydrate"),
+    "sodium_mg": ("sodium_mg", "sodium"),
+    "source_id": ("source_id", "menu_item_id", "id"),
+}
+
+
+def _first_present_value(row: dict[str, Any], aliases: tuple[str, ...]) -> str | None:
+    """Return first non-empty value for any alias."""
+    for alias in aliases:
+        raw = row.get(alias)
+        if raw is None:
+            continue
+        value = str(raw).strip()
+        if value:
+            return value
+    return None
+
+
+def normalize_row(raw_row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a MenuStat-style row into restaurant_store contract keys."""
+    normalized: dict[str, Any] = {}
+    for target_key, aliases in _FIELD_ALIASES.items():
+        value = _first_present_value(raw_row, aliases)
+        if value is not None:
+            normalized[target_key] = value
+    return normalized
+
+
+def load_menu_rows(csv_path: Path) -> list[dict[str, Any]]:
+    """Load and normalize valid rows from CSV file."""
+    if not csv_path.exists():
+        raise FileNotFoundError(f"input file does not exist: {csv_path}")
+
+    rows: list[dict[str, Any]] = []
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError("input CSV has no header row")
+        for raw_row in reader:
+            normalized = normalize_row(raw_row)
+            if not normalized.get("chain_name") or not normalized.get("item_name"):
+                continue
+            rows.append(normalized)
+    return rows
+
+
+def run_import(
+    *,
+    input_path: Path,
+    snapshot_date: str | None,
+    source_name: str,
+    db_path: Path | None,
+) -> dict[str, Any]:
+    """Execute import and return summary stats."""
+    if db_path is not None:
+        restaurant_store.DB_PATH = db_path
+        restaurant_store.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = load_menu_rows(input_path)
+    if not rows:
+        raise ValueError("no valid menu rows found in input")
+
+    stats = restaurant_store.import_menustat_rows(
+        rows,
+        snapshot_date=snapshot_date,
+        source_name=source_name,
+    )
+    return {
+        "input": str(input_path),
+        "db_path": str(restaurant_store.DB_PATH),
+        "rows_loaded": len(rows),
+        **stats,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Import MenuStat-style restaurant menu CSV into local store."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to CSV file with MenuStat-compatible columns.",
+    )
+    parser.add_argument(
+        "--snapshot-date",
+        default=None,
+        help="Snapshot date (YYYY-MM-DD). Defaults to today's UTC date.",
+    )
+    parser.add_argument(
+        "--source-name",
+        default="menustat",
+        help="Provenance source name for imported rows (default: menustat).",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        type=Path,
+        help="Optional override for SQLite DB path (default: FOOD_DB_PATH or data/food.sqlite).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        summary = run_import(
+            input_path=args.input,
+            snapshot_date=args.snapshot_date,
+            source_name=args.source_name,
+            db_path=args.db_path,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Import failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(summary, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -11,6 +11,7 @@ import argparse
 import csv
 import json
 import re
+import sqlite3
 import sys
 from datetime import date
 from pathlib import Path
@@ -29,7 +30,7 @@ _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
     "fat_g": ("fat_g", "total_fat"),
     "carbs_g": ("carbs_g", "total_carbohydrate"),
     "sodium_mg": ("sodium_mg", "sodium"),
-    "source_id": ("source_id", "menu_item_id", "id"),
+    "source_id": ("source_id", "menu_item_id"),
 }
 _DATE_YYYY_MM_DD = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -184,7 +185,7 @@ def main(argv: list[str] | None = None) -> int:
             source_name=args.source_name,
             db_path=args.db_path,
         )
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError, OSError, sqlite3.Error) as exc:
         print(f"Import failed: {exc}", file=sys.stderr)
         return 2
 

--- a/scripts/import_restaurant_menu.py
+++ b/scripts/import_restaurant_menu.py
@@ -14,10 +14,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
-
 from app.services import restaurant_store
 
 _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
@@ -33,6 +29,16 @@ _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
     "sodium_mg": ("sodium_mg", "sodium"),
     "source_id": ("source_id", "menu_item_id", "id"),
 }
+
+
+def _has_required_header_aliases(fieldnames: list[str] | None) -> bool:
+    """Check that CSV headers contain required alias groups."""
+    if fieldnames is None:
+        return False
+    headers = {field.strip() for field in fieldnames if field and field.strip()}
+    chain_aliases = set(_FIELD_ALIASES["chain_name"])
+    item_aliases = set(_FIELD_ALIASES["item_name"])
+    return bool(headers.intersection(chain_aliases)) and bool(headers.intersection(item_aliases))
 
 
 def _first_present_value(row: dict[str, Any], aliases: tuple[str, ...]) -> str | None:
@@ -65,7 +71,7 @@ def load_menu_rows(csv_path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
         reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
+        if not _has_required_header_aliases(reader.fieldnames):
             raise ValueError("input CSV has no header row")
         for raw_row in reader:
             normalized = normalize_row(raw_row)
@@ -83,25 +89,31 @@ def run_import(
     db_path: Path | None,
 ) -> dict[str, Any]:
     """Execute import and return summary stats."""
-    if db_path is not None:
-        restaurant_store.DB_PATH = db_path
-        restaurant_store.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    original_db_path = restaurant_store.DB_PATH
+    effective_db_path = original_db_path
+    try:
+        if db_path is not None:
+            restaurant_store.DB_PATH = db_path
+            restaurant_store.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+            effective_db_path = restaurant_store.DB_PATH
 
-    rows = load_menu_rows(input_path)
-    if not rows:
-        raise ValueError("no valid menu rows found in input")
+        rows = load_menu_rows(input_path)
+        if not rows:
+            raise ValueError("no valid menu rows found in input")
 
-    stats = restaurant_store.import_menustat_rows(
-        rows,
-        snapshot_date=snapshot_date,
-        source_name=source_name,
-    )
-    return {
-        "input": str(input_path),
-        "db_path": str(restaurant_store.DB_PATH),
-        "rows_loaded": len(rows),
-        **stats,
-    }
+        stats = restaurant_store.import_menustat_rows(
+            rows,
+            snapshot_date=snapshot_date,
+            source_name=source_name,
+        )
+        return {
+            "input": str(input_path),
+            "db_path": str(effective_db_path),
+            "rows_loaded": len(rows),
+            **stats,
+        }
+    finally:
+        restaurant_store.DB_PATH = original_db_path
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -1,32 +1,25 @@
 from __future__ import annotations
 
-import runpy
+import os
 from pathlib import Path
 
 import pytest
 
 from app.services import restaurant_store
-
-
-def _load_script_namespace() -> dict[str, object]:
-    repo_root = Path(__file__).resolve().parents[1]
-    script_path = repo_root / "scripts" / "import_restaurant_menu.py"
-    return runpy.run_path(str(script_path))
+from scripts import import_restaurant_menu
 
 
 def test_script_imports_sample_csv_into_local_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    namespace = _load_script_namespace()
-    main = namespace["main"]
-    assert callable(main)
-
     repo_root = Path(__file__).resolve().parents[1]
     sample_csv = repo_root / "data" / "restaurant_menu_sample.csv"
-    db_path = tmp_path / "restaurant_menu_cli.sqlite"
+    worker = os.getenv("PYTEST_XDIST_WORKER", "gw0")
+    db_path = tmp_path / f"restaurant_menu_cli_{worker}.sqlite"
+    original_db_path = restaurant_store.DB_PATH
 
-    exit_code = main(
+    exit_code = import_restaurant_menu.main(
         [
             "--input",
             str(sample_csv),
@@ -37,6 +30,7 @@ def test_script_imports_sample_csv_into_local_store(
         ]
     )
     assert exit_code == 0
+    assert restaurant_store.DB_PATH == original_db_path
 
     monkeypatch.setattr(restaurant_store, "DB_PATH", db_path)
     hits = restaurant_store.search_restaurants("pulse", limit=10, offset=0)
@@ -50,10 +44,6 @@ def test_script_imports_sample_csv_into_local_store(
 
 
 def test_load_menu_rows_maps_menustat_aliases(tmp_path: Path) -> None:
-    namespace = _load_script_namespace()
-    load_menu_rows = namespace["load_menu_rows"]
-    assert callable(load_menu_rows)
-
     csv_path = tmp_path / "menustat_like.csv"
     csv_path.write_text(
         (
@@ -62,7 +52,7 @@ def test_load_menu_rows_maps_menustat_aliases(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
-    rows = load_menu_rows(csv_path)
+    rows = import_restaurant_menu.load_menu_rows(csv_path)
     assert isinstance(rows, list)
     assert len(rows) == 1
     assert rows[0]["chain_name"] == "Chain A"
@@ -73,13 +63,34 @@ def test_load_menu_rows_maps_menustat_aliases(tmp_path: Path) -> None:
     assert rows[0]["sodium_mg"] == "800"
 
 
-def test_main_fails_when_no_valid_rows(tmp_path: Path) -> None:
-    namespace = _load_script_namespace()
-    main = namespace["main"]
-    assert callable(main)
-
+def test_main_fails_when_no_valid_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     csv_path = tmp_path / "empty_rows.csv"
     csv_path.write_text("restaurant,item_name\n,\n", encoding="utf-8")
 
-    exit_code = main(["--input", str(csv_path)])
+    exit_code = import_restaurant_menu.main(["--input", str(csv_path)])
     assert exit_code == 2
+    assert "Import failed:" in capsys.readouterr().err
+
+
+def test_main_fails_when_input_file_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing_path = tmp_path / "missing.csv"
+    exit_code = import_restaurant_menu.main(["--input", str(missing_path)])
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "Import failed:" in stderr
+    assert "input file does not exist" in stderr
+
+
+def test_main_fails_when_csv_has_no_header_row(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "headerless.csv"
+    csv_path.write_text("Chain A,Item 1,500\n", encoding="utf-8")
+
+    exit_code = import_restaurant_menu.main(["--input", str(csv_path)])
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "Import failed:" in stderr
+    assert "input CSV has no header row" in stderr

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -87,10 +87,36 @@ def test_main_fails_when_csv_has_no_header_row(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     csv_path = tmp_path / "headerless.csv"
-    csv_path.write_text("Chain A,Item 1,500\n", encoding="utf-8")
+    csv_path.write_text("", encoding="utf-8")
 
     exit_code = import_restaurant_menu.main(["--input", str(csv_path)])
     assert exit_code == 2
     stderr = capsys.readouterr().err
     assert "Import failed:" in stderr
     assert "input CSV has no header row" in stderr
+
+
+def test_main_fails_when_csv_lacks_required_header_aliases(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "missing_aliases.csv"
+    csv_path.write_text("foo,bar\nx,y\n", encoding="utf-8")
+
+    exit_code = import_restaurant_menu.main(["--input", str(csv_path)])
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "Import failed:" in stderr
+    assert "input CSV missing required columns/aliases" in stderr
+
+
+def test_main_rejects_invalid_snapshot_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "ok.csv"
+    csv_path.write_text("restaurant,item_name\nChain A,Item 1\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        import_restaurant_menu.main(["--input", str(csv_path), "--snapshot-date", "2026/02/25"])
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "snapshot-date must be YYYY-MM-DD" in stderr

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+from app.services import restaurant_store
+
+
+def _load_script_namespace() -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "import_restaurant_menu.py"
+    return runpy.run_path(str(script_path))
+
+
+def test_script_imports_sample_csv_into_local_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    namespace = _load_script_namespace()
+    main = namespace["main"]
+    assert callable(main)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sample_csv = repo_root / "data" / "restaurant_menu_sample.csv"
+    db_path = tmp_path / "restaurant_menu_cli.sqlite"
+
+    exit_code = main(
+        [
+            "--input",
+            str(sample_csv),
+            "--snapshot-date",
+            "2026-02-25",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    assert exit_code == 0
+
+    monkeypatch.setattr(restaurant_store, "DB_PATH", db_path)
+    hits = restaurant_store.search_restaurants("pulse", limit=10, offset=0)
+    assert len(hits) == 1
+    assert hits[0]["id"] == "pulse-grill"
+
+    menu = restaurant_store.get_restaurant_menu("pulse-grill", limit=10)
+    assert len(menu) == 2
+    assert menu[0]["provenance_source"] == "menustat"
+    assert menu[0]["snapshot_date"] == "2026-02-25"
+
+
+def test_load_menu_rows_maps_menustat_aliases(tmp_path: Path) -> None:
+    namespace = _load_script_namespace()
+    load_menu_rows = namespace["load_menu_rows"]
+    assert callable(load_menu_rows)
+
+    csv_path = tmp_path / "menustat_like.csv"
+    csv_path.write_text(
+        (
+            "restaurant,item_name,calories,total_fat,total_carbohydrate,protein,sodium\n"
+            "Chain A,Item 1,500,20,55,25,800\n"
+        ),
+        encoding="utf-8",
+    )
+    rows = load_menu_rows(csv_path)
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    assert rows[0]["chain_name"] == "Chain A"
+    assert rows[0]["kcal"] == "500"
+    assert rows[0]["fat_g"] == "20"
+    assert rows[0]["carbs_g"] == "55"
+    assert rows[0]["protein_g"] == "25"
+    assert rows[0]["sodium_mg"] == "800"
+
+
+def test_main_fails_when_no_valid_rows(tmp_path: Path) -> None:
+    namespace = _load_script_namespace()
+    main = namespace["main"]
+    assert callable(main)
+
+    csv_path = tmp_path / "empty_rows.csv"
+    csv_path.write_text("restaurant,item_name\n,\n", encoding="utf-8")
+
+    exit_code = main(["--input", str(csv_path)])
+    assert exit_code == 2

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -63,6 +63,19 @@ def test_load_menu_rows_maps_menustat_aliases(tmp_path: Path) -> None:
     assert rows[0]["sodium_mg"] == "800"
 
 
+def test_load_menu_rows_handles_whitespace_in_header_names(tmp_path: Path) -> None:
+    csv_path = tmp_path / "menustat_spaced_headers.csv"
+    csv_path.write_text(
+        ("restaurant ,item_name ,calories\n" "Chain B,Item 2,400\n"),
+        encoding="utf-8",
+    )
+    rows = import_restaurant_menu.load_menu_rows(csv_path)
+    assert len(rows) == 1
+    assert rows[0]["chain_name"] == "Chain B"
+    assert rows[0]["item_name"] == "Item 2"
+    assert rows[0]["kcal"] == "400"
+
+
 def test_main_fails_when_no_valid_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     csv_path = tmp_path / "empty_rows.csv"
     csv_path.write_text("restaurant,item_name\n,\n", encoding="utf-8")
@@ -81,6 +94,16 @@ def test_main_fails_when_input_file_missing(
     stderr = capsys.readouterr().err
     assert "Import failed:" in stderr
     assert "input file does not exist" in stderr
+
+
+def test_main_fails_when_input_path_is_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = import_restaurant_menu.main(["--input", str(tmp_path)])
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "Import failed:" in stderr
+    assert "input path is not a file" in stderr
 
 
 def test_main_fails_when_csv_has_no_header_row(

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -76,6 +77,17 @@ def test_load_menu_rows_handles_whitespace_in_header_names(tmp_path: Path) -> No
     assert rows[0]["kcal"] == "400"
 
 
+def test_load_menu_rows_does_not_use_generic_id_as_source_id(tmp_path: Path) -> None:
+    csv_path = tmp_path / "menu_with_generic_id.csv"
+    csv_path.write_text(
+        ("restaurant,item_name,id\n" "Chain C,Item 3,generic-123\n"),
+        encoding="utf-8",
+    )
+    rows = import_restaurant_menu.load_menu_rows(csv_path)
+    assert len(rows) == 1
+    assert "source_id" not in rows[0]
+
+
 def test_main_fails_when_no_valid_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     csv_path = tmp_path / "empty_rows.csv"
     csv_path.write_text("restaurant,item_name\n,\n", encoding="utf-8")
@@ -144,3 +156,31 @@ def test_main_rejects_invalid_snapshot_date(
     assert exc_info.value.code == 2
     stderr = capsys.readouterr().err
     assert "snapshot-date must be YYYY-MM-DD" in stderr
+
+
+@pytest.mark.parametrize(
+    ("raised_exc", "message"),
+    [
+        (PermissionError("denied"), "denied"),
+        (sqlite3.OperationalError("db locked"), "db locked"),
+    ],
+)
+def test_main_fail_closed_on_os_and_sqlite_errors(
+    raised_exc: Exception,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    csv_path = tmp_path / "ok.csv"
+    csv_path.write_text("restaurant,item_name\nChain A,Item 1\n", encoding="utf-8")
+
+    def _raise_error(**_: object) -> dict[str, object]:
+        raise raised_exc
+
+    monkeypatch.setattr(import_restaurant_menu, "run_import", _raise_error)
+    exit_code = import_restaurant_menu.main(["--input", str(csv_path)])
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "Import failed:" in stderr
+    assert message in stderr

--- a/tests/test_import_restaurant_menu_script.py
+++ b/tests/test_import_restaurant_menu_script.py
@@ -109,14 +109,15 @@ def test_main_fails_when_csv_lacks_required_header_aliases(
     assert "input CSV missing required columns/aliases" in stderr
 
 
+@pytest.mark.parametrize("bad_date", ["2026/02/25", "20260225"])
 def test_main_rejects_invalid_snapshot_date(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    bad_date: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     csv_path = tmp_path / "ok.csv"
     csv_path.write_text("restaurant,item_name\nChain A,Item 1\n", encoding="utf-8")
 
     with pytest.raises(SystemExit) as exc_info:
-        import_restaurant_menu.main(["--input", str(csv_path), "--snapshot-date", "2026/02/25"])
+        import_restaurant_menu.main(["--input", str(csv_path), "--snapshot-date", bad_date])
     assert exc_info.value.code == 2
     stderr = capsys.readouterr().err
     assert "snapshot-date must be YYYY-MM-DD" in stderr


### PR DESCRIPTION
## Summary
- add `scripts/import_restaurant_menu.py` CLI to import MenuStat-style CSV snapshots into local restaurant store
- add deterministic sample dataset `data/restaurant_menu_sample.csv`
- add end-to-end script tests in `tests/test_import_restaurant_menu_script.py`
- harden importer: restore `restaurant_store.DB_PATH` after run and cover additional fail-closed CLI error paths
- update strategy/backlog docs for W3-C operational bootstrap and concrete PR link `#904`

## Scope
- `scripts/import_restaurant_menu.py`
- `data/restaurant_menu_sample.csv`
- `tests/test_import_restaurant_menu_script.py`
- `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/ENGINEERING_LESSONS.md`

## Carryover
- Follow-up from W3 merged track (`PR #895`, `PR #901`) to close operational bootstrap gap for local MenuStat seed/import.
- Ledger mapping added: `P1: Execution Wave 3-C — operational MenuStat bootstrap importer`.

## Validation
- `pytest -q tests/test_import_restaurant_menu_script.py`
- `pytest -q tests/test_restaurant_store_service.py tests/test_restaurants_router.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3854833119 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853573713 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3854864874 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853602248 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853602262 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3854890990 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853625835 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853625837 -> 29745a08
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853625839 -> 29745a08

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3854983756 -> f4164e1b
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853711102 -> f4164e1b
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853711110 -> f4164e1b
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3855122104 -> 331a18ae
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853829438 -> 331a18ae
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3855190649 -> 71f51741
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853896256 -> 71f51741
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2853896263 -> 71f51741
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#pullrequestreview-3855343783 -> 777b2e12
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2854040405 -> 777b2e12
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/904#discussion_r2854040417 -> 777b2e12
## Merge Readiness
- [x] CI required checks pass
- [x] No unresolved review threads
- [x] CodeRabbit/Sourcery/Cubic actionables addressed or not present
- [x] Scope is isolated and non-breaking for existing `/api/v1/foods*` contracts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance for deterministic, local-first bootstrap and fail-closed imports for restaurant menu CSVs; includes normalization rules, sample CSV guidance, and checklist.
  * Added a backlog entry for the MenuStat operational bootstrap.

* **New Features**
  * Added a CLI tool to import and normalize restaurant menu CSVs with validation, snapshot/source metadata, JSON summary output, and non‑zero exit on no valid rows.

* **Tests**
  * Added end-to-end and unit tests covering import, normalization, validation, error cases, and fail-on-empty-input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



