### PR TITLE
fix(security): suppress CVE-2026-3184 util-linux (unfixed upstream)

### DIFF
--- a/docs/security/CVE-2026-3184-util-linux.md
+++ b/docs/security/CVE-2026-3184-util-linux.md
@@ -26,13 +26,13 @@ Suppression is temporary until upstream provides a patched version.
 
 ## Monitoring
 
-- **Debian Tracker:** https://security-tracker.debian.org/tracker/CVE-2026-3184
-- **NVD:** https://nvd.nist.gov/vuln/detail/CVE-2026-3184
+- **Debian Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-3184>
+- **NVD:** <https://nvd.nist.gov/vuln/detail/CVE-2026-3184>
 - **Review-by:** 2026-05-27 (90 days)
 
 ## Evidence
 
-- Code scanning alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550
+- Code scanning alert: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550>
 - Suppression policy: `AGENTS.md:1375` (Trivy suppression implementation)
 - Suppression rule: trivy/ignore-policy.rego line 196
 

--- a/docs/security/CVE-2026-3184-util-linux.md
+++ b/docs/security/CVE-2026-3184-util-linux.md
@@ -1,0 +1,42 @@
+# CVE-2026-3184: util-linux Access Control Bypass
+
+## Summary
+
+- **CVE:** CVE-2026-3184
+- **Package:** util-linux-extra
+- **Severity:** LOW
+- **Installed Version:** 2.38.1-5+deb12u3
+- **Fixed Version:** None (unfixed upstream)
+- **Status:** Suppressed (temporary)
+
+## Description
+
+util-linux: Access control bypass due to improper hostname canonicalization.
+
+## Impact Assessment
+
+- **Risk:** Low - requires specific network configuration and local access
+- **Exposure:** Container base image system library
+- **Mitigation:** No application-level mitigation possible; awaiting upstream fix
+
+## Suppression Rationale
+
+This CVE affects a system library in the Debian base image with no fix available upstream.
+Suppression is temporary until upstream provides a patched version.
+
+## Monitoring
+
+- **Debian Tracker:** https://security-tracker.debian.org/tracker/CVE-2026-3184
+- **NVD:** https://nvd.nist.gov/vuln/detail/CVE-2026-3184
+- **Review-by:** 2026-05-27 (90 days)
+
+## Evidence
+
+- Code scanning alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550
+- Trivy policy: `trivy/ignore-policy.rego:95` (suppression rule)
+
+## Removal Condition
+
+Remove suppression when:
+1. Debian releases fixed util-linux package, OR
+2. Base image is updated to a version with the fix

--- a/docs/security/CVE-2026-3184-util-linux.md
+++ b/docs/security/CVE-2026-3184-util-linux.md
@@ -33,7 +33,8 @@ Suppression is temporary until upstream provides a patched version.
 ## Evidence
 
 - Code scanning alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550
-- Trivy policy: `trivy/ignore-policy.rego:196` (suppression rule)
+- Suppression policy: `AGENTS.md:1375` (Trivy suppression implementation)
+- Suppression rule: trivy/ignore-policy.rego line 196
 
 ## Removal Condition
 

--- a/docs/security/CVE-2026-3184-util-linux.md
+++ b/docs/security/CVE-2026-3184-util-linux.md
@@ -33,7 +33,7 @@ Suppression is temporary until upstream provides a patched version.
 ## Evidence
 
 - Code scanning alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550
-- Trivy policy: `trivy/ignore-policy.rego:95` (suppression rule)
+- Trivy policy: `trivy/ignore-policy.rego:196` (suppression rule)
 
 ## Removal Condition
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,7 +10,7 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-10 (manual removal)
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-27171-zlib1g.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -191,4 +191,28 @@ ignore if {
 	input.PkgName == "zlib1g"
 	cve_2026_27171_version_match
 	cve_2026_27171_pkgid_match
+}
+
+# CVE-2026-3184 (util-linux) - upstream unfixed in Debian bookworm
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Unfixed distro CVE; access control bypass via hostname canonicalization; LOW severity
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-3184
+# Documented in: docs/security/CVE-2026-3184-util-linux.md
+# Removal condition: Remove when Debian bookworm publishes a fixed util-linux package or Trivy metadata includes Fixed Version
+
+# Helper rule: check if InstalledVersion matches observed version
+cve_2026_3184_version_match if {
+	input.InstalledVersion == "2.38.1-5+deb12u3"
+}
+
+# Helper rule: check if PkgID matches observed util-linux-extra package
+cve_2026_3184_pkgid_match if {
+	contains(input.PkgID, "util-linux-extra@2.38.1-5+deb12u3")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-3184"
+	input.PkgName == "util-linux-extra"
+	cve_2026_3184_version_match
+	cve_2026_3184_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -9,7 +9,7 @@ default ignore := false
 # - Limit to the installed versions reported at time of suppression
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
-# Suppression expires: 2026-05-10 (manual removal)
+# Suppression expires: 2026-05-27 (manual removal)
 # Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md
 
 ignore if {


### PR DESCRIPTION
## Summary

Add temporary suppression for CVE-2026-3184 (util-linux access control bypass).
No fixed version available in Debian bookworm.

## Security Advisory

- **CVE:** CVE-2026-3184
- **Package:** util-linux-extra
- **Severity:** LOW
- **Fixed Version:** None (unfixed upstream)
- **Review-by:** 2026-05-27 (90 days)

## Changes

- Add `docs/security/CVE-2026-3184-util-linux.md` (security doc)
- Add suppression rule to `trivy/ignore-policy.rego:196`
- Update header expiry to 2026-05-27

## Evidence

- Code scanning alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/550
- Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-3184

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#pullrequestreview-3866984775 -> 6e60cd49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#pullrequestreview-3866991339 -> 6e60cd49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#pullrequestreview-3866995625 -> a981b76c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#pullrequestreview-3867049379 -> ccb2ad99
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#discussion_r2864378082 -> 6e60cd49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#discussion_r2864383520 -> 6e60cd49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#discussion_r2864387068 -> a981b76c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#discussion_r2864387077 -> ccb2ad99
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/927#discussion_r2864435201 -> a981b76c

## Merge Readiness

- [x] Security suppression PR (runtime config + docs)
- [x] `pre-commit run --all-files` passes
- [x] Follows AGENTS.md security suppression policy

🤖 Generated with [Qoder][https://qoder.com]