### PR TITLE
docs(ledger): update suppression expiry review status

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2429,8 +2429,8 @@ If it is not recorded here — it does not exist.
   - Area: security
   - Finding Type: policy exception
   - Locations:
-    - `trivy/ignore-policy.rego` — Suppression expires: 2026-03-01
-    - `.trivyignore` — CVE-2026-0861 expires: 2026-03-01
+    - `trivy/ignore-policy.rego` — Suppression expires: 2026-05-27
+    - `.trivyignore` — CVE-2026-0861 expires: 2026-05-27
   - Reason: Upstream glibc CVEs unfixed; suppressions have expiry dates
   - Links:
     - docs/security/CVE-2026-0861-glibc.md
@@ -2439,6 +2439,9 @@ If it is not recorded here — it does not exist.
     - Weekly monitoring for upstream fixes
     - Remove suppressions when fixed versions available
     - Update base image when fixes land
+  - **Last reviewed: 2026-02-27**
+    - PR #929: Removed 4 upstream-fixed CVE suppressions (gpgv, gnutls, p11-kit)
+    - PR #930: Extended review-by dates to 2026-05-27 for unfixed CVEs
 
 ---
 


### PR DESCRIPTION
## Summary

Update Security suppression expiry monitoring entry in BACKLOG_LEDGER.md after completing the quarterly review:

- Extended expiry dates from 2026-03-01 to 2026-05-27
- Added last reviewed date (2026-02-27)
- Referenced completed PRs:
  - PR #929: Removed 4 upstream-fixed CVE suppressions (gpgv, gnutls, p11-kit)
  - PR #930: Extended review-by dates to 2026-05-27 for unfixed CVEs

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [ ] CI green
- [ ] Ready for merge

🤖 Generated with [Qoder][https://qoder.com]

## Summary by Sourcery

Документация:
- Продлить задокументированные сроки подавления и истечения срока действия CVE для связанного с glibc исключения по безопасности до 2026-05-27 и зафиксировать последние детали проверки, включая ссылки на связанные pull request’ы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Extend documented suppression and CVE expiry dates for the glibc-related security exception to 2026-05-27 and record the latest review details, including related PR references.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the security suppression entry in BACKLOG_LEDGER.md after the quarterly review. Extends expiry dates to 2026-05-27, adds the last reviewed date (2026-02-27), and links to PRs #929 and #930.

<sup>Written for commit 3fbf00155d8bb2743e50edba6e5b5abfbdeac74f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security suppression expiry dates to 2026-05-27
  * Added consolidated review notes tracking CVE suppression history and changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->