### PR TITLE
fix(cd): restore staging SSH deploy and fix staging domain

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Healthcheck (staging)
         run: |
+          set -euo pipefail
           for i in 1 2 3; do
             if curl -fsS --max-time 10 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null; then
               echo "Healthcheck passed"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 # CD Workflow - Continuous Deployment
 #
-# Simplified CD workflow: Build and push Docker images only.
-# SSH deployment steps are available. Production deploy runs on semver tags `v*`
-# when required production environment secrets are configured.
+# Staging: Build, push Docker image to GHCR, deploy to staging server over SSH.
+# Production: Build and push on semver tags `v*` when required secrets are configured.
+#
+# Required staging secrets (GitHub Environment "staging"):
+# - SSH_HOST_STAGING, SSH_USER, SSH_KEY, STAGING_DOMAIN, GHCR_READ_TOKEN
 #
 # To enable production auto-deploy:
 # - Configure `production` environment secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY,
@@ -32,11 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: staging
-      # Staging domain (subdomain or free domain)
-      # Options: staging.yourdomain.com, pulseplate-staging.duckdns.org, or free Freenom domain
-      # Set STAGING_DOMAIN secret in GitHub Environment (e.g., "pulseplate-staging.duckdns.org")
-      # Note: environment.url cannot use secrets context, using static fallback
-      url: https://staging.pulseplate.app
+      # Staging domain: pulseplate-staging.duckdns.org (DuckDNS, free DDNS)
+      # Note: environment.url cannot use secrets context, using static value
+      url: https://pulseplate-staging.duckdns.org
     concurrency:
       group: cd-build-${{ github.ref_name }}
       cancel-in-progress: true
@@ -71,30 +71,29 @@ jobs:
           # staging-specific customizations (e.g., debug logging, extended health checks)
           target: staging
 
-      # SSH deployment for staging (commented out until servers are available)
-      # - name: Prepare known_hosts (staging)
-      #   run: |
-      #     mkdir -p ~/.ssh
-      #     ssh-keyscan -H ${{ secrets.SSH_HOST_STAGING }} >> ~/.ssh/known_hosts 2>/dev/null
-      #     chmod 644 ~/.ssh/known_hosts
-      #
-      # - name: Deploy to staging over SSH
-      #   uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
-      #   with:
-      #     host: ${{ secrets.SSH_HOST_STAGING }}
-      #     username: ${{ secrets.SSH_USER }}
-      #     key: ${{ secrets.SSH_KEY }}
-      #     script: |
-      #       set -euo pipefail
-      #       export GHCR_USER='${{ github.actor }}'
-      #       export GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
-      #       export STAGING_DOMAIN='${{ secrets.STAGING_DOMAIN }}'
-      #       cd /srv/pulseplate-staging
-      #       ./deploy.sh '${{ github.sha }}'
-      #
-      # - name: Healthcheck (staging)
-      #   run: |
-      #     curl -fsS --max-time 5 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null
+      - name: Prepare known_hosts (staging)
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H ${{ secrets.SSH_HOST_STAGING }} >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Deploy to staging over SSH
+        uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
+        with:
+          host: ${{ secrets.SSH_HOST_STAGING }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -euo pipefail
+            export GHCR_USER='${{ github.actor }}'
+            export GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+            export STAGING_DOMAIN='${{ secrets.STAGING_DOMAIN }}'
+            cd /srv/pulseplate-staging
+            ./deploy.sh '${{ github.sha }}'
+
+      - name: Healthcheck (staging)
+        run: |
+          curl -fsS --max-time 5 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null
 
   # Pre-production quality gates
   production-gates:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,8 +94,8 @@ jobs:
               echo "Healthcheck passed"
               exit 0
             fi
-            echo "Attempt $i failed, retrying in 5s..."
-            sleep 5
+            echo "Attempt $i failed"
+            [ "$i" -lt 3 ] && sleep 5
           done
           echo "Healthcheck failed after 3 attempts"
           exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,8 @@
 # Production: Build and push on semver tags `v*` when required secrets are configured.
 #
 # Required staging secrets (GitHub Environment "staging"):
-# - SSH_HOST_STAGING, SSH_USER, SSH_KEY, STAGING_DOMAIN, GHCR_READ_TOKEN
+# - SSH_HOST_STAGING, SSH_USER, SSH_KEY, SSH_HOST_STAGING_FINGERPRINT,
+#   STAGING_DOMAIN, GHCR_READ_TOKEN
 #
 # To enable production auto-deploy:
 # - Configure `production` environment secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY,
@@ -71,21 +72,16 @@ jobs:
           # staging-specific customizations (e.g., debug logging, extended health checks)
           target: staging
 
-      - name: Prepare known_hosts (staging)
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -H ${{ secrets.SSH_HOST_STAGING }} >> ~/.ssh/known_hosts 2>/dev/null
-          chmod 644 ~/.ssh/known_hosts
-
       - name: Deploy to staging over SSH
         uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
         with:
           host: ${{ secrets.SSH_HOST_STAGING }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ secrets.SSH_HOST_STAGING_FINGERPRINT }}
           script: |
             set -euo pipefail
-            export GHCR_USER='${{ github.actor }}'
+            export GHCR_USER='${{ github.repository_owner }}'
             export GHCR_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
             export STAGING_DOMAIN='${{ secrets.STAGING_DOMAIN }}'
             cd /srv/pulseplate-staging
@@ -93,7 +89,16 @@ jobs:
 
       - name: Healthcheck (staging)
         run: |
-          curl -fsS --max-time 5 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null
+          for i in 1 2 3; do
+            if curl -fsS --max-time 10 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null; then
+              echo "Healthcheck passed"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "Healthcheck failed after 3 attempts"
+          exit 1
 
   # Pre-production quality gates
   production-gates:

--- a/docs/runbooks/RATE_LIMIT_TESTS.md
+++ b/docs/runbooks/RATE_LIMIT_TESTS.md
@@ -79,7 +79,7 @@ curl -X POST http://localhost:8000/api/v1/test/rate-limit
 
 ```bash
 # Test against staging environment
-BASE_URL=https://staging.pulseplate.app ./scripts/test_rate_limiting.sh
+BASE_URL=https://pulseplate-staging.duckdns.org ./scripts/test_rate_limiting.sh
 ```
 
 ### Production Verification


### PR DESCRIPTION
## Summary

- Restore staging SSH deployment that was accidentally removed in commit `8b800801` ("simplify CD workflow")
- Fix staging environment URL from placeholder `staging.pulseplate.app` (never a real DNS record) to `pulseplate-staging.duckdns.org`
- Update `RATE_LIMIT_TESTS.md` staging URL reference

## Root Cause

Staging SSH deploy was removed during CI simplification and replaced with commented-out skeleton + placeholder URL. The DuckDNS domain `pulseplate-staging.duckdns.org` -> `64.226.117.163` has been configured and resolving all along.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/cd.yml` | Restore SSH deploy, use `fingerprint` for host key verification, fix env URL, `repository_owner` for GHCR, healthcheck retry |
| `docs/runbooks/RATE_LIMIT_TESTS.md` | Fix staging URL reference |

## Prerequisites (GitHub Environment "staging")

These secrets must be configured for deploy to work:
- `SSH_HOST_STAGING` -- staging server IP (64.226.117.163)
- `SSH_USER` -- SSH username
- `SSH_KEY` -- SSH private key
- `SSH_HOST_STAGING_FINGERPRINT` -- SHA256 fingerprint (`ssh-keyscan -t ed25519 <host> | ssh-keygen -lf - | awk '{print $2}'`)
- `STAGING_DOMAIN` -- `pulseplate-staging.duckdns.org`
- `GHCR_READ_TOKEN` -- PAT with `read:packages` scope

## Deferred / Follow-ups

- Server-side: Docker/Caddy must be running on staging server for TLS and healthcheck to pass
- No backlog ledger items required (this restores previously working functionality)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#pullrequestreview-3877180941 -> b41742a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#pullrequestreview-3877203861 -> b41742a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#pullrequestreview-3877287744 -> 135c9c68
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#pullrequestreview-3877393536 -> 390248ef
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#discussion_r2873345916 -> b41742a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/953#discussion_r2873345920 -> b41742a4

## Merge Readiness

- [x] `pre-commit run --all-files` passed
- [x] No runtime code changes (CI/infra only)
- [x] CI green
- [x] Bot reviews clean