### PR TITLE
fix(ci): upgrade setup-trivy to v0.2.5 and Trivy to v0.68.2

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,9 +44,9 @@ jobs:
           target: production
 
       - name: Set up Trivy
-        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.5
         with:
-          version: 'v0.65.0'
+          version: 'v0.68.2'
 
       - name: Restore ignore-policy after setup-trivy
         run: git checkout -- trivy/ignore-policy.rego


### PR DESCRIPTION
## Summary

- Upgrades `aquasecurity/setup-trivy` from stale commit `e6c2c5e` to `3fb12ec` (v0.2.5) which pins the install script checkout to a specific commit, fixing the `fatal: couldn't find remote ref refs/heads/main` failure.
- Bumps Trivy scanner from v0.65.0 to v0.68.2 (latest stable).

## Motivation

The `trivy` workflow on main is broken: `setup-trivy` at the old commit tries to `git clone` the aquasecurity/trivy repo via `refs/heads/main`, which is no longer resolvable. This breaks the security-scan job on every push and on schedule.

v0.2.5 of setup-trivy (commit `3fb12ec`) includes the fix: "Pin Trivy install script checkout to a specific commit (#28)".

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [x] `pre-commit run --all-files` green
- [x] CI-only change, no backend/test code affected
- [x] Single scoped commit: workflow config only

## Deferred / Follow-ups

- None