### PR TITLE
feat(rag): RAG contract types, constants, and structured retrieval (PR-1)

### DIFF
--- a/core/rag/__init__.py
+++ b/core/rag/__init__.py
@@ -1,0 +1,24 @@
+"""RAG (Retrieval-Augmented Generation) module per RAG_CONTRACT.md."""
+
+from core.rag import simple_rag
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_CHUNKS_PER_HOP,
+    MAX_RAG_HOPS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+    RAG_PIPELINE_TIMEOUT_SEC,
+)
+
+__all__ = [
+    "RAGChunk",
+    "RAGContext",
+    "MAX_CHUNK_SIZE_CHARS",
+    "MAX_CHUNKS_PER_HOP",
+    "MAX_RAG_HOPS",
+    "MAX_SOURCES_IN_RESPONSE",
+    "MIN_CHUNK_SCORE",
+    "RAG_PIPELINE_TIMEOUT_SEC",
+    "simple_rag",
+]

--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -1,0 +1,36 @@
+"""
+RAG internal contract types per docs/contracts/RAG_CONTRACT.md §3.
+
+RAGChunk and RAGContext are passed between agents and used to build
+Insight response fields (sources, confidence, hops, latency_ms).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RAGChunk:
+    """Single retrieved chunk with provenance and score."""
+
+    chunk_id: str
+    file: str
+    content: str
+    score: float
+    hop: int = 1
+
+
+@dataclass
+class RAGContext:
+    """Full RAG retrieval result for agent/response pipeline."""
+
+    query: str
+    refined_queries: list[str]
+    chunks: list[RAGChunk]
+    confidence: float
+    hops: int
+    latency_ms: int
+    agent_id: Optional[str] = None
+    user_tier: Optional[str] = None

--- a/core/rag/rag_constants.py
+++ b/core/rag/rag_constants.py
@@ -1,0 +1,12 @@
+"""
+RAG budget and pipeline constants per docs/contracts/RAG_CONTRACT.md §4.
+
+Used by retrieval pipeline, response shaping (max sources), and timeouts.
+"""
+
+MAX_RAG_HOPS: int = 3
+MAX_CHUNKS_PER_HOP: int = 5
+MAX_SOURCES_IN_RESPONSE: int = 5
+RAG_PIPELINE_TIMEOUT_SEC: int = 10
+MIN_CHUNK_SCORE: float = 0.1
+MAX_CHUNK_SIZE_CHARS: int = 800

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -13,8 +13,16 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Iterable, List, Tuple
+
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+)
 
 ROOT = Path(os.getenv("PROJECT_ROOT", ".")).resolve()
 DOC_GLOBS = ["*.md"]
@@ -121,6 +129,61 @@ def retrieve_context(query: str, max_chunks: int = 3) -> str:
     for src, ch, sc in top:
         parts.append(f"# Source: {Path(src).name} (score={sc:.2f})\n{ch}")
     return "\n\n".join(parts)
+
+
+def retrieve_context_structured(
+    query: str,
+    max_chunks: int = 3,
+    agent_id: str | None = None,
+    user_tier: str | None = None,
+) -> RAGContext:
+    """
+    Return RAG retrieval result as RAGContext per RAG_CONTRACT.md §3.
+
+    Backward-compatible with retrieve_context: same index and scoring;
+    use this when response needs sources, confidence, hops, latency_ms.
+    """
+    start = time.perf_counter()
+    items = _get_index()
+    refined: list[str] = [query]
+    if not items:
+        return RAGContext(
+            query=query,
+            refined_queries=refined,
+            chunks=[],
+            confidence=0.0,
+            hops=1,
+            latency_ms=int((time.perf_counter() - start) * 1000),
+            agent_id=agent_id,
+            user_tier=user_tier,
+        )
+    scored = sorted(
+        ((src, ch, _score(query, ch)) for src, ch in items), key=lambda x: x[2], reverse=True
+    )
+    limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
+    top = [x for x in scored[:limit] if x[2] >= MIN_CHUNK_SCORE]
+    chunks = [
+        RAGChunk(
+            chunk_id=f"{Path(src).name}:{i}",
+            file=src,
+            content=ch[:MAX_CHUNK_SIZE_CHARS],
+            score=sc,
+            hop=1,
+        )
+        for i, (src, ch, sc) in enumerate(top, 1)
+    ]
+    confidence = sum(c.score for c in chunks) / len(chunks) if chunks else 0.0
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return RAGContext(
+        query=query,
+        refined_queries=refined,
+        chunks=chunks,
+        confidence=confidence,
+        hops=1,
+        latency_ms=latency_ms,
+        agent_id=agent_id,
+        user_tier=user_tier,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/orchestration/task_analysis_RAG_contract_impl.md
+++ b/docs/orchestration/task_analysis_RAG_contract_impl.md
@@ -1,0 +1,74 @@
+# Task Analysis: RAG contract implementation
+
+**Copy this template for each new task.**
+
+---
+
+## Task Analysis
+
+**Task:** Implement RAG contract types, constants, and Insight response fields per BACKLOG_LEDGER entry "P1: RAG contract implementation" (sources[], confidence, budget constants). Add RAGChunk/RAGContext in core/rag, rag_constants.py, and extend Insight response schema with sources, confidence, rag_used, hops, latency_ms per docs/contracts/RAG_CONTRACT.md.
+
+**Domain(s):** AI/ML, Architecture
+
+**Complexity:** Moderate
+
+**Priority:** P1
+
+- **Priority track (P0-A / P0-B / P1):** P1 _(see [AGENTS.md](../../AGENTS.md) — Release readiness priorities)_
+
+**Expected Outcome:**
+- RAGChunk and RAGContext in core/rag/contracts.py; budget constants in core/rag/rag_constants.py.
+- InsightResponse (or extended schema) includes sources, confidence, rag_used, hops, latency_ms.
+- Deterministic tests for new types, constants, and response fields; `make verify` passes.
+- BACKLOG_LEDGER DoD 1761 satisfied (or split across two PRs with clear DoD per PR).
+
+**Invariants Affected:**
+- [ ] One BMI Engine
+- [ ] Thin HTTP Adapter Policy
+- [x] Layer Separation (core/rag domain vs app schemas/routers)
+- [x] Contract-First (RAG_CONTRACT.md is SoT)
+
+**Domain hints (pick if relevant; links-only):**
+- `core/rag/*`: RAG contract types and constants (see RAG_CONTRACT.md, BACKLOG_LEDGER 1761)
+- `app/routers/*`, `legacy_app.py`: OpenAPI determinism, response_model, insight endpoint (see AGENTS.md)
+
+**Risks:**
+1. Breaking existing insight callers if response schema changes without backward compatibility — mitigate: extend schema with optional fields; default rag_used=false, sources=[], confidence=null when RAG not used.
+
+**Proposed Approach:**
+1. **PR-1 (this scope):** Add core/rag/contracts.py (RAGChunk, RAGContext) and core/rag/rag_constants.py; add tests in tests/test_rag_contracts.py. Optionally extend retrieve_context in core/rag/simple_rag.py to return RAGContext with backward-compatible overload or default args. No app/schemas or endpoint changes in PR-1.
+2. **PR-2 (follow-up):** Extend Insight response schema (app/schemas or legacy_app InsightResponse) with sources, confidence, rag_used, hops, latency_ms; wire insight endpoint to populate from RAGContext when rag_used=true; add tests for new response fields; run make openapi and commit artifacts.
+3. Decision: **Two PRs** — one focus per PR (audit §9.2). PR-1 = core/rag types + constants; PR-2 = API response schema + endpoint.
+
+**Agent Assignment:**
+- **Primary:** rag-systems-agent — contract compliance (RAG_CONTRACT §3–§4), safety and recursion budget.
+- **Secondary:** ai-app-architect — RAG placement in pipeline, feature flags, OpenAPI/app boundary; backend-engineer — response schema and router wiring when doing PR-2.
+- **Dependencies:** PR 928 merged (docs-only audit and RAG contract doc on main).
+
+**Constraints:**
+- One focus per PR; no mixing core/rag types with app-layer schema in same PR if splitting.
+- Pre-commit and make verify required before push; OpenAPI determinism if response schema changes (PR-2).
+- Insight endpoint remains tier-gated and rate-limited; no new endpoints in this task.
+
+---
+
+## File list (approved before branch)
+
+| File | Action |
+|------|--------|
+| `core/rag/contracts.py` | create or update — RAGChunk, RAGContext (RAG_CONTRACT §3) |
+| `core/rag/rag_constants.py` | create or update — MAX_RAG_HOPS, MAX_CHUNKS_PER_HOP, MAX_SOURCES_IN_RESPONSE, RAG_PIPELINE_TIMEOUT_SEC, MIN_CHUNK_SCORE, MAX_CHUNK_SIZE_CHARS (§4) |
+| `core/rag/simple_rag.py` | optional in PR-1 — extend retrieve_context (default args) to return RAGContext, keep backward compat |
+| `tests/test_rag_contracts.py` | create or update — tests for RAGChunk, RAGContext, constants |
+| _(PR-2)_ `app/schemas/*` or Insight response definition | extend — sources, confidence, rag_used, hops, latency_ms |
+| _(PR-2)_ `legacy_app.py` or app/routers (insight) | update — use extended schema, fill from RAGContext when rag_used=true |
+| _(PR-2)_ `tests/*` (insight/rag response) | add — tests for new response fields |
+
+**One vs two PRs:** Two. PR-1 = core/rag (contracts + constants + tests). PR-2 = Insight response schema + endpoint + openapi artifacts.
+
+---
+
+**Agent convening:** rag-systems-agent, ai-app-architect, backend-engineer — not invoked (mcp_task model unavailable). Proceeding with RAG_CONTRACT.md and AGENTS.md as authority.
+
+**Analysis by:** agent-coordinator (fallback: manual per plan)
+**Date:** 2026-02-27

--- a/tests/test_rag_contracts.py
+++ b/tests/test_rag_contracts.py
@@ -1,0 +1,104 @@
+"""
+Tests for RAG contract types and constants per RAG_CONTRACT.md §3–§4.
+
+Covers: RAGChunk, RAGContext, rag_constants, retrieve_context_structured.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_CHUNKS_PER_HOP,
+    MAX_RAG_HOPS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+    RAG_PIPELINE_TIMEOUT_SEC,
+)
+
+
+class TestRAGChunk:
+    """RAGChunk dataclass per RAG_CONTRACT §3."""
+
+    def test_rag_chunk_default_hop(self) -> None:
+        c = RAGChunk(chunk_id="a", file="f.md", content="x", score=0.5)
+        assert c.hop == 1
+
+    def test_rag_chunk_explicit_hop(self) -> None:
+        c = RAGChunk(chunk_id="b", file="g.md", content="y", score=0.8, hop=2)
+        assert c.hop == 2
+
+
+class TestRAGContext:
+    """RAGContext dataclass per RAG_CONTRACT §3."""
+
+    def test_rag_context_minimal(self) -> None:
+        ctx = RAGContext(
+            query="q",
+            refined_queries=["q"],
+            chunks=[],
+            confidence=0.0,
+            hops=1,
+            latency_ms=10,
+        )
+        assert ctx.agent_id is None
+        assert ctx.user_tier is None
+
+    def test_rag_context_with_agent_tier(self) -> None:
+        ctx = RAGContext(
+            query="q",
+            refined_queries=["q", "q2"],
+            chunks=[],
+            confidence=0.5,
+            hops=2,
+            latency_ms=100,
+            agent_id="cbt-agent",
+            user_tier="PRO",
+        )
+        assert ctx.agent_id == "cbt-agent"
+        assert ctx.user_tier == "PRO"
+
+
+class TestRAGConstants:
+    """Constants per RAG_CONTRACT §4."""
+
+    def test_budget_constants_values(self) -> None:
+        assert MAX_RAG_HOPS == 3
+        assert MAX_CHUNKS_PER_HOP == 5
+        assert MAX_SOURCES_IN_RESPONSE == 5
+        assert RAG_PIPELINE_TIMEOUT_SEC == 10
+        assert MIN_CHUNK_SCORE == 0.1
+        assert MAX_CHUNK_SIZE_CHARS == 800
+
+
+class TestRetrieveContextStructured:
+    """retrieve_context_structured returns RAGContext."""
+
+    def test_retrieve_context_structured_empty_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from core.rag import simple_rag
+
+        monkeypatch.setattr(simple_rag, "_get_index", lambda: [])
+        from core.rag.simple_rag import retrieve_context_structured
+
+        ctx = retrieve_context_structured("any query")
+        assert isinstance(ctx, RAGContext)
+        assert ctx.query == "any query"
+        assert ctx.chunks == []
+        assert ctx.confidence == 0.0
+        assert ctx.hops == 1
+        assert ctx.latency_ms >= 0
+        assert ctx.refined_queries == ["any query"]
+
+    def test_retrieve_context_structured_with_agent_tier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import simple_rag
+
+        monkeypatch.setattr(simple_rag, "_get_index", lambda: [])
+        from core.rag.simple_rag import retrieve_context_structured
+
+        ctx = retrieve_context_structured("query", agent_id="insight-default", user_tier="FREE")
+        assert ctx.agent_id == "insight-default"
+        assert ctx.user_tier == "FREE"


### PR DESCRIPTION
## Summary

**PR-1 of two:** RAG contract implementation (core/rag only). Implements RAGChunk/RAGContext, budget constants, and `retrieve_context_structured()` per `docs/contracts/RAG_CONTRACT.md` §3–§4. Backlog: BACKLOG_LEDGER P1 «RAG contract implementation».

**Scope (this PR):**
- `core/rag/contracts.py`: RAGChunk, RAGContext
- `core/rag/rag_constants.py`: MAX_RAG_HOPS, MAX_CHUNKS_PER_HOP, MAX_SOURCES_IN_RESPONSE, RAG_PIPELINE_TIMEOUT_SEC, MIN_CHUNK_SCORE, MAX_CHUNK_SIZE_CHARS
- `core/rag/__init__.py`: package exports + `simple_rag` for backward compat
- `core/rag/simple_rag.py`: `retrieve_context_structured()` returns RAGContext (existing `retrieve_context()` unchanged)
- `tests/test_rag_contracts.py`: deterministic tests for types, constants, structured retrieval
- `docs/orchestration/task_analysis_RAG_contract_impl.md`: task analysis and file list

**Out of scope (PR-2):** Insight response schema (sources, confidence, rag_used, hops, latency_ms) and endpoint wiring.

---

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments yet

---

## Merge Readiness

- [ ] CI green (lint, typecheck, test-fast, diff-cov)
- [ ] All review threads resolved
- [ ] Bot comments (CodeRabbit, Sourcery, Cubic) addressed or mapped above
- [ ] Pre-commit run locally before merge
- [ ] One review cycle after last bot activity

---

## Deferred / Follow-ups

- **PR-2:** Extend Insight response schema and wire insight endpoint to RAGContext (BACKLOG_LEDGER same entry; DoD: sources, confidence, rag_used, hops, latency_ms in response).
- Task analysis: `docs/orchestration/task_analysis_RAG_contract_impl.md`.

## Summary by Sourcery

Ввести структурированные контракты RAG и подключить простой RAG-поиск так, чтобы он возвращал типизированный объект контекста при сохранении обратной совместимости с текущим поведением.

Новые возможности:
- Добавить датаклассы `RAGChunk` и `RAGContext` для моделирования внутренних результатов RAG-поиска.
- Экспортировать типы контрактов RAG, константы и модуль `simple_rag` из пакета `core.rag` для повторного использования.
- Реализовать `retrieve_context_structured()`, возвращающую структурированный `RAGContext` с фрагментами (chunks), уверенностью (confidence), числом переходов (hops), задержкой (latency) и необязательными метаданными агента.

Документация:
- Добавить документацию по анализу задач, описывающую план реализации контракта RAG и структуру файлов.

Тесты:
- Добавить детерминированные тесты, покрывающие поведение `RAGChunk` и `RAGContext`, константы бюджета RAG и семантику `retrieve_context_structured()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce structured RAG contracts and wire simple RAG retrieval to return a typed context object while keeping existing behavior backward compatible.

New Features:
- Add RAGChunk and RAGContext dataclasses to model internal RAG retrieval results.
- Expose RAG contract types, constants, and the simple_rag module from the core.rag package for reuse.
- Implement retrieve_context_structured() to return a structured RAGContext with chunks, confidence, hops, latency, and optional agent metadata.

Documentation:
- Add task analysis documentation describing the RAG contract implementation plan and file layout.

Tests:
- Add deterministic tests covering RAGChunk and RAGContext behavior, RAG budget constants, and retrieve_context_structured() semantics.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RAG contract in core/rag with new types, budget constants, and a structured retrieval function to support sources, confidence, hops, and latency. Core-only scope; endpoint wiring and response schema land in PR-2.

- **New Features**
  - Added RAGChunk and RAGContext per RAG_CONTRACT.md §3.
  - Introduced budget constants (MAX_RAG_HOPS, MAX_CHUNKS_PER_HOP, MAX_SOURCES_IN_RESPONSE, RAG_PIPELINE_TIMEOUT_SEC, MIN_CHUNK_SCORE, MAX_CHUNK_SIZE_CHARS) per §4.
  - Added retrieve_context_structured() returning RAGContext; respects MIN_CHUNK_SCORE and MAX_CHUNK_SIZE_CHARS.
  - Exported types/constants via core/rag/__init__.py.
  - Added deterministic tests for types, constants, and structured retrieval.
  
- **Migration**
  - No API changes. Existing retrieve_context is unchanged; use retrieve_context_structured when you need sources, confidence, hops, and latency.

<sup>Written for commit 4adb981a830fc494eb2ba9763b9d856e6ef3447c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced retrieval-augmented generation infrastructure with structured context retrieval, configurable pipeline parameters, and enhanced response capabilities.

* **Documentation**
  * Added task analysis documentation detailing implementation roadmap.

* **Tests**
  * Added test coverage for contract validation and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->