### PR TITLE
chore(deps): bump fastapi 0.135.0, openai 2.24.0, sqlalchemy 2.0.47

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,13 +45,12 @@ dnspython==2.8.0
     # via email-validator
 email-validator==2.3.0
     # via -r requirements.in
-fastapi==0.129.2
+fastapi==0.135.0
     # via -r requirements.in
 filelock==3.24.3
     # via
     #   huggingface-hub
     #   torch
-    #   transformers
 fonttools==4.61.1
     # via matplotlib
 fsspec==2026.2.0
@@ -120,7 +119,7 @@ numpy==2.4.0
     #   scipy
     #   sentence-transformers
     #   transformers
-openai==2.21.0
+openai==2.24.0
     # via -r requirements.in
 packaging==25.0
     # via
@@ -189,7 +188,7 @@ slowapi==0.1.9
     # via -r requirements.in
 sniffio==1.3.1
     # via openai
-sqlalchemy==2.0.46
+sqlalchemy==2.0.47
     # via
     #   -r requirements.in
     #   alembic


### PR DESCRIPTION
## Summary

Clean local pip-compile replacing closed Dependabot PR #943 (which had CUDA/NVIDIA artifacts from a Linux-compiled lockfile).

- **fastapi** 0.129.2 → 0.135.0 (streaming JSON Lines, Starlette 1.0+ compat, strict Content-Type)
- **openai** 2.21.0 → 2.24.0 (Responses WebSocket API, realtime models, phase field)
- **sqlalchemy** 2.0.46 → 2.0.47 (PostgreSQL FK reflection fix, raw_connection context manager)

No CUDA, NVIDIA, or triton packages in lockfile — compiled on macOS with `pip-compile --allow-unsafe --strip-extras`.

## Motivation

Dependabot PR #943 was closed because its lockfile contained platform-specific CUDA artifacts (`cuda-bindings`, `nvidia-cublas-cu12`, etc.) that break macOS installs. This PR reapplies the same version bumps with a clean lockfile.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [x] `pre-commit run --all-files` green
- [x] `make test-fast` green
- [x] No CUDA/NVIDIA artifacts in lockfile
- [x] Only `requirements.txt` changed (1 file, 3 version bumps)

## Deferred / Follow-ups

- FastAPI 0.132.0 introduces `strict_content_type` checking by default — verify all clients send proper `Content-Type: application/json` headers (existing tests pass, no action needed now)