### PR TITLE
feat(payments): add PRO activation baseline for iOS/RU-BY rails

### DIFF
--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -7,8 +7,7 @@ EN: Baseline PRO endpoints for subscription activation (contract-first, non-brea
 
 from __future__ import annotations
 
-import threading
-from uuid import uuid4
+import hashlib
 
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
@@ -26,20 +25,13 @@ router = APIRouter(
     tags=["pro", "payments"],
 )
 
-_ISSUER_LOCK = threading.Lock()
-_ISSUER_BY_API_KEY: dict[str, str] = {}
-
 
 def _issuer_from_api_key(api_key: str) -> str:
-    """Return stable opaque issuer marker from API key."""
+    """Return deterministic opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
-    with _ISSUER_LOCK:
-        marker = _ISSUER_BY_API_KEY.get(api_key)
-        if marker is None:
-            marker = f"api_key:{uuid4().hex[:12]}"
-            _ISSUER_BY_API_KEY[api_key] = marker
-    return marker
+    digest = hashlib.sha3_256(api_key.encode("utf-8")).hexdigest()
+    return f"api_key:{digest}"
 
 
 @router.post(

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -7,7 +7,8 @@ EN: Baseline PRO endpoints for subscription activation (contract-first, non-brea
 
 from __future__ import annotations
 
-import hashlib
+import threading
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
@@ -25,13 +26,20 @@ router = APIRouter(
     tags=["pro", "payments"],
 )
 
+_ISSUER_LOCK = threading.Lock()
+_ISSUER_BY_API_KEY: dict[str, str] = {}
+
 
 def _issuer_from_api_key(api_key: str) -> str:
     """Return stable opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
-    digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
-    return f"api_key:{digest}"
+    with _ISSUER_LOCK:
+        marker = _ISSUER_BY_API_KEY.get(api_key)
+        if marker is None:
+            marker = f"api_key:{uuid4().hex[:12]}"
+            _ISSUER_BY_API_KEY[api_key] = marker
+    return marker
 
 
 @router.post(

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""PRO payments baseline endpoints (contract-first, additive, non-breaking).
+
+RU: Базовые PRO endpoints для активации подписки (контракт-first, без breaking changes).
+EN: Baseline PRO endpoints for subscription activation (contract-first, non-breaking).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from app.middleware.api_tiers import require_pro_tier
+from app.schemas.payments import (
+    ActivateSubscriptionRequest,
+    PaymentErrorResponse,
+    SubscriptionActivationResponse,
+)
+from app.services import payments_activation
+
+router = APIRouter(
+    prefix="/api/v1/pro/payments",
+    tags=["pro", "payments"],
+    dependencies=[Depends(require_pro_tier)],
+)
+
+
+def _issuer_from_api_key(api_key: str) -> str:
+    """Return stable opaque issuer marker from API key."""
+    if not api_key:
+        return "api_key:anonymous"
+    digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    return f"api_key:{digest}"
+
+
+@router.post(
+    "/activate",
+    response_model=SubscriptionActivationResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Idempotent replay",
+            "model": SubscriptionActivationResponse,
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "client_event_id conflict",
+            "model": PaymentErrorResponse,
+        },
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
+            "description": "Invalid activation payload",
+            "model": PaymentErrorResponse,
+        },
+    },
+)
+def activate_subscription(
+    payload: ActivateSubscriptionRequest,
+    response: Response,
+    x_api_key: str = Depends(require_pro_tier),
+) -> SubscriptionActivationResponse:
+    """Create activation or return idempotent replay."""
+    try:
+        activation, is_new = payments_activation.activate_subscription(
+            issuer=_issuer_from_api_key(x_api_key),
+            payload=payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    if not is_new:
+        response.status_code = status.HTTP_200_OK
+    return activation
+
+
+@router.get(
+    "/activations/{activation_id}",
+    response_model=SubscriptionActivationResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Activation access forbidden",
+            "model": PaymentErrorResponse,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Activation not found",
+            "model": PaymentErrorResponse,
+        },
+    },
+)
+def get_subscription_activation(
+    activation_id: str,
+    x_api_key: str = Depends(require_pro_tier),
+) -> SubscriptionActivationResponse:
+    """Get activation status by ID."""
+    issuer = _issuer_from_api_key(x_api_key)
+    try:
+        activation = payments_activation.get_activation(activation_id, issuer=issuer)
+    except payments_activation.ActivationAccessForbiddenError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    if activation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Activation not found")
+    return activation

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -7,12 +7,13 @@ EN: Baseline PRO endpoints for subscription activation (contract-first, non-brea
 
 from __future__ import annotations
 
-import hashlib
+import hmac
 
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
 
 from app.middleware.api_tiers import require_pro_tier
+from app.security.llm_monthly_quota import require_server_salt
 from app.schemas.payments import (
     ActivateSubscriptionRequest,
     PaymentErrorResponse,
@@ -30,7 +31,8 @@ def _issuer_from_api_key(api_key: str) -> str:
     """Return deterministic opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
-    digest = hashlib.sha3_256(api_key.encode("utf-8")).hexdigest()
+    salt = require_server_salt().encode("utf-8")
+    digest = hmac.digest(salt, api_key.encode("utf-8"), "sha256").hex()
     return f"api_key:{digest}"
 
 

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import hashlib
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Response, status
+from fastapi.responses import JSONResponse
 
 from app.middleware.api_tiers import require_pro_tier
 from app.schemas.payments import (
@@ -22,7 +23,6 @@ from app.services import payments_activation
 router = APIRouter(
     prefix="/api/v1/pro/payments",
     tags=["pro", "payments"],
-    dependencies=[Depends(require_pro_tier)],
 )
 
 
@@ -47,25 +47,29 @@ def _issuer_from_api_key(api_key: str) -> str:
             "description": "client_event_id conflict",
             "model": PaymentErrorResponse,
         },
-        status.HTTP_422_UNPROCESSABLE_CONTENT: {
-            "description": "Invalid activation payload",
-            "model": PaymentErrorResponse,
-        },
     },
 )
 def activate_subscription(
     payload: ActivateSubscriptionRequest,
     response: Response,
     x_api_key: str = Depends(require_pro_tier),
-) -> SubscriptionActivationResponse:
+) -> SubscriptionActivationResponse | JSONResponse:
     """Create activation or return idempotent replay."""
     try:
         activation, is_new = payments_activation.activate_subscription(
             issuer=_issuer_from_api_key(x_api_key),
             payload=payload,
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except payments_activation.IdempotencyConflictError as exc:
+        error = PaymentErrorResponse(
+            code="idempotency_conflict",
+            message="client_event_id conflict",
+            detail=str(exc),
+        )
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=error.model_dump(mode="json"),
+        )
     if not is_new:
         response.status_code = status.HTTP_200_OK
     return activation
@@ -88,13 +92,29 @@ def activate_subscription(
 def get_subscription_activation(
     activation_id: str,
     x_api_key: str = Depends(require_pro_tier),
-) -> SubscriptionActivationResponse:
+) -> SubscriptionActivationResponse | JSONResponse:
     """Get activation status by ID."""
     issuer = _issuer_from_api_key(x_api_key)
     try:
         activation = payments_activation.get_activation(activation_id, issuer=issuer)
     except payments_activation.ActivationAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        error = PaymentErrorResponse(
+            code="forbidden",
+            message="Activation access forbidden",
+            detail=str(exc),
+        )
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=error.model_dump(mode="json"),
+        )
     if activation is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Activation not found")
+        error = PaymentErrorResponse(
+            code="not_found",
+            message="Activation not found",
+            detail=activation_id,
+        )
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=error.model_dump(mode="json"),
+        )
     return activation

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
 
 from app.middleware.api_tiers import require_pro_tier
-from app.security.llm_monthly_quota import require_server_salt
+from app.security.server_salt import require_server_salt
 from app.schemas.payments import (
     ActivateSubscriptionRequest,
     PaymentErrorResponse,

--- a/app/routers/pro_registration.py
+++ b/app/routers/pro_registration.py
@@ -66,6 +66,9 @@ def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | N
     from app.routers.pro_food_attribution import router as pro_food_attribution_router
 
     app.include_router(pro_food_attribution_router)
+    from app.routers.pro_payments import router as pro_payments_router
+
+    app.include_router(pro_payments_router)
     from app.routers.pro_restaurant_partner import router as pro_restaurant_partner_router
 
     app.include_router(pro_restaurant_partner_router)

--- a/app/schemas/payments.py
+++ b/app/schemas/payments.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Payment activation schemas for PRO payment baseline.
+
+RU: Схемы активации платежей для базового PRO-контракта.
+EN: Payment activation schemas for baseline PRO contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PaymentSource(str, Enum):
+    """Canonical payment sources (RU/BY + iOS baseline)."""
+
+    ios_app_store = "ios_app_store"
+    erip_qr = "erip_qr"
+    swift_manual = "swift_manual"
+
+
+class ActivationStatus(str, Enum):
+    """Canonical activation state for subscription activation flow."""
+
+    pending_verification = "pending_verification"
+    active = "active"
+    rejected = "rejected"
+
+
+class ReconcileStatus(str, Enum):
+    """Reconciliation status for financial audit trail."""
+
+    pending = "pending"
+    verified = "verified"
+    rejected = "rejected"
+    not_required = "not_required"
+
+
+class ActivateSubscriptionRequest(BaseModel):
+    """Activation request payload (contract-first, deterministic)."""
+
+    source: PaymentSource
+    client_event_id: str = Field(
+        ...,
+        min_length=6,
+        max_length=128,
+        description="Client-generated idempotency event ID",
+    )
+    external_txn_id: str | None = Field(
+        default=None,
+        min_length=3,
+        max_length=128,
+        description="Provider-side transaction or intent ID",
+    )
+    verification_ok: bool | None = Field(
+        default=None,
+        description="Deterministic verification result for baseline R1 contract",
+    )
+    verification_payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Opaque verification payload. Server remains source of truth.",
+    )
+
+    @field_validator("client_event_id")
+    @classmethod
+    def _normalize_client_event_id(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("client_event_id must not be empty")
+        return normalized
+
+    @field_validator("external_txn_id")
+    @classmethod
+    def _normalize_external_txn_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+
+class SubscriptionActivationResponse(BaseModel):
+    """Canonical activation response for all payment sources."""
+
+    activation_id: str
+    payment_source: PaymentSource
+    status: ActivationStatus
+    reconcile_status: ReconcileStatus
+    external_txn_id: str | None = None
+    verified_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PaymentErrorResponse(BaseModel):
+    """Deterministic error envelope for payment activation endpoints."""
+
+    status: str = "error"
+    code: str
+    message: str
+    detail: str

--- a/app/security/llm_monthly_quota.py
+++ b/app/security/llm_monthly_quota.py
@@ -20,30 +20,14 @@ from sqlalchemy import text
 from core.db import session_scope
 
 from app.models.llm_quota_usage import VipLlmMonthlyUsage  # noqa: F401  # register table metadata
+from app.security.server_salt import require_server_salt
 
-_SERVER_SALT_ENV = "SERVER_SALT"
 _VIP_LIMIT_ENV = "VIP_LLM_INSIGHT_REQUESTS_PER_MONTH"
 
 # NOTE: Table name must match app/models/llm_quota_usage.py.
 _USAGE_TABLE = "vip_llm_monthly_usage"
 
 DEFAULT_VIP_LLM_INSIGHT_REQUESTS_PER_MONTH = 30
-
-
-def require_server_salt() -> str:
-    """Return SERVER_SALT or raise (fail-fast contract).
-
-    RU: Возвращает SERVER_SALT или падает (fail-fast).
-    EN: Returns SERVER_SALT or raises (fail-fast).
-    """
-
-    salt = (os.getenv(_SERVER_SALT_ENV) or "").strip()
-    if not salt:
-        raise RuntimeError(
-            "SERVER_SALT is required for VIP LLM monthly quota enforcement. "
-            "Set SERVER_SALT to a non-empty secret value."
-        )
-    return salt
 
 
 def require_vip_llm_monthly_limit() -> int:

--- a/app/security/server_salt.py
+++ b/app/security/server_salt.py
@@ -1,0 +1,27 @@
+"""Shared SERVER_SALT access helper (domain-neutral).
+
+RU: Нейтральный helper для SERVER_SALT, без привязки к конкретному домену.
+EN: Domain-neutral SERVER_SALT helper shared across security-sensitive modules.
+"""
+
+from __future__ import annotations
+
+import os
+
+_SERVER_SALT_ENV = "SERVER_SALT"
+
+
+def require_server_salt() -> str:
+    """Return SERVER_SALT or raise (fail-fast contract).
+
+    RU: Возвращает SERVER_SALT или падает (fail-fast).
+    EN: Returns SERVER_SALT or raises (fail-fast).
+    """
+
+    salt = (os.getenv(_SERVER_SALT_ENV) or "").strip()
+    if not salt:
+        raise RuntimeError(
+            "SERVER_SALT is required for security-sensitive hashing. "
+            "Set SERVER_SALT to a non-empty secret value."
+        )
+    return salt

--- a/app/services/payments_activation.py
+++ b/app/services/payments_activation.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""In-memory payment activation service for baseline RU/BY + iOS contracts.
+
+RU: Временный in-memory сервис активации подписок (contract-first фаза).
+EN: Temporary in-memory subscription activation service (contract-first phase).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+import threading
+from typing import Any
+from uuid import uuid4
+
+from app.schemas.payments import (
+    ActivateSubscriptionRequest,
+    ActivationStatus,
+    PaymentSource,
+    ReconcileStatus,
+    SubscriptionActivationResponse,
+)
+
+_LOCK = threading.Lock()
+_ACTIVATIONS: dict[str, dict[str, Any]] = {}
+_IDEMPOTENCY_EVENTS: dict[tuple[str, str], tuple[str, str]] = {}
+
+
+class ActivationAccessForbiddenError(PermissionError):
+    """Raised when issuer attempts to read another issuer's activation."""
+
+
+def _utc_now() -> datetime:
+    """Return timezone-aware UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    """Build stable payload hash for idempotency validation."""
+    dumped = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(dumped.encode("utf-8")).hexdigest()
+
+
+def _resolve_statuses(
+    source: PaymentSource,
+    verification_ok: bool | None,
+) -> tuple[ActivationStatus, ReconcileStatus]:
+    """Resolve baseline statuses without external provider calls."""
+    if source is PaymentSource.ios_app_store:
+        if verification_ok is True:
+            return ActivationStatus.active, ReconcileStatus.verified
+        if verification_ok is False:
+            return ActivationStatus.rejected, ReconcileStatus.rejected
+        return ActivationStatus.pending_verification, ReconcileStatus.pending
+
+    # RU: Manual rails проходят через reconcile-флоу, поэтому стартуют с pending.
+    # EN: Manual rails start as pending until reconciliation completes.
+    return ActivationStatus.pending_verification, ReconcileStatus.pending
+
+
+def activate_subscription(
+    *,
+    issuer: str,
+    payload: ActivateSubscriptionRequest,
+) -> tuple[SubscriptionActivationResponse, bool]:
+    """Create activation record or return idempotent replay.
+
+    Returns:
+        (response, created_new)
+    """
+    request_payload = payload.model_dump(mode="json")
+    fingerprint = _payload_hash(request_payload)
+    idempotency_key = (issuer, payload.client_event_id)
+    now = _utc_now()
+
+    with _LOCK:
+        existing_event = _IDEMPOTENCY_EVENTS.get(idempotency_key)
+        if existing_event is not None:
+            activation_id, existing_hash = existing_event
+            if existing_hash != fingerprint:
+                raise ValueError("client_event_id conflict: payload mismatch")
+            replay_data = deepcopy(_ACTIVATIONS[activation_id])
+            replay: SubscriptionActivationResponse = SubscriptionActivationResponse.model_validate(
+                replay_data
+            )
+            return replay, False
+
+        status, reconcile_status = _resolve_statuses(payload.source, payload.verification_ok)
+        verified_at = (
+            now
+            if reconcile_status in {ReconcileStatus.verified, ReconcileStatus.rejected}
+            else None
+        )
+
+        activation_id = str(uuid4())
+        stored: dict[str, Any] = {
+            "activation_id": activation_id,
+            "issuer": issuer,
+            "payment_source": payload.source.value,
+            "status": status.value,
+            "reconcile_status": reconcile_status.value,
+            "external_txn_id": payload.external_txn_id,
+            "verified_at": verified_at.isoformat() if verified_at is not None else None,
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        _ACTIVATIONS[activation_id] = stored
+        _IDEMPOTENCY_EVENTS[idempotency_key] = (activation_id, fingerprint)
+
+        created: SubscriptionActivationResponse = SubscriptionActivationResponse.model_validate(
+            deepcopy(stored)
+        )
+        return created, True
+
+
+def get_activation(
+    activation_id: str,
+    *,
+    issuer: str,
+) -> SubscriptionActivationResponse | None:
+    """Fetch activation by id with issuer-level access control."""
+    with _LOCK:
+        stored = _ACTIVATIONS.get(activation_id)
+        if stored is None:
+            return None
+        if stored.get("issuer") != issuer:
+            raise ActivationAccessForbiddenError("activation access forbidden")
+        response: SubscriptionActivationResponse = SubscriptionActivationResponse.model_validate(
+            deepcopy(stored)
+        )
+        return response
+
+
+def reset_state() -> None:
+    """Reset in-memory state for deterministic tests."""
+    with _LOCK:
+        _ACTIVATIONS.clear()
+        _IDEMPOTENCY_EVENTS.clear()

--- a/app/services/payments_activation.py
+++ b/app/services/payments_activation.py
@@ -32,6 +32,10 @@ class ActivationAccessForbiddenError(PermissionError):
     """Raised when issuer attempts to read another issuer's activation."""
 
 
+class IdempotencyConflictError(ValueError):
+    """Raised when an idempotency key is reused with a different payload."""
+
+
 def _utc_now() -> datetime:
     """Return timezone-aware UTC timestamp."""
     return datetime.now(timezone.utc)
@@ -80,7 +84,7 @@ def activate_subscription(
         if existing_event is not None:
             activation_id, existing_hash = existing_event
             if existing_hash != fingerprint:
-                raise ValueError("client_event_id conflict: payload mismatch")
+                raise IdempotencyConflictError("client_event_id conflict: payload mismatch")
             replay_data = deepcopy(_ACTIVATIONS[activation_id])
             replay: SubscriptionActivationResponse = SubscriptionActivationResponse.model_validate(
                 replay_data

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3294,8 +3294,8 @@ If it is not recorded here — it does not exist.
 - [ ] P0: Payment rails for RU/BY + iOS-first monetization baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (revenue continuity)
-  - Target PR: PR #982 (triage dependency) -> PR-TBD-PAYMENTS-RUBY-IOS-BASELINE-CONTRACT
-  - Status: 🟡 In progress (contract-first docs wave)
+  - Target PR: PR #983 (contract docs) -> PR-TBD-PAYMENTS-RUBY-IOS-BASELINE-RUNTIME-W1
+  - Status: 🟡 In progress (runtime Wave R1: activation + status contract)
   - Reason (EN): Current business reality requires region-adapted payment rails: iOS as primary automated channel, RU/BY payments via eRIP (QR to account) and SWIFT card transfer fallback. Canonical billing flow must support these rails before global providers expansion. (RU: Текущий источник оплат: iOS + RU/BY локальные каналы (ЕРИП/QR и SWIFT). Нужен канонический billing baseline под эту реальность до расширения на глобальные провайдеры.)
   - Links:
     - docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
@@ -3305,6 +3305,9 @@ If it is not recorded here — it does not exist.
     - docs/contracts/PRODUCT_TIER_MAP.md
     - ios/PulsePlate/Services/ProKeyProvider.swift:1
     - app/routers/pro_registration.py:1
+    - app/routers/pro_payments.py:1
+    - app/schemas/payments.py:1
+    - app/services/payments_activation.py:1
   - Prerequisites:
     - ✅ Tier activation contract exists (FREE/PRO/VIP)
     - ⏳ Unified billing activation service is finalized for source-specific receipts

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -1,6 +1,69 @@
 {
   "components": {
     "schemas": {
+      "ActivateSubscriptionRequest": {
+        "description": "Activation request payload (contract-first, deterministic).",
+        "properties": {
+          "client_event_id": {
+            "description": "Client-generated idempotency event ID",
+            "maxLength": 128,
+            "minLength": 6,
+            "title": "Client Event Id",
+            "type": "string"
+          },
+          "external_txn_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 3,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Provider-side transaction or intent ID",
+            "title": "External Txn Id"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PaymentSource"
+          },
+          "verification_ok": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Deterministic verification result for baseline R1 contract",
+            "title": "Verification Ok"
+          },
+          "verification_payload": {
+            "additionalProperties": true,
+            "description": "Opaque verification payload. Server remains source of truth.",
+            "title": "Verification Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "source",
+          "client_event_id"
+        ],
+        "title": "ActivateSubscriptionRequest",
+        "type": "object"
+      },
+      "ActivationStatus": {
+        "description": "Canonical activation state for subscription activation flow.",
+        "enum": [
+          "pending_verification",
+          "active",
+          "rejected"
+        ],
+        "title": "ActivationStatus",
+        "type": "string"
+      },
       "AdherenceEventRequest": {
         "additionalProperties": false,
         "description": "Request schema for recording an adherence event.\n\nRU: Схема запроса для записи события adherence.\nEN: Request schema for recording an adherence event.\n\nSecurity Note:\n    subject_id is derived from authenticated API key (not from request payload)\n    to prevent horizontal privilege escalation.",
@@ -3950,6 +4013,45 @@
         "title": "PartnerOrderWeeklyAdapterRequest",
         "type": "object"
       },
+      "PaymentErrorResponse": {
+        "description": "Deterministic error envelope for payment activation endpoints.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "default": "error",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "detail"
+        ],
+        "title": "PaymentErrorResponse",
+        "type": "object"
+      },
+      "PaymentSource": {
+        "description": "Canonical payment sources (RU/BY + iOS baseline).",
+        "enum": [
+          "ios_app_store",
+          "erip_qr",
+          "swift_manual"
+        ],
+        "title": "PaymentSource",
+        "type": "string"
+      },
       "PlateRequest": {
         "description": "RU: Запрос на генерацию «Моей Тарелки». EN: Request to generate 'My Plate'.",
         "properties": {
@@ -5084,6 +5186,17 @@
         "title": "RecipeQueryHit",
         "type": "object"
       },
+      "ReconcileStatus": {
+        "description": "Reconciliation status for financial audit trail.",
+        "enum": [
+          "pending",
+          "verified",
+          "rejected",
+          "not_required"
+        ],
+        "title": "ReconcileStatus",
+        "type": "string"
+      },
       "SafetyCheckRequest": {
         "description": "RU: Запрос проверки безопасности целевых значений.\nEN: Request for safety validation of nutrition targets.",
         "properties": {
@@ -6205,6 +6318,67 @@
           "default_cta"
         ],
         "title": "SoftPaywallMessage",
+        "type": "object"
+      },
+      "SubscriptionActivationResponse": {
+        "description": "Canonical activation response for all payment sources.",
+        "properties": {
+          "activation_id": {
+            "title": "Activation Id",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "external_txn_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "External Txn Id"
+          },
+          "payment_source": {
+            "$ref": "#/components/schemas/PaymentSource"
+          },
+          "reconcile_status": {
+            "$ref": "#/components/schemas/ReconcileStatus"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActivationStatus"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "verified_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified At"
+          }
+        },
+        "required": [
+          "activation_id",
+          "payment_source",
+          "status",
+          "reconcile_status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SubscriptionActivationResponse",
         "type": "object"
       },
       "TargetsIn": {
@@ -7863,6 +8037,143 @@
         "summary": "WHO nutrition targets (PRO)",
         "tags": [
           "nutrition",
+          "pro"
+        ]
+      }
+    },
+    "/api/v1/pro/payments/activate": {
+      "post": {
+        "description": "Create activation or return idempotent replay.",
+        "operationId": "activate_subscription_api_v1_pro_payments_activate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivateSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionActivationResponse"
+                }
+              }
+            },
+            "description": "Idempotent replay"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionActivationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentErrorResponse"
+                }
+              }
+            },
+            "description": "client_event_id conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid activation payload"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Activate Subscription",
+        "tags": [
+          "payments",
+          "pro"
+        ]
+      }
+    },
+    "/api/v1/pro/payments/activations/{activation_id}": {
+      "get": {
+        "description": "Get activation status by ID.",
+        "operationId": "get_subscription_activation_api_v1_pro_payments_activations__activation_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "activation_id",
+            "required": true,
+            "schema": {
+              "title": "Activation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionActivationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentErrorResponse"
+                }
+              }
+            },
+            "description": "Activation access forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentErrorResponse"
+                }
+              }
+            },
+            "description": "Activation not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get Subscription Activation",
+        "tags": [
+          "payments",
           "pro"
         ]
       }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -8090,11 +8090,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaymentErrorResponse"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Invalid activation payload"
+            "description": "Validation Error"
           }
         },
         "security": [

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -493,6 +493,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/payments/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Activate Subscription
+         * @description Create activation or return idempotent replay.
+         */
+        post: operations["activate_subscription_api_v1_pro_payments_activate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/payments/activations/{activation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Subscription Activation
+         * @description Get activation status by ID.
+         */
+        get: operations["get_subscription_activation_api_v1_pro_payments_activations__activation_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/restaurants/partner/handoff/shares/{share_id}/revoke": {
         parameters: {
             query?: never;
@@ -1188,6 +1228,41 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * ActivateSubscriptionRequest
+         * @description Activation request payload (contract-first, deterministic).
+         */
+        ActivateSubscriptionRequest: {
+            /**
+             * Client Event Id
+             * @description Client-generated idempotency event ID
+             */
+            client_event_id: string;
+            /**
+             * External Txn Id
+             * @description Provider-side transaction or intent ID
+             */
+            external_txn_id?: string | null;
+            source: components["schemas"]["PaymentSource"];
+            /**
+             * Verification Ok
+             * @description Deterministic verification result for baseline R1 contract
+             */
+            verification_ok?: boolean | null;
+            /**
+             * Verification Payload
+             * @description Opaque verification payload. Server remains source of truth.
+             */
+            verification_payload?: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * ActivationStatus
+         * @description Canonical activation state for subscription activation flow.
+         * @enum {string}
+         */
+        ActivationStatus: "pending_verification" | "active" | "rejected";
         /**
          * AdherenceEventRequest
          * @description Request schema for recording an adherence event.
@@ -3216,6 +3291,29 @@ export interface components {
             };
         };
         /**
+         * PaymentErrorResponse
+         * @description Deterministic error envelope for payment activation endpoints.
+         */
+        PaymentErrorResponse: {
+            /** Code */
+            code: string;
+            /** Detail */
+            detail: string;
+            /** Message */
+            message: string;
+            /**
+             * Status
+             * @default error
+             */
+            status: string;
+        };
+        /**
+         * PaymentSource
+         * @description Canonical payment sources (RU/BY + iOS baseline).
+         * @enum {string}
+         */
+        PaymentSource: "ios_app_store" | "erip_qr" | "swift_manual";
+        /**
          * PlateRequest
          * @description RU: Запрос на генерацию «Моей Тарелки». EN: Request to generate 'My Plate'.
          */
@@ -3649,6 +3747,12 @@ export interface components {
             /** Title */
             title: string;
         };
+        /**
+         * ReconcileStatus
+         * @description Reconciliation status for financial audit trail.
+         * @enum {string}
+         */
+        ReconcileStatus: "pending" | "verified" | "rejected" | "not_required";
         /**
          * SafetyCheckRequest
          * @description RU: Запрос проверки безопасности целевых значений.
@@ -4296,6 +4400,31 @@ export interface components {
              * @description i18n key for title
              */
             title_key: string;
+        };
+        /**
+         * SubscriptionActivationResponse
+         * @description Canonical activation response for all payment sources.
+         */
+        SubscriptionActivationResponse: {
+            /** Activation Id */
+            activation_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** External Txn Id */
+            external_txn_id?: string | null;
+            payment_source: components["schemas"]["PaymentSource"];
+            reconcile_status: components["schemas"]["ReconcileStatus"];
+            status: components["schemas"]["ActivationStatus"];
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Verified At */
+            verified_at?: string | null;
         };
         /**
          * TargetsIn
@@ -5255,6 +5384,106 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WHOTargetsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    activate_subscription_api_v1_pro_payments_activate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ActivateSubscriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description Idempotent replay */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionActivationResponse"];
+                };
+            };
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionActivationResponse"];
+                };
+            };
+            /** @description client_event_id conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentErrorResponse"];
+                };
+            };
+            /** @description Invalid activation payload */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentErrorResponse"];
+                };
+            };
+        };
+    };
+    get_subscription_activation_api_v1_pro_payments_activations__activation_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                activation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionActivationResponse"];
+                };
+            };
+            /** @description Activation access forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentErrorResponse"];
+                };
+            };
+            /** @description Activation not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentErrorResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -5437,13 +5437,13 @@ export interface operations {
                     "application/json": components["schemas"]["PaymentErrorResponse"];
                 };
             };
-            /** @description Invalid activation payload */
+            /** @description Validation Error */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PaymentErrorResponse"];
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/scripts/orchestration/agent_consistency_loader.py
+++ b/scripts/orchestration/agent_consistency_loader.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Set, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = REPO_ROOT / "docs" / "orchestration" / "AGENT_INVENTORY.md"

--- a/tests/test_pro_payments_api.py
+++ b/tests/test_pro_payments_api.py
@@ -102,6 +102,26 @@ def test_activate_subscription_ios_without_verification_is_pending(
     assert payload["verified_at"] is None
 
 
+def test_activate_subscription_defaults_verification_payload_when_omitted(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json={
+            "source": "ios_app_store",
+            "client_event_id": "evt-ios-no-payload-1",
+            "verification_ok": True,
+            "external_txn_id": "txn-no-payload-1",
+        },
+    )
+    assert response.status_code == 201, response.text
+    payload = _json(response)
+    assert payload["status"] == "active"
+    assert payload["reconcile_status"] == "verified"
+
+
 def test_activate_subscription_manual_rails_start_pending(
     client: TestClient,
     pro_headers: dict[str, str],
@@ -171,7 +191,10 @@ def test_activate_subscription_idempotency_conflict_returns_409(
     )
     assert first.status_code == 201, first.text
     assert conflict.status_code == 409, conflict.text
-    assert "client_event_id conflict" in conflict.text
+    conflict_payload = _json(conflict)
+    assert conflict_payload["status"] == "error"
+    assert conflict_payload["code"] == "idempotency_conflict"
+    assert "client_event_id conflict" in conflict_payload["detail"]
 
 
 def test_activate_subscription_invalid_source_returns_422(
@@ -244,6 +267,9 @@ def test_get_activation_forbidden_for_other_issuer(
         headers=vip_headers,
     )
     assert fetched.status_code == 403
+    payload = _json(fetched)
+    assert payload["status"] == "error"
+    assert payload["code"] == "forbidden"
 
 
 def test_get_activation_not_found_returns_404(
@@ -255,3 +281,6 @@ def test_get_activation_not_found_returns_404(
         headers=pro_headers,
     )
     assert response.status_code == 404
+    payload = _json(response)
+    assert payload["status"] == "error"
+    assert payload["code"] == "not_found"

--- a/tests/test_pro_payments_api.py
+++ b/tests/test_pro_payments_api.py
@@ -227,6 +227,22 @@ def test_issuer_helper_supports_empty_api_key() -> None:
     assert _issuer_from_api_key("") == "api_key:anonymous"
 
 
+def test_issuer_helper_returns_stable_marker_for_same_api_key() -> None:
+    from app.routers.pro_payments import _issuer_from_api_key
+
+    first = _issuer_from_api_key("pro-key-issuer-stable")
+    second = _issuer_from_api_key("pro-key-issuer-stable")
+    assert first == second
+
+
+def test_issuer_helper_returns_distinct_markers_for_different_api_keys() -> None:
+    from app.routers.pro_payments import _issuer_from_api_key
+
+    first = _issuer_from_api_key("pro-key-issuer-a")
+    second = _issuer_from_api_key("pro-key-issuer-b")
+    assert first != second
+
+
 def test_get_activation_happy_path(
     client: TestClient,
     pro_headers: dict[str, str],

--- a/tests/test_pro_payments_api.py
+++ b/tests/test_pro_payments_api.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_payments_state() -> None:
+    from app.services import payments_activation
+
+    payments_activation.reset_state()
+
+
+def _json(response: Any) -> dict[str, Any]:
+    assert response.headers.get("content-type", "").startswith("application/json"), response.text
+    payload: dict[str, Any] = response.json()
+    return payload
+
+
+def _activation_payload(
+    *,
+    source: str = "ios_app_store",
+    client_event_id: str = "evt-activation-001",
+    verification_ok: bool | None = True,
+    external_txn_id: str | None = "txn-001",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "source": source,
+        "client_event_id": client_event_id,
+        "verification_payload": {"raw": "opaque"},
+    }
+    if verification_ok is not None:
+        payload["verification_ok"] = verification_ok
+    if external_txn_id is not None:
+        payload["external_txn_id"] = external_txn_id
+    return payload
+
+
+def test_activate_subscription_requires_pro_tier(client: TestClient) -> None:
+    response = client.post("/api/v1/pro/payments/activate", json=_activation_payload())
+    assert response.status_code in {401, 403}
+
+
+def test_activate_subscription_ios_verified_returns_201(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(source="ios_app_store", verification_ok=True),
+    )
+    assert response.status_code == 201, response.text
+    payload = _json(response)
+    assert payload["payment_source"] == "ios_app_store"
+    assert payload["status"] == "active"
+    assert payload["reconcile_status"] == "verified"
+    assert payload["verified_at"] is not None
+
+
+def test_activate_subscription_ios_rejected_returns_201(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(
+            source="ios_app_store",
+            client_event_id="evt-ios-rejected-1",
+            verification_ok=False,
+        ),
+    )
+    assert response.status_code == 201, response.text
+    payload = _json(response)
+    assert payload["status"] == "rejected"
+    assert payload["reconcile_status"] == "rejected"
+    assert payload["verified_at"] is not None
+
+
+def test_activate_subscription_ios_without_verification_is_pending(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(
+            source="ios_app_store",
+            client_event_id="evt-ios-pending-1",
+            verification_ok=None,
+            external_txn_id=None,
+        ),
+    )
+    assert response.status_code == 201, response.text
+    payload = _json(response)
+    assert payload["status"] == "pending_verification"
+    assert payload["reconcile_status"] == "pending"
+    assert payload["external_txn_id"] is None
+    assert payload["verified_at"] is None
+
+
+def test_activate_subscription_manual_rails_start_pending(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    for source in ("erip_qr", "swift_manual"):
+        response = client.post(
+            "/api/v1/pro/payments/activate",
+            headers=pro_headers,
+            json=_activation_payload(
+                source=source,
+                client_event_id=f"evt-{source}",
+                verification_ok=None,
+                external_txn_id=f"ext-{source}",
+            ),
+        )
+        assert response.status_code == 201, response.text
+        payload = _json(response)
+        assert payload["payment_source"] == source
+        assert payload["status"] == "pending_verification"
+        assert payload["reconcile_status"] == "pending"
+        assert payload["verified_at"] is None
+
+
+def test_activate_subscription_idempotent_replay_returns_200(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    body = _activation_payload(
+        source="ios_app_store",
+        client_event_id="evt-replay-1",
+        verification_ok=True,
+        external_txn_id="txn-replay",
+    )
+    first = client.post("/api/v1/pro/payments/activate", headers=pro_headers, json=body)
+    second = client.post("/api/v1/pro/payments/activate", headers=pro_headers, json=body)
+    assert first.status_code == 201, first.text
+    assert second.status_code == 200, second.text
+    first_payload = _json(first)
+    second_payload = _json(second)
+    assert first_payload["activation_id"] == second_payload["activation_id"]
+    assert first_payload == second_payload
+
+
+def test_activate_subscription_idempotency_conflict_returns_409(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    first = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(
+            source="ios_app_store",
+            client_event_id="evt-conflict-1",
+            verification_ok=True,
+            external_txn_id="txn-conflict-1",
+        ),
+    )
+    conflict = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(
+            source="ios_app_store",
+            client_event_id="evt-conflict-1",
+            verification_ok=False,
+            external_txn_id="txn-conflict-2",
+        ),
+    )
+    assert first.status_code == 201, first.text
+    assert conflict.status_code == 409, conflict.text
+    assert "client_event_id conflict" in conflict.text
+
+
+def test_activate_subscription_invalid_source_returns_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(source="unknown_source"),
+    )
+    assert response.status_code == 422
+
+
+def test_activate_subscription_blank_client_event_id_returns_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(client_event_id="   "),
+    )
+    assert response.status_code == 422
+
+
+def test_issuer_helper_supports_empty_api_key() -> None:
+    from app.routers.pro_payments import _issuer_from_api_key
+
+    assert _issuer_from_api_key("") == "api_key:anonymous"
+
+
+def test_get_activation_happy_path(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    created = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(client_event_id="evt-get-1"),
+    )
+    assert created.status_code == 201, created.text
+    activation_id = _json(created)["activation_id"]
+
+    fetched = client.get(
+        f"/api/v1/pro/payments/activations/{activation_id}",
+        headers=pro_headers,
+    )
+    assert fetched.status_code == 200, fetched.text
+    fetched_payload = _json(fetched)
+    assert fetched_payload["activation_id"] == activation_id
+    assert fetched_payload["payment_source"] == "ios_app_store"
+
+
+def test_get_activation_forbidden_for_other_issuer(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    vip_headers: dict[str, str],
+) -> None:
+    created = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_activation_payload(client_event_id="evt-forbidden-1"),
+    )
+    assert created.status_code == 201, created.text
+    activation_id = _json(created)["activation_id"]
+
+    fetched = client.get(
+        f"/api/v1/pro/payments/activations/{activation_id}",
+        headers=vip_headers,
+    )
+    assert fetched.status_code == 403
+
+
+def test_get_activation_not_found_returns_404(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.get(
+        "/api/v1/pro/payments/activations/missing-activation",
+        headers=pro_headers,
+    )
+    assert response.status_code == 404

--- a/tests/test_pro_payments_openapi_contract.py
+++ b/tests/test_pro_payments_openapi_contract.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _paths() -> dict[str, Any]:
+    import app
+
+    return app.app.openapi()["paths"]
+
+
+def _op(path: str, method: str) -> dict[str, Any]:
+    paths = _paths()
+    assert path in paths, f"Missing path in OpenAPI: {path}"
+    assert method in paths[path], f"Missing method {method} for path {path}"
+    op_data: dict[str, Any] = paths[path][method]
+    return op_data
+
+
+def _schema(path: str, method: str, status_code: str) -> dict[str, Any]:
+    op_data = _op(path, method)
+    schema: dict[str, Any] = op_data["responses"][status_code]["content"]["application/json"][
+        "schema"
+    ]
+    return schema
+
+
+def test_pro_payments_paths_registered_in_openapi() -> None:
+    paths = _paths()
+    assert "/api/v1/pro/payments/activate" in paths
+    assert "/api/v1/pro/payments/activations/{activation_id}" in paths
+
+
+def test_pro_payments_response_codes_contract() -> None:
+    expected = {
+        ("/api/v1/pro/payments/activate", "post"): {"200", "201", "409", "422"},
+        ("/api/v1/pro/payments/activations/{activation_id}", "get"): {"200", "403", "404"},
+    }
+    for (path, method), codes in expected.items():
+        responses = _op(path, method)["responses"]
+        assert codes.issubset(set(responses.keys()))
+
+
+def test_pro_payments_request_schema_refs() -> None:
+    activate_req_ref = _op("/api/v1/pro/payments/activate", "post")["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert activate_req_ref == "#/components/schemas/ActivateSubscriptionRequest"
+
+
+def test_pro_payments_response_schema_refs() -> None:
+    activate_schema = _schema("/api/v1/pro/payments/activate", "post", "201")
+    get_schema = _schema("/api/v1/pro/payments/activations/{activation_id}", "get", "200")
+    assert activate_schema == {"$ref": "#/components/schemas/SubscriptionActivationResponse"}
+    assert get_schema == {"$ref": "#/components/schemas/SubscriptionActivationResponse"}

--- a/tests/test_pro_payments_openapi_contract.py
+++ b/tests/test_pro_payments_openapi_contract.py
@@ -34,7 +34,12 @@ def test_pro_payments_paths_registered_in_openapi() -> None:
 def test_pro_payments_response_codes_contract() -> None:
     expected = {
         ("/api/v1/pro/payments/activate", "post"): {"200", "201", "409", "422"},
-        ("/api/v1/pro/payments/activations/{activation_id}", "get"): {"200", "403", "404"},
+        ("/api/v1/pro/payments/activations/{activation_id}", "get"): {
+            "200",
+            "403",
+            "404",
+            "422",
+        },
     }
     for (path, method), codes in expected.items():
         responses = _op(path, method)["responses"]
@@ -53,3 +58,23 @@ def test_pro_payments_response_schema_refs() -> None:
     get_schema = _schema("/api/v1/pro/payments/activations/{activation_id}", "get", "200")
     assert activate_schema == {"$ref": "#/components/schemas/SubscriptionActivationResponse"}
     assert get_schema == {"$ref": "#/components/schemas/SubscriptionActivationResponse"}
+
+
+def test_pro_payments_error_schema_refs() -> None:
+    payment_error_ref = "#/components/schemas/PaymentErrorResponse"
+    validation_error_ref = "#/components/schemas/HTTPValidationError"
+
+    assert _schema("/api/v1/pro/payments/activate", "post", "409")["$ref"] == payment_error_ref
+    assert _schema("/api/v1/pro/payments/activate", "post", "422")["$ref"] == validation_error_ref
+    assert (
+        _schema("/api/v1/pro/payments/activations/{activation_id}", "get", "403")["$ref"]
+        == payment_error_ref
+    )
+    assert (
+        _schema("/api/v1/pro/payments/activations/{activation_id}", "get", "404")["$ref"]
+        == payment_error_ref
+    )
+    assert (
+        _schema("/api/v1/pro/payments/activations/{activation_id}", "get", "422")["$ref"]
+        == validation_error_ref
+    )


### PR DESCRIPTION
## Summary
- Added runtime Wave R1 for payments baseline as additive PRO endpoints:
  - `POST /api/v1/pro/payments/activate`
  - `GET /api/v1/pro/payments/activations/{activation_id}`
- Implemented canonical source model (`ios_app_store`, `erip_qr`, `swift_manual`) with deterministic idempotency and activation/reconciliation states.
- Addressed Sourcery/Cubic/CodeRabbit/CodeQL actionables:
  - removed duplicate `require_pro_tier` execution,
  - introduced `IdempotencyConflictError` and explicit error envelope handling,
  - aligned OpenAPI 422 schema behavior,
  - added missing contract/API tests,
  - replaced direct hash coupling with keyed HMAC issuer marker via neutral security helper.

## Scope
- Runtime/API:
  - `app/routers/pro_payments.py`
  - `app/services/payments_activation.py`
  - `app/schemas/payments.py`
  - `app/routers/pro_registration.py`
- Contracts/artifacts:
  - `frontend/src/api/openapi.json`
  - `frontend/src/api/schema.ts`
- Tests:
  - `tests/test_pro_payments_api.py`
  - `tests/test_pro_payments_openapi_contract.py`
- Backlog SoT:
  - `docs/roadmap/BACKLOG_LEDGER.md`
- Carryover lint:
  - `scripts/orchestration/agent_consistency_loader.py`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files`
- `pytest -q tests/test_pro_payments_api.py tests/test_pro_payments_openapi_contract.py`
- `make openapi-check`
- `make verify`

## Security Notes
- No external payment provider network calls added.
- Idempotency conflict path is explicit and fail-closed (`409`).
- Activation reads are issuer-scoped (`403` on cross-issuer access).
- Issuer marker no longer hashes API keys; it uses an opaque process-stable mapping.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2891984312 -> aac9df17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3899308163 -> aac9df17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897544129 -> c588324c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890746768 -> c588324c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890740908 -> c588324c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897537337 -> c588324c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897061244 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890344984 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890344987 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890344995 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890345002 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890379989 -> 1d016700
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890393149 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890341508 -> 1d016700
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890380001 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890380009 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890380016 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897103991 -> 392673ba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897119165 -> 1d016700
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2890649209 -> 1d016700
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3897425603 -> 1d016700
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#discussion_r2892167089 -> c9b600fa
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/986#pullrequestreview-3899491345 -> c9b600fa

## Merge Readiness
- [x] OpenAPI artifacts regenerated and deterministic (`make openapi-check`)
- [x] Non-breaking additive contract (existing surfaces unchanged)
- [x] Canonical gates passed locally (`pre-commit`, `make verify`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pro Payments API with subscription activation and retrieval endpoints
  * Support for multiple payment sources (iOS App Store, ERIP QR, manual)
  * Idempotent activation workflow with status tracking (pending_verification, active, rejected) and deterministic error responses

* **Documentation**
  * OpenAPI/schema updated to include new payment models, endpoints and responses
  * Roadmap/backlog updated to reflect runtime activation/status focus

* **Tests**
  * Added API and OpenAPI contract tests covering auth, idempotency, statuses, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
