### PR TITLE
docs(ledger): sync merged P0 hotfix statuses

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -162,11 +162,11 @@ If it is not recorded here — it does not exist.
   - Reason: If an exception is ever needed for a trigger-only mapping, add TTL allowlist (same style as nosec: remove-by, ref); empty by default.
   - DoD: Allowlist file exists (or doc); format documented; guard consults allowlist when present.
 
-- [ ] P0: OFF Vitamin D unit normalization (µg -> IU) + nameless-row guard
+- [x] P0: OFF Vitamin D unit normalization (µg -> IU) + nameless-row guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (data correctness)
   - Target PR: PR #976 (`fix/off-vitd-unit-conversion`)
-  - Status: 🟡 In progress (PR open)
+  - Status: ✅ Merged (PR #976, 2026-03-05)
   - Area: backend / food data normalization
   - Finding Type: correctness hotfix
   - Reason: Open Food Facts normalization writes `vitamin-d_100g` without deterministic µg→IU conversion and may ingest nameless rows; this degrades canonical nutrition trust and search quality.
@@ -180,11 +180,11 @@ If it is not recorded here — it does not exist.
     - Deterministic tests cover µg→IU mapping and nameless-row skip behavior
     - `pre-commit run --all-files` and `make verify` pass in PR scope
 
-- [ ] P0: GDPR retention cleanup implementation (replace stub with safe deletion)
+- [x] P0: GDPR retention cleanup implementation (replace stub with safe deletion)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (privacy/compliance)
   - Target PR: PR #978 (`fix/gdpr-log-retention-cleanup`)
-  - Status: 🟡 In progress (PR open)
+  - Status: ✅ Merged (PR #978, 2026-03-05)
   - Area: backend / compliance / operations
   - Finding Type: compliance hotfix
   - Reason: `cleanup_expired_logs()` was a non-destructive stub; privacy posture requires real retention enforcement with path safety and deterministic dry-run checks.
@@ -213,7 +213,7 @@ If it is not recorded here — it does not exist.
     - PR #974 (orchestration telemetry/spec package)
   - DoD:
     - Stale claims are marked as implemented with repository evidence
-    - Remaining open items track only fact-valid deltas (VitD, GDPR cleanup, RAG technical debt)
+    - Remaining open items track only fact-valid deltas (RAG technical debt + runtime governance follow-ups)
 
 - [x] P0: Food Data Platform Foundation (snapshot-first, multi-source, low-API-cost)
   - Owner: @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
- Sync only `BACKLOG_LEDGER` to reflect fact state already present in `main`.
- Marked two P0 items as merged (not in-progress):
  - OFF Vitamin D normalization + nameless-row guard (`PR #976`)
  - GDPR retention cleanup implementation (`PR #978`)
- Updated stale note in fact-check closure section to remove already-closed deltas.

## Scope
- Docs-only change:
  - `docs/roadmap/BACKLOG_LEDGER.md`

## Validation
- `pre-commit run --all-files`
- `make verify`

## Security Notes
- No runtime/API/code-path changes.
- No config/env/secret changes.

## Carryover
- This PR closes stale ledger state after merged runtime hotfixes (#976, #978).

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments.

## Merge Readiness
- [x] Docs-only scope
- [x] Canonical local gates passed (`pre-commit`, `make verify`)
- [x] No runtime contract changes

## Summary by Sourcery

Обновить дорожную карту BACKLOG_LEDGER, чтобы отразить влитые P0 хотфиксы и очистить устаревшие статусные заметки.

Документация:
- Отметить P0-задачи по нормализации OFF Vitamin D и очистке сроков хранения по GDPR как влитые, указав даты и ссылки на PR в BACKLOG_LEDGER.
- Скорректировать раздел закрытия фактчекинга, чтобы он отражал только оставшиеся факт-валидные дельты (технический долг по RAG и последующие шаги по runtime-governance).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the BACKLOG_LEDGER roadmap to reflect merged P0 hotfixes and clean up stale status notes.

Documentation:
- Mark OFF Vitamin D normalization and GDPR retention cleanup P0 items as merged with dates and PR references in BACKLOG_LEDGER.
- Adjust the fact-check closure section to indicate only remaining fact-valid deltas (RAG technical debt and runtime governance follow-ups).

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced BACKLOG_LEDGER to mark OFF Vitamin D unit normalization + nameless-row guard (PR #976) and GDPR retention cleanup (PR #978) as merged with dates, and updated the fact-check closure to track only RAG technical debt and runtime governance follow-ups. Docs-only; no runtime changes.

<sup>Written for commit 60c2f1d88b9f24e5cf3574881de2a5940a49d985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked two P0 backlog items as merged and added current merge dates/PR references.
  * Updated a previously "In progress" item to "Merged".
  * Refined summary wording to note remaining open items as “RAG technical debt + runtime governance follow-ups”.
  * Minor editorial adjustments to preserve structure and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->