### PR TITLE
test(guards): add pro vip dependency inventory

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -131,6 +131,12 @@ Rule: RUNBOOK does not duplicate checklists; it only links to the canonical sour
    - All violations of the same class should be fixed in this PR
    - If additional violations exist, either fix them or track in `BACKLOG_LEDGER.md`
 
+4. **Route guard check for tiered surfaces:**
+   - When a PR touches canonical `/api/v1/pro/*` or `/api/v1/vip/*` routing,
+     run `pytest -q tests/test_pro_vip_route_dependency_guard.py`
+   - This guard inspects the live `app.main.app` route table and fails on missing
+     `require_pro_tier` / `require_vip_tier` coverage or undocumented alias drift.
+
 **Rationale:** EVMbench scores on comprehensive coverage. Partial fixes (fix one, leave others) result in low scores and technical debt.
 
 ## Oracle / Known-Good Gate Behavior (EVMbench-inspired)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3487,12 +3487,13 @@ If it is not recorded here — it does not exist.
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (access-control integrity)
   - Target PR: PR-TBD-PRO-VIP-DEPENDS-GUARD
-  - Status: 📋 Planned
+  - Status: 🟡 In progress (deterministic live-route guard implementation)
   - Reason (EN): Master checklist item #7 requires deterministic proof that all protected endpoints enforce explicit dependency gates and no silent bypass is introduced by future routing changes.
   - Links:
     - docs/roadmap/P0_MASTER_CHECKLIST_PHASE_FIT_TRIAGE_2026-03-05.md
     - app/security/api_tiers.py
     - app/routers
+    - tests/test_pro_vip_route_dependency_guard.py
     - tests/test_api_tiers_db_lookup.py
   - DoD:
     - Guard test enumerates canonical PRO/VIP surfaces and fails on missing dependency gate

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3486,7 +3486,7 @@ If it is not recorded here — it does not exist.
 - [ ] P0: PRO/VIP route `Depends` coverage guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (access-control integrity)
-  - Target PR: PR-TBD-PRO-VIP-DEPENDS-GUARD
+  - Target PR: PR #994
   - Status: 🟡 In progress (deterministic live-route guard implementation)
   - Reason (EN): Master checklist item #7 requires deterministic proof that all protected endpoints enforce explicit dependency gates and no silent bypass is introduced by future routing changes.
   - Links:

--- a/tests/test_pro_vip_route_dependency_guard.py
+++ b/tests/test_pro_vip_route_dependency_guard.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute
+
+from app.middleware.api_tiers import require_pro_tier, require_vip_tier
+from app.routers.api_key import api_key_header
+
+CANONICAL_PREFIX_GUARD = {
+    "/api/v1/pro/": require_pro_tier,
+    "/api/v1/vip/": require_vip_tier,
+}
+LEGACY_HTTP_ALIAS_ALLOWLIST = {
+    ("POST", "/api/v1/vip/weekly-plan"),
+}
+
+
+def _load_routes() -> list[APIRoute]:
+    os.environ.setdefault("VIP_MODULE_ENABLED", "1")
+    os.environ.setdefault("FEATURE_BMI_PRO_ENABLED", "0")
+
+    from app.main import app
+
+    return [route for route in app.routes if isinstance(route, APIRoute)]
+
+
+def _flatten_dependency_calls(route: APIRoute) -> list[Callable[..., Any]]:
+    seen: set[int] = set()
+    calls: list[Callable[..., Any]] = []
+
+    def visit(dep: Dependant) -> None:
+        call = getattr(dep, "call", None)
+        if callable(call) and id(call) not in seen:
+            seen.add(id(call))
+            calls.append(call)
+        for child in getattr(dep, "dependencies", []) or []:
+            visit(child)
+
+    for dep in getattr(route.dependant, "dependencies", []) or []:
+        visit(dep)
+    return calls
+
+
+def _canonical_pro_vip_routes(routes: list[APIRoute]) -> list[APIRoute]:
+    canonical: list[APIRoute] = []
+    for route in routes:
+        if route.deprecated:
+            continue
+        if (getattr(route, "openapi_extra", None) or {}).get("x-alias-of"):
+            continue
+        if route.path.startswith("/api/v1/pro/") or route.path.startswith("/api/v1/vip/"):
+            canonical.append(route)
+    return canonical
+
+
+def test_canonical_pro_vip_routes_require_expected_tier_dependency() -> None:
+    routes = _canonical_pro_vip_routes(_load_routes())
+    missing_guards: list[str] = []
+    saw_prefixes = {prefix: False for prefix in CANONICAL_PREFIX_GUARD}
+
+    for route in routes:
+        for prefix, expected_guard in CANONICAL_PREFIX_GUARD.items():
+            if not route.path.startswith(prefix):
+                continue
+            saw_prefixes[prefix] = True
+            flattened_calls = _flatten_dependency_calls(route)
+            if expected_guard not in flattened_calls:
+                methods = ",".join(sorted(route.methods))
+                names = ", ".join(
+                    getattr(call, "__name__", type(call).__name__) for call in flattened_calls
+                )
+                missing_guards.append(
+                    f"{methods} {route.path} missing {expected_guard.__name__}; got [{names}]"
+                )
+            break
+
+    assert all(
+        saw_prefixes.values()
+    ), f"Expected guarded canonical prefixes missing: {saw_prefixes}"
+    assert not missing_guards, "Canonical PRO/VIP route guard drift detected:\n" + "\n".join(
+        missing_guards
+    )
+
+
+def test_canonical_vip_routes_keep_api_key_header_dependency() -> None:
+    routes = [
+        route
+        for route in _canonical_pro_vip_routes(_load_routes())
+        if route.path.startswith("/api/v1/vip/")
+    ]
+    missing_header: list[str] = []
+
+    for route in routes:
+        flattened_calls = _flatten_dependency_calls(route)
+        if api_key_header not in flattened_calls:
+            methods = ",".join(sorted(route.methods))
+            missing_header.append(f"{methods} {route.path}")
+
+    assert not missing_header, "Canonical VIP routes must keep API key extraction:\n" + "\n".join(
+        missing_header
+    )
+
+
+def test_legacy_vip_weekly_plan_alias_is_deprecated_and_not_treated_as_canonical() -> None:
+    routes = _load_routes()
+    alias_route = next(
+        route
+        for route in routes
+        if route.path == "/api/v1/vip/weekly-plan" and "POST" in route.methods
+    )
+
+    flattened_calls = _flatten_dependency_calls(alias_route)
+
+    assert alias_route.deprecated is True
+    assert ("POST", alias_route.path) in LEGACY_HTTP_ALIAS_ALLOWLIST
+    assert require_vip_tier not in flattened_calls
+    assert api_key_header in flattened_calls

--- a/tests/test_pro_vip_route_dependency_guard.py
+++ b/tests/test_pro_vip_route_dependency_guard.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from typing import Any
 
 from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute
 
+from app.main import app
 from app.middleware.api_tiers import require_pro_tier, require_vip_tier
 from app.routers.api_key import api_key_header
 
@@ -20,11 +20,6 @@ LEGACY_HTTP_ALIAS_ALLOWLIST = {
 
 
 def _load_routes() -> list[APIRoute]:
-    os.environ.setdefault("VIP_MODULE_ENABLED", "1")
-    os.environ.setdefault("FEATURE_BMI_PRO_ENABLED", "0")
-
-    from app.main import app
-
     return [route for route in app.routes if isinstance(route, APIRoute)]
 
 
@@ -119,3 +114,20 @@ def test_legacy_vip_weekly_plan_alias_is_deprecated_and_not_treated_as_canonical
     assert ("POST", alias_route.path) in LEGACY_HTTP_ALIAS_ALLOWLIST
     assert require_vip_tier not in flattened_calls
     assert api_key_header in flattened_calls
+
+
+def test_legacy_http_alias_allowlist_matches_deprecated_routes() -> None:
+    routes = _load_routes()
+
+    for method, path in LEGACY_HTTP_ALIAS_ALLOWLIST:
+        matching_routes = [
+            route
+            for route in routes
+            if path in {route.path, getattr(route, "path_format", route.path)}
+            and method in (route.methods or set())
+            and bool(getattr(route, "deprecated", False))
+        ]
+        assert matching_routes, (
+            f"LEGACY_HTTP_ALIAS_ALLOWLIST entry ({method} {path}) does not map "
+            "to any deprecated alias route in the live router table"
+        )

--- a/tests/test_pro_vip_route_dependency_guard.py
+++ b/tests/test_pro_vip_route_dependency_guard.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from fastapi import FastAPI
 from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute
 
-from app.main import app
 from app.middleware.api_tiers import require_pro_tier, require_vip_tier
 from app.routers.api_key import api_key_header
 
@@ -19,7 +19,7 @@ LEGACY_HTTP_ALIAS_ALLOWLIST = {
 }
 
 
-def _load_routes() -> list[APIRoute]:
+def _load_routes(app: FastAPI) -> list[APIRoute]:
     return [route for route in app.routes if isinstance(route, APIRoute)]
 
 
@@ -52,8 +52,8 @@ def _canonical_pro_vip_routes(routes: list[APIRoute]) -> list[APIRoute]:
     return canonical
 
 
-def test_canonical_pro_vip_routes_require_expected_tier_dependency() -> None:
-    routes = _canonical_pro_vip_routes(_load_routes())
+def test_canonical_pro_vip_routes_require_expected_tier_dependency(app: FastAPI) -> None:
+    routes = _canonical_pro_vip_routes(_load_routes(app))
     missing_guards: list[str] = []
     saw_prefixes = {prefix: False for prefix in CANONICAL_PREFIX_GUARD}
 
@@ -81,10 +81,10 @@ def test_canonical_pro_vip_routes_require_expected_tier_dependency() -> None:
     )
 
 
-def test_canonical_vip_routes_keep_api_key_header_dependency() -> None:
+def test_canonical_vip_routes_keep_api_key_header_dependency(app: FastAPI) -> None:
     routes = [
         route
-        for route in _canonical_pro_vip_routes(_load_routes())
+        for route in _canonical_pro_vip_routes(_load_routes(app))
         if route.path.startswith("/api/v1/vip/")
     ]
     missing_header: list[str] = []
@@ -100,8 +100,10 @@ def test_canonical_vip_routes_keep_api_key_header_dependency() -> None:
     )
 
 
-def test_legacy_vip_weekly_plan_alias_is_deprecated_and_not_treated_as_canonical() -> None:
-    routes = _load_routes()
+def test_legacy_vip_weekly_plan_alias_is_deprecated_and_not_treated_as_canonical(
+    app: FastAPI,
+) -> None:
+    routes = _load_routes(app)
     alias_route = next(
         route
         for route in routes
@@ -116,8 +118,8 @@ def test_legacy_vip_weekly_plan_alias_is_deprecated_and_not_treated_as_canonical
     assert api_key_header in flattened_calls
 
 
-def test_legacy_http_alias_allowlist_matches_deprecated_routes() -> None:
-    routes = _load_routes()
+def test_legacy_http_alias_allowlist_matches_deprecated_routes(app: FastAPI) -> None:
+    routes = _load_routes(app)
 
     for method, path in LEGACY_HTTP_ALIAS_ALLOWLIST:
         matching_routes = [


### PR DESCRIPTION
## Summary
- add deterministic live-route guard for canonical `/api/v1/pro/*` and `/api/v1/vip/*` HTTP surfaces
- exclude deprecated legacy alias from canonical matrix while asserting it stays documented and non-canonical
- record guard traceability in runbook and backlog ledger

## Testing
- `pytest -q tests/test_pro_vip_route_dependency_guard.py tests/test_vip_tier_guard_matrix.py tests/test_vip_guard_consistency.py tests/test_pro_router.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#discussion_r2894321302 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#discussion_r2894331526 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#discussion_r2894333941 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#discussion_r2894340042 -> 469c9433
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#discussion_r2894340047 -> 469c9433
  Disposition: NOT-A-BUG
  Evidence: app/routers/vip.py:697 and app/routers/vip.py:741 keep the deprecated alias on the documented JSON-before-auth compatibility path; canonical VIP guard enforcement remains on non-deprecated `/api/v1/vip/*` routes only.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#pullrequestreview-3902013073 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#pullrequestreview-3902027058 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#pullrequestreview-3902029891 -> 2f6b1693
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#pullrequestreview-3902038714 -> 469c9433
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/994#pullrequestreview-3902175552 -> 469c9433

## Merge Readiness
- [x] Local quality gates passed
- [x] No known unresolved threads at PR creation time
- [x] No known unmapped actionable bot comments at PR creation time

## Summary by Sourcery

Добавить детерминированные тесты для контроля ограничений зависимостей и требований к заголовкам для канонических маршрутов PRO/VIP API, а также задокументировать новый guard в эксплуатационных runbook'ах и бэклоге.

Новые возможности:
- Ввести тест guard'а зависимостей маршрута, который проверяет живые маршруты FastAPI на наличие необходимых зависимостей уровня PRO/VIP и извлечение API-ключа на канонических эндпоинтах.

Улучшения:
- Задокументировать проверку guard'а маршрутов по уровням в runbook'е агента и добавить ссылку на новый тест guard'а из элемента бэклога, отслеживающего обеспечение зависимостей PRO/VIP.

Тесты:
- Добавить тесты для проверки, что канонические маршруты PRO/VIP включают ожидаемые зависимости по уровням, маршруты VIP сохраняют извлечение заголовка API-ключа, а устаревший псевдоним VIP weekly-plan остаётся депрецированным и неканоническим.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add deterministic tests to enforce dependency guards and header requirements for canonical PRO/VIP API routes and document the new guard in operational runbooks and backlog.

New Features:
- Introduce a route dependency guard test that inspects live FastAPI routes for required PRO/VIP tier dependencies and API key extraction on canonical endpoints.

Enhancements:
- Document the tiered route guard check in the agent runbook and link the new guard test from the backlog item tracking PRO/VIP dependency enforcement.

Tests:
- Add tests to verify canonical PRO/VIP routes include the expected tier dependencies, VIP routes retain API key header extraction, and the legacy VIP weekly-plan alias remains deprecated and non-canonical.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add deterministic guard tests for canonical /api/v1/pro/* and /api/v1/vip/* routes that scan the live FastAPI app via the shared app fixture to enforce tier guards, require VIP API key extraction, and flag alias drift. The runbook now includes a step to run this guard, and the backlog ledger links to this PR.

- **New Features**
  - Live-route guard (via app fixture) enumerates canonical PRO/VIP endpoints, fails on missing require_pro_tier/require_vip_tier, and asserts canonical prefixes exist.
  - Ensures VIP routes include api_key_header.
  - Validates legacy alias handling: POST /api/v1/vip/weekly-plan is deprecated and non-canonical, and allowlist entries map to actual deprecated routes.

<sup>Written for commit 469c943334553415eaa199a1f0b071440cbdf764. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a runbook step and backlog entry describing a deterministic route-guard verification for PRO/VIP endpoints to ensure canonical route coverage and detect alias drift.

* **Tests**
  * Added a test suite that validates PRO/VIP endpoint access controls, confirms canonicalization behavior, and detects missing tier guards or missing API key header dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


