### PR TITLE
fix/orch ban trigger commit mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
 4. Every resolved actionable must appear in **Fixed in Commit Mapping** with disposition-specific proof: **FIXED** → Commit SHA (and mapping line `- <url> -> <sha>`); **NOT-A-BUG** → Evidence (no commit required); **DEFERRED** → Backlog link (no commit required).
 5. If no disposition can be determined, **the thread remains open**.
 6. **Commit-after-comment:** When a thread is mapped to a commit SHA (e.g. `- <url> -> <sha>`), that commit MUST have been made **after** the comment timestamp. Merge readiness gate fails otherwise (enforced by `check_review_threads_disposition.py`). This prevents "map/resolve without fix": fix code first, then add mapping and resolve.
+7. **FIXED proof quality (trigger-only ban):** A commit SHA used as FIXED proof (`- <thread_url> -> <commit_sha>`) MUST NOT be a trigger-only commit. **Trigger-only** means: (a) **empty commit** (no changed files), or (b) commit subject containing `trigger ci`, `rerun ci`, or `rerun checks` (case-insensitive). Such SHAs are invalid FIXED proof and fail the merge readiness gate. Exceptions only via allowlist with TTL (empty by default; P2 if needed).
 
 **Purpose:** This policy prevents "checkbox-only" resolutions and ensures that every review comment results in a concrete action, justification, or backlog entry.
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -126,6 +126,24 @@ If it is not recorded here — it does not exist.
     - Guard detects banned binaries when call spans multiple lines, or document limitation
     - No false negatives on existing codebase
 
+- [ ] P1: Disposition guard — ban mapping to trigger-only commits
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (fix/orch-ban-trigger-commit-mapping)
+  - Area: orchestration / review governance
+  - Finding Type: process hardening
+  - Reason: Prevent FIXED proof bypass via empty or CI rerun/trigger commits. Mapping `- <url> -> <sha>` must not accept empty commits or commits whose subject matches trigger/rerun patterns.
+  - Links:
+    - `scripts/orchestration/check_review_threads_disposition.py`
+    - `tests/test_review_threads_disposition_strict.py`
+    - `AGENTS.md` (Review Governance)
+  - DoD:
+    - Gate fails when mapping SHA is empty commit (no changed files)
+    - Gate fails when commit subject matches trigger/rerun patterns (trigger ci, re-run ci, re-run checks)
+    - Tests cover deny (empty, trigger subject) and allow (normal commit)
+    - AGENTS.md updated with FIXED proof quality (trigger-only ban) rule
+    - Optional allowlist with TTL remains empty by default (P2 if needed)
+
 - [ ] P0: OFF Vitamin D unit normalization (µg -> IU) + nameless-row guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (data correctness)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -144,6 +144,24 @@ If it is not recorded here — it does not exist.
     - AGENTS.md updated with FIXED proof quality (trigger-only ban) rule
     - Optional allowlist with TTL remains empty by default (P2 if needed)
 
+- [ ] P2: Stabilize nosec allowlist keys (path + token/hash, not line)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR-TBD
+  - Area: guards / tech-debt
+  - Finding Type: robustness
+  - Reason: Line-based allowlist entries drift on any file edit; allowlist should key by path + code-fragment hash or token so refactors do not require allowlist updates.
+  - Links: `tests/guards/fixtures/nosec_policy_allowlist.txt`, `tests/guards/test_nosec_policy_guard.py`
+  - DoD: Allowlist format supports path + stable identifier (hash/snippet); guard matches by identifier; line number optional or derived.
+
+- [ ] P2: Extend trigger-only ban with optional allowlist TTL (if needed)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR-TBD
+  - Area: orchestration / review governance
+  - Reason: If an exception is ever needed for a trigger-only mapping, add TTL allowlist (same style as nosec: remove-by, ref); empty by default.
+  - DoD: Allowlist file exists (or doc); format documented; guard consults allowlist when present.
+
 - [ ] P0: OFF Vitamin D unit normalization (µg -> IU) + nameless-row guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (data correctness)

--- a/scripts/orchestration/check_review_threads_disposition.py
+++ b/scripts/orchestration/check_review_threads_disposition.py
@@ -89,6 +89,12 @@ def _parse_iso_datetime(value: str) -> datetime:
 # Allow only git rev format (7–40 hex chars) so argv is safe (Sourcery / injection)
 _GIT_SHA_RE = re.compile(r"^[a-f0-9]{7,40}$", re.IGNORECASE)
 
+# Trigger-only commit subject patterns (P1: ban mapping to rerun/trigger commits)
+_TRIGGER_SUBJECT_RE = re.compile(
+    r"(?:^|\b)(trigger\s+ci|re-?run\s+ci|re-?run\s+checks)(?:\b|$)",
+    re.IGNORECASE,
+)
+
 
 def _git_commit_time_iso(commit_sha: str) -> str:
     """
@@ -115,6 +121,80 @@ def _git_commit_time_iso(commit_sha: str) -> str:
     if not out:
         raise RuntimeError(f"git returned empty commit time for sha={commit_sha}")
     return out
+
+
+def _git_commit_subject(commit_sha: str) -> str:
+    """Return commit subject line for a SHA (git show -s --format=%s). SHA validated for safe argv."""
+    sha = commit_sha.strip()
+    if not _GIT_SHA_RE.match(sha):
+        raise RuntimeError(f"Invalid commit SHA format: {commit_sha!r}")
+    git_path = shutil.which("git")
+    if not git_path:
+        raise RuntimeError("git not found in PATH; required for trigger-only mapping guard")
+    result = subprocess.run(  # nosec B603 — fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
+        [git_path, "show", "-s", "--format=%s", sha],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_SEC,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git show subject failed for sha={commit_sha}: rc={result.returncode} stderr={result.stderr.strip()!r}"
+        )
+    return result.stdout.strip()
+
+
+def _git_changed_files(commit_sha: str) -> list[str]:
+    """Return list of files changed in a SHA (git show --name-only). Empty means empty commit. SHA validated."""
+    sha = commit_sha.strip()
+    if not _GIT_SHA_RE.match(sha):
+        raise RuntimeError(f"Invalid commit SHA format: {commit_sha!r}")
+    git_path = shutil.which("git")
+    if not git_path:
+        raise RuntimeError("git not found in PATH; required for trigger-only mapping guard")
+    result = subprocess.run(  # nosec B603 — fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
+        [git_path, "show", "--name-only", "--pretty=format:", sha],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_SEC,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git show name-only failed for sha={commit_sha}: rc={result.returncode} stderr={result.stderr.strip()!r}"
+        )
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+def _check_trigger_only_mapping(
+    resolved_threads: list[ResolvedThreadRef],
+    fixed_mapping_section: str,
+) -> list[str]:
+    """
+    Validate that each mapped SHA is not trigger-only (empty commit or rerun/trigger subject).
+    Returns list of violation messages; empty if all pass.
+    """
+    mapping = _parse_mapping_section(fixed_mapping_section)
+    violations: list[str] = []
+    for t in resolved_threads:
+        sha = mapping.get(t.url)
+        if not sha:
+            continue
+        changed_files = _git_changed_files(sha)
+        if not changed_files:
+            violations.append(
+                f"{t.url}: mapped to {sha} but commit is EMPTY (no changed files). "
+                "Trigger-only commits are not valid FIXED proof."
+            )
+            continue
+        subject = _git_commit_subject(sha)
+        if _TRIGGER_SUBJECT_RE.search(subject):
+            violations.append(
+                f"{t.url}: mapped to {sha} but commit subject looks like CI rerun/trigger "
+                f"('{subject}'). Trigger-only commits are not valid FIXED proof."
+            )
+    return violations
 
 
 def _parse_mapping_section(section: str) -> dict[str, str]:
@@ -432,6 +512,17 @@ def main() -> None:
             print(f"  - {v}")
         print(
             "\nFix: Make a code/doc fix commit, then add '- <thread_url> -> <commit_sha>' in Fixed in Commit Mapping."
+        )
+        sys.exit(1)
+
+    # Trigger-only mapping ban (P1): mapping to empty or rerun/trigger subject is not valid FIXED proof
+    trigger_violations = _check_trigger_only_mapping(resolved_threads, section)
+    if trigger_violations:
+        print("ERROR: Trigger-only commit policy violated. Map only real fix commits.\n")
+        for v in trigger_violations:
+            print(f"  - {v}")
+        print(
+            "\nFix: Do not map to empty commits or commits whose subject contains 'trigger ci' / 'rerun ci' / 'rerun checks'."
         )
         sys.exit(1)
 

--- a/tests/guards/fixtures/nosec_policy_allowlist.txt
+++ b/tests/guards/fixtures/nosec_policy_allowlist.txt
@@ -27,10 +27,12 @@ scripts/normalize_off_version.py:263 remove-by=2026-04-30 ref=PR-985
 scripts/orchestration/check_preflight.py:14 remove-by=2026-04-30 ref=PR-985
 scripts/orchestration/check_preflight.py:33 remove-by=2026-04-30 ref=PR-985
 scripts/orchestration/check_review_threads_disposition.py:62 remove-by=2026-04-30 ref=PR-985
-scripts/orchestration/check_review_threads_disposition.py:103 remove-by=2026-04-30 ref=PR-985
-scripts/orchestration/check_review_threads_disposition.py:188 remove-by=2026-04-30 ref=PR-985
-scripts/orchestration/check_review_threads_disposition.py:306 remove-by=2026-04-30 ref=PR-985
-scripts/orchestration/check_review_threads_disposition.py:348 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:109 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:134 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:156 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:268 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:386 remove-by=2026-04-30 ref=PR-985
+scripts/orchestration/check_review_threads_disposition.py:428 remove-by=2026-04-30 ref=PR-985
 scripts/schedule_food_db_update.py:13 remove-by=2026-04-30 ref=PR-985
 scripts/schedule_food_db_update.py:329 remove-by=2026-04-30 ref=PR-985
 scripts/schedule_food_db_update.py:596 remove-by=2026-04-30 ref=PR-985

--- a/tests/test_review_threads_disposition_strict.py
+++ b/tests/test_review_threads_disposition_strict.py
@@ -15,6 +15,7 @@ import scripts.orchestration.check_review_threads_disposition as _disposition_mo
 from scripts.orchestration.check_review_threads_disposition import (
     ResolvedThreadRef,
     _check_commit_after_comment,
+    _check_trigger_only_mapping,
     _env_diagnostic,
     _extract_fixed_mapping_section,
     _find_disposition_block_in_section,
@@ -334,3 +335,76 @@ def test_require_gh_token_preflight_passes_when_gh_token_set_and_gh_ok(
     fake_ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
     monkeypatch.setattr(_disposition_mod.subprocess, "run", lambda *a, **k: fake_ok)
     _require_gh_token_preflight(True, True)
+
+
+def test_trigger_only_mapping_fails_on_empty_commit(monkeypatch: "MonkeyPatch") -> None:
+    """Mapped SHA with no changed files → violation (empty commit)."""
+    monkeypatch.setattr(_disposition_mod, "_git_changed_files", lambda _sha: [])
+    monkeypatch.setattr(_disposition_mod, "_git_commit_subject", lambda _sha: "fix: real change")
+
+    threads = [
+        ResolvedThreadRef(
+            url="https://github.com/org/repo/pull/985#discussion_r1",
+            source="comment",
+            is_resolved=True,
+            created_at="2026-03-01T00:00:00Z",
+        )
+    ]
+    section = "- https://github.com/org/repo/pull/985#discussion_r1 -> abcdef12"
+
+    violations = _check_trigger_only_mapping(threads, section)
+    assert violations
+    assert "EMPTY" in violations[0]
+
+
+def test_trigger_only_mapping_fails_on_rerun_subject(monkeypatch: "MonkeyPatch") -> None:
+    """Mapped SHA with trigger/rerun subject → violation."""
+    monkeypatch.setattr(
+        _disposition_mod, "_git_changed_files", lambda _sha: ["scripts/orchestration/x.py"]
+    )
+    monkeypatch.setattr(
+        _disposition_mod,
+        "_git_commit_subject",
+        lambda _sha: "chore: trigger CI after resolving threads",
+    )
+
+    threads = [
+        ResolvedThreadRef(
+            url="https://github.com/org/repo/pull/985#discussion_r2",
+            source="comment",
+            is_resolved=True,
+            created_at="2026-03-01T00:00:00Z",
+        )
+    ]
+    section = "- https://github.com/org/repo/pull/985#discussion_r2 -> deadbeef"
+
+    violations = _check_trigger_only_mapping(threads, section)
+    assert violations
+    assert "rerun/trigger" in violations[0]
+
+
+def test_trigger_only_mapping_passes_on_normal_commit(monkeypatch: "MonkeyPatch") -> None:
+    """Mapped SHA with real changes and normal subject → no violation."""
+    monkeypatch.setattr(
+        _disposition_mod,
+        "_git_changed_files",
+        lambda _sha: ["scripts/orchestration/check_review_threads_disposition.py"],
+    )
+    monkeypatch.setattr(
+        _disposition_mod,
+        "_git_commit_subject",
+        lambda _sha: "fix(orchestration): enforce mapping proof correctness",
+    )
+
+    threads = [
+        ResolvedThreadRef(
+            url="https://github.com/org/repo/pull/985#discussion_r3",
+            source="comment",
+            is_resolved=True,
+            created_at="2026-03-01T00:00:00Z",
+        )
+    ]
+    section = "- https://github.com/org/repo/pull/985#discussion_r3 -> cafe1234"
+
+    violations = _check_trigger_only_mapping(threads, section)
+    assert violations == []


### PR DESCRIPTION
## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#pullrequestreview-3899772795 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#pullrequestreview-3899785610 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#discussion_r2892425548 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#discussion_r2892439509 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#discussion_r2892439517 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#discussion_r2892439525 -> e8ed7c98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/990#pullrequestreview-3899800153 -> e8ed7c98

---

- **docs(ledger): add P1 ban trigger-only commit mapping in disposition guard**
- **fix(orchestration): reject trigger-only commit SHAs in Fixed mapping (empty diff / rerun subject)**
- **test(orchestration): cover trigger-only commit mapping guard (empty diff, rerun subject, normal)**
- **docs(agents): forbid mapping FIXED to trigger-only commits (empty / rerun subject)**

## Summary by Sourcery

Обеспечить, что сопоставления тредов ревью в статусе FIXED не могут указывать на коммиты, содержащие только триггеры, и задокументировать новую политику.

Bug Fixes:
- Отклонять сопоставление тредов ревью с пустыми коммитами или коммитами с темами, соответствующими CI trigger/rerun, при валидации доказательства FIXED.

Enhancements:
- Добавить git‑хелперы и детектор trigger‑subject, используемые для проверки сопоставленных SHA коммитов в disposition guard.

Documentation:
- Задокументировать запрет на коммиты, содержащие только триггеры, и требования к качеству доказательства FIXED в backlog ledger и руководстве по review governance.

Tests:
- Добавить тесты, покрывающие сценарии с пустым коммитом, trigger/rerun‑subject и обычным коммитом для guard, предотвращающего сопоставление с коммитами, содержащими только триггеры.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce that review thread FIXED mappings cannot point to trigger-only commits and document the new policy.

Bug Fixes:
- Reject mapping review threads to empty commits or commits with CI trigger/rerun subjects when validating FIXED proof.

Enhancements:
- Add git helpers and a trigger-subject detector used to validate mapped commit SHAs in the disposition guard.

Documentation:
- Document the trigger-only commit ban and FIXED proof quality requirements in the backlog ledger and review governance guidelines.

Tests:
- Add tests covering empty-commit, trigger/rerun-subject, and normal-commit scenarios for the trigger-only mapping guard.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ban mapping FIXED threads to trigger-only commits in the disposition guard. Reject SHAs with empty diffs or CI rerun/trigger subjects to ensure real fixes.

- **Bug Fixes**
  - Enforce SHA validation in check_review_threads_disposition.py: fail gate on empty diff or subject matching "trigger ci", "rerun ci", or "rerun checks".
  - Add tests covering empty commit, rerun subject, and normal commit.
  - Update AGENTS.md and expand BACKLOG_LEDGER with the P1 rule DoD plus P2 follow-ups (nosec allowlist key stabilization and optional TTL allowlist for trigger-only ban).

<sup>Written for commit e8ed7c98f8823bf07f24a29c595d54d4d9cdfa0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented validation to prevent using trigger-only commits (e.g., "trigger CI", "rerun checks") as proof of fixes. Exceptions available via allowlist with TTL support.

* **Documentation**
  * Updated enforcement rules documentation and added three governance backlog items for disposition guards and trigger-only ban improvements.

* **Tests**
  * Added comprehensive test coverage for trigger-only commit validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

