### PR TITLE
chore(security): extend review-by dates for unfixed CVEs to 2026-05-27

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,8 +1,8 @@
 ## Trivy vulnerability ignore list
 ##
-## Last reviewed: 2026-01-28
+## Last reviewed: 2026-02-27
 ## Base image: python:3.13.6-slim (Debian 12 bookworm)
-## Next review: 2026-04-28
+## Next review: 2026-05-27
 ## Review process: Re-verify versions when base image updates or quarterly
 ##
 ## IMPORTANT: Container uses python:3.13.6-slim based on Debian bookworm.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1102,7 +1102,7 @@ CVE-2025-8058
 ##   - When fixed version available: remove suppression, update base image
 ##   - Documented in: docs/security/CVE-2026-0861-glibc.md
 ##
-## Suppression expires: 2026-03-01
+## Suppression expires: 2026-05-27
 ## Review cadence: Weekly (e.g., Fridays) as part of Security triage routine
 ## Remove suppression when: Debian releases security update with fixed glibc
 

--- a/docs/security/CVE-2025-15281-glibc.md
+++ b/docs/security/CVE-2025-15281-glibc.md
@@ -2,7 +2,7 @@
 
 **Status:** UNFIXED in Debian bookworm at time of suppression (see Monitor link)
 **Severity:** Minor (per Debian Security Tracker)
-**Suppression Expires:** 2026-03-01
+**Suppression Expires:** 2026-05-27
 **Monitor:** <https://security-tracker.debian.org/tracker/CVE-2025-15281>
 
 ---
@@ -27,6 +27,8 @@ Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.r
 - `CVE-2025-15281`
 - Packages: `libc6`, `libc-bin`
 - Observed versions: `2.36-9+deb12u10`, `2.36-9+deb12u13` (GitHub runner base image variants)
+
+**Evidence:** `trivy/ignore-policy.rego:30`, `AGENTS.md:1375`
 
 ---
 
@@ -55,5 +57,5 @@ Suppression is intentionally narrow and version-pinned in `trivy/ignore-policy.r
 
 ---
 
-**Last updated:** 2026-01-21
+**Last updated:** 2026-02-27
 **Review cadence:** Weekly (e.g., Fridays) as part of Security triage routine

--- a/docs/security/CVE-2026-0861-glibc.md
+++ b/docs/security/CVE-2026-0861-glibc.md
@@ -2,7 +2,7 @@
 
 **Status:** UNFIXED (upstream glibc); UNFIXED in Debian bookworm (distro)
 **Severity:** HIGH (CVSS 3.1 = 8.4, CISA-ADP)
-**Suppression Expires:** 2026-03-01
+**Suppression Expires:** 2026-05-27
 **Monitor:** <https://security-tracker.debian.org/tracker/CVE-2026-0861>
 
 ---
@@ -12,6 +12,8 @@
 CVE-2026-0861 affects glibc memalign-family functions (`memalign`, `posix_memalign`, `aligned_alloc`). This is a **system library vulnerability**, not application code.
 
 **Vulnerability:** Alignment overflow check missing in memalign-family functions can lead to integer overflow and potential security issues.
+
+**Evidence:** `.trivyignore:1109`, `AGENTS.md:1375`
 
 ---
 
@@ -54,7 +56,7 @@ CVE-2026-0861 affects glibc memalign-family functions (`memalign`, `posix_memali
 ### Immediate (PR-SEC)
 
 1. **Document:** This security note
-2. **Suppress:** Add to `.trivyignore` with expiry date (2026-03-01)
+2. **Suppress:** Add to `.trivyignore` with expiry date (2026-05-27)
 3. **Monitor:** Check Debian security tracker weekly
 
 ### When Fixed Version Available
@@ -84,7 +86,7 @@ Review weekly (e.g., every Friday) as part of Security triage routine. Check Deb
 ```text
 ## CVE-2026-0861 – glibc memalign alignment overflow (HIGH (CVSS 3.1 = 8.4, CISA-ADP))
 ## ... (detailed comments) ...
-## Suppression expires: 2026-03-01
+## Suppression expires: 2026-05-27
 ## Monitor: <https://security-tracker.debian.org/tracker/CVE-2026-0861>
 ## See: docs/security/CVE-2026-0861-glibc.md
 
@@ -103,5 +105,5 @@ CVE-2026-0861
 
 ---
 
-**Last updated:** 2026-01-16
+**Last updated:** 2026-02-27
 **Review cadence:** Weekly (e.g., Fridays) as part of Security triage routine

--- a/docs/security/CVE-2026-27171-zlib1g.md
+++ b/docs/security/CVE-2026-27171-zlib1g.md
@@ -45,4 +45,4 @@ Remove this suppression when either:
 
 ## Review / expiry
 
-- **Review-by**: 2026-05-10 (shared policy-file expiry window)
+- **Review-by**: 2026-05-27 (shared policy-file expiry window)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,6 +10,7 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-27 (manual removal)
+# Last reviewed: 2026-02-27
 # Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md
 
 ignore if {
@@ -27,7 +28,7 @@ ignore if {
 }
 
 # CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image
-# Review-by: 2026-03-01 (manual removal)
+# Review-by: 2026-05-27 (manual removal)
 # Rationale: Upstream unfixed; GitHub runner base image (deb12u10/deb12u13); no actionable remediation in repo
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2025-15281
 # Documented in: docs/security/CVE-2025-15281-glibc.md
@@ -67,7 +68,7 @@ ignore if {
 }
 
 # CVE-2026-27171 (zlib1g) - upstream unfixed in Debian bookworm
-# Review-by: 2026-05-10 (manual removal)
+# Review-by: 2026-05-27 (manual removal)
 # Rationale: Unfixed distro CVE; no fixed version reported in Trivy metadata for bookworm at time of triage
 # Note: CI expiry is enforced once per policy file (see header); do not add another "Suppression expires:" line.
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-27171


### PR DESCRIPTION
## Summary

Extend suppression review-by dates for 5 CVEs that remain unfixed upstream in Debian bookworm:

- **CVE-2026-0915** (glibc libc6/libc-bin): header expiry 2026-05-27
- **CVE-2025-15281** (glibc libc6/libc-bin): 2026-03-01 → 2026-05-27
- **CVE-2026-27171** (zlib1g): 2026-05-10 → 2026-05-27
- **CVE-2026-3184** (util-linux-extra): already 2026-05-27 (no change needed)
- **CVE-2026-0861** (.trivyignore glibc): 2026-03-01 → 2026-05-27

All CVEs verified as still unfixed in Debian bookworm via Debian Security Tracker on 2026-02-27.

## Changes

- `trivy/ignore-policy.rego`: Updated Review-by comments for CVE-2025-15281 and CVE-2026-27171
- `.trivyignore`: Updated expiry date for CVE-2026-0861, header metadata
- `docs/security/CVE-2025-15281-glibc.md`: Updated expiry date and last updated
- `docs/security/CVE-2026-0861-glibc.md`: Updated expiry date and last updated
- `docs/security/CVE-2026-27171-zlib1g.md`: Updated review-by date

## Test plan

- [x] `python scripts/ci/check_trivy_ignore_policy_expiry.py trivy/ignore-policy.rego` passes
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/security/*.md` passes
- [x] Pre-commit hooks pass

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/930#pullrequestreview-3867522119 -> edddad86
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/930#pullrequestreview-3867536466 -> edddad86

## Merge Readiness

- [ ] CI green
- [ ] Bot reviews addressed
- [ ] Ready for merge

🤖 Generated with [Qoder][https://qoder.com]