### PR TITLE
feat(orchestration): load canonical routing graph for routing helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ A **task** is any unit of work that:
 
 **Orchestration telemetry:** Advisory only (no auto-routing writes). Telemetry outputs live under `artifacts/` (gitignored) and must not be committed. See `docs/orchestration/ORCHESTRATION_TELEMETRY_SPEC.md`.
 
-**Routing helper:** No hardcoded routing defaults except coordinator fallback; canonical `docs/orchestration/AGENT_ROUTING_GRAPH.md` is the baseline. Telemetry is advisory.
+**Routing helper:** No hardcoded routing defaults except coordinator fallback; canonical `docs/orchestration/AGENT_ROUTING_GRAPH.md` is the baseline. Telemetry is advisory. Routing helper MUST NOT modify routing docs; it emits decisions only (JSON stdout).
 
 **Templates:**
 - Task Analysis: `docs/orchestration/task_analysis.template.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,8 @@ A **task** is any unit of work that:
 
 **Orchestration telemetry:** Advisory only (no auto-routing writes). Telemetry outputs live under `artifacts/` (gitignored) and must not be committed. See `docs/orchestration/ORCHESTRATION_TELEMETRY_SPEC.md`.
 
+**Routing helper:** No hardcoded routing defaults except coordinator fallback; canonical `docs/orchestration/AGENT_ROUTING_GRAPH.md` is the baseline. Telemetry is advisory.
+
 **Templates:**
 - Task Analysis: `docs/orchestration/task_analysis.template.md`
 - Work Review: `docs/orchestration/work_review.template.md`

--- a/scripts/orchestration/route_with_telemetry.py
+++ b/scripts/orchestration/route_with_telemetry.py
@@ -75,8 +75,11 @@ def _rewrite_rate(stats: Dict[str, Any]) -> float:
     meta = stats.get("meta", {})
     if not isinstance(meta, dict):
         return 0.0
-    runs = int(meta.get("runs", 0) or 0)
-    rewrites = int(meta.get("decision_REWRITE_REQUIRED", 0) or 0)
+    try:
+        runs = int(meta.get("runs", 0) or 0)
+        rewrites = int(meta.get("decision_REWRITE_REQUIRED", 0) or 0)
+    except (ValueError, TypeError):
+        return 0.0
     if runs <= 0:
         return 0.0
     return rewrites / runs
@@ -139,8 +142,12 @@ def route(
         rationale["primary_reason"] = "no_telemetry_primary_fallback_canonical"
 
     if isinstance(suggested_secondary, str) and suggested_secondary:
-        secondary = suggested_secondary
-        rationale["secondary_reason"] = "telemetry_secondary"
+        ss_stats = _get_agent_stats(telemetry, suggested_secondary)
+        if _is_stable(ss_stats):
+            secondary = suggested_secondary
+            rationale["secondary_reason"] = "telemetry_secondary_stable"
+        else:
+            rationale["secondary_reason"] = "telemetry_secondary_low_data_fallback_canonical"
     else:
         rationale["secondary_reason"] = "fallback_canonical"
 

--- a/scripts/orchestration/route_with_telemetry.py
+++ b/scripts/orchestration/route_with_telemetry.py
@@ -100,6 +100,7 @@ def route(
     routing: Dict[str, DomainRoute],
 ) -> RoutingDecision:
     """Compute routing decision from telemetry (advisory) + canonical graph."""
+    domain = domain.strip().lower()
     canon_primary, canon_secondary, canon_reviewer = _canonical_fallback(domain, routing)
 
     rationale: Dict[str, Any] = {"source": "canonical_only"}

--- a/scripts/orchestration/route_with_telemetry.py
+++ b/scripts/orchestration/route_with_telemetry.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Self-optimizing routing helper: telemetry + canonical graph → RoutingDecision.
+
+Reads artifacts/orchestration/telemetry_rollup.json (advisory) and
+docs/orchestration/AGENT_ROUTING_GRAPH.md (canonical baseline).
+Outputs JSON with primary/secondary/reviewer. No network calls, no auto-commits.
+
+Usage:
+    python scripts/orchestration/route_with_telemetry.py --domain safety --task-type "Safety / Philosophy / Logic"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration.routing_graph_loader import (
+    DomainRoute,
+    load_routing_graph,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TELEMETRY_PATH = REPO_ROOT / "artifacts" / "orchestration" / "telemetry_rollup.json"
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Routing decision: primary, optional secondary, reviewer, rationale."""
+
+    domain: str
+    task_type: str
+    primary: str
+    secondary: Optional[str]
+    reviewer: str
+    rationale: Dict[str, Any]
+
+
+def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _get_agent_stats(telemetry: Dict[str, Any], agent: str) -> Dict[str, Any]:
+    agents = telemetry.get("agents", {})
+    if not isinstance(agents, dict):
+        return {}
+    stats = agents.get(agent, {})
+    return stats if isinstance(stats, dict) else {}
+
+
+def _is_stable(stats: Dict[str, Any]) -> bool:
+    return stats.get("stability") == "STABLE"
+
+
+def _avg_score(stats: Dict[str, Any]) -> float:
+    try:
+        return float(stats.get("avg_score", 0.0))
+    except Exception:
+        return 0.0
+
+
+def _rewrite_rate(stats: Dict[str, Any]) -> float:
+    meta = stats.get("meta", {})
+    if not isinstance(meta, dict):
+        return 0.0
+    runs = int(meta.get("runs", 0) or 0)
+    rewrites = int(meta.get("decision_REWRITE_REQUIRED", 0) or 0)
+    if runs <= 0:
+        return 0.0
+    return rewrites / runs
+
+
+def _canonical_fallback(
+    domain: str, routing: Dict[str, DomainRoute]
+) -> Tuple[str, Optional[str], str]:
+    """Get primary/secondary/reviewer from canonical routing graph."""
+    dr = routing.get(domain)
+    if dr:
+        return (dr.primary, dr.secondary, dr.reviewer)
+    return ("agent-coordinator", None, "agent-coordinator")
+
+
+def route(
+    domain: str,
+    task_type: str,
+    *,
+    telemetry: Optional[Dict[str, Any]],
+    routing: Dict[str, DomainRoute],
+) -> RoutingDecision:
+    """Compute routing decision from telemetry (advisory) + canonical graph."""
+    canon_primary, canon_secondary, canon_reviewer = _canonical_fallback(domain, routing)
+
+    rationale: Dict[str, Any] = {"source": "canonical_only"}
+    primary = canon_primary
+    secondary = canon_secondary
+    reviewer = canon_reviewer
+
+    if not telemetry:
+        return RoutingDecision(domain, task_type, primary, secondary, reviewer, rationale)
+
+    domains = telemetry.get("domains", {})
+    if not isinstance(domains, dict):
+        return RoutingDecision(domain, task_type, primary, secondary, reviewer, rationale)
+
+    dom = domains.get(domain, {})
+    if not isinstance(dom, dict):
+        return RoutingDecision(domain, task_type, primary, secondary, reviewer, rationale)
+
+    suggested_primary = dom.get("primary_suggested")
+    suggested_secondary = dom.get("secondary_suggested")
+
+    rationale = {
+        "source": "telemetry+canonical",
+        "suggested_primary": suggested_primary,
+        "suggested_secondary": suggested_secondary,
+    }
+
+    if isinstance(suggested_primary, str) and suggested_primary:
+        sp_stats = _get_agent_stats(telemetry, suggested_primary)
+        if _is_stable(sp_stats):
+            primary = suggested_primary
+            rationale["primary_reason"] = "telemetry_primary_stable"
+        else:
+            rationale["primary_reason"] = "telemetry_primary_low_data_fallback_canonical"
+    else:
+        rationale["primary_reason"] = "no_telemetry_primary_fallback_canonical"
+
+    if isinstance(suggested_secondary, str) and suggested_secondary:
+        secondary = suggested_secondary
+        rationale["secondary_reason"] = "telemetry_secondary"
+    else:
+        rationale["secondary_reason"] = "fallback_canonical"
+
+    p_stats = _get_agent_stats(telemetry, primary)
+    p_avg = _avg_score(p_stats)
+    p_rewrite = _rewrite_rate(p_stats)
+    p_stable = _is_stable(p_stats)
+
+    rationale["primary_stats"] = {
+        "avg_score": p_avg,
+        "rewrite_rate": round(p_rewrite, 4),
+        "stability": p_stats.get("stability"),
+    }
+
+    escalate = False
+    if domain == "safety":
+        escalate = True
+        reviewer = "philosophy-agent"
+        rationale["reviewer_reason"] = "domain_safety_forced_philosophy_review"
+    elif p_stable and p_avg < 0.70:
+        escalate = True
+        rationale["reviewer_reason"] = "primary_avg_score_low"
+    elif p_stable and p_rewrite > 0.25:
+        escalate = True
+        rationale["reviewer_reason"] = "primary_rewrite_rate_high"
+    else:
+        rationale["reviewer_reason"] = "canonical_reviewer"
+
+    if escalate and domain != "safety":
+        if domain == "backend":
+            reviewer = "architecture-specialist"
+        elif domain in ("ai", "ml"):
+            reviewer = "rag-systems-agent"
+        else:
+            reviewer = "agent-coordinator"
+
+    return RoutingDecision(domain, task_type, primary, secondary, reviewer, rationale)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="route_with_telemetry")
+    ap.add_argument("--domain", required=True)
+    ap.add_argument("--task-type", required=True)
+    ap.add_argument("--telemetry", default=str(TELEMETRY_PATH))
+    args = ap.parse_args()
+
+    routing = load_routing_graph()
+    telemetry = _read_json(Path(args.telemetry))
+    decision = route(args.domain, args.task_type, telemetry=telemetry, routing=routing)
+
+    print(
+        json.dumps(
+            {
+                "domain": decision.domain,
+                "task_type": decision.task_type,
+                "primary": decision.primary,
+                "secondary": decision.secondary,
+                "reviewer": decision.reviewer,
+                "rationale": decision.rationale,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/route_with_telemetry.py
+++ b/scripts/orchestration/route_with_telemetry.py
@@ -44,12 +44,13 @@ class RoutingDecision:
 
 
 def _read_json(path: Path) -> Optional[Dict[str, Any]]:
-    if not path.exists():
+    if not path.is_file():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _get_agent_stats(telemetry: Dict[str, Any], agent: str) -> Dict[str, Any]:

--- a/scripts/orchestration/routing_graph_loader.py
+++ b/scripts/orchestration/routing_graph_loader.py
@@ -1,0 +1,138 @@
+"""Load canonical routing graph from docs/orchestration/AGENT_ROUTING_GRAPH.md.
+
+Parses the Domains → Agents table and returns Dict[str, DomainRoute].
+Used by route_with_telemetry.py as baseline fallback (telemetry is advisory).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ROUTING_GRAPH = REPO_ROOT / "docs" / "orchestration" / "AGENT_ROUTING_GRAPH.md"
+
+_TABLE_ROW_RE = re.compile(r"^\|\s*(?P<cols>.+?)\s*\|\s*$")
+
+
+@dataclass(frozen=True)
+class DomainRoute:
+    """Canonical route for a domain: primary, optional secondary, reviewer."""
+
+    primary: str
+    secondary: Optional[str]
+    reviewer: str
+
+
+def _split_md_row(row: str) -> Tuple[str, ...]:
+    """Parse markdown table row: | a | b | c | -> ('a','b','c')."""
+    m = _TABLE_ROW_RE.match(row.strip())
+    if not m:
+        return ()
+    parts = [p.strip() for p in m.group("cols").split("|")]
+    return tuple(parts)
+
+
+def _is_delimiter_row(line: str) -> bool:
+    """True if line is a markdown table delimiter (|---|---|)."""
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return False
+    content = stripped.replace("|", "").strip()
+    return bool(content and set(content) <= {"-", ":", " "})
+
+
+def load_routing_graph(path: Path = DEFAULT_ROUTING_GRAPH) -> Dict[str, DomainRoute]:
+    """
+    Parse canonical routing table from AGENT_ROUTING_GRAPH.md.
+
+    Expects table format:
+    | Domain   | Primary Agent            | Secondary                | Reviewer                |
+    |----------|--------------------------|--------------------------|-------------------------|
+    | safety   | philosophy-agent         | logic-agent             | agent-coordinator       |
+
+    Returns:
+        Dict mapping domain -> DomainRoute(primary, secondary, reviewer).
+        Secondary is first agent when comma-separated (e.g. "a, b" -> "a").
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Routing graph not found: {path}")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    header_idx: Optional[int] = None
+    header_cols: Tuple[str, ...] = ()
+    for i, line in enumerate(lines):
+        cols = _split_md_row(line)
+        if not cols:
+            continue
+        norm = [c.lower() for c in cols]
+        joined = " ".join(norm)
+        if "domain" in norm and "primary" in joined and "reviewer" in joined:
+            header_idx = i
+            header_cols = cols
+            break
+
+    if header_idx is None:
+        raise ValueError("Routing graph table header not found")
+
+    start = header_idx + 1
+    if start < len(lines) and _is_delimiter_row(lines[start]):
+        start += 1
+
+    header_norm = [c.strip().lower() for c in header_cols]
+
+    def idx_of(key: str) -> int:
+        for j, h in enumerate(header_norm):
+            if key in h:
+                return j
+        raise ValueError(f"Required column missing: {key}")
+
+    i_domain = idx_of("domain")
+    i_primary = idx_of("primary")
+    i_reviewer = idx_of("reviewer")
+
+    i_secondary: Optional[int] = None
+    for j, h in enumerate(header_norm):
+        if "secondary" in h:
+            i_secondary = j
+            break
+
+    routes: Dict[str, DomainRoute] = {}
+
+    for line in lines[start:]:
+        cols = _split_md_row(line)
+        if not cols:
+            continue
+        if len(cols) <= max(i_domain, i_primary, i_reviewer):
+            continue
+
+        domain = cols[i_domain].strip()
+        primary = cols[i_primary].strip()
+        reviewer = cols[i_reviewer].strip()
+        secondary_raw = (
+            cols[i_secondary].strip() if i_secondary is not None and i_secondary < len(cols) else ""
+        )
+
+        if not domain or domain.startswith("-"):
+            continue
+        if not primary or not reviewer:
+            continue
+
+        secondary: Optional[str] = None
+        if secondary_raw:
+            first = secondary_raw.split(",")[0].strip()
+            secondary = first if first else None
+
+        routes[domain] = DomainRoute(
+            primary=primary,
+            secondary=secondary,
+            reviewer=reviewer,
+        )
+
+    if not routes:
+        raise ValueError("No routing rows parsed from routing graph")
+
+    return routes

--- a/scripts/orchestration/routing_graph_loader.py
+++ b/scripts/orchestration/routing_graph_loader.py
@@ -103,13 +103,16 @@ def load_routing_graph(path: Path = DEFAULT_ROUTING_GRAPH) -> Dict[str, DomainRo
     routes: Dict[str, DomainRoute] = {}
 
     for line in lines[start:]:
+        stripped = line.strip()
+        if stripped == "---" or stripped.startswith("##"):
+            break
         cols = _split_md_row(line)
         if not cols:
             continue
         if len(cols) <= max(i_domain, i_primary, i_reviewer):
             continue
 
-        domain = cols[i_domain].strip()
+        domain = cols[i_domain].strip().lower()
         primary = cols[i_primary].strip()
         reviewer = cols[i_reviewer].strip()
         secondary_raw = (

--- a/scripts/orchestration/routing_graph_loader.py
+++ b/scripts/orchestration/routing_graph_loader.py
@@ -57,7 +57,7 @@ def load_routing_graph(path: Path = DEFAULT_ROUTING_GRAPH) -> Dict[str, DomainRo
         Dict mapping domain -> DomainRoute(primary, secondary, reviewer).
         Secondary is first agent when comma-separated (e.g. "a, b" -> "a").
     """
-    if not path.exists():
+    if not path.is_file():
         raise FileNotFoundError(f"Routing graph not found: {path}")
 
     lines = path.read_text(encoding="utf-8").splitlines()
@@ -108,6 +108,8 @@ def load_routing_graph(path: Path = DEFAULT_ROUTING_GRAPH) -> Dict[str, DomainRo
             break
         cols = _split_md_row(line)
         if not cols:
+            if routes:
+                break
             continue
         if len(cols) <= max(i_domain, i_primary, i_reviewer):
             continue
@@ -129,6 +131,8 @@ def load_routing_graph(path: Path = DEFAULT_ROUTING_GRAPH) -> Dict[str, DomainRo
             first = secondary_raw.split(",")[0].strip()
             secondary = first if first else None
 
+        if domain in routes:
+            raise ValueError(f"Duplicate domain in routing graph: {domain}")
         routes[domain] = DomainRoute(
             primary=primary,
             secondary=secondary,

--- a/tests/test_routing_graph_loader.py
+++ b/tests/test_routing_graph_loader.py
@@ -7,6 +7,11 @@ import pytest
 from scripts.orchestration.routing_graph_loader import load_routing_graph
 from scripts.orchestration.route_with_telemetry import route
 
+_MINIMAL_TABLE = (
+    "| Domain   | Primary Agent   | Secondary | Reviewer |\n"
+    "|----------|-----------------|-----------|----------|\n"
+)
+
 
 def test_parses_safety_domain() -> None:
     """Safety domain must exist with non-empty primary and reviewer."""
@@ -41,6 +46,69 @@ def test_missing_file_raises(tmp_path: Path) -> None:
         load_routing_graph(tmp_path / "nope.md")
 
 
+def test_directory_raises_file_not_found(tmp_path: Path) -> None:
+    """FileNotFoundError when path is a directory (is_file rejects dirs)."""
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    with pytest.raises(FileNotFoundError, match="Routing graph not found"):
+        load_routing_graph(subdir)
+
+
+def test_missing_header_raises(tmp_path: Path) -> None:
+    """ValueError when the routing table header row is missing."""
+    bad_path = tmp_path / "no_header.md"
+    bad_path.write_text(
+        "# Routing Graph\n\n"
+        "Some introductory text, but no routing table header.\n\n"
+        "| something | else |\n"
+        "| --------- | ---- |\n"
+        "| foo       | bar  |\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Routing graph table header not found"):
+        load_routing_graph(bad_path)
+
+
+def test_no_routing_rows_raises(tmp_path: Path) -> None:
+    """ValueError when header exists but no routing rows are parsed."""
+    empty_table_path = tmp_path / "no_rows.md"
+    empty_table_path.write_text(
+        "# Routing Graph\n\n"
+        "| domain | primary | secondary | reviewer |\n"
+        "| ------ | ------- | --------- | -------- |\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="No routing rows parsed from routing graph"):
+        load_routing_graph(empty_table_path)
+
+
+def test_secondary_empty_yields_none(tmp_path: Path) -> None:
+    """Empty secondary cell must yield None; non-empty yields agent name."""
+    table_path = tmp_path / "secondary_test.md"
+    table_path.write_text(
+        _MINIMAL_TABLE
+        + "| foo | agent-a |           | reviewer-a |\n"
+        + "| bar | agent-b | agent-c    | reviewer-b |\n",
+        encoding="utf-8",
+    )
+    routes = load_routing_graph(table_path)
+    assert routes["foo"].secondary is None
+    assert routes["bar"].secondary == "agent-c"
+
+
+def test_duplicate_domain_raises(tmp_path: Path) -> None:
+    """ValueError when same domain appears twice in routing table."""
+    dup_path = tmp_path / "duplicate.md"
+    dup_path.write_text(
+        _MINIMAL_TABLE
+        + "| safety | philosophy-agent | logic-agent | agent-coordinator |\n"
+        + "| safety | backend-engineer  |             | bug-hunter         |\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Duplicate domain in routing graph: safety"):
+        load_routing_graph(dup_path)
+
+
 def test_parses_all_known_domains() -> None:
     """All domains from AGENT_ROUTING_GRAPH section 3 must be present."""
     routes = load_routing_graph()
@@ -72,3 +140,99 @@ def test_route_normalizes_domain_lookup() -> None:
     d1 = route("Safety", "test", telemetry=None, routing=routing)
     d2 = route("safety", "test", telemetry=None, routing=routing)
     assert d1.primary == d2.primary == "philosophy-agent"
+
+
+def test_route_keeps_canonical_primary_when_suggested_primary_not_stable() -> None:
+    """When suggested_primary exists but telemetry is not STABLE, use canonical."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {
+            "safety": {"primary_suggested": "logic-agent", "secondary_suggested": None},
+        },
+        "agents": {"logic-agent": {"stability": "LOW_DATA"}},
+    }
+    d = route("safety", "test", telemetry=telemetry, routing=routing)
+    assert d.primary == "philosophy-agent"
+    assert d.rationale["primary_reason"] == "telemetry_primary_low_data_fallback_canonical"
+
+
+def test_route_uses_telemetry_secondary_only_when_stable() -> None:
+    """Secondary override only when suggested_secondary has STABLE telemetry."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {
+            "safety": {"primary_suggested": None, "secondary_suggested": "logic-agent"},
+        },
+        "agents": {"logic-agent": {"stability": "STABLE"}},
+    }
+    d = route("safety", "test", telemetry=telemetry, routing=routing)
+    assert d.secondary == "logic-agent"
+    assert d.rationale["secondary_reason"] == "telemetry_secondary_stable"
+
+
+def test_route_fallback_canonical_secondary_when_suggested_not_stable() -> None:
+    """When suggested_secondary exists but not STABLE, use canonical secondary."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {
+            "safety": {"primary_suggested": None, "secondary_suggested": "backend-engineer"},
+        },
+        "agents": {"backend-engineer": {"stability": "LOW_DATA"}},
+    }
+    d = route("safety", "test", telemetry=telemetry, routing=routing)
+    assert d.secondary == "logic-agent"
+    assert d.rationale["secondary_reason"] == "telemetry_secondary_low_data_fallback_canonical"
+
+
+def test_route_escalates_reviewer_on_low_avg_score() -> None:
+    """Reviewer escalates when primary avg_score < 0.70 and stable."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {"backend": {"primary_suggested": "architecture-specialist"}},
+        "agents": {
+            "architecture-specialist": {
+                "stability": "STABLE",
+                "avg_score": 0.5,
+                "meta": {"runs": 10, "decision_REWRITE_REQUIRED": 0},
+            },
+        },
+    }
+    d = route("backend", "test", telemetry=telemetry, routing=routing)
+    assert d.reviewer == "architecture-specialist"
+    assert d.rationale["reviewer_reason"] == "primary_avg_score_low"
+
+
+def test_route_escalates_reviewer_on_high_rewrite_rate() -> None:
+    """Reviewer escalates when primary rewrite_rate > 0.25 and stable."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {"backend": {"primary_suggested": "architecture-specialist"}},
+        "agents": {
+            "architecture-specialist": {
+                "stability": "STABLE",
+                "avg_score": 0.9,
+                "meta": {"runs": 10, "decision_REWRITE_REQUIRED": 4},
+            },
+        },
+    }
+    d = route("backend", "test", telemetry=telemetry, routing=routing)
+    assert d.reviewer == "architecture-specialist"
+    assert d.rationale["reviewer_reason"] == "primary_rewrite_rate_high"
+
+
+def test_route_ignores_non_numeric_rewrite_meta_without_crashing() -> None:
+    """Malformed meta (non-numeric runs/rewrites) must not crash; fallback to 0."""
+    routing = load_routing_graph()
+    telemetry = {
+        "domains": {"backend": {"primary_suggested": "architecture-specialist"}},
+        "agents": {
+            "architecture-specialist": {
+                "stability": "STABLE",
+                "avg_score": 0.9,
+                "meta": {"runs": "N/A", "decision_REWRITE_REQUIRED": "invalid"},
+            },
+        },
+    }
+    d = route("backend", "test", telemetry=telemetry, routing=routing)
+    assert d.primary == "architecture-specialist"
+    assert d.rationale["primary_stats"]["rewrite_rate"] == 0.0

--- a/tests/test_routing_graph_loader.py
+++ b/tests/test_routing_graph_loader.py
@@ -1,0 +1,58 @@
+"""Tests for routing graph loader (canonical docs/orchestration/AGENT_ROUTING_GRAPH.md)."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration.routing_graph_loader import load_routing_graph
+
+
+def test_parses_safety_domain() -> None:
+    """Safety domain must exist with non-empty primary and reviewer."""
+    routes = load_routing_graph()
+    assert "safety" in routes
+    assert routes["safety"].primary
+    assert routes["safety"].reviewer
+    assert routes["safety"].primary == "philosophy-agent"
+    assert routes["safety"].reviewer == "agent-coordinator"
+
+
+def test_secondary_optional_supported() -> None:
+    """Empty secondary in table must yield None in DomainRoute."""
+    routes = load_routing_graph()
+    for domain, dr in routes.items():
+        assert isinstance(dr.secondary, (str, type(None)))
+        if dr.secondary is not None:
+            assert len(dr.secondary) > 0
+
+
+def test_secondary_comma_separated_takes_first() -> None:
+    """When secondary column has 'a, b', we take first agent."""
+    routes = load_routing_graph()
+    backend = routes.get("backend")
+    assert backend is not None
+    assert backend.secondary == "backend-engineer"
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    """FileNotFoundError when path does not exist."""
+    with pytest.raises(FileNotFoundError, match="Routing graph not found"):
+        load_routing_graph(tmp_path / "nope.md")
+
+
+def test_parses_all_known_domains() -> None:
+    """All domains from AGENT_ROUTING_GRAPH section 3 must be present."""
+    routes = load_routing_graph()
+    expected = {
+        "backend",
+        "ios",
+        "frontend",
+        "infra",
+        "security",
+        "ml",
+        "docs",
+        "design",
+        "research",
+        "safety",
+    }
+    assert expected.issubset(set(routes.keys()))

--- a/tests/test_routing_graph_loader.py
+++ b/tests/test_routing_graph_loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from scripts.orchestration.routing_graph_loader import load_routing_graph
+from scripts.orchestration.route_with_telemetry import route
 
 
 def test_parses_safety_domain() -> None:
@@ -56,3 +57,18 @@ def test_parses_all_known_domains() -> None:
         "safety",
     }
     assert expected.issubset(set(routes.keys()))
+
+
+def test_domain_normalized_to_lowercase() -> None:
+    """Domain keys must be lowercase for consistent lookup."""
+    routes = load_routing_graph()
+    for key in routes.keys():
+        assert key == key.lower(), f"Domain key must be lowercase: {key!r}"
+
+
+def test_route_normalizes_domain_lookup() -> None:
+    """route() must resolve 'Safety' and 'safety' to same canonical route."""
+    routing = load_routing_graph()
+    d1 = route("Safety", "test", telemetry=None, routing=routing)
+    d2 = route("safety", "test", telemetry=None, routing=routing)
+    assert d1.primary == d2.primary == "philosophy-agent"


### PR DESCRIPTION
## Summary

Replace hardcoded `_canonical_fallback()` in routing helper with loader that parses `docs/orchestration/AGENT_ROUTING_GRAPH.md`. Canonical routing graph is now the baseline SoT; telemetry remains advisory.

## Scope

**IN:**
- `scripts/orchestration/routing_graph_loader.py` (new) — parse Domains → Agents table
- `scripts/orchestration/route_with_telemetry.py` (new) — self-optimizing routing (telemetry + canonical)
- `tests/test_routing_graph_loader.py` (new) — loader + fallback behavior
- `AGENTS.md` — routing helper rules (baseline, no-modify)

**OUT:**
- No edits to `AGENT_ROUTING_GRAPH.md` or other orchestration docs
- No CI changes

## Behavior

- Loader parses `| Domain | Primary Agent | Secondary | Reviewer |` table
- Parser stops at `---` or `##` to avoid picking up other tables
- Domain keys normalized to lowercase (Safety/safety → same route)
- Secondary: first agent when comma-separated
- `route_with_telemetry.py` uses loader as baseline; telemetry overrides only when STABLE

## Security Notes

- Loader reads only repo-local `docs/...` (no network)
- Does not write to docs, no auto-commits
- Telemetry remains advisory

## Gates

- [x] `pytest tests/test_routing_graph_loader.py` green
- [x] `pre-commit run --all-files` green
- [x] `python scripts/orchestration/route_with_telemetry.py --domain Safety --task-type "Safety / Philosophy / Logic"` outputs valid JSON

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894200704 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2887977039 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894209660 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894209884 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2887977243 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2887977245 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2887977249 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888003563 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888003570 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888003573 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888003577 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894238696 -> 5ca800bd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#discussion_r2888478492 -> cdd740f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/980#pullrequestreview-3894776185 -> cdd740f7

## Merge Readiness

- [ ] CI green
- [ ] CodeRabbit / Sourcery / Cubic no actionables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified routing policy: defaults, canonical reference, and advisory telemetry guidance.

* **New Features**
  * Added a routing decision system that combines advisory telemetry with the canonical routing graph to determine primary, secondary, and reviewer assignments.

* **Tests**
  * Added comprehensive tests covering routing graph parsing, domain normalization, telemetry-influenced decisions, fallbacks, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->