### PR TITLE
feat(rag): implement RAG contract response schema (sources, confidence, hops)

### DIFF
--- a/core/rag/__init__.py
+++ b/core/rag/__init__.py
@@ -1,0 +1,24 @@
+"""RAG (Retrieval-Augmented Generation) module per RAG_CONTRACT.md."""
+
+from core.rag import simple_rag
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_CHUNKS_PER_HOP,
+    MAX_RAG_HOPS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+    RAG_PIPELINE_TIMEOUT_SEC,
+)
+
+__all__ = [
+    "RAGChunk",
+    "RAGContext",
+    "MAX_CHUNK_SIZE_CHARS",
+    "MAX_CHUNKS_PER_HOP",
+    "MAX_RAG_HOPS",
+    "MAX_SOURCES_IN_RESPONSE",
+    "MIN_CHUNK_SCORE",
+    "RAG_PIPELINE_TIMEOUT_SEC",
+    "simple_rag",
+]

--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -1,0 +1,36 @@
+"""
+RAG internal contract types per docs/contracts/RAG_CONTRACT.md §3.
+
+RAGChunk and RAGContext are passed between agents and used to build
+Insight response fields (sources, confidence, hops, latency_ms).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RAGChunk:
+    """Single retrieved chunk with provenance and score."""
+
+    chunk_id: str
+    file: str
+    content: str
+    score: float
+    hop: int = 1
+
+
+@dataclass
+class RAGContext:
+    """Full RAG retrieval result for agent/response pipeline."""
+
+    query: str
+    refined_queries: list[str]
+    chunks: list[RAGChunk]
+    confidence: float
+    hops: int
+    latency_ms: int
+    agent_id: Optional[str] = None
+    user_tier: Optional[str] = None

--- a/core/rag/formatting.py
+++ b/core/rag/formatting.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 from typing import Any
 
 from core.insight.safety import redact_rag_context_for_insight
+from core.rag.contracts import RAGChunk
 
 
-def format_rag_chunks_for_prompt(chunks: list[Any]) -> str:
+def format_rag_chunks_for_prompt(chunks: list[RAGChunk]) -> str:
     """Concatenate RAGChunk objects into a prompt-ready string with source headers."""
     parts: list[str] = []
     for ch in chunks:
@@ -18,7 +19,7 @@ def format_rag_chunks_for_prompt(chunks: list[Any]) -> str:
     return "\n\n".join(parts)
 
 
-def build_rag_source_dicts(chunks: list[Any]) -> list[dict[str, Any]]:
+def build_rag_source_dicts(chunks: list[RAGChunk]) -> list[dict[str, Any]]:
     """Build source-item dicts from RAGChunks with redacted previews.
 
     Returns plain dicts so the caller (``legacy_app.py``) can wrap them in

--- a/core/rag/formatting.py
+++ b/core/rag/formatting.py
@@ -5,10 +5,19 @@ Moved out of ``legacy_app.py`` so it stays a thin proxy (AGENTS.md policy).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TypedDict
 
 from core.insight.safety import redact_rag_context_for_insight
 from core.rag.contracts import RAGChunk
+
+
+class RAGSourceDict(TypedDict):
+    """Typed dict for RAG source items returned by build_rag_source_dicts."""
+
+    chunk_id: str
+    file: str
+    preview: str
+    score: float
 
 
 def format_rag_chunks_for_prompt(chunks: list[RAGChunk]) -> str:
@@ -19,21 +28,21 @@ def format_rag_chunks_for_prompt(chunks: list[RAGChunk]) -> str:
     return "\n\n".join(parts)
 
 
-def build_rag_source_dicts(chunks: list[RAGChunk]) -> list[dict[str, Any]]:
+def build_rag_source_dicts(chunks: list[RAGChunk]) -> list[RAGSourceDict]:
     """Build source-item dicts from RAGChunks with redacted previews.
 
     Returns plain dicts so the caller (``legacy_app.py``) can wrap them in
     ``RAGSourceItem`` without introducing a core→legacy import.
     """
-    items: list[dict[str, Any]] = []
+    items: list[RAGSourceDict] = []
     for ch in chunks:
         preview = redact_rag_context_for_insight(ch.content)
         items.append(
-            {
-                "chunk_id": ch.chunk_id,
-                "file": ch.file,
-                "preview": preview[:200] if preview else "",
-                "score": round(ch.score, 4),
-            }
+            RAGSourceDict(
+                chunk_id=ch.chunk_id,
+                file=ch.file,
+                preview=preview[:200] if preview else "",
+                score=round(ch.score, 4),
+            )
         )
     return items

--- a/core/rag/formatting.py
+++ b/core/rag/formatting.py
@@ -1,0 +1,38 @@
+"""RAG formatting helpers — prompt building and source-item construction.
+
+Moved out of ``legacy_app.py`` so it stays a thin proxy (AGENTS.md policy).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.insight.safety import redact_rag_context_for_insight
+
+
+def format_rag_chunks_for_prompt(chunks: list[Any]) -> str:
+    """Concatenate RAGChunk objects into a prompt-ready string with source headers."""
+    parts: list[str] = []
+    for ch in chunks:
+        parts.append(f"# Source: {ch.file} (score={ch.score:.2f})\n{ch.content}")
+    return "\n\n".join(parts)
+
+
+def build_rag_source_dicts(chunks: list[Any]) -> list[dict[str, Any]]:
+    """Build source-item dicts from RAGChunks with redacted previews.
+
+    Returns plain dicts so the caller (``legacy_app.py``) can wrap them in
+    ``RAGSourceItem`` without introducing a core→legacy import.
+    """
+    items: list[dict[str, Any]] = []
+    for ch in chunks:
+        preview = redact_rag_context_for_insight(ch.content)
+        items.append(
+            {
+                "chunk_id": ch.chunk_id,
+                "file": ch.file,
+                "preview": preview[:200] if preview else "",
+                "score": round(ch.score, 4),
+            }
+        )
+    return items

--- a/core/rag/rag_constants.py
+++ b/core/rag/rag_constants.py
@@ -1,0 +1,12 @@
+"""
+RAG budget and pipeline constants per docs/contracts/RAG_CONTRACT.md §4.
+
+Used by retrieval pipeline, response shaping (max sources), and timeouts.
+"""
+
+MAX_RAG_HOPS: int = 3
+MAX_CHUNKS_PER_HOP: int = 5
+MAX_SOURCES_IN_RESPONSE: int = 5
+RAG_PIPELINE_TIMEOUT_SEC: int = 10
+MIN_CHUNK_SCORE: float = 0.1
+MAX_CHUNK_SIZE_CHARS: int = 800

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -13,8 +13,16 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Iterable, List, Tuple
+
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+)
 
 ROOT = Path(os.getenv("PROJECT_ROOT", ".")).resolve()
 DOC_GLOBS = ["*.md"]
@@ -121,6 +129,61 @@ def retrieve_context(query: str, max_chunks: int = 3) -> str:
     for src, ch, sc in top:
         parts.append(f"# Source: {Path(src).name} (score={sc:.2f})\n{ch}")
     return "\n\n".join(parts)
+
+
+def retrieve_context_structured(
+    query: str,
+    max_chunks: int = 3,
+    agent_id: str | None = None,
+    user_tier: str | None = None,
+) -> RAGContext:
+    """
+    Return RAG retrieval result as RAGContext per RAG_CONTRACT.md §3.
+
+    Backward-compatible with retrieve_context: same index and scoring;
+    use this when response needs sources, confidence, hops, latency_ms.
+    """
+    start = time.perf_counter()
+    items = _get_index()
+    refined: list[str] = [query]
+    if not items:
+        return RAGContext(
+            query=query,
+            refined_queries=refined,
+            chunks=[],
+            confidence=0.0,
+            hops=1,
+            latency_ms=int((time.perf_counter() - start) * 1000),
+            agent_id=agent_id,
+            user_tier=user_tier,
+        )
+    scored = sorted(
+        ((src, ch, _score(query, ch)) for src, ch in items), key=lambda x: x[2], reverse=True
+    )
+    limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
+    top = [x for x in scored[:limit] if x[2] >= MIN_CHUNK_SCORE]
+    chunks = [
+        RAGChunk(
+            chunk_id=f"{Path(src).name}:{i}",
+            file=src,
+            content=ch[:MAX_CHUNK_SIZE_CHARS],
+            score=sc,
+            hop=1,
+        )
+        for i, (src, ch, sc) in enumerate(top, 1)
+    ]
+    confidence = sum(c.score for c in chunks) / len(chunks) if chunks else 0.0
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return RAGContext(
+        query=query,
+        refined_queries=refined,
+        chunks=chunks,
+        confidence=confidence,
+        hops=1,
+        latency_ms=latency_ms,
+        agent_id=agent_id,
+        user_tier=user_tier,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -164,8 +164,12 @@ def retrieve_context_structured(
     top = [x for x in scored[:limit] if x[2] >= MIN_CHUNK_SCORE]
     chunks = [
         RAGChunk(
-            chunk_id=f"{Path(src).name}:{i}",
-            file=src,
+            chunk_id=f"{Path(src).relative_to(ROOT) if Path(src).is_relative_to(ROOT) else Path(src).name}:{i}",
+            file=(
+                str(Path(src).relative_to(ROOT))
+                if Path(src).is_relative_to(ROOT)
+                else Path(src).name
+            ),
             content=ch[:MAX_CHUNK_SIZE_CHARS],
             score=sc,
             hop=1,

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1742,11 +1742,11 @@ If it is not recorded here — it does not exist.
     - Outputs include explicit `sources[]` and confidence/uncertainty fields per contract
     - No OpenAPI determinism regressions; `make verify` passes
 
-- [ ] P1: RAG implementation audit — baseline (docs-only)
+- [x] P1: RAG implementation audit — baseline (docs-only)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI / RAG / docs)
-  - Target PR: TBD (branch `docs/audit-rag-implementation-and-agent-knowledge`)
-  - Status: In progress
+  - Target PR: PR #928 (merged)
+  - Status: Done
   - Area: docs / audit
   - Reason (EN): Establish evidence-based baseline for current RAG (insight-only, Jaccard), backlog gaps (sources[], confidence, multi-hop, feedback storage, agent RAG), and prioritized follow-up. No runtime changes in this PR.
   - Links:
@@ -1758,11 +1758,11 @@ If it is not recorded here — it does not exist.
     - BACKLOG_LEDGER updated with follow-up items below
     - Branch follows PR scope guard (docs only)
 
-- [ ] P1: RAG contract implementation (sources[], confidence, budget constants)
+- [x] P1: RAG contract implementation (sources[], confidence, budget constants)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI / RAG)
-  - Target PR: PR-next-1 (runtime)
-  - Status: Planned (after audit merged)
+  - Target PR: feat/rag-contract-impl-v2 (pending PR)
+  - Status: Done (implementation complete, PR pending)
   - Reason (EN): Implement response schema and internal RAGContext/RAGChunk per `docs/contracts/RAG_CONTRACT.md`; add `sources[]`, `confidence`, `rag_used`, `hops`, `latency_ms` to Insight response; add `core/rag/contracts.py` and `rag_constants.py`.
   - Links:
     - `docs/contracts/RAG_CONTRACT.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1761,8 +1761,8 @@ If it is not recorded here — it does not exist.
 - [x] P1: RAG contract implementation (sources[], confidence, budget constants)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI / RAG)
-  - Target PR: feat/rag-contract-impl-v2 (pending PR)
-  - Status: Done (implementation complete, PR pending)
+  - Target PR: PR #935
+  - Status: In review (PR open, pending merge)
   - Reason (EN): Implement response schema and internal RAGContext/RAGChunk per `docs/contracts/RAG_CONTRACT.md`; add `sources[]`, `confidence`, `rag_used`, `hops`, `latency_ms` to Insight response; add `core/rag/contracts.py` and `rag_constants.py`.
   - Links:
     - `docs/contracts/RAG_CONTRACT.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1758,7 +1758,7 @@ If it is not recorded here — it does not exist.
     - BACKLOG_LEDGER updated with follow-up items below
     - Branch follows PR scope guard (docs only)
 
-- [x] P1: RAG contract implementation (sources[], confidence, budget constants)
+- [ ] P1: RAG contract implementation (sources[], confidence, budget constants)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI / RAG)
   - Target PR: PR #935

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1171,15 +1171,32 @@ class InsightRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=INSIGHT_TEXT_MAX_LENGTH)
 
 
+class RAGSourceItem(BaseModel):
+    """Single RAG source in Insight response per RAG_CONTRACT.md §2."""
+
+    chunk_id: str
+    file: str
+    preview: str
+    score: float
+
+
 class InsightResponse(BaseModel):
-    """Insight response payload.
+    """Insight response payload per RAG_CONTRACT.md §2.
 
     RU: Явная модель ответа нужна для стабильного OpenAPI и генерации типов фронтенда.
     EN: Explicit response model keeps OpenAPI stable and enables TS type generation.
+
+    New RAG fields (sources, confidence, rag_used, hops, latency_ms) are all optional
+    with safe defaults so old clients keep working without changes.
     """
 
     provider: str = Field(..., min_length=1)
     insight: str = Field(..., min_length=1)
+    sources: list[RAGSourceItem] = Field(default_factory=list)
+    confidence: Optional[float] = None
+    rag_used: bool = False
+    hops: int = 0
+    latency_ms: int = 0
 
 
 class BMIRequest(BaseModel):
@@ -2137,6 +2154,30 @@ from core.insight.llm_provider_loader import (  # noqa: E402
 )
 
 
+def _format_rag_chunks_for_prompt(chunks: list[Any]) -> str:
+    """Concatenate RAGChunk objects into a prompt-ready string with source headers."""
+    parts: list[str] = []
+    for ch in chunks:
+        parts.append(f"# Source: {ch.file} (score={ch.score:.2f})\n{ch.content}")
+    return "\n\n".join(parts)
+
+
+def _build_rag_source_items(chunks: list[Any]) -> list[RAGSourceItem]:
+    """Build RAGSourceItem list from RAGChunks with redacted previews."""
+    items: list[RAGSourceItem] = []
+    for ch in chunks:
+        preview = _redact_rag_context_for_insight(ch.content)
+        items.append(
+            RAGSourceItem(
+                chunk_id=ch.chunk_id,
+                file=ch.file,
+                preview=preview[:200] if preview else "",
+                score=round(ch.score, 4),
+            )
+        )
+    return items
+
+
 async def insight_v1(req: InsightRequest) -> InsightResponse:
     """Generate insight using LLM provider (v1 with API key).
 
@@ -2162,20 +2203,38 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
 
     use_rag = str(os.getenv("FEATURE_RAG", "")).strip().lower() in {"1", "true", "on", "yes"}
     prompt_text = prompt_input
+    rag_sources: list[RAGSourceItem] = []
+    rag_confidence: Optional[float] = None
+    rag_hops: int = 0
+    rag_latency_ms: int = 0
     if use_rag:
         with suppress(Exception):
-            from core.rag.simple_rag import retrieve_context as _rag_retrieve
+            from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
-            if ctx := _rag_retrieve(prompt_input, max_chunks=3):
+            rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_hops = rag_ctx.hops
+            rag_latency_ms = rag_ctx.latency_ms
+            if rag_ctx.chunks:
+                rag_confidence = round(rag_ctx.confidence, 4)
+                rag_sources = _build_rag_source_items(rag_ctx.chunks)
+                raw_context = _format_rag_chunks_for_prompt(rag_ctx.chunks)
                 prompt_text = _build_insight_prompt(
                     prompt_input,
-                    _redact_rag_context_for_insight(ctx),
+                    _redact_rag_context_for_insight(raw_context),
                 )
     if len(prompt_text) > INSIGHT_TEXT_MAX_LENGTH:
         prompt_text = prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
     try:
         insight_text = await provider.generate(prompt_text)
-        return InsightResponse(provider=provider.name, insight=insight_text)
+        return InsightResponse(
+            provider=provider.name,
+            insight=insight_text,
+            sources=rag_sources,
+            confidence=rag_confidence,
+            rag_used=use_rag,
+            hops=rag_hops,
+            latency_ms=rag_latency_ms,
+        )
     except Exception:
         # Log server-side only; never return exception details to client (privacy/safety).
         logger.exception("Insight provider call failed (/api/v1/insight)")
@@ -2207,20 +2266,38 @@ async def insight(req: InsightRequest) -> InsightResponse:
 
     use_rag = str(os.getenv("FEATURE_RAG", "")).strip().lower() in {"1", "true", "on", "yes"}
     prompt_text = prompt_input
+    rag_sources: list[RAGSourceItem] = []
+    rag_confidence: Optional[float] = None
+    rag_hops: int = 0
+    rag_latency_ms: int = 0
     if use_rag:
         with suppress(Exception):
-            from core.rag.simple_rag import retrieve_context as _rag_retrieve
+            from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
-            if ctx := _rag_retrieve(prompt_input, max_chunks=3):
+            rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_hops = rag_ctx.hops
+            rag_latency_ms = rag_ctx.latency_ms
+            if rag_ctx.chunks:
+                rag_confidence = round(rag_ctx.confidence, 4)
+                rag_sources = _build_rag_source_items(rag_ctx.chunks)
+                raw_context = _format_rag_chunks_for_prompt(rag_ctx.chunks)
                 prompt_text = _build_insight_prompt(
                     prompt_input,
-                    _redact_rag_context_for_insight(ctx),
+                    _redact_rag_context_for_insight(raw_context),
                 )
     if len(prompt_text) > INSIGHT_TEXT_MAX_LENGTH:
         prompt_text = prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
     try:
         insight_text = await provider.generate(prompt_text)
-        return InsightResponse(provider=provider.name, insight=insight_text)
+        return InsightResponse(
+            provider=provider.name,
+            insight=insight_text,
+            sources=rag_sources,
+            confidence=rag_confidence,
+            rag_used=use_rag,
+            hops=rag_hops,
+            latency_ms=rag_latency_ms,
+        )
     except Exception:
         logger.exception("Insight provider call failed (/insight)")
         raise HTTPException(status_code=503, detail=INSIGHT_TEMP_UNAVAILABLE_MESSAGE) from None

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2213,7 +2213,6 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
             rag_ctx = _rag_structured(prompt_input, max_chunks=3)
-            rag_actually_used = True
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:
@@ -2224,6 +2223,7 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
                     prompt_input,
                     _redact_rag_context_for_insight(raw_context),
                 )
+            rag_actually_used = True
     if len(prompt_text) > INSIGHT_TEXT_MAX_LENGTH:
         prompt_text = prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
     try:
@@ -2278,7 +2278,6 @@ async def insight(req: InsightRequest) -> InsightResponse:
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
             rag_ctx = _rag_structured(prompt_input, max_chunks=3)
-            rag_actually_used = True
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:
@@ -2289,6 +2288,7 @@ async def insight(req: InsightRequest) -> InsightResponse:
                     prompt_input,
                     _redact_rag_context_for_insight(raw_context),
                 )
+            rag_actually_used = True
     if len(prompt_text) > INSIGHT_TEXT_MAX_LENGTH:
         prompt_text = prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
     try:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2155,27 +2155,17 @@ from core.insight.llm_provider_loader import (  # noqa: E402
 
 
 def _format_rag_chunks_for_prompt(chunks: list[Any]) -> str:
-    """Concatenate RAGChunk objects into a prompt-ready string with source headers."""
-    parts: list[str] = []
-    for ch in chunks:
-        parts.append(f"# Source: {ch.file} (score={ch.score:.2f})\n{ch.content}")
-    return "\n\n".join(parts)
+    """Thin proxy → core.rag.formatting.format_rag_chunks_for_prompt."""
+    from core.rag.formatting import format_rag_chunks_for_prompt
+
+    return format_rag_chunks_for_prompt(chunks)
 
 
 def _build_rag_source_items(chunks: list[Any]) -> list[RAGSourceItem]:
-    """Build RAGSourceItem list from RAGChunks with redacted previews."""
-    items: list[RAGSourceItem] = []
-    for ch in chunks:
-        preview = _redact_rag_context_for_insight(ch.content)
-        items.append(
-            RAGSourceItem(
-                chunk_id=ch.chunk_id,
-                file=ch.file,
-                preview=preview[:200] if preview else "",
-                score=round(ch.score, 4),
-            )
-        )
-    return items
+    """Thin proxy → core.rag.formatting.build_rag_source_dicts."""
+    from core.rag.formatting import build_rag_source_dicts
+
+    return [RAGSourceItem(**d) for d in build_rag_source_dicts(chunks)]
 
 
 async def insight_v1(req: InsightRequest) -> InsightResponse:
@@ -2212,7 +2202,7 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
         with suppress(Exception):
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
-            rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_ctx = await run_in_threadpool(_rag_structured, prompt_input, max_chunks=3)
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:
@@ -2277,7 +2267,7 @@ async def insight(req: InsightRequest) -> InsightResponse:
         with suppress(Exception):
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
-            rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_ctx = await run_in_threadpool(_rag_structured, prompt_input, max_chunks=3)
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2207,11 +2207,13 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
     rag_confidence: Optional[float] = None
     rag_hops: int = 0
     rag_latency_ms: int = 0
+    rag_actually_used = False
     if use_rag:
         with suppress(Exception):
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
             rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_actually_used = True
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:
@@ -2231,7 +2233,7 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
             insight=insight_text,
             sources=rag_sources,
             confidence=rag_confidence,
-            rag_used=use_rag,
+            rag_used=rag_actually_used,
             hops=rag_hops,
             latency_ms=rag_latency_ms,
         )
@@ -2270,11 +2272,13 @@ async def insight(req: InsightRequest) -> InsightResponse:
     rag_confidence: Optional[float] = None
     rag_hops: int = 0
     rag_latency_ms: int = 0
+    rag_actually_used = False
     if use_rag:
         with suppress(Exception):
             from core.rag.simple_rag import retrieve_context_structured as _rag_structured
 
             rag_ctx = _rag_structured(prompt_input, max_chunks=3)
+            rag_actually_used = True
             rag_hops = rag_ctx.hops
             rag_latency_ms = rag_ctx.latency_ms
             if rag_ctx.chunks:
@@ -2294,7 +2298,7 @@ async def insight(req: InsightRequest) -> InsightResponse:
             insight=insight_text,
             sources=rag_sources,
             confidence=rag_confidence,
-            rag_used=use_rag,
+            rag_used=rag_actually_used,
             hops=rag_hops,
             latency_ms=rag_latency_ms,
         )

--- a/tests/test_insight_error_hygiene.py
+++ b/tests/test_insight_error_hygiene.py
@@ -60,6 +60,49 @@ def test_insight_redacts_rag_source_headers(
     """Ensure RAG context source lines are not forwarded to the LLM prompt."""
 
     import llm
+    from dataclasses import dataclass
+    from typing import Optional
+
+    @dataclass
+    class _FakeChunk:
+        chunk_id: str
+        file: str
+        content: str
+        score: float
+        hop: int = 1
+
+    @dataclass
+    class _FakeCtx:
+        query: str
+        refined_queries: list[str]
+        chunks: list[_FakeChunk]
+        confidence: float
+        hops: int
+        latency_ms: int
+        agent_id: Optional[str] = None
+        user_tier: Optional[str] = None
+
+    def fake_structured(
+        query: str,
+        max_chunks: int = 3,
+        agent_id: str | None = None,
+        user_tier: str | None = None,
+    ) -> _FakeCtx:
+        return _FakeCtx(
+            query=query,
+            refined_queries=[query],
+            chunks=[
+                _FakeChunk(
+                    chunk_id="secret.md:1",
+                    file="secret.md",
+                    content="# Source: secret.md (score=0.99)\n\nHELLO",
+                    score=0.99,
+                ),
+            ],
+            confidence=0.99,
+            hops=1,
+            latency_ms=10,
+        )
 
     class EchoProvider:
         name = "echo"
@@ -67,16 +110,12 @@ def test_insight_redacts_rag_source_headers(
         async def generate(self, text: str) -> str:
             return text
 
-    def fake_retrieve_context(query: str, max_chunks: int = 3) -> str:
-        # Simulate internal metadata that must NOT leak.
-        return "# Source: secret.md (score=0.99)\n\nHELLO"
-
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
     monkeypatch.setenv("FEATURE_RAG", "true")
     monkeypatch.setattr(llm, "get_provider", lambda: EchoProvider(), raising=True)
     monkeypatch.setattr(
-        "core.rag.simple_rag.retrieve_context",
-        fake_retrieve_context,
+        "core.rag.simple_rag.retrieve_context_structured",
+        fake_structured,
         raising=True,
     )
 

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -1,0 +1,303 @@
+"""
+Deterministic tests for RAG response fields in InsightResponse per RAG_CONTRACT.md §2.
+
+Covers: sources[], confidence, rag_used, hops, latency_ms in both
+/api/v1/insight and /insight endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@dataclass
+class _FakeRAGChunk:
+    chunk_id: str
+    file: str
+    content: str
+    score: float
+    hop: int = 1
+
+
+@dataclass
+class _FakeRAGContext:
+    query: str
+    refined_queries: list[str]
+    chunks: list[_FakeRAGChunk]
+    confidence: float
+    hops: int
+    latency_ms: int
+    agent_id: Optional[str] = None
+    user_tier: Optional[str] = None
+
+
+def _make_fake_structured(
+    query: str,
+    max_chunks: int = 3,
+    agent_id: str | None = None,
+    user_tier: str | None = None,
+) -> _FakeRAGContext:
+    """Fake retrieve_context_structured that returns two chunks."""
+    chunks = [
+        _FakeRAGChunk(
+            chunk_id="readme.md:1",
+            file="readme.md",
+            content="BMI is body mass index.",
+            score=0.85,
+            hop=1,
+        ),
+        _FakeRAGChunk(
+            chunk_id="faq.md:1",
+            file="faq.md",
+            content="# Source: internal.py (score=0.5)\nFrequently asked.",
+            score=0.65,
+            hop=1,
+        ),
+    ]
+    return _FakeRAGContext(
+        query=query,
+        refined_queries=[query],
+        chunks=chunks[:max_chunks],
+        confidence=0.75,
+        hops=1,
+        latency_ms=42,
+        agent_id=agent_id,
+        user_tier=user_tier,
+    )
+
+
+def _make_empty_structured(
+    query: str,
+    max_chunks: int = 3,
+    agent_id: str | None = None,
+    user_tier: str | None = None,
+) -> _FakeRAGContext:
+    """Fake retrieve_context_structured that returns zero chunks."""
+    return _FakeRAGContext(
+        query=query,
+        refined_queries=[query],
+        chunks=[],
+        confidence=0.0,
+        hops=1,
+        latency_ms=5,
+        agent_id=agent_id,
+        user_tier=user_tier,
+    )
+
+
+class _EchoProvider:
+    name = "echo"
+
+    async def generate(self, text: str) -> str:
+        return text
+
+
+class TestInsightV1RAGFields:
+    """RAG response fields on /api/v1/insight."""
+
+    def test_rag_enabled_returns_sources_and_metadata(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        monkeypatch.setattr(
+            "core.rag.simple_rag.retrieve_context_structured",
+            _make_fake_structured,
+            raising=True,
+        )
+
+        resp = client.post("/api/v1/insight", json={"text": "What is BMI?"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rag_used"] is True
+        assert data["hops"] == 1
+        assert data["latency_ms"] == 42
+        assert data["confidence"] == 0.75
+
+        sources = data["sources"]
+        assert len(sources) == 2
+        assert sources[0]["chunk_id"] == "readme.md:1"
+        assert sources[0]["file"] == "readme.md"
+        assert sources[0]["score"] == 0.85
+        # preview exists and is a string
+        assert isinstance(sources[0]["preview"], str)
+
+    def test_rag_enabled_empty_chunks_returns_zero_sources(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        monkeypatch.setattr(
+            "core.rag.simple_rag.retrieve_context_structured",
+            _make_empty_structured,
+            raising=True,
+        )
+
+        resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rag_used"] is True
+        assert data["sources"] == []
+        assert data["confidence"] is None
+        assert data["hops"] == 1
+        assert data["latency_ms"] == 5
+
+    def test_rag_disabled_returns_defaults(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "false")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+
+        resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rag_used"] is False
+        assert data["sources"] == []
+        assert data["confidence"] is None
+        assert data["hops"] == 0
+        assert data["latency_ms"] == 0
+
+    def test_rag_source_preview_redacts_internal_metadata(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        """sources[].preview must not contain '# Source:' lines (redaction)."""
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        monkeypatch.setattr(
+            "core.rag.simple_rag.retrieve_context_structured",
+            _make_fake_structured,
+            raising=True,
+        )
+
+        resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        for src in data["sources"]:
+            assert "# Source:" not in src["preview"]
+
+    def test_insight_text_not_contaminated_by_source_headers(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        """insight text (echoed prompt) must not leak internal file paths."""
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        monkeypatch.setattr(
+            "core.rag.simple_rag.retrieve_context_structured",
+            _make_fake_structured,
+            raising=True,
+        )
+
+        resp = client.post("/api/v1/insight", json={"text": "What is BMI?"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Source:" not in data["insight"]
+
+
+class TestInsightLegacyRAGFields:
+    """RAG response fields on /insight (legacy path)."""
+
+    def test_legacy_rag_enabled_returns_fields(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        monkeypatch.setattr(
+            "core.rag.simple_rag.retrieve_context_structured",
+            _make_fake_structured,
+            raising=True,
+        )
+
+        resp = client.post("/insight", json={"text": "test"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rag_used"] is True
+        assert len(data["sources"]) == 2
+        assert data["confidence"] == 0.75
+        assert data["hops"] == 1
+        assert data["latency_ms"] == 42
+
+    def test_legacy_rag_disabled_returns_defaults(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "false")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+
+        resp = client.post("/insight", json={"text": "test"}, headers=vip_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rag_used"] is False
+        assert data["sources"] == []
+        assert data["confidence"] is None
+        assert data["hops"] == 0
+        assert data["latency_ms"] == 0
+
+
+class TestRAGSourceItemModel:
+    """Unit tests for RAGSourceItem and InsightResponse Pydantic models."""
+
+    def test_insight_response_backward_compat(self) -> None:
+        """Old-style (provider + insight only) must still work."""
+        from legacy_app import InsightResponse
+
+        r = InsightResponse(provider="test", insight="hello")
+        d = r.model_dump()
+        assert d["sources"] == []
+        assert d["confidence"] is None
+        assert d["rag_used"] is False
+        assert d["hops"] == 0
+        assert d["latency_ms"] == 0
+
+    def test_rag_source_item_fields(self) -> None:
+        from legacy_app import RAGSourceItem
+
+        item = RAGSourceItem(chunk_id="a:1", file="a.md", preview="text", score=0.77)
+        assert item.chunk_id == "a:1"
+        assert item.file == "a.md"
+        assert item.preview == "text"
+        assert item.score == 0.77

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -118,6 +118,7 @@ class TestInsightV1RAGFields:
 
         resp = client.post("/api/v1/insight", json={"text": "What is BMI?"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert data["rag_used"] is True
         assert data["hops"] == 1
@@ -151,6 +152,7 @@ class TestInsightV1RAGFields:
 
         resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert data["rag_used"] is True
         assert data["sources"] == []
@@ -172,6 +174,7 @@ class TestInsightV1RAGFields:
 
         resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert data["rag_used"] is False
         assert data["sources"] == []
@@ -199,6 +202,7 @@ class TestInsightV1RAGFields:
 
         resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         for src in data["sources"]:
             assert "# Source:" not in src["preview"]
@@ -223,6 +227,7 @@ class TestInsightV1RAGFields:
 
         resp = client.post("/api/v1/insight", json={"text": "What is BMI?"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert "Source:" not in data["insight"]
 
@@ -249,6 +254,7 @@ class TestInsightLegacyRAGFields:
 
         resp = client.post("/insight", json={"text": "test"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert data["rag_used"] is True
         assert len(data["sources"]) == 2
@@ -270,6 +276,7 @@ class TestInsightLegacyRAGFields:
 
         resp = client.post("/insight", json={"text": "test"}, headers=vip_headers)
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert data["rag_used"] is False
         assert data["sources"] == []

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -307,10 +307,41 @@ async def test_insight_v1_rag_path_builds_prompt(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(llm, "get_provider", lambda: _Provider())
 
-    # Patch retrieve_context to return context (exercise walrus branch)
+    # Patch retrieve_context_structured to return a context with chunks
     import core.rag.simple_rag as simple_rag
+    from dataclasses import dataclass
+    from typing import Optional
 
-    monkeypatch.setattr(simple_rag, "retrieve_context", lambda *_a, **_k: "ctx")
+    @dataclass
+    class _Chunk:
+        chunk_id: str
+        file: str
+        content: str
+        score: float
+        hop: int = 1
+
+    @dataclass
+    class _Ctx:
+        query: str
+        refined_queries: list[str]
+        chunks: list[_Chunk]
+        confidence: float
+        hops: int
+        latency_ms: int
+        agent_id: Optional[str] = None
+        user_tier: Optional[str] = None
+
+    def _fake_structured(*_a: object, **_k: object) -> _Ctx:
+        return _Ctx(
+            query="question",
+            refined_queries=["question"],
+            chunks=[_Chunk(chunk_id="a:1", file="a.md", content="ctx", score=0.9)],
+            confidence=0.9,
+            hops=1,
+            latency_ms=10,
+        )
+
+    monkeypatch.setattr(simple_rag, "retrieve_context_structured", _fake_structured)
 
     req = legacy_app.InsightRequest(text="question")
     out = await legacy_app.insight_v1(req)
@@ -334,8 +365,39 @@ async def test_insight_v1_trims_prompt_text(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(llm, "get_provider", lambda: _Provider())
     import core.rag.simple_rag as simple_rag
+    from dataclasses import dataclass
+    from typing import Optional
 
-    monkeypatch.setattr(simple_rag, "retrieve_context", lambda *_a, **_k: "ctx")
+    @dataclass
+    class _Chunk:
+        chunk_id: str
+        file: str
+        content: str
+        score: float
+        hop: int = 1
+
+    @dataclass
+    class _Ctx:
+        query: str
+        refined_queries: list[str]
+        chunks: list[_Chunk]
+        confidence: float
+        hops: int
+        latency_ms: int
+        agent_id: Optional[str] = None
+        user_tier: Optional[str] = None
+
+    def _fake_structured(*_a: object, **_k: object) -> _Ctx:
+        return _Ctx(
+            query="q",
+            refined_queries=["q"],
+            chunks=[_Chunk(chunk_id="a:1", file="a.md", content="ctx", score=0.9)],
+            confidence=0.9,
+            hops=1,
+            latency_ms=10,
+        )
+
+    monkeypatch.setattr(simple_rag, "retrieve_context_structured", _fake_structured)
     monkeypatch.setattr(
         legacy_app,
         "_build_insight_prompt",
@@ -363,13 +425,42 @@ async def test_legacy_insight_rag_path_trims(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr(llm, "get_provider", lambda: _Provider())
     import core.rag.simple_rag as simple_rag
+    from dataclasses import dataclass
+    from typing import Optional
+
+    @dataclass
+    class _Chunk:
+        chunk_id: str
+        file: str
+        content: str
+        score: float
+        hop: int = 1
+
+    @dataclass
+    class _Ctx:
+        query: str
+        refined_queries: list[str]
+        chunks: list[_Chunk]
+        confidence: float
+        hops: int
+        latency_ms: int
+        agent_id: Optional[str] = None
+        user_tier: Optional[str] = None
 
     # Return a large context to force prompt trimming
-    monkeypatch.setattr(
-        simple_rag,
-        "retrieve_context",
-        lambda *_a, **_k: "c" * (legacy_app.INSIGHT_TEXT_MAX_LENGTH * 2),
-    )
+    big_content = "c" * (legacy_app.INSIGHT_TEXT_MAX_LENGTH * 2)
+
+    def _fake_structured(*_a: object, **_k: object) -> _Ctx:
+        return _Ctx(
+            query="q",
+            refined_queries=["q"],
+            chunks=[_Chunk(chunk_id="a:1", file="a.md", content=big_content, score=0.9)],
+            confidence=0.9,
+            hops=1,
+            latency_ms=10,
+        )
+
+    monkeypatch.setattr(simple_rag, "retrieve_context_structured", _fake_structured)
 
     req = legacy_app.InsightRequest(text="q")
     out = await legacy_app.insight(req)
@@ -393,8 +484,39 @@ async def test_legacy_insight_trims_prompt_text(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(llm, "get_provider", lambda: _Provider())
     import core.rag.simple_rag as simple_rag
+    from dataclasses import dataclass
+    from typing import Optional
 
-    monkeypatch.setattr(simple_rag, "retrieve_context", lambda *_a, **_k: "ctx")
+    @dataclass
+    class _Chunk:
+        chunk_id: str
+        file: str
+        content: str
+        score: float
+        hop: int = 1
+
+    @dataclass
+    class _Ctx:
+        query: str
+        refined_queries: list[str]
+        chunks: list[_Chunk]
+        confidence: float
+        hops: int
+        latency_ms: int
+        agent_id: Optional[str] = None
+        user_tier: Optional[str] = None
+
+    def _fake_structured(*_a: object, **_k: object) -> _Ctx:
+        return _Ctx(
+            query="q",
+            refined_queries=["q"],
+            chunks=[_Chunk(chunk_id="a:1", file="a.md", content="ctx", score=0.9)],
+            confidence=0.9,
+            hops=1,
+            latency_ms=10,
+        )
+
+    monkeypatch.setattr(simple_rag, "retrieve_context_structured", _fake_structured)
     monkeypatch.setattr(
         legacy_app,
         "_build_insight_prompt",

--- a/tests/test_rag_contracts.py
+++ b/tests/test_rag_contracts.py
@@ -1,0 +1,129 @@
+"""
+Tests for RAG contract types and constants per RAG_CONTRACT.md §3–§4.
+
+Covers: RAGChunk, RAGContext, rag_constants, retrieve_context_structured.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.rag_constants import (
+    MAX_CHUNK_SIZE_CHARS,
+    MAX_CHUNKS_PER_HOP,
+    MAX_RAG_HOPS,
+    MAX_SOURCES_IN_RESPONSE,
+    MIN_CHUNK_SCORE,
+    RAG_PIPELINE_TIMEOUT_SEC,
+)
+
+
+class TestRAGChunk:
+    """RAGChunk dataclass per RAG_CONTRACT §3."""
+
+    def test_rag_chunk_default_hop(self) -> None:
+        c = RAGChunk(chunk_id="a", file="f.md", content="x", score=0.5)
+        assert c.hop == 1
+
+    def test_rag_chunk_explicit_hop(self) -> None:
+        c = RAGChunk(chunk_id="b", file="g.md", content="y", score=0.8, hop=2)
+        assert c.hop == 2
+
+
+class TestRAGContext:
+    """RAGContext dataclass per RAG_CONTRACT §3."""
+
+    def test_rag_context_minimal(self) -> None:
+        ctx = RAGContext(
+            query="q",
+            refined_queries=["q"],
+            chunks=[],
+            confidence=0.0,
+            hops=1,
+            latency_ms=10,
+        )
+        assert ctx.agent_id is None
+        assert ctx.user_tier is None
+
+    def test_rag_context_with_agent_tier(self) -> None:
+        ctx = RAGContext(
+            query="q",
+            refined_queries=["q", "q2"],
+            chunks=[],
+            confidence=0.5,
+            hops=2,
+            latency_ms=100,
+            agent_id="cbt-agent",
+            user_tier="PRO",
+        )
+        assert ctx.agent_id == "cbt-agent"
+        assert ctx.user_tier == "PRO"
+
+
+class TestRAGConstants:
+    """Constants per RAG_CONTRACT §4."""
+
+    def test_budget_constants_values(self) -> None:
+        assert MAX_RAG_HOPS == 3
+        assert MAX_CHUNKS_PER_HOP == 5
+        assert MAX_SOURCES_IN_RESPONSE == 5
+        assert RAG_PIPELINE_TIMEOUT_SEC == 10
+        assert MIN_CHUNK_SCORE == 0.1
+        assert MAX_CHUNK_SIZE_CHARS == 800
+
+
+class TestRetrieveContextStructured:
+    """retrieve_context_structured returns RAGContext."""
+
+    def test_retrieve_context_structured_empty_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from core.rag import simple_rag
+
+        monkeypatch.setattr(simple_rag, "_get_index", lambda: [])
+        from core.rag.simple_rag import retrieve_context_structured
+
+        ctx = retrieve_context_structured("any query")
+        assert isinstance(ctx, RAGContext)
+        assert ctx.query == "any query"
+        assert ctx.chunks == []
+        assert ctx.confidence == 0.0
+        assert ctx.hops == 1
+        assert ctx.latency_ms >= 0
+        assert ctx.refined_queries == ["any query"]
+
+    def test_retrieve_context_structured_with_agent_tier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import simple_rag
+
+        monkeypatch.setattr(simple_rag, "_get_index", lambda: [])
+        from core.rag.simple_rag import retrieve_context_structured
+
+        ctx = retrieve_context_structured("query", agent_id="insight-default", user_tier="FREE")
+        assert ctx.agent_id == "insight-default"
+        assert ctx.user_tier == "FREE"
+
+    def test_retrieve_context_structured_with_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-empty index produces RAGChunks with confidence and latency."""
+        from core.rag import simple_rag
+        from core.rag.simple_rag import retrieve_context_structured
+
+        fake_index = [
+            ("docs/readme.md", "BMI is body mass index used in health"),
+            ("docs/faq.md", "Frequently asked questions about nutrition"),
+        ]
+        monkeypatch.setattr(simple_rag, "_get_index", lambda: fake_index)
+
+        ctx = retrieve_context_structured("BMI body mass", max_chunks=3)
+        assert isinstance(ctx, RAGContext)
+        assert ctx.hops == 1
+        assert ctx.latency_ms >= 0
+        # At least one chunk should match (Jaccard on shared tokens)
+        assert len(ctx.chunks) >= 1
+        for chunk in ctx.chunks:
+            assert isinstance(chunk, RAGChunk)
+            assert chunk.score >= 0.0
+            assert chunk.hop == 1
+            assert chunk.chunk_id
+            assert chunk.file
+        assert ctx.confidence > 0.0


### PR DESCRIPTION
## Summary

- Extend `InsightResponse` with RAG metadata fields (`sources[]`, `confidence`, `rag_used`, `hops`, `latency_ms`) per `docs/contracts/RAG_CONTRACT.md` §2
- Add core RAG types (`RAGChunk`, `RAGContext` in `core/rag/contracts.py`) and budget constants (`core/rag/rag_constants.py`) per contract §3–§4
- Wire `retrieve_context_structured()` into both `/api/v1/insight` and `/insight` endpoints, replacing old `retrieve_context()` string API
- All new fields optional with safe defaults — backward compatible (old clients unaffected)
- Source previews redacted via `redact_rag_context_for_insight()` — no PII/internal structure leaks

Supersedes #934.

## Key files

| File | Change |
|------|--------|
| `core/rag/contracts.py` | New: `RAGChunk`, `RAGContext` dataclasses |
| `core/rag/rag_constants.py` | New: budget constants (MAX_RAG_HOPS, MAX_SOURCES, etc.) |
| `core/rag/__init__.py` | New: package exports |
| `core/rag/simple_rag.py` | Add `retrieve_context_structured()` returning `RAGContext` |
| `core/rag/formatting.py` | New: RAG formatting helpers with TypedDict (moved from legacy_app.py) |
| `legacy_app.py` | Extend `InsightResponse`, add `RAGSourceItem`, wire structured RAG |
| `docs/roadmap/BACKLOG_LEDGER.md` | Update RAG contract item status |

## Verification

- `make lint` — pass
- `make typecheck` — pass (225 files, no issues)
- `make test-fast` — pass
- `diff-cover` — **100%** (102 new lines, 0 missing)
- `pre-commit run --all-files` — pass
- `test_openapi_determinism` — pass
- `test_repo_policy_guards` — pass

## Deferred / Follow-ups

- P1: RAG feedback storage — tracked in `BACKLOG_LEDGER.md`
- P2: Multi-hop RAG — tracked in `BACKLOG_LEDGER.md`
- P2: Agent-specific RAG corpus routing — tracked in `BACKLOG_LEDGER.md`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869337423 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869349902 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869350194 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869419308 -> 9ccea684
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869420422 -> 9ccea684
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869457566 -> 523af7bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869516346 -> e0ccdaa4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#pullrequestreview-3869521478 -> 812f7ef5
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443238 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443245 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443252 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443258 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443490 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866443493 -> d2067c60
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866504199 -> 9ccea684
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866505310 -> 9ccea684
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866542781 -> 523af7bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866542782 -> 523af7bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866595727 -> e0ccdaa4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/935#discussion_r2866600577 -> 812f7ef5

## Merge Readiness

- [x] `make verify` passes locally
- [x] `pre-commit run --all-files` passes
- [x] Diff-coverage ≥97% (actual: 100%)
- [x] OpenAPI artifacts regenerated and committed
- [x] No `PR: TBD` in docs
- [ ] CI green
- [ ] CodeRabbit / Sourcery / bot reviews addressed
