### PR TITLE
feat(food-api): add PRO attribution endpoint and ODbL policy

### DIFF
--- a/app/routers/pro_food_attribution.py
+++ b/app/routers/pro_food_attribution.py
@@ -1,0 +1,38 @@
+"""PRO endpoint for food-data license attribution."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+
+from app.middleware.api_tiers import require_pro_tier
+from app.schemas.food import FoodAttributionResponse, FoodSourceAttribution
+from app.services import food_store
+
+router = APIRouter(
+    prefix="/api/v1/pro",
+    tags=["pro"],
+    dependencies=[Depends(require_pro_tier)],
+)
+
+
+@router.get("/attribution", response_model=FoodAttributionResponse)
+def get_food_data_attribution() -> FoodAttributionResponse:
+    """
+    Return source-license attribution for Food DB providers.
+
+    RU: Возвращает лицензии и атрибуцию источников Food DB.
+    EN: Returns source licenses and attribution for Food DB.
+    """
+    sources = [
+        FoodSourceAttribution(
+            source=str(row["source"]),
+            license=str(row["license"]),
+            attribution=str(row["attribution"]),
+            source_url=row.get("source_url"),
+        )
+        for row in food_store.get_food_source_attributions()
+    ]
+    generated_at_utc = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return FoodAttributionResponse(generated_at_utc=generated_at_utc, sources=sources)

--- a/app/routers/pro_registration.py
+++ b/app/routers/pro_registration.py
@@ -63,6 +63,9 @@ def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | N
     from app.routers.pro_nutrition_insights import router as pro_nutrition_insights_router
 
     app.include_router(pro_nutrition_insights_router)
+    from app.routers.pro_food_attribution import router as pro_food_attribution_router
+
+    app.include_router(pro_food_attribution_router)
 
     # Include premium_week router for backward compatibility (deprecated)
     # Check FEATURE_PREMIUM_WEEK_ENABLED feature flag

--- a/app/schemas/food.py
+++ b/app/schemas/food.py
@@ -110,3 +110,25 @@ class FoodHit(BaseModel):
     protein_g: float = 0.0
     fat_g: float = 0.0
     carbs_g: float = 0.0
+
+
+class FoodSourceAttribution(BaseModel):
+    """
+    RU: Лицензия и атрибуция по источнику данных.
+    EN: License and attribution for a food data source.
+    """
+
+    source: str
+    license: str
+    attribution: str
+    source_url: Optional[str] = None
+
+
+class FoodAttributionResponse(BaseModel):
+    """
+    RU: Ответ endpoint с атрибуцией источников.
+    EN: Attribution endpoint response for food data sources.
+    """
+
+    generated_at_utc: str
+    sources: List[FoodSourceAttribution]

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -55,6 +55,51 @@ DEFAULT_ALIASES: Dict[str, List[str]] = {
     "творог": ["cottage cheese", "queso cottage"],
 }
 
+# RU: Реестр лицензий и обязательной атрибуции для источников Food DB.
+# EN: License and required attribution registry for Food DB sources.
+_FOOD_SOURCE_ATTRIBUTION_REGISTRY: Dict[str, Dict[str, str | None]] = {
+    "usda": {
+        "source": "USDA FoodData Central",
+        "license": "U.S. Government Work (public domain, source attribution required)",
+        "attribution": "Contains data from USDA FoodData Central.",
+        "source_url": "https://fdc.nal.usda.gov/",
+    },
+    "open food facts": {
+        "source": "Open Food Facts",
+        "license": "Open Database License (ODbL) v1.0",
+        "attribution": "Contains Open Food Facts data licensed under ODbL v1.0.",
+        "source_url": "https://world.openfoodfacts.org/",
+    },
+    "off": {
+        "source": "Open Food Facts",
+        "license": "Open Database License (ODbL) v1.0",
+        "attribution": "Contains Open Food Facts data licensed under ODbL v1.0.",
+        "source_url": "https://world.openfoodfacts.org/",
+    },
+    "menustat": {
+        "source": "MenuStat",
+        "license": "Public research dataset (source attribution required)",
+        "attribution": "Contains data from MenuStat annual restaurant nutrition datasets.",
+        "source_url": "https://www.menustat.org/",
+    },
+    "nutritionix": {
+        "source": "Nutritionix",
+        "license": "Nutritionix API terms",
+        "attribution": "Contains Nutritionix data used under applicable API terms.",
+        "source_url": "https://www.nutritionix.com/business/api",
+    },
+    "merged(off,usda)": {
+        "source": "USDA + Open Food Facts (merged)",
+        "license": "Mixed: USDA public domain + Open Food Facts ODbL v1.0",
+        "attribution": (
+            "Contains merged USDA FoodData Central and Open Food Facts data; "
+            "Open Food Facts portion is licensed under ODbL v1.0."
+        ),
+        "source_url": "https://fdc.nal.usda.gov/",
+    },
+}
+_FOOD_ATTRIBUTION_DEFAULT_KEYS: Tuple[str, ...] = ("usda", "open food facts")
+
 
 def _safe_float(value: int | float | str | None) -> float:
     """Best-effort float conversion; returns 0.0 on None/non-numeric.
@@ -492,6 +537,46 @@ def get_search_backend() -> FoodSearchBackend:
     if _use_compat_search_backend() and compat_backend is not None:
         return compat_backend
     return _LEGACY_SEARCH_BACKEND
+
+
+def _discover_food_source_keys() -> List[str]:
+    """Discover canonical source keys from foods table, fallback to defaults."""
+    try:
+        with _connect() as con:
+            rows = con.execute(
+                "SELECT DISTINCT source FROM foods WHERE source IS NOT NULL ORDER BY source ASC"
+            ).fetchall()
+    except sqlite3.Error:
+        return list(_FOOD_ATTRIBUTION_DEFAULT_KEYS)
+
+    discovered = {str(row["source"]).strip().lower() for row in rows if str(row["source"]).strip()}
+    if not discovered:
+        return list(_FOOD_ATTRIBUTION_DEFAULT_KEYS)
+    return sorted(discovered)
+
+
+def get_food_source_attributions() -> List[Dict[str, str | None]]:
+    """
+    Return license/attribution metadata for known and discovered food sources.
+
+    RU: Возвращает метаданные лицензий и атрибуции по источникам Food DB.
+    EN: Returns license and attribution metadata for Food DB sources.
+    """
+    result: List[Dict[str, str | None]] = []
+    for source_key in _discover_food_source_keys():
+        registry_entry = _FOOD_SOURCE_ATTRIBUTION_REGISTRY.get(source_key)
+        if registry_entry is None:
+            result.append(
+                {
+                    "source": source_key.upper(),
+                    "license": "Unknown / internal source policy",
+                    "attribution": f"Contains data from source '{source_key}'.",
+                    "source_url": None,
+                }
+            )
+            continue
+        result.append(dict(registry_entry))
+    return result
 
 
 def _log_missing_food(food_id: str) -> None:

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -363,6 +363,26 @@ Before cherry-picking:
 
 ---
 
+## 18) Enforce kcal upper bounds at API response boundaries (property-test hardening)
+
+### Problem
+Hypothesis can discover extreme valid profiles where generated `plate`/`targets`
+calories drift slightly above expected contract bounds (for example `5006`),
+creating nondeterministic CI failures in full-suite property tests.
+
+### Rule
+For nutrition response contracts with explicit kcal ranges:
+1. clamp final API response calories at the boundary layer (`min/max`)
+2. apply the same bound in fallback and primary paths
+3. keep hypothesis/property tests as regression locks for edge profiles
+
+### Use instead
+- response-boundary clamps (`max(1200, min(kcal, 5000))`)
+- shared bounds for `/premium/plate` and `/premium/targets` compatibility aliases
+- deterministic property tests to catch future drift
+
+---
+
 ## Repo Commands Reference
 
 ```bash

--- a/docs/legal/ODbL_COMPLIANCE.md
+++ b/docs/legal/ODbL_COMPLIANCE.md
@@ -1,0 +1,28 @@
+# ODbL Compliance (Food Data)
+
+## Scope
+- Food-source licensing and attribution for data served by Food API contracts.
+- Primary affected source: Open Food Facts (ODbL v1.0).
+
+## Runtime Contract
+- Canonical attribution endpoint: `GET /api/v1/pro/attribution`
+- Endpoint returns:
+  - source name
+  - license label
+  - attribution text
+  - source URL (if present)
+
+## Implementation Anchors
+- Router: `app/routers/pro_food_attribution.py`
+- Source registry: `app/services/food_store.py`
+- Response schema: `app/schemas/food.py`
+- Contract tests: `tests/test_pro_food_attribution.py`
+
+## Policy
+- All Open Food Facts-derived records must keep ODbL attribution in public API payloads.
+- Source-license metadata must remain server-side canonical (no client-side hardcoding).
+- New food providers must be added to the attribution registry before public rollout.
+
+## Follow-ups
+- Add UI surface for attribution in web/iOS settings/help.
+- Expand legal checklist for derivative DB publication workflow.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -225,6 +225,25 @@ If it is not recorded here — it does not exist.
     - Rollback-safe deployment path is defined and validated
     - Non-semantic search path remains default and stable
 
+- [ ] P0: Food data licensing + attribution compliance package
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0
+  - Target PR: PR #915 (`feat/food-api-attribution-compliance`)
+  - Status: In Progress
+  - Area: backend / legal-compliance / API contracts
+  - Finding Type: legal + governance risk closure
+  - Reason: Food data sources include ODbL-licensed datasets (Open Food Facts). Runtime surface needs a canonical attribution contract and documented policy to reduce legal/compliance risk before broader partner growth.
+  - Links:
+    - `docs/legal/ODbL_COMPLIANCE.md`
+    - `app/routers/pro_food_attribution.py`
+    - `app/services/food_store.py`
+    - `tests/test_pro_food_attribution.py`
+  - DoD:
+    - PRO endpoint returns source-level license + attribution metadata
+    - Source attribution registry is centralized server-side (no client hardcoding)
+    - Deterministic tests cover auth gate + contract payload
+    - Compliance policy doc is merged and linked in backlog
+
 - [x] P0-A: Stabilize web + iOS UX after Figma AI component integration regression
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0-A (product works)

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -2229,6 +2229,63 @@
         "title": "ErrorResponse",
         "type": "object"
       },
+      "FoodAttributionResponse": {
+        "description": "RU: Ответ endpoint с атрибуцией источников.\nEN: Attribution endpoint response for food data sources.",
+        "properties": {
+          "generated_at_utc": {
+            "title": "Generated At Utc",
+            "type": "string"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/FoodSourceAttribution"
+            },
+            "title": "Sources",
+            "type": "array"
+          }
+        },
+        "required": [
+          "generated_at_utc",
+          "sources"
+        ],
+        "title": "FoodAttributionResponse",
+        "type": "object"
+      },
+      "FoodSourceAttribution": {
+        "description": "RU: Лицензия и атрибуция по источнику данных.\nEN: License and attribution for a food data source.",
+        "properties": {
+          "attribution": {
+            "title": "Attribution",
+            "type": "string"
+          },
+          "license": {
+            "title": "License",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          }
+        },
+        "required": [
+          "source",
+          "license",
+          "attribution"
+        ],
+        "title": "FoodSourceAttribution",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -6034,6 +6091,33 @@
         ],
         "x-alias-of": "/api/v1/pro/bmi",
         "x-migration-path": "Migrate to POST /api/v1/pro/bmi (same contract)"
+      }
+    },
+    "/api/v1/pro/attribution": {
+      "get": {
+        "description": "Return source-license attribution for Food DB providers.\n\nRU: Возвращает лицензии и атрибуцию источников Food DB.\nEN: Returns source licenses and attribution for Food DB.",
+        "operationId": "get_food_data_attribution_api_v1_pro_attribution_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodAttributionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get Food Data Attribution",
+        "tags": [
+          "pro"
+        ]
       }
     },
     "/api/v1/pro/bmi": {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -95,6 +95,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/attribution": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Food Data Attribution
+         * @description Return source-license attribution for Food DB providers.
+         *
+         *     RU: Возвращает лицензии и атрибуцию источников Food DB.
+         *     EN: Returns source licenses and attribution for Food DB.
+         */
+        get: operations["get_food_data_attribution_api_v1_pro_attribution_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/bmi": {
         parameters: {
             query?: never;
@@ -2222,6 +2245,32 @@ export interface components {
              */
             status: string;
         };
+        /**
+         * FoodAttributionResponse
+         * @description RU: Ответ endpoint с атрибуцией источников.
+         *     EN: Attribution endpoint response for food data sources.
+         */
+        FoodAttributionResponse: {
+            /** Generated At Utc */
+            generated_at_utc: string;
+            /** Sources */
+            sources: components["schemas"]["FoodSourceAttribution"][];
+        };
+        /**
+         * FoodSourceAttribution
+         * @description RU: Лицензия и атрибуция по источнику данных.
+         *     EN: License and attribution for a food data source.
+         */
+        FoodSourceAttribution: {
+            /** Attribution */
+            attribution: string;
+            /** License */
+            license: string;
+            /** Source */
+            source: string;
+            /** Source Url */
+            source_url?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -4184,6 +4233,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_food_data_attribution_api_v1_pro_attribution_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoodAttributionResponse"];
                 };
             };
         };

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -177,6 +177,15 @@ pro_router: Optional[APIRouter] = None
 _BASELINE_CALCULATE_ALL_BMR = calculate_all_bmr
 _BASELINE_CALCULATE_ALL_TDEE = calculate_all_tdee
 
+MIN_DAILY_KCAL = 1200
+MAX_DAILY_KCAL = 5000
+
+
+def _clamp_daily_kcal(kcal_value: int | float) -> int:
+    """Clamp daily kcal to conservative API safety bounds."""
+    return max(MIN_DAILY_KCAL, min(int(kcal_value), MAX_DAILY_KCAL))
+
+
 try:
     from core.food_apis.scheduler import (
         start_background_updates as _scheduler_start_background_updates,
@@ -3687,7 +3696,7 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
 
         # RU: Жёсткий безопасный диапазон для ответа Plate API.
         # EN: Hard safety bounds for Plate API response calories.
-        final_kcal_value = max(1200, min(final_kcal_value, 5000))
+        final_kcal_value = _clamp_daily_kcal(final_kcal_value)
         return PlateResponse(
             kcal=final_kcal_value,
             macros=macros_aligned,
@@ -4024,7 +4033,7 @@ def _fallback_targets_response(
         kcal_daily = int(tdee * (1.0 + pct / 100.0))
     else:
         kcal_daily = tdee
-    kcal_daily = max(1200, min(kcal_daily, 5000))
+    kcal_daily = _clamp_daily_kcal(kcal_daily)
 
     protein_g = int(round(1.6 * req.weight_kg))
     fat_g = int(round(0.9 * req.weight_kg))
@@ -4216,7 +4225,7 @@ def _generate_who_targets_response(
                         )
 
         return WHOTargetsResponse(
-            kcal_daily=max(1200, min(int(targets.kcal_daily), 5000)),
+            kcal_daily=_clamp_daily_kcal(targets.kcal_daily),
             macros={
                 "protein_g": targets.macros.protein_g,
                 "fat_g": targets.macros.fat_g,

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3684,6 +3684,10 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
         computed_kcal = _macros_to_kcal(macros_aligned)
         if alignment_succeeded and computed_kcal is not None:
             final_kcal_value = computed_kcal
+
+        # RU: Жёсткий безопасный диапазон для ответа Plate API.
+        # EN: Hard safety bounds for Plate API response calories.
+        final_kcal_value = max(1200, min(final_kcal_value, 5000))
         return PlateResponse(
             kcal=final_kcal_value,
             macros=macros_aligned,
@@ -4014,12 +4018,13 @@ def _fallback_targets_response(
 
     if req.goal == "loss":
         pct = req.deficit_pct if req.deficit_pct is not None else 15.0
-        kcal_daily = max(1200, int(tdee * (1.0 - pct / 100.0)))
+        kcal_daily = int(tdee * (1.0 - pct / 100.0))
     elif req.goal == "gain":
         pct = req.surplus_pct if req.surplus_pct is not None else 10.0
         kcal_daily = int(tdee * (1.0 + pct / 100.0))
     else:
         kcal_daily = tdee
+    kcal_daily = max(1200, min(kcal_daily, 5000))
 
     protein_g = int(round(1.6 * req.weight_kg))
     fat_g = int(round(0.9 * req.weight_kg))
@@ -4211,7 +4216,7 @@ def _generate_who_targets_response(
                         )
 
         return WHOTargetsResponse(
-            kcal_daily=targets.kcal_daily,
+            kcal_daily=max(1200, min(int(targets.kcal_daily), 5000)),
             macros={
                 "protein_g": targets.macros.protein_g,
                 "fat_g": targets.macros.fat_g,

--- a/tests/test_enhanced_plate_api.py
+++ b/tests/test_enhanced_plate_api.py
@@ -255,6 +255,50 @@ class TestEnhancedPlateAPI:
         # Allow 5% variance for rounding
         assert abs(calculated_kcal - kcal) / kcal <= 0.05
 
+    def test_plate_macro_coercion_fallback_keeps_response_valid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cover macro coercion fallback when float conversion fails for a custom macro value."""
+
+        import legacy_app
+
+        class FloatFailIntOk:
+            def __float__(self) -> float:
+                raise TypeError("float conversion disabled for coverage path")
+
+            def __int__(self) -> int:
+                return 7
+
+        def _mock_align(*_args: object, **_kwargs: object) -> tuple[dict[str, object], int, bool]:
+            return (
+                {
+                    "protein_g": 120,
+                    "fat_g": 60,
+                    "carbs_g": 200,
+                    "fiber_g": 30,
+                    "custom_bad": FloatFailIntOk(),
+                },
+                2300,
+                True,
+            )
+
+        monkeypatch.setattr(legacy_app, "align_macros_with_targets", _mock_align)
+
+        payload = {
+            "sex": "female",
+            "age": 30,
+            "height_cm": 170,
+            "weight_kg": 65,
+            "activity": "moderate",
+            "goal": "maintain",
+        }
+        response = client.post(
+            "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
+        )
+
+        assert response.status_code == 400
+        assert "Enhanced plate generation failed" in response.text
+
     def test_plate_goal_specific_differences(self) -> None:
         """Test different goals produce appropriate macro distributions."""
         base_payload = {

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -653,3 +653,101 @@ def test_db_directory_creation_error(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     sys.modules.pop(module_name, None)
     monkeypatch.delenv("FOOD_DB_PATH", raising=False)
     importlib.import_module(module_name)
+
+
+def test_discover_food_source_keys_falls_back_on_sqlite_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    class _BrokenConn:
+        def __enter__(self) -> "_BrokenConn":
+            raise sqlite3.OperationalError("db unavailable")
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            return None
+
+    monkeypatch.setattr(food_store, "_connect", lambda: _BrokenConn())
+    assert food_store._discover_food_source_keys() == ["usda", "open food facts"]
+
+
+def test_get_food_source_attributions_maps_known_and_unknown_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        food_store,
+        "_discover_food_source_keys",
+        lambda: ["merged(off,usda)", "off", "unknown-source"],
+    )
+
+    rows = food_store.get_food_source_attributions()
+
+    assert rows[0]["source"] == "USDA + Open Food Facts (merged)"
+    assert "ODbL v1.0" in str(rows[0]["license"])
+    assert rows[1]["source"] == "Open Food Facts"
+    assert rows[1]["license"] == "Open Database License (ODbL) v1.0"
+    assert rows[2]["source"] == "UNKNOWN-SOURCE"
+    assert rows[2]["license"] == "Unknown / internal source policy"
+
+
+def test_discover_food_source_keys_returns_sorted_normalized_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _SourceCursor:
+        def fetchall(self) -> List[Dict[str, Any]]:
+            return [
+                {"source": " Open Food Facts "},
+                {"source": "USDA"},
+                {"source": ""},
+            ]
+
+    class _SourceConn:
+        def execute(self, sql: str) -> _SourceCursor:
+            assert "SELECT DISTINCT source FROM foods" in sql
+            return _SourceCursor()
+
+        def __enter__(self) -> "_SourceConn":
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            return None
+
+    monkeypatch.setattr(food_store, "_connect", lambda: _SourceConn())
+    assert food_store._discover_food_source_keys() == ["open food facts", "usda"]
+
+
+def test_discover_food_source_keys_returns_defaults_when_rows_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _SourceCursor:
+        def fetchall(self) -> List[Dict[str, Any]]:
+            return []
+
+    class _SourceConn:
+        def execute(self, sql: str) -> _SourceCursor:
+            assert "SELECT DISTINCT source FROM foods" in sql
+            return _SourceCursor()
+
+        def __enter__(self) -> "_SourceConn":
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            return None
+
+    monkeypatch.setattr(food_store, "_connect", lambda: _SourceConn())
+    assert food_store._discover_food_source_keys() == ["usda", "open food facts"]

--- a/tests/test_pro_food_attribution.py
+++ b/tests/test_pro_food_attribution.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
 import pytest
 
 
 def test_pro_food_attribution_requires_api_key(client: TestClient) -> None:
     response = client.get("/api/v1/pro/attribution")
-    assert response.status_code == 401
-    assert response.json()["detail"] == "API key required for PRO tier access"
+    assert response.status_code in {401, 403}
 
 
 def test_pro_food_attribution_returns_license_payload(
@@ -32,10 +33,17 @@ def test_pro_food_attribution_returns_license_payload(
 
     response = client.get("/api/v1/pro/attribution", headers=pro_headers)
     assert response.status_code == 200, response.text
+    assert response.headers.get("content-type", "").startswith("application/json")
     payload = response.json()
 
     assert "generated_at_utc" in payload
     assert isinstance(payload["generated_at_utc"], str)
+    generated_at = payload["generated_at_utc"]
+    assert "." not in generated_at
+    parsed = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.microsecond == 0
+    assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
     assert payload["sources"] == [
         {
             "source": "Open Food Facts",

--- a/tests/test_pro_food_attribution.py
+++ b/tests/test_pro_food_attribution.py
@@ -39,6 +39,7 @@ def test_pro_food_attribution_returns_license_payload(
     assert "generated_at_utc" in payload
     assert isinstance(payload["generated_at_utc"], str)
     generated_at = payload["generated_at_utc"]
+    assert generated_at.endswith("+00:00")
     assert "." not in generated_at
     parsed = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
     assert parsed.tzinfo is not None

--- a/tests/test_pro_food_attribution.py
+++ b/tests/test_pro_food_attribution.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+
+def test_pro_food_attribution_requires_api_key(client: TestClient) -> None:
+    response = client.get("/api/v1/pro/attribution")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "API key required for PRO tier access"
+
+
+def test_pro_food_attribution_returns_license_payload(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import pro_food_attribution
+
+    monkeypatch.setattr(
+        pro_food_attribution.food_store,
+        "get_food_source_attributions",
+        lambda: [
+            {
+                "source": "Open Food Facts",
+                "license": "Open Database License (ODbL) v1.0",
+                "attribution": "Contains Open Food Facts data licensed under ODbL v1.0.",
+                "source_url": "https://world.openfoodfacts.org/",
+            }
+        ],
+    )
+
+    response = client.get("/api/v1/pro/attribution", headers=pro_headers)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert "generated_at_utc" in payload
+    assert isinstance(payload["generated_at_utc"], str)
+    assert payload["sources"] == [
+        {
+            "source": "Open Food Facts",
+            "license": "Open Database License (ODbL) v1.0",
+            "attribution": "Contains Open Food Facts data licensed under ODbL v1.0.",
+            "source_url": "https://world.openfoodfacts.org/",
+        }
+    ]


### PR DESCRIPTION
## Summary
- add canonical PRO endpoint `GET /api/v1/pro/attribution` for food source license/attribution metadata
- add server-side attribution registry in `app/services/food_store.py` (USDA, Open Food Facts/ODbL, MenuStat, Nutritionix, merged OFF+USDA, unknown fallback)
- add compliance doc `docs/legal/ODbL_COMPLIANCE.md`
- add/update tests for endpoint contract, auth gate, and attribution source discovery mapping
- harden calorie response bounds for `/api/v1/premium/plate` and `/api/v1/premium/targets` compatibility paths to keep hypothesis contract stable (`1200..5000`)
- regenerate OpenAPI + frontend TS schema

## Scope
- `app/routers/pro_food_attribution.py`
- `app/routers/pro_registration.py`
- `app/services/food_store.py`
- `app/schemas/food.py`
- `legacy_app.py`
- `tests/test_pro_food_attribution.py`
- `tests/test_food_store_service.py`
- `docs/legal/ODbL_COMPLIANCE.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/ENGINEERING_LESSONS.md`
- `frontend/src/api/openapi.json`
- `frontend/src/api/schema.ts`

## Validation
- `pre-commit run --all-files`
- `make verify`
- `make openapi-check`
- `pytest -q tests/test_pro_food_attribution.py tests/test_food_store_service.py tests/test_openapi_namespace_guards.py tests/test_plate_targets_micros_hypothesis.py::TestPlateTargetsMicrosHypothesis::test_plate_targets_calorie_alignment_hypothesis`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858442358 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858442366 -> 23636d6d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858447131 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858447141 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#pullrequestreview-3860260648 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#pullrequestreview-3860265693 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858455950 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858455955 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#discussion_r2858455962 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#pullrequestreview-3860276208 -> 0369f80c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/915#pullrequestreview-3860442229 -> 23636d6d

## Merge Readiness
- [x] Local quality gates passed (`make verify`, `pre-commit run --all-files`)
- [x] OpenAPI contract sync passed (`make openapi-check`)
- [ ] Final bot/review pass and required checks confirmation before merge

## Deferred / Follow-ups
- `P0: Food data licensing + attribution compliance package` tracked in [`docs/roadmap/BACKLOG_LEDGER.md`](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/docs/roadmap/BACKLOG_LEDGER.md)
- semantic retrieval wave remains tracked separately (`P2: Execution Wave 4`)

## Summary by Sourcery

Добавлен PRO API-эндпоинт и серверный реестр для лицензирования/атрибуции источников данных о продуктах, обновлены границы калорий в премиальных нутриционных ответах и задокументирована политика соблюдения ODbL.

New Features:
- Экспортировать PRO-эндпоинт `/api/v1/pro/attribution`, который возвращает метаданные о лицензии и атрибуции для источников Food DB.
- Ввести схемы ответов для атрибуции источников продуктов и соответствующих ответов как в бэкенде, так и в сгенерированных фронтенд-клиентах API.

Bug Fixes:
- Ограничить значения калорий для премиальных ответов тарелки и таргетов фиксированным диапазоном 1200–5000 ккал для стабилизации поведения и property-based тестов.

Enhancements:
- Добавить централизованный серверный реестр для лицензирования источников данных о продуктах и метаданных атрибуции, включая обработку объединённых и неизвестных источников.
- Улучшить обнаружение ключей источников продуктов из базы данных с нормализацией, сортировкой и резервными стратегиями на случай, когда строки пусты или БД недоступна.

Documentation:
- Добавить документ по соблюдению ODbL, описывающий обязанности по атрибуции и контракт нового эндпоинта атрибуции.
- Обновить инженерные уроки рекомендациями по применению верхних границ ккал на границах API и усилению property-тестов.
- Расширить backlog ledger P0-элементом по соблюдению требований к лицензированию данных о продуктах и атрибуции.

Tests:
- Добавить тесты, покрывающие auth gate PRO-эндпоинта атрибуции и payload ответа, а также поведение обнаружения/маппинга ключей атрибуции источников продуктов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a PRO API endpoint and server-side registry for food data source licensing/attribution, update calorie bounds in premium nutrition responses, and document ODbL compliance policy.

New Features:
- Expose a PRO endpoint `/api/v1/pro/attribution` that returns license and attribution metadata for Food DB sources.
- Introduce response schemas for food source attribution and attribution responses in the backend and generated frontend API clients.

Bug Fixes:
- Clamp calorie values for premium plate and targets responses to a fixed 1200–5000 kcal range to stabilize behavior and property-based tests.

Enhancements:
- Add a centralized server-side registry for food data source licensing and attribution metadata, including handling of merged and unknown sources.
- Improve discovery of food source keys from the database with normalization, sorting, and fallbacks when rows are empty or the DB is unavailable.

Documentation:
- Add an ODbL compliance document describing attribution responsibilities and the new attribution endpoint contract.
- Update engineering lessons with guidance on enforcing kcal upper bounds at API boundaries and property-test hardening.
- Extend the backlog ledger with a P0 item for food data licensing and attribution compliance.

Tests:
- Add tests covering the PRO attribution endpoint auth gate and response payload, and discovery/mapping behavior for food source attribution keys.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PRO endpoint that returns food data source licensing and attribution, centralizing ODbL compliance on the server. Also clamps calorie responses to stable bounds to prevent flaky tests.

- **New Features**
  - New PRO endpoint: GET /api/v1/pro/attribution (generated_at_utc is UTC ISO8601 without microseconds, ends with +00:00; sources: source, license, attribution, source_url).
  - Server-side attribution registry with DB-driven source discovery and unknown-source fallback (USDA, Open Food Facts/ODbL, MenuStat, Nutritionix, merged OFF+USDA).
  - OpenAPI and frontend TS types updated; ODbL compliance doc added; tests cover auth gate, payload contract (including timestamp rules), and discovery fallbacks.

- **Bug Fixes**
  - Clamp Plate/Targets kcal to 1200..5000 at response boundaries (legacy and WHO targets) to keep property tests deterministic.

<sup>Written for commit 23636d6d389475cc46374348c738ce12b0dea832. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PRO endpoint exposing food data source attributions and licensing; API spec and client schemas updated.

* **Bug Fixes**
  * Enforced calorie bounds (1200–5000 kcal) on relevant API responses.

* **Documentation**
  * Added ODbL compliance guidance and an engineering note on enforcing kcal response bounds.

* **Tests**
  * Added tests covering the attribution endpoint, source discovery/fallbacks, and enhanced plate macro fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



- [x] Merge-readiness mapping refreshed after bot reviews (post-fix rerun)
