### PR TITLE
fix(cd): make SSH deploy optional to fix 'ssh: no key found'

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,14 +4,14 @@
 # Staging: Build, push Docker image to GHCR, deploy to staging server over SSH.
 # Production: Build and push on semver tags `v*` when required secrets are configured.
 #
-# Required staging secrets (GitHub Environment "staging"):
-# - SSH_HOST_STAGING, SSH_USER, SSH_KEY, SSH_HOST_STAGING_FINGERPRINT,
-#   STAGING_DOMAIN, GHCR_READ_TOKEN
+# Staging deploy (optional): set Environment "staging" variable STAGING_DEPLOY_ENABLED=true
+# and secrets: SSH_HOST_STAGING, SSH_USER, SSH_KEY, SSH_HOST_STAGING_FINGERPRINT,
+# STAGING_DOMAIN, GHCR_READ_TOKEN. If unset, only build+push run (no SSH); avoids "ssh: no key found".
 #
-# To enable production auto-deploy:
-# - Configure `production` environment secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY,
-#   PRODUCTION_DOMAIN, GHCR_READ_TOKEN (if needed)
-# - Ensure the server has the deploy directory and docker compose files (see deploy/PRODUCTION.md)
+# Production deploy: set repository/environment variable PROD_DEPLOY_MODE to 'ssh' or 'self-hosted'.
+# When unset, deploy jobs are skipped (images still built). For SSH: configure "production"
+# environment secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY, PRODUCTION_DOMAIN, GHCR_READ_TOKEN.
+# See deploy/PRODUCTION.md.
 
 name: CD
 
@@ -73,6 +73,7 @@ jobs:
           target: staging
 
       - name: Deploy to staging over SSH
+        if: vars.STAGING_DEPLOY_ENABLED == 'true'
         uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
         with:
           host: ${{ secrets.SSH_HOST_STAGING }}
@@ -88,6 +89,7 @@ jobs:
             ./deploy.sh '${{ github.sha }}'
 
       - name: Healthcheck (staging)
+        if: vars.STAGING_DEPLOY_ENABLED == 'true'
         run: |
           set -euo pipefail
           for i in 1 2 3; do
@@ -216,9 +218,9 @@ jobs:
           target: production
 
   deploy-production:
-    # Default deploy mode is SSH from GitHub-hosted runners unless explicitly set to self-hosted.
-    # This prevents both prod deploy jobs from being eligible at the same time.
-    if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE != 'self-hosted'
+    # Run only when PROD_DEPLOY_MODE is explicitly 'ssh' (SSH from GitHub-hosted runners).
+    # When unset or 'self-hosted', this job is skipped; avoids "ssh: no key found" when secrets not configured.
+    if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE == 'ssh'
     needs: [production-gates, build-production]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,9 +8,9 @@
 # and secrets: SSH_HOST_STAGING, SSH_USER, SSH_KEY, SSH_HOST_STAGING_FINGERPRINT,
 # STAGING_DOMAIN, GHCR_READ_TOKEN. If unset, only build+push run (no SSH); avoids "ssh: no key found".
 #
-# Production deploy: set repository/environment variable PROD_DEPLOY_MODE to 'ssh' or 'self-hosted'.
-# When unset, deploy jobs are skipped (images still built). For SSH: configure "production"
-# environment secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY, PRODUCTION_DOMAIN, GHCR_READ_TOKEN.
+# Production deploy: set PROD_DEPLOY_MODE to 'ssh' or 'self-hosted'. When unset or any other value,
+# deploy jobs are skipped (container images are still built and pushed to GHCR). For PROD_DEPLOY_MODE=ssh
+# configure Environment "production" secrets: SSH_HOST_PRODUCTION, SSH_USER, SSH_KEY, PRODUCTION_DOMAIN, GHCR_READ_TOKEN.
 # See deploy/PRODUCTION.md.
 
 name: CD
@@ -219,7 +219,7 @@ jobs:
 
   deploy-production:
     # Run only when PROD_DEPLOY_MODE is explicitly 'ssh' (SSH from GitHub-hosted runners).
-    # When unset or 'self-hosted', this job is skipped; avoids "ssh: no key found" when secrets not configured.
+    # When unset or any value other than 'ssh', this job is skipped; avoids "ssh: no key found" when secrets not configured.
     if: startsWith(github.ref, 'refs/tags/v') && vars.PROD_DEPLOY_MODE == 'ssh'
     needs: [production-gates, build-production]
     runs-on: ubuntu-latest

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -7,12 +7,12 @@ SSH + `docker compose`.
 
 ## Deploy mode (required)
 
-Auto-deploy is controlled by repository variable `PROD_DEPLOY_MODE`:
+Auto-deploy is controlled by repository or environment variable `PROD_DEPLOY_MODE`:
 
-- `ssh`: Deploy from GitHub-hosted runners over SSH (requires port 22 reachable from the internet).
+- `ssh`: Deploy from GitHub-hosted runners over SSH (requires port 22 reachable; set Environment "production" secrets: `SSH_HOST_PRODUCTION`, `SSH_USER`, `SSH_KEY`, `PRODUCTION_DOMAIN`, `GHCR_READ_TOKEN`). SSH key must be full PEM including newlines to avoid "ssh: no key found".  # pragma: allowlist secret
 - `self-hosted`: Deploy from a self-hosted runner inside your infrastructure (recommended).
 
-If `PROD_DEPLOY_MODE` is unset or any other value, deploy jobs are skipped (images are still built).
+If `PROD_DEPLOY_MODE` is unset or any other value, deploy jobs are skipped (images are still built and pushed to GHCR).
 
 ## Source of truth: production image
 

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -9,7 +9,7 @@ SSH + `docker compose`.
 
 Auto-deploy is controlled by repository or environment variable `PROD_DEPLOY_MODE`:
 
-- `ssh`: Deploy from GitHub-hosted runners over SSH (requires port 22 reachable; set Environment "production" secrets: `SSH_HOST_PRODUCTION`, `SSH_USER`, `SSH_KEY`, `PRODUCTION_DOMAIN`, `GHCR_READ_TOKEN`). SSH key must be full PEM including newlines to avoid "ssh: no key found".  # pragma: allowlist secret
+- `ssh`: Deploy from GitHub-hosted runners over SSH (port 22 reachable). SSH key must be full PEM including newlines to avoid "ssh: no key found". Required Environment "production" secrets: `SSH_HOST_PRODUCTION`, `SSH_USER`, `SSH_KEY`, `PRODUCTION_DOMAIN`, `GHCR_READ_TOKEN`.  <!-- pragma: allowlist secret -->
 - `self-hosted`: Deploy from a self-hosted runner inside your infrastructure (recommended).
 
 If `PROD_DEPLOY_MODE` is unset or any other value, deploy jobs are skipped (images are still built and pushed to GHCR).

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -213,13 +213,18 @@ ssh -i ~/.ssh/pulseplate_staging user@your-server-ip
 2. Click "New environment"
 3. Name: `staging`
 
-### 2. Add Secrets
+### 2. Enable staging deploy and add secrets
 
-Add these secrets to the `staging` environment:
+Set the **Environment variable** (Settings → Environments → staging → Environment variables):
+
+- `STAGING_DEPLOY_ENABLED` = `true` — required for CD to run SSH deploy. If unset, the CD workflow only builds and pushes the image (no deploy); this avoids "ssh: no key found" when secrets are not yet configured.
+
+Add these **secrets** to the `staging` environment:
 
 - `SSH_HOST_STAGING` - Your server IP or domain
 - `SSH_USER` - SSH username (usually `root` or `ubuntu`)
-- `SSH_KEY` - Your private SSH key content
+- `SSH_KEY` - Full private SSH key (PEM format), including `-----BEGIN ... KEY-----` and `-----END ... KEY-----`; preserve newlines when pasting to avoid "ssh: no key found"
+- `SSH_HOST_STAGING_FINGERPRINT` - Server host key fingerprint (optional but recommended)
 - `GHCR_READ_TOKEN` - GitHub PAT with `read:packages` permission
 - `STAGING_DOMAIN` - Your staging domain
 

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -224,7 +224,7 @@ Add these **secrets** to the `staging` environment:
 - `SSH_HOST_STAGING` - Your server IP or domain
 - `SSH_USER` - SSH username (usually `root` or `ubuntu`)
 - `SSH_KEY` - Full private SSH key (PEM format), including `-----BEGIN ... KEY-----` and `-----END ... KEY-----`; preserve newlines when pasting to avoid "ssh: no key found"
-- `SSH_HOST_STAGING_FINGERPRINT` - Server host key fingerprint (optional but recommended)
+- `SSH_HOST_STAGING_FINGERPRINT` - Staging **server** host key fingerprint, usually `SHA256:...` (optional but recommended). **Easiest from your laptop:** run `ssh -o VisualHostKey=yes user@your-staging-host` and copy the `SHA256:...` line shown when connecting. **Or on the server:** after SSH in, run `sudo ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub` (or `ssh_host_rsa_key.pub` / `ssh_host_ecdsa_key.pub` if present; list with `ls /etc/ssh/ssh_host_*.pub`).
 - `GHCR_READ_TOKEN` - GitHub PAT with `read:packages` permission
 - `STAGING_DOMAIN` - Your staging domain
 


### PR DESCRIPTION
## Summary

Fix CD workflow failure `ssh: no key found` by making SSH deploy optional and aligning production deploy condition with docs.

- Staging: run "Deploy to staging over SSH" and healthcheck only when `vars.STAGING_DEPLOY_ENABLED == 'true'`. If unset, CD only builds and pushes the image (no SSH step).
- Production: run `deploy-production` job only when `vars.PROD_DEPLOY_MODE == 'ssh'` (was `!= 'self-hosted'`, so unset triggered SSH and failed). Unset = skip deploy; images still built and pushed.
- Docs: STAGING.md and PRODUCTION.md updated with variable names, secret list, and SSH key format (full PEM with newlines).

## Risk & Impact

- No user-facing change; CI/CD only.
- Enables green CD on main when staging/production secrets are not configured; deploy runs only when explicitly enabled.

## Test Plan

- No new unit tests (workflow and markdown only).
- Manual: after merge, push to main → CD build job should pass (deploy steps skipped unless vars set). When `STAGING_DEPLOY_ENABLED=true` and secrets set, staging deploy runs.

## CI Gates

- Lint and test-fast run locally (passed).
- Rely on CI for full verify and diff-coverage.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/954#pullrequestreview-3878436220 -> 5841554e21f7dcd6481a4768cf9e00e683761660
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/954#discussion_r2874451078 -> 5841554e21f7dcd6481a4768cf9e00e683761660
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/954#discussion_r2874451083 -> 5841554e21f7dcd6481a4768cf9e00e683761660
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/954#pullrequestreview-3878449261 -> 5841554e21f7dcd6481a4768cf9e00e683761660

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [x] No unresolved review threads
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- Ledger: None
- To run last tag in production after nightly on main: set `PROD_DEPLOY_MODE=ssh` (or use self-hosted) and configure production environment secrets; then push tag or re-run CD workflow for the tag.

## Notes

After merge, to enable staging deploy: Environment "staging" → variable `STAGING_DEPLOY_ENABLED=true`, secrets `SSH_HOST_STAGING`, `SSH_USER`, `SSH_KEY`, `SSH_HOST_STAGING_FINGERPRINT`, `STAGING_DOMAIN`, `GHCR_READ_TOKEN`. To enable production SSH deploy: `PROD_DEPLOY_MODE=ssh` and production environment secrets.

## Summary by Sourcery

Сделать развертывания на staging и production по SSH в CD‑workflow режимом opt-in, чтобы избежать сбоев, когда SSH‑секреты не настроены, и обновить документацию по деплою в соответствии с новым управлением.

CI:
- Ограничить шаги SSH‑деплоя и healthcheck для staging переменной окружения `STAGING_DEPLOY_ENABLED`, чтобы CD мог выполнять build-and-push без необходимости в SSH‑секретах.
- Изменить job SSH‑деплоя в production так, чтобы он выполнялся только когда `PROD_DEPLOY_MODE` явно установлен в `'ssh'`, пропуская деплой, если он не задан или установлен в `'self-hosted'`.
- Уточнить комментарии в workflow по настройке деплоев на staging и production и сценариям отказа.

Документация:
- Обновить документацию по деплою на staging, чтобы описать `STAGING_DEPLOY_ENABLED`, необходимые секреты и корректный PEM‑формат SSH‑ключа для предотвращения ошибок вида `ssh: no key found`.
- Обновить документацию по деплою на production, чтобы разрешить использование `PROD_DEPLOY_MODE` как переменной репозитория или окружения, а также задокументировать необходимые SSH‑секреты и поведение при отсутствии значения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make SSH-based staging and production deploys opt-in in the CD workflow to avoid failures when SSH secrets are not configured, and update deployment docs to match the new controls.

CI:
- Gate the staging SSH deploy and healthcheck steps on a STAGING_DEPLOY_ENABLED environment variable so CD can run build-and-push without requiring SSH secrets.
- Change the production SSH deploy job to run only when PROD_DEPLOY_MODE is explicitly set to 'ssh', skipping deploy when unset or set to 'self-hosted'.
- Clarify workflow comments for staging and production deploy configuration and failure modes.

Documentation:
- Update staging deployment docs to describe STAGING_DEPLOY_ENABLED, required secrets, and correct SSH key PEM format to prevent 'ssh: no key found' errors.
- Update production deployment docs to allow PROD_DEPLOY_MODE as a repository or environment variable and to document required SSH secrets and behavior when unset.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SSH deploy optional in CD to stop "ssh: no key found" failures when secrets aren’t set. Deploys run only when explicitly enabled; images still build and push to GHCR.

- **Bug Fixes**
  - Staging: run SSH deploy and healthcheck only when vars.STAGING_DEPLOY_ENABLED == 'true'; otherwise skip.
  - Production: run deploy-production only when vars.PROD_DEPLOY_MODE == 'ssh'; any other value (including unset) skips the job.
  - Docs: clarified PROD_DEPLOY_MODE (repo or environment var), required production secrets, SSH key PEM format, and how to get SSH_HOST_STAGING_FINGERPRINT.

- **Migration**
  - To enable staging SSH deploy: set STAGING_DEPLOY_ENABLED=true and configure staging SSH/GHCR secrets (include fingerprint).
  - To enable production SSH deploy: set PROD_DEPLOY_MODE=ssh and configure production SSH/GHCR secrets.

<sup>Written for commit 64a5c62facc65bc2ffe580e820734b88e92fccf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated staging and production deployment guides to require explicit environment variables to enable SSH deploys; added SSH key PEM formatting notes, fingerprint guidance, and required secret lists.
* **Chores**
  * Deployment workflow now gates staging and production deploy steps via environment variables; when deploy mode is unset or unrecognized, images are still built and pushed but SSH deploys are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
