### PR TITLE
fix(ci): simplify CD workflows by removing buggy retry logic

### DIFF
--- a/.github/workflows/auto-delete-branches.yml
+++ b/.github/workflows/auto-delete-branches.yml
@@ -21,8 +21,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           echo "Deleting merged branch: ${HEAD_REF}"
-          curl -s -X DELETE \
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}" \
-            | jq -r '.message // "deleted"' || true
+            "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}")
+          # 204 = deleted, 404 = already deleted (both acceptable)
+          if [ "$http_code" = "204" ] || [ "$http_code" = "404" ]; then
+            echo "✅ Branch deleted or already gone (HTTP $http_code)"
+          else
+            echo "❌ Failed to delete branch (HTTP $http_code)"
+            exit 1
+          fi

--- a/.github/workflows/auto-delete-branches.yml
+++ b/.github/workflows/auto-delete-branches.yml
@@ -21,25 +21,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           echo "Deleting merged branch: ${HEAD_REF}"
-
-          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
-          delete_branch() {
-            curl -s -X DELETE \
-              --connect-timeout 10 \
-              --max-time 30 \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}"
-          }
-
-          n=0 max=3 delay=5
-          until result=$(delete_branch) && echo "$result" | jq -e '.message // empty' >/dev/null 2>&1; do
-            n=$((n + 1))
-            if [ "$n" -ge "$max" ]; then
-              echo "$result" | jq -r '.message // "deleted"'
-              break
-            fi
-            echo "API call failed, retry $n/$max in ${delay}s..." >&2
-            sleep "$delay"
-          done
-          echo "$result" | jq -r '.message // "deleted"' || true
+          curl -s -X DELETE \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/git/refs/heads/${HEAD_REF}" \
+            | jq -r '.message // "deleted"' || true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,19 +122,8 @@ jobs:
         run: |
           TAG_COMMIT=$(git rev-parse "${GITHUB_REF#refs/tags/}")
 
-          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
-          gh_retry() {
-            local n=0 max=3 delay=5
-            until "$@"; do
-              n=$((n + 1))
-              if [ "$n" -ge "$max" ]; then return 1; fi
-              echo "gh command failed, retry $n/$max in ${delay}s..." >&2
-              sleep "$delay"
-            done
-          }
-
-          LAST_NIGHTLY_CONCLUSION=$(gh_retry gh run list --workflow=nightly.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
-          LAST_NIGHTLY_COMMIT=$(gh_retry gh run list --workflow=nightly.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
+          LAST_NIGHTLY_CONCLUSION=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
+          LAST_NIGHTLY_COMMIT=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
 
           if [ "$LAST_NIGHTLY_CONCLUSION" != "success" ] || [ "$LAST_NIGHTLY_CONCLUSION" = "null" ]; then
             echo "❌ Last nightly test did not pass or is missing: $LAST_NIGHTLY_CONCLUSION"
@@ -160,19 +149,8 @@ jobs:
         run: |
           TAG_COMMIT=$(git rev-parse "${GITHUB_REF#refs/tags/}")
 
-          # Retry wrapper for GitHub API flakiness (3 retries, 5s delay)
-          gh_retry() {
-            local n=0 max=3 delay=5
-            until "$@"; do
-              n=$((n + 1))
-              if [ "$n" -ge "$max" ]; then return 1; fi
-              echo "gh command failed, retry $n/$max in ${delay}s..." >&2
-              sleep "$delay"
-            done
-          }
-
-          MAIN_CI_CONCLUSION=$(gh_retry gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
-          MAIN_CI_COMMIT=$(gh_retry gh run list --workflow=ci.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
+          MAIN_CI_CONCLUSION=$(gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
+          MAIN_CI_COMMIT=$(gh run list --workflow=ci.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
 
           if [ "$MAIN_CI_CONCLUSION" != "success" ] || [ "$MAIN_CI_CONCLUSION" = "null" ]; then
             echo "❌ CI on main branch did not pass or is missing: $MAIN_CI_CONCLUSION"


### PR DESCRIPTION
## Summary

- Remove buggy retry wrapper from cd.yml production-gates (was using `-ge` instead of `-gt`)
- Simplify auto-delete-branches.yml to direct curl call (had inverted logic)

## Problem

The retry logic in these workflows had bugs:
- `cd.yml`: retry condition `-ge` caused off-by-one error
- `auto-delete-branches.yml`: inverted logic that retried on success and exited on failure

## Solution

Simplify by removing retry logic entirely. GitHub API flakiness should be handled at infrastructure level, not in shell scripts.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies
- [x] Bug fix

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Pre-commit passes
- [x] `make test-fast` passes
- [ ] CI passes

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/918#pullrequestreview-3861824180 -> 373dd7a1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/918#discussion_r2859760953 -> 373dd7a1

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Wait-window completed after latest bot/review activity

## Deferred / Follow-ups

- [x] Ledger item(s): None
- [x] GitHub issue(s): None