### PR TITLE
Feat/p0 2 ws namespace migration clean

### DIFF
--- a/.github/workflows/auto-delete-branches.yml
+++ b/.github/workflows/auto-delete-branches.yml
@@ -22,24 +22,21 @@ jobs:
         run: |
           echo "Deleting merged branch: ${HEAD_REF}"
 
-          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
-          delete_branch() {
-            curl -s -X DELETE \
-              --connect-timeout 10 \
-              --max-time 30 \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}"
-          }
+          # Delete with retry using curl's native --retry for network errors
+          # GitHub API returns 204 on success (no body) or 404 if already deleted
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 5 \
+            --retry-all-errors \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}")
 
-          n=0 max=3 delay=5
-          until result=$(delete_branch) && echo "$result" | jq -e '.message // empty' >/dev/null 2>&1; do
-            n=$((n + 1))
-            if [ "$n" -ge "$max" ]; then
-              echo "$result" | jq -r '.message // "deleted"'
-              break
-            fi
-            echo "API call failed, retry $n/$max in ${delay}s..." >&2
-            sleep "$delay"
-          done
-          echo "$result" | jq -r '.message // "deleted"' || true
+          # 204 = deleted, 404 = already deleted (both are success)
+          if [ "$http_code" = "204" ] || [ "$http_code" = "404" ]; then
+            echo "✅ Branch deleted (HTTP $http_code)"
+          else
+            echo "⚠️ Unexpected HTTP $http_code (branch may already be deleted)"
+          fi

--- a/.github/workflows/auto-delete-branches.yml
+++ b/.github/workflows/auto-delete-branches.yml
@@ -21,8 +21,25 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           echo "Deleting merged branch: ${HEAD_REF}"
-          curl -s -X DELETE \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}" \
-            | jq -r '.message // "deleted"' || true
+
+          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
+          delete_branch() {
+            curl -s -X DELETE \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}"
+          }
+
+          n=0 max=3 delay=5
+          until result=$(delete_branch) && echo "$result" | jq -e '.message // empty' >/dev/null 2>&1; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "$result" | jq -r '.message // "deleted"'
+              break
+            fi
+            echo "API call failed, retry $n/$max in ${delay}s..." >&2
+            sleep "$delay"
+          done
+          echo "$result" | jq -r '.message // "deleted"' || true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,7 +127,7 @@ jobs:
             local n=0 max=3 delay=5
             until "$@"; do
               n=$((n + 1))
-              if [ "$n" -ge "$max" ]; then return 1; fi
+              if [ "$n" -gt "$max" ]; then return 1; fi
               echo "gh command failed, retry $n/$max in ${delay}s..." >&2
               sleep "$delay"
             done
@@ -165,7 +165,7 @@ jobs:
             local n=0 max=3 delay=5
             until "$@"; do
               n=$((n + 1))
-              if [ "$n" -ge "$max" ]; then return 1; fi
+              if [ "$n" -gt "$max" ]; then return 1; fi
               echo "gh command failed, retry $n/$max in ${delay}s..." >&2
               sleep "$delay"
             done

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,8 +122,19 @@ jobs:
         run: |
           TAG_COMMIT=$(git rev-parse "${GITHUB_REF#refs/tags/}")
 
-          LAST_NIGHTLY_CONCLUSION=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
-          LAST_NIGHTLY_COMMIT=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
+          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
+          gh_retry() {
+            local n=0 max=3 delay=5
+            until "$@"; do
+              n=$((n + 1))
+              if [ "$n" -ge "$max" ]; then return 1; fi
+              echo "gh command failed, retry $n/$max in ${delay}s..." >&2
+              sleep "$delay"
+            done
+          }
+
+          LAST_NIGHTLY_CONCLUSION=$(gh_retry gh run list --workflow=nightly.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
+          LAST_NIGHTLY_COMMIT=$(gh_retry gh run list --workflow=nightly.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
 
           if [ "$LAST_NIGHTLY_CONCLUSION" != "success" ] || [ "$LAST_NIGHTLY_CONCLUSION" = "null" ]; then
             echo "❌ Last nightly test did not pass or is missing: $LAST_NIGHTLY_CONCLUSION"
@@ -149,8 +160,19 @@ jobs:
         run: |
           TAG_COMMIT=$(git rev-parse "${GITHUB_REF#refs/tags/}")
 
-          MAIN_CI_CONCLUSION=$(gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
-          MAIN_CI_COMMIT=$(gh run list --workflow=ci.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
+          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
+          gh_retry() {
+            local n=0 max=3 delay=5
+            until "$@"; do
+              n=$((n + 1))
+              if [ "$n" -ge "$max" ]; then return 1; fi
+              echo "gh command failed, retry $n/$max in ${delay}s..." >&2
+              sleep "$delay"
+            done
+          }
+
+          MAIN_CI_CONCLUSION=$(gh_retry gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
+          MAIN_CI_COMMIT=$(gh_retry gh run list --workflow=ci.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
 
           if [ "$MAIN_CI_CONCLUSION" != "success" ] || [ "$MAIN_CI_CONCLUSION" = "null" ]; then
             echo "❌ CI on main branch did not pass or is missing: $MAIN_CI_CONCLUSION"

--- a/app/main.py
+++ b/app/main.py
@@ -27,8 +27,15 @@ register_pro_contract_routes(app)
 
 
 def _assert_no_duplicate_ws_route() -> None:
-    """Fail fast if /ws is already registered elsewhere."""
+    """Fail fast if /ws or /api/v1/pro/ws is already registered elsewhere."""
     existing_paths = {getattr(route, "path", None) for route in app.routes}
+    # Check for duplicate canonical PRO WS path
+    if "/api/v1/pro/ws" in existing_paths:
+        raise RuntimeError(
+            "Duplicate /api/v1/pro/ws route detected. "
+            "Check legacy_app.py or other router registration points."
+        )
+    # Check for duplicate legacy WS path (will be registered by realtime_ws.router)
     if "/ws" in existing_paths:
         raise RuntimeError(
             "Duplicate /ws route detected. "

--- a/app/middleware/metrics.py
+++ b/app/middleware/metrics.py
@@ -37,7 +37,8 @@ ROUTE_CACHE_MAX_SIZE: int = 1024
 ROUTE_CACHE_TTL_S: float | None = None
 
 # Bounded WS observability labels (low-cardinality contract).
-WS_ALLOWED_PATH_LABELS: frozenset[str] = frozenset({"/ws"})
+WS_ALLOWED_PATH_LABELS: frozenset[str] = frozenset({"/ws", "/api/v1/pro/ws"})
+# Note: /ws is deprecated; /api/v1/pro/ws is the canonical PRO namespace
 WS_ALLOWED_CLOSE_REASONS: frozenset[str] = frozenset(
     {
         "ws_disabled",

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -427,7 +427,7 @@ async def _ws_handler(ws: WebSocket, path_label: str = WS_ROUTE_LABEL) -> None:
 @router.websocket(WS_CANONICAL_PATH)
 async def ws_pro(ws: WebSocket) -> None:
     """Canonical PRO WebSocket endpoint at /api/v1/pro/ws."""
-    await _ws_handler(ws, path_label=WS_ROUTE_LABEL)
+    await _ws_handler(ws, path_label=WS_CANONICAL_PATH)
 
 
 @router.websocket(WS_LEGACY_PATH)
@@ -440,4 +440,4 @@ async def ws_root(ws: WebSocket) -> None:
     logger.warning(
         "ws_legacy_path_deprecated", extra={"path": WS_LEGACY_PATH, "canonical": WS_CANONICAL_PATH}
     )
-    await _ws_handler(ws, path_label=WS_ROUTE_LABEL)
+    await _ws_handler(ws, path_label=WS_LEGACY_PATH)

--- a/app/routers/realtime_ws.py
+++ b/app/routers/realtime_ws.py
@@ -25,7 +25,13 @@ from app.middleware.metrics import (
 
 router = APIRouter(tags=["realtime"])
 logger = logging.getLogger(__name__)
-WS_ROUTE_LABEL: str = "/ws"
+
+# Canonical PRO namespace for WebSocket (P0-2)
+WS_CANONICAL_PATH: str = "/api/v1/pro/ws"
+# Legacy root path (deprecated, kept for transition window)
+WS_LEGACY_PATH: str = "/ws"
+# Route label for metrics (use canonical path)
+WS_ROUTE_LABEL: str = WS_CANONICAL_PATH
 
 DEFAULT_MAX_MESSAGE_BYTES: int = 4_096
 DEFAULT_WINDOW_SECONDS: int = 10
@@ -175,11 +181,13 @@ def _extract_bearer_token(ws: WebSocket) -> str | None:
     return token or None
 
 
-async def _authenticate_or_close(ws: WebSocket) -> bool:
+async def _authenticate_or_close(ws: WebSocket, path_label: str = WS_ROUTE_LABEL) -> bool:
     """Authenticate websocket and close with policy code on failure."""
     token = _extract_bearer_token(ws)
     if not token:
-        await _close_with_policy(ws, REASON_AUTH_REQUIRED, record_rejected_connect=True)
+        await _close_with_policy(
+            ws, REASON_AUTH_REQUIRED, record_rejected_connect=True, path_override=path_label
+        )
         return False
 
     try:
@@ -187,7 +195,9 @@ async def _authenticate_or_close(ws: WebSocket) -> bool:
         await run_in_threadpool(verifier, token)
         return True
     except Exception:
-        await _close_with_policy(ws, REASON_AUTH_INVALID, record_rejected_connect=True)
+        await _close_with_policy(
+            ws, REASON_AUTH_INVALID, record_rejected_connect=True, path_override=path_label
+        )
         return False
 
 
@@ -255,7 +265,7 @@ def _encode_event(event: dict[str, Any]) -> str:
 
 
 async def _receive_frame_with_idle_timeout(
-    ws: WebSocket, idle_timeout_seconds: int
+    ws: WebSocket, idle_timeout_seconds: int, path_label: str = WS_ROUTE_LABEL
 ) -> MutableMapping[str, Any] | None:
     """Receive one frame, optionally enforcing idle timeout."""
     try:
@@ -263,7 +273,7 @@ async def _receive_frame_with_idle_timeout(
             return await ws.receive()
         return await asyncio.wait_for(ws.receive(), timeout=float(idle_timeout_seconds))
     except asyncio.TimeoutError:
-        await _close_with_policy(ws, REASON_IDLE_TIMEOUT)
+        await _close_with_policy(ws, REASON_IDLE_TIMEOUT, path_override=path_label)
         return None
 
 
@@ -273,13 +283,15 @@ async def _close_with_policy(
     *,
     extra_fields: dict[str, Any] | None = None,
     record_rejected_connect: bool = False,
+    path_override: str | None = None,
 ) -> None:
     """Close websocket with normalized, structured policy log."""
+    path_label = path_override if path_override is not None else WS_ROUTE_LABEL
     if record_rejected_connect:
-        record_ws_connect(WS_ROUTE_LABEL, result="rejected", reason=reason)
+        record_ws_connect(path_label, result="rejected", reason=reason)
 
     log_payload: dict[str, Any] = {
-        "path": WS_ROUTE_LABEL,
+        "path": path_label,
         "close_code": POLICY_CLOSE_CODE,
         "reason": normalize_ws_close_reason(reason),
     }
@@ -289,29 +301,32 @@ async def _close_with_policy(
     await ws.close(code=POLICY_CLOSE_CODE, reason=reason)
 
 
-@router.websocket("/ws")
-async def ws_root(ws: WebSocket) -> None:
-    """Secure and deterministic WebSocket endpoint."""
+async def _ws_handler(ws: WebSocket, path_label: str = WS_ROUTE_LABEL) -> None:
+    """Shared WebSocket handler for canonical and legacy paths."""
     await ws.accept()
 
     ws_metrics_active = False
 
     if not _is_ws_enabled():
-        await _close_with_policy(ws, REASON_WS_DISABLED, record_rejected_connect=True)
+        await _close_with_policy(
+            ws, REASON_WS_DISABLED, record_rejected_connect=True, path_override=path_label
+        )
         return
 
     policy = _policy_from_env()
     connection_acquired = _active_connections.try_acquire(policy.max_connections)
     if not connection_acquired:
-        await _close_with_policy(ws, REASON_TOO_MANY_CONNECTIONS, record_rejected_connect=True)
+        await _close_with_policy(
+            ws, REASON_TOO_MANY_CONNECTIONS, record_rejected_connect=True, path_override=path_label
+        )
         return
 
     try:
-        if not await _authenticate_or_close(ws):
+        if not await _authenticate_or_close(ws, path_label):
             return
 
-        record_ws_connect(WS_ROUTE_LABEL, reason="none")
-        inc_ws_active_connections(WS_ROUTE_LABEL)
+        record_ws_connect(path_label, reason="none")
+        inc_ws_active_connections(path_label)
         ws_metrics_active = True
 
         limiter = _BurstLimiter(
@@ -323,6 +338,7 @@ async def ws_root(ws: WebSocket) -> None:
             frame = await _receive_frame_with_idle_timeout(
                 ws,
                 policy.idle_timeout_seconds,
+                path_label,
             )
             if frame is None:
                 return
@@ -331,27 +347,29 @@ async def ws_root(ws: WebSocket) -> None:
 
             text = frame.get("text")
             if text is None:
-                await _close_with_policy(ws, REASON_TEXT_FRAME_REQUIRED)
+                await _close_with_policy(ws, REASON_TEXT_FRAME_REQUIRED, path_override=path_label)
                 return
 
             if not _is_within_size_limit(text, policy.max_message_bytes):
-                await _close_with_policy(ws, REASON_PAYLOAD_TOO_LARGE)
+                await _close_with_policy(ws, REASON_PAYLOAD_TOO_LARGE, path_override=path_label)
                 return
 
-            record_ws_message(WS_ROUTE_LABEL, direction="in")
+            record_ws_message(path_label, direction="in")
 
             if not limiter.allow():
-                await _close_with_policy(ws, REASON_RATE_LIMITED)
+                await _close_with_policy(ws, REASON_RATE_LIMITED, path_override=path_label)
                 return
 
             message = _parse_message(text)
             if message is None:
-                await _close_with_policy(ws, REASON_INVALID_JSON)
+                await _close_with_policy(ws, REASON_INVALID_JSON, path_override=path_label)
                 return
 
             message_type = message.get("type")
             if not isinstance(message_type, str) or message_type not in policy.allowed_event_types:
-                await _close_with_policy(ws, REASON_EVENT_TYPE_NOT_ALLOWED)
+                await _close_with_policy(
+                    ws, REASON_EVENT_TYPE_NOT_ALLOWED, path_override=path_label
+                )
                 return
 
             version = _resolve_message_version(message, policy)
@@ -360,6 +378,7 @@ async def ws_root(ws: WebSocket) -> None:
                     ws,
                     REASON_UNSUPPORTED_VERSION,
                     extra_fields={"version": version, "type": message_type},
+                    path_override=path_label,
                 )
                 return
 
@@ -373,13 +392,15 @@ async def ws_root(ws: WebSocket) -> None:
                         }
                     )
                 )
-                record_ws_message(WS_ROUTE_LABEL, direction="out")
+                record_ws_message(path_label, direction="out")
                 continue
 
             if message_type == "subscribe":
                 channel = message.get("channel")
                 if not isinstance(channel, str) or channel not in policy.allowed_channels:
-                    await _close_with_policy(ws, REASON_CHANNEL_NOT_ALLOWED)
+                    await _close_with_policy(
+                        ws, REASON_CHANNEL_NOT_ALLOWED, path_override=path_label
+                    )
                     return
 
                 await ws.send_text(
@@ -391,13 +412,32 @@ async def ws_root(ws: WebSocket) -> None:
                         }
                     )
                 )
-                record_ws_message(WS_ROUTE_LABEL, direction="out")
+                record_ws_message(path_label, direction="out")
                 continue
     except WebSocketDisconnect:
         logger.info("ws_disconnect", extra={"reason": "client_disconnected"})
         return
     finally:
         if ws_metrics_active:
-            dec_ws_active_connections(WS_ROUTE_LABEL)
+            dec_ws_active_connections(path_label)
         if connection_acquired:
             _active_connections.release()
+
+
+@router.websocket(WS_CANONICAL_PATH)
+async def ws_pro(ws: WebSocket) -> None:
+    """Canonical PRO WebSocket endpoint at /api/v1/pro/ws."""
+    await _ws_handler(ws, path_label=WS_ROUTE_LABEL)
+
+
+@router.websocket(WS_LEGACY_PATH)
+async def ws_root(ws: WebSocket) -> None:
+    """Legacy WebSocket endpoint at /ws (deprecated, use /api/v1/pro/ws).
+
+    This endpoint is kept for backward compatibility during the transition window.
+    Clients should migrate to /api/v1/pro/ws.
+    """
+    logger.warning(
+        "ws_legacy_path_deprecated", extra={"path": WS_LEGACY_PATH, "canonical": WS_CANONICAL_PATH}
+    )
+    await _ws_handler(ws, path_label=WS_ROUTE_LABEL)

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -30,7 +30,7 @@ describe("wsClient", (): void => {
     };
     setApiClientDependencies(deps);
 
-    expect(buildRealtimeWsUrl("/ws")).toBe("wss://api.example.com/ws");
+    expect(buildRealtimeWsUrl("/api/v1/pro/ws")).toBe("wss://api.example.com/api/v1/pro/ws");
   });
 
   it("buildRealtimeWsUrl appends token in query string", (): void => {
@@ -41,7 +41,7 @@ describe("wsClient", (): void => {
     };
     setApiClientDependencies(deps);
 
-    expect(buildRealtimeWsUrl("/ws", "abc123")).toBe("ws://localhost:8000/ws?token=abc123");
+    expect(buildRealtimeWsUrl("/api/v1/pro/ws", "abc123")).toBe("ws://localhost:8000/api/v1/pro/ws?token=abc123");
   });
 
   it("connectRealtimeWs emits state transitions and parses messages", (): void => {
@@ -71,7 +71,7 @@ describe("wsClient", (): void => {
     });
 
     expect(states).toEqual(["connecting"]);
-    expect(wsCtor).toHaveBeenCalledWith("ws://localhost:8000/ws");
+    expect(wsCtor).toHaveBeenCalledWith("ws://localhost:8000/api/v1/pro/ws");
 
     fakeSocket.onopen?.();
     fakeSocket.onmessage?.({ data: '{"version":"1","type":"pong"}' });

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -2317,42 +2317,6 @@
         "title": "Ingredient",
         "type": "object"
       },
-      "InsightRequest": {
-        "properties": {
-          "text": {
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Text",
-            "type": "string"
-          }
-        },
-        "required": [
-          "text"
-        ],
-        "title": "InsightRequest",
-        "type": "object"
-      },
-      "InsightResponse": {
-        "description": "Insight response payload.\n\nRU: Явная модель ответа нужна для стабильного OpenAPI и генерации типов фронтенда.\nEN: Explicit response model keeps OpenAPI stable and enables TS type generation.",
-        "properties": {
-          "insight": {
-            "minLength": 1,
-            "title": "Insight",
-            "type": "string"
-          },
-          "provider": {
-            "minLength": 1,
-            "title": "Provider",
-            "type": "string"
-          }
-        },
-        "required": [
-          "provider",
-          "insight"
-        ],
-        "title": "InsightResponse",
-        "type": "object"
-      },
       "LegacyWeekPlanRequest": {
         "additionalProperties": false,
         "description": "Extended request for week plan with optional pre-calculated targets.\n\nSupports two modes:\n- Mode A: With targets (pre-calculated nutrition goals)\n- Mode B: Calculate targets from user profile (sex, age, etc.)",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2283,24 +2283,6 @@ export interface components {
             /** Grams */
             grams: number;
         };
-        /** InsightRequest */
-        InsightRequest: {
-            /** Text */
-            text: string;
-        };
-        /**
-         * InsightResponse
-         * @description Insight response payload.
-         *
-         *     RU: Явная модель ответа нужна для стабильного OpenAPI и генерации типов фронтенда.
-         *     EN: Explicit response model keeps OpenAPI stable and enables TS type generation.
-         */
-        InsightResponse: {
-            /** Insight */
-            insight: string;
-            /** Provider */
-            provider: string;
-        };
         /**
          * LegacyWeekPlanRequest
          * @description Extended request for week plan with optional pre-calculated targets.

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -18,7 +18,8 @@ export interface RealtimeWsConnectOptions {
   onStateChange?: (state: WsConnectionState) => void;
 }
 
-const DEFAULT_WS_PATH = "/ws";
+const DEFAULT_WS_PATH = "/api/v1/pro/ws";
+// Legacy path "/ws" is deprecated; migrate to canonical PRO namespace
 
 function toWsBaseUrl(apiBase: string): string {
   const parsed = new URL(apiBase);

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -714,7 +714,9 @@ _OPENAPI_ALLOWED_PREFIXES: tuple[str, ...] = (
     "/api/v1/pro/",
     "/api/v1/vip/",
 )
-_OPENAPI_ALLOWED_EXACT: frozenset[str] = frozenset({"/api/v1/bmi", "/ws"})
+_OPENAPI_ALLOWED_EXACT: frozenset[str] = frozenset({"/api/v1/bmi"})
+# Note: /ws is no longer in allowed exact - WebSocket is now at /api/v1/pro/ws
+# which is covered by _OPENAPI_ALLOWED_PREFIXES
 
 
 def _is_openapi_public_path(path: str) -> bool:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2242,6 +2242,7 @@ def _enforce_vip_llm_monthly_quota(vip_key: str) -> None:
     "/api/v1/insight",
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
+    include_in_schema=False,
 )
 @limit_if_available(RATE_LIMIT_INSIGHT)
 async def insight_v1_route(

--- a/tests/test_openapi_namespace_guards.py
+++ b/tests/test_openapi_namespace_guards.py
@@ -9,7 +9,9 @@ ALLOWED_PREFIXES: tuple[str, ...] = (
     "/api/v1/pro/",
     "/api/v1/vip/",
 )
-ALLOWED_EXACT: frozenset[str] = frozenset({"/api/v1/bmi", "/ws"})
+ALLOWED_EXACT: frozenset[str] = frozenset({"/api/v1/bmi"})
+# Legacy WS path is kept at runtime but should NOT appear in OpenAPI schema
+# (WebSocket endpoints are not included in OpenAPI by default)
 LEGACY_DENY_PREFIXES: tuple[str, ...] = (
     "/api/v1/foods",
     "/api/v1/restaurants",
@@ -50,6 +52,10 @@ def test_openapi_does_not_leak_legacy_food_or_restaurant_surface() -> None:
 
 def test_runtime_keeps_legacy_routes_and_ws_for_transition_window() -> None:
     runtime_paths = _runtime_paths()
+    # Legacy WS path (deprecated, kept for transition)
     assert "/ws" in runtime_paths
+    # Canonical PRO WS path
+    assert "/api/v1/pro/ws" in runtime_paths
+    # Legacy food/restaurant routes (hidden from schema, kept at runtime)
     assert "/api/v1/foods" in runtime_paths
     assert "/api/v1/restaurants/search" in runtime_paths

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -153,7 +153,7 @@ def test_ws_rejects_missing_token(
     assert exc.value.code == 1008
     assert metrics_stub.ws_connect_total.value == 1.0
     assert metrics_stub.ws_connect_total.label_calls[-1] == {
-        "path": "/ws",
+        "path": "/api/v1/pro/ws",
         "result": "rejected",
         "reason": "auth_required",
     }
@@ -485,7 +485,7 @@ def test_ws_metrics_increment_and_active_gauge_restore(
     assert metrics_stub.ws_messages_total.value == 2.0  # in + out for ping/pong
     assert metrics_stub.ws_active_connections.value == 0.0
 
-    assert metrics_stub.ws_connect_total.label_calls[-1]["path"] == "/ws"
+    assert metrics_stub.ws_connect_total.label_calls[-1]["path"] == "/api/v1/pro/ws"
     assert metrics_stub.ws_connect_total.label_calls[-1]["result"] == "accepted"
     assert metrics_stub.ws_connect_total.label_calls[-1]["reason"] == "none"
     assert {labels["direction"] for labels in metrics_stub.ws_messages_total.label_calls[-2:]} == {
@@ -493,7 +493,7 @@ def test_ws_metrics_increment_and_active_gauge_restore(
         "out",
     }
     for labels in metrics_stub.ws_messages_total.label_calls[-2:]:
-        assert labels["path"] == "/ws"
+        assert labels["path"] == "/api/v1/pro/ws"
         assert labels["status"] == "ok"
 
 
@@ -511,7 +511,7 @@ def test_ws_policy_close_log_contains_bounded_fields(
     assert policy_records, "Expected at least one ws_policy_close record"
     record = policy_records[-1]
 
-    assert getattr(record, "path", "") == "/ws"
+    assert getattr(record, "path", "") == "/api/v1/pro/ws"
     assert getattr(record, "close_code", 0) == 1008
     assert getattr(record, "reason", "") == "auth_required"
 
@@ -557,10 +557,62 @@ async def test_ws_handles_websocket_disconnect_exception(
         async def send_text(self, _text: str) -> None:
             return None
 
-    async def _auth_ok(_ws: object) -> bool:
+    async def _auth_ok(_ws: object, _path_label: str = "/api/v1/pro/ws") -> bool:
         return True
 
     monkeypatch.setattr(realtime_ws, "_is_ws_enabled", lambda: True)
     monkeypatch.setattr(realtime_ws, "_authenticate_or_close", _auth_ok)
 
     await realtime_ws.ws_root(cast(WebSocket, _DummyWebSocket()))
+
+
+def test_canonical_ws_path_accepts_valid_token_and_responds_pong(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the canonical /api/v1/pro/ws endpoint."""
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect(
+        "/api/v1/pro/ws", headers={"Authorization": "Bearer valid-token"}
+    ) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+        response = json.loads(ws.receive_text())
+    assert response["version"] == "1"
+    assert response["type"] == "pong"
+    assert isinstance(response["server_time_ms"], int)
+
+
+def test_canonical_ws_path_rejects_missing_token(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the canonical /api/v1/pro/ws endpoint rejects missing token."""
+    with ws_client.websocket_connect("/api/v1/pro/ws") as ws:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_duplicate_ws_route_detection_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that duplicate WS route registration raises RuntimeError."""
+    from app.main import _assert_no_duplicate_ws_route
+
+    # Create a mock routes list with /api/v1/pro/ws already present
+    mock_routes = [type("Route", (), {"path": "/api/v1/pro/ws"})()]
+
+    # Patch the app.routes property via __class__
+    import app.main as main_mod
+
+    original_app = main_mod.app
+
+    class MockApp:
+        @property
+        def routes(self):
+            return mock_routes
+
+    monkeypatch.setattr(main_mod, "app", MockApp())
+
+    with pytest.raises(RuntimeError, match="Duplicate /api/v1/pro/ws route detected"):
+        _assert_no_duplicate_ws_route()

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -153,7 +154,7 @@ def test_ws_rejects_missing_token(
     assert exc.value.code == 1008
     assert metrics_stub.ws_connect_total.value == 1.0
     assert metrics_stub.ws_connect_total.label_calls[-1] == {
-        "path": "/api/v1/pro/ws",
+        "path": "/ws",
         "result": "rejected",
         "reason": "auth_required",
     }
@@ -485,7 +486,7 @@ def test_ws_metrics_increment_and_active_gauge_restore(
     assert metrics_stub.ws_messages_total.value == 2.0  # in + out for ping/pong
     assert metrics_stub.ws_active_connections.value == 0.0
 
-    assert metrics_stub.ws_connect_total.label_calls[-1]["path"] == "/api/v1/pro/ws"
+    assert metrics_stub.ws_connect_total.label_calls[-1]["path"] == "/ws"
     assert metrics_stub.ws_connect_total.label_calls[-1]["result"] == "accepted"
     assert metrics_stub.ws_connect_total.label_calls[-1]["reason"] == "none"
     assert {labels["direction"] for labels in metrics_stub.ws_messages_total.label_calls[-2:]} == {
@@ -493,7 +494,7 @@ def test_ws_metrics_increment_and_active_gauge_restore(
         "out",
     }
     for labels in metrics_stub.ws_messages_total.label_calls[-2:]:
-        assert labels["path"] == "/api/v1/pro/ws"
+        assert labels["path"] == "/ws"
         assert labels["status"] == "ok"
 
 
@@ -511,7 +512,7 @@ def test_ws_policy_close_log_contains_bounded_fields(
     assert policy_records, "Expected at least one ws_policy_close record"
     record = policy_records[-1]
 
-    assert getattr(record, "path", "") == "/api/v1/pro/ws"
+    assert getattr(record, "path", "") == "/ws"
     assert getattr(record, "close_code", 0) == 1008
     assert getattr(record, "reason", "") == "auth_required"
 
@@ -616,3 +617,52 @@ def test_duplicate_ws_route_detection_raises_runtime_error(
 
     with pytest.raises(RuntimeError, match="Duplicate /api/v1/pro/ws route detected"):
         _assert_no_duplicate_ws_route()
+
+
+def test_canonical_ws_path_rejects_payload_too_large(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the canonical /api/v1/pro/ws endpoint rejects oversized payload."""
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect(
+        "/api/v1/pro/ws", headers={"Authorization": "Bearer valid-token"}
+    ) as ws:
+        # Send a payload larger than WS_MAX_MESSAGE_BYTES (128 in test fixture)
+        ws.send_text("x" * 200)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            ws.receive_text()
+    assert exc.value.code == 1008
+
+
+def test_canonical_ws_path_handles_subscribe(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the canonical /api/v1/pro/ws endpoint handles subscribe event."""
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with ws_client.websocket_connect(
+        "/api/v1/pro/ws", headers={"Authorization": "Bearer valid-token"}
+    ) as ws:
+        ws.send_text(json.dumps({"version": "1", "type": "subscribe", "channel": "progress"}))
+        response = json.loads(ws.receive_text())
+    assert response["version"] == "1"
+    assert response["type"] == "subscribed"
+    assert response["channel"] == "progress"
+
+
+def test_legacy_ws_path_logs_deprecation_warning(
+    ws_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that legacy /ws path logs deprecation warning."""
+    monkeypatch.setattr(realtime_ws, "_get_token_verifier", lambda: _accept_stub)
+    with caplog.at_level(logging.WARNING):
+        with ws_client.websocket_connect(
+            "/ws", headers={"Authorization": "Bearer valid-token"}
+        ) as ws:
+            ws.send_text(json.dumps({"version": "1", "type": "ping"}))
+            ws.receive_text()
+    # Check that deprecation warning was logged
+    assert any("ws_legacy_path_deprecated" in record.message for record in caplog.records)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

WebSocket namespace migration (P0-2) + CI retry logic fixes

### WebSocket Changes
- Canonical PRO WebSocket endpoint at `/api/v1/pro/ws`
- Legacy `/ws` kept for backward compatibility with deprecation warning
- Separate metrics tracking for canonical vs legacy paths

### CI Fixes
- Fixed retry logic in `auto-delete-branches.yml` (was inverted)
- Fixed retry count in `cd.yml` (`-gt` instead of `-ge`)
- Added `include_in_schema=False` for `/api/v1/insight` endpoint

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

- [x] User-facing change (WebSocket endpoint migration)
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [x] Manual verification steps

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/917#discussion_r2859611496 -> b26724e1 (CodeRabbit: retry logic inverted)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/917#discussion_r2859611502 -> b26724e1 (Cubic: retry loop count)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/917#discussion_r2859611508 -> N/A (P3: gh_retry duplication - deferred)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/917#discussion_r2859560094 -> N/A (Sourcery: legacy /ws test already exists in test_main_ws_registration_guard.py)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/917#discussion_r2859611496 -> N/A (CodeRabbit: legacy /ws tracking - already implemented)

## Merge Readiness

- [ ] All required CI checks pass
- [ ] Zero unresolved review threads
- [ ] PR body sections complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical WebSocket endpoint now at /api/v1/pro/ws; client defaults updated to use it.
  * Workflow retry wrapper added to improve resilience of remote CLI/API operations.

* **Bug Fixes**
  * Improved detection of duplicate WebSocket routes during startup.

* **Deprecations**
  * Legacy WebSocket endpoint /ws deprecated; migrate to /api/v1/pro/ws.

* **Documentation**
  * /ws removed from public OpenAPI surface; two OpenAPI schemas removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->