### PR TITLE
fix(security): resolve dependabot alert #47 (dompurify)

### DIFF
--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -12,26 +12,28 @@ Dependabot reported XSS vulnerability in DOMPurify. Affected versions: 2.5.3–2
 
 ## Remediation strategy
 
-- Add npm `overrides` in `frontend/package.json` to force `dompurify` to the patched commit `729097f` from DOMPurify main (fix not yet published to npm; verified on 2026-03-04 UTC).
-- When upstream releases a patched version (e.g. 3.3.2), replace override with version pin and remove this doc's "override" note.
+- Pin npm override to the patched release `dompurify@3.3.2`.
+- Regenerate `frontend/package-lock.json` so lock resolution also points to `3.3.2`.
 
 ## Evidence anchors
 
-- `frontend/package.json:82` — `overrides.dompurify` git resolution
-- `frontend/package-lock.json:5219` — resolved dompurify from git
+- `frontend/package.json:83` — `overrides.dompurify` pinned to `3.3.2`.
+- `frontend/package-lock.json:5219` — lockfile node for `dompurify@3.3.2`.
+- `frontend/package-lock.json:5221` — npm registry tarball resolution for `dompurify-3.3.2.tgz`.
 
 ## Validation
 
 ```bash
 cd frontend
 npm ls dompurify
-# Expect: dompurify overridden (git+...729097f...)
+# Expect: dompurify@3.3.2
+npm audit --omit=dev
+# Expect: found 0 vulnerabilities
 npm run build
 npm run test:ci
 ```
 
 ## Notes
 
-- Upstream fix: [commit 729097f](https://github.com/cure53/DOMPurify/commit/729097f63a78e3e0e9f771e648f462bee100e78f)
-- `npm audit` may still report the vulnerability; it does not recognize git-override as patched. Manual verification via commit hash is authoritative.
-- Monitor: [DOMPurify releases](https://github.com/cure53/DOMPurify/releases) for official patched release.
+- Upstream advisory: [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv).
+- Patch release is now available on npm; no transitional git-override workflow remains.

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -12,28 +12,26 @@ Dependabot reported XSS vulnerability in DOMPurify. Affected versions: 2.5.3–2
 
 ## Remediation strategy
 
-- Pin npm override to the patched release `dompurify@3.3.2`.
-- Regenerate `frontend/package-lock.json` so lock resolution also points to `3.3.2`.
+- Add npm `overrides` in `frontend/package.json` to force `dompurify` to the patched commit `729097f` from DOMPurify main (fix not yet published to npm; verified on 2026-03-04 UTC).
+- When upstream releases a patched version (e.g. 3.3.2), replace override with version pin and remove this doc's "override" note.
 
 ## Evidence anchors
 
-- `frontend/package.json:83` — `overrides.dompurify` pinned to `3.3.2`.
-- `frontend/package-lock.json:5219` — lockfile node for `dompurify@3.3.2`.
-- `frontend/package-lock.json:5221` — npm registry tarball resolution for `dompurify-3.3.2.tgz`.
+- `frontend/package.json:82` — `overrides.dompurify` git resolution
+- `frontend/package-lock.json:5219` — resolved dompurify from git
 
 ## Validation
 
 ```bash
 cd frontend
 npm ls dompurify
-# Expect: dompurify@3.3.2
-npm audit --omit=dev
-# Expect: found 0 vulnerabilities
+# Expect: dompurify overridden (git+...729097f...)
 npm run build
 npm run test:ci
 ```
 
 ## Notes
 
-- Upstream advisory: [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv).
-- Patch release is now available on npm; no transitional git-override workflow remains.
+- Upstream fix: [commit 729097f](https://github.com/cure53/DOMPurify/commit/729097f63a78e3e0e9f771e648f462bee100e78f)
+- `npm audit` may still report the vulnerability; it does not recognize git-override as patched. Manual verification via commit hash is authoritative.
+- Monitor: [DOMPurify releases](https://github.com/cure53/DOMPurify/releases) for official patched release.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5217,9 +5217,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "git+ssh://git@github.com/cure53/DOMPurify.git#729097f63a78e3e0e9f771e648f462bee100e78f",
-      "integrity": "sha512-SGZR0QPkK8tSpOaDuOzq+CRLs2EBvAQ4qa3BdaSbXLPsK1jQlB6jberaniJD1mnq3CJWIGidqj8kiPYE8a1C4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/expect": "^3.2.4",
     "autoprefixer": "^10.4.19",
+    "esbuild": "^0.25.0",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.7",
@@ -76,11 +77,10 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
     "vite": "^6.3.4",
-    "vitest": "^3.2.4",
-    "esbuild": "^0.25.0"
+    "vitest": "^3.2.4"
   },
   "overrides": {
-    "dompurify": "github:cure53/DOMPurify#729097f63a78e3e0e9f771e648f462bee100e78f"
+    "dompurify": "3.3.2"
   },
   "msw": {
     "workerDirectory": [

--- a/scripts/orchestration/agent_consistency_loader.py
+++ b/scripts/orchestration/agent_consistency_loader.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Set, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = REPO_ROOT / "docs" / "orchestration" / "AGENT_INVENTORY.md"

--- a/tests/test_frontend_dependency_guards.py
+++ b/tests/test_frontend_dependency_guards.py
@@ -1,0 +1,43 @@
+"""Deterministic frontend dependency security guards.
+
+RU: Проверяем, что dompurify закреплен на безопасной версии без git-override.
+EN: Ensure dompurify is pinned to a safe npm release without git overrides.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_PACKAGE_JSON = REPO_ROOT / "frontend" / "package.json"
+FRONTEND_LOCK_JSON = REPO_ROOT / "frontend" / "package-lock.json"
+MIN_DOMPURIFY_VERSION = Version("3.3.2")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_frontend_package_has_dompurify_override_floor() -> None:
+    """RU/EN: package.json override must keep dompurify at secure floor version."""
+    package_json = _load_json(FRONTEND_PACKAGE_JSON)
+    overrides = package_json.get("overrides", {})
+    dompurify_override = overrides.get("dompurify")
+    assert isinstance(dompurify_override, str), "frontend/package.json: overrides.dompurify missing"
+    assert Version(dompurify_override) >= MIN_DOMPURIFY_VERSION
+
+
+def test_frontend_lock_resolves_dompurify_to_safe_npm_release() -> None:
+    """RU/EN: package-lock must resolve dompurify from npm registry at secure floor version."""
+    package_lock = _load_json(FRONTEND_LOCK_JSON)
+    dompurify_pkg = package_lock.get("packages", {}).get("node_modules/dompurify", {})
+    lock_version = dompurify_pkg.get("version")
+    resolved = dompurify_pkg.get("resolved", "")
+
+    assert isinstance(lock_version, str), "frontend/package-lock.json: dompurify version missing"
+    assert Version(lock_version) >= MIN_DOMPURIFY_VERSION
+    assert isinstance(resolved, str) and "registry.npmjs.org/dompurify" in resolved
+    assert not resolved.startswith("git+"), "dompurify lock resolution must not use git override"

--- a/tests/test_frontend_dependency_guards.py
+++ b/tests/test_frontend_dependency_guards.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 from packaging.version import Version
 
@@ -39,5 +40,11 @@ def test_frontend_lock_resolves_dompurify_to_safe_npm_release() -> None:
 
     assert isinstance(lock_version, str), "frontend/package-lock.json: dompurify version missing"
     assert Version(lock_version) >= MIN_DOMPURIFY_VERSION
-    assert isinstance(resolved, str) and "registry.npmjs.org/dompurify" in resolved
+    assert (
+        isinstance(resolved, str) and resolved
+    ), "frontend/package-lock.json: dompurify resolved missing"
+    parsed = urlparse(resolved.removeprefix("git+"))
+    assert parsed.scheme == "https", "dompurify lock resolution must use https"
+    assert parsed.netloc == "registry.npmjs.org", "dompurify must resolve from npm registry"
+    assert parsed.path.startswith("/dompurify/"), "dompurify lock resolution path mismatch"
     assert not resolved.startswith("git+"), "dompurify lock resolution must not use git override"


### PR DESCRIPTION
## Summary
- Resolved Dependabot alert `#47` (`GHSA-v2wj-7wpq-c8vv`, `CVE-2026-0540`) by updating frontend `dompurify` override to `3.3.2`.
- Refreshed `frontend/package-lock.json` deterministically via `npm install --package-lock-only`.
- Included one minimal carryover lint fix from current `main` baseline (`scripts/orchestration/agent_consistency_loader.py`) to keep canonical gates green.

## Scope
- `frontend/package.json`
- `frontend/package-lock.json`
- `scripts/orchestration/agent_consistency_loader.py` (carryover lint-only)

## Validation
- `cd frontend && npm audit --omit=dev` (0 vulnerabilities)
- `pre-commit run --all-files`
- `make verify`

## Security Notes
- Patch addresses XSS advisory in DOMPurify vulnerable range (`3.1.3..3.3.1`).
- No runtime API behavior changes.
- Lockfile update is deterministic and scoped to frontend dependency graph.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#pullrequestreview-3899248885 -> e6a2c0c8
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#discussion_r2891931578 -> e6a2c0c8
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#pullrequestreview-3897747601 -> fbcea575
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#discussion_r2890888216 -> fbcea575
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#pullrequestreview-3897705372 -> fbcea575
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#discussion_r2890643575 -> 2ca7126c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/987#pullrequestreview-3897418720 -> 2ca7126c

## Merge Readiness
- [x] Canonical local gates passed (`pre-commit`, `make verify`)
- [x] Security fix is scoped and non-breaking




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dompurify to 3.3.2 and removed esbuild from build/dev dependencies

* **Tests**
  * Added deterministic dependency guard tests to ensure dompurify is pinned to a secure npm release and not a git reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
