### PR TITLE
fix(ci): stabilize openapi determinism gate on main

### DIFF
--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -318,6 +318,29 @@ For operational import scripts (MenuStat-style and similar):
 3. fail with non-zero exit code when no valid rows remain after normalization
 4. keep a deterministic sample CSV + end-to-end script test in-repo
 
+## 16) Subprocess-backed determinism tests must expose failure diagnostics
+
+### Problem
+When tests call shell pipelines (for example `make openapi`) and fully suppress
+`stdout/stderr`, CI failures become opaque (`CalledProcessError` only), which blocks
+fast triage and encourages blind reruns.
+
+### Real incident (main CI, 2026-02-25)
+`tests/test_openapi_determinism.py` failed in `test-main (3.12)` with
+`Command '['make', 'openapi']' returned non-zero exit status 2`, but no actionable
+stderr was available in job logs because both streams were redirected to `DEVNULL`.
+
+### Rule
+For subprocess-based deterministic tests:
+1. capture subprocess output (`capture_output=True`, `text=True`)
+2. on failure, emit bounded `stdout/stderr` tails in pytest failure message
+3. allow a single retry for transient toolchain/network hiccups, then fail-closed
+
+### Use instead
+- helper wrappers that centralize retry + bounded log tail emission
+- clear failure messages with command, exit code, and log tails
+- deterministic assertions remain strict after command succeeds
+
 ---
 
 ## Repo Commands Reference

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -8,10 +8,60 @@ from pathlib import Path
 
 import pytest
 
+_OPENAPI_MAKE_CMD = ["make", "openapi"]
+_OPENAPI_PIPELINE_ATTEMPTS = 2
+_SUBPROCESS_LOG_TAIL_LINES = 120
+
 
 def _sha256(path: Path) -> str:
     """Calculate SHA256 hash of file."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tail_log(log_text: str) -> str:
+    """Return a bounded tail for subprocess logs to keep pytest output readable."""
+    lines = log_text.splitlines()
+    return "\n".join(lines[-_SUBPROCESS_LOG_TAIL_LINES:])
+
+
+def _run_openapi_pipeline(repo_root: Path) -> None:
+    """
+    Run `make openapi` with bounded retry and actionable failure diagnostics.
+
+    RU: В CI иногда бывают транзиентные падения npm/make.
+    Делаем 1 ретрай, но если команда стабильно падает — падаем с хвостом stdout/stderr.
+    EN: CI can hit transient npm/make failures.
+    We retry once, but still fail-closed with stdout/stderr tail if persistent.
+    """
+    last_process: subprocess.CompletedProcess[str] | None = None
+    for _attempt in range(1, _OPENAPI_PIPELINE_ATTEMPTS + 1):
+        process = subprocess.run(
+            _OPENAPI_MAKE_CMD,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        last_process = process
+        if process.returncode == 0:
+            return
+
+    assert last_process is not None  # pragma: no cover - defensive, loop always runs
+    stdout_tail = _tail_log(last_process.stdout)
+    stderr_tail = _tail_log(last_process.stderr)
+    pytest.fail(
+        "\n".join(
+            [
+                f"`{' '.join(_OPENAPI_MAKE_CMD)}` failed "
+                f"after {_OPENAPI_PIPELINE_ATTEMPTS} attempts "
+                f"(exit={last_process.returncode}).",
+                "--- stdout (tail) ---",
+                stdout_tail or "<empty>",
+                "--- stderr (tail) ---",
+                stderr_tail or "<empty>",
+            ]
+        )
+    )
 
 
 def test_openapi_and_schema_ts_are_deterministic() -> None:
@@ -33,13 +83,7 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
     schema_path = repo_root / "frontend" / "src" / "api" / "schema.ts"
 
     # Run full pipeline twice (same as CI)
-    # Use make directly (not bash -lc) for better compatibility
-    subprocess.check_call(
-        ["make", "openapi"],
-        cwd=repo_root,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    _run_openapi_pipeline(repo_root)
     # Sanity-check: generator must produce FULL schema (no schema-only markers) and include
     # key endpoints that were previously excluded behind schema-only mode.
     schema = json.loads(openapi_path.read_text(encoding="utf-8"))
@@ -55,12 +99,7 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
 
     h1: tuple[str, str] = (_sha256(openapi_path), _sha256(schema_path))
 
-    subprocess.check_call(
-        ["make", "openapi"],
-        cwd=repo_root,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    _run_openapi_pipeline(repo_root)
     h2: tuple[str, str] = (_sha256(openapi_path), _sha256(schema_path))
 
     if h1 != h2:


### PR DESCRIPTION
## Summary
- Fixes flaky/opaque failure path in `tests/test_openapi_determinism.py` seen on `main` CI run `22410999585`, job `64884141460`.
- Replaces silent `subprocess.check_call(..., DEVNULL)` with a bounded helper that:
  - retries `make openapi` once for transient toolchain/network hiccups,
  - fails closed with bounded `stdout/stderr` tails when still failing.
- Keeps the determinism contract unchanged (pipeline still runs twice and compares `openapi.json` + `schema.ts` hashes).

## Root Cause
- CI failure surfaced as `CalledProcessError: make openapi exit 2` without actionable logs because test redirected both stdout/stderr to `/dev/null`.
- This made triage non-deterministic and forced blind reruns.

## Changes
- `tests/test_openapi_determinism.py`
  - added `_run_openapi_pipeline()` with bounded retry and failure diagnostics,
  - switched both pipeline invocations to this helper.
- `docs/ENGINEERING_LESSONS.md`
  - added lesson: subprocess-backed determinism tests must emit bounded diagnostics and avoid fully silent failures.

## Validation
- `pre-commit run --all-files` ✅
- `make verify` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/907#pullrequestreview-3856707956 -> 57d7a5df

## Merge Readiness
- [x] Ready for merge after required checks pass and one final review cycle.

<!-- refresh 2026-02-25 -->

## Summary by Sourcery

Стабилизировать тест детерминизма OpenAPI в CI, добавив повторяющийся диагностический помощник вокруг конвейера генерации OpenAPI и задокументировав наилучшие практики для тестов детерминизма, использующих подпроцессы.

Bug Fixes:
- Предотвратить неочевидные сбои CI в тесте детерминизма OpenAPI за счёт вывода ограниченного stdout/stderr при сбое `make openapi`.

Enhancements:
- Ввести многоразовый помощник для конвейера OpenAPI, который повторяет попытку один раз при временных сбоях и завершает работу с понятной, ограниченной диагностикой вместо полного подавления вывода подпроцесса.

Documentation:
- Добавить инженерный урок с описанием рекомендаций для тестов детерминизма, использующих подпроцессы, включая захват вывода, ограниченные хвосты логов и ограниченное число повторных попыток.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the OpenAPI determinism CI test by adding a retrying, diagnostic helper around the OpenAPI generation pipeline and documenting best practices for subprocess-backed determinism tests.

Bug Fixes:
- Prevent opaque CI failures in the OpenAPI determinism test by surfacing bounded stdout/stderr output when `make openapi` fails.

Enhancements:
- Introduce a reusable OpenAPI pipeline helper that retries once on transient failures and fails with clear, bounded diagnostics instead of fully suppressing subprocess output.

Documentation:
- Add an engineering lesson documenting guidelines for subprocess-backed determinism tests, including output capture, bounded log tails, and limited retries.

</details>