### PR TITLE
feat(rag): add RAG contract types and constants in core/rag

### DIFF
--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -1,0 +1,35 @@
+"""
+RAG contract types: RAGChunk and RAGContext (per docs/contracts/RAG_CONTRACT.md §3).
+
+RU: Внутренний контракт агента — структуры, передаваемые между RAG и LLM/агентами.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RAGChunk:
+    """Single retrieved chunk with metadata."""
+
+    chunk_id: str
+    file: str
+    content: str
+    score: float
+    hop: int = 1
+
+
+@dataclass
+class RAGContext:
+    """Context produced by retrieval, passed to agents/LLM."""
+
+    query: str
+    refined_queries: list[str]
+    chunks: list[RAGChunk]
+    confidence: float
+    hops: int
+    latency_ms: int
+    agent_id: Optional[str] = None
+    user_tier: Optional[str] = None

--- a/core/rag/rag_constants.py
+++ b/core/rag/rag_constants.py
@@ -1,0 +1,12 @@
+"""
+RAG budget and pipeline constants (per docs/contracts/RAG_CONTRACT.md §4).
+
+RU: Константы бюджета рекурсии и латентности для RAG-пайплайна.
+"""
+
+MAX_RAG_HOPS: int = 3
+MAX_CHUNKS_PER_HOP: int = 5
+MAX_SOURCES_IN_RESPONSE: int = 5
+RAG_PIPELINE_TIMEOUT_SEC: int = 10
+MIN_CHUNK_SCORE: float = 0.1
+MAX_CHUNK_SIZE_CHARS: int = 800

--- a/tests/test_rag_contracts.py
+++ b/tests/test_rag_contracts.py
@@ -1,0 +1,76 @@
+"""Tests for core.rag.contracts and core.rag.rag_constants (RAG contract types)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_CHUNKS_PER_HOP,
+    MAX_RAG_HOPS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+    RAG_PIPELINE_TIMEOUT_SEC,
+)
+
+
+def test_rag_chunk_dataclass() -> None:
+    """RAGChunk has required fields and default hop=1."""
+    ch = RAGChunk(
+        chunk_id="c1",
+        file="docs/foo.md",
+        content="Some text",
+        score=0.85,
+    )
+    assert ch.chunk_id == "c1"
+    assert ch.file == "docs/foo.md"
+    assert ch.content == "Some text"
+    assert ch.score == 0.85
+    assert ch.hop == 1
+
+    ch2 = RAGChunk(chunk_id="c2", file="f", content="x", score=0.1, hop=2)
+    assert ch2.hop == 2
+
+
+def test_rag_context_dataclass() -> None:
+    """RAGContext has required fields and optional agent_id/user_tier."""
+    ctx = RAGContext(
+        query="q",
+        refined_queries=["q"],
+        chunks=[],
+        confidence=0.0,
+        hops=1,
+        latency_ms=50,
+    )
+    assert ctx.query == "q"
+    assert ctx.refined_queries == ["q"]
+    assert ctx.chunks == []
+    assert ctx.confidence == 0.0
+    assert ctx.hops == 1
+    assert ctx.latency_ms == 50
+    assert ctx.agent_id is None
+    assert ctx.user_tier is None
+
+    ctx2 = RAGContext(
+        query="q2",
+        refined_queries=[],
+        chunks=[],
+        confidence=0.9,
+        hops=2,
+        latency_ms=100,
+        agent_id="cbt-agent",
+        user_tier="VIP",
+    )
+    assert ctx2.agent_id == "cbt-agent"
+    assert ctx2.user_tier == "VIP"
+
+
+def test_rag_constants_values() -> None:
+    """Constants match RAG_CONTRACT.md §4."""
+    assert MAX_RAG_HOPS == 3
+    assert MAX_CHUNKS_PER_HOP == 5
+    assert MAX_SOURCES_IN_RESPONSE == 5
+    assert RAG_PIPELINE_TIMEOUT_SEC == 10
+    assert MIN_CHUNK_SCORE == 0.1
+    assert MAX_CHUNK_SIZE_CHARS == 800


### PR DESCRIPTION
## Summary

First runtime step for RAG contract: add `RAGChunk` and `RAGContext` types and budget constants in `core/rag/` per `docs/contracts/RAG_CONTRACT.md` (§3–§4). No API or `retrieve_context` signature change in this PR.

**Deliverables:**
- `core/rag/contracts.py` — `RAGChunk`, `RAGContext` dataclasses
- `core/rag/rag_constants.py` — `MAX_RAG_HOPS`, `MAX_CHUNKS_PER_HOP`, `MAX_SOURCES_IN_RESPONSE`, `RAG_PIPELINE_TIMEOUT_SEC`, `MIN_CHUNK_SCORE`, `MAX_CHUNK_SIZE_CHARS`
- `tests/test_rag_contracts.py` — unit tests for types and constants

**Scope:** Single focus (core/rag contract types + constants). Branch `feat/rag-contract-core` from `main` to avoid mixing with colleague work.

**Refs:** BACKLOG_LEDGER ~1727 (Orchestration: implement AI multi-agent contracts RAG/UQ/CV + safety), RAG_CONTRACT.md §9 Next Steps (1) and (5).

---

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

---

## Deferred / Follow-ups

- Next: extend `retrieve_context` in `core/rag/simple_rag.py` to return `RAGContext` (backward-compatible signature) — separate PR.
- Then: `sources[]` and `confidence` in Insight response schema; feedback storage migration (BACKLOG_LEDGER).

---

## Merge Readiness

- [ ] All checks pass
- [ ] Review completed
- [ ] Pre-commit run `--all-files` passed
- [ ] `make test-fast` and `make lint` passed locally

## Summary by Sourcery

Введение основных структур данных контракта RAG и общих констант бюджета для использования по всему конвейеру RAG.

Новые возможности:
- Добавлены датаклассы `RAGChunk` и `RAGContext` для моделирования полученных фрагментов и контекста извлечения, передаваемого между RAG и агентами.

Улучшения:
- Определены централизованные константы бюджета и конвейера RAG (число переходов, лимиты фрагментов, таймаут, скоринг и размер фрагмента) для единообразной конфигурации по всей системе.

Тесты:
- Добавлены модульные тесты, проверяющие поля и значения по умолчанию для `RAGChunk` и `RAGContext`, а также проверяющие значения констант бюджета и конвейера RAG.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce core RAG contract data structures and shared budget constants for use across the RAG pipeline.

New Features:
- Add RAGChunk and RAGContext dataclasses to model retrieved chunks and retrieval context passed between RAG and agents.

Enhancements:
- Define centralized RAG budget and pipeline constants (hops, chunk limits, timeout, scoring, and chunk size) for consistent configuration across the system.

Tests:
- Add unit tests covering RAGChunk and RAGContext fields and defaults, and verifying the values of the RAG budget and pipeline constants.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RAG contract types (RAGChunk, RAGContext) and pipeline budget constants under core/rag to align with RAG_CONTRACT.md. No API changes or retrieve_context signature updates.

- **New Features**
  - core/rag/contracts.py: RAGChunk and RAGContext dataclasses
  - core/rag/rag_constants.py: MAX_RAG_HOPS, MAX_CHUNKS_PER_HOP, MAX_SOURCES_IN_RESPONSE, RAG_PIPELINE_TIMEOUT_SEC, MIN_CHUNK_SCORE, MAX_CHUNK_SIZE_CHARS
  - tests/test_rag_contracts.py: unit tests for dataclasses and constants

<sup>Written for commit 5746500f678f16f9dfbe14ead7f042e303f1676f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced retrieval-augmented generation capabilities with improved data structure support for search results and context management
  * Optimized RAG pipeline with configurable parameters for retrieval depth, result limits, and performance tuning

* **Tests**
  * Comprehensive test coverage added for RAG system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->