### PR TITLE
fix(api): hide /api/v1/insight from OpenAPI schema

### DIFF
--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -2317,42 +2317,6 @@
         "title": "Ingredient",
         "type": "object"
       },
-      "InsightRequest": {
-        "properties": {
-          "text": {
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Text",
-            "type": "string"
-          }
-        },
-        "required": [
-          "text"
-        ],
-        "title": "InsightRequest",
-        "type": "object"
-      },
-      "InsightResponse": {
-        "description": "Insight response payload.\n\nRU: Явная модель ответа нужна для стабильного OpenAPI и генерации типов фронтенда.\nEN: Explicit response model keeps OpenAPI stable and enables TS type generation.",
-        "properties": {
-          "insight": {
-            "minLength": 1,
-            "title": "Insight",
-            "type": "string"
-          },
-          "provider": {
-            "minLength": 1,
-            "title": "Provider",
-            "type": "string"
-          }
-        },
-        "required": [
-          "provider",
-          "insight"
-        ],
-        "title": "InsightResponse",
-        "type": "object"
-      },
       "LegacyWeekPlanRequest": {
         "additionalProperties": false,
         "description": "Extended request for week plan with optional pre-calculated targets.\n\nSupports two modes:\n- Mode A: With targets (pre-calculated nutrition goals)\n- Mode B: Calculate targets from user profile (sex, age, etc.)",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2283,24 +2283,6 @@ export interface components {
             /** Grams */
             grams: number;
         };
-        /** InsightRequest */
-        InsightRequest: {
-            /** Text */
-            text: string;
-        };
-        /**
-         * InsightResponse
-         * @description Insight response payload.
-         *
-         *     RU: Явная модель ответа нужна для стабильного OpenAPI и генерации типов фронтенда.
-         *     EN: Explicit response model keeps OpenAPI stable and enables TS type generation.
-         */
-        InsightResponse: {
-            /** Insight */
-            insight: string;
-            /** Provider */
-            provider: string;
-        };
         /**
          * LegacyWeekPlanRequest
          * @description Extended request for week plan with optional pre-calculated targets.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2240,6 +2240,7 @@ def _enforce_vip_llm_monthly_quota(vip_key: str) -> None:
     "/api/v1/insight",
     response_model=InsightResponse,
     responses=RATE_LIMIT_429_RESPONSES,
+    include_in_schema=False,
 )
 @limit_if_available(RATE_LIMIT_INSIGHT)
 async def insight_v1_route(


### PR DESCRIPTION
## Summary
- Add `include_in_schema=False` to `/api/v1/insight` endpoint to match `/insight` legacy endpoint

## Problem
Test `test_app_openapi_schema` failed on main after PR #918 merge because `/api/v1/insight` was appearing in the public OpenAPI schema.

## Solution
Hide the insight endpoint from OpenAPI schema since it is a VIP-only feature.

## Test Plan
- [x] Pre-commit passes
- [x] `test_app_openapi_schema` passes locally
- [ ] CI passes

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/920#pullrequestreview-3863336771 -> 158508419de29ca73ea1f98b2d9f6444d8bf73b0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/920#pullrequestreview-3863338862 -> 158508419de29ca73ea1f98b2d9f6444d8bf73b0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/920#discussion_r2861101018 -> 158508419de29ca73ea1f98b2d9f6444d8bf73b0

## Merge Readiness (Mandatory)
- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Wait-window completed after latest bot/review activity

## Deferred / Follow-ups
- [x] Ledger item(s): None
- [x] GitHub issue(s): None

## Summary by Sourcery

Исправления ошибок:
- Предотвратить появление `/api/v1/insight` в сгенерированной схеме OpenAPI, восстановив ожидаемую схему, используемую в тестах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent /api/v1/insight from appearing in the generated OpenAPI schema, restoring the expected schema used by tests.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide /api/v1/insight from the public OpenAPI schema to match the legacy /insight VIP-only endpoint and regenerate OpenAPI artifacts to drop Insight types. Fixes the test_app_openapi_schema failure.

<sup>Written for commit 158508419de29ca73ea1f98b2d9f6444d8bf73b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated public API documentation: one legacy endpoint is no longer listed in the generated OpenAPI schema (it remains operational).
  * Cleaned up public models: removed the previously published "insight" request and response schemas from the public API documentation and generated types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->