### PR TITLE
fix(cd): make staging SSH fingerprint failures non-blocking

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,6 +89,8 @@ jobs:
           fi
 
       - name: Deploy to staging over SSH
+        id: deploy-staging
+        continue-on-error: true
         if: vars.STAGING_DEPLOY_ENABLED == 'true' && steps.staging-deploy-ready.outputs.skip != '1'
         uses: appleboy/ssh-action@3ca8a7c5359ac6ad91aa47f1946ece1c3b025004
         with:
@@ -104,8 +106,21 @@ jobs:
             cd /srv/pulseplate-staging
             ./deploy.sh '${{ github.sha }}'
 
+      - name: Handle staging deploy failure (non-blocking by default)
+        if: vars.STAGING_DEPLOY_ENABLED == 'true' && steps.staging-deploy-ready.outputs.skip != '1' && steps.deploy-staging.outcome == 'failure'
+        env:
+          STAGING_DEPLOY_REQUIRED: ${{ vars.STAGING_DEPLOY_REQUIRED }}
+        run: |
+          echo "::warning::Staging SSH deploy failed. Common cause: SSH_HOST_STAGING_FINGERPRINT is outdated (host key rotated)."
+          echo "::warning::Rotate staging host fingerprint secret and re-run CD."
+          if [ "${STAGING_DEPLOY_REQUIRED:-false}" = "true" ]; then
+            echo "::error::STAGING_DEPLOY_REQUIRED=true, failing workflow due to staging deploy failure."
+            exit 1
+          fi
+          echo "Continuing because STAGING_DEPLOY_REQUIRED is not true."
+
       - name: Healthcheck (staging)
-        if: vars.STAGING_DEPLOY_ENABLED == 'true' && steps.staging-deploy-ready.outputs.skip != '1'
+        if: vars.STAGING_DEPLOY_ENABLED == 'true' && steps.staging-deploy-ready.outputs.skip != '1' && steps.deploy-staging.outcome == 'success'
         run: |
           set -euo pipefail
           for i in 1 2 3; do

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -218,6 +218,7 @@ ssh -i ~/.ssh/pulseplate_staging user@your-server-ip
 Set the **Environment variable** (Settings → Environments → staging → Environment variables):
 
 - `STAGING_DEPLOY_ENABLED` = `true` — required for CD to run SSH deploy. If unset, the CD workflow only builds and pushes the image (no deploy); this avoids "ssh: no key found" when secrets are not yet configured. If set to `true` but `SSH_KEY` or `SSH_HOST_STAGING` is missing, the workflow skips the deploy and healthcheck steps (job still succeeds; build+push already done).
+- `STAGING_DEPLOY_REQUIRED` = `true|false` (optional, default `false`) — controls whether a failed staging SSH deploy should fail the whole CD workflow. Keep `false` for non-blocking staging; set `true` when staging deploy must be strict/blocking.
 
 Add these **secrets** to the `staging` environment:
 
@@ -227,6 +228,21 @@ Add these **secrets** to the `staging` environment:
 - `SSH_HOST_STAGING_FINGERPRINT` - Staging **server** host key fingerprint, usually `SHA256:...` (optional but recommended). **Easiest from your laptop:** run `ssh -o VisualHostKey=yes user@your-staging-host` and copy the `SHA256:...` line shown when connecting. **Or on the server:** after SSH in, run `sudo ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub` (or `ssh_host_rsa_key.pub` / `ssh_host_ecdsa_key.pub` if present; list with `ls /etc/ssh/ssh_host_*.pub`).
 - `GHCR_READ_TOKEN` - GitHub PAT with `read:packages` permission
 - `STAGING_DOMAIN` - Your staging domain
+
+#### Host key fingerprint mismatch (CI error)
+
+If CD fails with `ssh: handshake failed: ssh: host key fingerprint mismatch`, rotate `SSH_HOST_STAGING_FINGERPRINT` to the current host key:
+
+```bash
+# From your laptop (preferred): get current ed25519 host key fingerprint
+ssh-keyscan -t ed25519 your-staging-host 2>/dev/null \
+  | ssh-keygen -lf - -E sha256 \
+  | awk '{print $2}'
+```
+
+Expected output format: `SHA256:...`
+
+After updating the GitHub environment secret, re-run the failed CD workflow.
 
 ### 3. Create GitHub PAT
 


### PR DESCRIPTION
## Summary
- handle staging SSH fingerprint mismatch as non-blocking by default in CD
- add strict mode via `STAGING_DEPLOY_REQUIRED=true` to fail workflow when staging deploy must be mandatory
- keep healthcheck gated on successful SSH deploy only
- document fingerprint rotation playbook in staging runbook

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/956#pullrequestreview-3881671155 -> e629b6f3
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/956#discussion_r2877437559 -> e629b6f3

## Merge Readiness
- [x] Local gates passed: `pre-commit run --all-files`, `make verify`
- [x] Scope is minimal and isolated (CD workflow + staging docs only)
- [x] No runtime API contract changes

## Summary by Sourcery

Сделать сбои SSH‑деплоя на staging некритичными для CD‑workflow, с опцией строгого контроля ошибок, а также задокументировать соответствующую конфигурацию и процедуру ротации отпечатков.

New Features:
- Ввести необязательный флаг `STAGING_DEPLOY_REQUIRED` для управления тем, должны ли сбои SSH‑деплоя на staging приводить к падению CD‑workflow.

Enhancements:
- По умолчанию считать SSH‑деплой на staging некритичным, при этом привязывать проверку работоспособности staging только к успешному деплою.

Documentation:
- Задокументировать переменную окружения `STAGING_DEPLOY_REQUIRED` и добавить раздел в runbook по устранению несоответствий отпечатков SSH‑ключа хоста staging в CI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make staging SSH deployment failures non-blocking in the CD workflow, with an option to enforce strict failure, and document the related configuration and fingerprint rotation procedure.

New Features:
- Introduce optional STAGING_DEPLOY_REQUIRED flag to control whether staging SSH deploy failures should fail the CD workflow.

Enhancements:
- Treat staging SSH deployment as non-blocking by default while gating the staging healthcheck on successful deployment only.

Documentation:
- Document the STAGING_DEPLOY_REQUIRED environment variable and add a runbook section for resolving staging SSH host key fingerprint mismatches in CI.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made staging deployment failures non-blocking by default; workflow continues even if staging deployment fails
  * Health checks now only run after successful staging deployments

* **Documentation**
  * Added STAGING_DEPLOY_REQUIRED environment variable to optionally make staging deployment failures block the workflow
  * Added troubleshooting guide for SSH host key fingerprint mismatch issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

