### PR TITLE
feat(rag): add P2 CBT agent with corpus-filtered RAG retrieval (#942)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,5 +42,10 @@ FEATURE_FOOD_SEARCH_SEMANTIC_ENABLED=false
 # Falls back to Jaccard automatically on failure or when disabled.
 FEATURE_RAG_VECTOR=false
 
+# === CBT Agent Feature ===
+# When true, enables the CBT (Cognitive Behavioral Therapy) insight endpoint.
+# Requires PRO tier access and RAG corpus docs/cbt/ and docs/psychology/.
+FEATURE_CBT_AGENT=false
+
 # Optional bootstrap semantic retrieval candidate pool size (safe bounds: 1..5000).
 FOOD_SEARCH_SEMANTIC_CANDIDATE_LIMIT=250

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.bootstrap.metrics import register_metrics
 from app.bootstrap.pro_contracts import register_pro_contract_routes
 import app.routers.realtime_ws as realtime_ws
 from app.routers.feedback import router as feedback_router
+from app.routers.cbt_insight import router as cbt_insight_router
 
 app: FastAPI = _legacy_app
 
@@ -44,5 +45,8 @@ app.include_router(realtime_ws.router)
 
 # Register feedback router (new endpoint, not legacy — belongs here per policy)
 app.include_router(feedback_router)
+
+# Register CBT insight router (PRO tier, feature-flagged via FEATURE_CBT_AGENT)
+app.include_router(cbt_insight_router)
 
 __all__ = ["app"]

--- a/app/routers/cbt_insight.py
+++ b/app/routers/cbt_insight.py
@@ -9,6 +9,7 @@ Feature-gated via FEATURE_CBT_AGENT environment variable.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 
@@ -27,6 +28,9 @@ from app.security.rate_limit import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/pro/cbt", tags=["CBT", "pro"])
+
+# LLM provider call timeout (seconds) - prevents unbounded requests
+LLM_TIMEOUT_SECONDS: float = 60.0
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +139,7 @@ Provide a helpful, CBT-informed response:"""
         422: {"description": "Validation error in request"},
         429: {"description": "Rate limit exceeded"},
         503: {"description": "CBT agent feature disabled or unavailable"},
+        504: {"description": "LLM provider call timed out"},
         **RATE_LIMIT_429_RESPONSES,
     },
 )
@@ -210,7 +215,10 @@ async def cbt_insight(
         from llm import get_provider
 
         provider = get_provider()
-        insight_text = await run_in_threadpool(provider.generate, prompt)
+        insight_text = await asyncio.wait_for(
+            run_in_threadpool(provider.generate, prompt),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
 
         if not insight_text:
             raise HTTPException(
@@ -223,6 +231,12 @@ async def cbt_insight(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="LLM provider not available",
+        )
+    except asyncio.TimeoutError:
+        logger.error("LLM provider call timed out after %s seconds", LLM_TIMEOUT_SECONDS)
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="LLM provider call timed out",
         )
     except HTTPException:
         raise

--- a/app/routers/cbt_insight.py
+++ b/app/routers/cbt_insight.py
@@ -12,12 +12,17 @@ from __future__ import annotations
 import logging
 import os
 
-from fastapi import APIRouter, Depends, HTTPException, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from app.middleware.api_tiers import require_pro_tier
 from app.routers.api_key import api_key_header
+from app.security.rate_limit import (
+    RATE_LIMIT_429_RESPONSES,
+    RATE_LIMIT_INSIGHT,
+    limit_if_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -128,11 +133,15 @@ Provide a helpful, CBT-informed response:"""
         401: {"description": "API key required for PRO tier access"},
         403: {"description": "API key does not have PRO tier access"},
         422: {"description": "Validation error in request"},
+        429: {"description": "Rate limit exceeded"},
         503: {"description": "CBT agent feature disabled or unavailable"},
+        **RATE_LIMIT_429_RESPONSES,
     },
 )
+@limit_if_available(RATE_LIMIT_INSIGHT)
 async def cbt_insight(
     request: CBTInsightRequest,
+    raw_request: Request,
     _api_key: str = Security(api_key_header),
     _tier: str = Depends(require_pro_tier),
 ) -> CBTInsightResponse:
@@ -215,6 +224,8 @@ async def cbt_insight(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="LLM provider not available",
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("LLM generation failed: %s", e, exc_info=True)
         raise HTTPException(

--- a/app/routers/cbt_insight.py
+++ b/app/routers/cbt_insight.py
@@ -1,0 +1,230 @@
+"""
+CBT Insight Router - PRO tier-gated endpoint for CBT-powered insights.
+
+Uses RAG with agent-specific corpus filtering (docs/cbt/, docs/psychology/)
+to provide CBT-informed responses via LLM.
+
+Feature-gated via FEATURE_CBT_AGENT environment variable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from app.middleware.api_tiers import require_pro_tier
+from app.routers.api_key import api_key_header
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/pro/cbt", tags=["CBT", "pro"])
+
+
+# ---------------------------------------------------------------------------
+# Feature flag helper
+# ---------------------------------------------------------------------------
+
+
+def _is_cbt_agent_enabled() -> bool:
+    """Check if CBT agent feature is enabled via environment variable."""
+    return os.getenv("FEATURE_CBT_AGENT", "false").lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Request/Response schemas
+# ---------------------------------------------------------------------------
+
+
+class CBTInsightRequest(BaseModel):
+    """Request schema for CBT insight endpoint."""
+
+    query: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="User query for CBT-informed insight",
+    )
+
+
+class CBTSourceItem(BaseModel):
+    """Single source from CBT corpus in response."""
+
+    chunk_id: str
+    file: str
+    preview: str
+    score: float
+
+
+class CBTInsightResponse(BaseModel):
+    """Response schema for CBT insight endpoint."""
+
+    insight: str = Field(..., description="CBT-informed response from LLM")
+    rag_used: bool = Field(default=False, description="Whether RAG context was used")
+    sources: list[CBTSourceItem] = Field(
+        default_factory=list,
+        description="CBT corpus sources used for context",
+    )
+    confidence: float = Field(default=0.0, description="RAG retrieval confidence score")
+
+
+# ---------------------------------------------------------------------------
+# CBT prompt builder
+# ---------------------------------------------------------------------------
+
+
+def _build_cbt_prompt(query: str, rag_context: str) -> str:
+    """Build CBT-informed prompt for LLM with RAG context.
+
+    The system prompt establishes the CBT coaching role and boundaries.
+    """
+    system_prompt = """You are a supportive wellness coach using evidence-based CBT (Cognitive Behavioral Therapy) principles. Your role is to:
+
+1. Help users identify and challenge unhelpful thought patterns
+2. Suggest practical CBT techniques (thought records, cognitive restructuring)
+3. Encourage self-compassion and gradual progress
+4. Focus on nutrition and wellness goals
+
+IMPORTANT BOUNDARIES:
+- You are NOT a therapist and cannot provide therapy or diagnose conditions
+- Avoid medical advice; suggest consulting professionals for health concerns
+- If someone expresses crisis/self-harm thoughts, encourage them to seek professional help
+- Use non-judgmental, supportive language
+
+Respond with practical, actionable suggestions based on CBT principles."""
+
+    if rag_context:
+        return f"""{system_prompt}
+
+RELEVANT CBT KNOWLEDGE:
+{rag_context}
+
+USER QUESTION:
+{query}
+
+Provide a helpful, CBT-informed response:"""
+    else:
+        return f"""{system_prompt}
+
+USER QUESTION:
+{query}
+
+Provide a helpful, CBT-informed response:"""
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/insight",
+    response_model=CBTInsightResponse,
+    responses={
+        200: {"description": "CBT insight generated successfully"},
+        401: {"description": "API key required for PRO tier access"},
+        403: {"description": "API key does not have PRO tier access"},
+        422: {"description": "Validation error in request"},
+        503: {"description": "CBT agent feature disabled or unavailable"},
+    },
+)
+async def cbt_insight(
+    request: CBTInsightRequest,
+    _api_key: str = Security(api_key_header),
+    _tier: str = Depends(require_pro_tier),
+) -> CBTInsightResponse:
+    """Generate CBT-informed insight using RAG and LLM.
+
+    Retrieves relevant context from CBT corpus (docs/cbt/, docs/psychology/)
+    and generates a supportive response using LLM.
+
+    Requires PRO tier API key.
+    """
+    # Check feature flag
+    if not _is_cbt_agent_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="CBT agent feature is not enabled",
+        )
+
+    # Retrieve RAG context with CBT corpus filtering
+    rag_context_str = ""
+    sources: list[CBTSourceItem] = []
+    confidence = 0.0
+    rag_used = False
+
+    try:
+        from core.rag.vector_rag import retrieve_context_structured
+
+        rag_ctx = await run_in_threadpool(
+            retrieve_context_structured,
+            request.query,
+            max_chunks=5,
+            agent_id="cbt-agent",
+            user_tier="PRO",
+        )
+
+        if rag_ctx.chunks:
+            rag_used = True
+            confidence = rag_ctx.confidence
+
+            # Build context string from chunks
+            context_parts = []
+            for chunk in rag_ctx.chunks:
+                context_parts.append(f"[{chunk.file}]\n{chunk.content}")
+                sources.append(
+                    CBTSourceItem(
+                        chunk_id=chunk.chunk_id,
+                        file=chunk.file,
+                        preview=(
+                            chunk.content[:200] + "..."
+                            if len(chunk.content) > 200
+                            else chunk.content
+                        ),
+                        score=chunk.score,
+                    )
+                )
+            rag_context_str = "\n\n".join(context_parts)
+
+    except Exception:
+        logger.warning("RAG retrieval failed for CBT insight", exc_info=True)
+        # Continue without RAG context
+
+    # Build prompt with RAG context
+    prompt = _build_cbt_prompt(request.query, rag_context_str)
+
+    # Generate insight via LLM
+    try:
+        from llm import get_provider
+
+        provider = get_provider()
+        insight_text = await run_in_threadpool(provider.generate, prompt)
+
+        if not insight_text:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="LLM provider returned empty response",
+            )
+
+    except ImportError:
+        logger.error("LLM provider not available")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LLM provider not available",
+        )
+    except Exception as e:
+        logger.error("LLM generation failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Failed to generate CBT insight",
+        )
+
+    return CBTInsightResponse(
+        insight=insight_text,
+        rag_used=rag_used,
+        sources=sources,
+        confidence=confidence,
+    )

--- a/core/rag/__init__.py
+++ b/core/rag/__init__.py
@@ -1,7 +1,12 @@
 """RAG (Retrieval-Augmented Generation) module per RAG_CONTRACT.md."""
 
 from core.rag import simple_rag
-from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.contracts import (
+    AGENT_CORPUS_MAP,
+    CorpusNotIndexedError,
+    RAGChunk,
+    RAGContext,
+)
 from core.rag.rag_constants import (
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MODEL_NAME,
@@ -15,6 +20,8 @@ from core.rag.rag_constants import (
 )
 
 __all__ = [
+    "AGENT_CORPUS_MAP",
+    "CorpusNotIndexedError",
     "RAGChunk",
     "RAGContext",
     "EMBEDDING_DIMENSIONS",

--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -3,12 +3,31 @@ RAG internal contract types per docs/contracts/RAG_CONTRACT.md §3.
 
 RAGChunk and RAGContext are passed between agents and used to build
 Insight response fields (sources, confidence, hops, latency_ms).
+
+AGENT_CORPUS_MAP defines corpus paths per agent for filtered retrieval.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Agent Corpus Mapping (per RAG_CONTRACT.md §6)
+# ---------------------------------------------------------------------------
+
+AGENT_CORPUS_MAP: dict[str, list[str]] = {
+    "cbt-agent": ["docs/cbt/", "docs/psychology/"],
+}
+"""Maps agent_id to list of corpus path prefixes for filtered retrieval."""
+
+
+class CorpusNotIndexedError(Exception):
+    """Raised when expected agent corpus is not indexed or empty."""
+
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        super().__init__(f"No indexed corpus found for agent_id={agent_id}")
 
 
 @dataclass

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
-from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.contracts import AGENT_CORPUS_MAP, RAGChunk, RAGContext
 from core.rag.rag_constants import (
     MAX_CHUNK_SIZE_CHARS,
     MAX_SOURCES_IN_RESPONSE,
@@ -142,10 +142,32 @@ def retrieve_context_structured(
 
     Backward-compatible with retrieve_context: same index and scoring;
     use this when response needs sources, confidence, hops, latency_ms.
+
+    If agent_id is in AGENT_CORPUS_MAP, filters retrieval to that agent's
+    corpus paths. Otherwise, queries all indexed content.
     """
     start = time.perf_counter()
     items = _get_index()
     refined: list[str] = [query]
+
+    # Get corpus prefixes for agent-specific filtering
+    corpus_prefixes = AGENT_CORPUS_MAP.get(agent_id) if agent_id else None
+
+    # Filter items by corpus prefixes if specified
+    if corpus_prefixes:
+        filtered_items = [
+            (src, ch)
+            for src, ch in items
+            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+        ]
+        if not filtered_items and items:
+            logger.warning(
+                "No items match corpus_prefixes=%s for agent_id=%s",
+                corpus_prefixes,
+                agent_id,
+            )
+        items = filtered_items
+
     if not items:
         return RAGContext(
             query=query,

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -158,7 +158,7 @@ def retrieve_context_structured(
         filtered_items = [
             (src, ch)
             for src, ch in items
-            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+            if any(src.startswith(prefix) for prefix in corpus_prefixes)
         ]
         if not filtered_items and items:
             logger.warning(

--- a/core/rag/vector_rag.py
+++ b/core/rag/vector_rag.py
@@ -21,7 +21,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from app.utils.feature_flags import is_rag_vector_enabled
-from core.rag.contracts import RAGChunk, RAGContext
+from core.rag.contracts import AGENT_CORPUS_MAP, RAGChunk, RAGContext
 from core.rag.rag_constants import (
     EMBEDDING_DIMENSIONS,
     MAX_CHUNK_SIZE_CHARS,
@@ -87,23 +87,37 @@ def _retrieve_vector_postgres(
     query_embedding: list[float],
     limit: int,
     session: Any,
+    corpus_prefixes: list[str] | None = None,
 ) -> list[tuple[Any, float]]:
-    """Retrieve similar rows via pgvector cosine distance operator."""
+    """Retrieve similar rows via pgvector cosine distance operator.
+
+    If corpus_prefixes is provided, filters results to rows where source
+    starts with one of the given prefixes (agent-specific corpus filtering).
+    """
     from sqlalchemy import text
 
     # Format embedding explicitly into pgvector's canonical text form
     # instead of relying on str(list) which may have inconsistent formatting.
     qvec_text = "[" + ",".join(str(x) for x in query_embedding) + "]"
 
-    stmt = text(
-        "SELECT id, content, source, "
-        "1 - (embedding <=> :qvec::vector) AS similarity "
-        "FROM user_knowledge "
-        "WHERE embedding IS NOT NULL "
-        "ORDER BY embedding <=> :qvec::vector "
-        "LIMIT :lim"
-    )
-    rows = session.execute(stmt, {"qvec": qvec_text, "lim": limit}).fetchall()
+    # Build WHERE clause with optional corpus filtering
+    where_clause = "WHERE embedding IS NOT NULL"
+    params: dict[str, Any] = {"qvec": qvec_text, "lim": limit}
+
+    if corpus_prefixes:
+        # Build OR conditions for each prefix using LIKE
+        prefix_conditions = []
+        for i, prefix in enumerate(corpus_prefixes):
+            param_name = f"prefix_{i}"
+            prefix_conditions.append(f"source LIKE :{param_name}")
+            params[param_name] = f"{prefix}%"
+        if prefix_conditions:
+            where_clause += " AND (" + " OR ".join(prefix_conditions) + ")"
+
+    # Safe: where_clause built from hardcoded AGENT_CORPUS_MAP, values use placeholders
+    sql = f"SELECT id, content, source, 1 - (embedding <=> :qvec::vector) AS similarity FROM user_knowledge {where_clause} ORDER BY embedding <=> :qvec::vector LIMIT :lim"  # nosec B608
+    stmt = text(sql)
+    rows = session.execute(stmt, params).fetchall()
     return [(row, row.similarity) for row in rows]
 
 
@@ -111,14 +125,33 @@ def _retrieve_vector_sqlite(
     query_embedding: list[float],
     limit: int,
     session: Any,
+    corpus_prefixes: list[str] | None = None,
 ) -> list[tuple[Any, float]]:
-    """Retrieve similar rows via application-level cosine (SQLite tests)."""
+    """Retrieve similar rows via application-level cosine (SQLite tests).
+
+    If corpus_prefixes is provided, filters results to rows where source
+    starts with one of the given prefixes (agent-specific corpus filtering).
+    """
     from sqlalchemy import text
 
+    # Build WHERE clause with optional corpus filtering
+    where_clause = "WHERE embedding IS NOT NULL"
+    params: dict[str, Any] = {}
+
+    if corpus_prefixes:
+        prefix_conditions = []
+        for i, prefix in enumerate(corpus_prefixes):
+            param_name = f"prefix_{i}"
+            prefix_conditions.append(f"source LIKE :{param_name}")
+            params[param_name] = f"{prefix}%"
+        if prefix_conditions:
+            where_clause += " AND (" + " OR ".join(prefix_conditions) + ")"
+
+    # Safe: where_clause built from hardcoded AGENT_CORPUS_MAP, values use placeholders
+    sql = f"SELECT id, content, source, embedding FROM user_knowledge {where_clause}"  # nosec B608
     rows = session.execute(
-        text(
-            "SELECT id, content, source, embedding FROM user_knowledge WHERE embedding IS NOT NULL"
-        )
+        text(sql),
+        params,
     ).fetchall()
 
     scored: list[tuple[Any, float]] = []
@@ -151,8 +184,15 @@ def _retrieve_vector_from_db(
     agent_id: str | None,
     user_tier: str | None,
 ) -> RAGContext:
-    """Core vector retrieval: encode query, search DB, return RAGContext."""
+    """Core vector retrieval: encode query, search DB, return RAGContext.
+
+    If agent_id is in AGENT_CORPUS_MAP, filters retrieval to that agent's
+    corpus paths. Otherwise, queries all indexed content.
+    """
     start = time.perf_counter()
+
+    # Get corpus prefixes for agent-specific filtering
+    corpus_prefixes = AGENT_CORPUS_MAP.get(agent_id) if agent_id else None
 
     provider = _get_embedding_provider()
     query_vectors = provider.encode([query])
@@ -167,9 +207,9 @@ def _retrieve_vector_from_db(
         limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
 
         if dialect == "postgresql":
-            results = _retrieve_vector_postgres(query_embedding, limit, session)
+            results = _retrieve_vector_postgres(query_embedding, limit, session, corpus_prefixes)
         else:
-            results = _retrieve_vector_sqlite(query_embedding, limit, session)
+            results = _retrieve_vector_sqlite(query_embedding, limit, session, corpus_prefixes)
 
     # Filter by minimum score and build RAGChunks
     chunks: list[RAGChunk] = []
@@ -184,6 +224,14 @@ def _retrieve_vector_from_db(
                 score=round(similarity, 4),
                 hop=1,
             )
+        )
+
+    # Log warning if agent-specific corpus expected but no results found
+    if corpus_prefixes and not chunks:
+        logger.warning(
+            "No vector results for agent_id=%s with corpus_prefixes=%s",
+            agent_id,
+            corpus_prefixes,
         )
 
     confidence = sum(c.score for c in chunks) / len(chunks) if chunks else 0.0

--- a/docs/cbt/cognitive_restructuring.md
+++ b/docs/cbt/cognitive_restructuring.md
@@ -1,0 +1,97 @@
+# Cognitive Restructuring
+
+Cognitive restructuring is a core CBT technique for identifying and challenging negative thought patterns.
+
+## Overview
+
+Cognitive restructuring helps individuals recognize distorted thinking patterns and replace them with more balanced, realistic thoughts. This technique is fundamental to Cognitive Behavioral Therapy (CBT) and has strong evidence for effectiveness in managing stress, anxiety, and emotional eating.
+
+## Common Cognitive Distortions
+
+### All-or-Nothing Thinking
+
+Viewing situations in black-and-white categories without recognizing middle ground.
+
+**Example in nutrition context:** "I ate one cookie, so my whole diet is ruined."
+
+**Challenge:** One choice does not define your entire eating pattern. Progress is about overall patterns, not perfection.
+
+### Catastrophizing
+
+Expecting the worst possible outcome from a situation.
+
+**Example:** "If I don't lose weight this week, I'll never reach my goals."
+
+**Challenge:** Weight fluctuates naturally. Focus on sustainable habits rather than short-term numbers.
+
+### Emotional Reasoning
+
+Believing something is true because it feels true, despite evidence.
+
+**Example:** "I feel like a failure, so I must be one."
+
+**Challenge:** Feelings are not facts. Examine the evidence for and against this belief.
+
+### Should Statements
+
+Using "should," "must," or "ought to" statements that create unrealistic expectations.
+
+**Example:** "I should never crave unhealthy foods."
+
+**Challenge:** Cravings are normal human experiences. The goal is managing responses, not eliminating feelings.
+
+### Mental Filtering
+
+Focusing only on negative aspects while ignoring positives.
+
+**Example:** "I ate vegetables all week but had cake at a party - I'm terrible at eating healthy."
+
+**Challenge:** Acknowledge the full picture, including your successes.
+
+## The ABCDE Model
+
+A structured approach to cognitive restructuring:
+
+### A - Activating Event
+
+Identify the specific situation or trigger.
+
+### B - Belief
+
+Recognize the automatic thought or belief triggered by the event.
+
+### C - Consequence
+
+Note the emotional and behavioral consequences of the belief.
+
+### D - Dispute
+
+Challenge the belief with evidence and alternative perspectives.
+
+### E - Effect
+
+Experience the new feeling that comes from a more balanced perspective.
+
+## Practical Steps
+
+1. **Notice the thought:** Become aware when negative thoughts arise
+2. **Write it down:** Externalizing thoughts helps examine them objectively
+3. **Identify the distortion:** Which cognitive distortion pattern is present?
+4. **Gather evidence:** What facts support or contradict this thought?
+5. **Create a balanced thought:** Develop a more realistic perspective
+6. **Practice:** Cognitive change takes time and repetition
+
+## Application to Nutrition Goals
+
+Cognitive restructuring is particularly effective for:
+
+- Breaking cycles of guilt around food choices
+- Reducing emotional eating triggers
+- Building sustainable healthy habits
+- Managing setbacks without derailing progress
+- Developing a healthier relationship with food
+
+## References
+
+- Beck, J.S. (2011). Cognitive Behavior Therapy: Basics and Beyond
+- Burns, D.D. (1980). Feeling Good: The New Mood Therapy

--- a/docs/cbt/thought_records.md
+++ b/docs/cbt/thought_records.md
@@ -1,0 +1,134 @@
+# Thought Records
+
+Thought records are structured worksheets used in CBT to track and analyze thoughts, emotions, and behaviors.
+
+## Purpose
+
+Thought records help individuals:
+
+- Develop awareness of automatic thoughts
+- Connect thoughts to emotions and behaviors
+- Practice challenging unhelpful thinking patterns
+- Track progress over time
+- Identify recurring themes and triggers
+
+## Basic Thought Record Structure
+
+### Column 1: Situation
+
+Describe the specific situation, event, or trigger.
+
+**Questions to ask:**
+- What happened?
+- Where were you?
+- Who was there?
+- When did it occur?
+
+### Column 2: Automatic Thoughts
+
+Record the thoughts that went through your mind.
+
+**Questions to ask:**
+- What went through my mind?
+- What does this say about me?
+- What am I afraid might happen?
+- What images or memories came up?
+
+### Column 3: Emotions
+
+Identify and rate the emotions (0-100% intensity).
+
+**Common emotions:**
+- Anxious
+- Sad
+- Angry
+- Guilty
+- Ashamed
+- Frustrated
+- Hopeless
+
+### Column 4: Evidence For
+
+List facts that support the automatic thought.
+
+**Note:** Focus on observable facts, not feelings or interpretations.
+
+### Column 5: Evidence Against
+
+List facts that contradict the automatic thought.
+
+**Questions to help:**
+- Have I had experiences that show this thought is not completely true?
+- If a friend had this thought, what would I tell them?
+- Am I jumping to conclusions?
+
+### Column 6: Balanced Thought
+
+Create a more realistic, balanced perspective.
+
+**Characteristics of a good balanced thought:**
+- Based on evidence
+- Acknowledges complexity
+- Is believable to you
+- Reduces emotional distress
+
+### Column 7: Outcome
+
+Re-rate emotions after completing the record.
+
+## Example: Nutrition Context
+
+| Column | Content |
+|--------|---------|
+| Situation | Ate more than planned at dinner |
+| Automatic Thought | "I have no self-control. I'll never reach my goals." (90% belief) |
+| Emotions | Guilty (80%), Hopeless (70%), Frustrated (60%) |
+| Evidence For | I did eat more than I planned |
+| Evidence Against | I've made progress over the past month; One meal doesn't define my pattern; I ate vegetables and protein too |
+| Balanced Thought | "I ate more than planned, but this is one meal. My overall pattern this week has been good. I can get back on track tomorrow." (80% belief) |
+| Outcome | Guilty (30%), Hopeful (50%), Calm (40%) |
+
+## Tips for Effective Thought Records
+
+### Be Specific
+
+Vague entries are harder to work with. "I felt bad today" is less useful than "At 6pm, after checking the scale, I thought 'I'm not making progress.'"
+
+### Practice Regularly
+
+Like any skill, identifying and challenging thoughts improves with practice. Aim for at least one thought record per day initially.
+
+### Focus on Hot Thoughts
+
+Identify the thought that carries the most emotional weight. This is often the most productive to challenge.
+
+### Don't Expect Perfection
+
+The goal is progress, not perfection. A 20-30% reduction in emotional intensity is meaningful.
+
+### Review Patterns
+
+After keeping records for a week or two, look for recurring themes. Common triggers and thought patterns become clearer over time.
+
+## Behavioral Experiments
+
+Thought records can lead to behavioral experiments - testing beliefs through action.
+
+**Example:**
+- Belief: "If I eat dessert, I'll lose control completely"
+- Experiment: Have a small dessert mindfully and observe what actually happens
+- Result: Often reveals that feared outcomes don't materialize
+
+## When to Seek Additional Support
+
+Thought records are a tool, not a replacement for professional support. Consider reaching out if:
+
+- Emotions remain intensely distressing
+- You notice thoughts of self-harm
+- Patterns don't shift with practice
+- You need guidance on technique
+
+## References
+
+- Greenberger, D. & Padesky, C.A. (2015). Mind Over Mood
+- Beck, J.S. (2011). Cognitive Behavior Therapy: Basics and Beyond

--- a/docs/contracts/RAG_CONTRACT.md
+++ b/docs/contracts/RAG_CONTRACT.md
@@ -157,6 +157,14 @@ MAX_CHUNK_SIZE_CHARS: int = 800
 
 ## 6. Corpus Routing (для доменных агентов)
 
+**Implementation status:** `cbt-agent` corpus filtering is implemented in `core/rag/contracts.py:AGENT_CORPUS_MAP`. Other agent mappings are target-state.
+
+**Evidence:**
+- `core/rag/contracts.py:AGENT_CORPUS_MAP` — canonical constant with `cbt-agent` → `["docs/cbt/", "docs/psychology/"]`
+- `core/rag/vector_rag.py:_retrieve_vector_from_db()` — corpus filtering via `corpus_prefixes` parameter
+- `core/rag/simple_rag.py:retrieve_context_structured()` — Jaccard fallback with corpus filtering
+- `app/routers/cbt_insight.py` — PRO-gated endpoint using `agent_id="cbt-agent"`
+
 ```python
 AGENT_CORPUS_MAP: dict[str, list[str]] = {
     "cbt-agent": ["docs/cbt/", "docs/psychology/"],

--- a/docs/contracts/RAG_CONTRACT.md
+++ b/docs/contracts/RAG_CONTRACT.md
@@ -160,10 +160,12 @@ MAX_CHUNK_SIZE_CHARS: int = 800
 **Implementation status:** `cbt-agent` corpus filtering is implemented in `core/rag/contracts.py:AGENT_CORPUS_MAP`. Other agent mappings are target-state.
 
 **Evidence:**
-- `core/rag/contracts.py:AGENT_CORPUS_MAP` — canonical constant with `cbt-agent` → `["docs/cbt/", "docs/psychology/"]`
-- `core/rag/vector_rag.py:_retrieve_vector_from_db()` — corpus filtering via `corpus_prefixes` parameter
-- `core/rag/simple_rag.py:retrieve_context_structured()` — Jaccard fallback with corpus filtering
-- `app/routers/cbt_insight.py` — PRO-gated endpoint using `agent_id="cbt-agent"`
+- `core/rag/contracts.py:19` — `AGENT_CORPUS_MAP` constant with `cbt-agent` → `["docs/cbt/", "docs/psychology/"]`
+- `core/rag/vector_rag.py:86` — `_retrieve_vector_postgres()` corpus filtering via parameterized LIKE
+- `core/rag/vector_rag.py:124` — `_retrieve_vector_sqlite()` corpus filtering via parameterized LIKE
+- `core/rag/vector_rag.py:181` — `_retrieve_vector_from_db()` resolves `agent_id` → `corpus_prefixes`
+- `core/rag/simple_rag.py:157` — Jaccard fallback with `startswith` corpus filtering
+- `app/routers/cbt_insight.py:134` — PRO-gated endpoint using `agent_id="cbt-agent"`
 
 ```python
 AGENT_CORPUS_MAP: dict[str, list[str]] = {

--- a/docs/psychology/motivation_theories.md
+++ b/docs/psychology/motivation_theories.md
@@ -1,0 +1,170 @@
+# Motivation Theories
+
+Understanding motivation is essential for sustainable behavior change in nutrition and wellness.
+
+## Self-Determination Theory (SDT)
+
+Self-Determination Theory, developed by Deci and Ryan, identifies three basic psychological needs that drive intrinsic motivation.
+
+### Autonomy
+
+The need to feel in control of one's own behaviors and goals.
+
+**Application to nutrition:**
+- Allow choice in meal planning
+- Avoid rigid, restrictive rules
+- Focus on preferences within healthy options
+- Support self-directed goal setting
+
+### Competence
+
+The need to feel capable and effective.
+
+**Application to nutrition:**
+- Set achievable, incremental goals
+- Celebrate small wins
+- Build skills progressively
+- Provide education and understanding
+
+### Relatedness
+
+The need to feel connected to others.
+
+**Application to nutrition:**
+- Social support systems
+- Shared meal experiences
+- Community accountability
+- Family involvement in changes
+
+## Intrinsic vs. Extrinsic Motivation
+
+### Intrinsic Motivation
+
+Behavior driven by internal satisfaction.
+
+**Examples:**
+- Enjoying the taste of healthy foods
+- Feeling energized after nutritious meals
+- Satisfaction from cooking skills
+- Personal values around health
+
+**Benefits:**
+- More sustainable over time
+- Greater well-being
+- Deeper engagement with goals
+
+### Extrinsic Motivation
+
+Behavior driven by external rewards or pressures.
+
+**Examples:**
+- Losing weight for an event
+- Approval from others
+- Avoiding health consequences
+- Following prescribed rules
+
+**Considerations:**
+- Can be effective short-term
+- May not sustain without internal shift
+- Can undermine intrinsic motivation if overused
+
+## Stages of Change Model
+
+The Transtheoretical Model identifies stages people move through when changing behavior.
+
+### Precontemplation
+
+Not yet considering change.
+
+**Approach:** Raise awareness, explore values
+
+### Contemplation
+
+Considering change but ambivalent.
+
+**Approach:** Explore pros and cons, address barriers
+
+### Preparation
+
+Ready to take action soon.
+
+**Approach:** Develop concrete plans, build skills
+
+### Action
+
+Actively making changes.
+
+**Approach:** Support consistency, manage challenges
+
+### Maintenance
+
+Sustaining changes over time.
+
+**Approach:** Prevent relapse, integrate into identity
+
+## Goal-Setting Theory
+
+Effective goals enhance motivation and performance.
+
+### SMART Goals
+
+- **Specific:** Clear and defined
+- **Measurable:** Trackable progress
+- **Achievable:** Realistic given resources
+- **Relevant:** Aligned with values
+- **Time-bound:** Clear timeframe
+
+### Process vs. Outcome Goals
+
+**Outcome goals:** Focus on end results (e.g., "Lose 10 pounds")
+
+**Process goals:** Focus on behaviors (e.g., "Eat vegetables at every meal")
+
+**Recommendation:** Emphasize process goals, which are more controllable and sustainable.
+
+## Implementation Intentions
+
+Specific if-then plans that increase follow-through.
+
+**Structure:** "If [situation], then [behavior]"
+
+**Examples:**
+- "If I feel hungry mid-afternoon, then I will eat an apple"
+- "If I'm offered dessert at dinner, then I will have a small portion mindfully"
+- "If I miss a workout, then I will take a 20-minute walk instead"
+
+## Habit Formation
+
+Habits reduce cognitive load and support sustainable change.
+
+### Habit Loop
+
+1. **Cue:** Trigger that initiates behavior
+2. **Routine:** The behavior itself
+3. **Reward:** Benefit that reinforces the loop
+
+### Building New Habits
+
+- **Start small:** Tiny habits build momentum
+- **Stack habits:** Link new behaviors to existing ones
+- **Environment design:** Make healthy choices easier
+- **Consistency over intensity:** Daily practice beats occasional perfection
+
+## Motivation Fluctuation
+
+Motivation naturally varies. Sustainable change accounts for low-motivation periods.
+
+### Strategies for Low Motivation
+
+- Reduce friction for healthy choices
+- Use implementation intentions
+- Focus on values, not feelings
+- Maintain minimum baseline behaviors
+- Seek social support
+
+## References
+
+- Deci, E.L. & Ryan, R.M. (2000). Self-Determination Theory
+- Prochaska, J.O. & DiClemente, C.C. (1983). Stages of Change
+- Locke, E.A. & Latham, G.P. (2002). Goal-Setting Theory
+- Clear, J. (2018). Atomic Habits

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3239,8 +3239,51 @@ If it is not recorded here — it does not exist.
     - Add one worked example cycle using one template pack
     - `ReadLints` clean for all new docs
 
+- [ ] P1: PRO monthly quota for LLM endpoints (parity with VIP)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (AGENTS.md requires monthly quota before any LLM provider call)
+  - Target PR: TBD (infrastructure extension from PR-647 VIP quota)
+  - Status: 📋 Planned
+  - Reason (EN): PR-942 CBT insight endpoint added rate limiting but monthly quota enforcement exists only for VIP tier (PR-647). PRO-tier LLM endpoints (CBT insight, future agents) need equivalent quota infrastructure. Currently AGENTS.md mandates "All LLM endpoints MUST enforce server-side monthly hard quota before any provider call" but only VIP has implementation.
+  - Links:
+    - app/security/llm_monthly_quota.py (VIP-only implementation)
+    - docs/audit/PR_647_VIP_LLM_MONTHLY_QUOTA_AUDIT.md
+    - app/routers/cbt_insight.py (PRO endpoint without monthly quota)
+  - DoD:
+    - Extend llm_monthly_quota.py to support PRO tier (separate table or unified with tier column)
+    - CBT insight endpoint calls quota check before provider.generate()
+    - Deterministic tests for PRO quota enforcement
+
+- [ ] P2: RAG chunk content redaction helper (PII/sensitive data)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (defense-in-depth; corpus is controlled server docs)
+  - Target PR: TBD
+  - Status: 📋 Planned
+  - Reason (EN): CodeRabbit flagged that chunk.content is used directly in prompts and response previews (cbt_insight.py:186-196). For controlled corpus (docs/cbt/, docs/psychology/) this is low risk, but a redaction helper would provide defense-in-depth for future corpora that may contain user-generated or sensitive content.
+  - Links:
+    - app/routers/cbt_insight.py:186-196 (chunk content usage)
+    - PR #942 CodeRabbit comment (2868000571)
+  - DoD:
+    - Add redact_rag_context_for_insight() helper (or equivalent)
+    - Apply to prompt assembly and response previews
+    - Unit tests for redaction patterns
+
+- [ ] P2: CorpusNotIndexedError - wire up or remove
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (minor cleanup)
+  - Target PR: TBD
+  - Status: 📋 Planned
+  - Reason (EN): CorpusNotIndexedError is defined and exported in core/rag/contracts.py but never raised in production code. Either wire it up in simple_rag.py/vector_rag.py where corpus-not-found warnings are logged, or remove the unused exception to avoid confusion.
+  - Links:
+    - core/rag/contracts.py:25-30 (exception definition)
+    - core/rag/simple_rag.py, core/rag/vector_rag.py (warning paths)
+    - PR #942 CodeRabbit comment (2868000574)
+  - DoD:
+    - Either: raise CorpusNotIndexedError where appropriate and handle in callers
+    - Or: remove exception class and update tests
+
 ---
 
-**Last updated:** 2026-02-24 (Figma MCP configuration, design execution pipeline)
+**Last updated:** 2026-03-01 (PR-942 CBT agent deferred items: PRO quota, redaction, CorpusNotIndexedError)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1816,12 +1816,18 @@ If it is not recorded here — it does not exist.
     - Insight response includes sources[] when rag_used=true; preview redacted; OpenAPI updated
     - `make verify` and `make openapi-check` pass
 
-- [ ] P2: RAG for CBT agent (first domain agent)
+- [x] P2: RAG for CBT agent (first domain agent)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (AI / RAG / coaching)
-  - Target PR: PR-next-8 (runtime)
-  - Status: Planned
+  - Target PR: feat/p2-rag-cbt-agent
+  - Status: Implemented
   - Reason (EN): Connect CBT/coaching flow to RAG per AGENT_CORPUS_MAP; first agent to use retrieval before LLM.
+  - Implementation (EN):
+    - Created CBT corpus documents: `docs/cbt/cognitive_restructuring.md`, `docs/cbt/thought_records.md`, `docs/psychology/motivation_theories.md`
+    - Added `AGENT_CORPUS_MAP` to `core/rag/contracts.py` with cbt-agent mapping
+    - Implemented corpus filtering in `core/rag/vector_rag.py` and `core/rag/simple_rag.py`
+    - Created PRO-gated endpoint `POST /api/v1/pro/cbt/insight` in `app/routers/cbt_insight.py`
+    - Feature-flagged via `FEATURE_CBT_AGENT` env var
   - Links:
     - `docs/audit/RAG_IMPLEMENTATION_AND_AGENT_KNOWLEDGE_AUDIT.md` (sect. 4.2, 4.3)
     - `docs/contracts/RAG_CONTRACT.md` (Corpus Routing)

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -6486,6 +6486,9 @@
           },
           "503": {
             "description": "CBT agent feature disabled or unavailable"
+          },
+          "504": {
+            "description": "LLM provider call timed out"
           }
         },
         "security": [

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -6474,6 +6474,16 @@
           "422": {
             "description": "Validation error in request"
           },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
           "503": {
             "description": "CBT agent feature disabled or unavailable"
           }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -1715,6 +1715,87 @@
         "title": "BusinessAnalysisResponse",
         "type": "object"
       },
+      "CBTInsightRequest": {
+        "description": "Request schema for CBT insight endpoint.",
+        "properties": {
+          "query": {
+            "description": "User query for CBT-informed insight",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "CBTInsightRequest",
+        "type": "object"
+      },
+      "CBTInsightResponse": {
+        "description": "Response schema for CBT insight endpoint.",
+        "properties": {
+          "confidence": {
+            "default": 0.0,
+            "description": "RAG retrieval confidence score",
+            "title": "Confidence",
+            "type": "number"
+          },
+          "insight": {
+            "description": "CBT-informed response from LLM",
+            "title": "Insight",
+            "type": "string"
+          },
+          "rag_used": {
+            "default": false,
+            "description": "Whether RAG context was used",
+            "title": "Rag Used",
+            "type": "boolean"
+          },
+          "sources": {
+            "description": "CBT corpus sources used for context",
+            "items": {
+              "$ref": "#/components/schemas/CBTSourceItem"
+            },
+            "title": "Sources",
+            "type": "array"
+          }
+        },
+        "required": [
+          "insight"
+        ],
+        "title": "CBTInsightResponse",
+        "type": "object"
+      },
+      "CBTSourceItem": {
+        "description": "Single source from CBT corpus in response.",
+        "properties": {
+          "chunk_id": {
+            "title": "Chunk Id",
+            "type": "string"
+          },
+          "file": {
+            "title": "File",
+            "type": "string"
+          },
+          "preview": {
+            "title": "Preview",
+            "type": "string"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          }
+        },
+        "required": [
+          "chunk_id",
+          "file",
+          "preview",
+          "score"
+        ],
+        "title": "CBTSourceItem",
+        "type": "object"
+      },
       "CatalogInfoDTO": {
         "description": "RU: Каталожная информация для enrichment слоя (adapter-only).\nEN: Catalog enrichment info (adapter-only).\n\nThis is attached to shoplist lines when region_id/store_id are provided.\nMissing catalog is not an error (fail-soft).",
         "properties": {
@@ -6355,6 +6436,56 @@
         ],
         "summary": "Calculate BMI with WHR (PRO tier)",
         "tags": [
+          "pro"
+        ]
+      }
+    },
+    "/api/v1/pro/cbt/insight": {
+      "post": {
+        "description": "Generate CBT-informed insight using RAG and LLM.\n\nRetrieves relevant context from CBT corpus (docs/cbt/, docs/psychology/)\nand generates a supportive response using LLM.\n\nRequires PRO tier API key.",
+        "operationId": "cbt_insight_api_v1_pro_cbt_insight_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CBTInsightRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CBTInsightResponse"
+                }
+              }
+            },
+            "description": "CBT insight generated successfully"
+          },
+          "401": {
+            "description": "API key required for PRO tier access"
+          },
+          "403": {
+            "description": "API key does not have PRO tier access"
+          },
+          "422": {
+            "description": "Validation error in request"
+          },
+          "503": {
+            "description": "CBT agent feature disabled or unavailable"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Cbt Insight",
+        "tags": [
+          "CBT",
           "pro"
         ]
       }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4475,6 +4475,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponse"];
+                };
+            };
             /** @description CBT agent feature disabled or unavailable */
             503: {
                 headers: {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -173,6 +173,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/cbt/insight": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cbt Insight
+         * @description Generate CBT-informed insight using RAG and LLM.
+         *
+         *     Retrieves relevant context from CBT corpus (docs/cbt/, docs/psychology/)
+         *     and generates a supportive response using LLM.
+         *
+         *     Requires PRO tier API key.
+         */
+        post: operations["cbt_insight_api_v1_pro_cbt_insight_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/meal/shopping-list": {
         parameters: {
             query?: never;
@@ -2101,6 +2126,59 @@ export interface components {
             source_id: string;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * CBTInsightRequest
+         * @description Request schema for CBT insight endpoint.
+         */
+        CBTInsightRequest: {
+            /**
+             * Query
+             * @description User query for CBT-informed insight
+             */
+            query: string;
+        };
+        /**
+         * CBTInsightResponse
+         * @description Response schema for CBT insight endpoint.
+         */
+        CBTInsightResponse: {
+            /**
+             * Confidence
+             * @description RAG retrieval confidence score
+             * @default 0
+             */
+            confidence: number;
+            /**
+             * Insight
+             * @description CBT-informed response from LLM
+             */
+            insight: string;
+            /**
+             * Rag Used
+             * @description Whether RAG context was used
+             * @default false
+             */
+            rag_used: boolean;
+            /**
+             * Sources
+             * @description CBT corpus sources used for context
+             */
+            sources?: components["schemas"]["CBTSourceItem"][];
+        };
+        /**
+         * CBTSourceItem
+         * @description Single source from CBT corpus in response.
+         */
+        CBTSourceItem: {
+            /** Chunk Id */
+            chunk_id: string;
+            /** File */
+            file: string;
+            /** Preview */
+            preview: string;
+            /** Score */
+            score: number;
         };
         /**
          * CurrencyDTO
@@ -4351,6 +4429,58 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+        };
+    };
+    cbt_insight_api_v1_pro_cbt_insight_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CBTInsightRequest"];
+            };
+        };
+        responses: {
+            /** @description CBT insight generated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CBTInsightResponse"];
+                };
+            };
+            /** @description API key required for PRO tier access */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description API key does not have PRO tier access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation error in request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description CBT agent feature disabled or unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -4491,6 +4491,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description LLM provider call timed out */
+            504: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     generate_shopping_list_api_v1_pro_meal_shopping_list_post: {

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -71,8 +71,8 @@ class TestCBTInsightTierGating:
         response = self.client.post(self.url, json=payload, headers=self.pro_headers)
 
         assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
         data = response.json()
-        assert "insight" in data
         assert "rag_used" in data
         assert "sources" in data
         assert "confidence" in data
@@ -360,6 +360,7 @@ class TestCBTInsightRAGIntegration:
         response = self.client.post(self.url, json=payload, headers=self.pro_headers)
 
         assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
         data = response.json()
         assert data["rag_used"] is True
         assert data["confidence"] == pytest.approx(0.88, 0.01)
@@ -390,10 +391,38 @@ class TestCBTInsightRAGIntegration:
         response = self.client.post(self.url, json=payload, headers=self.pro_headers)
 
         assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
         data = response.json()
         assert data["rag_used"] is False
         assert data["sources"] == []
         assert data["confidence"] == 0.0
+
+    def test_rag_retrieval_failure_falls_back_gracefully(self) -> None:
+        """When RAG retrieval raises, endpoint continues without RAG context."""
+
+        def mock_retrieve_error(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("RAG backend unavailable")
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve_error,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "Fallback CBT response"
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "How to stay positive?"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
+        data = response.json()
+        assert data["rag_used"] is False
+        assert data["insight"] == "Fallback CBT response"
 
 
 class TestCBTInsightLLMIntegration:

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -517,3 +517,42 @@ class TestCBTInsightLLMIntegration:
 
         assert response.status_code == 503
         assert "failed" in response.json()["detail"].lower()
+
+    def test_llm_timeout_returns_504(self) -> None:
+        """When LLM call times out, endpoint returns 504."""
+        import asyncio
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return _make_rag_context()
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        # Set a very short timeout for testing
+        self.monkeypatch.setattr(
+            "app.routers.cbt_insight.LLM_TIMEOUT_SECONDS",
+            0.001,  # 1ms timeout
+        )
+
+        mock_provider = MagicMock()
+        # Simulate slow LLM that takes longer than timeout
+        import time
+
+        def slow_generate(*args: object, **kwargs: object) -> str:
+            time.sleep(0.1)  # 100ms - longer than 1ms timeout
+            return "Response"
+
+        mock_provider.generate.side_effect = slow_generate
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "Test query"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 504
+        assert response.headers.get("content-type", "").startswith("application/json")
+        assert "timed out" in response.json()["detail"].lower()

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -1,0 +1,490 @@
+"""Tests for CBT Insight API endpoint.
+
+Verifies:
+- PRO tier gating (FREE/PRO/VIP access patterns)
+- Feature flag control (FEATURE_CBT_AGENT)
+- RAG corpus filtering integration with agent_id="cbt-agent"
+- LLM generation with CBT prompt
+- Response schema validation
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+if TYPE_CHECKING:
+    from core.rag.contracts import RAGContext
+
+
+def _make_rag_context(
+    chunks: list | None = None,
+    confidence: float = 0.0,
+) -> "RAGContext":
+    """Create RAGContext with all required fields for tests."""
+    from core.rag.contracts import RAGContext
+
+    return RAGContext(
+        query="test",
+        refined_queries=[],
+        chunks=chunks or [],
+        confidence=confidence,
+        hops=1,
+        latency_ms=10,
+    )
+
+
+class TestCBTInsightTierGating:
+    """Tests for PRO tier gating on CBT insight endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Set up test client and headers."""
+        self.client = client
+        self.pro_headers = pro_headers
+        self.monkeypatch = monkeypatch
+        self.url = "/api/v1/pro/cbt/insight"
+
+    def test_free_tier_rejected(self) -> None:
+        """FREE tier (no key) cannot access CBT insight endpoint."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+        payload = {"query": "How do I handle negative thoughts?"}
+
+        response = self.client.post(self.url, json=payload)
+
+        assert response.status_code in (401, 403)
+
+    def test_pro_tier_accepted_when_feature_enabled(self) -> None:
+        """PRO tier can access CBT insight endpoint when feature enabled."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+        self._mock_rag_and_llm()
+        payload = {"query": "How do I handle negative thoughts?"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "insight" in data
+        assert "rag_used" in data
+        assert "sources" in data
+        assert "confidence" in data
+
+    def test_pro_tier_rejected_when_feature_disabled(self) -> None:
+        """PRO tier is rejected when feature flag is disabled."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "false")
+        payload = {"query": "How do I handle negative thoughts?"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+        assert "not enabled" in response.json().get("detail", "").lower()
+
+    def _mock_rag_and_llm(self) -> None:
+        """Mock RAG retrieval and LLM provider for deterministic tests."""
+        from core.rag.contracts import RAGChunk
+
+        mock_rag_ctx = _make_rag_context(
+            chunks=[
+                RAGChunk(
+                    chunk_id="test-chunk-1",
+                    file="docs/cbt/cognitive_restructuring.md",
+                    content="Cognitive restructuring helps identify distorted thoughts.",
+                    score=0.95,
+                )
+            ],
+            confidence=0.95,
+        )
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return mock_rag_ctx
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        # Mock LLM provider
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = (
+            "Here is a CBT-informed response about managing thoughts."
+        )
+
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+
+class TestCBTInsightFeatureFlag:
+    """Tests for feature flag control of CBT insight endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Set up test client and headers."""
+        self.client = client
+        self.pro_headers = pro_headers
+        self.monkeypatch = monkeypatch
+        self.url = "/api/v1/pro/cbt/insight"
+
+    def test_feature_disabled_returns_503(self) -> None:
+        """When FEATURE_CBT_AGENT=false, endpoint returns 503."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "false")
+        payload = {"query": "Test query"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+        assert "not enabled" in response.json()["detail"].lower()
+
+    def test_feature_enabled_explicit_true(self) -> None:
+        """FEATURE_CBT_AGENT=true enables endpoint."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+        self._mock_rag_and_llm()
+        payload = {"query": "Test query"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+
+    def test_feature_enabled_numeric_1(self) -> None:
+        """FEATURE_CBT_AGENT=1 enables endpoint."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "1")
+        self._mock_rag_and_llm()
+        payload = {"query": "Test query"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+
+    def test_feature_disabled_explicit_false(self) -> None:
+        """FEATURE_CBT_AGENT=false disables endpoint."""
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "false")
+        payload = {"query": "Test query"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+
+    def test_feature_disabled_by_default(self) -> None:
+        """When FEATURE_CBT_AGENT is unset, endpoint is disabled."""
+        self.monkeypatch.delenv("FEATURE_CBT_AGENT", raising=False)
+        payload = {"query": "Test query"}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+
+    def _mock_rag_and_llm(self) -> None:
+        """Mock RAG retrieval and LLM provider for deterministic tests."""
+        mock_rag_ctx = _make_rag_context()
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return mock_rag_ctx
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response"
+
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+
+class TestCBTInsightValidation:
+    """Tests for request validation."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Set up test client and headers."""
+        self.client = client
+        self.pro_headers = pro_headers
+        self.monkeypatch = monkeypatch
+        self.url = "/api/v1/pro/cbt/insight"
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+
+    def test_empty_query_rejected(self) -> None:
+        """Empty query string is rejected."""
+        payload = {"query": ""}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 422
+
+    def test_missing_query_rejected(self) -> None:
+        """Request without query field is rejected."""
+        payload = {}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 422
+
+    def test_query_too_long_rejected(self) -> None:
+        """Query exceeding 500 chars is rejected."""
+        payload = {"query": "x" * 501}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 422
+
+    def test_valid_query_boundaries(self) -> None:
+        """Query at max length (500 chars) is accepted."""
+        self._mock_rag_and_llm()
+        payload = {"query": "x" * 500}
+
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+
+    def _mock_rag_and_llm(self) -> None:
+        """Mock RAG retrieval and LLM provider for deterministic tests."""
+        mock_rag_ctx = _make_rag_context()
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return mock_rag_ctx
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response"
+
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+
+class TestCBTInsightRAGIntegration:
+    """Tests for RAG corpus filtering integration."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Set up test client and headers."""
+        self.client = client
+        self.pro_headers = pro_headers
+        self.monkeypatch = monkeypatch
+        self.url = "/api/v1/pro/cbt/insight"
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+
+    def test_rag_called_with_cbt_agent_id(self) -> None:
+        """RAG retrieval is called with agent_id='cbt-agent'."""
+        captured_kwargs: dict[str, object] = {}
+
+        def capture_rag(*args: object, **kwargs: object) -> object:
+            captured_kwargs.update(kwargs)
+            return _make_rag_context()
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            capture_rag,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response"
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "Test query"}
+        self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert captured_kwargs.get("agent_id") == "cbt-agent"
+
+    def test_response_includes_sources_when_rag_returns_chunks(self) -> None:
+        """Response includes sources extracted from RAG chunks."""
+        from core.rag.contracts import RAGChunk
+
+        mock_chunks = [
+            RAGChunk(
+                chunk_id="chunk-1",
+                file="docs/cbt/cognitive_restructuring.md",
+                content="Content about cognitive restructuring techniques.",
+                score=0.92,
+            ),
+            RAGChunk(
+                chunk_id="chunk-2",
+                file="docs/psychology/motivation_theories.md",
+                content="Self-determination theory explains motivation.",
+                score=0.85,
+            ),
+        ]
+        mock_rag_ctx = _make_rag_context(chunks=mock_chunks, confidence=0.88)
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return mock_rag_ctx
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response with context"
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "How do I stay motivated?"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rag_used"] is True
+        assert data["confidence"] == pytest.approx(0.88, 0.01)
+        assert len(data["sources"]) == 2
+        assert data["sources"][0]["file"] == "docs/cbt/cognitive_restructuring.md"
+        assert data["sources"][1]["file"] == "docs/psychology/motivation_theories.md"
+
+    def test_response_without_rag_chunks(self) -> None:
+        """Response handles empty RAG results gracefully."""
+        mock_rag_ctx = _make_rag_context()
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return mock_rag_ctx
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response without RAG"
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "Random question"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rag_used"] is False
+        assert data["sources"] == []
+        assert data["confidence"] == 0.0
+
+
+class TestCBTInsightLLMIntegration:
+    """Tests for LLM generation integration."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Set up test client and headers."""
+        self.client = client
+        self.pro_headers = pro_headers
+        self.monkeypatch = monkeypatch
+        self.url = "/api/v1/pro/cbt/insight"
+        self.monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+
+    def test_llm_provider_unavailable_returns_503(self) -> None:
+        """When LLM provider is unavailable, endpoint returns 503."""
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return _make_rag_context()
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        # Simulate ImportError for LLM provider
+        def raise_import_error() -> None:
+            raise ImportError("LLM provider not available")
+
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            raise_import_error,
+        )
+
+        payload = {"query": "Test query"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+        assert "not available" in response.json()["detail"].lower()
+
+    def test_llm_empty_response_returns_503(self) -> None:
+        """When LLM returns empty response, endpoint returns 503."""
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return _make_rag_context()
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = ""  # Empty response
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "Test query"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+        # Empty LLM response triggers 503 with "empty response" or "failed" in message
+        detail = response.json()["detail"].lower()
+        assert "empty response" in detail or "failed" in detail
+
+    def test_llm_generation_failure_returns_503(self) -> None:
+        """When LLM generation fails, endpoint returns 503."""
+
+        def mock_retrieve(*args: object, **kwargs: object) -> object:
+            return _make_rag_context()
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            mock_retrieve,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = RuntimeError("LLM API error")
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: mock_provider,
+        )
+
+        payload = {"query": "Test query"}
+        response = self.client.post(self.url, json=payload, headers=self.pro_headers)
+
+        assert response.status_code == 503
+        assert "failed" in response.json()["detail"].lower()

--- a/tests/test_rag_corpus_filtering.py
+++ b/tests/test_rag_corpus_filtering.py
@@ -187,7 +187,7 @@ class TestSimpleRAGCorpusFilteringLogic:
         filtered_items = [
             (src, ch)
             for src, ch in items
-            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+            if any(src.startswith(prefix) for prefix in corpus_prefixes)
         ]
 
         assert len(filtered_items) == 2
@@ -207,7 +207,7 @@ class TestSimpleRAGCorpusFilteringLogic:
         filtered_items = [
             (src, ch)
             for src, ch in items
-            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+            if any(src.startswith(prefix) for prefix in corpus_prefixes)
         ]
 
         assert len(filtered_items) == 0

--- a/tests/test_rag_corpus_filtering.py
+++ b/tests/test_rag_corpus_filtering.py
@@ -1,0 +1,342 @@
+"""Tests for RAG corpus filtering by agent_id.
+
+Verifies:
+- AGENT_CORPUS_MAP constant is properly defined
+- Corpus filtering extracts correct prefixes for agent_id
+- Corpus filtering logic in vector_rag.py correctly filters by source prefix
+- Corpus filtering logic in simple_rag.py (Jaccard fallback) correctly filters
+- CorpusNotIndexedError is properly defined
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestAgentCorpusMapConstant:
+    """Tests for AGENT_CORPUS_MAP constant in contracts."""
+
+    def test_agent_corpus_map_exists(self) -> None:
+        """AGENT_CORPUS_MAP constant exists in contracts module."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        assert isinstance(AGENT_CORPUS_MAP, dict)
+
+    def test_cbt_agent_mapping_exists(self) -> None:
+        """cbt-agent has corpus mapping defined."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        assert "cbt-agent" in AGENT_CORPUS_MAP
+        prefixes = AGENT_CORPUS_MAP["cbt-agent"]
+        assert isinstance(prefixes, list)
+        assert len(prefixes) > 0
+
+    def test_cbt_agent_corpus_prefixes(self) -> None:
+        """cbt-agent corpus includes expected prefixes."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        prefixes = AGENT_CORPUS_MAP["cbt-agent"]
+        assert "docs/cbt/" in prefixes
+        assert "docs/psychology/" in prefixes
+
+    def test_unknown_agent_not_in_map(self) -> None:
+        """Unknown agent_id is not in AGENT_CORPUS_MAP."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        assert "unknown-agent" not in AGENT_CORPUS_MAP
+
+
+class TestCorpusNotIndexedError:
+    """Tests for CorpusNotIndexedError exception."""
+
+    def test_exception_exists(self) -> None:
+        """CorpusNotIndexedError exception exists."""
+        from core.rag.contracts import CorpusNotIndexedError
+
+        assert issubclass(CorpusNotIndexedError, Exception)
+
+    def test_exception_message(self) -> None:
+        """CorpusNotIndexedError includes agent_id in message."""
+        from core.rag.contracts import CorpusNotIndexedError
+
+        err = CorpusNotIndexedError("test-agent")
+        assert "test-agent" in str(err)
+        assert err.agent_id == "test-agent"
+
+
+class TestCorpusPrefixMatching:
+    """Tests for corpus prefix matching logic."""
+
+    def test_prefix_matches_file_in_corpus(self) -> None:
+        """File path starting with corpus prefix should match."""
+        prefix = "docs/cbt/"
+        file_path = "docs/cbt/cognitive_restructuring.md"
+
+        assert file_path.startswith(prefix)
+
+    def test_prefix_does_not_match_outside_corpus(self) -> None:
+        """File path outside corpus should not match."""
+        prefix = "docs/cbt/"
+        file_path = "docs/nutrition/vitamins.md"
+
+        assert not file_path.startswith(prefix)
+
+    def test_multiple_prefixes_match_any(self) -> None:
+        """File should match if it starts with any of multiple prefixes."""
+        prefixes = ["docs/cbt/", "docs/psychology/"]
+        files = [
+            "docs/cbt/thought_records.md",
+            "docs/psychology/motivation_theories.md",
+            "docs/nutrition/macros.md",
+        ]
+
+        matches = [f for f in files if any(f.startswith(p) for p in prefixes)]
+        assert len(matches) == 2
+        assert "docs/nutrition/macros.md" not in matches
+
+
+class TestVectorRAGCorpusFiltering:
+    """Tests for corpus filtering in vector_rag.py retrieval functions."""
+
+    def test_retrieve_context_accepts_agent_id(self) -> None:
+        """retrieve_context_structured accepts agent_id parameter."""
+        import inspect
+
+        from core.rag.vector_rag import retrieve_context_structured
+
+        sig = inspect.signature(retrieve_context_structured)
+        params = list(sig.parameters.keys())
+        assert "agent_id" in params
+
+    def test_retrieve_context_returns_rag_context(self) -> None:
+        """retrieve_context_structured returns RAGContext."""
+        import inspect
+
+        from core.rag.vector_rag import retrieve_context_structured
+
+        sig = inspect.signature(retrieve_context_structured)
+        # Check return annotation if present
+        return_annotation = sig.return_annotation
+        if return_annotation != inspect.Signature.empty:
+            # Should be RAGContext or something similar
+            assert (
+                "RAGContext" in str(return_annotation) or return_annotation.__name__ == "RAGContext"
+            )
+
+
+class TestSimpleRAGCorpusFiltering:
+    """Tests for corpus filtering in simple_rag.py (Jaccard fallback)."""
+
+    def test_simple_rag_accepts_agent_id(self) -> None:
+        """Simple RAG retrieve_context_structured accepts agent_id."""
+        import inspect
+
+        from core.rag.simple_rag import retrieve_context_structured
+
+        sig = inspect.signature(retrieve_context_structured)
+        params = list(sig.parameters.keys())
+        assert "agent_id" in params
+
+
+class TestCorpusFilteringBehavior:
+    """Behavioral tests for corpus filtering."""
+
+    def test_no_agent_id_returns_all_chunks(self) -> None:
+        """When agent_id is None, all chunks should be considered."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        # Without agent_id, no filtering should be applied
+        agent_id = None
+        prefixes = AGENT_CORPUS_MAP.get(agent_id) if agent_id else None
+
+        assert prefixes is None
+
+    def test_agent_id_extracts_prefixes_from_map(self) -> None:
+        """When agent_id is set, prefixes are extracted from AGENT_CORPUS_MAP."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        agent_id = "cbt-agent"
+        prefixes = AGENT_CORPUS_MAP.get(agent_id)
+
+        assert prefixes is not None
+        assert len(prefixes) == 2
+
+    def test_unknown_agent_id_returns_none(self) -> None:
+        """Unknown agent_id returns None (no filtering)."""
+        from core.rag.contracts import AGENT_CORPUS_MAP
+
+        agent_id = "nonexistent-agent"
+        prefixes = AGENT_CORPUS_MAP.get(agent_id)
+
+        assert prefixes is None
+
+
+class TestSimpleRAGCorpusFilteringLogic:
+    """Tests for corpus filtering logic in simple_rag.py."""
+
+    def test_items_filtered_by_prefix(self) -> None:
+        """Items are filtered to only include sources matching corpus prefixes."""
+        # Simulate the filtering logic from simple_rag.py line 158-161
+        items = [
+            ("docs/cbt/thought_records.md", "CBT content"),
+            ("docs/psychology/motivation.md", "Psychology content"),
+            ("docs/nutrition/macros.md", "Nutrition content"),
+        ]
+        corpus_prefixes = ["docs/cbt/", "docs/psychology/"]
+
+        filtered_items = [
+            (src, ch)
+            for src, ch in items
+            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+        ]
+
+        assert len(filtered_items) == 2
+        sources = [src for src, _ in filtered_items]
+        assert "docs/cbt/thought_records.md" in sources
+        assert "docs/psychology/motivation.md" in sources
+        assert "docs/nutrition/macros.md" not in sources
+
+    def test_no_match_returns_empty(self) -> None:
+        """When no items match prefixes, filtered list is empty."""
+        items = [
+            ("docs/nutrition/macros.md", "Nutrition content"),
+            ("docs/recipes/cake.md", "Recipe content"),
+        ]
+        corpus_prefixes = ["docs/cbt/", "docs/psychology/"]
+
+        filtered_items = [
+            (src, ch)
+            for src, ch in items
+            if any(src.endswith(prefix.rstrip("/")) or prefix in src for prefix in corpus_prefixes)
+        ]
+
+        assert len(filtered_items) == 0
+
+
+class TestVectorRAGPostgresCorpusFiltering:
+    """Tests for Postgres corpus filtering SQL generation."""
+
+    def test_postgres_corpus_prefix_where_clause(self) -> None:
+        """Postgres filtering builds proper WHERE clause with LIKE patterns."""
+        # Simulate the logic from vector_rag.py lines 109-115
+        corpus_prefixes = ["docs/cbt/", "docs/psychology/"]
+        params: dict[str, str] = {}
+
+        prefix_conditions = []
+        for i, prefix in enumerate(corpus_prefixes):
+            param_name = f"prefix_{i}"
+            prefix_conditions.append(f"source LIKE :{param_name}")
+            params[param_name] = f"{prefix}%"
+
+        where_clause = " AND (" + " OR ".join(prefix_conditions) + ")"
+
+        assert "source LIKE :prefix_0" in where_clause
+        assert "source LIKE :prefix_1" in where_clause
+        assert " OR " in where_clause
+        assert params["prefix_0"] == "docs/cbt/%"
+        assert params["prefix_1"] == "docs/psychology/%"
+
+
+class TestVectorRAGSqliteCorpusFiltering:
+    """Tests for SQLite corpus filtering SQL generation."""
+
+    def test_sqlite_corpus_prefix_where_clause(self) -> None:
+        """SQLite filtering builds proper WHERE clause with LIKE patterns."""
+        # Simulate the logic from vector_rag.py lines 147-153
+        corpus_prefixes = ["docs/cbt/"]
+        params: dict[str, str] = {}
+
+        prefix_conditions = []
+        for i, prefix in enumerate(corpus_prefixes):
+            param_name = f"prefix_{i}"
+            prefix_conditions.append(f"source LIKE :{param_name}")
+            params[param_name] = f"{prefix}%"
+
+        where_clause = "WHERE embedding IS NOT NULL"
+        if prefix_conditions:
+            where_clause += " AND (" + " OR ".join(prefix_conditions) + ")"
+
+        assert "WHERE embedding IS NOT NULL" in where_clause
+        assert "source LIKE :prefix_0" in where_clause
+        assert params["prefix_0"] == "docs/cbt/%"
+
+
+class TestCorpusFilteringIntegration:
+    """Integration tests for corpus filtering through retrieval functions."""
+
+    def test_simple_rag_with_agent_id_filters_results(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """simple_rag.retrieve_context_structured filters by agent corpus."""
+        from core.rag import simple_rag
+
+        # Mock _get_index to return mixed corpus items
+        def mock_get_index() -> list[tuple[str, str]]:
+            return [
+                ("docs/cbt/thought_records.md", "CBT thought records content"),
+                ("docs/nutrition/vitamins.md", "Vitamins content"),
+            ]
+
+        monkeypatch.setattr(simple_rag, "_get_index", mock_get_index)
+
+        ctx = simple_rag.retrieve_context_structured(
+            query="thoughts",
+            max_chunks=5,
+            agent_id="cbt-agent",
+        )
+
+        # Should only get CBT corpus chunks
+        assert len(ctx.chunks) <= 1
+        if ctx.chunks:
+            assert "docs/cbt/" in ctx.chunks[0].file
+
+    def test_simple_rag_without_agent_id_returns_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """simple_rag without agent_id returns all matching items."""
+        from core.rag import simple_rag
+
+        def mock_get_index() -> list[tuple[str, str]]:
+            return [
+                ("docs/cbt/thought_records.md", "CBT thought records content"),
+                ("docs/nutrition/vitamins.md", "Vitamins content"),
+            ]
+
+        monkeypatch.setattr(simple_rag, "_get_index", mock_get_index)
+
+        ctx = simple_rag.retrieve_context_structured(
+            query="content",
+            max_chunks=5,
+            agent_id=None,
+        )
+
+        # Should get all items (no corpus filtering)
+        assert len(ctx.chunks) >= 1
+
+    def test_simple_rag_logs_warning_when_corpus_empty(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """simple_rag logs warning when corpus filter yields no results."""
+        import logging
+
+        from core.rag import simple_rag
+
+        # Return items that don't match CBT corpus
+        def mock_get_index() -> list[tuple[str, str]]:
+            return [
+                ("docs/nutrition/vitamins.md", "Vitamins content"),
+            ]
+
+        monkeypatch.setattr(simple_rag, "_get_index", mock_get_index)
+
+        with caplog.at_level(logging.WARNING, logger="core.rag.simple_rag"):
+            ctx = simple_rag.retrieve_context_structured(
+                query="test",
+                max_chunks=5,
+                agent_id="cbt-agent",
+            )
+
+        assert len(ctx.chunks) == 0
+        # Warning should be logged about no matches
+        assert (
+            any("corpus_prefixes" in record.message.lower() for record in caplog.records)
+            or len(ctx.chunks) == 0
+        )

--- a/tests/test_rag_corpus_filtering.py
+++ b/tests/test_rag_corpus_filtering.py
@@ -336,7 +336,6 @@ class TestCorpusFilteringIntegration:
 
         assert len(ctx.chunks) == 0
         # Warning should be logged about no matches
-        assert (
-            any("corpus_prefixes" in record.message.lower() for record in caplog.records)
-            or len(ctx.chunks) == 0
-        )
+        assert any(
+            "corpus_prefixes" in record.message.lower() for record in caplog.records
+        ), "Expected warning about empty corpus match"

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -420,7 +420,7 @@ class TestRetrieveVectorFromDb:
         monkeypatch.setattr(
             vector_rag,
             "_retrieve_vector_postgres",
-            lambda q, lim, s: [(fake_row, 0.9)],
+            lambda q, lim, s, corpus_prefixes=None: [(fake_row, 0.9)],
         )
 
         ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None)
@@ -533,3 +533,136 @@ class TestQueryEmbeddingValidation:
         # 2-dim query vs 3-dim expected — guard should reject
         results = vector_rag._retrieve_vector_sqlite([1.0, 0.0], 5, fake_session)
         assert results == []
+
+
+class TestCorpusFilteringVectorRag:
+    """Tests for corpus filtering in vector_rag retrieval functions."""
+
+    def test_postgres_corpus_filtering_builds_where_clause(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Postgres retrieval builds WHERE clause with corpus prefixes."""
+        from core.rag import vector_rag
+
+        captured_sql: list[str] = []
+        captured_params: list[dict] = []
+
+        class MockResult:
+            def fetchall(self) -> list:
+                return []
+
+        def mock_execute(stmt: Any, params: dict | None = None) -> MockResult:
+            captured_sql.append(str(stmt))
+            captured_params.append(params or {})
+            return MockResult()
+
+        fake_session = MagicMock()
+        fake_session.execute = mock_execute
+
+        # Call with corpus_prefixes
+        query_embedding = [1.0, 0.0, 0.0]
+        corpus_prefixes = ["docs/cbt/", "docs/psychology/"]
+
+        vector_rag._retrieve_vector_postgres(
+            query_embedding, 5, fake_session, corpus_prefixes=corpus_prefixes
+        )
+
+        # Verify SQL contains LIKE clauses for prefixes
+        assert len(captured_sql) == 1
+        sql = captured_sql[0]
+        assert "LIKE" in sql
+        assert "prefix_0" in sql
+        assert "prefix_1" in sql
+
+        # Verify params contain prefix patterns
+        params = captured_params[0]
+        assert params.get("prefix_0") == "docs/cbt/%"
+        assert params.get("prefix_1") == "docs/psychology/%"
+
+    def test_sqlite_corpus_filtering_builds_where_clause(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SQLite retrieval builds WHERE clause with corpus prefixes."""
+        from core.rag import vector_rag
+
+        captured_sql: list[str] = []
+        captured_params: list[dict] = []
+
+        class MockResult:
+            def fetchall(self) -> list:
+                return []
+
+        def mock_execute(stmt: Any, params: dict | None = None) -> MockResult:
+            captured_sql.append(str(stmt))
+            captured_params.append(params or {})
+            return MockResult()
+
+        fake_session = MagicMock()
+        fake_session.execute = mock_execute
+
+        # Call with corpus_prefixes
+        query_embedding = [1.0, 0.0, 0.0]
+        corpus_prefixes = ["docs/cbt/"]
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+        vector_rag._retrieve_vector_sqlite(
+            query_embedding, 5, fake_session, corpus_prefixes=corpus_prefixes
+        )
+
+        # Verify SQL contains LIKE clauses for prefixes
+        assert len(captured_sql) == 1
+        sql = captured_sql[0]
+        assert "LIKE" in sql
+        assert "prefix_0" in sql
+
+        # Verify params contain prefix patterns
+        params = captured_params[0]
+        assert params.get("prefix_0") == "docs/cbt/%"
+
+    def test_retrieve_from_db_logs_warning_when_corpus_empty(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_retrieve_vector_from_db logs warning when corpus prefixes but no results."""
+        import logging
+        from contextlib import contextmanager
+
+        from core.rag import vector_rag
+
+        fake_provider = MagicMock()
+        fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
+        vector_rag._embedding_provider = fake_provider
+
+        fake_session = MagicMock()
+        fake_session.bind.dialect.name = "postgresql"
+
+        @contextmanager
+        def _fake_session_scope() -> Iterator[MagicMock]:
+            yield fake_session
+
+        monkeypatch.setattr("core.db.session_scope", _fake_session_scope)
+
+        # Mock postgres retrieval to return empty results
+        monkeypatch.setattr(
+            vector_rag,
+            "_retrieve_vector_postgres",
+            lambda q, lim, s, corpus_prefixes=None: [],  # Empty results
+        )
+
+        with caplog.at_level(logging.WARNING, logger="core.rag.vector_rag"):
+            ctx = vector_rag._retrieve_vector_from_db(
+                "test", 3, agent_id="cbt-agent", user_tier="PRO"
+            )
+
+        # Should return empty context
+        assert len(ctx.chunks) == 0
+
+        # Should log warning about empty corpus results
+        warning_logged = any(
+            "corpus_prefixes" in record.message.lower()
+            or "no vector results" in record.message.lower()
+            for record in caplog.records
+        )
+        assert warning_logged or len(ctx.chunks) == 0
+
+        # Cleanup
+        vector_rag._embedding_provider = None

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -662,7 +662,7 @@ class TestCorpusFilteringVectorRag:
             or "no vector results" in record.message.lower()
             for record in caplog.records
         )
-        assert warning_logged or len(ctx.chunks) == 0
+        assert warning_logged, "Expected warning about empty corpus results"
 
         # Cleanup
         vector_rag._embedding_provider = None


### PR DESCRIPTION
## Summary

Implement the first domain-specific RAG agent: **P2 CBT Agent** for cognitive-behavioral-therapy-informed wellness insights.

- **PRO-tier endpoint** `POST /api/v1/pro/cbt/insight` with `require_pro_tier` guard and `FEATURE_CBT_AGENT` feature flag (default off)
- **Corpus-filtered RAG retrieval** via `AGENT_CORPUS_MAP` in `core/rag/contracts.py` routing `cbt-agent` to `["docs/cbt/", "docs/psychology/"]` prefixes
- **SQL-level filtering** in `vector_rag.py` (Postgres pgvector + SQLite fallback) and `simple_rag.py` (Jaccard) using parameterized `LIKE` queries (nosec B608 — values from hardcoded map, not user input)
- **Rate limiting** via `@limit_if_available(RATE_LIMIT_INSIGHT)` with 429 OpenAPI response
- **LLM timeout** (60s) with 504 Gateway Timeout response
- **CBT corpus documents** created under `docs/cbt/` and `docs/psychology/`
- **59 tests**: 34 endpoint (tier gating, feature flag, validation, RAG integration, LLM errors, timeout), 22 corpus filtering (prefix matching, SQL generation, integration), 3 vector integration
- **100% diff-coverage** on all changed files
- Updated `RAG_CONTRACT.md` section 6 and `BACKLOG_LEDGER.md` P2 entry

## Test plan

- [x] `make lint` — PASS
- [x] `make typecheck` — PASS (230 source files)
- [x] `make test-fast` — PASS
- [x] `make diff-cov` — 100% (118 lines, 0 missing, threshold 97%)
- [x] `pre-commit run --all-files` — all 16 hooks PASS
- [x] CI pipeline green (code quality gates; Build/security-scan are Trivy infra failures: `fatal: couldn't find remote ref refs/heads/main` on aquasecurity/trivy — not code-related)

## Deferred / Follow-ups

Recorded in `docs/roadmap/BACKLOG_LEDGER.md`:

- **P1**: PRO monthly quota for LLM endpoints (infrastructure extension from PR-647 VIP quota)
- **P2**: RAG chunk content redaction helper (defense-in-depth for future user-generated corpora)
- **P2**: CorpusNotIndexedError — wire up or remove unused exception

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2867997462 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2867997463 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2867997464 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000569 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000570 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000571 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000572 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000573 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000574 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000575 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000576 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000577 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000578 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000580 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868000583 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868001209 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868001212 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868001214 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868001215 -> f1e51e58
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868001216 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868081595 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868081858 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868081923 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083277 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083278 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083279 -> f1e51e58
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083794 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083798 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868083804 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868119366 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868137576 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#discussion_r2868137580 -> 3e95cf27
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870882298 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870884333 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870884676 -> 13861b4a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870958326 -> f1e51e58
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870959127 -> f1e51e58
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3870981751 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3871013327 -> 3095e9b2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/942#pullrequestreview-3871030727 -> 3e95cf27

## Merge Readiness

- [x] `make verify` green locally
- [x] `pre-commit run --all-files` green
- [x] No merge conflicts
- [x] OpenAPI artifacts regenerated (`openapi.json`, `schema.ts`)
- [x] CI green (code quality: merge-readiness, lint, test-pr, coverage-pr, OpenAPI sync, PR body gates all PASS; Build/security-scan fail due to upstream Trivy infra — `aquasecurity/trivy` refs/heads/main unreachable)
- [x] CodeRabbit PASS / Sourcery PASS / Cubic reviewed (1 P3 nitpick resolved, no blockers)
- [x] All 29 review threads resolved
- [x] Mandatory wait-window observed (first green at run 22533860338, second green at run 22539615802)