### PR TITLE
fix(food-sources): correct OFF vitamin D conversion + nameless-row guard

### DIFF
--- a/core/food_sources/off.py
+++ b/core/food_sources/off.py
@@ -70,18 +70,22 @@ class OFFAdapter(BaseAdapter):
         today = date.today().isoformat()
         for row in self.fetch():
             # Get product name (try multiple fields)
-            raw_name = next(
-                (
-                    str(candidate).strip()
-                    for candidate in (
-                        row.get("product_name", ""),
-                        row.get("generic_name", ""),
-                        row.get("product_name_en", ""),
-                    )
-                    if str(candidate).strip()
-                ),
-                "",
-            )
+            raw_name = ""
+            for candidate in (
+                row.get("product_name", ""),
+                row.get("generic_name", ""),
+                row.get("product_name_en", ""),
+            ):
+                if candidate is None:
+                    continue
+                candidate_name = str(candidate).strip()
+                if not candidate_name:
+                    continue
+                # Fail-closed for malformed CSV null markers.
+                if candidate_name.lower() in {"none", "null", "nan"}:
+                    continue
+                raw_name = candidate_name
+                break
             if not raw_name:
                 continue
             canonical = map_to_canonical(raw_name, locale=self.locale)

--- a/core/food_sources/off.py
+++ b/core/food_sources/off.py
@@ -13,6 +13,7 @@ from datetime import date
 from typing import Dict, Iterable, Optional
 
 from ..aliases import map_to_canonical
+from ..units import iu_vitd_from_ug
 from .base import BaseAdapter, FoodRecord
 
 
@@ -69,11 +70,20 @@ class OFFAdapter(BaseAdapter):
         today = date.today().isoformat()
         for row in self.fetch():
             # Get product name (try multiple fields)
-            raw_name = (
-                row.get("product_name", "")
-                or row.get("generic_name", "")
-                or row.get("product_name_en", "")
+            raw_name = next(
+                (
+                    str(candidate).strip()
+                    for candidate in (
+                        row.get("product_name", ""),
+                        row.get("generic_name", ""),
+                        row.get("product_name_en", ""),
+                    )
+                    if str(candidate).strip()
+                ),
+                "",
             )
+            if not raw_name:
+                continue
             canonical = map_to_canonical(raw_name, locale=self.locale)
             per_g = 100.0
 
@@ -87,7 +97,9 @@ class OFFAdapter(BaseAdapter):
             # Micro nutrients (often empty in OFF)
             Fe_mg = float(row.get("iron_100g", 0) or 0)
             Ca_mg = float(row.get("calcium_100g", 0) or 0)
-            VitD_IU = float(row.get("vitamin-d_100g", 0) or 0)  # May be in µg, needs conversion
+            # OFF vitamin-d_100g is reported in µg; canonical storage is IU.
+            vitd_ug = float(row.get("vitamin-d_100g", 0) or 0)
+            VitD_IU = iu_vitd_from_ug(vitd_ug)
             B12_ug = float(row.get("vitamin-b12_100g", 0) or 0)
             Folate_ug = float(row.get("vitamin-b9_100g", 0) or 0)
             Iodine_ug = float(row.get("iodine_100g", 0) or 0)

--- a/tests/test_food_sources_simple.py
+++ b/tests/test_food_sources_simple.py
@@ -177,6 +177,39 @@ class TestOFFAdapter:
         with pytest.raises(FileNotFoundError):
             list(adapter.fetch())
 
+    def test_off_vitamin_d_converts_ug_to_iu(self):
+        """OFF vitamin-d_100g must convert from µg to IU."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(["product_name", "vitamin-d_100g"])
+            writer.writerow(["Test Product", "10.0"])  # 10 µg -> 400 IU
+            f.flush()
+
+            adapter = OFFAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            assert results[0].VitD_IU == 400.0
+
+        os.unlink(f.name)
+
+    def test_off_skips_nameless_rows(self):
+        """Rows without product_name/generic_name/product_name_en are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(["product_name", "generic_name", "product_name_en", "energy-kcal_100g"])
+            writer.writerow(["", "", "", "50"])  # nameless row should be skipped
+            writer.writerow(["Named Product", "", "", "120"])
+            f.flush()
+
+            adapter = OFFAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            assert results[0].name
+
+        os.unlink(f.name)
+
 
 class TestBaseAdapter:
     """Test base adapter abstract methods."""

--- a/tests/test_food_sources_simple.py
+++ b/tests/test_food_sources_simple.py
@@ -177,7 +177,7 @@ class TestOFFAdapter:
         with pytest.raises(FileNotFoundError):
             list(adapter.fetch())
 
-    def test_off_vitamin_d_converts_ug_to_iu(self):
+    def test_off_vitamin_d_converts_ug_to_iu(self) -> None:
         """OFF vitamin-d_100g must convert from µg to IU."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
             writer = csv.writer(f)
@@ -193,12 +193,13 @@ class TestOFFAdapter:
 
         os.unlink(f.name)
 
-    def test_off_skips_nameless_rows(self):
+    def test_off_skips_nameless_rows(self) -> None:
         """Rows without product_name/generic_name/product_name_en are skipped."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
             writer = csv.writer(f)
             writer.writerow(["product_name", "generic_name", "product_name_en", "energy-kcal_100g"])
             writer.writerow(["", "", "", "50"])  # nameless row should be skipped
+            writer.writerow(["None", "", "", "60"])  # explicit malformed null marker
             writer.writerow(["Named Product", "", "", "120"])
             f.flush()
 
@@ -209,6 +210,34 @@ class TestOFFAdapter:
             assert results[0].name
 
         os.unlink(f.name)
+
+    def test_off_skips_none_name_candidates_from_fetch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """None candidate values should be ignored as nameless input."""
+        adapter = OFFAdapter(csv_path="/tmp/unused.csv")
+
+        def _fake_fetch() -> list[dict[str, object]]:
+            return [
+                {
+                    "product_name": None,
+                    "generic_name": None,
+                    "product_name_en": None,
+                    "energy-kcal_100g": "50",
+                },
+                {
+                    "product_name": None,
+                    "generic_name": "Valid Fallback Name",
+                    "product_name_en": None,
+                    "energy-kcal_100g": "120",
+                },
+            ]
+
+        monkeypatch.setattr(adapter, "fetch", _fake_fetch)
+        results = list(adapter.normalize())
+
+        assert len(results) == 1
+        assert results[0].name
 
 
 class TestBaseAdapter:


### PR DESCRIPTION
## Summary

P0 hotfix for Open Food Facts normalization: fix Vitamin D unit conversion and skip nameless rows.

## Scope

### IN
- `core/food_sources/off.py`
  - Convert `vitamin-d_100g` from µg to IU via `iu_vitd_from_ug(...)`.
  - Skip rows where all product name candidates are empty.
- `tests/test_food_sources_simple.py`
  - Add deterministic test: `10.0 µg -> 400.0 IU`.
  - Add deterministic test: nameless rows are skipped.

### OUT
- No public API/response shape changes.
- No changes to USDA/OFF network clients.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#pullrequestreview-3892640158 -> a5f4b463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#pullrequestreview-3892650598 -> a5f4b463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#discussion_r2886695604 -> a5f4b463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#discussion_r2886696189 -> a5f4b463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#discussion_r2886696198 -> a5f4b463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/976#pullrequestreview-3892651161 -> a5f4b463

## Merge Readiness

- [x] `pre-commit run --all-files` passed locally
- [x] `make verify` passed locally
- [ ] All required CI checks pass
- [ ] Zero unresolved review threads
- [ ] All bot comments mapped

## How to test

```bash
cd /tmp/pulseplate_hotfix_off_vitd
pre-commit run --all-files
make verify
pytest -q tests/test_food_sources_simple.py
```

## Summary by Sourcery

Исправлена нормализация данных Open Food Facts для витамина D и добавлена защита от строк продуктов без имени.

Исправления ошибок:
- Исправлена нормализация витамина D за счёт преобразования значений OFF `vitamin-d_100g` из микрограммов в МЕ (IU) перед сохранением.
- Пропускать строки Open Food Facts, в которых все возможные варианты названия продукта пусты, чтобы избежать создания записей без названий.

Тесты:
- Добавлены регрессионные тесты, покрывающие преобразование витамина D из мкг в МЕ (IU) для данных OFF.
- Добавлен регрессионный тест, который гарантирует, что строки OFF без названий пропускаются и нормализуются только продукты с именами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Open Food Facts normalization for vitamin D and guard against nameless product rows.

Bug Fixes:
- Correct vitamin D normalization by converting OFF vitamin-d_100g values from micrograms to IU before storage.
- Skip Open Food Facts rows where all product name candidates are empty to avoid creating nameless records.

Tests:
- Add regression tests covering vitamin D µg-to-IU conversion for OFF data.
- Add regression test ensuring nameless OFF rows are skipped and only named products are normalized.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vitamin D handling to convert micrograms to IU.
  * Improved product-name extraction by validating multiple candidate fields and skipping invalid markers.
  * Enhanced robustness when encountering incomplete or nameless product entries.

* **Tests**
  * Added tests covering vitamin D conversion and handling of nameless or invalid-name rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
