### PR TITLE
fix(ci): use absolute path for Trivy ignore-policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TRIVY_IGNORE_POLICY_PATH: trivy/ignore-policy.rego
 
 jobs:
   # Build and test Docker image
@@ -110,7 +109,7 @@ jobs:
           # FS scan is report-only: publish SARIF findings without blocking merges.
           exit-code: '0'
           trivyignores: '.trivyignore'
-          ignore-policy: ${{ env.TRIVY_IGNORE_POLICY_PATH }}
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
@@ -188,7 +187,7 @@ jobs:
           output: 'trivy-image.sarif'
           severity: 'CRITICAL,HIGH'
           trivyignores: '.trivyignore'
-          ignore-policy: ${{ env.TRIVY_IGNORE_POLICY_PATH }}
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
 
       - name: Upload Trivy image scan results
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,20 +96,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - name: Run Trivy vulnerability scanner (filesystem scan)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
         with:
-          scan-type: 'fs'
-          scan-ref: .
-          scanners: vuln
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          # FS scan is report-only: publish SARIF findings without blocking merges.
-          exit-code: '0'
-          trivyignores: '.trivyignore'
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          version: 'v0.65.0'
+
+      - name: Run Trivy vulnerability scanner (filesystem scan)
+        run: |
+          trivy fs . \
+            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
+            --scanners vuln \
+            --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
+            --ignore-unfixed --exit-code 0 --trivyignore .trivyignore
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
@@ -177,17 +175,19 @@ jobs:
         run: |
           echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
+        with:
+          version: 'v0.65.0'
+
       - name: Run Trivy vulnerability scanner (image scan, report-only)
         continue-on-error: true
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
-        with:
-          scan-type: 'image'
-          image-ref: ${{ steps.image-ref.outputs.ref }}
-          format: 'sarif'
-          output: 'trivy-image.sarif'
-          severity: 'CRITICAL,HIGH'
-          trivyignores: '.trivyignore'
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+        run: |
+          trivy image \
+            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
+            --format sarif --output trivy-image.sarif --severity CRITICAL,HIGH \
+            --trivyignore .trivyignore \
+            '${{ steps.image-ref.outputs.ref }}'
 
       - name: Upload Trivy image scan results
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,9 @@ jobs:
         with:
           version: 'v0.65.0'
 
+      - name: Restore ignore-policy after setup-trivy
+        run: git checkout -- trivy/ignore-policy.rego
+
       - name: Run Trivy vulnerability scanner (filesystem scan)
         run: |
           trivy fs . \
@@ -179,6 +182,9 @@ jobs:
         uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
         with:
           version: 'v0.65.0'
+
+      - name: Restore ignore-policy after setup-trivy
+        run: git checkout -- trivy/ignore-policy.rego
 
       - name: Run Trivy vulnerability scanner (image scan, report-only)
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
             --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
             --scanners vuln \
             --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
-            --ignore-unfixed --exit-code 0 --trivyignore .trivyignore
+            --ignore-unfixed --exit-code 0 --ignorefile .trivyignore
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
@@ -186,7 +186,7 @@ jobs:
           trivy image \
             --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
             --format sarif --output trivy-image.sarif --severity CRITICAL,HIGH \
-            --trivyignore .trivyignore \
+            --ignorefile .trivyignore \
             '${{ steps.image-ref.outputs.ref }}'
 
       - name: Upload Trivy image scan results

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,9 +18,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TRIVY_IGNORE_POLICY_PATH: trivy/ignore-policy.rego
-
 jobs:
   build:
     permissions:
@@ -55,7 +52,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           trivyignores: '.trivyignore'
-          ignore-policy: ${{ env.TRIVY_IGNORE_POLICY_PATH }}
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -53,7 +53,7 @@ jobs:
           trivy image \
             --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
             --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
-            --trivyignore .trivyignore \
+            --ignorefile .trivyignore \
             'pulseplate:trivy-scan-${{ github.sha }}'
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,16 +43,18 @@ jobs:
           tags: pulseplate:trivy-scan-${{ github.sha }}
           target: production
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.30.0
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
         with:
-          image-ref: 'pulseplate:trivy-scan-${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          trivyignores: '.trivyignore'
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          version: 'v0.65.0'
+
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
+            --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
+            --trivyignore .trivyignore \
+            'pulseplate:trivy-scan-${{ github.sha }}'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           version: 'v0.65.0'
 
+      - name: Restore ignore-policy after setup-trivy
+        run: git checkout -- trivy/ignore-policy.rego
+
       - name: Run Trivy vulnerability scanner
         run: |
           trivy image \


### PR DESCRIPTION
## Summary

- Fixes Trivy workflow failure: "unable to read the policy file: open trivy/ignore-policy.rego: no such file or directory"
- Root cause 1: `TRIVY_IGNORE_POLICY_PATH` env var was set to a relative path at workflow level; Trivy reads this env var directly, bypassing the step-level override
- Root cause 2: Previous fix attempt switched to `trivy-action` (Docker container action) where `${{ github.workspace }}` host paths are not accessible inside the container
- Fix: Remove workflow-level env var, keep `setup-trivy` + CLI approach (runs on host), pass absolute path inline via `${{ github.workspace }}/trivy/ignore-policy.rego`

## Changes

### Modified Files
- `.github/workflows/trivy.yml` - Remove workflow-level `TRIVY_IGNORE_POLICY_PATH`, use inline absolute path in CLI `--ignore-policy` flag
- `.github/workflows/build.yml` - Same fix for `security-scan` job; replace `trivy-action` with `setup-trivy` + CLI for `publish` job image scan

## Test Plan

- [x] Pre-commit hooks pass locally
- [ ] CI `trivy` workflow passes on PR
- [ ] CI `Docker Build and Push` workflow passes on PR

## Definition of Done

- [x] Absolute path used for Trivy policy file in all workflows
- [x] No workflow-level `TRIVY_IGNORE_POLICY_PATH` env var (avoids Trivy auto-reading it)
- [x] All Trivy invocations use `setup-trivy` + CLI (not `trivy-action` Docker container)
- [ ] CI green on main after merge

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/941#pullrequestreview-3870578437 -> 2874b5f0

## Merge Readiness

- [ ] CI checks: pending
- [x] Minimal scope: infra fix only

## Deferred / Follow-ups

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI security scanning switched from action-based runs to explicit CLI invocations with dedicated setup steps for the scanner.
  * Scans now pass policy and ignore rules via inline paths and the newer ignore-file option; SARIF outputs and severity handling remain unchanged.
  * Added a restore step to ensure tracked policy files are preserved after scanner setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->