### PR TITLE
fix(security): bump ajv to fix ReDoS vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4036,9 +4036,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Fix GHSA-2g4f-4pwh-qvx6: ajv <6.14.0 has ReDoS vulnerability when using `$data` option.

## Changes

- Bump ajv to >=6.14.0 via `npm audit fix`

## Security Advisory

- **Advisory:** https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
- **Severity:** Moderate
- **Vulnerable:** ajv <6.14.0
- **Fixed in:** ajv >=6.14.0

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [x] Security fix (npm audit fix)
- [x] `npm audit` shows 0 vulnerabilities
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Qoder][https://qoder.com]

## Summary by Sourcery

Обновление фронтенд-зависимостей для устранения уязвимости безопасности в **ajv** и обеспечения чистого результата `npm audit`.

Исправления ошибок:
- Устранение уязвимости ReDoS путем обновления **ajv** до невосприимчивой к уязвимости версии в дереве фронтенд-зависимостей.

Сборка:
- Обновление lock-файла фронтенда через `npm audit fix`, чтобы зафиксировать безопасную версию **ajv**.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update frontend dependencies to address a security vulnerability in ajv and ensure a clean npm audit.

Bug Fixes:
- Resolve ReDoS vulnerability by upgrading ajv to a non-vulnerable version in the frontend dependency tree.

Build:
- Refresh frontend lockfile via npm audit fix to capture the secure ajv version.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded ajv from 6.12.6 to 6.14.0 to fix a ReDoS vulnerability when the $data option is used (GHSA-2g4f-4pwh-qvx6).

<sup>Written for commit 44d8d27a188ef2af673314742a2882c402f95d5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

