### PR TITLE
fix(security): replace fingerprint hashing helper

### DIFF
--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -30,8 +30,8 @@ def _issuer_from_api_key(api_key: str) -> str:
     """Return deterministic opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
-    # RU: Используем солёный blake2 fingerprint без хранения raw API key в памяти.
-    # EN: Use salted blake2 fingerprint and avoid storing raw API keys in module state.
+    # RU: Используем солёный fingerprint без хранения raw API key в памяти.
+    # EN: Use a salted fingerprint and avoid storing raw API keys in module state.
     marker = compute_fingerprint(api_key, truncate=32)
     return f"api_key:{marker}"
 

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
 
-from core.fingerprint_security import compute_fingerprint
+from core.fingerprint_security import compute_secret_marker
 
 from app.middleware.api_tiers import require_pro_tier
 from app.schemas.payments import (
@@ -30,9 +30,9 @@ def _issuer_from_api_key(api_key: str) -> str:
     """Return deterministic opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
-    # RU: Используем солёный fingerprint без хранения raw API key в памяти.
-    # EN: Use a salted fingerprint and avoid storing raw API keys in module state.
-    marker = compute_fingerprint(api_key, truncate=32)
+    # RU: Используем PBKDF2-based marker без хранения raw API key в module state.
+    # EN: Use a PBKDF2-based marker and avoid storing raw API keys in module state.
+    marker = compute_secret_marker(api_key, truncate=32)
     return f"api_key:{marker}"
 
 

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -30,6 +30,10 @@ def _issuer_from_api_key(api_key: str) -> str:
     """Return deterministic opaque issuer marker from API key."""
     if not api_key:
         return "api_key:anonymous"
+    # RU: Текущий activation store process-local/in-memory, поэтому cross-deploy
+    #     migration старых issuer marker-ов не требуется до появления durable storage.
+    # EN: The current activation store is process-local/in-memory, so cross-deploy
+    #     migration of historical issuer markers is not required until durable storage lands.
     # RU: Используем PBKDF2-based marker без хранения raw API key в module state.
     # EN: Use a PBKDF2-based marker and avoid storing raw API keys in module state.
     marker = compute_secret_marker(api_key, truncate=32)

--- a/core/fingerprint_security.py
+++ b/core/fingerprint_security.py
@@ -11,12 +11,13 @@ fails or is disabled), a process-local salt is generated as a last-resort fallba
 Note that this process-local salt is NOT persisted across restarts, so fingerprints
 will not be stable between processes unless a persistent salt is provided via
 environment variable or a successfully written cache file. The fallback salt
-provides 256-bit (32-byte) entropy for enhanced Blake2s keyed-hash security.
+provides 256-bit (32-byte) entropy for HMAC-SHA256 pseudonymous hashing.
 """
 
 from __future__ import annotations
 
 import hashlib
+import hmac
 import logging
 import os
 import secrets
@@ -74,43 +75,30 @@ def _load_salt_from_file(path: Path) -> str | None:
     same stable salt being used process-wide via lru_cache.
     """
     try:
-        # Try reading existing salt first
         if path.exists():
             saved = _read_salt(path)
             if saved:
                 return saved
 
-        # Ensure parent directory exists
         _ensure_dir_and_perms(path)
+        generated = secrets.token_hex(32)
 
-        # Generate new salt
-        generated = secrets.token_hex(32)  # Generate 256-bit (32-byte) salt
-
-        # Try exclusive write (creates file only if it doesn't exist)
         if _write_salt_exclusive(path, generated):
-            # Successfully created file, set permissions and return
             _ensure_dir_and_perms(path)
             return generated
 
-        # File was created by another process - try reading it
         saved = _read_salt(path)
         if saved:
             return saved
 
-        # File exists but is empty - attempt to persist generated salt for stability
-        # Note: Race condition possible here; first writer wins, losers will
-        # read their value on next restart. Acceptable for this use case.
         try:
             path.write_text(generated)
         except (OSError, IOError, PermissionError):
-            # If we cannot write, still return the generated value
-            # (process-stable via caller cache)
             logger.debug("Could not persist fingerprint salt", exc_info=True)
 
         _ensure_dir_and_perms(path)
         return generated
     except (OSError, IOError, PermissionError):
-        # Fallback handled by caller - return None if we cannot access filesystem
         return None
 
 
@@ -118,7 +106,7 @@ def _load_salt_from_file(path: Path) -> str | None:
 def _get_salt() -> str:
     """Return a secret salt used for pseudonymous hashing.
 
-    Provides 256-bit (32-byte) entropy for Blake2s keyed-hash security
+    Provides 256-bit (32-byte) entropy for HMAC-SHA256 keyed hashing
     when using fallback generation.
     """
     env_salt = os.getenv(SALT_ENV_VAR)
@@ -130,13 +118,13 @@ def _get_salt() -> str:
     if file_salt:
         return file_salt
 
-    # Last-resort fallback; keeps process-stable but not persisted
-    # Provides 256-bit (32-byte) entropy for Blake2s keyed-hash security
-    return secrets.token_hex(32)  # Generate 256-bit (32-byte) salt
+    # Last-resort fallback; keeps process-stable but not persisted.
+    # Provides 256-bit (32-byte) entropy for HMAC-SHA256 keyed hashing.
+    return secrets.token_hex(32)
 
 
 def compute_fingerprint(source: str, *, truncate: int = 12) -> str:
-    """Return a pseudonymous fingerprint for the given identifier."""
+    """Return a salted pseudonymous fingerprint for the given identifier."""
     if not source:
         return ""
 
@@ -144,12 +132,8 @@ def compute_fingerprint(source: str, *, truncate: int = 12) -> str:
         raise ValueError(f"truncate must be non-negative, got {truncate}")
 
     salt = _get_salt().encode("utf-8")
-    # Blake2s key is limited to 32 bytes; hash longer salts
-    if len(salt) > 32:
-        salt = hashlib.blake2s(salt, digest_size=32).digest()
     data = source.encode("utf-8")
-
-    digest = hashlib.blake2s(data, key=salt).hexdigest()
+    digest = hmac.new(salt, data, hashlib.sha256).hexdigest()
     length = truncate if truncate > 0 else len(digest)
     return digest[:length]
 
@@ -194,34 +178,27 @@ def _client_fingerprint(request: ClientFingerprintRequest) -> str | None:
     """
     import ipaddress
 
-    # Load trusted proxies from config/env
     trusted_proxies_str = os.getenv("TRUSTED_PROXIES", "")
     trusted_proxies = {proxy.strip() for proxy in trusted_proxies_str.split(",") if proxy.strip()}
 
-    # Get the immediate remote host
     remote_host = request.client.host if request.client else ""
 
-    # Determine the source IP based on trusted proxy configuration
     source = remote_host
     if remote_host in trusted_proxies:
-        # Only trust X-Forwarded-For when the immediate remote host is a trusted proxy
         forwarded_for = request.headers.get("x-forwarded-for", "")
         if forwarded_for:
-            # Split and strip the X-Forwarded-For header to get the client IP
             forwarded_ips = [ip.strip() for ip in forwarded_for.split(",")]
             if forwarded_ips:
-                # Validate the first IP syntactically
                 try:
                     ipaddress.ip_address(forwarded_ips[0])
                     source = forwarded_ips[0]
                 except ValueError:
-                    # Ignore malformed IP addresses
                     pass
 
     if not source:
         return None
     # Hash with salt so raw IP is never logged while keeping ability to correlate requests.
-    # Uses secure salt storage - see core.fingerprint_security for details
+    # Uses secure salt storage - see core.fingerprint_security for details.
     return compute_fingerprint(source)
 
 

--- a/core/fingerprint_security.py
+++ b/core/fingerprint_security.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 SALT_ENV_VAR: Final[str] = "FINGERPRINT_SALT"
 SALT_FILE_ENV_VAR: Final[str] = "FINGERPRINT_SALT_FILE"
 DEFAULT_SALT_PATH: Final[Path] = Path("cache") / "fingerprint_salt.txt"
+SECRET_MARKER_ITERATIONS: Final[int] = 120_000
 
 
 def _read_salt(path: Path) -> str | None:
@@ -138,6 +139,31 @@ def compute_fingerprint(source: str, *, truncate: int = 12) -> str:
     return digest[:length]
 
 
+def compute_secret_marker(secret: str, *, truncate: int = 32) -> str:
+    """Return a PBKDF2-based opaque marker for limited-input secrets.
+
+    RU: Возвращает opaque marker для секретов с ограниченным пространством значений.
+    EN: Returns an opaque marker for limited-input secrets using PBKDF2-HMAC-SHA256.
+    """
+    if not secret:
+        return ""
+
+    if truncate < 0:
+        raise ValueError(f"truncate must be non-negative, got {truncate}")
+
+    salt = _get_salt().encode("utf-8")
+    secret_bytes = secret.encode("utf-8")
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        secret_bytes,
+        salt,
+        SECRET_MARKER_ITERATIONS,
+        dklen=32,
+    ).hex()
+    length = truncate if truncate > 0 else len(digest)
+    return digest[:length]
+
+
 @runtime_checkable
 class _ClientLike(Protocol):
     """Protocol for request.client attribute."""
@@ -202,4 +228,4 @@ def _client_fingerprint(request: ClientFingerprintRequest) -> str | None:
     return compute_fingerprint(source)
 
 
-__all__ = ["compute_fingerprint", "_client_fingerprint"]
+__all__ = ["compute_fingerprint", "compute_secret_marker", "_client_fingerprint"]

--- a/tests/test_fingerprint_and_retention.py
+++ b/tests/test_fingerprint_and_retention.py
@@ -217,6 +217,32 @@ def test_secret_marker_empty_secret_returns_empty_string() -> None:
     assert fingerprint_security.compute_secret_marker("", truncate=16) == ""
 
 
+def test_secret_marker_truncate_zero_returns_full_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """truncate=0 should return the full PBKDF2-HMAC-SHA256 hex digest."""
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "secret-salt-a")
+    fingerprint_security._get_salt.cache_clear()
+
+    digest = fingerprint_security.compute_secret_marker("api-key-123", truncate=0)
+
+    assert len(digest) == 64
+    fingerprint_security._get_salt.cache_clear()
+
+
+def test_secret_marker_truncate_larger_than_digest_returns_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large truncate values should still return the full digest."""
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "secret-salt-a")
+    fingerprint_security._get_salt.cache_clear()
+
+    digest = fingerprint_security.compute_secret_marker("api-key-123", truncate=9999)
+
+    assert len(digest) == 64
+    fingerprint_security._get_salt.cache_clear()
+
+
 def test_secret_marker_negative_truncate_raises_value_error() -> None:
     """Negative truncate must fail fast for secret markers too."""
     with pytest.raises(ValueError, match=r"truncate must be non-negative, got -1"):

--- a/tests/test_fingerprint_and_retention.py
+++ b/tests/test_fingerprint_and_retention.py
@@ -21,6 +21,18 @@ def test_fingerprint_uses_env_salt(monkeypatch: pytest.MonkeyPatch) -> None:
     fingerprint_security._get_salt.cache_clear()
 
 
+def test_fingerprint_changes_when_source_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Different inputs must produce different pseudonymous fingerprints."""
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "stable-salt")
+    fingerprint_security._get_salt.cache_clear()
+
+    first = fingerprint_security.compute_fingerprint("client-ip-a", truncate=16)
+    second = fingerprint_security.compute_fingerprint("client-ip-b", truncate=16)
+
+    assert first != second
+    fingerprint_security._get_salt.cache_clear()
+
+
 def test_fingerprint_creates_salt_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When no env salt is provided, module should create/read a salt file."""
     salt_file = tmp_path / "salt.txt"
@@ -109,9 +121,8 @@ def test_fingerprint_empty_source_returns_empty_string() -> None:
 
 
 def test_fingerprint_truncate_zero_returns_full_digest() -> None:
-    """truncate=0 should return full blake2s hex digest (64 chars)."""
+    """truncate=0 should return the full HMAC-SHA256 hex digest."""
     fp = fingerprint_security.compute_fingerprint("test-data", truncate=0)
-    # blake2s produces 32-byte digest, hexdigest is 64 characters
     assert len(fp) == 64
     assert isinstance(fp, str)
 
@@ -127,7 +138,6 @@ def test_fingerprint_negative_truncate_raises_value_error() -> None:
 
 def test_fingerprint_truncate_larger_than_digest_returns_full() -> None:
     """truncate larger than digest length should return full digest (64 chars)."""
-    # blake2s hexdigest is 64 chars, request 100
     fp = fingerprint_security.compute_fingerprint("test-data", truncate=100)
     assert len(fp) == 64  # Returns full digest, not padded
 
@@ -136,17 +146,18 @@ def test_fingerprint_truncate_larger_than_digest_returns_full() -> None:
     assert len(fp_large) == 64
 
 
-def test_fingerprint_long_salt_hashed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Salt longer than 32 bytes is hashed before use in blake2s."""
-    # Force a very long salt via environment
+def test_fingerprint_long_salt_is_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Long salts remain supported and deterministic."""
     long_salt = "a" * 100
 
     monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, long_salt)
     fingerprint_security._get_salt.cache_clear()
 
-    fp = fingerprint_security.compute_fingerprint("test-source", truncate=12)
-    assert isinstance(fp, str)
-    assert len(fp) == 12
+    first = fingerprint_security.compute_fingerprint("test-source", truncate=12)
+    second = fingerprint_security.compute_fingerprint("test-source", truncate=12)
+    assert isinstance(first, str)
+    assert len(first) == 12
+    assert first == second
     fingerprint_security._get_salt.cache_clear()
 
 

--- a/tests/test_fingerprint_and_retention.py
+++ b/tests/test_fingerprint_and_retention.py
@@ -33,6 +33,20 @@ def test_fingerprint_changes_when_source_changes(monkeypatch: pytest.MonkeyPatch
     fingerprint_security._get_salt.cache_clear()
 
 
+def test_fingerprint_changes_when_salt_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Changing salt must change the fingerprint for the same source."""
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "salt-a")
+    fingerprint_security._get_salt.cache_clear()
+    first = fingerprint_security.compute_fingerprint("client-ip", truncate=16)
+
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "salt-b")
+    fingerprint_security._get_salt.cache_clear()
+    second = fingerprint_security.compute_fingerprint("client-ip", truncate=16)
+
+    assert first != second
+    fingerprint_security._get_salt.cache_clear()
+
+
 def test_fingerprint_creates_salt_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When no env salt is provided, module should create/read a salt file."""
     salt_file = tmp_path / "salt.txt"
@@ -176,6 +190,37 @@ def test_fingerprint_file_read_exception_fallback(
         assert result is None
 
     fingerprint_security._get_salt.cache_clear()
+
+
+def test_secret_marker_uses_pbkdf2_for_limited_input_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API-key style markers remain deterministic and salt-sensitive."""
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "secret-salt-a")
+    fingerprint_security._get_salt.cache_clear()
+    first = fingerprint_security.compute_secret_marker("api-key-123", truncate=32)
+    repeat = fingerprint_security.compute_secret_marker("api-key-123", truncate=32)
+
+    monkeypatch.setenv(fingerprint_security.SALT_ENV_VAR, "secret-salt-b")
+    fingerprint_security._get_salt.cache_clear()
+    changed = fingerprint_security.compute_secret_marker("api-key-123", truncate=32)
+
+    assert first == repeat
+    assert first != changed
+    assert len(first) == 32
+    fingerprint_security._get_salt.cache_clear()
+
+
+def test_secret_marker_empty_secret_returns_empty_string() -> None:
+    """Empty limited-input secrets should not produce opaque markers."""
+    assert fingerprint_security.compute_secret_marker("") == ""
+    assert fingerprint_security.compute_secret_marker("", truncate=16) == ""
+
+
+def test_secret_marker_negative_truncate_raises_value_error() -> None:
+    """Negative truncate must fail fast for secret markers too."""
+    with pytest.raises(ValueError, match=r"truncate must be non-negative, got -1"):
+        fingerprint_security.compute_secret_marker("api-key-123", truncate=-1)
 
 
 def test_log_retention_manager_properties() -> None:

--- a/tests/test_pro_payments_api.py
+++ b/tests/test_pro_payments_api.py
@@ -300,3 +300,33 @@ def test_get_activation_not_found_returns_404(
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "not_found"
+
+
+def test_payments_activation_reset_state_clears_process_local_records() -> None:
+    from app.schemas.payments import ActivateSubscriptionRequest
+    from app.services import payments_activation
+
+    payload = ActivateSubscriptionRequest.model_validate(_activation_payload())
+    activation, created = payments_activation.activate_subscription(
+        issuer="api_key:test-process-local",
+        payload=payload,
+    )
+
+    assert created is True
+    assert (
+        payments_activation.get_activation(
+            activation.activation_id,
+            issuer="api_key:test-process-local",
+        )
+        is not None
+    )
+
+    payments_activation.reset_state()
+
+    assert (
+        payments_activation.get_activation(
+            activation.activation_id,
+            issuer="api_key:test-process-local",
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- replace pseudonymous fingerprint helper hashing with salted HMAC-SHA256
- keep `compute_fingerprint()` contract stable for callers and tests
- update fingerprint tests/comments to assert behavior instead of Blake2-specific implementation

## Testing
- `pytest -q tests/test_fingerprint_and_retention.py tests/test_pro_payments_api.py tests/test_rate_limit_client_key_api.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/992#discussion_r2894271076 -> d2a9fe40
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/992#pullrequestreview-3901945159 -> d2a9fe40
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/992#discussion_r2894273058 -> d2a9fe40
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/992#discussion_r2894432044 -> 5101bfd4
  Disposition: NOT-A-BUG for the persistence concern; Evidence: app/services/payments_activation.py:1 and app/routers/pro_payments.py:31 describe the current process-local in-memory baseline, while 5101bfd4 adds contract-parity tests and explicit process-local reset evidence.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/992#pullrequestreview-3902157200 -> 5101bfd4

## Merge Readiness
- [x] Local quality gates passed
- [x] No known unresolved threads at PR creation time
- [x] No known unmapped actionable bot comments at PR creation time

## Summary by Sourcery

Переключить вычисление псевдонимного отпечатка на схему с солью на основе HMAC-SHA256, сохранив при этом публичный API отпечатков и поведение для вызывающего кода.

Исправления ошибок:
- Обеспечить вычисление отпечатков клиента и API-ключа с использованием хеша HMAC-SHA256 с солью вместо прежнего вспомогательного механизма на базе Blake2 для повышения безопасности.

Улучшения:
- Упростить работу с файлoм соли и уточнить документацию, связанную с использованием соли и длиной дайджеста.
- Усилить и обновить тесты отпечатков так, чтобы они проверяли поведение (стабильность, уникальность, усечение и обработку длинной соли), а не детали реализации, специфичные для Blake2.

Тесты:
- Добавить и скорректировать тесты отпечатков, чтобы покрыть поведенческие гарантии, такие как различающиеся результаты для разных источников, полная длина дайджеста и детерминированные результаты при использовании длинных солей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch pseudonymous fingerprint computation to a salted HMAC-SHA256 scheme while preserving the public fingerprint API and behavior for callers.

Bug Fixes:
- Ensure client and API key fingerprints are derived using a salted HMAC-SHA256 hash instead of the previous Blake2-based helper for improved security.

Enhancements:
- Simplify salt file handling and clarify documentation around salt usage and digest length.
- Strengthen and update fingerprint tests to validate behavior (stability, uniqueness, truncation, and long-salt handling) rather than Blake2-specific implementation details.

Tests:
- Add and adjust fingerprint tests to cover behavioral guarantees such as differing outputs for different sources, full-digest length, and deterministic results with long salts.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched pseudonymous fingerprinting to salted HMAC-SHA256 and introduced a PBKDF2-based secret marker for API keys to harden issuer IDs. compute_fingerprint behavior stays the same; pro_payments now derives issuer markers with compute_secret_marker.

- **Refactors**
  - Replaced Blake2s fingerprint with HMAC-SHA256; truncation and 64-char full digest unchanged.
  - Added compute_secret_marker (PBKDF2-HMAC-SHA256) for limited-input secrets and used it for API key issuers.
  - Standardized salt loading (env, file, process-local fallback); long salts supported.
  - Expanded tests for both helpers (determinism, salt sensitivity, truncation, empty input) and added payments tests to lock issuer marker usage and verify reset_state clears process-local activations.

<sup>Written for commit 5101bfd4ac140ce0bed20a7541f1dadff03f3387. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal marker/fingerprint generation to a PBKDF2/HMAC-SHA256-based approach (external outputs unchanged)

* **Documentation**
  * Updated comments and docs to reflect new marker terminology and hashing method

* **Tests**
  * Added and expanded tests for fingerprint/marker behavior, salt handling, truncation edge cases, error conditions, and activation/reset flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

