### PR TITLE
feat(rag): add philosophy validation pipeline

### DIFF
--- a/core/rag/__init__.py
+++ b/core/rag/__init__.py
@@ -11,6 +11,10 @@ from core.rag.orchestration import (
     RAGOrchestrationResult,
     retrieve_and_validate_rag,
 )
+from core.rag.philosophy_pipeline import (
+    PipelineResult,
+    run_pipeline,
+)
 from core.rag.rag_constants import (
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MODEL_NAME,
@@ -30,6 +34,8 @@ __all__ = [
     "RAGContext",
     "RAGOrchestrationResult",
     "retrieve_and_validate_rag",
+    "PipelineResult",
+    "run_pipeline",
     "EMBEDDING_DIMENSIONS",
     "EMBEDDING_MODEL_NAME",
     "MAX_CHUNK_SIZE_CHARS",

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -143,15 +143,15 @@ async def _run_orchestration(
     chunks_filtered = 0
 
     if philo_enabled:
-        from core.rag.validation import validate_rag_chunks
+        from core.rag.philosophy_pipeline import run_pipeline
 
-        val_result = validate_rag_chunks(rag_ctx.chunks)
-        chunks_to_use = val_result.filtered_chunks
-        chunks_filtered = val_result.rejected_count
-        warnings = val_result.warnings
+        pipeline_result = run_pipeline(rag_ctx.chunks, query=prompt_input)
+        chunks_to_use = pipeline_result.filtered_chunks
+        chunks_filtered = len(rag_ctx.chunks) - len(pipeline_result.filtered_chunks)
+        warnings = pipeline_result.warnings
 
         for w in warnings:
-            logger.debug("rag_validation: %s", w)
+            logger.debug("rag_pipeline: %s", w)
 
     # If no chunks survived validation
     if not chunks_to_use:

--- a/core/rag/philosophy_pipeline.py
+++ b/core/rag/philosophy_pipeline.py
@@ -105,11 +105,13 @@ _NUMERIC_RANGE_RE = re.compile(
 )
 
 # Stage 3: Alignment thresholds
-_HIGH_SCORE_THRESHOLD = 0.7
-_SHORT_TEXT_THRESHOLD = 30
-_VERY_SHORT_TEXT_THRESHOLD = 20
-_MEDIUM_SCORE_THRESHOLD = 0.5
-_ALIGNMENT_WARNING_THRESHOLD = 0.5
+# These thresholds detect score-vs-content quality mismatches.
+# High score + short text suggests the retriever matched on boilerplate/headers.
+_HIGH_SCORE_THRESHOLD = 0.7  # Above this, chunk is considered "high confidence"
+_SHORT_TEXT_THRESHOLD = 30  # Below 30 chars is suspiciously short for useful content
+_VERY_SHORT_TEXT_THRESHOLD = 20  # Below 20 chars is almost certainly low quality
+_MEDIUM_SCORE_THRESHOLD = 0.5  # Medium confidence threshold
+_ALIGNMENT_WARNING_THRESHOLD = 0.5  # Misalignment score above this triggers warning
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +329,7 @@ def _extract_numeric_ranges(text: str) -> list[tuple[float, float]]:
             high = float(match.group(2))
             if low < high:
                 ranges.append((low, high))
-        except ValueError:
+        except ValueError:  # pragma: no cover - defensive; regex ensures valid floats
             continue
     return ranges
 
@@ -339,9 +341,19 @@ def _ranges_contradict(a: tuple[float, float], b: tuple[float, float]) -> bool:
 
 def _stage4_logical_consistency(
     chunks: list[RAGChunk],
-    query: str,
+    query: str,  # noqa: ARG001 - reserved for future semantic contradiction detection
 ) -> StageResult:
-    """Detect contradictory numeric claims and single-source echo."""
+    """Detect contradictory numeric claims and single-source echo.
+
+    Parameters
+    ----------
+    chunks:
+        Filtered chunks to check for consistency.
+    query:
+        Original user query (reserved for future query-aware contradiction
+        detection, e.g. flagging when query asks about X but chunks contradict on X).
+    """
+    _ = query  # Silence unused-variable linters; see docstring for rationale
     start = time.perf_counter()
     warnings: list[str] = []
     metadata: dict[str, Any] = {}

--- a/core/rag/philosophy_pipeline.py
+++ b/core/rag/philosophy_pipeline.py
@@ -1,0 +1,386 @@
+"""Philosophy-agent RAG validation pipeline.
+
+Multi-stage deterministic validation of RAG chunks before LLM generation.
+Replaces flat ``validate_rag_chunks()`` call when philosophy validation is
+enabled (``FEATURE_PHILOSOPHY_VALIDATION``).
+
+Stages:
+1. **Rule validation** — delegate to existing ``validation.validate_rag_chunks``
+2. **Claim classification** — classify chunks (fact / recommendation / speculation)
+3. **Source-claim alignment** — flag score-vs-content mismatches
+4. **Logical consistency** — detect contradictions and single-source echo
+
+Only stage 1 blocks chunks.  Stages 2-4 add advisory warnings.
+On any internal exception the pipeline returns original chunks (fail-safe).
+
+See: docs/roadmap/BACKLOG_LEDGER.md line 1852 (P2 Philosophy-agent pipeline)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from core.rag.contracts import RAGChunk
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Claim type taxonomy
+# ---------------------------------------------------------------------------
+
+
+class ClaimType(str, Enum):
+    """Claim classification for RAG chunks."""
+
+    NUTRITION_FACT = "nutrition_fact"
+    RECOMMENDATION = "recommendation"
+    SPECULATION = "speculation"
+    UNKNOWN = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StageResult:
+    """Result of a single pipeline stage."""
+
+    stage_name: str
+    passed: bool
+    warnings: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    latency_ms: float = 0.0
+
+
+@dataclass
+class PipelineResult:
+    """Result of the full philosophy validation pipeline."""
+
+    filtered_chunks: list[RAGChunk]
+    """Chunks that survived blocking stages."""
+
+    stage_results: list[StageResult]
+    """Per-stage results in execution order."""
+
+    warnings: list[str]
+    """Aggregated warnings from all stages."""
+
+    total_latency_ms: float
+    """Total pipeline execution time in milliseconds."""
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+# Stage 2: Claim classification
+_NUTRITION_FACT_RE = re.compile(
+    r"\b\d+\.?\d*\s*(?:kcal|cal|kj|grams?|mg|mcg|g/kg|ml)\b"
+    r"|\b(?:BMI|BMR|TDEE|RDA|DRI)\s*[\d<>=]",
+    re.IGNORECASE,
+)
+
+_RECOMMENDATION_RE = re.compile(
+    r"\b(?:aim\s+for|try\s+to|consider|should|recommended?|at\s+least|no\s+more\s+than)\b",
+    re.IGNORECASE,
+)
+
+_SPECULATION_RE = re.compile(
+    r"\b(?:some\s+say|possibly|it\s+is\s+believed|reportedly"
+    r"|might\s+be|could\s+be|may\s+or\s+may\s+not|some\s+experts)\b",
+    re.IGNORECASE,
+)
+
+# Stage 4: Numeric range extraction
+_NUMERIC_RANGE_RE = re.compile(
+    r"(\d+\.?\d*)\s*[-\u2013]\s*(\d+\.?\d*)",
+)
+
+# Stage 3: Alignment thresholds
+_HIGH_SCORE_THRESHOLD = 0.7
+_SHORT_TEXT_THRESHOLD = 30
+_VERY_SHORT_TEXT_THRESHOLD = 20
+_MEDIUM_SCORE_THRESHOLD = 0.5
+_ALIGNMENT_WARNING_THRESHOLD = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_pipeline(
+    chunks: list[RAGChunk],
+    query: str,
+) -> PipelineResult:
+    """Run all 4 stages sequentially with fail-safe error handling.
+
+    Parameters
+    ----------
+    chunks:
+        RAG chunks to validate.
+    query:
+        Original user query for context.
+
+    Returns
+    -------
+    PipelineResult
+        Filtered chunks, per-stage results, and aggregated warnings.
+        On any unhandled exception returns original chunks unchanged.
+    """
+    try:
+        return _run_pipeline_inner(chunks, query)
+    except Exception:
+        logger.warning(
+            "Philosophy pipeline failed; returning original chunks",
+            exc_info=True,
+        )
+        return PipelineResult(
+            filtered_chunks=list(chunks),
+            stage_results=[],
+            warnings=["pipeline_error: internal failure, chunks unfiltered"],
+            total_latency_ms=0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal implementation
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline_inner(
+    chunks: list[RAGChunk],
+    query: str,
+) -> PipelineResult:
+    """Execute all 4 stages sequentially."""
+    pipeline_start = time.perf_counter()
+    all_warnings: list[str] = []
+    stage_results: list[StageResult] = []
+
+    # Stage 1: Rule-based validation (blocking)
+    filtered, s1 = _stage1_rule_validation(chunks)
+    stage_results.append(s1)
+    all_warnings.extend(s1.warnings)
+
+    # Stage 2: Claim classification (enrichment only)
+    s2 = _stage2_claim_classification(filtered)
+    stage_results.append(s2)
+    all_warnings.extend(s2.warnings)
+
+    # Stage 3: Source-claim alignment (advisory)
+    s3 = _stage3_source_alignment(filtered)
+    stage_results.append(s3)
+    all_warnings.extend(s3.warnings)
+
+    # Stage 4: Logical consistency (advisory)
+    s4 = _stage4_logical_consistency(filtered, query)
+    stage_results.append(s4)
+    all_warnings.extend(s4.warnings)
+
+    total_ms = (time.perf_counter() - pipeline_start) * 1000
+
+    return PipelineResult(
+        filtered_chunks=filtered,
+        stage_results=stage_results,
+        warnings=all_warnings,
+        total_latency_ms=round(total_ms, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: Rule-based validation (delegates to validation.py)
+# ---------------------------------------------------------------------------
+
+
+def _stage1_rule_validation(
+    chunks: list[RAGChunk],
+) -> tuple[list[RAGChunk], StageResult]:
+    """Delegate to existing ``validate_rag_chunks()`` for blocking rules."""
+    start = time.perf_counter()
+
+    from core.rag.validation import validate_rag_chunks
+
+    val_result = validate_rag_chunks(chunks)
+    latency = (time.perf_counter() - start) * 1000
+
+    return val_result.filtered_chunks, StageResult(
+        stage_name="rule_validation",
+        passed=val_result.passed,
+        warnings=val_result.warnings,
+        metadata={
+            "rejected_count": val_result.rejected_count,
+            "validation_latency_ms": val_result.validation_latency_ms,
+        },
+        latency_ms=round(latency, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: Claim classification (enrichment — no blocking)
+# ---------------------------------------------------------------------------
+
+
+def classify_chunk(chunk: RAGChunk) -> ClaimType:
+    """Classify a single chunk by claim type.
+
+    Priority: NUTRITION_FACT > RECOMMENDATION > SPECULATION > UNKNOWN.
+    """
+    text = chunk.content
+    if _NUTRITION_FACT_RE.search(text):
+        return ClaimType.NUTRITION_FACT
+    if _RECOMMENDATION_RE.search(text):
+        return ClaimType.RECOMMENDATION
+    if _SPECULATION_RE.search(text):
+        return ClaimType.SPECULATION
+    return ClaimType.UNKNOWN
+
+
+def _stage2_claim_classification(chunks: list[RAGChunk]) -> StageResult:
+    """Classify each chunk and record distribution in metadata."""
+    start = time.perf_counter()
+    warnings: list[str] = []
+    classifications: dict[str, list[str]] = {}
+
+    for chunk in chunks:
+        claim_type = classify_chunk(chunk)
+        classifications.setdefault(claim_type.value, []).append(chunk.chunk_id)
+        if claim_type == ClaimType.SPECULATION:
+            warnings.append(f"claim_speculation: chunk {chunk.chunk_id} classified as speculation")
+
+    latency = (time.perf_counter() - start) * 1000
+
+    return StageResult(
+        stage_name="claim_classification",
+        passed=True,
+        warnings=warnings,
+        metadata={"classifications": classifications},
+        latency_ms=round(latency, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: Source-claim alignment (advisory — no blocking)
+# ---------------------------------------------------------------------------
+
+
+def _alignment_score(chunk: RAGChunk) -> float:
+    """Score misalignment between retrieval score and content quality.
+
+    Returns 0.0 for well-aligned chunks, higher for suspicious mismatches.
+    A high retrieval score on very short text suggests a quality issue.
+    """
+    text_len = len(chunk.content.strip())
+    if chunk.score > _HIGH_SCORE_THRESHOLD and text_len < _VERY_SHORT_TEXT_THRESHOLD:
+        return 0.9
+    if chunk.score > _HIGH_SCORE_THRESHOLD and text_len < _SHORT_TEXT_THRESHOLD:
+        return 0.8
+    if chunk.score > _MEDIUM_SCORE_THRESHOLD and text_len < _VERY_SHORT_TEXT_THRESHOLD:
+        return 0.7
+    return 0.0
+
+
+def _stage3_source_alignment(chunks: list[RAGChunk]) -> StageResult:
+    """Flag chunks where retrieval score does not match content quality."""
+    start = time.perf_counter()
+    warnings: list[str] = []
+    flagged: list[str] = []
+
+    for chunk in chunks:
+        score = _alignment_score(chunk)
+        if score > _ALIGNMENT_WARNING_THRESHOLD:
+            flagged.append(chunk.chunk_id)
+            warnings.append(
+                f"alignment_mismatch: chunk {chunk.chunk_id} "
+                f"(score={chunk.score:.2f}, len={len(chunk.content.strip())})"
+            )
+
+    latency = (time.perf_counter() - start) * 1000
+
+    return StageResult(
+        stage_name="source_alignment",
+        passed=True,
+        warnings=warnings,
+        metadata={"flagged_chunks": flagged},
+        latency_ms=round(latency, 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 4: Logical consistency (advisory — no blocking)
+# ---------------------------------------------------------------------------
+
+
+def _extract_numeric_ranges(text: str) -> list[tuple[float, float]]:
+    """Extract numeric ranges (e.g. '18.5-24.9') from text."""
+    ranges: list[tuple[float, float]] = []
+    for match in _NUMERIC_RANGE_RE.finditer(text):
+        try:
+            low = float(match.group(1))
+            high = float(match.group(2))
+            if low < high:
+                ranges.append((low, high))
+        except ValueError:
+            continue
+    return ranges
+
+
+def _ranges_contradict(a: tuple[float, float], b: tuple[float, float]) -> bool:
+    """Return True if two numeric ranges are non-overlapping (contradiction)."""
+    return a[1] < b[0] or b[1] < a[0]
+
+
+def _stage4_logical_consistency(
+    chunks: list[RAGChunk],
+    query: str,
+) -> StageResult:
+    """Detect contradictory numeric claims and single-source echo."""
+    start = time.perf_counter()
+    warnings: list[str] = []
+    metadata: dict[str, Any] = {}
+
+    # Check 1: Single-source echo
+    if len(chunks) > 1:
+        unique_sources = {c.file for c in chunks}
+        metadata["unique_sources"] = len(unique_sources)
+        if len(unique_sources) == 1:
+            warnings.append(
+                f"single_source_echo: all {len(chunks)} chunks from {next(iter(unique_sources))}"
+            )
+
+    # Check 2: Contradictory numeric ranges
+    chunk_ranges: list[tuple[str, tuple[float, float]]] = []
+    for chunk in chunks:
+        for r in _extract_numeric_ranges(chunk.content):
+            chunk_ranges.append((chunk.chunk_id, r))
+
+    contradictions: list[str] = []
+    for i, (id_a, range_a) in enumerate(chunk_ranges):
+        for id_b, range_b in chunk_ranges[i + 1 :]:
+            if id_a != id_b and _ranges_contradict(range_a, range_b):
+                contradictions.append(
+                    f"{id_a}({range_a[0]}-{range_a[1]}) vs {id_b}({range_b[0]}-{range_b[1]})"
+                )
+
+    if contradictions:
+        metadata["contradictions"] = contradictions
+        warnings.append(
+            f"numeric_contradiction: {len(contradictions)} conflicting range(s) detected"
+        )
+
+    latency = (time.perf_counter() - start) * 1000
+
+    return StageResult(
+        stage_name="logical_consistency",
+        passed=True,
+        warnings=warnings,
+        metadata=metadata,
+        latency_ms=round(latency, 2),
+    )

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1849,19 +1849,25 @@ If it is not recorded here — it does not exist.
     - retrieve_context supports max_hops>1; timeout enforced; deterministic tests
     - `make verify` passes
 
-- [ ] P2: Philosophy-agent + RAG validation pipeline
+- [x] P2: Philosophy-agent + RAG validation pipeline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (AI / RAG / philosophy)
-  - Target PR: PR-next-10 (runtime)
-  - Status: Planned
+  - Target PR: feat/p2-philosophy-rag-pipeline
+  - Status: ✅ Implemented (2026-03-02)
   - Reason (EN): Pipeline query → RAG → philosophy-agent → LLM so that RAG context is validated before response; per BACKLOG Philosophical logic principles.
   - Links:
     - `docs/audit/RAG_IMPLEMENTATION_AND_AGENT_KNOWLEDGE_AUDIT.md` (sect. 3.2)
     - `docs/insights/PHILOSOPHICAL_LOGIC_LLM_RELIABILITY.md`
     - `.cursor/agents/philosophy-agent.md`
+    - `core/rag/philosophy_pipeline.py` (4-stage pipeline implementation)
   - DoD:
     - RAG context passed to philosophy validation layer; integration test
     - `make verify` passes
+  - Evidence:
+    - 4-stage deterministic pipeline: rule validation → claim classification → source alignment → logical consistency
+    - Stage 1 blocks (medical/weasel/malformed); stages 2-4 advisory-only warnings
+    - 42 unit tests in `tests/test_philosophy_pipeline.py`
+    - diff-coverage 98% (>=97%)
 
 - [x] Observability: measure legacy nutrition alias usage (deprecation removal readiness)
   - Owner: @katsiaryna_kavaleuskaya

--- a/tests/test_philosophy_pipeline.py
+++ b/tests/test_philosophy_pipeline.py
@@ -18,7 +18,6 @@ from core.rag.contracts import RAGChunk
 from core.rag.philosophy_pipeline import (
     ClaimType,
     PipelineResult,
-    StageResult,
     _alignment_score,
     _extract_numeric_ranges,
     _ranges_contradict,

--- a/tests/test_philosophy_pipeline.py
+++ b/tests/test_philosophy_pipeline.py
@@ -1,0 +1,429 @@
+"""Unit tests for philosophy validation pipeline (core/rag/philosophy_pipeline.py).
+
+Tests cover all 4 stages individually plus pipeline-level integration:
+- Stage 1: Rule validation delegation to validation.py
+- Stage 2: Claim classification (NUTRITION_FACT / RECOMMENDATION / SPECULATION / UNKNOWN)
+- Stage 3: Source-claim alignment (score-vs-content mismatch detection)
+- Stage 4: Logical consistency (contradictions, single-source echo)
+- Pipeline: All stages run, fail-safe, warning accumulation, latency
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core.rag.contracts import RAGChunk
+from core.rag.philosophy_pipeline import (
+    ClaimType,
+    PipelineResult,
+    StageResult,
+    _alignment_score,
+    _extract_numeric_ranges,
+    _ranges_contradict,
+    _stage1_rule_validation,
+    _stage2_claim_classification,
+    _stage3_source_alignment,
+    _stage4_logical_consistency,
+    classify_chunk,
+    run_pipeline,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chunk(
+    chunk_id: str = "c1",
+    content: str = "Some test content for chunk.",
+    score: float = 0.85,
+    file: str = "docs/test.md",
+) -> RAGChunk:
+    return RAGChunk(chunk_id=chunk_id, file=file, content=content, score=score)
+
+
+# ===========================================================================
+# Stage 1: Rule validation (delegates to validation.py)
+# ===========================================================================
+
+
+class TestStage1RuleValidation:
+    """Stage 1 delegates to validate_rag_chunks and wraps the result."""
+
+    def test_delegation_filters_medical_chunks(self) -> None:
+        """Medical chunks are rejected by the underlying validator."""
+        chunks = [
+            _chunk("c1", "You need a diagnosis from a doctor.", 0.9),
+            _chunk("c2", "Balanced nutrition supports wellness.", 0.85),
+        ]
+        filtered, result = _stage1_rule_validation(chunks)
+
+        assert result.stage_name == "rule_validation"
+        assert len(filtered) == 1
+        assert filtered[0].chunk_id == "c2"
+        assert result.metadata["rejected_count"] == 1
+        assert any("medical_boundary" in w for w in result.warnings)
+
+    def test_clean_chunks_pass_through(self) -> None:
+        """All clean chunks survive stage 1."""
+        chunks = [
+            _chunk("c1", "Hydration improves energy levels.", 0.88),
+            _chunk("c2", "Sleep quality affects metabolism.", 0.82),
+        ]
+        filtered, result = _stage1_rule_validation(chunks)
+
+        assert result.stage_name == "rule_validation"
+        assert result.passed is True
+        assert len(filtered) == 2
+        assert result.metadata["rejected_count"] == 0
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty chunk list produces empty result."""
+        filtered, result = _stage1_rule_validation([])
+
+        assert result.stage_name == "rule_validation"
+        assert filtered == []
+        assert result.passed is False
+        assert result.metadata["rejected_count"] == 0
+
+
+# ===========================================================================
+# Stage 2: Claim classification
+# ===========================================================================
+
+
+class TestClassifyChunk:
+    """classify_chunk() categorises individual chunks."""
+
+    def test_nutrition_fact(self) -> None:
+        chunk = _chunk(content="Adults need approximately 2000 kcal per day.")
+        assert classify_chunk(chunk) == ClaimType.NUTRITION_FACT
+
+    def test_nutrition_fact_bmi_reference(self) -> None:
+        chunk = _chunk(content="A healthy BMI 18.5 to 24.9 range is typical.")
+        assert classify_chunk(chunk) == ClaimType.NUTRITION_FACT
+
+    def test_recommendation(self) -> None:
+        chunk = _chunk(content="You should aim for at least 150 minutes of activity.")
+        assert classify_chunk(chunk) == ClaimType.RECOMMENDATION
+
+    def test_speculation(self) -> None:
+        chunk = _chunk(content="Some experts say this approach might be effective.")
+        assert classify_chunk(chunk) == ClaimType.SPECULATION
+
+    def test_unknown_plain_text(self) -> None:
+        chunk = _chunk(content="The weather is nice today and birds are singing.")
+        assert classify_chunk(chunk) == ClaimType.UNKNOWN
+
+    def test_priority_nutrition_over_recommendation(self) -> None:
+        """NUTRITION_FACT takes priority over RECOMMENDATION."""
+        chunk = _chunk(content="You should aim for 2000 kcal per day.")
+        assert classify_chunk(chunk) == ClaimType.NUTRITION_FACT
+
+    def test_priority_recommendation_over_speculation(self) -> None:
+        """RECOMMENDATION takes priority over SPECULATION."""
+        chunk = _chunk(content="Some experts say you should consider this approach.")
+        assert classify_chunk(chunk) == ClaimType.RECOMMENDATION
+
+
+class TestStage2ClaimClassification:
+    """Stage 2 classifies and produces warnings for speculation."""
+
+    def test_speculation_produces_warning(self) -> None:
+        chunks = [
+            _chunk("c1", "Some say this diet might be beneficial."),
+        ]
+        result = _stage2_claim_classification(chunks)
+
+        assert result.stage_name == "claim_classification"
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "claim_speculation" in result.warnings[0]
+        assert "c1" in result.warnings[0]
+
+    def test_clean_chunks_no_warnings(self) -> None:
+        chunks = [
+            _chunk("c1", "Adults need approximately 2000 kcal per day."),
+            _chunk("c2", "Sleep quality affects metabolic health strongly."),
+        ]
+        result = _stage2_claim_classification(chunks)
+
+        assert result.passed is True
+        assert result.warnings == []
+
+    def test_classification_distribution_in_metadata(self) -> None:
+        chunks = [
+            _chunk("c1", "Protein intake is 50 grams daily."),
+            _chunk("c2", "You should consider stretching routines."),
+            _chunk("c3", "The weather is nice today outside."),
+        ]
+        result = _stage2_claim_classification(chunks)
+
+        dist = result.metadata["classifications"]
+        assert "c1" in dist.get("nutrition_fact", [])
+        assert "c2" in dist.get("recommendation", [])
+        assert "c3" in dist.get("unknown", [])
+
+    def test_empty_input(self) -> None:
+        result = _stage2_claim_classification([])
+        assert result.passed is True
+        assert result.warnings == []
+        assert result.metadata["classifications"] == {}
+
+
+# ===========================================================================
+# Stage 3: Source-claim alignment
+# ===========================================================================
+
+
+class TestAlignmentScore:
+    """_alignment_score detects score-vs-content mismatches."""
+
+    def test_high_score_very_short_text(self) -> None:
+        chunk = _chunk(content="Short.", score=0.9)
+        assert _alignment_score(chunk) == 0.9
+
+    def test_high_score_short_text(self) -> None:
+        chunk = _chunk(content="A slightly longer text.", score=0.8)
+        assert _alignment_score(chunk) == 0.8
+
+    def test_medium_score_very_short_text(self) -> None:
+        chunk = _chunk(content="Tiny.", score=0.6)
+        assert _alignment_score(chunk) == 0.7
+
+    def test_normal_chunk_zero_score(self) -> None:
+        chunk = _chunk(
+            content="This is a perfectly normal chunk with enough content.",
+            score=0.85,
+        )
+        assert _alignment_score(chunk) == 0.0
+
+    def test_low_score_short_text_zero(self) -> None:
+        chunk = _chunk(content="Short.", score=0.3)
+        assert _alignment_score(chunk) == 0.0
+
+
+class TestStage3SourceAlignment:
+    """Stage 3 flags score-content mismatches."""
+
+    def test_flags_high_score_short_text(self) -> None:
+        chunks = [
+            _chunk("c1", "Short.", score=0.9),
+            _chunk("c2", "This is a normal chunk with decent content.", score=0.85),
+        ]
+        result = _stage3_source_alignment(chunks)
+
+        assert result.stage_name == "source_alignment"
+        assert result.passed is True  # advisory only
+        assert len(result.warnings) == 1
+        assert "alignment_mismatch" in result.warnings[0]
+        assert "c1" in result.warnings[0]
+        assert "c1" in result.metadata["flagged_chunks"]
+
+    def test_no_flags_for_normal_chunks(self) -> None:
+        chunks = [
+            _chunk("c1", "Good content with substance and detail.", score=0.8),
+            _chunk("c2", "Another solid chunk with real information.", score=0.7),
+        ]
+        result = _stage3_source_alignment(chunks)
+
+        assert result.warnings == []
+        assert result.metadata["flagged_chunks"] == []
+
+    def test_empty_input(self) -> None:
+        result = _stage3_source_alignment([])
+        assert result.warnings == []
+        assert result.metadata["flagged_chunks"] == []
+
+
+# ===========================================================================
+# Stage 4: Logical consistency
+# ===========================================================================
+
+
+class TestNumericRangeExtraction:
+    """_extract_numeric_ranges and _ranges_contradict."""
+
+    def test_extracts_simple_range(self) -> None:
+        ranges = _extract_numeric_ranges("BMI 18.5-24.9 is healthy")
+        assert ranges == [(18.5, 24.9)]
+
+    def test_extracts_multiple_ranges(self) -> None:
+        ranges = _extract_numeric_ranges("BMI 18.5-24.9 and 25-30 range")
+        assert len(ranges) == 2
+        assert (18.5, 24.9) in ranges
+        assert (25.0, 30.0) in ranges
+
+    def test_ignores_reversed_range(self) -> None:
+        """Ranges where low >= high are skipped."""
+        ranges = _extract_numeric_ranges("Values 30-10 are wrong")
+        assert ranges == []
+
+    def test_no_ranges_found(self) -> None:
+        ranges = _extract_numeric_ranges("No numbers here at all.")
+        assert ranges == []
+
+    def test_unicode_en_dash(self) -> None:
+        ranges = _extract_numeric_ranges("BMI 18.5\u201324.9 is healthy")
+        assert ranges == [(18.5, 24.9)]
+
+    def test_ranges_contradict_non_overlapping(self) -> None:
+        assert _ranges_contradict((10.0, 20.0), (25.0, 30.0)) is True
+
+    def test_ranges_do_not_contradict_overlapping(self) -> None:
+        assert _ranges_contradict((10.0, 25.0), (20.0, 30.0)) is False
+
+    def test_ranges_touching_do_not_contradict(self) -> None:
+        assert _ranges_contradict((10.0, 20.0), (20.0, 30.0)) is False
+
+
+class TestStage4LogicalConsistency:
+    """Stage 4 detects contradictions and single-source echo."""
+
+    def test_single_source_echo_detected(self) -> None:
+        chunks = [
+            _chunk("c1", "Fact one about health.", 0.9, file="docs/a.md"),
+            _chunk("c2", "Fact two about health.", 0.8, file="docs/a.md"),
+        ]
+        result = _stage4_logical_consistency(chunks, "health query")
+
+        assert result.stage_name == "logical_consistency"
+        assert any("single_source_echo" in w for w in result.warnings)
+        assert result.metadata["unique_sources"] == 1
+
+    def test_diverse_sources_no_echo(self) -> None:
+        chunks = [
+            _chunk("c1", "Fact one about health.", 0.9, file="docs/a.md"),
+            _chunk("c2", "Fact two about health.", 0.8, file="docs/b.md"),
+        ]
+        result = _stage4_logical_consistency(chunks, "health query")
+
+        assert not any("single_source_echo" in w for w in result.warnings)
+        assert result.metadata["unique_sources"] == 2
+
+    def test_contradictory_numeric_ranges(self) -> None:
+        chunks = [
+            _chunk("c1", "Healthy BMI is 18.5-24.9 for adults.", 0.9),
+            _chunk("c2", "Normal BMI range is 30-40 in this system.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "BMI query")
+
+        assert any("numeric_contradiction" in w for w in result.warnings)
+        assert len(result.metadata["contradictions"]) >= 1
+
+    def test_no_contradictions_consistent_ranges(self) -> None:
+        chunks = [
+            _chunk("c1", "BMI 18.5-24.9 is normal weight.", 0.9),
+            _chunk("c2", "BMI 20.0-22.0 is the ideal sub-range.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "BMI query")
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+
+    def test_single_chunk_no_echo(self) -> None:
+        """Single chunk cannot produce echo or contradiction."""
+        chunks = [_chunk("c1", "BMI 18.5-24.9 is healthy.", 0.9)]
+        result = _stage4_logical_consistency(chunks, "query")
+
+        assert result.warnings == []
+
+    def test_empty_input(self) -> None:
+        result = _stage4_logical_consistency([], "query")
+        assert result.warnings == []
+        assert result.passed is True
+
+
+# ===========================================================================
+# Pipeline integration (run_pipeline)
+# ===========================================================================
+
+
+class TestRunPipeline:
+    """Integration tests for the full run_pipeline entry point."""
+
+    def test_all_four_stages_run(self) -> None:
+        """Pipeline produces 4 stage results."""
+        chunks = [
+            _chunk("c1", "Adults need approximately 2000 kcal per day.", 0.9, "a.md"),
+            _chunk("c2", "Sleep quality affects metabolic health.", 0.8, "b.md"),
+        ]
+        result = run_pipeline(chunks, "nutrition query")
+
+        assert isinstance(result, PipelineResult)
+        assert len(result.stage_results) == 4
+        stage_names = [s.stage_name for s in result.stage_results]
+        assert stage_names == [
+            "rule_validation",
+            "claim_classification",
+            "source_alignment",
+            "logical_consistency",
+        ]
+
+    def test_fail_safe_returns_original_chunks(self) -> None:
+        """On internal exception, original chunks returned unchanged."""
+        chunks = [_chunk("c1", "Some valid content here.", 0.9)]
+
+        with patch(
+            "core.rag.philosophy_pipeline._run_pipeline_inner",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = run_pipeline(chunks, "query")
+
+        assert len(result.filtered_chunks) == 1
+        assert result.filtered_chunks[0].chunk_id == "c1"
+        assert result.stage_results == []
+        assert any("pipeline_error" in w for w in result.warnings)
+
+    def test_warning_accumulation(self) -> None:
+        """Warnings from all stages are accumulated."""
+        chunks = [
+            # This chunk has speculation AND high score + short text
+            _chunk("c1", "Some say this is true.", 0.9, "a.md"),
+            _chunk("c2", "Some say that is true.", 0.9, "a.md"),
+        ]
+        result = run_pipeline(chunks, "query")
+
+        # Should have: speculation warnings + single_source_echo
+        assert len(result.warnings) >= 2
+        # Stage 2 speculation + stage 4 echo at minimum
+        warning_text = " ".join(result.warnings)
+        assert "claim_speculation" in warning_text
+        assert "single_source_echo" in warning_text
+
+    def test_latency_tracked(self) -> None:
+        """Pipeline records total and per-stage latency."""
+        chunks = [_chunk("c1", "Hydration improves energy levels.", 0.85)]
+        result = run_pipeline(chunks, "query")
+
+        assert result.total_latency_ms >= 0
+        for stage in result.stage_results:
+            assert stage.latency_ms >= 0
+
+    def test_stage1_blocking_propagates(self) -> None:
+        """Chunks rejected by stage 1 are not seen by stages 2-4."""
+        chunks = [
+            _chunk("c1", "You need a diagnosis from a doctor.", 0.9, "a.md"),
+            _chunk("c2", "Balanced nutrition supports wellness.", 0.85, "b.md"),
+        ]
+        result = run_pipeline(chunks, "query")
+
+        # Only c2 survives stage 1
+        assert len(result.filtered_chunks) == 1
+        assert result.filtered_chunks[0].chunk_id == "c2"
+
+        # Stage 2 classification should only see c2
+        s2 = result.stage_results[1]
+        all_classified_ids = []
+        for ids in s2.metadata["classifications"].values():
+            all_classified_ids.extend(ids)
+        assert "c1" not in all_classified_ids
+        assert "c2" in all_classified_ids
+
+    def test_empty_input(self) -> None:
+        """Empty input produces empty pipeline result."""
+        result = run_pipeline([], "query")
+
+        assert result.filtered_chunks == []
+        assert len(result.stage_results) == 4

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -24,6 +24,7 @@ from core.rag.orchestration import (
     _empty_result,
     retrieve_and_validate_rag,
 )
+from core.rag.philosophy_pipeline import PipelineResult, StageResult
 from core.rag.validation import ValidationResult
 
 
@@ -138,21 +139,20 @@ class TestRetrieveAndValidateRag:
 
     @pytest.mark.asyncio
     async def test_validation_enabled_filters_chunks(self) -> None:
-        """When validation enabled, filtered chunks are used."""
+        """When validation enabled, pipeline filters chunks."""
         chunks = [
             _make_chunk("c1", content="Clean content here.", score=0.9),
             _make_chunk("c2", content="Contains diagnosis term.", score=0.7),
         ]
         rag_ctx = _make_rag_context(chunks=chunks, confidence=0.8)
 
-        # Validation returns only first chunk (second filtered)
+        # Pipeline returns only first chunk (second filtered by stage 1)
         filtered = [chunks[0]]
-        val_result = ValidationResult(
-            passed=True,
+        pipeline_result = PipelineResult(
             filtered_chunks=filtered,
+            stage_results=[],
             warnings=["medical_boundary: chunk c2 rejected"],
-            rejected_count=1,
-            validation_latency_ms=5,
+            total_latency_ms=5.0,
         )
 
         with (
@@ -163,8 +163,8 @@ class TestRetrieveAndValidateRag:
             ),
             patch("core.rag.vector_rag.retrieve_context_structured"),
             patch(
-                "core.rag.validation.validate_rag_chunks",
-                return_value=val_result,
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
             ),
             patch(
                 "core.rag.formatting.format_rag_chunks_for_prompt",
@@ -186,16 +186,16 @@ class TestRetrieveAndValidateRag:
 
     @pytest.mark.asyncio
     async def test_all_chunks_filtered_returns_not_used(self) -> None:
-        """When all chunks filtered by validation, rag_actually_used=False."""
+        """When all chunks filtered by pipeline, rag_actually_used=False."""
         chunks = [_make_chunk("c1", content="Medical diagnosis required.", score=0.9)]
         rag_ctx = _make_rag_context(chunks=chunks)
 
-        # Validation filters all chunks
-        val_result = ValidationResult(
-            passed=False,
+        # Pipeline filters all chunks
+        pipeline_result = PipelineResult(
             filtered_chunks=[],
+            stage_results=[],
             warnings=["medical_boundary: chunk c1 rejected"],
-            rejected_count=1,
+            total_latency_ms=3.0,
         )
 
         with (
@@ -206,8 +206,8 @@ class TestRetrieveAndValidateRag:
             ),
             patch("core.rag.vector_rag.retrieve_context_structured"),
             patch(
-                "core.rag.validation.validate_rag_chunks",
-                return_value=val_result,
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
             ),
         ):
             result = await retrieve_and_validate_rag("test prompt", philo_validation_enabled=True)
@@ -228,13 +228,13 @@ class TestRetrieveAndValidateRag:
         ]
         rag_ctx = _make_rag_context(chunks=chunks, confidence=0.73)
 
-        # Keep c1 and c3 (scores 0.9 and 0.8) -> mean = 0.85
+        # Pipeline keeps c1 and c3 (scores 0.9 and 0.8) -> mean = 0.85
         filtered = [chunks[0], chunks[2]]
-        val_result = ValidationResult(
-            passed=True,
+        pipeline_result = PipelineResult(
             filtered_chunks=filtered,
+            stage_results=[],
             warnings=[],
-            rejected_count=1,
+            total_latency_ms=4.0,
         )
 
         with (
@@ -245,8 +245,8 @@ class TestRetrieveAndValidateRag:
             ),
             patch("core.rag.vector_rag.retrieve_context_structured"),
             patch(
-                "core.rag.validation.validate_rag_chunks",
-                return_value=val_result,
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
             ),
             patch(
                 "core.rag.formatting.format_rag_chunks_for_prompt",
@@ -263,16 +263,19 @@ class TestRetrieveAndValidateRag:
         assert result.confidence == 0.85
 
     @pytest.mark.asyncio
-    async def test_warnings_propagated_from_validation(self) -> None:
-        """Validation warnings are included in result."""
+    async def test_warnings_propagated_from_pipeline(self) -> None:
+        """Pipeline warnings are included in result."""
         chunks = [_make_chunk("c1", content="Some say this is true.", score=0.9)]
         rag_ctx = _make_rag_context(chunks=chunks)
 
-        val_result = ValidationResult(
-            passed=True,
+        pipeline_result = PipelineResult(
             filtered_chunks=chunks,
-            warnings=["weasel_word: chunk c1 contains 'some say'"],
-            rejected_count=0,
+            stage_results=[],
+            warnings=[
+                "weasel_word: chunk c1 contains 'some say'",
+                "claim_speculation: chunk c1 classified as speculation",
+            ],
+            total_latency_ms=2.0,
         )
 
         with (
@@ -283,8 +286,8 @@ class TestRetrieveAndValidateRag:
             ),
             patch("core.rag.vector_rag.retrieve_context_structured"),
             patch(
-                "core.rag.validation.validate_rag_chunks",
-                return_value=val_result,
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
             ),
             patch(
                 "core.rag.formatting.format_rag_chunks_for_prompt",
@@ -297,8 +300,9 @@ class TestRetrieveAndValidateRag:
         ):
             result = await retrieve_and_validate_rag("test prompt", philo_validation_enabled=True)
 
-        assert len(result.warnings) == 1
+        assert len(result.warnings) == 2
         assert "weasel_word" in result.warnings[0]
+        assert "claim_speculation" in result.warnings[1]
 
     @pytest.mark.asyncio
     async def test_failsafe_on_exception_returns_empty(self) -> None:


### PR DESCRIPTION
## Summary

- Replace flat `validate_rag_chunks()` call with a 4-stage deterministic pipeline when `FEATURE_PHILOSOPHY_VALIDATION` is enabled
- Stage 1 (rule validation): delegates to existing `validation.py` - blocking filter for medical/weasel/malformed content
- Stage 2 (claim classification): categorizes chunks as NUTRITION_FACT / RECOMMENDATION / SPECULATION / UNKNOWN
- Stage 3 (source alignment): advisory warnings for high score + low quality text mismatches
- Stage 4 (logical consistency): detects contradictory numeric ranges and single-source echo

## Key Design Decisions

- Only stage 1 blocks chunks; stages 2-4 are advisory-only (add warnings, don't filter)
- Pipeline is fail-safe: any internal exception returns original chunks unchanged
- Reuses existing `FEATURE_PHILOSOPHY_VALIDATION` feature flag
- Zero LLM calls, fully deterministic (regex patterns + heuristics)

## Test plan

- [x] 42 unit tests in `tests/test_philosophy_pipeline.py` covering all 4 stages
- [x] Updated `tests/test_rag_orchestration.py` to mock `run_pipeline()`
- [x] Existing integration tests in `tests/test_philosophy_validation_integration.py` pass
- [x] `make lint` passes
- [x] `make typecheck` passes  
- [x] `pre-commit run --all-files` passes
- [x] diff-coverage 98% (>=97% required)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [x] CI green
- [x] Bot reviews addressed
- [x] Required checks pass

## Deferred / Follow-ups

- P2 item closed in `docs/roadmap/BACKLOG_LEDGER.md` (line 1852)

---

🤖 Generated with [Qoder][https://qoder.com]