### PR TITLE
feat(food-db): promote approved submissions into canonical menu (W3-E)

### DIFF
--- a/app/services/restaurant_store.py
+++ b/app/services/restaurant_store.py
@@ -30,6 +30,22 @@ STATUS_REJECTED = "rejected"
 _ALLOWED_REVIEW_STATUSES = {STATUS_APPROVED, STATUS_REJECTED}
 MAX_RESTAURANT_SEARCH_LIMIT = 100
 MAX_RESTAURANT_MENU_LIMIT = 500
+DEFAULT_SUBMISSION_CHAIN_NAME = "Community Submissions"
+SUBMISSION_MENU_SOURCE = "user_submission"
+_CHAIN_NAME_ALIASES = (
+    "chain_name",
+    "restaurant_chain",
+    "chain",
+    "restaurant_name",
+)
+_CATEGORY_ALIASES = ("category", "menu_category")
+_COUNTRY_ALIASES = ("country", "country_code")
+_SERVING_SIZE_ALIASES = ("serving_size_g", "serving_g")
+_KCAL_ALIASES = ("kcal", "calories")
+_PROTEIN_ALIASES = ("protein_g", "protein")
+_FAT_ALIASES = ("fat_g", "fat")
+_CARBS_ALIASES = ("carbs_g", "carbs")
+_SODIUM_ALIASES = ("sodium_mg", "sodium")
 
 
 def _utc_now_iso() -> str:
@@ -70,6 +86,56 @@ def _as_float(value: Any) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _as_clean_str(value: Any) -> str | None:
+    """Return stripped string value or None for empty/non-string-like values."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _first_alias(payload: Dict[str, Any], aliases: tuple[str, ...]) -> str | None:
+    """Return first non-empty alias value from payload."""
+    for key in aliases:
+        value = _as_clean_str(payload.get(key))
+        if value:
+            return value
+    return None
+
+
+def _decode_submission_payload(raw_payload_json: str) -> Dict[str, Any]:
+    """Parse submission payload JSON into dict, fail-closed to empty dict on decode errors."""
+    try:
+        parsed = json.loads(raw_payload_json) if raw_payload_json else {}
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _build_menu_row_from_submission(
+    *,
+    submission_id: str,
+    canonical_name: str,
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Convert approved submission payload to MenuStat-like row contract."""
+    return {
+        "chain_name": _first_alias(payload, _CHAIN_NAME_ALIASES) or DEFAULT_SUBMISSION_CHAIN_NAME,
+        "item_name": canonical_name.strip(),
+        "category": _first_alias(payload, _CATEGORY_ALIASES),
+        "country": _first_alias(payload, _COUNTRY_ALIASES) or "US",
+        "serving_size_g": _first_alias(payload, _SERVING_SIZE_ALIASES),
+        "kcal": _first_alias(payload, _KCAL_ALIASES),
+        "protein_g": _first_alias(payload, _PROTEIN_ALIASES),
+        "fat_g": _first_alias(payload, _FAT_ALIASES),
+        "carbs_g": _first_alias(payload, _CARBS_ALIASES),
+        "sodium_mg": _first_alias(payload, _SODIUM_ALIASES),
+        "source_id": f"submission-{submission_id}",
+    }
 
 
 def _validate_pagination(limit: int, offset: int, *, max_limit: int) -> tuple[int, int]:
@@ -195,91 +261,111 @@ def import_menustat_rows(
     items_upserted = 0
     with _connect() as con:
         for row in rows:
-            chain_name = str(row.get("chain_name", "")).strip()
-            item_name = str(row.get("item_name", "")).strip()
-            if not chain_name or not item_name:
-                continue
-            chain_id = _slugify(chain_name)
             now_iso = _utc_now_iso()
-            country = str(row.get("country", "US")).strip() or "US"
-            source_id = str(row.get("source_id", "")).strip() or None
-
-            con.execute(
-                """
-                INSERT INTO restaurant_chains (id, name, country, source, source_id, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    name = excluded.name,
-                    country = excluded.country,
-                    source = excluded.source,
-                    source_id = excluded.source_id,
-                    updated_at = excluded.updated_at
-                """,
-                (chain_id, chain_name, country, source_name, source_id, now_iso),
-            )
-            chains_upserted += 1
-
-            menu_source_part = source_id or _slugify(item_name)
-            menu_id = f"{chain_id}:{menu_source_part}"
-            con.execute(
-                """
-                INSERT INTO restaurant_menu_items (
-                    id, chain_id, item_name, category, serving_size_g, kcal, protein_g,
-                    fat_g, carbs_g, sodium_mg, source, source_id, is_active, updated_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    chain_id = excluded.chain_id,
-                    item_name = excluded.item_name,
-                    category = excluded.category,
-                    serving_size_g = excluded.serving_size_g,
-                    kcal = excluded.kcal,
-                    protein_g = excluded.protein_g,
-                    fat_g = excluded.fat_g,
-                    carbs_g = excluded.carbs_g,
-                    sodium_mg = excluded.sodium_mg,
-                    source = excluded.source,
-                    source_id = excluded.source_id,
-                    is_active = excluded.is_active,
-                    updated_at = excluded.updated_at
-                """,
-                (
-                    menu_id,
-                    chain_id,
-                    item_name,
-                    str(row.get("category", "")).strip() or None,
-                    _as_float(row.get("serving_size_g")),
-                    _as_float(row.get("kcal")),
-                    _as_float(row.get("protein_g")),
-                    _as_float(row.get("fat_g")),
-                    _as_float(row.get("carbs_g")),
-                    _as_float(row.get("sodium_mg")),
-                    source_name,
-                    source_id,
-                    now_iso,
-                ),
-            )
-            items_upserted += 1
-            con.execute(
-                """
-                INSERT INTO source_catalog (
-                    id, entity_type, entity_id, source_name, source_record_id,
-                    snapshot_date, raw_data_json, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    str(uuid4()),
-                    "restaurant_menu_item",
-                    menu_id,
-                    source_name,
-                    source_id,
-                    snapshot,
-                    json.dumps(row, ensure_ascii=True),
-                    now_iso,
-                ),
-            )
+            if _upsert_menu_row(
+                con,
+                row=row,
+                source_name=source_name,
+                snapshot=snapshot,
+                now_iso=now_iso,
+            ):
+                chains_upserted += 1
+                items_upserted += 1
         con.commit()
     return {"chains_upserted": chains_upserted, "menu_items_upserted": items_upserted}
+
+
+def _upsert_menu_row(
+    con: sqlite3.Connection,
+    *,
+    row: Dict[str, Any],
+    source_name: str,
+    snapshot: str,
+    now_iso: str,
+) -> bool:
+    """Upsert a single menu row and its provenance into canonical restaurant tables."""
+    chain_name = _as_clean_str(row.get("chain_name")) or ""
+    item_name = _as_clean_str(row.get("item_name")) or ""
+    if not chain_name or not item_name:
+        return False
+
+    chain_id = _slugify(chain_name)
+    country = _as_clean_str(row.get("country")) or "US"
+    source_id = _as_clean_str(row.get("source_id"))
+
+    con.execute(
+        """
+        INSERT INTO restaurant_chains (id, name, country, source, source_id, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            country = excluded.country,
+            source = excluded.source,
+            source_id = excluded.source_id,
+            updated_at = excluded.updated_at
+        """,
+        (chain_id, chain_name, country, source_name, source_id, now_iso),
+    )
+
+    menu_source_part = source_id or _slugify(item_name)
+    menu_id = f"{chain_id}:{menu_source_part}"
+    con.execute(
+        """
+        INSERT INTO restaurant_menu_items (
+            id, chain_id, item_name, category, serving_size_g, kcal, protein_g,
+            fat_g, carbs_g, sodium_mg, source, source_id, is_active, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            chain_id = excluded.chain_id,
+            item_name = excluded.item_name,
+            category = excluded.category,
+            serving_size_g = excluded.serving_size_g,
+            kcal = excluded.kcal,
+            protein_g = excluded.protein_g,
+            fat_g = excluded.fat_g,
+            carbs_g = excluded.carbs_g,
+            sodium_mg = excluded.sodium_mg,
+            source = excluded.source,
+            source_id = excluded.source_id,
+            is_active = excluded.is_active,
+            updated_at = excluded.updated_at
+        """,
+        (
+            menu_id,
+            chain_id,
+            item_name,
+            _as_clean_str(row.get("category")),
+            _as_float(row.get("serving_size_g")),
+            _as_float(row.get("kcal")),
+            _as_float(row.get("protein_g")),
+            _as_float(row.get("fat_g")),
+            _as_float(row.get("carbs_g")),
+            _as_float(row.get("sodium_mg")),
+            source_name,
+            source_id,
+            now_iso,
+        ),
+    )
+    con.execute(
+        """
+        INSERT INTO source_catalog (
+            id, entity_type, entity_id, source_name, source_record_id,
+            snapshot_date, raw_data_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(uuid4()),
+            "restaurant_menu_item",
+            menu_id,
+            source_name,
+            source_id,
+            snapshot,
+            json.dumps(row, ensure_ascii=True),
+            now_iso,
+        ),
+    )
+    return True
 
 
 def search_restaurants(query: str, limit: int = 20, offset: int = 0) -> list[Dict[str, Any]]:
@@ -351,11 +437,7 @@ def get_restaurant_menu(chain_id: str, limit: int = 200) -> list[Dict[str, Any]]
 
 
 def _normalize_submission_record(row: sqlite3.Row, audit_rows: list[sqlite3.Row]) -> Dict[str, Any]:
-    payload: dict[str, Any]
-    try:
-        payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
-    except json.JSONDecodeError:
-        payload = {}
+    payload = _decode_submission_payload(str(row["payload_json"] or ""))
     record = dict(row)
     record["payload"] = payload
     record.pop("payload_json", None)
@@ -440,13 +522,35 @@ def review_submission(
     now_iso = _utc_now_iso()
     with _connect() as con:
         current = con.execute(
-            "SELECT id, status FROM user_submissions WHERE id = ?",
+            """
+            SELECT id, status, entity_type, canonical_name, payload_json
+            FROM user_submissions
+            WHERE id = ?
+            """,
             (submission_id,),
         ).fetchone()
         if current is None:
             return None
 
         from_status = str(current["status"])
+        did_promote_to_menu = False
+        if (
+            status == STATUS_APPROVED
+            and from_status != STATUS_APPROVED
+            and str(current["entity_type"]) == "restaurant_menu"
+        ):
+            payload = _decode_submission_payload(str(current["payload_json"] or ""))
+            did_promote_to_menu = _upsert_menu_row(
+                con,
+                row=_build_menu_row_from_submission(
+                    submission_id=submission_id,
+                    canonical_name=str(current["canonical_name"]),
+                    payload=payload,
+                ),
+                source_name=SUBMISSION_MENU_SOURCE,
+                snapshot=now_iso.split("T", maxsplit=1)[0],
+                now_iso=now_iso,
+            )
         con.execute(
             """
             UPDATE user_submissions
@@ -483,6 +587,7 @@ def review_submission(
                         "from_status": from_status,
                         "to_status": status,
                         "reviewer_notes": reviewer_notes,
+                        "promoted_to_menu": did_promote_to_menu,
                     },
                     ensure_ascii=True,
                 ),

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -106,11 +106,11 @@ If it is not recorded here — it does not exist.
     - Moderated user submission workflow is implemented (`pending/approved/rejected`)
     - Source audit trail persists provenance for imported and moderated records
 
-- [ ] P1: Execution Wave 3-C — operational MenuStat bootstrap importer
+- [x] P1: Execution Wave 3-C — operational MenuStat bootstrap importer
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #904 (`feat/food-db-w3d-menustat-importer`)
-  - Status: In Progress
+  - Status: ✅ Merged (PR #904, 2026-02-25)
   - Area: backend / ingestion operations / restaurant coverage
   - Finding Type: operational gap closure
   - Reason: Restaurant endpoints and storage contracts exist, but local environments need a deterministic, repeatable import command to seed menu data from MenuStat-style snapshots without manual DB editing.
@@ -125,6 +125,25 @@ If it is not recorded here — it does not exist.
     - Importer supports explicit snapshot date and source name for provenance
     - Deterministic sample dataset exists for local bootstrap and tests
     - End-to-end test verifies import command populates searchable chain/menu records
+
+- [ ] P1: Execution Wave 3-E — approved submission promotion to canonical restaurant menu
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOOD-DB-W3-E (`feat/food-db-wave3e-submission-promotion`)
+  - Status: In Progress
+  - Area: backend / moderation workflow / restaurant coverage
+  - Finding Type: correctness gap closure
+  - Reason: Moderated submissions reached `approved`, but approved restaurant-menu submissions were not deterministically promoted into canonical `restaurant_menu_items`, creating a product/database gap for local-first lookup.
+  - Links:
+    - `app/services/restaurant_store.py`
+    - `tests/test_restaurant_store_service.py`
+    - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
+  - DoD:
+    - `approved` submissions with `entity_type=restaurant_menu` are promoted into canonical menu rows in the same transaction scope
+    - Re-approving already approved submissions is idempotent (no duplicate promoted menu rows)
+    - `rejected` submissions do not create menu rows
+    - Promotion failures remain fail-closed (no partial moderation/audit state persisted)
+    - Deterministic tests cover approved/rejected/idempotency/rollback behavior
 
 - [x] P1: Food barcode hit contract normalization for canonical FoodItem response
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -129,7 +129,7 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Execution Wave 3-E — approved submission promotion to canonical restaurant menu
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DB-W3-E (`feat/food-db-wave3e-submission-promotion`)
+  - Target PR: PR #908 (`feat/food-db-wave3e-submission-promotion`)
   - Status: In Progress
   - Area: backend / moderation workflow / restaurant coverage
   - Finding Type: correctness gap closure

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -170,7 +170,7 @@ def test_approved_submission_promotion_is_idempotent(
             SELECT raw_data_json
             FROM source_catalog
             WHERE entity_type = 'user_submission' AND entity_id = ?
-            ORDER BY created_at ASC
+            ORDER BY created_at ASC, id ASC
             """,
             (created["id"],),
         ).fetchall()

--- a/tests/test_restaurant_store_service.py
+++ b/tests/test_restaurant_store_service.py
@@ -94,6 +94,165 @@ def test_submission_lifecycle_with_audit(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert source_payload["reviewer_notes"] == "verified"
 
 
+def test_approved_submission_promotes_menu_item(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    created = restaurant_store.create_submission(
+        canonical_name="Power Wrap",
+        payload={
+            "chain_name": "Fit Hub",
+            "category": "Wraps",
+            "kcal": 420,
+            "protein_g": 28,
+            "fat_g": 12,
+            "carbs_g": 44,
+            "sodium_mg": 640,
+        },
+    )
+
+    reviewed = restaurant_store.review_submission(created["id"], status="approved")
+    assert reviewed is not None
+    assert reviewed["status"] == "approved"
+
+    chains = restaurant_store.search_restaurants("fit hub", limit=10, offset=0)
+    assert len(chains) == 1
+    assert chains[0]["id"] == "fit-hub"
+    assert chains[0]["source"] == restaurant_store.SUBMISSION_MENU_SOURCE
+
+    menu = restaurant_store.get_restaurant_menu("fit-hub", limit=10)
+    assert len(menu) == 1
+    assert menu[0]["item_name"] == "Power Wrap"
+    assert menu[0]["category"] == "Wraps"
+    assert menu[0]["kcal"] == 420.0
+    assert menu[0]["provenance_source"] == restaurant_store.SUBMISSION_MENU_SOURCE
+    assert menu[0]["provenance_record_id"] == f"submission-{created['id']}"
+
+    with restaurant_store._connect() as con:
+        promoted = con.execute(
+            """
+            SELECT source_name, source_record_id
+            FROM source_catalog
+            WHERE entity_type = 'restaurant_menu_item' AND entity_id = ?
+            """,
+            (menu[0]["id"],),
+        ).fetchall()
+    assert len(promoted) == 1
+    assert promoted[0]["source_name"] == restaurant_store.SUBMISSION_MENU_SOURCE
+
+
+def test_approved_submission_promotion_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    created = restaurant_store.create_submission(
+        canonical_name="Idempotent Bowl",
+        payload={"chain_name": "Fit Hub", "kcal": 390},
+    )
+
+    first = restaurant_store.review_submission(created["id"], status="approved")
+    second = restaurant_store.review_submission(created["id"], status="approved")
+    assert first is not None
+    assert second is not None
+    assert second["status"] == "approved"
+
+    with restaurant_store._connect() as con:
+        menu_rows = con.execute(
+            """
+            SELECT id
+            FROM restaurant_menu_items
+            WHERE source = ? AND source_id = ?
+            """,
+            (restaurant_store.SUBMISSION_MENU_SOURCE, f"submission-{created['id']}"),
+        ).fetchall()
+        promoted_sources = con.execute(
+            """
+            SELECT raw_data_json
+            FROM source_catalog
+            WHERE entity_type = 'user_submission' AND entity_id = ?
+            ORDER BY created_at ASC
+            """,
+            (created["id"],),
+        ).fetchall()
+    assert len(menu_rows) == 1
+    assert len(promoted_sources) == 2
+    first_payload = json.loads(promoted_sources[0]["raw_data_json"])
+    second_payload = json.loads(promoted_sources[1]["raw_data_json"])
+    assert first_payload["promoted_to_menu"] is True
+    assert second_payload["promoted_to_menu"] is False
+
+
+def test_rejected_submission_does_not_promote_menu_item(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    created = restaurant_store.create_submission(
+        canonical_name="Rejected Salad",
+        payload={"chain_name": "Fit Hub", "kcal": 120},
+    )
+
+    reviewed = restaurant_store.review_submission(created["id"], status="rejected")
+    assert reviewed is not None
+    assert reviewed["status"] == "rejected"
+
+    with restaurant_store._connect() as con:
+        menu_count = con.execute("SELECT COUNT(*) FROM restaurant_menu_items").fetchone()[0]
+        promoted_count = con.execute("""
+            SELECT COUNT(*)
+            FROM source_catalog
+            WHERE entity_type = 'restaurant_menu_item'
+            """).fetchone()[0]
+        moderation_row = con.execute(
+            """
+            SELECT raw_data_json
+            FROM source_catalog
+            WHERE entity_type = 'user_submission' AND entity_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (created["id"],),
+        ).fetchone()
+    assert menu_count == 0
+    assert promoted_count == 0
+    assert moderation_row is not None
+    moderation_payload = json.loads(moderation_row["raw_data_json"])
+    assert moderation_payload["promoted_to_menu"] is False
+
+
+def test_review_submission_rolls_back_on_promotion_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_db(monkeypatch, tmp_path)
+    created = restaurant_store.create_submission(
+        canonical_name="Rollback Burger",
+        payload={"chain_name": "Fit Hub", "kcal": 500},
+    )
+
+    def _boom(*args: object, **kwargs: object) -> bool:
+        raise RuntimeError("promotion failed")
+
+    monkeypatch.setattr(restaurant_store, "_upsert_menu_row", _boom)
+    with pytest.raises(RuntimeError, match="promotion failed"):
+        restaurant_store.review_submission(created["id"], status="approved")
+
+    current = restaurant_store.get_submission(created["id"])
+    assert current is not None
+    assert current["status"] == "pending"
+    assert current["audit"] == []
+    with restaurant_store._connect() as con:
+        menu_count = con.execute("SELECT COUNT(*) FROM restaurant_menu_items").fetchone()[0]
+        moderation_count = con.execute(
+            """
+            SELECT COUNT(*)
+            FROM source_catalog
+            WHERE entity_type = 'user_submission' AND entity_id = ?
+            """,
+            (created["id"],),
+        ).fetchone()[0]
+    assert menu_count == 0
+    assert moderation_count == 0
+
+
 def test_review_submission_invalid_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _set_test_db(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## Summary
- Promote approved `restaurant_menu` submissions into canonical menu rows.
- Reuse shared `_upsert_menu_row` path for importer and submission promotion.
- Add deterministic tests for approve/reject/idempotency/rollback.
- Update backlog ledger: mark W3-C merged and track W3-E execution item.

## Scope
- `app/services/restaurant_store.py`
- `tests/test_restaurant_store_service.py`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Validation
- `pytest -q tests/test_repo_policy_guards.py`
- `pytest -q tests/test_restaurant_store_service.py`
- `pytest -q tests/test_restaurants_router.py -k "submission or restaurant"`
- `make lint`
- `make typecheck`
- `make test-fast`
- `make diff-cov`
- `pre-commit run --all-files`
- `make verify`

## Carryover
- W3-C ledger status synced to merged PR #904.
- New W3-E runtime execution item added for follow-up tracking.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/908#discussion_r2855709328 -> 1805731c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/908#discussion_r2855709343 -> 1805731c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/908#pullrequestreview-3857213770 -> 1805731c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/908#pullrequestreview-3857295198 -> 1805731c

## Merge Readiness
- [x] Local hard gates passed (`make verify`)
- [x] `pre-commit run --all-files` passed
- [x] Ready for bot/reviewer pass (CodeRabbit/Sourcery/Cubic)