### PR TITLE
fix(ci): prevent main red on gha cache export 404

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,9 @@ jobs:
           load: true
           tags: pulseplate:test
           # Omit cache-from to avoid 404 BlobNotFound when GHA cache entry is missing; still write cache for publish job.
-          # mode=min to avoid 30+ min export (mode=max exports every layer → huge upload to GHA).
-          cache-to: type=gha,mode=min
+          # mode=min to avoid 30+ min export (mode=max exports every layer -> huge upload to GHA).
+          # ignore-error=true keeps build green when GHA cache backend is transiently unavailable.
+          cache-to: type=gha,mode=min,ignore-error=true
           target: production
 
       - name: Test Docker image
@@ -181,7 +182,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           # mode=min to match build job and keep cache export/import fast (mode=max can hang 30+ min on export).
-          cache-to: type=gha,mode=min
+          # ignore-error=true prevents publish failure when cache exporter returns transient BlobNotFound.
+          cache-to: type=gha,mode=min,ignore-error=true
           # Disable provenance to prevent GHA cache export errors ("cache entry no longer exists").
           # Trade-off: SLSA attestations disabled; cosign verify-attestation will fail. Re-enable when buildx/GHA fix is available.
           provenance: false


### PR DESCRIPTION
## Summary
- Fixes main CI failure in `Docker Build and Push` workflow (`run 22736425991`, job `publish`).
- Root cause: `docker/build-push-action` failed during `cache-to: type=gha` export with transient Actions Cache backend `BlobNotFound (404)`.
- Makes cache export fail-safe by adding `ignore-error=true` to `cache-to` in build and publish steps.

## Scope
- `.github/workflows/build.yml`

## Validation
- `pre-commit run --all-files`
- `make verify`

## Security Notes
- No runtime code changes.
- No auth/secret changes.
- Container publish path remains intact; only cache export failure behavior is hardened.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/991#pullrequestreview-3900016499 -> 900ec48d

## Merge Readiness
- [x] Local quality gates passed (`pre-commit`, `make verify`)
- [x] Minimal infra-only diff
- [x] Non-breaking (workflow robustness only)

## Summary by Sourcery

Усилить устойчивость workflow GitHub Actions для сборки Docker-образа и публикации против временных сбоев экспорта кэша GitHub Actions.

CI:
- Настроить экспорт кэша в задаче сборки Docker так, чтобы игнорировать временные ошибки backend’а кэша GitHub Actions и не допускать падения основного CI.
- Настроить экспорт кэша в задаче публикации Docker так, чтобы игнорировать временные ошибки backend’а кэша GitHub Actions и сохранять успешность релизов несмотря на проблемы с кэшем.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the Docker build and publish GitHub Actions workflow against transient GitHub Actions cache export failures.

CI:
- Make Docker build job cache export ignore transient GitHub Actions cache backend errors to avoid failing main CI.
- Make Docker publish job cache export ignore transient GitHub Actions cache backend errors to keep releases green despite cache issues.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Docker Build and Push workflow resilient to transient GHA cache export failures. Adds ignore-error=true to cache-to so BlobNotFound (404) no longer breaks main.

- **Bug Fixes**
  - Add ignore-error=true to cache-to (mode=min) in both build and publish steps.
  - Keep publish cache-from as-is; test build still omits cache-from.
  - No runtime or secret changes; image build/publish behavior unchanged.

<sup>Written for commit 900ec48d327bb17c996c75511399f1b9de1a118a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and publish pipeline resilience to transient infrastructure issues, ensuring deployment processes continue smoothly even when temporary cache availability problems occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
