### PR TITLE
feat(security): generalize dependency vulnerability guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1533,11 +1533,12 @@ Rationale: prevents micro-PR fragmentation for flow-level outcomes while preserv
 **Rationale:** Prevents "deferred → forgotten → resurfaces later" anti-pattern. Single source of truth for follow-up work.
 
 **Dependency floor / security guard:** The guard enforces minimum allowed
-package versions (version floors) and detection of explicitly blocked or
-vulnerable packages. Schema and enforcement live in
-`tests/test_dependency_security_guard.py` and
-`tests/fixtures/dependency_security_schema.json`. To raise a minimum version
-or allow a new dependency, update the schema and test expectations together.
+package versions (version floors), blocked packages, and blocked version ranges.
+Schema and enforcement live in `tests/test_dependency_security_guard.py` and
+`tests/fixtures/dependency_security_schema.json`. To raise a minimum version,
+block a package, or block specific versions, update the schema and test
+expectations together. See `docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md`
+for CVE triage workflow.
 
 **Docs lint policy (markdownlint and ledger):**
 

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -174,9 +174,9 @@ make verify
 
 - Schema file: `tests/fixtures/dependency_security_schema.json`
 - Test file: `tests/test_dependency_security_guard.py`
-- Guard enforcement: `tests/test_dependency_security_guard.py:177` (min_versions test)
-- Blocked packages test: `tests/test_dependency_security_guard.py:213` (blocked_packages enforcement)
-- Blocked versions test: `tests/test_dependency_security_guard.py:229` (blocked_versions enforcement)
+- Guard enforcement: `tests/test_dependency_security_guard.py:176` (min_versions test)
+- Blocked packages test: `tests/test_dependency_security_guard.py:278` (blocked_packages enforcement)
+- Blocked versions test: `tests/test_dependency_security_guard.py:297` (blocked_versions enforcement)
 - AGENTS policy: `AGENTS.md:1535` (Dependency floor / security guard section)
 - CVE docs: `docs/security/CVE-*.md`
 

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -174,7 +174,10 @@ make verify
 
 - Schema file: `tests/fixtures/dependency_security_schema.json`
 - Test file: `tests/test_dependency_security_guard.py`
-- AGENTS policy: `AGENTS.md` (Dependency floor / security guard section)
+- Guard enforcement: `tests/test_dependency_security_guard.py:177` (min_versions test)
+- Blocked packages test: `tests/test_dependency_security_guard.py:213` (blocked_packages enforcement)
+- Blocked versions test: `tests/test_dependency_security_guard.py:229` (blocked_versions enforcement)
+- AGENTS policy: `AGENTS.md:1535` (Dependency floor / security guard section)
 - CVE docs: `docs/security/CVE-*.md`
 
 ## Future Enhancements

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -85,7 +85,8 @@ make verify
 
 - Link to CVE doc in PR description
 - Update `docs/roadmap/BACKLOG_LEDGER.md` if applicable
-- Include evidence: `rg "^<package>" requirements*.txt`
+- Include evidence across all tracked surfaces:
+  `rg -n "^<package>" requirements.in requirements.txt requirements-dev.txt requirements-lock.txt constraints.txt`
 
 ## Examples
 

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -1,0 +1,184 @@
+# Dependency Security Guard - CVE Triage Workflow
+
+## Overview
+
+The dependency security guard prevents vulnerable dependency versions from entering the codebase. It enforces:
+
+1. **Minimum version floors** - Packages must be at or above specified safe versions
+2. **Blocked packages** - Specific packages that must not appear anywhere
+3. **Blocked version ranges** - Specific vulnerable versions that must not be pinned
+
+The guard runs as part of `make verify` and validates all 5 requirement surfaces.
+
+## Schema Location
+
+**Source of Truth:** `tests/fixtures/dependency_security_schema.json`
+
+```json
+{
+  "min_versions": {
+    "cryptography": "46.0.5"
+  },
+  "blocked_packages": [],
+  "blocked_versions": {}
+}
+```
+
+## When to Update the Guard
+
+Update the schema when:
+
+- GitHub Dependabot alerts for Python dependencies
+- Trivy code scanning reports application dependency CVEs
+- Manual CVE triage identifies vulnerable package versions
+- Security audit requires blocking specific packages
+
+## Workflow Steps
+
+### 1. Triage CVE
+
+1. Verify CVE affects application dependencies (not distro/OS packages)
+2. Determine fixed version from advisory or upstream
+3. Create CVE doc: `docs/security/CVE-YYYY-NNNNN-<package>.md`
+
+### 2. Update Schema
+
+Choose the appropriate schema section:
+
+| Scenario | Schema Field | Example |
+|----------|-------------|---------|
+| Set minimum safe version | `min_versions` | `"pkg": "2.0.0"` |
+| Ban package entirely | `blocked_packages` | `["unsafe-pkg"]` |
+| Block specific versions | `blocked_versions` | `{"pkg": [">=1.0,<1.5"]}` |
+
+**Important:** Packages in `min_versions` must exist in ALL 5 requirement surfaces:
+- `requirements.in`
+- `requirements.txt`
+- `requirements-dev.txt`
+- `requirements-lock.txt`
+- `constraints.txt`
+
+Dev-only dependencies (like `marshmallow`) cannot currently be tracked in `min_versions` because they don't exist in runtime surfaces. This is a known limitation.
+
+### 3. Update Requirement Surfaces
+
+1. Bump version in `requirements.in` or `requirements-dev.in`
+2. Regenerate locks:
+   ```bash
+   pip-compile --allow-unsafe requirements.in -o requirements.txt
+   pip-compile --allow-unsafe requirements-dev.in -o requirements-dev.txt
+   pip-compile --allow-unsafe requirements.in requirements-dev.in -o requirements-lock.txt
+   ```
+3. Update `constraints.txt` if needed
+
+### 4. Verify Guard
+
+```bash
+# Run guard tests only
+pytest -q tests/test_dependency_security_guard.py
+
+# Full verification (includes guard)
+make verify
+```
+
+### 5. Document in PR
+
+- Link to CVE doc in PR description
+- Update `docs/roadmap/BACKLOG_LEDGER.md` if applicable
+- Include evidence: `rg "^<package>" requirements*.txt`
+
+## Examples
+
+### Example 1: Minimum Version Floor (cryptography CVE)
+
+**Scenario:** CVE-2026-26007 fixed in cryptography 46.0.5
+
+**Schema update:**
+```json
+{
+  "min_versions": {
+    "cryptography": "46.0.5"
+  }
+}
+```
+
+**Requirement updates:**
+- `requirements.in`: `cryptography>=46.0.5,<47.0.0`
+- `requirements-dev.in`: `cryptography>=46.0.5`
+- `constraints.txt`: `cryptography>=46.0.5`
+- Regenerate locks
+
+### Example 2: Blocked Package
+
+**Scenario:** Package `unsafe-lib` has no safe version, must be removed
+
+**Schema update:**
+```json
+{
+  "blocked_packages": ["unsafe-lib"]
+}
+```
+
+**Remediation:**
+- Remove from `requirements*.in` (and deps that pull it)
+- Regenerate locks
+- Guard will fail if any surface still contains it
+
+### Example 3: Blocked Version Range
+
+**Scenario:** Package `some-pkg` versions 2.0.0-2.0.5 are vulnerable
+
+**Schema update:**
+```json
+{
+  "blocked_versions": {
+    "some-pkg": [">=2.0.0,<2.0.6"]
+  }
+}
+```
+
+**Note:** Blocked versions are only checked on pinned (`==`) surfaces, not constraint-style surfaces.
+
+## Schema Maintenance Rules
+
+1. **Sorting:** All keys and lists must be sorted alphabetically (case-insensitive) for clean diffs
+2. **No comments:** JSON doesn't support comments; use CVE docs for rationale
+3. **Case-insensitive:** Package names are matched case-insensitively
+4. **All surfaces:** `min_versions` packages must exist in all 5 surfaces
+
+## CI Integration
+
+- Guard runs in `make test-fast` -> `make verify`
+- PR cannot merge if guard fails
+- Deterministic: no network calls, no external state
+
+## Validated Surfaces
+
+| Surface | Type | Purpose |
+|---------|------|---------|
+| `requirements.in` | Constraint (>=) | Runtime deps source |
+| `requirements.txt` | Pinned (==) | Runtime deps lock |
+| `requirements-dev.txt` | Pinned (==) | Dev deps lock |
+| `requirements-lock.txt` | Pinned (==) | Full lock |
+| `constraints.txt` | Constraint (>=) | Flexible ranges |
+
+## How to Fix Failures
+
+| Failure Type | Fix |
+|--------------|-----|
+| Min version floor violation | Bump package in requirements, regenerate locks |
+| Blocked package violation | Remove package from dependencies, regenerate locks |
+| Blocked version violation | Pin to safe version outside blocked range, regenerate locks |
+
+## References
+
+- Schema file: `tests/fixtures/dependency_security_schema.json`
+- Test file: `tests/test_dependency_security_guard.py`
+- AGENTS policy: `AGENTS.md` (Dependency floor / security guard section)
+- CVE docs: `docs/security/CVE-*.md`
+
+## Future Enhancements
+
+- Per-surface package targeting (for dev-only deps like `marshmallow`)
+- Pre-commit hook integration
+- Aggregate error reporting (show all violations, not fail-fast)

--- a/tests/fixtures/dependency_security_schema.json
+++ b/tests/fixtures/dependency_security_schema.json
@@ -1,5 +1,7 @@
 {
   "min_versions": {
     "cryptography": "46.0.5"
-  }
+  },
+  "blocked_packages": [],
+  "blocked_versions": {}
 }

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -10,6 +10,7 @@ import pytest
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.specifiers import InvalidSpecifier
+from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
@@ -49,7 +50,47 @@ def _load_schema(path: Path) -> dict:
             Version(v_str)
         except InvalidVersion as e:
             pytest.fail(f"Schema: {pkg!r} has unparseable version {v_str!r}: {e}")
+    # Validate optional blocked_packages field
+    _validate_blocked_packages(data)
+    # Validate optional blocked_versions field
+    _validate_blocked_versions(data)
     return data
+
+
+def _validate_blocked_packages(data: dict) -> None:
+    """Validate blocked_packages is list[str] if present."""
+    blocked_packages = data.get("blocked_packages")
+    if blocked_packages is None:
+        return
+    if not isinstance(blocked_packages, list):
+        pytest.fail("Schema: 'blocked_packages' must be a list.")
+    for i, pkg in enumerate(blocked_packages):
+        if not isinstance(pkg, str) or not pkg.strip():
+            pytest.fail(f"Schema: blocked_packages[{i}] must be a non-empty string.")
+
+
+def _validate_blocked_versions(data: dict) -> None:
+    """Validate blocked_versions is dict[str, list[str]] with parseable specifiers."""
+    blocked_versions = data.get("blocked_versions")
+    if blocked_versions is None:
+        return
+    if not isinstance(blocked_versions, dict):
+        pytest.fail("Schema: 'blocked_versions' must be a dict.")
+    for pkg, specifiers in blocked_versions.items():
+        if not isinstance(pkg, str) or not pkg.strip():
+            pytest.fail(f"Schema: blocked_versions key must be a non-empty string: {pkg!r}")
+        if not isinstance(specifiers, list):
+            pytest.fail(f"Schema: blocked_versions[{pkg!r}] must be a list of specifiers.")
+        for i, spec_str in enumerate(specifiers):
+            if not isinstance(spec_str, str) or not spec_str.strip():
+                pytest.fail(f"Schema: blocked_versions[{pkg!r}][{i}] must be a non-empty string.")
+            try:
+                SpecifierSet(spec_str)
+            except InvalidSpecifier as e:
+                pytest.fail(
+                    f"Schema: blocked_versions[{pkg!r}][{i}] has unparseable specifier "
+                    f"{spec_str!r}: {e}"
+                )
 
 
 def _iter_requirement_lines(path: Path) -> Iterable[str]:
@@ -208,3 +249,153 @@ def test_dependency_security_schema_is_stable_and_sorted() -> None:
         pytest.fail(
             "Schema min_versions keys must be sorted (case-insensitive) to keep diffs clean."
         )
+    # Validate blocked_packages is sorted (if present)
+    blocked_packages = schema.get("blocked_packages", [])
+    if blocked_packages:
+        if blocked_packages != sorted(blocked_packages, key=lambda s: s.lower()):
+            pytest.fail(
+                "Schema blocked_packages must be sorted (case-insensitive) to keep diffs clean."
+            )
+    # Validate blocked_versions keys are sorted (if present)
+    blocked_versions = schema.get("blocked_versions", {})
+    if blocked_versions:
+        bv_keys = list(blocked_versions.keys())
+        if bv_keys != sorted(bv_keys, key=lambda s: s.lower()):
+            pytest.fail(
+                "Schema blocked_versions keys must be sorted (case-insensitive) "
+                "to keep diffs clean."
+            )
+        # Validate each blocked_versions value list is sorted
+        for pkg, specifiers in blocked_versions.items():
+            if specifiers != sorted(specifiers):
+                pytest.fail(
+                    f"Schema blocked_versions[{pkg!r}] specifiers must be sorted "
+                    "to keep diffs clean."
+                )
+
+
+@pytest.mark.parametrize("surface", REQUIREMENT_SURFACES)
+def test_dependency_security_guard_enforces_blocked_packages(surface: Path) -> None:
+    """
+    Guard: No requirement surface may contain packages listed in
+    schema["blocked_packages"]. Entirely forbidden dependencies.
+    """
+    schema = _load_schema(SCHEMA_PATH)
+    blocked_packages = schema.get("blocked_packages", [])
+    if not blocked_packages:
+        pytest.skip("No blocked packages defined in schema.")
+    all_reqs = _effective_min_versions_per_package(surface)
+    for pkg in blocked_packages:
+        if pkg.lower() in all_reqs:
+            pytest.fail(
+                f"{surface.name}: package {pkg!r} is blocked by security policy. "
+                f"Remove it from this surface."
+            )
+
+
+@pytest.mark.parametrize("surface", REQUIREMENT_SURFACES)
+def test_dependency_security_guard_enforces_blocked_versions(surface: Path) -> None:
+    """
+    Guard: Packages with blocked version ranges must not match any
+    blocked specifier in schema["blocked_versions"].
+    Only checks pinned (==) versions; constraint-style ranges are not failed.
+    """
+    schema = _load_schema(SCHEMA_PATH)
+    blocked_versions = schema.get("blocked_versions", {})
+    if not blocked_versions:
+        pytest.skip("No blocked versions defined in schema.")
+    # Only check pinned surfaces (==) to avoid false positives on ranges
+    if _is_constraint_style(surface):
+        pytest.skip(
+            f"{surface.name} is constraint-style; blocked versions check skipped "
+            "(only pinned surfaces checked)."
+        )
+    all_reqs = _effective_min_versions_per_package(surface)
+    for pkg, specifiers in blocked_versions.items():
+        effective = all_reqs.get(pkg.lower())
+        if effective is None:
+            continue  # Package not in this surface
+        for spec_str in specifiers:
+            spec = SpecifierSet(spec_str)
+            if str(effective) in spec:
+                pytest.fail(
+                    f"{surface.name}: {pkg}=={effective} matches blocked specifier "
+                    f"{spec_str!r}. Update to a safe version."
+                )
+
+
+def test_validate_blocked_packages_fails_on_invalid_type(tmp_path: Path) -> None:
+    """blocked_packages must be a list."""
+    bad_schema = tmp_path / "schema.json"
+    bad_schema.write_text(
+        '{"min_versions": {"cryptography": "46.0.5"}, "blocked_packages": "not-a-list"}',
+        encoding="utf-8",
+    )
+    with pytest.raises(BaseException, match="must be a list"):
+        _load_schema(bad_schema)
+
+
+def test_validate_blocked_packages_fails_on_invalid_entry(tmp_path: Path) -> None:
+    """blocked_packages entries must be non-empty strings."""
+    bad_schema = tmp_path / "schema.json"
+    bad_schema.write_text(
+        '{"min_versions": {"cryptography": "46.0.5"}, "blocked_packages": [""]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(BaseException, match="must be a non-empty string"):
+        _load_schema(bad_schema)
+
+
+def test_validate_blocked_versions_fails_on_invalid_type(tmp_path: Path) -> None:
+    """blocked_versions must be a dict."""
+    bad_schema = tmp_path / "schema.json"
+    bad_schema.write_text(
+        '{"min_versions": {"cryptography": "46.0.5"}, "blocked_versions": "not-a-dict"}',
+        encoding="utf-8",
+    )
+    with pytest.raises(BaseException, match="must be a dict"):
+        _load_schema(bad_schema)
+
+
+def test_validate_blocked_versions_fails_on_invalid_specifier(tmp_path: Path) -> None:
+    """blocked_versions specifiers must be parseable."""
+    bad_schema = tmp_path / "schema.json"
+    bad_schema.write_text(
+        '{"min_versions": {"cryptography": "46.0.5"}, '
+        '"blocked_versions": {"pkg": [">=1.0.0,<=invalid"]}}',
+        encoding="utf-8",
+    )
+    with pytest.raises(BaseException, match="unparseable specifier"):
+        _load_schema(bad_schema)
+
+
+def test_blocked_package_enforcement_with_fake_surface(tmp_path: Path) -> None:
+    """Regression: blocked package in surface should be detected."""
+    fake_req = tmp_path / "requirements.txt"
+    fake_req.write_text("unsafe-pkg==1.0.0\nsome-other==2.0.0\n", encoding="utf-8")
+    all_reqs = _effective_min_versions_per_package(fake_req)
+    blocked_packages = ["unsafe-pkg"]
+    # Simulate the guard check
+    violations = [pkg for pkg in blocked_packages if pkg.lower() in all_reqs]
+    assert violations == ["unsafe-pkg"], "Blocked package should be detected."
+
+
+def test_blocked_version_enforcement_with_fake_surface(tmp_path: Path) -> None:
+    """Regression: blocked version match in surface should be detected."""
+    fake_req = tmp_path / "requirements.txt"
+    fake_req.write_text("some-pkg==2.0.3\n", encoding="utf-8")
+    all_reqs = _effective_min_versions_per_package(fake_req)
+    blocked_versions = {"some-pkg": [">=2.0.0,<2.1.0"]}
+    # Simulate the guard check
+    violations = []
+    for pkg, specifiers in blocked_versions.items():
+        effective = all_reqs.get(pkg.lower())
+        if effective is None:
+            continue
+        for spec_str in specifiers:
+            spec = SpecifierSet(spec_str)
+            if str(effective) in spec:
+                violations.append((pkg, str(effective), spec_str))
+    assert violations == [
+        ("some-pkg", "2.0.3", ">=2.0.0,<2.1.0")
+    ], "Blocked version match should be detected."


### PR DESCRIPTION
## Summary

- Expand dependency security guard from single-package (cryptography) to scalable schema-driven approach
- Add `blocked_packages` list for entirely forbidden dependencies
- Add `blocked_versions` dict for specific vulnerable version ranges
- Create developer documentation for CVE triage workflow

## Changes

### Schema Enhancement (`tests/fixtures/dependency_security_schema.json`)
- Add `blocked_packages: []` field (list of forbidden package names)
- Add `blocked_versions: {}` field (dict of package -> list of blocked version specifiers)
- Maintain backward compatibility (empty defaults)

### Test Logic Enhancement (`tests/test_dependency_security_guard.py`)
- Add `_validate_blocked_packages()` and `_validate_blocked_versions()` validation helpers
- Add parametrized tests for blocked packages/versions enforcement
- Enhance schema stability test for new fields sorting
- Add regression tests for validation edge cases

### Documentation (`docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md`)
- Complete CVE triage workflow guide
- Examples for each schema field type
- Schema maintenance rules
- CI integration notes

### AGENTS.md Update
- Update policy section to reference new enforcement types and workflow guide

## Backlog Item

Closes P1: Generalize dependency vulnerability guards beyond single-CVE floors (lines 2028-2041 in `docs/roadmap/BACKLOG_LEDGER.md`)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#pullrequestreview-3863745046 -> 30f5f0f4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#pullrequestreview-3863756221 -> 4030126a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#discussion_r2861479928 -> 4030126a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#discussion_r2861479939 -> 4030126a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#pullrequestreview-3863800004 -> 33fd85dd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/923#discussion_r2861521411 -> 33fd85dd

## Merge Readiness

- [x] `pre-commit run --all-files` passes
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test-fast` passes
- [x] Guard tests pass (`pytest -q tests/test_dependency_security_guard.py`)

## Test plan

- [x] Run `pytest -q tests/test_dependency_security_guard.py` - 15 passed, 10 skipped
- [x] Skipped tests are expected (blocked_packages and blocked_versions are empty)
- [x] Verify schema loads correctly with new fields
- [x] Verify validation helpers reject invalid schema entries

🤖 Generated with [Qoder][https://qoder.com]