### PR TITLE
feat(restaurants): W3-R4 export adapter deterministic contract

### DIFF
--- a/app/routers/pro_restaurant_partner.py
+++ b/app/routers/pro_restaurant_partner.py
@@ -10,19 +10,22 @@ from __future__ import annotations
 import threading
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.middleware.api_tiers import require_pro_tier
+from app.security.rate_limit import RATE_LIMIT_429_RESPONSES, RATE_LIMIT_EXPORTS, limit_if_available
 from app.schemas.restaurant_partner import (
     PartnerOrderConfirmRequest,
     PartnerOrderCreateRequest,
     PartnerOrderErrorResponse,
     PartnerHandoffShareIssueRequest,
     PartnerHandoffShareResponse,
+    PartnerOrderWeeklyAdapterRequest,
     PartnerOrderPreviewRequest,
     PartnerOrderPreviewResponse,
     PartnerOrderResponse,
 )
+from app.services import restaurant_partner_export_adapter
 from app.services import restaurant_partner_orders
 
 _ISSUER_LOCK = threading.Lock()
@@ -60,6 +63,46 @@ def _issuer_from_api_key(api_key: str) -> str:
 def preview_partner_order(payload: PartnerOrderPreviewRequest) -> PartnerOrderPreviewResponse:
     preview: PartnerOrderPreviewResponse = restaurant_partner_orders.preview_order(payload.draft)
     return preview
+
+
+@router.post(
+    "/orders/adapt/preview",
+    response_model=PartnerOrderPreviewResponse,
+    responses={
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
+            "description": "Invalid weekly plan adapter payload",
+            "model": PartnerOrderErrorResponse,
+        },
+        **RATE_LIMIT_429_RESPONSES,
+    },
+)
+@limit_if_available(RATE_LIMIT_EXPORTS)
+def preview_partner_order_from_weekly_plan(
+    request: Request,
+    payload: PartnerOrderWeeklyAdapterRequest,
+) -> PartnerOrderPreviewResponse:
+    del request
+    try:
+        draft = restaurant_partner_export_adapter.build_order_draft_from_weekly_plan(
+            week_plan=payload.week_plan,
+            restaurant_id=payload.restaurant_id,
+            currency=payload.currency,
+            fulfillment=payload.fulfillment,
+            service_fee_minor=payload.service_fee_minor,
+            delivery_fee_minor=payload.delivery_fee_minor,
+            customer_note=payload.customer_note,
+            dietary_tags=payload.dietary_tags,
+            allergens=payload.allergens,
+            consent=payload.consent,
+            attribution_source=payload.attribution_source,
+            unit_price_minor_default=payload.unit_price_minor_default,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return restaurant_partner_orders.preview_order(draft)
 
 
 @router.post(

--- a/app/schemas/restaurant_partner.py
+++ b/app/schemas/restaurant_partner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Any
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -116,6 +117,31 @@ class PartnerOrderDraft(BaseModel):
 
 class PartnerOrderPreviewRequest(BaseModel):
     draft: PartnerOrderDraft
+
+
+class PartnerOrderWeeklyAdapterRequest(BaseModel):
+    """Request schema for weekly-plan -> partner order adapter preview."""
+
+    week_plan: dict[str, Any]
+    restaurant_id: str = Field(..., min_length=1, max_length=64)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    fulfillment: FulfillmentMode = FulfillmentMode.pickup
+    service_fee_minor: int = Field(default=0, ge=0)
+    delivery_fee_minor: int = Field(default=0, ge=0)
+    customer_note: str | None = Field(default=None, max_length=500)
+    dietary_tags: list[str] = Field(default_factory=list, max_length=50)
+    allergens: list[str] = Field(default_factory=list, max_length=50)
+    consent: PartnerConsent
+    attribution_source: str | None = Field(default=None, max_length=128)
+    unit_price_minor_default: int = Field(default=0, ge=0)
+
+    @field_validator("currency")
+    @classmethod
+    def _validate_adapter_currency(cls, value: str) -> str:
+        upper = value.upper()
+        if len(upper) != 3 or not upper.isalpha():
+            raise ValueError("currency must be a 3-letter ISO code")
+        return upper
 
 
 class PartnerOrderPreviewResponse(BaseModel):

--- a/app/services/restaurant_partner_export_adapter.py
+++ b/app/services/restaurant_partner_export_adapter.py
@@ -41,7 +41,7 @@ def _coerce_qty(raw_qty: Any) -> int:
         return 1
     try:
         qty = int(float(raw_qty))
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("item qty must be numeric") from exc
     if qty < 1:
         return 1

--- a/app/services/restaurant_partner_export_adapter.py
+++ b/app/services/restaurant_partner_export_adapter.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Weekly-plan to partner-order adapter (W3-R4).
+
+RU: Детеминированный адаптер weekly plan -> PartnerOrderDraft.
+EN: Deterministic adapter from weekly plan payload to PartnerOrderDraft.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.schemas.restaurant_partner import (
+    FulfillmentMode,
+    PartnerConsent,
+    PartnerOrderDraft,
+    PartnerOrderItemIn,
+)
+
+
+def _extract_days(week_plan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract canonical days list from supported weekly-plan wrappers."""
+    for candidate in (week_plan, week_plan.get("menu") or {}, week_plan.get("data") or {}):
+        days = candidate.get("days")
+        if isinstance(days, list):
+            return [day for day in days if isinstance(day, dict)]
+
+    daily_menus = (week_plan.get("data") or {}).get("daily_menus")
+    if isinstance(daily_menus, list):
+        return [day for day in daily_menus if isinstance(day, dict)]
+
+    raise ValueError("week_plan must contain days/menu.days/data.daily_menus list")
+
+
+def _coerce_qty(raw_qty: Any) -> int:
+    """Convert arbitrary qty to bounded positive integer for partner payload."""
+    if raw_qty is None:
+        return 1
+    try:
+        qty = int(float(raw_qty))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("item qty must be numeric") from exc
+    if qty < 1:
+        return 1
+    if qty > 100:
+        return 100
+    return qty
+
+
+def build_order_draft_from_weekly_plan(
+    *,
+    week_plan: dict[str, Any],
+    restaurant_id: str,
+    currency: str,
+    fulfillment: FulfillmentMode,
+    service_fee_minor: int,
+    delivery_fee_minor: int,
+    customer_note: str | None,
+    dietary_tags: list[str],
+    allergens: list[str],
+    consent: PartnerConsent,
+    attribution_source: str | None,
+    unit_price_minor_default: int,
+) -> PartnerOrderDraft:
+    """Build deterministic PartnerOrderDraft by flattening week/day/meal items."""
+    if unit_price_minor_default < 0:
+        raise ValueError("unit_price_minor_default must be >= 0")
+
+    days = _extract_days(week_plan)
+    items: list[PartnerOrderItemIn] = []
+
+    for day_idx, day in enumerate(days, start=1):
+        meals = day.get("meals") or []
+        if not isinstance(meals, list):
+            continue
+        for meal_idx, meal in enumerate(meals, start=1):
+            if not isinstance(meal, dict):
+                continue
+            meal_items = meal.get("items") or []
+            if not isinstance(meal_items, list):
+                continue
+            for item_idx, item in enumerate(meal_items, start=1):
+                if not isinstance(item, dict):
+                    continue
+                title = str(item.get("title") or item.get("name") or "").strip()
+                if not title:
+                    continue
+                note_raw = item.get("note")
+                note = str(note_raw).strip() if note_raw else None
+                items.append(
+                    PartnerOrderItemIn(
+                        menu_item_id=f"wk-d{day_idx:02d}-m{meal_idx:02d}-i{item_idx:03d}",
+                        title=title,
+                        qty=_coerce_qty(item.get("qty")),
+                        unit_price_minor=unit_price_minor_default,
+                        note=note,
+                    )
+                )
+
+    if not items:
+        raise ValueError("week_plan contains no mappable items")
+
+    return PartnerOrderDraft(
+        restaurant_id=restaurant_id,
+        currency=currency,
+        fulfillment=fulfillment,
+        items=items,
+        service_fee_minor=service_fee_minor,
+        delivery_fee_minor=delivery_fee_minor,
+        customer_note=customer_note,
+        dietary_tags=dietary_tags,
+        allergens=allergens,
+        consent=consent,
+        attribution_source=attribution_source,
+    )

--- a/app/services/restaurant_partner_export_adapter.py
+++ b/app/services/restaurant_partner_export_adapter.py
@@ -19,14 +19,18 @@ from app.schemas.restaurant_partner import (
 
 def _extract_days(week_plan: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract canonical days list from supported weekly-plan wrappers."""
-    for candidate in (week_plan, week_plan.get("menu") or {}, week_plan.get("data") or {}):
+    for candidate in (week_plan, week_plan.get("menu"), week_plan.get("data")):
+        if not isinstance(candidate, dict):
+            continue
         days = candidate.get("days")
         if isinstance(days, list):
             return [day for day in days if isinstance(day, dict)]
 
-    daily_menus = (week_plan.get("data") or {}).get("daily_menus")
-    if isinstance(daily_menus, list):
-        return [day for day in daily_menus if isinstance(day, dict)]
+    data_node = week_plan.get("data")
+    if isinstance(data_node, dict):
+        daily_menus = data_node.get("daily_menus")
+        if isinstance(daily_menus, list):
+            return [day for day in daily_menus if isinstance(day, dict)]
 
     raise ValueError("week_plan must contain days/menu.days/data.daily_menus list")
 

--- a/docs/design/RESTAURANT_INTEGRATION_SPEC.md
+++ b/docs/design/RESTAURANT_INTEGRATION_SPEC.md
@@ -130,6 +130,24 @@ Out-of-scope boundary in W3-R3:
   `app/routers/pro_restaurant_partner.py:162`, `tests/test_pro_restaurant_partner_openapi_contract.py:7`,
   `docs/roadmap/BACKLOG_LEDGER.md:3032`.
 
+## W3-R4 Contract Notes (weekly export adapter)
+
+Adapter surface (non-breaking PRO):
+
+- `POST /api/v1/pro/restaurants/partner/orders/adapt/preview`
+  - Converts weekly-plan payload into partner-order draft and returns deterministic preview.
+  - `200` preview, `422` invalid adapter payload, `429` rate-limited export path.
+
+Deterministic mapping rules (v1):
+
+- Input accepts canonical `days[].meals[].items[]` and wrappers `menu.days` / `data.daily_menus`.
+- Flattening order is stable: day order -> meal order -> item order (no sorting).
+- `menu_item_id` is deterministic by position: `wk-d{day:02d}-m{meal:02d}-i{item:03d}`.
+- `title` maps from `item.title` or `item.name`; entries without title are dropped.
+- `qty` is numeric-coerced and bounded to `[1, 100]`.
+- `unit_price_minor` uses explicit adapter default (`unit_price_minor_default`), so totals stay deterministic.
+- No payment/delivery orchestration is introduced in this wave (preview-only adapter seam).
+
 Temporary seam governance (contract-first -> persistent integration):
 
 - ADR: `docs/architecture/ADR_RESTAURANT_PARTNER_CONTRACT_SEAM_2026-03-03.md` (explicit seam and exit conditions).

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3051,8 +3051,8 @@ If it is not recorded here — it does not exist.
 - [ ] P2: Execution Wave 3-R4 — Export adapter + deterministic contract tests
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #TBD-W3-R4-EXPORT-TESTS
-  - Status: 📋 Planned
+  - Target PR: PR #TBD-W3-R4-EXPORT-TESTS (`feat/restaurants-w3-r4-observability-rollback`)
+  - Status: 🟡 In progress
   - Reason: Guarantee stable mapping from weekly plan artifacts to partner payloads.
   - Links:
     - docs/design/RESTAURANT_INTEGRATION_SPEC.md

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -3855,6 +3855,101 @@
         "title": "PartnerOrderTotals",
         "type": "object"
       },
+      "PartnerOrderWeeklyAdapterRequest": {
+        "description": "Request schema for weekly-plan -> partner order adapter preview.",
+        "properties": {
+          "allergens": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50,
+            "title": "Allergens",
+            "type": "array"
+          },
+          "attribution_source": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attribution Source"
+          },
+          "consent": {
+            "$ref": "#/components/schemas/PartnerConsent"
+          },
+          "currency": {
+            "default": "USD",
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Currency",
+            "type": "string"
+          },
+          "customer_note": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Note"
+          },
+          "delivery_fee_minor": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Delivery Fee Minor",
+            "type": "integer"
+          },
+          "dietary_tags": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50,
+            "title": "Dietary Tags",
+            "type": "array"
+          },
+          "fulfillment": {
+            "$ref": "#/components/schemas/FulfillmentMode",
+            "default": "pickup"
+          },
+          "restaurant_id": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Restaurant Id",
+            "type": "string"
+          },
+          "service_fee_minor": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Service Fee Minor",
+            "type": "integer"
+          },
+          "unit_price_minor_default": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Unit Price Minor Default",
+            "type": "integer"
+          },
+          "week_plan": {
+            "additionalProperties": true,
+            "title": "Week Plan",
+            "type": "object"
+          }
+        },
+        "required": [
+          "week_plan",
+          "restaurant_id",
+          "consent"
+        ],
+        "title": "PartnerOrderWeeklyAdapterRequest",
+        "type": "object"
+      },
       "PlateRequest": {
         "description": "RU: Запрос на генерацию «Моей Тарелки». EN: Request to generate 'My Plate'.",
         "properties": {
@@ -7979,6 +8074,63 @@
           }
         ],
         "summary": "Create Partner Order",
+        "tags": [
+          "pro",
+          "restaurants"
+        ]
+      }
+    },
+    "/api/v1/pro/restaurants/partner/orders/adapt/preview": {
+      "post": {
+        "operationId": "preview_partner_order_from_weekly_plan_api_v1_pro_restaurants_partner_orders_adapt_preview_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartnerOrderWeeklyAdapterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartnerOrderPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartnerOrderErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid weekly plan adapter payload"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Preview Partner Order From Weekly Plan",
         "tags": [
           "pro",
           "restaurants"

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -595,6 +595,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/restaurants/partner/orders/adapt/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview Partner Order From Weekly Plan */
+        post: operations["preview_partner_order_from_weekly_plan_api_v1_pro_restaurants_partner_orders_adapt_preview_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/restaurants/partner/orders/preview": {
         parameters: {
             query?: never;
@@ -3156,6 +3173,49 @@ export interface components {
             total_minor: number;
         };
         /**
+         * PartnerOrderWeeklyAdapterRequest
+         * @description Request schema for weekly-plan -> partner order adapter preview.
+         */
+        PartnerOrderWeeklyAdapterRequest: {
+            /** Allergens */
+            allergens?: string[];
+            /** Attribution Source */
+            attribution_source?: string | null;
+            consent: components["schemas"]["PartnerConsent"];
+            /**
+             * Currency
+             * @default USD
+             */
+            currency: string;
+            /** Customer Note */
+            customer_note?: string | null;
+            /**
+             * Delivery Fee Minor
+             * @default 0
+             */
+            delivery_fee_minor: number;
+            /** Dietary Tags */
+            dietary_tags?: string[];
+            /** @default pickup */
+            fulfillment: components["schemas"]["FulfillmentMode"];
+            /** Restaurant Id */
+            restaurant_id: string;
+            /**
+             * Service Fee Minor
+             * @default 0
+             */
+            service_fee_minor: number;
+            /**
+             * Unit Price Minor Default
+             * @default 0
+             */
+            unit_price_minor_default: number;
+            /** Week Plan */
+            week_plan: {
+                [key: string]: unknown;
+            };
+        };
+        /**
          * PlateRequest
          * @description RU: Запрос на генерацию «Моей Тарелки». EN: Request to generate 'My Plate'.
          */
@@ -5544,6 +5604,48 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PartnerOrderErrorResponse"] | components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_partner_order_from_weekly_plan_api_v1_pro_restaurants_partner_orders_adapt_preview_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PartnerOrderWeeklyAdapterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerOrderPreviewResponse"];
+                };
+            };
+            /** @description Invalid weekly plan adapter payload */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerOrderErrorResponse"];
+                };
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponse"];
                 };
             };
         };

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -84,6 +84,114 @@ def test_preview_partner_order_validation_422(
     assert response.status_code == 422
 
 
+def test_preview_partner_order_from_weekly_plan_requires_pro_tier(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        json={
+            "restaurant_id": "resto-1",
+            "week_plan": {"days": []},
+            "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
+        },
+    )
+    assert response.status_code in {401, 403}
+
+
+def test_preview_partner_order_from_weekly_plan_happy_path(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    payload = {
+        "restaurant_id": "resto-weekly-1",
+        "currency": "usd",
+        "fulfillment": "pickup",
+        "week_plan": {
+            "menu": {
+                "days": [
+                    {
+                        "date": "2026-03-04",
+                        "meals": [
+                            {
+                                "name": "Breakfast",
+                                "items": [
+                                    {"name": "Oats", "qty": 2, "note": "with berries"},
+                                    {"title": "Greek yogurt", "qty": 1},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+        "service_fee_minor": 50,
+        "delivery_fee_minor": 0,
+        "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
+        "unit_price_minor_default": 0,
+    }
+
+    first = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json=payload,
+    )
+    second = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json=payload,
+    )
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+    first_payload = _json(first)
+    second_payload = _json(second)
+    assert first_payload == second_payload
+    assert first_payload["restaurant_id"] == "resto-weekly-1"
+    assert first_payload["totals"]["subtotal_minor"] == 0
+    assert [item["menu_item_id"] for item in first_payload["items"]] == [
+        "wk-d01-m01-i001",
+        "wk-d01-m01-i002",
+    ]
+
+
+def test_preview_partner_order_from_weekly_plan_invalid_shape_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json={
+            "restaurant_id": "resto-weekly-2",
+            "week_plan": {"menu": {}},
+            "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
+        },
+    )
+    assert response.status_code == 422
+    assert "days/menu.days/data.daily_menus" in _json(response)["detail"]
+
+
+def test_preview_partner_order_from_weekly_plan_invalid_currency_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json={
+            "restaurant_id": "resto-weekly-3",
+            "currency": "US1",
+            "week_plan": {
+                "days": [
+                    {
+                        "meals": [{"items": [{"name": "Oats", "qty": 1}]}],
+                    }
+                ]
+            },
+            "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
+        },
+    )
+    assert response.status_code == 422
+
+
 def test_create_partner_order_and_get(
     client: TestClient,
     pro_headers: dict[str, str],

--- a/tests/test_pro_restaurant_partner_openapi_contract.py
+++ b/tests/test_pro_restaurant_partner_openapi_contract.py
@@ -6,6 +6,7 @@ from app.main import app
 
 PARTNER_PATHS: set[str] = {
     "/api/v1/pro/restaurants/partner/orders/preview",
+    "/api/v1/pro/restaurants/partner/orders/adapt/preview",
     "/api/v1/pro/restaurants/partner/orders",
     "/api/v1/pro/restaurants/partner/orders/{order_id}",
     "/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
@@ -42,6 +43,11 @@ def test_partner_openapi_security_is_api_key_on_all_operations() -> None:
 def test_partner_openapi_response_codes_contract() -> None:
     expected_codes: dict[tuple[str, str], set[str]] = {
         ("/api/v1/pro/restaurants/partner/orders/preview", "post"): {"200", "422"},
+        ("/api/v1/pro/restaurants/partner/orders/adapt/preview", "post"): {
+            "200",
+            "422",
+            "429",
+        },
         ("/api/v1/pro/restaurants/partner/orders", "post"): {"200", "201", "409", "422"},
         ("/api/v1/pro/restaurants/partner/orders/{order_id}", "get"): {
             "200",
@@ -91,6 +97,12 @@ def test_partner_openapi_request_body_schemas() -> None:
         == "#/components/schemas/PartnerOrderPreviewRequest"
     )
     assert (
+        _op("/api/v1/pro/restaurants/partner/orders/adapt/preview", "post")["requestBody"][
+            "content"
+        ]["application/json"]["schema"]["$ref"]
+        == "#/components/schemas/PartnerOrderWeeklyAdapterRequest"
+    )
+    assert (
         _op("/api/v1/pro/restaurants/partner/orders", "post")["requestBody"]["content"][
             "application/json"
         ]["schema"]["$ref"]
@@ -119,6 +131,15 @@ def test_partner_openapi_response_schemas_contract() -> None:
     }
     assert _json_schema("/api/v1/pro/restaurants/partner/orders/preview", "post", "422") == {
         "$ref": "#/components/schemas/PartnerOrderErrorResponse"
+    }
+    assert _json_schema("/api/v1/pro/restaurants/partner/orders/adapt/preview", "post", "200") == {
+        "$ref": "#/components/schemas/PartnerOrderPreviewResponse"
+    }
+    assert _json_schema("/api/v1/pro/restaurants/partner/orders/adapt/preview", "post", "422") == {
+        "$ref": "#/components/schemas/PartnerOrderErrorResponse"
+    }
+    assert _json_schema("/api/v1/pro/restaurants/partner/orders/adapt/preview", "post", "429") == {
+        "$ref": "#/components/schemas/RateLimitErrorResponse"
     }
     assert _json_schema("/api/v1/pro/restaurants/partner/orders", "post", "201") == {
         "$ref": "#/components/schemas/PartnerOrderResponse"
@@ -262,7 +283,9 @@ def test_partner_openapi_component_schemas_exist() -> None:
         "PartnerOrderCreateRequest",
         "PartnerOrderErrorResponse",
         "PartnerOrderPreviewRequest",
+        "PartnerOrderWeeklyAdapterRequest",
         "PartnerOrderPreviewResponse",
         "PartnerOrderResponse",
+        "RateLimitErrorResponse",
     }
     assert required <= schemas

--- a/tests/test_rate_limit_llm_and_exports_api.py
+++ b/tests/test_rate_limit_llm_and_exports_api.py
@@ -84,6 +84,11 @@ def create_rate_limited_app() -> tuple[FastAPI, Limiter]:
     async def plan_export(request: Request) -> dict[str, str]:
         return {"export": "csv"}
 
+    @router.post("/api/v1/pro/restaurants/partner/orders/adapt/preview")
+    @test_limiter.limit("2/minute")
+    async def partner_order_adapt_preview(request: Request) -> dict[str, str]:
+        return {"status": "ok"}
+
     app.include_router(router)
     app.state.limiter = test_limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
@@ -198,3 +203,30 @@ def test_export_sign_rate_limited_200_then_429() -> None:
     lang = normalize_lang("en")
     expected_detail = t(lang, "rate_limit.exceeded")
     assert s3.json()["detail"] == expected_detail
+
+
+def test_partner_order_adapt_preview_rate_limited_200_then_429() -> None:
+    """Test partner export adapter preview endpoint returns 200 twice, then 429."""
+    app, _ = create_rate_limited_app()
+    client = TestClient(app)
+    headers = {"accept-language": "en", "x-test-id": "partner-adapt-preview"}
+    payload = {"restaurant_id": "r1", "week_plan": {"days": []}}
+
+    r1 = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview", headers=headers, json=payload
+    )
+    r2 = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview", headers=headers, json=payload
+    )
+    r3 = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview", headers=headers, json=payload
+    )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r3.status_code == 429
+    assert r3.headers.get("content-type", "").startswith("application/json")
+
+    lang = normalize_lang("en")
+    expected_detail = t(lang, "rate_limit.exceeded")
+    assert r3.json()["detail"] == expected_detail

--- a/tests/test_restaurant_partner_export_adapter.py
+++ b/tests/test_restaurant_partner_export_adapter.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import pytest
 
-from app.schemas.restaurant_partner import FulfillmentMode
+from app.schemas.restaurant_partner import FulfillmentMode, PartnerConsent
 from app.services.restaurant_partner_export_adapter import build_order_draft_from_weekly_plan
 
 
-def _consent() -> dict[str, object]:
-    return {
-        "consent_share_with_partner": True,
-        "consent_version": "v1",
-    }
+def _consent() -> PartnerConsent:
+    return PartnerConsent(
+        consent_share_with_partner=True,
+        consent_version="v1",
+    )
 
 
 def _week_plan() -> dict[str, object]:

--- a/tests/test_restaurant_partner_export_adapter.py
+++ b/tests/test_restaurant_partner_export_adapter.py
@@ -80,6 +80,70 @@ def test_build_order_draft_supports_menu_wrapper() -> None:
     assert all(item.unit_price_minor == 10 for item in draft.items)
 
 
+def test_build_order_draft_supports_data_days_wrapper() -> None:
+    base = build_order_draft_from_weekly_plan(
+        week_plan=_week_plan(),
+        restaurant_id="resto-base",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    wrapped = build_order_draft_from_weekly_plan(
+        week_plan={"data": _week_plan()},
+        restaurant_id="resto-base",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    assert wrapped == base
+
+
+def test_build_order_draft_supports_data_daily_menus_wrapper() -> None:
+    base = build_order_draft_from_weekly_plan(
+        week_plan=_week_plan(),
+        restaurant_id="resto-base-2",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    wrapped = build_order_draft_from_weekly_plan(
+        week_plan={"data": {"daily_menus": _week_plan()["days"]}},
+        restaurant_id="resto-base-2",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    assert wrapped == base
+
+
 def test_build_order_draft_qty_is_bounded() -> None:
     week = _week_plan()
     week["days"][0]["meals"][0]["items"][0]["qty"] = 0
@@ -102,6 +166,97 @@ def test_build_order_draft_qty_is_bounded() -> None:
     assert [item.qty for item in draft.items] == [1, 100]
 
 
+def test_build_order_draft_qty_none_defaults_to_one() -> None:
+    week = _week_plan()
+    week["days"][0]["meals"][0]["items"][0]["qty"] = None
+
+    draft = build_order_draft_from_weekly_plan(
+        week_plan=week,
+        restaurant_id="resto-qty-none",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    assert draft.items[0].qty == 1
+
+
+def test_build_order_draft_invalid_qty_raises_value_error() -> None:
+    week = _week_plan()
+    week["days"][0]["meals"][0]["items"][0]["qty"] = "abc"
+
+    with pytest.raises(ValueError, match="qty must be numeric"):
+        build_order_draft_from_weekly_plan(
+            week_plan=week,
+            restaurant_id="resto-bad-qty",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=0,
+        )
+
+
+def test_build_order_draft_rejects_negative_default_price() -> None:
+    with pytest.raises(ValueError, match="unit_price_minor_default must be >= 0"):
+        build_order_draft_from_weekly_plan(
+            week_plan=_week_plan(),
+            restaurant_id="resto-negative-price",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=-1,
+        )
+
+
+def test_build_order_draft_skips_non_list_and_non_dict_nodes() -> None:
+    week = {
+        "days": [
+            {"meals": "oops"},
+            {
+                "meals": [
+                    "not-a-dict-meal",
+                    {"items": "not-a-list"},
+                    {"items": ["not-a-dict-item", {"name": "Valid", "qty": 1}]},
+                ]
+            },
+        ]
+    }
+    draft = build_order_draft_from_weekly_plan(
+        week_plan=week,
+        restaurant_id="resto-shape-skip",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    assert len(draft.items) == 1
+    assert draft.items[0].title == "Valid"
+
+
 def test_build_order_draft_raises_when_shape_missing() -> None:
     with pytest.raises(ValueError, match="days/menu.days/data.daily_menus"):
         build_order_draft_from_weekly_plan(
@@ -109,6 +264,24 @@ def test_build_order_draft_raises_when_shape_missing() -> None:
             restaurant_id="resto-4",
             currency="USD",
             fulfillment=FulfillmentMode.pickup.value,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=0,
+        )
+
+
+def test_build_order_draft_rejects_non_dict_wrappers() -> None:
+    with pytest.raises(ValueError, match="days/menu.days/data.daily_menus"):
+        build_order_draft_from_weekly_plan(
+            week_plan={"menu": ["unexpected"], "data": ["unexpected"]},
+            restaurant_id="resto-4b",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup,
             service_fee_minor=0,
             delivery_fee_minor=0,
             customer_note=None,

--- a/tests/test_restaurant_partner_export_adapter.py
+++ b/tests/test_restaurant_partner_export_adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from app.schemas.restaurant_partner import FulfillmentMode, PartnerConsent
@@ -13,7 +15,7 @@ def _consent() -> PartnerConsent:
     )
 
 
-def _week_plan() -> dict[str, object]:
+def _week_plan() -> dict[str, Any]:
     return {
         "days": [
             {

--- a/tests/test_restaurant_partner_export_adapter.py
+++ b/tests/test_restaurant_partner_export_adapter.py
@@ -37,7 +37,7 @@ def test_build_order_draft_from_weekly_plan_happy_path_deterministic() -> None:
         week_plan=_week_plan(),
         restaurant_id="resto-1",
         currency="USD",
-        fulfillment=FulfillmentMode.pickup.value,
+        fulfillment=FulfillmentMode.pickup,
         service_fee_minor=99,
         delivery_fee_minor=0,
         customer_note="No peanuts",
@@ -66,7 +66,7 @@ def test_build_order_draft_supports_menu_wrapper() -> None:
         week_plan=wrapped,
         restaurant_id="resto-2",
         currency="USD",
-        fulfillment=FulfillmentMode.delivery.value,
+        fulfillment=FulfillmentMode.delivery,
         service_fee_minor=0,
         delivery_fee_minor=199,
         customer_note=None,
@@ -153,7 +153,7 @@ def test_build_order_draft_qty_is_bounded() -> None:
         week_plan=week,
         restaurant_id="resto-3",
         currency="USD",
-        fulfillment=FulfillmentMode.pickup.value,
+        fulfillment=FulfillmentMode.pickup,
         service_fee_minor=0,
         delivery_fee_minor=0,
         customer_note=None,
@@ -195,6 +195,27 @@ def test_build_order_draft_invalid_qty_raises_value_error() -> None:
         build_order_draft_from_weekly_plan(
             week_plan=week,
             restaurant_id="resto-bad-qty",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=0,
+        )
+
+
+def test_build_order_draft_overflow_qty_raises_value_error() -> None:
+    week = _week_plan()
+    week["days"][0]["meals"][0]["items"][0]["qty"] = "1e309"
+
+    with pytest.raises(ValueError, match="qty must be numeric"):
+        build_order_draft_from_weekly_plan(
+            week_plan=week,
+            restaurant_id="resto-overflow-qty",
             currency="USD",
             fulfillment=FulfillmentMode.pickup,
             service_fee_minor=0,
@@ -263,7 +284,7 @@ def test_build_order_draft_raises_when_shape_missing() -> None:
             week_plan={"menu": {}},
             restaurant_id="resto-4",
             currency="USD",
-            fulfillment=FulfillmentMode.pickup.value,
+            fulfillment=FulfillmentMode.pickup,
             service_fee_minor=0,
             delivery_fee_minor=0,
             customer_note=None,
@@ -299,7 +320,7 @@ def test_build_order_draft_raises_when_no_mappable_items() -> None:
             week_plan={"days": [{"meals": [{"items": [{"qty": 2}]}]}]},
             restaurant_id="resto-5",
             currency="USD",
-            fulfillment=FulfillmentMode.pickup.value,
+            fulfillment=FulfillmentMode.pickup,
             service_fee_minor=0,
             delivery_fee_minor=0,
             customer_note=None,

--- a/tests/test_restaurant_partner_export_adapter.py
+++ b/tests/test_restaurant_partner_export_adapter.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.restaurant_partner import FulfillmentMode
+from app.services.restaurant_partner_export_adapter import build_order_draft_from_weekly_plan
+
+
+def _consent() -> dict[str, object]:
+    return {
+        "consent_share_with_partner": True,
+        "consent_version": "v1",
+    }
+
+
+def _week_plan() -> dict[str, object]:
+    return {
+        "days": [
+            {
+                "date": "2026-03-04",
+                "meals": [
+                    {
+                        "name": "Breakfast",
+                        "items": [
+                            {"name": "Oats", "qty": 2, "note": "with berries"},
+                            {"title": "Greek yogurt", "qty": 1},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_build_order_draft_from_weekly_plan_happy_path_deterministic() -> None:
+    draft = build_order_draft_from_weekly_plan(
+        week_plan=_week_plan(),
+        restaurant_id="resto-1",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup.value,
+        service_fee_minor=99,
+        delivery_fee_minor=0,
+        customer_note="No peanuts",
+        dietary_tags=["high-protein"],
+        allergens=["nuts"],
+        consent=_consent(),
+        attribution_source="vip-weekly-plan",
+        unit_price_minor_default=0,
+    )
+
+    assert draft.restaurant_id == "resto-1"
+    assert draft.currency == "USD"
+    assert draft.fulfillment == FulfillmentMode.pickup
+    assert [item.menu_item_id for item in draft.items] == [
+        "wk-d01-m01-i001",
+        "wk-d01-m01-i002",
+    ]
+    assert [item.title for item in draft.items] == ["Oats", "Greek yogurt"]
+    assert [item.qty for item in draft.items] == [2, 1]
+    assert draft.items[0].note == "with berries"
+
+
+def test_build_order_draft_supports_menu_wrapper() -> None:
+    wrapped = {"menu": _week_plan()}
+    draft = build_order_draft_from_weekly_plan(
+        week_plan=wrapped,
+        restaurant_id="resto-2",
+        currency="USD",
+        fulfillment=FulfillmentMode.delivery.value,
+        service_fee_minor=0,
+        delivery_fee_minor=199,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=10,
+    )
+    assert len(draft.items) == 2
+    assert all(item.unit_price_minor == 10 for item in draft.items)
+
+
+def test_build_order_draft_qty_is_bounded() -> None:
+    week = _week_plan()
+    week["days"][0]["meals"][0]["items"][0]["qty"] = 0
+    week["days"][0]["meals"][0]["items"][1]["qty"] = 999
+
+    draft = build_order_draft_from_weekly_plan(
+        week_plan=week,
+        restaurant_id="resto-3",
+        currency="USD",
+        fulfillment=FulfillmentMode.pickup.value,
+        service_fee_minor=0,
+        delivery_fee_minor=0,
+        customer_note=None,
+        dietary_tags=[],
+        allergens=[],
+        consent=_consent(),
+        attribution_source=None,
+        unit_price_minor_default=0,
+    )
+    assert [item.qty for item in draft.items] == [1, 100]
+
+
+def test_build_order_draft_raises_when_shape_missing() -> None:
+    with pytest.raises(ValueError, match="days/menu.days/data.daily_menus"):
+        build_order_draft_from_weekly_plan(
+            week_plan={"menu": {}},
+            restaurant_id="resto-4",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup.value,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=0,
+        )
+
+
+def test_build_order_draft_raises_when_no_mappable_items() -> None:
+    with pytest.raises(ValueError, match="no mappable items"):
+        build_order_draft_from_weekly_plan(
+            week_plan={"days": [{"meals": [{"items": [{"qty": 2}]}]}]},
+            restaurant_id="resto-5",
+            currency="USD",
+            fulfillment=FulfillmentMode.pickup.value,
+            service_fee_minor=0,
+            delivery_fee_minor=0,
+            customer_note=None,
+            dietary_tags=[],
+            allergens=[],
+            consent=_consent(),
+            attribution_source=None,
+            unit_price_minor_default=0,
+        )


### PR DESCRIPTION
## Summary
- Implement W3-R4 export adapter seam: weekly-plan payload -> partner order preview under PRO namespace.
- Add deterministic read-only endpoint `POST /api/v1/pro/restaurants/partner/orders/adapt/preview`.
- Lock adapter behavior with deterministic tests (shape wrappers, stable mapping IDs, qty bounds, invalid-shape/currency errors).
- Update OpenAPI + frontend schema artifacts and W3-R4 mapping docs.

## Scope
- Runtime:
  - `app/services/restaurant_partner_export_adapter.py` (new)
  - `app/schemas/restaurant_partner.py`
  - `app/routers/pro_restaurant_partner.py`
- Tests/contracts:
  - `tests/test_restaurant_partner_export_adapter.py` (new)
  - `tests/test_pro_restaurant_partner_api.py`
  - `tests/test_pro_restaurant_partner_openapi_contract.py`
  - `tests/test_rate_limit_llm_and_exports_api.py`
  - `frontend/src/api/openapi.json`
  - `frontend/src/api/schema.ts`
- Docs:
  - `docs/design/RESTAURANT_INTEGRATION_SPEC.md`
  - `docs/roadmap/BACKLOG_LEDGER.md`

## Out Of Scope
- Payment, delivery orchestration, partner marketplace directory, fulfillment lifecycle expansion.
- DB migrations or persistent storage replacement.
- Infra/deploy workflows.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889080439 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883480165 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883486321 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883490869 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883490870 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883490874 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883490885 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889093808 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889105029 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883499668 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883499674 -> ebd23df1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883499677 -> ebd23df1

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889270295 -> bff7058f

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889395126 -> 86a8c3b0

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#pullrequestreview-3889570210 -> 084ad113

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/964#discussion_r2883920690 -> 084ad113

## Validation
- `pytest -q tests/test_restaurant_partner_export_adapter.py tests/test_pro_restaurant_partner_api.py tests/test_pro_restaurant_partner_openapi_contract.py tests/test_rate_limit_llm_and_exports_api.py`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" make openapi`
- `pytest -q tests/test_openapi_determinism.py`
- `pre-commit run --all-files`
- `make verify`

## Merge Readiness
- [x] PR scope is focused and non-breaking (additive adapter endpoint only)
- [x] Local gates passed (`pre-commit`, `make verify`)
- [x] OpenAPI artifacts regenerated and committed
- [x] W3-R4 mapping rules documented in design spec + ledger status updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /api/v1/pro/restaurants/partner/orders/adapt/preview to preview deterministic partner-order drafts from weekly-plan payloads (returns 200/422/429).

* **Bug Fixes / Validation**
  * Enforced 3-letter currency codes and non-negative default unit price; robust quantity coercion and error responses for malformed weekly plans.

* **Documentation**
  * Updated OpenAPI and integration spec with request schema, mapping rules, and contract details.

* **Tests**
  * Added adapter, endpoint, contract, and rate-limit tests for happy paths, validations, idempotency, and 2/min limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


