### PR TITLE
feat(security): harden web auth with HttpOnly session cookie (P0 W1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ APP_ENV=local
 # SERVER_SALT is required at app startup for VIP LLM monthly quota enforcement.
 SERVER_SALT=replace_me_with_secret
 
+# === Web session cookie (PRO browser flow) ===
+# Optional: defaults to 43200 (12h); must be an integer >= 1 if set.
+WEB_SESSION_TTL_SECONDS=43200
+
 # === VIP LLM quota (requests/month) ===
 # Optional: defaults to 30 if unset; must be an integer >= 1 if set.
 VIP_LLM_INSIGHT_REQUESTS_PER_MONTH=30

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -316,7 +316,7 @@
         "filename": "frontend/src/lib/__tests__/useApiKey.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 80
       }
     ],
     "frontend/vitest.config.ts": [
@@ -1607,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-06T12:48:58Z"
+  "generated_at": "2026-03-06T13:57:52Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -309,14 +309,14 @@
         "filename": "frontend/src/lib/__tests__/useApiKey.test.ts",
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 25
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/src/lib/__tests__/useApiKey.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 75
       }
     ],
     "frontend/vitest.config.ts": [
@@ -1607,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-06T13:57:52Z"
+  "generated_at": "2026-03-06T15:03:42Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -291,7 +291,7 @@
         "filename": "frontend/src/auth/storage.ts",
         "hashed_secret": "3e55be9a36c0bb4b1451a6d6deb16fde61321538",
         "is_verified": false,
-        "line_number": 5
+        "line_number": 7
       }
     ],
     "frontend/src/components/__tests__/TabBar.test.tsx": [
@@ -594,7 +594,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 306
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1607,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-05T15:29:12Z"
+  "generated_at": "2026-03-06T12:48:58Z"
 }

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -30,10 +30,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from fastapi import Depends, HTTPException, Security, status
+from fastapi import Depends, HTTPException, Request, Security, status
 from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
+from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
 
 from app.utils.feature_flags import is_vip_module_enabled
 
@@ -67,6 +68,23 @@ class DBLookupResult:
 
     status: DBLookupStatus
     tier: SubscriptionTier | None = None
+
+
+class AuthSource(str, Enum):
+    """Authentication source used for tier resolution."""
+
+    HEADER = "header"
+    COOKIE = "cookie"
+
+
+@dataclass(frozen=True)
+class TierAuthContext:
+    """Resolved authentication context (header or cookie)."""
+
+    api_key: str
+    tier: SubscriptionTier
+    source: AuthSource
+    session_expires_at_epoch: int | None = None
 
 
 # Test API keys for development/testing (nosec B105)
@@ -228,7 +246,147 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
     return False
 
 
-def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
+def _request_dependency(request: Request) -> Request:
+    """FastAPI helper to inject Request while preserving direct-call compatibility."""
+
+    return request
+
+
+def _as_request(request: object | None) -> Request | None:
+    """Return Request instance or None for direct function invocations."""
+
+    return request if isinstance(request, Request) else None
+
+
+def _resolve_effective_tier(api_key: str, *, required_tier: SubscriptionTier) -> SubscriptionTier:
+    """Resolve effective tier for a validated key, fail-closed to required tier."""
+
+    resolved = get_subscription_tier(api_key)
+    if _tier_allows_access(resolved, required_tier):
+        return resolved
+    return required_tier
+
+
+def _resolve_cookie_auth_context(
+    *,
+    request: Request | None,
+    required_tier: SubscriptionTier,
+) -> TierAuthContext | None:
+    """Resolve cookie-backed auth context or None."""
+
+    if request is None:
+        return None
+
+    raw_cookie = request.cookies.get(WEB_SESSION_COOKIE_NAME, "")
+    if not raw_cookie:
+        return None
+
+    try:
+        claims = verify_web_session(raw_cookie)
+    except RuntimeError:
+        logger.warning(
+            "Session cookie verification failed due to server configuration", exc_info=True
+        )
+        return None
+    if claims is None:
+        return None
+
+    tier = _parse_tier_value(claims.tier)
+    if tier is None or not _tier_allows_access(tier, required_tier):
+        return None
+
+    return TierAuthContext(
+        api_key=claims.api_key,
+        tier=tier,
+        source=AuthSource.COOKIE,
+        session_expires_at_epoch=claims.expires_at_epoch,
+    )
+
+
+def resolve_pro_auth_context(
+    *,
+    x_api_key: Optional[str] = Security(api_key_header),
+    request: Request = Depends(_request_dependency),
+) -> TierAuthContext:
+    """Resolve PRO auth using header-first precedence, then cookie fallback."""
+
+    request_obj = _as_request(request)
+    if x_api_key:
+        if not _validate_api_key_tier(x_api_key, SubscriptionTier.PRO):
+            logger.warning("Invalid API key for PRO tier")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key does not have PRO tier access",
+            )
+        return TierAuthContext(
+            api_key=x_api_key,
+            tier=_resolve_effective_tier(x_api_key, required_tier=SubscriptionTier.PRO),
+            source=AuthSource.HEADER,
+        )
+
+    cookie_context = _resolve_cookie_auth_context(
+        request=request_obj,
+        required_tier=SubscriptionTier.PRO,
+    )
+    if cookie_context is not None:
+        return cookie_context
+
+    logger.warning("PRO endpoint accessed without API key and without valid session cookie")
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="API key required for PRO tier access",
+        headers={"WWW-Authenticate": "ApiKey"},
+    )
+
+
+def resolve_vip_auth_context(
+    *,
+    x_api_key: Optional[str] = Security(api_key_header),
+    request: Request = Depends(_request_dependency),
+) -> TierAuthContext:
+    """Resolve VIP auth using header-first precedence, then cookie fallback."""
+
+    request_obj = _as_request(request)
+    if x_api_key:
+        if not _validate_api_key_tier(x_api_key, SubscriptionTier.VIP):
+            logger.warning("Invalid API key for VIP tier")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key does not have VIP tier access. Upgrade to VIP to access this feature.",
+            )
+        return TierAuthContext(
+            api_key=x_api_key,
+            tier=_resolve_effective_tier(x_api_key, required_tier=SubscriptionTier.VIP),
+            source=AuthSource.HEADER,
+        )
+
+    cookie_context = _resolve_cookie_auth_context(
+        request=request_obj,
+        required_tier=SubscriptionTier.VIP,
+    )
+    if cookie_context is not None:
+        return cookie_context
+
+    logger.warning("VIP endpoint accessed without API key and without valid session cookie")
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="VIP access required",
+    )
+
+
+def get_request_pro_auth_context(request: Request) -> TierAuthContext | None:
+    """Return cached PRO auth context stored by require_pro_tier dependency."""
+
+    cached = getattr(request.state, "pro_auth_context", None)
+    if isinstance(cached, TierAuthContext):
+        return cached
+    return None
+
+
+def require_pro_tier(
+    x_api_key: Optional[str] = Security(api_key_header),
+    request: Request = Depends(_request_dependency),
+) -> str:
     """Require PRO tier API key for endpoint access.
 
     RU: Требуется API ключ уровня PRO для доступа к endpoint.
@@ -249,26 +407,18 @@ def require_pro_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str
         async def pro_feature():
             return {"message": "PRO feature accessed"}
     """
-    if not x_api_key:
-        logger.warning("PRO endpoint accessed without API key")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="API key required for PRO tier access",
-            headers={"WWW-Authenticate": "ApiKey"},
-        )
-
-    if not _validate_api_key_tier(x_api_key, SubscriptionTier.PRO):
-        logger.warning("Invalid API key for PRO tier")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API key does not have PRO tier access",
-        )
-
-    logger.debug("PRO tier access granted")
-    return x_api_key
+    context = resolve_pro_auth_context(x_api_key=x_api_key, request=request)
+    request_obj = _as_request(request)
+    if request_obj is not None:
+        request_obj.state.pro_auth_context = context
+    logger.debug("PRO tier access granted via %s", context.source.value)
+    return context.api_key
 
 
-def require_vip_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str:
+def require_vip_tier(
+    x_api_key: Optional[str] = Security(api_key_header),
+    request: Request = Depends(_request_dependency),
+) -> str:
     """Require VIP tier API key for endpoint access.
 
     RU: Требуется API ключ уровня VIP для доступа к endpoint.
@@ -289,22 +439,12 @@ def require_vip_tier(x_api_key: Optional[str] = Security(api_key_header)) -> str
         async def vip_feature():
             return {"message": "VIP feature accessed"}
     """
-    if not x_api_key:
-        logger.warning("VIP endpoint accessed without API key")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="VIP access required",
-        )
-
-    if not _validate_api_key_tier(x_api_key, SubscriptionTier.VIP):
-        logger.warning("Invalid API key for VIP tier")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API key does not have VIP tier access. Upgrade to VIP to access this feature.",
-        )
-
-    logger.debug("VIP tier access granted")
-    return x_api_key
+    context = resolve_vip_auth_context(x_api_key=x_api_key, request=request)
+    request_obj = _as_request(request)
+    if request_obj is not None:
+        request_obj.state.vip_auth_context = context
+    logger.debug("VIP tier access granted via %s", context.source.value)
+    return context.api_key
 
 
 def get_subscription_tier(api_key: str) -> SubscriptionTier:

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -198,6 +198,49 @@ def _is_production_environment() -> tuple[bool, str]:
     return is_production, app_env
 
 
+def _resolve_authorized_api_key_tier(
+    api_key: str,
+    *,
+    required_tier: SubscriptionTier,
+) -> SubscriptionTier | None:
+    """Resolve authorized tier in a single pass, else None."""
+
+    is_production, app_env = _is_production_environment()
+
+    if _is_subscription_db_enabled():
+        db_lookup = _lookup_tier_from_db(api_key)
+        if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
+            if _tier_allows_access(db_lookup.tier, required_tier):
+                return db_lookup.tier
+            return None
+        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
+            return None
+
+    resolved_env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
+    if resolved_env_tier is not None:
+        if _tier_allows_access(resolved_env_tier, required_tier):
+            return resolved_env_tier
+        return None
+
+    # In non-production mode with anonymous access enabled, allow any key.
+    if not is_production:
+        allow_anonymous = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+            "on",
+        )
+        if allow_anonymous:
+            logger.warning(
+                "Anonymous API key accepted in %s mode for tier %s",
+                app_env,
+                required_tier.value,
+            )
+            return required_tier
+
+    return None
+
+
 def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> bool:
     """Validate if API key has access to required tier.
 
@@ -215,35 +258,7 @@ def _validate_api_key_tier(api_key: str, required_tier: SubscriptionTier) -> boo
 
         In production, this should query the subscriptions database.
     """
-    is_production, app_env = _is_production_environment()
-
-    if _is_subscription_db_enabled():
-        db_lookup = _lookup_tier_from_db(api_key)
-        if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
-            return _tier_allows_access(db_lookup.tier, required_tier)
-        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
-            return False
-
-    resolved_env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
-    if resolved_env_tier is not None:
-        return _tier_allows_access(resolved_env_tier, required_tier)
-
-    # In non-production mode with anonymous access enabled, allow any key.
-    # Check env var dynamically to support testing with mock.patch.dict.
-    if not is_production:
-        allow_anonymous = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in (
-            "true",
-            "1",
-            "yes",
-            "on",
-        )
-        if allow_anonymous:
-            logger.warning(
-                f"Anonymous API key accepted in {app_env} mode for tier {required_tier.value}"
-            )
-            return True
-
-    return False
+    return _resolve_authorized_api_key_tier(api_key, required_tier=required_tier) is not None
 
 
 def _request_dependency(request: Request) -> Request:
@@ -256,15 +271,6 @@ def _as_request(request: object | None) -> Request | None:
     """Return Request instance or None for direct function invocations."""
 
     return request if isinstance(request, Request) else None
-
-
-def _resolve_effective_tier(api_key: str, *, required_tier: SubscriptionTier) -> SubscriptionTier:
-    """Resolve effective tier for a validated key, fail-closed to required tier."""
-
-    resolved = get_subscription_tier(api_key)
-    if _tier_allows_access(resolved, required_tier):
-        return resolved
-    return required_tier
 
 
 def _resolve_cookie_auth_context(
@@ -312,7 +318,11 @@ def resolve_pro_auth_context(
 
     request_obj = _as_request(request)
     if x_api_key:
-        if not _validate_api_key_tier(x_api_key, SubscriptionTier.PRO):
+        resolved_tier = _resolve_authorized_api_key_tier(
+            x_api_key,
+            required_tier=SubscriptionTier.PRO,
+        )
+        if resolved_tier is None:
             logger.warning("Invalid API key for PRO tier")
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -320,7 +330,7 @@ def resolve_pro_auth_context(
             )
         return TierAuthContext(
             api_key=x_api_key,
-            tier=_resolve_effective_tier(x_api_key, required_tier=SubscriptionTier.PRO),
+            tier=resolved_tier,
             source=AuthSource.HEADER,
         )
 
@@ -348,7 +358,11 @@ def resolve_vip_auth_context(
 
     request_obj = _as_request(request)
     if x_api_key:
-        if not _validate_api_key_tier(x_api_key, SubscriptionTier.VIP):
+        resolved_tier = _resolve_authorized_api_key_tier(
+            x_api_key,
+            required_tier=SubscriptionTier.VIP,
+        )
+        if resolved_tier is None:
             logger.warning("Invalid API key for VIP tier")
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -356,7 +370,7 @@ def resolve_vip_auth_context(
             )
         return TierAuthContext(
             api_key=x_api_key,
-            tier=_resolve_effective_tier(x_api_key, required_tier=SubscriptionTier.VIP),
+            tier=resolved_tier,
             source=AuthSource.HEADER,
         )
 

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -31,7 +31,6 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request, Security, status
-from fastapi.security import APIKeyCookie
 from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
@@ -40,12 +39,6 @@ from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
 from app.utils.feature_flags import is_vip_module_enabled
 
 logger = logging.getLogger(__name__)
-
-web_session_cookie = APIKeyCookie(
-    name=WEB_SESSION_COOKIE_NAME,
-    scheme_name="CookieSession",
-    auto_error=False,
-)
 
 
 class SubscriptionTier(str, Enum):
@@ -284,15 +277,13 @@ def _resolve_cookie_auth_context(
     *,
     request: Request | None,
     required_tier: SubscriptionTier,
-    web_session_token: str | None = None,
 ) -> TierAuthContext | None:
     """Resolve cookie-backed auth context or None."""
 
     if request is None:
         return None
 
-    normalized_token = web_session_token if isinstance(web_session_token, str) else ""
-    raw_cookie = (normalized_token or request.cookies.get(WEB_SESSION_COOKIE_NAME, "")).strip()
+    raw_cookie = request.cookies.get(WEB_SESSION_COOKIE_NAME, "")
     if not raw_cookie:
         return None
 
@@ -321,7 +312,6 @@ def _resolve_cookie_auth_context(
 def resolve_pro_auth_context(
     *,
     x_api_key: Optional[str] = Security(api_key_header),
-    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> TierAuthContext:
     """Resolve PRO auth using header-first precedence, then cookie fallback."""
@@ -347,7 +337,6 @@ def resolve_pro_auth_context(
     cookie_context = _resolve_cookie_auth_context(
         request=request_obj,
         required_tier=SubscriptionTier.PRO,
-        web_session_token=x_web_session,
     )
     if cookie_context is not None:
         return cookie_context
@@ -363,7 +352,6 @@ def resolve_pro_auth_context(
 def resolve_vip_auth_context(
     *,
     x_api_key: Optional[str] = Security(api_key_header),
-    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> TierAuthContext:
     """Resolve VIP auth using header-first precedence, then cookie fallback."""
@@ -389,7 +377,6 @@ def resolve_vip_auth_context(
     cookie_context = _resolve_cookie_auth_context(
         request=request_obj,
         required_tier=SubscriptionTier.VIP,
-        web_session_token=x_web_session,
     )
     if cookie_context is not None:
         return cookie_context
@@ -412,7 +399,6 @@ def get_request_pro_auth_context(request: Request) -> TierAuthContext | None:
 
 def require_pro_tier(
     x_api_key: Optional[str] = Security(api_key_header),
-    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> str:
     """Require PRO tier API key for endpoint access.
@@ -437,7 +423,6 @@ def require_pro_tier(
     """
     context = resolve_pro_auth_context(
         x_api_key=x_api_key,
-        x_web_session=x_web_session,
         request=request,
     )
     request_obj = _as_request(request)
@@ -449,7 +434,6 @@ def require_pro_tier(
 
 def require_vip_tier(
     x_api_key: Optional[str] = Security(api_key_header),
-    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> str:
     """Require VIP tier API key for endpoint access.
@@ -474,7 +458,6 @@ def require_vip_tier(
     """
     context = resolve_vip_auth_context(
         x_api_key=x_api_key,
-        x_web_session=x_web_session,
         request=request,
     )
     request_obj = _as_request(request)

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -297,13 +297,16 @@ def _resolve_cookie_auth_context(
     if claims is None:
         return None
 
-    tier = _parse_tier_value(claims.tier)
-    if tier is None or not _tier_allows_access(tier, required_tier):
+    resolved_tier = _resolve_authorized_api_key_tier(
+        claims.api_key,
+        required_tier=required_tier,
+    )
+    if resolved_tier is None:
         return None
 
     return TierAuthContext(
         api_key=claims.api_key,
-        tier=tier,
+        tier=resolved_tier,
         source=AuthSource.COOKIE,
         session_expires_at_epoch=claims.expires_at_epoch,
     )

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -31,6 +31,7 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request, Security, status
+from fastapi.security import APIKeyCookie
 from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
@@ -39,6 +40,12 @@ from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
 from app.utils.feature_flags import is_vip_module_enabled
 
 logger = logging.getLogger(__name__)
+
+web_session_cookie = APIKeyCookie(
+    name=WEB_SESSION_COOKIE_NAME,
+    scheme_name="CookieSession",
+    auto_error=False,
+)
 
 
 class SubscriptionTier(str, Enum):
@@ -87,9 +94,9 @@ class TierAuthContext:
     session_expires_at_epoch: int | None = None
 
 
-# Test API keys for development/testing (nosec B105)
-TEST_KEY_PRO = "test_pro_key"  # nosec B105
-TEST_KEY_VIP = "test_vip_key"  # nosec B105
+# Test API keys for deterministic test/development tier checks.
+TEST_KEY_PRO = "test_pro_key"  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-995)
+TEST_KEY_VIP = "test_vip_key"  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-995)
 
 # Environment configuration
 VIP_MODULE_ENABLED = is_vip_module_enabled()
@@ -277,13 +284,15 @@ def _resolve_cookie_auth_context(
     *,
     request: Request | None,
     required_tier: SubscriptionTier,
+    web_session_token: str | None = None,
 ) -> TierAuthContext | None:
     """Resolve cookie-backed auth context or None."""
 
     if request is None:
         return None
 
-    raw_cookie = request.cookies.get(WEB_SESSION_COOKIE_NAME, "")
+    normalized_token = web_session_token if isinstance(web_session_token, str) else ""
+    raw_cookie = (normalized_token or request.cookies.get(WEB_SESSION_COOKIE_NAME, "")).strip()
     if not raw_cookie:
         return None
 
@@ -312,6 +321,7 @@ def _resolve_cookie_auth_context(
 def resolve_pro_auth_context(
     *,
     x_api_key: Optional[str] = Security(api_key_header),
+    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> TierAuthContext:
     """Resolve PRO auth using header-first precedence, then cookie fallback."""
@@ -337,6 +347,7 @@ def resolve_pro_auth_context(
     cookie_context = _resolve_cookie_auth_context(
         request=request_obj,
         required_tier=SubscriptionTier.PRO,
+        web_session_token=x_web_session,
     )
     if cookie_context is not None:
         return cookie_context
@@ -352,6 +363,7 @@ def resolve_pro_auth_context(
 def resolve_vip_auth_context(
     *,
     x_api_key: Optional[str] = Security(api_key_header),
+    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> TierAuthContext:
     """Resolve VIP auth using header-first precedence, then cookie fallback."""
@@ -377,6 +389,7 @@ def resolve_vip_auth_context(
     cookie_context = _resolve_cookie_auth_context(
         request=request_obj,
         required_tier=SubscriptionTier.VIP,
+        web_session_token=x_web_session,
     )
     if cookie_context is not None:
         return cookie_context
@@ -399,6 +412,7 @@ def get_request_pro_auth_context(request: Request) -> TierAuthContext | None:
 
 def require_pro_tier(
     x_api_key: Optional[str] = Security(api_key_header),
+    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> str:
     """Require PRO tier API key for endpoint access.
@@ -421,7 +435,11 @@ def require_pro_tier(
         async def pro_feature():
             return {"message": "PRO feature accessed"}
     """
-    context = resolve_pro_auth_context(x_api_key=x_api_key, request=request)
+    context = resolve_pro_auth_context(
+        x_api_key=x_api_key,
+        x_web_session=x_web_session,
+        request=request,
+    )
     request_obj = _as_request(request)
     if request_obj is not None:
         request_obj.state.pro_auth_context = context
@@ -431,6 +449,7 @@ def require_pro_tier(
 
 def require_vip_tier(
     x_api_key: Optional[str] = Security(api_key_header),
+    x_web_session: Optional[str] = Security(web_session_cookie),
     request: Request = Depends(_request_dependency),
 ) -> str:
     """Require VIP tier API key for endpoint access.
@@ -453,7 +472,11 @@ def require_vip_tier(
         async def vip_feature():
             return {"message": "VIP feature accessed"}
     """
-    context = resolve_vip_auth_context(x_api_key=x_api_key, request=request)
+    context = resolve_vip_auth_context(
+        x_api_key=x_api_key,
+        x_web_session=x_web_session,
+        request=request,
+    )
     request_obj = _as_request(request)
     if request_obj is not None:
         request_obj.state.vip_auth_context = context

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -317,9 +317,16 @@ def resolve_pro_auth_context(
     """Resolve PRO auth using header-first precedence, then cookie fallback."""
 
     request_obj = _as_request(request)
-    if x_api_key:
+    if x_api_key is not None:
+        normalized_api_key = x_api_key.strip()
+        if not normalized_api_key:
+            logger.warning("Empty X-API-Key header is not allowed for PRO tier")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key does not have PRO tier access",
+            )
         resolved_tier = _resolve_authorized_api_key_tier(
-            x_api_key,
+            normalized_api_key,
             required_tier=SubscriptionTier.PRO,
         )
         if resolved_tier is None:
@@ -329,7 +336,7 @@ def resolve_pro_auth_context(
                 detail="API key does not have PRO tier access",
             )
         return TierAuthContext(
-            api_key=x_api_key,
+            api_key=normalized_api_key,
             tier=resolved_tier,
             source=AuthSource.HEADER,
         )
@@ -357,9 +364,16 @@ def resolve_vip_auth_context(
     """Resolve VIP auth using header-first precedence, then cookie fallback."""
 
     request_obj = _as_request(request)
-    if x_api_key:
+    if x_api_key is not None:
+        normalized_api_key = x_api_key.strip()
+        if not normalized_api_key:
+            logger.warning("Empty X-API-Key header is not allowed for VIP tier")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key does not have VIP tier access. Upgrade to VIP to access this feature.",
+            )
         resolved_tier = _resolve_authorized_api_key_tier(
-            x_api_key,
+            normalized_api_key,
             required_tier=SubscriptionTier.VIP,
         )
         if resolved_tier is None:
@@ -369,7 +383,7 @@ def resolve_vip_auth_context(
                 detail="API key does not have VIP tier access. Upgrade to VIP to access this feature.",
             )
         return TierAuthContext(
-            api_key=x_api_key,
+            api_key=normalized_api_key,
             tier=resolved_tier,
             source=AuthSource.HEADER,
         )

--- a/app/routers/pro_registration.py
+++ b/app/routers/pro_registration.py
@@ -59,6 +59,10 @@ def register_pro_routes(app: "FastAPI") -> tuple[APIRouter | None, APIRouter | N
         app.include_router(pro_router_imported)
         pro_router_result = pro_router_imported
 
+    from app.routers.pro_session import router as pro_session_router
+
+    app.include_router(pro_session_router)
+
     # Include PRO nutrition insights router (coverage scoring)
     from app.routers.pro_nutrition_insights import router as pro_nutrition_insights_router
 

--- a/app/routers/pro_session.py
+++ b/app/routers/pro_session.py
@@ -1,0 +1,173 @@
+"""PRO web-session endpoints.
+
+RU: Web-session endpoints для browser cookie auth поверх PRO/VIP tier.
+EN: Web-session endpoints for browser cookie auth on top of PRO/VIP tier.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from app.middleware.api_tiers import (
+    SubscriptionTier,
+    TierAuthContext,
+    get_request_pro_auth_context,
+    require_pro_tier,
+)
+from app.schemas.session import (
+    SessionExchangeResponse,
+    SessionLogoutResponse,
+    SessionStatusResponse,
+)
+from app.security.web_session import (
+    clear_web_session_cookie,
+    issue_web_session,
+    require_web_session_ttl_seconds,
+    set_web_session_cookie,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/v1/pro",
+    tags=["pro", "session"],
+)
+
+
+def _get_cached_pro_context(request: Request) -> TierAuthContext:
+    """Get PRO auth context produced by require_pro_tier dependency."""
+
+    context = get_request_pro_auth_context(request)
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Missing authentication context",
+        )
+    return context
+
+
+def _to_exchange_response(payload: object) -> SessionExchangeResponse:
+    """Typed conversion helper for Pydantic v2 discipline."""
+
+    response_obj: SessionExchangeResponse
+    response_obj = SessionExchangeResponse.model_validate(payload)
+    return response_obj
+
+
+def _to_status_response(payload: object) -> SessionStatusResponse:
+    """Typed conversion helper for Pydantic v2 discipline."""
+
+    response_obj: SessionStatusResponse
+    response_obj = SessionStatusResponse.model_validate(payload)
+    return response_obj
+
+
+def _to_logout_response(payload: object) -> SessionLogoutResponse:
+    """Typed conversion helper for Pydantic v2 discipline."""
+
+    response_obj: SessionLogoutResponse
+    response_obj = SessionLogoutResponse.model_validate(payload)
+    return response_obj
+
+
+def _issue_and_set_cookie(
+    *,
+    response: Response,
+    context: TierAuthContext,
+) -> SessionExchangeResponse:
+    """Issue signed cookie and set hardened cookie attributes."""
+
+    resolved_tier = context.tier
+    if resolved_tier not in (SubscriptionTier.PRO, SubscriptionTier.VIP):
+        resolved_tier = SubscriptionTier.PRO
+
+    ttl_seconds = require_web_session_ttl_seconds()
+    issued = issue_web_session(
+        api_key=context.api_key,
+        tier=resolved_tier.value,
+        ttl_seconds=ttl_seconds,
+    )
+    set_web_session_cookie(
+        response=response,
+        token=issued.token,
+        ttl_seconds=ttl_seconds,
+    )
+    return _to_exchange_response(
+        {
+            "status": "ok",
+            "tier": resolved_tier.value,
+            "auth_source": context.source.value,
+            "expires_at_epoch": issued.claims.expires_at_epoch,
+            "ttl_seconds": ttl_seconds,
+        }
+    )
+
+
+@router.post("/session/exchange", response_model=SessionExchangeResponse)
+def exchange_session_cookie(
+    request: Request,
+    response: Response,
+    _api_key: str = Depends(require_pro_tier),
+) -> SessionExchangeResponse:
+    """Exchange authenticated PRO/VIP session into hardened HttpOnly cookie."""
+
+    context = _get_cached_pro_context(request)
+    try:
+        return _issue_and_set_cookie(response=response, context=context)
+    except RuntimeError as exc:
+        logger.warning("Session exchange failed due to security misconfiguration", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Web session is unavailable",
+        ) from exc
+
+
+@router.get("/session", response_model=SessionStatusResponse)
+def get_session_status(
+    request: Request,
+    _api_key: str = Depends(require_pro_tier),
+) -> SessionStatusResponse:
+    """Return current auth source and tier for PRO/VIP session."""
+
+    context = _get_cached_pro_context(request)
+    return _to_status_response(
+        {
+            "status": "ok",
+            "authenticated": True,
+            "tier": context.tier.value,
+            "auth_source": context.source.value,
+            "expires_at_epoch": context.session_expires_at_epoch,
+        }
+    )
+
+
+@router.post("/session/refresh", response_model=SessionExchangeResponse)
+def refresh_session_cookie(
+    request: Request,
+    response: Response,
+    _api_key: str = Depends(require_pro_tier),
+) -> SessionExchangeResponse:
+    """Refresh session cookie for currently authenticated PRO/VIP principal."""
+
+    context = _get_cached_pro_context(request)
+    try:
+        return _issue_and_set_cookie(response=response, context=context)
+    except RuntimeError as exc:
+        logger.warning("Session refresh failed due to security misconfiguration", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Web session is unavailable",
+        ) from exc
+
+
+@router.post("/session/logout", response_model=SessionLogoutResponse)
+def logout_session(
+    response: Response,
+    _api_key: str = Depends(require_pro_tier),
+) -> SessionLogoutResponse:
+    """Logout by clearing session cookie (idempotent)."""
+
+    clear_web_session_cookie(response=response)
+    return _to_logout_response({"status": "ok", "logged_out": True})

--- a/app/routers/pro_session.py
+++ b/app/routers/pro_session.py
@@ -81,7 +81,8 @@ def _issue_and_set_cookie(
 
     resolved_tier = context.tier
     if resolved_tier not in (SubscriptionTier.PRO, SubscriptionTier.VIP):
-        resolved_tier = SubscriptionTier.PRO
+        logger.warning("Unexpected tier in session context: %s", resolved_tier.value)
+        raise RuntimeError("Unexpected tier for web session exchange")
 
     ttl_seconds = require_web_session_ttl_seconds()
     issued = issue_web_session(

--- a/app/routers/pro_session.py
+++ b/app/routers/pro_session.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security, status
+from fastapi.security import APIKeyCookie
 
 from app.middleware.api_tiers import (
     SubscriptionTier,
@@ -22,6 +23,7 @@ from app.schemas.session import (
     SessionStatusResponse,
 )
 from app.security.web_session import (
+    WEB_SESSION_COOKIE_NAME,
     clear_web_session_cookie,
     issue_web_session,
     require_web_session_ttl_seconds,
@@ -29,6 +31,12 @@ from app.security.web_session import (
 )
 
 logger = logging.getLogger(__name__)
+
+session_cookie_security = APIKeyCookie(
+    name=WEB_SESSION_COOKIE_NAME,
+    scheme_name="CookieSession",
+    auto_error=False,
+)
 
 router = APIRouter(
     prefix="/api/v1/pro",
@@ -110,6 +118,7 @@ def _issue_and_set_cookie(
 def exchange_session_cookie(
     request: Request,
     response: Response,
+    _session_cookie: str | None = Security(session_cookie_security),
     _api_key: str = Depends(require_pro_tier),
 ) -> SessionExchangeResponse:
     """Exchange authenticated PRO/VIP session into hardened HttpOnly cookie."""
@@ -128,6 +137,7 @@ def exchange_session_cookie(
 @router.get("/session", response_model=SessionStatusResponse)
 def get_session_status(
     request: Request,
+    _session_cookie: str | None = Security(session_cookie_security),
     _api_key: str = Depends(require_pro_tier),
 ) -> SessionStatusResponse:
     """Return current auth source and tier for PRO/VIP session."""
@@ -148,6 +158,7 @@ def get_session_status(
 def refresh_session_cookie(
     request: Request,
     response: Response,
+    _session_cookie: str | None = Security(session_cookie_security),
     _api_key: str = Depends(require_pro_tier),
 ) -> SessionExchangeResponse:
     """Refresh session cookie for currently authenticated PRO/VIP principal."""
@@ -166,6 +177,7 @@ def refresh_session_cookie(
 @router.post("/session/logout", response_model=SessionLogoutResponse)
 def logout_session(
     response: Response,
+    _session_cookie: str | None = Security(session_cookie_security),
     _api_key: str = Depends(require_pro_tier),
 ) -> SessionLogoutResponse:
     """Logout by clearing session cookie (idempotent)."""

--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -1,0 +1,53 @@
+"""Session endpoint schemas.
+
+RU: Схемы для web session endpoints.
+EN: Schemas for web session endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SessionTier = Literal["PRO", "VIP"]
+SessionSource = Literal["header", "cookie"]
+
+
+class SessionExchangeRequest(BaseModel):
+    """Exchange request schema (empty body, explicit contract)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SessionExchangeResponse(BaseModel):
+    """Exchange/refresh response contract."""
+
+    status: Literal["ok"] = "ok"
+    tier: SessionTier = Field(..., description="Resolved tier stored in session cookie")
+    auth_source: SessionSource = Field(
+        ...,
+        description="Authentication source used for this request",
+    )
+    expires_at_epoch: int = Field(..., ge=1, description="Session expiry Unix epoch (UTC)")
+    ttl_seconds: int = Field(..., ge=1, description="Session TTL in seconds")
+
+
+class SessionStatusResponse(BaseModel):
+    """Session status response contract."""
+
+    status: Literal["ok"] = "ok"
+    authenticated: Literal[True] = True
+    tier: SessionTier = Field(..., description="Current authenticated tier")
+    auth_source: SessionSource = Field(..., description="Current authentication source")
+    expires_at_epoch: int | None = Field(
+        default=None,
+        description="Cookie expiry Unix epoch (UTC), null when header auth is used",
+    )
+
+
+class SessionLogoutResponse(BaseModel):
+    """Logout response contract."""
+
+    status: Literal["ok"] = "ok"
+    logged_out: Literal[True] = True

--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -23,7 +23,7 @@ class SessionExchangeRequest(BaseModel):
 class SessionExchangeResponse(BaseModel):
     """Exchange/refresh response contract."""
 
-    status: Literal["ok"] = "ok"
+    status: Literal["ok"] = Field(..., description="Deterministic exchange status")
     tier: SessionTier = Field(..., description="Resolved tier stored in session cookie")
     auth_source: SessionSource = Field(
         ...,
@@ -36,8 +36,8 @@ class SessionExchangeResponse(BaseModel):
 class SessionStatusResponse(BaseModel):
     """Session status response contract."""
 
-    status: Literal["ok"] = "ok"
-    authenticated: Literal[True] = True
+    status: Literal["ok"] = Field(..., description="Deterministic status value")
+    authenticated: Literal[True] = Field(..., description="Always true for authorized session")
     tier: SessionTier = Field(..., description="Current authenticated tier")
     auth_source: SessionSource = Field(..., description="Current authentication source")
     expires_at_epoch: int | None = Field(
@@ -49,5 +49,5 @@ class SessionStatusResponse(BaseModel):
 class SessionLogoutResponse(BaseModel):
     """Logout response contract."""
 
-    status: Literal["ok"] = "ok"
-    logged_out: Literal[True] = True
+    status: Literal["ok"] = Field(..., description="Deterministic logout status")
+    logged_out: Literal[True] = Field(..., description="Always true for successful logout")

--- a/app/security/web_session.py
+++ b/app/security/web_session.py
@@ -1,4 +1,4 @@
-"""Stateless web session cookie helpers (HMAC-SHA256, fail-closed).
+"""Stateless web session cookie helpers (HMAC-BLAKE2s, fail-closed).
 
 RU: Stateless web session cookie для PRO/VIP web-потока.
 EN: Stateless web session cookie for PRO/VIP web flow.
@@ -70,7 +70,7 @@ def _derive_session_hmac_key(secret: str | None = None) -> bytes:
 
     server_salt = require_server_salt()
     scoped_key = f"web_session_v1::{server_salt}"
-    return hashlib.sha256(scoped_key.encode("utf-8")).digest()
+    return hashlib.blake2s(scoped_key.encode("utf-8")).digest()
 
 
 def _b64url_encode(raw: bytes) -> str:
@@ -138,7 +138,7 @@ def issue_web_session(
     signature = hmac.new(
         _derive_session_hmac_key(secret),
         payload_b64.encode("ascii"),
-        hashlib.sha256,
+        hashlib.blake2s,
     ).hexdigest()
 
     return IssuedWebSession(token=f"{payload_b64}.{signature}", claims=claims)
@@ -167,7 +167,7 @@ def verify_web_session(
     expected_sig = hmac.new(
         _derive_session_hmac_key(secret),
         payload_b64.encode("ascii"),
-        hashlib.sha256,
+        hashlib.blake2s,
     ).hexdigest()
     if not hmac.compare_digest(expected_sig, signature):
         return None

--- a/app/security/web_session.py
+++ b/app/security/web_session.py
@@ -1,0 +1,253 @@
+"""Stateless web session cookie helpers (HMAC-SHA256, fail-closed).
+
+RU: Stateless web session cookie для PRO/VIP web-потока.
+EN: Stateless web session cookie for PRO/VIP web flow.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import Response
+
+from app.security.server_salt import require_server_salt
+
+WEB_SESSION_COOKIE_NAME = "pp_web_session"
+WEB_SESSION_TTL_ENV = "WEB_SESSION_TTL_SECONDS"
+DEFAULT_WEB_SESSION_TTL_SECONDS = 60 * 60 * 12  # 12h
+_COOKIE_PATH = "/"
+_COOKIE_SAMESITE: Literal["lax"] = "lax"
+
+
+@dataclass(frozen=True)
+class WebSessionClaims:
+    """Validated web session claims payload."""
+
+    api_key: str
+    tier: str
+    issued_at_epoch: int
+    expires_at_epoch: int
+
+
+@dataclass(frozen=True)
+class IssuedWebSession:
+    """Issued web session token with normalized claims."""
+
+    token: str
+    claims: WebSessionClaims
+
+
+def require_web_session_ttl_seconds() -> int:
+    """Return session TTL from env with strict validation."""
+
+    raw = (os.getenv(WEB_SESSION_TTL_ENV) or "").strip()
+    if raw == "":
+        return DEFAULT_WEB_SESSION_TTL_SECONDS
+    try:
+        ttl = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{WEB_SESSION_TTL_ENV} must be an integer >= 1.") from exc
+    if ttl < 1:
+        raise RuntimeError(f"{WEB_SESSION_TTL_ENV} must be an integer >= 1.")
+    return ttl
+
+
+def _derive_session_hmac_key(secret: str | None = None) -> bytes:
+    """Derive scoped HMAC key from explicit secret or SERVER_SALT."""
+
+    if secret is not None:
+        normalized = secret.strip()
+        if not normalized:
+            raise RuntimeError("Explicit web-session secret must be non-empty (fail-closed).")
+        return normalized.encode("utf-8")
+
+    server_salt = require_server_salt()
+    scoped_key = f"web_session_v1::{server_salt}"
+    return hashlib.sha256(scoped_key.encode("utf-8")).digest()
+
+
+def _b64url_encode(raw: bytes) -> str:
+    """Encode bytes into URL-safe base64 without padding."""
+
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(encoded: str) -> bytes:
+    """Decode URL-safe base64 with optional stripped padding."""
+
+    pad_len = (-len(encoded)) % 4
+    return base64.urlsafe_b64decode(encoded + ("=" * pad_len))
+
+
+def _normalized_tier(raw_tier: str) -> str:
+    """Normalize and validate tier claim."""
+
+    tier = raw_tier.strip().upper()
+    if tier not in {"PRO", "VIP"}:
+        raise ValueError("web session tier must be PRO or VIP")
+    return tier
+
+
+def issue_web_session(
+    *,
+    api_key: str,
+    tier: str,
+    now: datetime | None = None,
+    ttl_seconds: int | None = None,
+    secret: str | None = None,
+) -> IssuedWebSession:
+    """Issue signed stateless web session token."""
+
+    normalized_key = api_key.strip()
+    if not normalized_key:
+        raise ValueError("api_key must be non-empty")
+
+    normalized_tier = _normalized_tier(tier)
+    ttl = ttl_seconds if ttl_seconds is not None else require_web_session_ttl_seconds()
+    if ttl < 1:
+        raise ValueError("ttl_seconds must be >= 1")
+
+    now_dt = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    issued_at = int(now_dt.timestamp())
+    expires_at = issued_at + ttl
+    claims = WebSessionClaims(
+        api_key=normalized_key,
+        tier=normalized_tier,
+        issued_at_epoch=issued_at,
+        expires_at_epoch=expires_at,
+    )
+
+    payload = {
+        "api_key": claims.api_key,
+        "tier": claims.tier,
+        "iat": claims.issued_at_epoch,
+        "exp": claims.expires_at_epoch,
+        "v": 1,
+    }
+    payload_bytes = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    payload_b64 = _b64url_encode(payload_bytes)
+    signature = hmac.new(
+        _derive_session_hmac_key(secret),
+        payload_b64.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return IssuedWebSession(token=f"{payload_b64}.{signature}", claims=claims)
+
+
+def verify_web_session(
+    token: str,
+    *,
+    now: datetime | None = None,
+    secret: str | None = None,
+) -> WebSessionClaims | None:
+    """Verify signed token and return claims, else None (fail-closed)."""
+
+    raw = token.strip()
+    if not raw:
+        return None
+
+    parts = raw.split(".")
+    if len(parts) != 2:
+        return None
+
+    payload_b64, signature = parts
+    if not payload_b64 or not signature:
+        return None
+
+    expected_sig = hmac.new(
+        _derive_session_hmac_key(secret),
+        payload_b64.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(expected_sig, signature):
+        return None
+
+    try:
+        payload_obj = json.loads(_b64url_decode(payload_b64))
+    except Exception:
+        return None
+    if not isinstance(payload_obj, dict):
+        return None
+
+    api_key = payload_obj.get("api_key")
+    tier = payload_obj.get("tier")
+    issued_at = payload_obj.get("iat")
+    expires_at = payload_obj.get("exp")
+    version = payload_obj.get("v")
+
+    if not isinstance(api_key, str) or not api_key.strip():
+        return None
+    if not isinstance(tier, str):
+        return None
+    if not isinstance(issued_at, int) or not isinstance(expires_at, int):
+        return None
+    if version != 1:
+        return None
+
+    try:
+        normalized_tier = _normalized_tier(tier)
+    except ValueError:
+        return None
+
+    if issued_at < 0 or expires_at <= issued_at:
+        return None
+
+    now_epoch = int((now or datetime.now(timezone.utc)).astimezone(timezone.utc).timestamp())
+    if now_epoch >= expires_at:
+        return None
+
+    return WebSessionClaims(
+        api_key=api_key.strip(),
+        tier=normalized_tier,
+        issued_at_epoch=issued_at,
+        expires_at_epoch=expires_at,
+    )
+
+
+def _is_secure_cookie_environment() -> bool:
+    """Return Secure-cookie mode for staging/production."""
+
+    app_env = (os.getenv("APP_ENV") or "local").strip().lower()
+    return app_env in {"production", "prod", "staging"}
+
+
+def set_web_session_cookie(
+    *,
+    response: Response,
+    token: str,
+    ttl_seconds: int | None = None,
+) -> None:
+    """Set hardened session cookie."""
+
+    ttl = ttl_seconds if ttl_seconds is not None else require_web_session_ttl_seconds()
+    response.set_cookie(
+        key=WEB_SESSION_COOKIE_NAME,
+        value=token,
+        max_age=ttl,
+        httponly=True,
+        samesite=_COOKIE_SAMESITE,
+        secure=_is_secure_cookie_environment(),
+        path=_COOKIE_PATH,
+    )
+
+
+def clear_web_session_cookie(*, response: Response) -> None:
+    """Clear hardened session cookie."""
+
+    response.delete_cookie(
+        key=WEB_SESSION_COOKIE_NAME,
+        path=_COOKIE_PATH,
+        httponly=True,
+        samesite=_COOKIE_SAMESITE,
+        secure=_is_secure_cookie_environment(),
+    )

--- a/app/security/web_session.py
+++ b/app/security/web_session.py
@@ -1,4 +1,4 @@
-"""Stateless web session cookie helpers (HMAC-BLAKE2s, fail-closed).
+"""Stateless web session cookie helpers (PBKDF2-HMAC signature, fail-closed).
 
 RU: Stateless web session cookie для PRO/VIP web-потока.
 EN: Stateless web session cookie for PRO/VIP web flow.
@@ -24,6 +24,7 @@ WEB_SESSION_TTL_ENV = "WEB_SESSION_TTL_SECONDS"
 DEFAULT_WEB_SESSION_TTL_SECONDS = 60 * 60 * 12  # 12h
 _COOKIE_PATH = "/"
 _COOKIE_SAMESITE: Literal["lax"] = "lax"
+_SESSION_SIGNATURE_ITERATIONS = 20_000
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,19 @@ def _normalized_tier(raw_tier: str) -> str:
     return tier
 
 
+def _sign_payload(*, payload_b64: str, secret: str | None = None) -> str:
+    """Return deterministic PBKDF2-HMAC signature for payload string."""
+
+    key = _derive_session_hmac_key(secret)
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        payload_b64.encode("ascii"),
+        key,
+        _SESSION_SIGNATURE_ITERATIONS,
+        dklen=32,
+    ).hex()
+
+
 def issue_web_session(
     *,
     api_key: str,
@@ -135,11 +149,7 @@ def issue_web_session(
         payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
     payload_b64 = _b64url_encode(payload_bytes)
-    signature = hmac.new(
-        _derive_session_hmac_key(secret),
-        payload_b64.encode("ascii"),
-        hashlib.blake2s,
-    ).hexdigest()
+    signature = _sign_payload(payload_b64=payload_b64, secret=secret)
 
     return IssuedWebSession(token=f"{payload_b64}.{signature}", claims=claims)
 
@@ -164,11 +174,7 @@ def verify_web_session(
     if not payload_b64 or not signature:
         return None
 
-    expected_sig = hmac.new(
-        _derive_session_hmac_key(secret),
-        payload_b64.encode("ascii"),
-        hashlib.blake2s,
-    ).hexdigest()
+    expected_sig = _sign_payload(payload_b64=payload_b64, secret=secret)
     if not hmac.compare_digest(expected_sig, signature):
         return None
 

--- a/app/security/web_session.py
+++ b/app/security/web_session.py
@@ -215,10 +215,10 @@ def verify_web_session(
 
 
 def _is_secure_cookie_environment() -> bool:
-    """Return Secure-cookie mode for staging/production."""
+    """Return Secure-cookie mode (fail-closed by default)."""
 
-    app_env = (os.getenv("APP_ENV") or "local").strip().lower()
-    return app_env in {"production", "prod", "staging"}
+    app_env = (os.getenv("APP_ENV") or "").strip().lower()
+    return app_env not in {"local", "dev", "development", "test"}
 
 
 def set_web_session_cookie(

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3496,8 +3496,8 @@ If it is not recorded here — it does not exist.
 - [ ] P0: Web session token transport hardening (`localStorage` -> `httpOnly` cookie)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (security blocker)
-  - Target PR: PR-TBD-SESSION-COOKIE-HARDENING
-  - Status: 📋 Planned
+  - Target PR: PR-TBD-SESSION-COOKIE-HARDENING-W1 (`feat/p0-session-cookie-hardening-w1`)
+  - Status: 🟡 In progress (Wave W1: cookie transport + session contract hardening)
   - Reason (EN): Master checklist item #1 identifies XSS exposure when auth/session keys are persisted in browser storage. Canonical path is server-issued `httpOnly` session cookie plus explicit session endpoint contracts.
   - Links:
     - docs/roadmap/P0_MASTER_CHECKLIST_PHASE_FIT_TRIAGE_2026-03-05.md
@@ -3575,11 +3575,11 @@ If it is not recorded here — it does not exist.
     - Guard tests prevent insecure storage fallback on Android
 
 <a id="ledger-p0-pro-vip-depends-guard"></a>
-- [ ] P0: PRO/VIP route `Depends` coverage guard
+- [x] P0: PRO/VIP route `Depends` coverage guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (access-control integrity)
   - Target PR: PR #994
-  - Status: 🟡 In progress (deterministic live-route guard implementation)
+  - Status: ✅ Merged (PR #994, 2026-03-06)
   - Reason (EN): Master checklist item #7 requires deterministic proof that all protected endpoints enforce explicit dependency gates and no silent bypass is introduced by future routing changes.
   - Links:
     - docs/roadmap/P0_MASTER_CHECKLIST_PHASE_FIT_TRIAGE_2026-03-05.md

--- a/frontend/src/api/__tests__/client.fetchBlob.test.ts
+++ b/frontend/src/api/__tests__/client.fetchBlob.test.ts
@@ -6,7 +6,7 @@
  *
  * These tests verify the critical security invariant:
  * - External URLs MUST NOT receive API credentials (headers or cookies)
- * - API paths MUST include credentials
+ * - API paths MUST include cookie credentials
  * - Auth errors (401/403) on API paths trigger key clearing and redirect
  *
  * Implementation: Uses vi.stubGlobal + setApiClientDependencies (no MSW).
@@ -107,8 +107,8 @@ describe('fetchBlob security contract', () => {
     });
   });
 
-  describe('Test 2: API path — credentials include + auth header present', () => {
-    it('should include credentials, prepend API base, and add auth header for API paths', async () => {
+  describe('Test 2: API path — credentials include + no key header leak', () => {
+    it('should include credentials, prepend API base, and avoid X-API-Key for API paths', async () => {
       // Stub fetch to capture the call and return success
       const mockBlob = new Blob(['api-data']);
       vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
@@ -130,9 +130,9 @@ describe('fetchBlob security contract', () => {
       // Verify credentials default to 'include'
       expect(capturedInit?.credentials).toBe('include');
 
-      // Verify auth header IS present (contrast with Test 1 where it's stripped)
+      // Cookie session transport: do not attach legacy API key header automatically.
       const headers = capturedInit?.headers as Headers;
-      expect(headers.get('X-API-Key')).toBe('test-api-key');
+      expect(headers.get('X-API-Key')).toBeNull();
     });
   });
 

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -111,16 +111,15 @@ describe('API Client Auth', () => {
       await expect(api('/test-endpoint')).rejects.toThrow('VITE_API_BASE is not set');
     });
 
-    it('includes X-API-Key header when API key is set in storage', async () => {
-      testStorage.getStoredApiKey.mockReturnValue('test-api-key');
-
+    it('does not attach X-API-Key header for regular API calls', async () => {
       const { api } = await import('../client');
 
       fetchMock.mockImplementationOnce((input: any, options?: any) => {
         const url = typeof input === 'string' ? input : input.url;
         expect(url).toBe('http://test-api.com/test-endpoint');
         const requestOptions = typeof input === 'string' ? options : input;
-        expect(requestOptions.headers.get('X-API-Key')).toBe('test-api-key');
+        expect(requestOptions.credentials).toBe('include');
+        expect(requestOptions.headers.get('X-API-Key')).toBeNull();
         return Promise.resolve(createMockResponse({ data: 'test' }, {
           ok: true,
           status: 200,
@@ -139,7 +138,7 @@ describe('API Client Auth', () => {
         status: 401,
       })));
 
-      await expect(api('/test-endpoint')).rejects.toThrow('API key invalid or expired (401).');
+      await expect(api('/test-endpoint')).rejects.toThrow('Session invalid or expired (401).');
 
       expect(testStorage.clearStoredApiKey).toHaveBeenCalled();
       expect(window.location.replace).toHaveBeenCalledWith('/enter-key');
@@ -177,8 +176,6 @@ describe('API Client Auth', () => {
     });
 
     it('resolves successfully on authenticated request', async () => {
-      testStorage.getStoredApiKey.mockReturnValue('valid-api-key');
-
       const { api } = await import('../client');
       const mockResponse = { success: true, data: 'authenticated' };
       fetchMock.mockImplementationOnce(() => Promise.resolve(createMockResponse(mockResponse, {
@@ -190,6 +187,57 @@ describe('API Client Auth', () => {
 
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('server-session helpers', () => {
+    it('checkProSession returns true for authenticated response', async () => {
+      const { checkProSession } = await import('../client');
+      fetchMock.mockImplementationOnce(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        expect(request.url).toBe('http://test-api.com/api/v1/pro/session');
+        expect(request.method).toBe('GET');
+        expect(request.credentials).toBe('include');
+        return createMockResponse({ authenticated: true }, { ok: true, status: 200 });
+      });
+
+      await expect(checkProSession()).resolves.toBe(true);
+    });
+
+    it('checkProSession returns false for unauthorized response', async () => {
+      const { checkProSession } = await import('../client');
+      fetchMock.mockResolvedValueOnce(createMockResponse({}, { ok: false, status: 401 }));
+
+      await expect(checkProSession()).resolves.toBe(false);
+    });
+
+    it('exchangeApiKeyForSession posts exchange payload and returns true', async () => {
+      const { exchangeApiKeyForSession } = await import('../client');
+
+      fetchMock.mockImplementationOnce(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        expect(request.url).toBe('http://test-api.com/api/v1/pro/session/exchange');
+        expect(request.method).toBe('POST');
+        expect(request.credentials).toBe('include');
+        expect(request.headers.get('X-API-Key')).toBe('test-session-key');
+        return createMockResponse({ authenticated: true }, { ok: true, status: 200 });
+      });
+
+      await expect(exchangeApiKeyForSession('test-session-key')).resolves.toBe(true);
+    });
+
+    it('clearProSession calls logout endpoint with POST', async () => {
+      const { clearProSession } = await import('../client');
+
+      fetchMock.mockImplementationOnce(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        expect(request.url).toBe('http://test-api.com/api/v1/pro/session/logout');
+        expect(request.method).toBe('POST');
+        expect(request.credentials).toBe('include');
+        return createMockResponse({ status: 'ok' }, { ok: true, status: 200 });
+      });
+
+      await expect(clearProSession()).resolves.toBeUndefined();
     });
   });
 

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -211,6 +211,13 @@ describe('API Client Auth', () => {
       await expect(checkProSession()).resolves.toBe(false);
     });
 
+    it('checkProSession fails closed for unknown payload shape', async () => {
+      const { checkProSession } = await import('../client');
+      fetchMock.mockResolvedValueOnce(createMockResponse({ status: 'ok' }, { ok: true, status: 200 }));
+
+      await expect(checkProSession()).resolves.toBe(false);
+    });
+
     it('exchangeApiKeyForSession posts exchange payload and returns true', async () => {
       const { exchangeApiKeyForSession } = await import('../client');
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -203,12 +203,21 @@ function inferSessionActive(payload: unknown): boolean {
     return false;
   }
 
+  const isSuccessStatus = (value: unknown): boolean =>
+    typeof value === "string" && ["ok", "success"].includes(value.trim().toLowerCase());
+
+  const hasSessionIdentity = (source: Record<string, unknown>): boolean =>
+    typeof source.tier === "string" || typeof source.auth_source === "string";
+
   const source = payload as Record<string, unknown>;
   const rootBooleanKeys = ["authenticated", "active", "ok", "has_session", "is_authenticated"];
   for (const key of rootBooleanKeys) {
     if (typeof source[key] === "boolean") {
       return source[key] as boolean;
     }
+  }
+  if (hasSessionIdentity(source) && isSuccessStatus(source.status)) {
+    return true;
   }
 
   const nestedSession = source.session;
@@ -218,6 +227,9 @@ function inferSessionActive(payload: unknown): boolean {
       if (typeof nested[key] === "boolean") {
         return nested[key] as boolean;
       }
+    }
+    if (hasSessionIdentity(nested) && isSuccessStatus(nested.status)) {
+      return true;
     }
   }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -204,7 +204,7 @@ export async function validateApiKey(): Promise<boolean> {
 
 function inferSessionActive(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") {
-    return true;
+    return false;
   }
 
   const source = payload as Record<string, unknown>;
@@ -225,7 +225,7 @@ function inferSessionActive(payload: unknown): boolean {
     }
   }
 
-  return true;
+  return false;
 }
 
 /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,8 +1,8 @@
-// RU: API клиент с поддержкой аутентификации. Обрабатывает 401 ошибки, перенаправляя на страницу ввода ключа.
-// EN: API client with authentication support. Handles 401 errors by redirecting to key entry page.
+// RU: API клиент с поддержкой серверной cookie-сессии. Обрабатывает 401 ошибки, перенаправляя на страницу входа.
+// EN: API client with server-session cookie support. Handles 401 errors by redirecting to key entry page.
 
 import { logError } from "../lib/analytics";
-import { getStoredApiKey, clearStoredApiKey } from "../auth/storage";
+import { clearStoredApiKey } from "../auth/storage";
 import type { components } from "./schema";
 
 /**
@@ -18,7 +18,7 @@ export interface ApiClientDependencies {
  * Default dependencies using production implementations
  */
 const defaultDependencies: ApiClientDependencies = {
-  getStoredApiKey,
+  getStoredApiKey: () => null,
   clearStoredApiKey,
   apiBase: ((import.meta as any).env?.VITE_API_BASE || "") as string,
 };
@@ -51,7 +51,6 @@ export function setApiClientDependencies(deps: ApiClientDependencies | null): vo
 }
 
 // Extract functions from current dependencies
-const _getStoredApiKey = () => getDependencies().getStoredApiKey();
 const _clearStoredApiKey = () => getDependencies().clearStoredApiKey();
 
 /**
@@ -158,6 +157,9 @@ const forceMock = searchParams.get("mock") === "1";
 // PRO nutrition endpoint paths (canonical)
 export const PRO_NUTRITION_TARGETS_PATH = "/api/v1/pro/nutrition/targets";
 export const PRO_NUTRITION_PLATE_PATH = "/api/v1/pro/nutrition/plate";
+export const PRO_SESSION_PATH = "/api/v1/pro/session";
+export const PRO_SESSION_EXCHANGE_PATH = "/api/v1/pro/session/exchange";
+export const PRO_SESSION_LOGOUT_PATH = "/api/v1/pro/session/logout";
 
 function mockUrl(path: string): string | null {
   if (path.includes("/api/v1/premium/bmr") || path.includes("/premium/bmr")) {
@@ -176,8 +178,8 @@ function mockUrl(path: string): string | null {
   return null;
 }
 
-// API Key management moved to auth context
-// Re-export for backward compatibility
+// Legacy API key management exports kept for backward compatibility.
+// Browser persistence is disabled in storage.ts.
 export { getStoredApiKey, setStoredApiKey, clearStoredApiKey } from "../auth/storage";
 
 /**
@@ -200,18 +202,121 @@ export async function validateApiKey(): Promise<boolean> {
   }
 }
 
+function inferSessionActive(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") {
+    return true;
+  }
+
+  const source = payload as Record<string, unknown>;
+  const rootBooleanKeys = ["authenticated", "active", "ok", "has_session", "is_authenticated"];
+  for (const key of rootBooleanKeys) {
+    if (typeof source[key] === "boolean") {
+      return source[key] as boolean;
+    }
+  }
+
+  const nestedSession = source.session;
+  if (nestedSession && typeof nestedSession === "object") {
+    const nested = nestedSession as Record<string, unknown>;
+    for (const key of rootBooleanKeys) {
+      if (typeof nested[key] === "boolean") {
+        return nested[key] as boolean;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check whether server-side PRO session is currently active.
+ * Auth source of truth for web flow.
+ */
+export async function checkProSession(): Promise<boolean> {
+  try {
+    validateApiBase();
+    const response = await fetch(normalizeApiUrl(getApiBase(), PRO_SESSION_PATH), {
+      method: "GET",
+      headers: mergeHeaders(),
+      credentials: "include",
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return false;
+    }
+    if (!response.ok) {
+      return false;
+    }
+
+    const payload = await response.json().catch(() => null);
+    return inferSessionActive(payload);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Exchange a legacy API key for a secure server-side session cookie.
+ * Returns true only when a valid session is established.
+ */
+export async function exchangeApiKeyForSession(apiKey: string): Promise<boolean> {
+  const trimmedKey = apiKey.trim();
+  if (!trimmedKey) {
+    return false;
+  }
+
+  try {
+    validateApiBase();
+
+    const response = await fetch(normalizeApiUrl(getApiBase(), PRO_SESSION_EXCHANGE_PATH), {
+      method: "POST",
+      headers: mergeHeaders(
+        {
+          headers: {
+            "X-API-Key": trimmedKey,
+          },
+        },
+      ),
+      credentials: "include",
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return false;
+    }
+    if (!response.ok) {
+      return false;
+    }
+
+    const payload = await response.json().catch(() => null);
+    return inferSessionActive(payload);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort server session clear (logout).
+ * Errors are intentionally swallowed to keep UX deterministic.
+ */
+export async function clearProSession(): Promise<void> {
+  try {
+    validateApiBase();
+    await fetch(normalizeApiUrl(getApiBase(), PRO_SESSION_LOGOUT_PATH), {
+      method: "POST",
+      headers: mergeHeaders(),
+      credentials: "include",
+    });
+  } catch {
+    // no-op
+  }
+}
+
 function mergeHeaders(init?: RequestInit, forceJson?: boolean): Headers {
   const defaults: Record<string, string> = {
     Accept: "application/json",
     "Accept-Language":
       (typeof navigator !== "undefined" && navigator.language) || "en",
   };
-
-  // Add API key if available
-  const apiKey = _getStoredApiKey();
-  if (apiKey) {
-    defaults["X-API-Key"] = apiKey;
-  }
 
   // NOTE: api() сам сериализует body в JSON для методов ≠ GET.
   // Высшим слоям (createPremiumEndpoint, hooks) нужно передавать body как объект.
@@ -337,9 +442,9 @@ export async function api<T = unknown>(
           }
         }
         // Log the auth error
-        logError(new UnauthorizedError(`API key invalid or expired (${res.status}).`));
+        logError(new UnauthorizedError(`Session invalid or expired (${res.status}).`));
         // Throw specific UnauthorizedError so callers can detect auth errors
-        throw new UnauthorizedError(`API key invalid or expired (${res.status}).`);
+        throw new UnauthorizedError(`Session invalid or expired (${res.status}).`);
       }
 
       const errorBody = await res.text().catch(() => "<response body unavailable>");
@@ -400,10 +505,10 @@ function classifyUrl(url: string): 'api' | 'absolute' {
  * EN: Fetch binary data (Blob) from API or external URL.
  *
  * URL Classification:
- * - `/api/...` (API path): Prepends VITE_API_BASE, adds auth headers, handles 401/403
+ * - `/api/...` (API path): Prepends VITE_API_BASE, includes cookie credentials, handles 401/403
  * - `https://...` (External): Pass-through fetch, NO auth headers (signed URLs have token in query)
  *
- * Security: API key is NEVER sent to external URLs to prevent credential leaks.
+ * Security: auth headers are NEVER sent to external URLs to prevent credential leaks.
  *
  * @param url - API path (/api/v1/...) or absolute URL (https://...)
  * @param init - Optional fetch init options
@@ -424,7 +529,7 @@ export async function fetchBlob(
     validateApiBase();
   }
 
-  // For API paths: add auth headers; for external: strip auth and omit credentials
+  // For API paths: include cookies; for external: strip auth headers and omit credentials
   let finalInit: RequestInit;
 
   if (kind === 'api') {
@@ -457,7 +562,7 @@ export async function fetchBlob(
       if (typeof window !== 'undefined') {
         window.location.replace('/enter-key');
       }
-      const authError = new UnauthorizedError(`API key invalid or expired (${res.status}).`);
+      const authError = new UnauthorizedError(`Session invalid or expired (${res.status}).`);
       logError(authError);
       throw authError;
     }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -187,17 +187,13 @@ export { getStoredApiKey, setStoredApiKey, clearStoredApiKey } from "../auth/sto
  * @returns Promise<boolean> - true if key is valid
  */
 export async function validateApiKey(): Promise<boolean> {
-  // Validate API base on first use
+  // Validate API base on first use.
   validateApiBase();
 
   try {
-    // Use direct fetch to avoid 401 error handling that clears keys and redirects
-    const res = await fetch(`${getApiBase()}/health`, {
-      method: "GET",
-      headers: mergeHeaders(),
-    });
-    return res.ok;
-  } catch (error) {
+    // Session cookie is canonical web auth source.
+    return await checkProSession();
+  } catch {
     return false;
   }
 }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5239,6 +5239,127 @@
         "title": "SafetyCheckResponse",
         "type": "object"
       },
+      "SessionExchangeResponse": {
+        "description": "Exchange/refresh response contract.",
+        "properties": {
+          "auth_source": {
+            "description": "Authentication source used for this request",
+            "enum": [
+              "header",
+              "cookie"
+            ],
+            "title": "Auth Source",
+            "type": "string"
+          },
+          "expires_at_epoch": {
+            "description": "Session expiry Unix epoch (UTC)",
+            "minimum": 1.0,
+            "title": "Expires At Epoch",
+            "type": "integer"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "tier": {
+            "description": "Resolved tier stored in session cookie",
+            "enum": [
+              "PRO",
+              "VIP"
+            ],
+            "title": "Tier",
+            "type": "string"
+          },
+          "ttl_seconds": {
+            "description": "Session TTL in seconds",
+            "minimum": 1.0,
+            "title": "Ttl Seconds",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tier",
+          "auth_source",
+          "expires_at_epoch",
+          "ttl_seconds"
+        ],
+        "title": "SessionExchangeResponse",
+        "type": "object"
+      },
+      "SessionLogoutResponse": {
+        "description": "Logout response contract.",
+        "properties": {
+          "logged_out": {
+            "const": true,
+            "default": true,
+            "title": "Logged Out",
+            "type": "boolean"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "SessionLogoutResponse",
+        "type": "object"
+      },
+      "SessionStatusResponse": {
+        "description": "Session status response contract.",
+        "properties": {
+          "auth_source": {
+            "description": "Current authentication source",
+            "enum": [
+              "header",
+              "cookie"
+            ],
+            "title": "Auth Source",
+            "type": "string"
+          },
+          "authenticated": {
+            "const": true,
+            "default": true,
+            "title": "Authenticated",
+            "type": "boolean"
+          },
+          "expires_at_epoch": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Cookie expiry Unix epoch (UTC), null when header auth is used",
+            "title": "Expires At Epoch"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "tier": {
+            "description": "Current authenticated tier",
+            "enum": [
+              "PRO",
+              "VIP"
+            ],
+            "title": "Tier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tier",
+          "auth_source"
+        ],
+        "title": "SessionStatusResponse",
+        "type": "object"
+      },
       "ShopAisle": {
         "description": "Stable aisle/category for iOS (do not rename; only extend).\n\nRU: Категории для группировки списка покупок (не переименовывать).",
         "enum": [
@@ -8753,6 +8874,118 @@
         "tags": [
           "pro",
           "restaurants"
+        ]
+      }
+    },
+    "/api/v1/pro/session": {
+      "get": {
+        "description": "Return current auth source and tier for PRO/VIP session.",
+        "operationId": "get_session_status_api_v1_pro_session_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get Session Status",
+        "tags": [
+          "pro",
+          "session"
+        ]
+      }
+    },
+    "/api/v1/pro/session/exchange": {
+      "post": {
+        "description": "Exchange authenticated PRO/VIP session into hardened HttpOnly cookie.",
+        "operationId": "exchange_session_cookie_api_v1_pro_session_exchange_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionExchangeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Exchange Session Cookie",
+        "tags": [
+          "pro",
+          "session"
+        ]
+      }
+    },
+    "/api/v1/pro/session/logout": {
+      "post": {
+        "description": "Logout by clearing session cookie (idempotent).",
+        "operationId": "logout_session_api_v1_pro_session_logout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionLogoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Logout Session",
+        "tags": [
+          "pro",
+          "session"
+        ]
+      }
+    },
+    "/api/v1/pro/session/refresh": {
+      "post": {
+        "description": "Refresh session cookie for currently authenticated PRO/VIP principal.",
+        "operationId": "refresh_session_cookie_api_v1_pro_session_refresh_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionExchangeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Refresh Session Cookie",
+        "tags": [
+          "pro",
+          "session"
         ]
       }
     },

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -7342,9 +7342,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Bmi Pro Legacy Alias",
@@ -7374,9 +7371,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Food Data Attribution",
@@ -7425,9 +7419,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "[DEPRECATED] Legacy PRO BMI endpoint",
@@ -7475,9 +7466,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Calculate BMI with WHR (PRO tier)",
@@ -7540,9 +7528,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Cbt Insight",
@@ -7591,9 +7576,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Generate Shopping List",
@@ -7642,9 +7624,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Generate weekly meal plan (PRO tier)",
@@ -7692,9 +7671,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Nutrient coverage scoring (PRO)",
@@ -7854,9 +7830,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get daily nutrition data (PRO tier)",
@@ -7904,9 +7877,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Close day (PRO)",
@@ -7955,9 +7925,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Food-based deficiency recommendations (PRO)",
@@ -8006,9 +7973,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Log meal event (PRO)",
@@ -8057,9 +8021,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Extended micronutrient targets with ranges (PRO)",
@@ -8108,9 +8069,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Enhanced plate (PRO)",
@@ -8159,9 +8117,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Safety validation of nutrition targets (PRO)",
@@ -8210,9 +8165,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "WHO nutrition targets (PRO)",
@@ -8281,9 +8233,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Activate Subscription",
@@ -8353,9 +8302,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Subscription Activation",
@@ -8424,9 +8370,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Revoke Handoff Share",
@@ -8505,9 +8448,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Handoff Share Status",
@@ -8575,9 +8515,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Create Partner Order",
@@ -8635,9 +8572,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Preview Partner Order From Weekly Plan",
@@ -8685,9 +8619,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Preview Partner Order",
@@ -8766,9 +8697,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Partner Order",
@@ -8867,9 +8795,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Confirm Partner Order",
@@ -8955,9 +8880,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Issue Handoff Share",
@@ -8985,10 +8907,10 @@
         },
         "security": [
           {
-            "APIKeyHeader": []
+            "CookieSession": []
           },
           {
-            "CookieSession": []
+            "APIKeyHeader": []
           }
         ],
         "summary": "Get Session Status",
@@ -9016,10 +8938,10 @@
         },
         "security": [
           {
-            "APIKeyHeader": []
+            "CookieSession": []
           },
           {
-            "CookieSession": []
+            "APIKeyHeader": []
           }
         ],
         "summary": "Exchange Session Cookie",
@@ -9047,10 +8969,10 @@
         },
         "security": [
           {
-            "APIKeyHeader": []
+            "CookieSession": []
           },
           {
-            "CookieSession": []
+            "APIKeyHeader": []
           }
         ],
         "summary": "Logout Session",
@@ -9078,10 +9000,10 @@
         },
         "security": [
           {
-            "APIKeyHeader": []
+            "CookieSession": []
           },
           {
-            "CookieSession": []
+            "APIKeyHeader": []
           }
         ],
         "summary": "Refresh Session Cookie",
@@ -9145,9 +9067,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Shopping list suggestions for a day (MVP placeholder)",
@@ -9178,9 +9097,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Repair Strategies",
@@ -9232,9 +9148,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Manual Repair Suggestions",
@@ -9286,9 +9199,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Auto Repair Weekly Plan",
@@ -9318,9 +9228,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Vip Health",
@@ -9372,9 +9279,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Weekly Menu Plan",
@@ -9426,9 +9330,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Weekly Menu Repair",
@@ -9480,9 +9381,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Synthesize Recipe",
@@ -9512,9 +9410,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Recipe Templates",
@@ -9566,9 +9461,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Synthesize Weekly Recipes",
@@ -9598,9 +9490,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Regions",
@@ -9661,9 +9550,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Compare Product Prices",
@@ -9714,9 +9600,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Region Categories",
@@ -9796,9 +9679,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Search Region Products",
@@ -9849,9 +9729,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Get Region Stores",
@@ -9903,9 +9780,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Daily Shoplist",
@@ -10022,9 +9896,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Export VIP shoplist to CSV or PDF",
@@ -10055,9 +9926,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Available Export Formats",
@@ -10148,9 +10016,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Generate VIP shoplist (deterministic)",
@@ -10194,9 +10059,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "VIP shoplist preview (legacy)",
@@ -10249,9 +10111,6 @@
         "security": [
           {
             "APIKeyHeader": []
-          },
-          {
-            "CookieSession": []
           }
         ],
         "summary": "Weekly Shoplist",

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -5259,7 +5259,7 @@
           },
           "status": {
             "const": "ok",
-            "default": "ok",
+            "description": "Deterministic exchange status",
             "title": "Status",
             "type": "string"
           },
@@ -5280,6 +5280,7 @@
           }
         },
         "required": [
+          "status",
           "tier",
           "auth_source",
           "expires_at_epoch",
@@ -5293,17 +5294,21 @@
         "properties": {
           "logged_out": {
             "const": true,
-            "default": true,
+            "description": "Always true for successful logout",
             "title": "Logged Out",
             "type": "boolean"
           },
           "status": {
             "const": "ok",
-            "default": "ok",
+            "description": "Deterministic logout status",
             "title": "Status",
             "type": "string"
           }
         },
+        "required": [
+          "status",
+          "logged_out"
+        ],
         "title": "SessionLogoutResponse",
         "type": "object"
       },
@@ -5321,7 +5326,7 @@
           },
           "authenticated": {
             "const": true,
-            "default": true,
+            "description": "Always true for authorized session",
             "title": "Authenticated",
             "type": "boolean"
           },
@@ -5339,7 +5344,7 @@
           },
           "status": {
             "const": "ok",
-            "default": "ok",
+            "description": "Deterministic status value",
             "title": "Status",
             "type": "string"
           },
@@ -5354,6 +5359,8 @@
           }
         },
         "required": [
+          "status",
+          "authenticated",
           "tier",
           "auth_source"
         ],
@@ -7190,6 +7197,11 @@
         "in": "header",
         "name": "X-API-Key",
         "type": "apiKey"
+      },
+      "CookieSession": {
+        "in": "cookie",
+        "name": "pp_web_session",
+        "type": "apiKey"
       }
     }
   },
@@ -7330,6 +7342,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Bmi Pro Legacy Alias",
@@ -7359,6 +7374,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Food Data Attribution",
@@ -7407,6 +7425,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "[DEPRECATED] Legacy PRO BMI endpoint",
@@ -7454,6 +7475,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Calculate BMI with WHR (PRO tier)",
@@ -7516,6 +7540,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Cbt Insight",
@@ -7564,6 +7591,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Generate Shopping List",
@@ -7612,6 +7642,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Generate weekly meal plan (PRO tier)",
@@ -7659,6 +7692,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Nutrient coverage scoring (PRO)",
@@ -7818,6 +7854,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get daily nutrition data (PRO tier)",
@@ -7865,6 +7904,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Close day (PRO)",
@@ -7913,6 +7955,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Food-based deficiency recommendations (PRO)",
@@ -7961,6 +8006,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Log meal event (PRO)",
@@ -8009,6 +8057,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Extended micronutrient targets with ranges (PRO)",
@@ -8057,6 +8108,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Enhanced plate (PRO)",
@@ -8105,6 +8159,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Safety validation of nutrition targets (PRO)",
@@ -8153,6 +8210,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "WHO nutrition targets (PRO)",
@@ -8221,6 +8281,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Activate Subscription",
@@ -8290,6 +8353,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Subscription Activation",
@@ -8358,6 +8424,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Revoke Handoff Share",
@@ -8436,6 +8505,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Handoff Share Status",
@@ -8503,6 +8575,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Create Partner Order",
@@ -8560,6 +8635,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Preview Partner Order From Weekly Plan",
@@ -8607,6 +8685,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Preview Partner Order",
@@ -8685,6 +8766,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Partner Order",
@@ -8783,6 +8867,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Confirm Partner Order",
@@ -8868,6 +8955,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Issue Handoff Share",
@@ -8896,6 +8986,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Session Status",
@@ -8924,6 +9017,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Exchange Session Cookie",
@@ -8952,6 +9048,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Logout Session",
@@ -8980,6 +9079,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Refresh Session Cookie",
@@ -9043,6 +9145,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Shopping list suggestions for a day (MVP placeholder)",
@@ -9073,6 +9178,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Repair Strategies",
@@ -9124,6 +9232,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Manual Repair Suggestions",
@@ -9175,6 +9286,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Auto Repair Weekly Plan",
@@ -9204,6 +9318,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Vip Health",
@@ -9255,6 +9372,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Weekly Menu Plan",
@@ -9306,6 +9426,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Weekly Menu Repair",
@@ -9357,6 +9480,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Synthesize Recipe",
@@ -9386,6 +9512,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Recipe Templates",
@@ -9437,6 +9566,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Synthesize Weekly Recipes",
@@ -9466,6 +9598,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Regions",
@@ -9526,6 +9661,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Compare Product Prices",
@@ -9576,6 +9714,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Region Categories",
@@ -9655,6 +9796,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Search Region Products",
@@ -9705,6 +9849,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Get Region Stores",
@@ -9756,6 +9903,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Daily Shoplist",
@@ -9872,6 +10022,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Export VIP shoplist to CSV or PDF",
@@ -9902,6 +10055,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Available Export Formats",
@@ -9992,6 +10148,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Generate VIP shoplist (deterministic)",
@@ -10035,6 +10194,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "VIP shoplist preview (legacy)",
@@ -10087,6 +10249,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "CookieSession": []
           }
         ],
         "summary": "Weekly Shoplist",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -669,6 +669,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pro/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Session Status
+         * @description Return current auth source and tier for PRO/VIP session.
+         */
+        get: operations["get_session_status_api_v1_pro_session_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/session/exchange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exchange Session Cookie
+         * @description Exchange authenticated PRO/VIP session into hardened HttpOnly cookie.
+         */
+        post: operations["exchange_session_cookie_api_v1_pro_session_exchange_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/session/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Logout Session
+         * @description Logout by clearing session cookie (idempotent).
+         */
+        post: operations["logout_session_api_v1_pro_session_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pro/session/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh Session Cookie
+         * @description Refresh session cookie for currently authenticated PRO/VIP principal.
+         */
+        post: operations["refresh_session_cookie_api_v1_pro_session_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pro/shoplist/day": {
         parameters: {
             query?: never;
@@ -3781,6 +3861,93 @@ export interface components {
             warnings: string[];
         };
         /**
+         * SessionExchangeResponse
+         * @description Exchange/refresh response contract.
+         */
+        SessionExchangeResponse: {
+            /**
+             * Auth Source
+             * @description Authentication source used for this request
+             * @enum {string}
+             */
+            auth_source: "header" | "cookie";
+            /**
+             * Expires At Epoch
+             * @description Session expiry Unix epoch (UTC)
+             */
+            expires_at_epoch: number;
+            /**
+             * Status
+             * @default ok
+             * @constant
+             */
+            status: "ok";
+            /**
+             * Tier
+             * @description Resolved tier stored in session cookie
+             * @enum {string}
+             */
+            tier: "PRO" | "VIP";
+            /**
+             * Ttl Seconds
+             * @description Session TTL in seconds
+             */
+            ttl_seconds: number;
+        };
+        /**
+         * SessionLogoutResponse
+         * @description Logout response contract.
+         */
+        SessionLogoutResponse: {
+            /**
+             * Logged Out
+             * @default true
+             * @constant
+             */
+            logged_out: true;
+            /**
+             * Status
+             * @default ok
+             * @constant
+             */
+            status: "ok";
+        };
+        /**
+         * SessionStatusResponse
+         * @description Session status response contract.
+         */
+        SessionStatusResponse: {
+            /**
+             * Auth Source
+             * @description Current authentication source
+             * @enum {string}
+             */
+            auth_source: "header" | "cookie";
+            /**
+             * Authenticated
+             * @default true
+             * @constant
+             */
+            authenticated: true;
+            /**
+             * Expires At Epoch
+             * @description Cookie expiry Unix epoch (UTC), null when header auth is used
+             */
+            expires_at_epoch?: number | null;
+            /**
+             * Status
+             * @default ok
+             * @constant
+             */
+            status: "ok";
+            /**
+             * Tier
+             * @description Current authenticated tier
+             * @enum {string}
+             */
+            tier: "PRO" | "VIP";
+        };
+        /**
          * ShopAisle
          * @description Stable aisle/category for iOS (do not rename; only extend).
          *
@@ -5908,6 +6075,86 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PartnerOrderErrorResponse"];
+                };
+            };
+        };
+    };
+    get_session_status_api_v1_pro_session_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionStatusResponse"];
+                };
+            };
+        };
+    };
+    exchange_session_cookie_api_v1_pro_session_exchange_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionExchangeResponse"];
+                };
+            };
+        };
+    };
+    logout_session_api_v1_pro_session_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionLogoutResponse"];
+                };
+            };
+        };
+    };
+    refresh_session_cookie_api_v1_pro_session_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionExchangeResponse"];
                 };
             };
         };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3878,7 +3878,7 @@ export interface components {
             expires_at_epoch: number;
             /**
              * Status
-             * @default ok
+             * @description Deterministic exchange status
              * @constant
              */
             status: "ok";
@@ -3901,13 +3901,13 @@ export interface components {
         SessionLogoutResponse: {
             /**
              * Logged Out
-             * @default true
+             * @description Always true for successful logout
              * @constant
              */
             logged_out: true;
             /**
              * Status
-             * @default ok
+             * @description Deterministic logout status
              * @constant
              */
             status: "ok";
@@ -3925,7 +3925,7 @@ export interface components {
             auth_source: "header" | "cookie";
             /**
              * Authenticated
-             * @default true
+             * @description Always true for authorized session
              * @constant
              */
             authenticated: true;
@@ -3936,7 +3936,7 @@ export interface components {
             expires_at_epoch?: number | null;
             /**
              * Status
-             * @default ok
+             * @description Deterministic status value
              * @constant
              */
             status: "ok";

--- a/frontend/src/auth/storage.ts
+++ b/frontend/src/auth/storage.ts
@@ -1,6 +1,8 @@
-// API Key management utilities
-// SECURITY NOTE: API keys are stored in plain text in browser storage.
-// This is acceptable only for user-provided keys that can be easily rotated.
+// RU: Legacy API key storage utilities (migration-only).
+// EN: Legacy API key storage utilities (migration-only).
+//
+// SECURITY: Persistent browser storage for auth secrets is deprecated.
+// The app now uses server-side session cookies.
 
 const API_KEY_STORAGE_KEY = 'pulseplate_api_key';
 
@@ -14,13 +16,15 @@ export function getStoredApiKey(): string | null {
   return localStorage.getItem(API_KEY_STORAGE_KEY) || sessionStorage.getItem(API_KEY_STORAGE_KEY);
 }
 
-export function setStoredApiKey(key: string, remember: boolean = false): void {
+/**
+ * @deprecated
+ * RU: Сохранение API-ключа в браузере отключено по security policy.
+ * EN: Browser persistence for API keys is disabled by security policy.
+ */
+export function setStoredApiKey(_key: string, _remember: boolean = false): void {
   if (typeof window === 'undefined') return;
-  const storage = remember ? localStorage : sessionStorage;
-  storage.setItem(API_KEY_STORAGE_KEY, key);
-  // Clear from other storage
-  const otherStorage = remember ? sessionStorage : localStorage;
-  otherStorage.removeItem(API_KEY_STORAGE_KEY);
+  // Keep behavior deterministic: remove any legacy value instead of persisting new secrets.
+  clearStoredApiKey();
 }
 
 export function clearStoredApiKey(): void {

--- a/frontend/src/lib/__tests__/auth.session.test.tsx
+++ b/frontend/src/lib/__tests__/auth.session.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../auth';
+
+const checkProSessionMock = vi.fn<() => Promise<boolean>>();
+const exchangeApiKeyForSessionMock = vi.fn<(apiKey: string) => Promise<boolean>>();
+const clearProSessionMock = vi.fn<() => Promise<void>>();
+const getStoredApiKeyMock = vi.fn<() => string | null>();
+const clearStoredApiKeyMock = vi.fn<() => void>();
+let legacyStoredKey: string | null = null;
+
+vi.mock('../../api/client', () => ({
+  checkProSession: (...args: []) => checkProSessionMock(...args),
+  exchangeApiKeyForSession: (apiKey: string) => exchangeApiKeyForSessionMock(apiKey),
+  clearProSession: (...args: []) => clearProSessionMock(...args),
+}));
+
+vi.mock('../../auth/storage', () => ({
+  getStoredApiKey: (...args: []) => getStoredApiKeyMock(...args),
+  clearStoredApiKey: (...args: []) => clearStoredApiKeyMock(...args),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+describe('AuthProvider session migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    legacyStoredKey = null;
+    getStoredApiKeyMock.mockImplementation(() => legacyStoredKey);
+    clearStoredApiKeyMock.mockImplementation(() => {
+      legacyStoredKey = null;
+    });
+    checkProSessionMock.mockResolvedValue(false);
+    exchangeApiKeyForSessionMock.mockResolvedValue(true);
+    clearProSessionMock.mockResolvedValue(undefined);
+  });
+
+  it('migrates legacy stored API key to session and clears storage', async () => {
+    legacyStoredKey = 'legacy-session-key';
+    checkProSessionMock.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(exchangeApiKeyForSessionMock).toHaveBeenCalledWith('legacy-session-key');
+    expect(clearStoredApiKeyMock).toHaveBeenCalled();
+    expect(legacyStoredKey).toBeNull();
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.apiKey).not.toBeNull();
+  });
+
+  it('setApiKey exchanges for session and never persists key in storage', async () => {
+    checkProSessionMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setApiKey('sk-session12345678901234567890');
+    });
+
+    expect(exchangeApiKeyForSessionMock).toHaveBeenCalledWith('sk-session12345678901234567890');
+    expect(clearStoredApiKeyMock).toHaveBeenCalled();
+    expect(legacyStoredKey).toBeNull();
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/auth.session.test.tsx
+++ b/frontend/src/lib/__tests__/auth.session.test.tsx
@@ -56,6 +56,23 @@ describe('AuthProvider session migration', () => {
     expect(result.current.apiKey).not.toBeNull();
   });
 
+  it('clears legacy storage even when exchange fails', async () => {
+    legacyStoredKey = 'legacy-session-key';
+    exchangeApiKeyForSessionMock.mockRejectedValueOnce(new Error('exchange failed'));
+    checkProSessionMock.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(exchangeApiKeyForSessionMock).toHaveBeenCalledWith('legacy-session-key');
+    expect(clearStoredApiKeyMock).toHaveBeenCalled();
+    expect(legacyStoredKey).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.apiKey).toBeNull();
+  });
+
   it('setApiKey exchanges for session and never persists key in storage', async () => {
     checkProSessionMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 

--- a/frontend/src/lib/__tests__/useApiKey.test.ts
+++ b/frontend/src/lib/__tests__/useApiKey.test.ts
@@ -8,6 +8,15 @@ vi.mock('../auth', () => ({
   useAuth: vi.fn(),
 }));
 
+const EXPECTED_HOOK_KEYS = [
+  'apiKey',
+  'setApiKey',
+  'clearApiKey',
+  'setApiKeyAsync',
+  'clearApiKeyAsync',
+  'isAuthenticated',
+] as const;
+
 describe('useApiKey', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,14 +45,7 @@ describe('useApiKey', () => {
     expect(result.current.isAuthenticated).toBe(mockIsAuthenticated);
 
     // Validate that expected compatibility and async keys are returned.
-    expect(Object.keys(result.current)).toEqual([
-      'apiKey',
-      'setApiKey',
-      'clearApiKey',
-      'setApiKeyAsync',
-      'clearApiKeyAsync',
-      'isAuthenticated'
-    ]);
+    expect(Object.keys(result.current)).toEqual(EXPECTED_HOOK_KEYS);
   });
 
   it('returns null apiKey and defined functions when not authenticated', () => {
@@ -65,14 +67,7 @@ describe('useApiKey', () => {
     expect(result.current.isAuthenticated).toBe(false);
 
     // Validate that expected compatibility and async keys are returned.
-    expect(Object.keys(result.current)).toEqual([
-      'apiKey',
-      'setApiKey',
-      'clearApiKey',
-      'setApiKeyAsync',
-      'clearApiKeyAsync',
-      'isAuthenticated'
-    ]);
+    expect(Object.keys(result.current)).toEqual(EXPECTED_HOOK_KEYS);
   });
 
   it('calls useAuth hook', () => {
@@ -91,14 +86,7 @@ describe('useApiKey', () => {
     expect(useAuth).toHaveBeenCalledTimes(1);
 
     // Validate that expected compatibility and async keys are returned.
-    expect(Object.keys(result.current)).toEqual([
-      'apiKey',
-      'setApiKey',
-      'clearApiKey',
-      'setApiKeyAsync',
-      'clearApiKeyAsync',
-      'isAuthenticated'
-    ]);
+    expect(Object.keys(result.current)).toEqual(EXPECTED_HOOK_KEYS);
   });
 
   it('compat wrappers call async auth methods (fire-and-forget)', () => {

--- a/frontend/src/lib/__tests__/useApiKey.test.ts
+++ b/frontend/src/lib/__tests__/useApiKey.test.ts
@@ -14,14 +14,14 @@ describe('useApiKey', () => {
   });
   it('returns API key management functions from useAuth', () => {
     const mockApiKey = 'test-api-key';
-    const mockSetApiKey = vi.fn();
-    const mockClearApiKey = vi.fn();
+    const mockSetApiKeyAsync = vi.fn();
+    const mockClearApiKeyAsync = vi.fn();
     const mockIsAuthenticated = true;
 
     vi.mocked(useAuth).mockReturnValue({
       apiKey: mockApiKey,
-      setApiKey: mockSetApiKey,
-      clearApiKey: mockClearApiKey,
+      setApiKey: mockSetApiKeyAsync,
+      clearApiKey: mockClearApiKeyAsync,
       isAuthenticated: mockIsAuthenticated,
       isLoading: false,
       showAuthPrompt: false,
@@ -31,15 +31,17 @@ describe('useApiKey', () => {
     const { result } = renderHook(() => useApiKey());
 
     expect(result.current.apiKey).toBe(mockApiKey);
-    expect(result.current.setApiKey).toBe(mockSetApiKey);
-    expect(result.current.clearApiKey).toBe(mockClearApiKey);
+    expect(result.current.setApiKeyAsync).toBe(mockSetApiKeyAsync);
+    expect(result.current.clearApiKeyAsync).toBe(mockClearApiKeyAsync);
     expect(result.current.isAuthenticated).toBe(mockIsAuthenticated);
 
-    // Validate that only expected properties are returned
+    // Validate that expected compatibility and async keys are returned.
     expect(Object.keys(result.current)).toEqual([
       'apiKey',
       'setApiKey',
       'clearApiKey',
+      'setApiKeyAsync',
+      'clearApiKeyAsync',
       'isAuthenticated'
     ]);
   });
@@ -62,11 +64,13 @@ describe('useApiKey', () => {
     expect(result.current.clearApiKey).toBeDefined();
     expect(result.current.isAuthenticated).toBe(false);
 
-    // Validate that only expected properties are returned
+    // Validate that expected compatibility and async keys are returned.
     expect(Object.keys(result.current)).toEqual([
       'apiKey',
       'setApiKey',
       'clearApiKey',
+      'setApiKeyAsync',
+      'clearApiKeyAsync',
       'isAuthenticated'
     ]);
   });
@@ -86,12 +90,36 @@ describe('useApiKey', () => {
 
     expect(useAuth).toHaveBeenCalledTimes(1);
 
-    // Validate that only expected properties are returned
+    // Validate that expected compatibility and async keys are returned.
     expect(Object.keys(result.current)).toEqual([
       'apiKey',
       'setApiKey',
       'clearApiKey',
+      'setApiKeyAsync',
+      'clearApiKeyAsync',
       'isAuthenticated'
     ]);
+  });
+
+  it('compat wrappers call async auth methods (fire-and-forget)', () => {
+    const mockSetApiKeyAsync = vi.fn().mockResolvedValue(undefined);
+    const mockClearApiKeyAsync = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(useAuth).mockReturnValue({
+      apiKey: 'test',
+      setApiKey: mockSetApiKeyAsync,
+      clearApiKey: mockClearApiKeyAsync,
+      isAuthenticated: true,
+      isLoading: false,
+      showAuthPrompt: false,
+      setShowAuthPrompt: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useApiKey());
+    result.current.setApiKey('abc', true);
+    result.current.clearApiKey();
+
+    expect(mockSetApiKeyAsync).toHaveBeenCalledWith('abc', true);
+    expect(mockClearApiKeyAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -63,6 +63,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (legacyKey) {
         try {
           await exchangeApiKeyForSession(legacyKey);
+        } catch {
+          // Fail closed: migration best-effort, auth state is derived from session check below.
         } finally {
           // Always clear legacy persistence even if exchange fails.
           clearStoredApiKey();
@@ -122,7 +124,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const clearApiKey = async () => {
     clearPromptTimeout();
     clearStoredApiKey();
-    await clearProSession();
+    try {
+      await clearProSession();
+    } catch {
+      // Best-effort logout: local auth state is still cleared deterministically.
+    }
     setIsAuthenticated(false);
     setApiKeyState(null);
     scheduleAuthPrompt();

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,8 +1,10 @@
-import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react';
-import { getStoredApiKey, setStoredApiKey, clearStoredApiKey } from '../auth/storage';
+import { createContext, useContext, useState, useEffect, useRef, useCallback, ReactNode } from 'react';
+import { getStoredApiKey, clearStoredApiKey } from '../auth/storage';
+import { checkProSession, clearProSession, exchangeApiKeyForSession } from '../api/client';
 
 const MIN_API_KEY_LENGTH = 20;
 const AUTH_PROMPT_DELAY_MS = 500;
+const SESSION_AUTH_SENTINEL = '__session_auth__';
 
 export class AuthError extends Error {
   code: string;
@@ -19,8 +21,8 @@ export interface AuthContextType {
   apiKey: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  setApiKey: (key: string, remember?: boolean) => void;
-  clearApiKey: () => void;
+  setApiKey: (key: string, remember?: boolean) => Promise<void>;
+  clearApiKey: () => Promise<void>;
   showAuthPrompt: boolean;
   setShowAuthPrompt: (show: boolean) => void;
 }
@@ -33,68 +35,102 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [apiKey, setApiKeyState] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [showAuthPrompt, setShowAuthPrompt] = useState(false);
   const promptTimeoutRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    // Load API key from storage on mount
-    const storedKey = getStoredApiKey();
-    setApiKeyState(storedKey);
-    setIsLoading(false);
-
-    // Show auth prompt if no key is stored
-    if (!storedKey) {
-      // Delay showing prompt to avoid flash on initial load
-      promptTimeoutRef.current = window.setTimeout(() => {
-        // Double-check that no key was set during the delay
-        const currentKey = getStoredApiKey();
-        if (!currentKey) {
-          setShowAuthPrompt(true);
-        }
-      }, AUTH_PROMPT_DELAY_MS);
+  const clearPromptTimeout = useCallback(() => {
+    if (promptTimeoutRef.current !== null) {
+      clearTimeout(promptTimeoutRef.current);
+      promptTimeoutRef.current = null;
     }
-
-    return () => {
-      if (promptTimeoutRef.current !== null) {
-        clearTimeout(promptTimeoutRef.current);
-        promptTimeoutRef.current = null;
-      }
-    };
   }, []);
 
-  const setApiKey = (key: string, remember: boolean = false) => {
+  const scheduleAuthPrompt = useCallback(() => {
+    clearPromptTimeout();
+    promptTimeoutRef.current = window.setTimeout(() => {
+      setShowAuthPrompt(true);
+    }, AUTH_PROMPT_DELAY_MS);
+  }, [clearPromptTimeout]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const initializeAuth = async () => {
+      // One-time migration: exchange legacy browser key for secure server session cookie.
+      const legacyKey = getStoredApiKey();
+      if (legacyKey) {
+        try {
+          await exchangeApiKeyForSession(legacyKey);
+        } finally {
+          // Always clear legacy persistence even if exchange fails.
+          clearStoredApiKey();
+        }
+      }
+
+      const sessionActive = await checkProSession();
+      if (cancelled) {
+        return;
+      }
+
+      setIsAuthenticated(sessionActive);
+      setApiKeyState(sessionActive ? SESSION_AUTH_SENTINEL : null);
+      setIsLoading(false);
+      if (!sessionActive) {
+        scheduleAuthPrompt();
+      } else {
+        clearPromptTimeout();
+        setShowAuthPrompt(false);
+      }
+    };
+
+    void initializeAuth();
+
+    return () => {
+      cancelled = true;
+      clearPromptTimeout();
+    };
+  }, [clearPromptTimeout, scheduleAuthPrompt]);
+
+  const setApiKey = async (key: string, _remember: boolean = false) => {
     const trimmedKey = key.trim();
-    // Validate minimum API key length
     if (trimmedKey.length < MIN_API_KEY_LENGTH) {
       throw new AuthError('API_KEY_TOO_SHORT');
     }
-    // Add format check: only allow alphanumeric, dashes, and underscores
     if (!/^[A-Za-z0-9_-]+$/.test(trimmedKey)) {
       throw new AuthError('API_KEY_INVALID_FORMAT');
     }
-    if (promptTimeoutRef.current !== null) {
-      clearTimeout(promptTimeoutRef.current);
-      promptTimeoutRef.current = null;
+    clearPromptTimeout();
+
+    const exchanged = await exchangeApiKeyForSession(trimmedKey);
+    if (!exchanged) {
+      throw new AuthError('API_KEY_INVALID');
     }
-    setStoredApiKey(trimmedKey, remember);
-    setApiKeyState(trimmedKey);
+
+    const sessionActive = await checkProSession();
+    if (!sessionActive) {
+      throw new AuthError('SESSION_NOT_ESTABLISHED');
+    }
+
+    clearStoredApiKey();
+    setIsAuthenticated(true);
+    setApiKeyState(SESSION_AUTH_SENTINEL);
     setShowAuthPrompt(false);
   };
 
-  const clearApiKey = () => {
-    if (promptTimeoutRef.current !== null) {
-      clearTimeout(promptTimeoutRef.current);
-      promptTimeoutRef.current = null;
-    }
+  const clearApiKey = async () => {
+    clearPromptTimeout();
     clearStoredApiKey();
+    await clearProSession();
+    setIsAuthenticated(false);
     setApiKeyState(null);
-    setShowAuthPrompt(true);
+    scheduleAuthPrompt();
   };
 
   const value: AuthContextType = {
     apiKey,
-    isAuthenticated: !!apiKey,
+    isAuthenticated,
     isLoading,
     setApiKey,
     clearApiKey,

--- a/frontend/src/lib/useApiKey.ts
+++ b/frontend/src/lib/useApiKey.ts
@@ -1,15 +1,34 @@
 import { useAuth } from './auth';
 
 /**
- * Hook for API key management - simplified interface to useAuth
+ * Hook for API key/session management.
+ *
+ * Compatibility note:
+ * - `setApiKey`/`clearApiKey` keep legacy fire-and-forget behavior for older callers.
+ * - Async variants are exposed for new flows that need explicit error handling.
  */
 export function useApiKey() {
-  const { apiKey, setApiKey, clearApiKey, isAuthenticated } = useAuth();
+  const {
+    apiKey,
+    setApiKey: setApiKeyAsync,
+    clearApiKey: clearApiKeyAsync,
+    isAuthenticated,
+  } = useAuth();
+
+  const setApiKey = (key: string, remember?: boolean): void => {
+    void setApiKeyAsync(key, remember);
+  };
+
+  const clearApiKey = (): void => {
+    void clearApiKeyAsync();
+  };
 
   return {
     apiKey,
     setApiKey,
     clearApiKey,
+    setApiKeyAsync,
+    clearApiKeyAsync,
     isAuthenticated,
   };
 }

--- a/frontend/src/lib/useApiKey.ts
+++ b/frontend/src/lib/useApiKey.ts
@@ -16,11 +16,11 @@ export function useApiKey() {
   } = useAuth();
 
   const setApiKey = (key: string, remember?: boolean): void => {
-    void setApiKeyAsync(key, remember);
+    void setApiKeyAsync(key, remember).catch(() => {});
   };
 
   const clearApiKey = (): void => {
-    void clearApiKeyAsync();
+    void clearApiKeyAsync().catch(() => {});
   };
 
   return {

--- a/frontend/src/pages/Onboarding/EnterKey.tsx
+++ b/frontend/src/pages/Onboarding/EnterKey.tsx
@@ -49,10 +49,14 @@ export default function EnterKey() {
 
   const handleClear = async () => {
     const hadKey = auth.isAuthenticated || !!value.trim();
-    await auth.clearApiKey();
-    setValue("");
-    if (hadKey) {
-      toast.success(t("onboarding.enterKey.keyCleared"));
+    try {
+      await auth.clearApiKey();
+      setValue("");
+      if (hadKey) {
+        toast.success(t("onboarding.enterKey.keyCleared"));
+      }
+    } catch {
+      toast.error(t("onboarding.enterKey.errorGeneric"));
     }
   };
 

--- a/frontend/src/pages/Onboarding/EnterKey.tsx
+++ b/frontend/src/pages/Onboarding/EnterKey.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth, AuthError } from "../../lib/auth";
 import { useTranslation } from "react-i18next";
@@ -15,24 +15,19 @@ export default function EnterKey() {
   const auth = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [value, setValue] = useState(auth.apiKey || "");
-
-  // Sync value state with auth.apiKey to avoid stale inputs
-  useEffect(() => {
-    setValue(auth.apiKey || "");
-  }, [auth.apiKey]);
+  const [value, setValue] = useState("");
 
   // Get the page user was trying to access
   const from = (location.state as LocationState)?.from?.pathname || "/";
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const trimmed = value.trim();
     if (!trimmed) {
       toast.error(t("onboarding.enterKey.errorEmpty"));
       return;
     }
     try {
-      auth.setApiKey(trimmed, true); // Remember by default for onboarding
+      await auth.setApiKey(trimmed, true);
       toast.success(t("onboarding.enterKey.successSaved"));
       if (from && from !== "/enter-key" && from !== "/") {
         navigate(from, { replace: true });
@@ -52,9 +47,9 @@ export default function EnterKey() {
     }
   };
 
-  const handleClear = () => {
-    const hadKey = !!value.trim();
-    auth.clearApiKey();
+  const handleClear = async () => {
+    const hadKey = auth.isAuthenticated || !!value.trim();
+    await auth.clearApiKey();
     setValue("");
     if (hadKey) {
       toast.success(t("onboarding.enterKey.keyCleared"));
@@ -70,7 +65,12 @@ export default function EnterKey() {
         </p>
       </header>
 
-        <form onSubmit={(e) => { e.preventDefault(); handleSave(); }}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleSave();
+        }}
+      >
         <div className="space-y-3">
           <label htmlFor="api-key-input" className="sr-only">
             {t("onboarding.enterKey.label")}
@@ -94,7 +94,9 @@ export default function EnterKey() {
             <button
               className="rounded-xl border border-white/15 text-white py-3 px-4"
               type="button"
-              onClick={handleClear}
+              onClick={() => {
+                void handleClear();
+              }}
             >
               {t("onboarding.enterKey.clear")}
             </button>

--- a/frontend/src/pages/Onboarding/__tests__/EnterKey.test.tsx
+++ b/frontend/src/pages/Onboarding/__tests__/EnterKey.test.tsx
@@ -6,6 +6,24 @@ import EnterKey from '../EnterKey';
 import { AuthProvider } from '../../../lib/auth';
 import toast from 'react-hot-toast';
 
+const checkProSessionMock = vi.fn<() => Promise<boolean>>();
+const exchangeApiKeyForSessionMock = vi.fn<(apiKey: string) => Promise<boolean>>();
+const clearProSessionMock = vi.fn<() => Promise<void>>();
+const getStoredApiKeyMock = vi.fn<() => string | null>();
+const clearStoredApiKeyMock = vi.fn<() => void>();
+
+vi.mock('../../../api/client', () => ({
+  checkProSession: (...args: []) => checkProSessionMock(...args),
+  exchangeApiKeyForSession: (apiKey: string) => exchangeApiKeyForSessionMock(apiKey),
+  clearProSession: (...args: []) => clearProSessionMock(...args),
+}));
+
+vi.mock('../../../auth/storage', () => ({
+  getStoredApiKey: (...args: []) => getStoredApiKeyMock(...args),
+  setStoredApiKey: vi.fn(),
+  clearStoredApiKey: (...args: []) => clearStoredApiKeyMock(...args),
+}));
+
 
 // Mock i18next
 vi.mock('react-i18next', () => ({
@@ -30,25 +48,30 @@ vi.mock('react-hot-toast', () => ({
   },
 }));
 
-const renderWithProviders = (component: React.ReactElement) => {
-  // Clear any stored API keys before each test
-  localStorage.removeItem('pulseplate_api_key');
-  sessionStorage.removeItem('pulseplate_api_key');
-
-  return render(
+const renderWithProviders = async (component: React.ReactElement) => {
+  const rendered = render(
     <AuthProvider>
       {component}
     </AuthProvider>
   );
+  await waitFor(() => {
+    expect(checkProSessionMock).toHaveBeenCalled();
+  });
+  return rendered;
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getStoredApiKeyMock.mockReturnValue(null);
+  clearStoredApiKeyMock.mockImplementation(() => {});
+  checkProSessionMock.mockResolvedValue(false);
+  exchangeApiKeyForSessionMock.mockResolvedValue(true);
+  clearProSessionMock.mockResolvedValue(undefined);
 });
 
 describe('EnterKey', () => {
-  it('renders the API key input form', () => {
-    renderWithProviders(<EnterKey />);
+  it('renders the API key input form', async () => {
+    await renderWithProviders(<EnterKey />);
 
     expect(screen.getByText('onboarding.enterKey.title')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('onboarding.enterKey.placeholder')).toBeInTheDocument();
@@ -57,7 +80,7 @@ describe('EnterKey', () => {
   });
 
   it('shows error for empty API key', async () => {
-    renderWithProviders(<EnterKey />);
+    await renderWithProviders(<EnterKey />);
 
     const saveButton = screen.getByText('onboarding.enterKey.save');
     fireEvent.click(saveButton);
@@ -68,7 +91,7 @@ describe('EnterKey', () => {
   });
 
   it('shows error for API key shorter than minimum length', async () => {
-    renderWithProviders(<EnterKey />);
+    await renderWithProviders(<EnterKey />);
 
     const input = screen.getByPlaceholderText('onboarding.enterKey.placeholder');
     fireEvent.change(input, { target: { value: 'short' } }); // 5 characters, less than minimum
@@ -82,7 +105,9 @@ describe('EnterKey', () => {
   });
 
   it('saves API key when valid', async () => {
-    renderWithProviders(<EnterKey />);
+    checkProSessionMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await renderWithProviders(<EnterKey />);
 
     const input = screen.getByPlaceholderText('onboarding.enterKey.placeholder');
     fireEvent.change(input, { target: { value: 'sk-test12345678901234567890' } });
@@ -93,10 +118,11 @@ describe('EnterKey', () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('onboarding.enterKey.successSaved');
     });
+    expect(exchangeApiKeyForSessionMock).toHaveBeenCalledWith('sk-test12345678901234567890');
   });
 
   it('clears API key when clear button is clicked', async () => {
-    renderWithProviders(<EnterKey />);
+    await renderWithProviders(<EnterKey />);
 
     const input = screen.getByPlaceholderText('onboarding.enterKey.placeholder');
     fireEvent.change(input, { target: { value: 'sk-test12345678901234567890' } });
@@ -111,7 +137,7 @@ describe('EnterKey', () => {
   });
 
   it('does not show success message when clearing empty API key', async () => {
-    renderWithProviders(<EnterKey />);
+    await renderWithProviders(<EnterKey />);
 
     const clearButton = screen.getByText('onboarding.enterKey.clear');
     fireEvent.click(clearButton);

--- a/tests/guards/fixtures/nosec_policy_allowlist.txt
+++ b/tests/guards/fixtures/nosec_policy_allowlist.txt
@@ -2,8 +2,8 @@
 # Entries past remove-by date cause guard FAIL. Phase 2: migrate to full nosec format, shrink to 0.
 # See docs/roadmap/BACKLOG_LEDGER.md "Phase 2: Remove nosec allowlist".
 app/metrics.py:105 remove-by=2026-04-30 ref=PR-985
-app/middleware/api_tiers.py:73 remove-by=2026-04-30 ref=PR-985
-app/middleware/api_tiers.py:74 remove-by=2026-04-30 ref=PR-985
+app/middleware/api_tiers.py:91 remove-by=2026-04-30 ref=PR-985
+app/middleware/api_tiers.py:92 remove-by=2026-04-30 ref=PR-985
 app/middleware/metrics.py:224 remove-by=2026-04-30 ref=PR-985
 app/middleware/metrics.py:238 remove-by=2026-04-30 ref=PR-985
 app/middleware/metrics.py:248 remove-by=2026-04-30 ref=PR-985

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -352,11 +352,14 @@ class TestRequireProTier:
     ) -> None:
         """Test verifier runtime errors do not bypass PRO guard."""
 
+        def raise_runtime_error(_: str) -> None:
+            raise RuntimeError("bad server salt")
+
         request = _request_with_cookie("signed-cookie-value")
         monkeypatch.setattr(
             api_tiers_mod,
             "verify_web_session",
-            lambda _: (_ for _ in ()).throw(RuntimeError("bad server salt")),
+            raise_runtime_error,
         )
 
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -428,6 +428,42 @@ class TestRequireVIPTier:
             require_vip_tier(x_api_key=None, request=request)
         assert exc_info.value.status_code == 403
 
+    def test_cookie_fallback_revalidates_current_key_tier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test cookie auth rechecks current tier instead of trusting embedded claims."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_PRO, tier="VIP")
+        request = _request_with_cookie(issued.token)
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_resolve_authorized_api_key_tier",
+            lambda *_args, **_kwargs: SubscriptionTier.PRO,
+        )
+
+        result = require_pro_tier(x_api_key=None, request=request)
+        assert result == TEST_KEY_PRO
+        context = api_tiers_mod.get_request_pro_auth_context(request)
+        assert context is not None
+        assert context.tier == SubscriptionTier.PRO
+
+    def test_cookie_fallback_fails_closed_when_current_key_tier_revoked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test cookie auth is denied when current tier no longer authorizes access."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_VIP, tier="VIP")
+        request = _request_with_cookie(issued.token)
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "_resolve_authorized_api_key_tier",
+            lambda *_args, **_kwargs: None,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_vip_tier(x_api_key=None, request=request)
+        assert exc_info.value.status_code == 403
+
     def test_empty_header_rejected_for_vip_even_with_valid_cookie(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -335,6 +335,18 @@ class TestRequireProTier:
             require_pro_tier(x_api_key="invalid_key", request=request)
         assert exc_info.value.status_code == 403
 
+    def test_empty_header_rejected_even_with_valid_cookie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test empty X-API-Key header does not fall back to cookie auth."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_PRO, tier="PRO")
+        request = _request_with_cookie(issued.token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_pro_tier(x_api_key="   ", request=request)
+        assert exc_info.value.status_code == 403
+
     def test_cookie_verifier_runtime_error_fails_closed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -414,6 +426,18 @@ class TestRequireVIPTier:
 
         with pytest.raises(HTTPException) as exc_info:
             require_vip_tier(x_api_key=None, request=request)
+        assert exc_info.value.status_code == 403
+
+    def test_empty_header_rejected_for_vip_even_with_valid_cookie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test empty X-API-Key header does not bypass VIP guard via cookie fallback."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_VIP, tier="VIP")
+        request = _request_with_cookie(issued.token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_vip_tier(x_api_key=" ", request=request)
         assert exc_info.value.status_code == 403
 
 

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -6,9 +6,11 @@ EN: Tests for API tier validation middleware.
 
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 import app.middleware.api_tiers as api_tiers_mod
 from app.middleware.api_tiers import (
+    AuthSource,
     DBLookupResult,
     DBLookupStatus,
     CurrentUser,
@@ -23,6 +25,7 @@ from app.middleware.api_tiers import (
     require_pro_tier,
     require_vip_tier,
 )
+from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
 
 
 class TestSubscriptionTier:
@@ -182,6 +185,24 @@ class _FakeSession:
         self.closed = True
 
 
+def _request_with_cookie(token: str) -> Request:
+    """Build minimal Starlette Request carrying a cookie header."""
+
+    cookie_header = f"{WEB_SESSION_COOKIE_NAME}={token}".encode("utf-8")
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "scheme": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "headers": [(b"cookie", cookie_header)],
+    }
+    return Request(scope)
+
+
 class TestDBLookupHelpers:
     """Test low-level DB tier lookup helpers."""
 
@@ -286,6 +307,56 @@ class TestRequireProTier:
         assert exc_info.value.status_code == 403
         assert "does not have PRO tier access" in exc_info.value.detail
 
+    def test_cookie_fallback_accepts_valid_pro_cookie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test missing header falls back to valid PRO cookie."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_PRO, tier="PRO")
+        request = _request_with_cookie(issued.token)
+
+        result = require_pro_tier(x_api_key=None, request=request)
+        assert result == TEST_KEY_PRO
+        context = api_tiers_mod.get_request_pro_auth_context(request)
+        assert context is not None
+        assert context.source == AuthSource.COOKIE
+        assert context.tier == SubscriptionTier.PRO
+        assert context.session_expires_at_epoch == issued.claims.expires_at_epoch
+
+    def test_header_precedence_rejects_invalid_header_even_with_valid_cookie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test invalid X-API-Key blocks access even when cookie is valid."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_PRO, tier="PRO")
+        request = _request_with_cookie(issued.token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_pro_tier(x_api_key="invalid_key", request=request)
+        assert exc_info.value.status_code == 403
+
+    def test_cookie_verifier_runtime_error_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test verifier runtime errors do not bypass PRO guard."""
+
+        request = _request_with_cookie("signed-cookie-value")
+        monkeypatch.setattr(
+            api_tiers_mod,
+            "verify_web_session",
+            lambda _: (_ for _ in ()).throw(RuntimeError("bad server salt")),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_pro_tier(x_api_key=None, request=request)
+        assert exc_info.value.status_code == 401
+
+    def test_get_request_pro_auth_context_returns_none_when_missing(self) -> None:
+        """Test helper returns None when request state has no cached context."""
+
+        request = _request_with_cookie("token")
+        assert api_tiers_mod.get_request_pro_auth_context(request) is None
+
 
 class TestRequireVIPTier:
     """Test require_vip_tier dependency function (sync, runs in threadpool in FastAPI)."""
@@ -321,6 +392,29 @@ class TestRequireVIPTier:
             require_vip_tier(x_api_key="invalid_key")
         assert exc_info.value.status_code == 403
         assert "Upgrade to VIP" in exc_info.value.detail
+
+    def test_cookie_fallback_accepts_valid_vip_cookie(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test missing header falls back to valid VIP cookie."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_VIP, tier="VIP")
+        request = _request_with_cookie(issued.token)
+
+        result = require_vip_tier(x_api_key=None, request=request)
+        assert result == TEST_KEY_VIP
+
+    def test_cookie_fallback_rejects_pro_cookie_for_vip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test VIP guard rejects PRO-tier cookie."""
+        monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+        issued = issue_web_session(api_key=TEST_KEY_PRO, tier="PRO")
+        request = _request_with_cookie(issued.token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_vip_tier(x_api_key=None, request=request)
+        assert exc_info.value.status_code == 403
 
 
 class TestGetSubscriptionTier:

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -1,0 +1,155 @@
+"""Deterministic tests for PRO web-session cookie flow."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.middleware.api_tiers import TEST_KEY_PRO
+from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
+
+
+@pytest.fixture(autouse=True)
+def _session_cookie_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set deterministic env for cookie signing and local cookie policy."""
+
+    monkeypatch.setenv("SERVER_SALT", "test-server-salt")
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("DEBUG", "true")
+
+
+def test_exchange_success_sets_hardened_cookie(client: TestClient) -> None:
+    """Exchange should issue HttpOnly Lax cookie in local mode (Secure off)."""
+
+    response = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["tier"] == "PRO"
+    assert body["auth_source"] == "header"
+    assert body["ttl_seconds"] >= 1
+    assert body["expires_at_epoch"] >= 1
+
+    set_cookie = response.headers.get("set-cookie", "")
+    assert f"{WEB_SESSION_COOKIE_NAME}=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "Path=/" in set_cookie
+    assert "samesite=lax" in set_cookie.lower()
+    assert "secure" not in set_cookie.lower()
+
+
+def test_exchange_fail_invalid_key(client: TestClient) -> None:
+    """Invalid header key should be rejected at exchange."""
+
+    response = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": "invalid_key"},
+    )
+    assert response.status_code == 403
+    assert "PRO tier" in response.json()["detail"]
+
+
+def test_status_uses_cookie_after_exchange(client: TestClient) -> None:
+    """Status should authenticate with cookie when header is absent."""
+
+    exchange = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert exchange.status_code == 200
+
+    response = client.get("/api/v1/pro/session")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authenticated"] is True
+    assert body["auth_source"] == "cookie"
+    assert body["tier"] == "PRO"
+    assert body["expires_at_epoch"] >= 1
+
+
+def test_header_has_precedence_over_cookie(client: TestClient) -> None:
+    """Invalid header must not fall back to valid cookie (header-first precedence)."""
+
+    exchange = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert exchange.status_code == 200
+
+    response = client.get(
+        "/api/v1/pro/session",
+        headers={"X-API-Key": "invalid_key"},
+    )
+    assert response.status_code == 403
+    assert "PRO tier" in response.json()["detail"]
+
+
+def test_refresh_and_logout_flow(client: TestClient) -> None:
+    """Refresh keeps auth valid; logout clears cookie and blocks cookie-only status."""
+
+    exchange = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert exchange.status_code == 200
+
+    refreshed = client.post("/api/v1/pro/session/refresh")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["status"] == "ok"
+    assert refreshed.json()["auth_source"] == "cookie"
+    assert f"{WEB_SESSION_COOKIE_NAME}=" in refreshed.headers.get("set-cookie", "")
+
+    logout = client.post("/api/v1/pro/session/logout")
+    assert logout.status_code == 200
+    assert logout.json() == {"status": "ok", "logged_out": True}
+    clear_cookie = logout.headers.get("set-cookie", "").lower()
+    assert f"{WEB_SESSION_COOKIE_NAME}=" in clear_cookie
+    assert "max-age=0" in clear_cookie
+
+    status_after_logout = client.get("/api/v1/pro/session")
+    assert status_after_logout.status_code == 401
+
+
+def test_expired_cookie_is_rejected(client: TestClient) -> None:
+    """Expired cookie must be rejected fail-closed."""
+
+    issued = issue_web_session(
+        api_key=TEST_KEY_PRO,
+        tier="PRO",
+        now=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        ttl_seconds=1,
+    )
+    client.cookies.set(WEB_SESSION_COOKIE_NAME, issued.token, path="/")
+
+    response = client.get("/api/v1/pro/session")
+    assert response.status_code == 401
+    assert "API key required" in response.json()["detail"]
+
+
+def test_invalid_cookie_is_rejected(client: TestClient) -> None:
+    """Malformed/invalid signature cookie must be rejected fail-closed."""
+
+    client.cookies.set(WEB_SESSION_COOKIE_NAME, "bad-token-value", path="/")
+    response = client.get("/api/v1/pro/session")
+    assert response.status_code == 401
+    assert "API key required" in response.json()["detail"]
+
+
+def test_vip_endpoint_rejects_pro_cookie(client: TestClient) -> None:
+    """VIP endpoint must reject PRO-tier cookie (no privilege escalation)."""
+
+    exchange = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert exchange.status_code == 200
+
+    response = client.get("/api/v1/vip/health")
+    assert response.status_code == 403
+    assert "VIP access required" in response.json()["detail"]

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from fastapi import HTTPException, Response
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
-from app.middleware.api_tiers import TEST_KEY_PRO
+import app.routers.pro_session as pro_session_mod
+from app.middleware.api_tiers import AuthSource, SubscriptionTier, TEST_KEY_PRO, TierAuthContext
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
 
 
@@ -153,3 +156,76 @@ def test_vip_endpoint_rejects_pro_cookie(client: TestClient) -> None:
     response = client.get("/api/v1/vip/health")
     assert response.status_code == 403
     assert "VIP access required" in response.json()["detail"]
+
+
+def test_get_cached_context_missing_returns_500() -> None:
+    """Internal helper should fail closed when dependency did not cache auth context."""
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "scheme": "http",
+            "method": "GET",
+            "path": "/api/v1/pro/session",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1111),
+            "server": ("testserver", 80),
+        }
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        pro_session_mod._get_cached_pro_context(request)
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Missing authentication context"
+
+
+def test_issue_and_set_cookie_normalizes_non_pro_tier_to_pro() -> None:
+    """Defensive normalization should downgrade unexpected tiers to PRO."""
+
+    response = Response()
+    context = TierAuthContext(
+        api_key=TEST_KEY_PRO,
+        tier=SubscriptionTier.FREE,
+        source=AuthSource.HEADER,
+    )
+    payload = pro_session_mod._issue_and_set_cookie(response=response, context=context)
+    assert payload.tier == "PRO"
+    assert payload.auth_source == "header"
+    assert payload.ttl_seconds >= 1
+
+
+def test_exchange_returns_503_when_cookie_issue_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exchange endpoint must return deterministic 503 on cookie issuance runtime errors."""
+
+    monkeypatch.setattr(
+        pro_session_mod,
+        "_issue_and_set_cookie",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("session unavailable")),
+    )
+    response = client.post(
+        "/api/v1/pro/session/exchange",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Web session is unavailable"
+
+
+def test_refresh_returns_503_when_cookie_issue_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refresh endpoint must return deterministic 503 on cookie issuance runtime errors."""
+
+    monkeypatch.setattr(
+        pro_session_mod,
+        "_issue_and_set_cookie",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("session unavailable")),
+    )
+    response = client.post(
+        "/api/v1/pro/session/refresh",
+        headers={"X-API-Key": TEST_KEY_PRO},
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Web session is unavailable"

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -32,16 +32,26 @@ def isolated_client() -> TestClient:
         yield test_client
 
 
-def test_exchange_success_sets_hardened_cookie(isolated_client: TestClient) -> None:
+def _assert_json_response(response) -> dict:
+    """Assert JSON content type before parsing response body."""
+
+    content_type = response.headers.get("content-type", "").lower()
+    assert content_type.startswith("application/json")
+    return response.json()
+
+
+def test_exchange_success_sets_hardened_cookie(
+    isolated_client: TestClient, pro_headers: dict[str, str]
+) -> None:
     """Exchange should issue HttpOnly Lax cookie in local mode (Secure off)."""
 
     response = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert response.status_code == 200
 
-    body = response.json()
+    body = _assert_json_response(response)
     assert body["status"] == "ok"
     assert body["tier"] == "PRO"
     assert body["auth_source"] == "header"
@@ -64,33 +74,37 @@ def test_exchange_fail_invalid_key(isolated_client: TestClient) -> None:
         headers={"X-API-Key": "invalid_key"},
     )
     assert response.status_code == 403
-    assert "PRO tier" in response.json()["detail"]
+    assert "PRO tier" in _assert_json_response(response)["detail"]
 
 
-def test_status_uses_cookie_after_exchange(isolated_client: TestClient) -> None:
+def test_status_uses_cookie_after_exchange(
+    isolated_client: TestClient, pro_headers: dict[str, str]
+) -> None:
     """Status should authenticate with cookie when header is absent."""
 
     exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert exchange.status_code == 200
 
     response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 200
-    body = response.json()
+    body = _assert_json_response(response)
     assert body["authenticated"] is True
     assert body["auth_source"] == "cookie"
     assert body["tier"] == "PRO"
     assert body["expires_at_epoch"] >= 1
 
 
-def test_header_has_precedence_over_cookie(isolated_client: TestClient) -> None:
+def test_header_has_precedence_over_cookie(
+    isolated_client: TestClient, pro_headers: dict[str, str]
+) -> None:
     """Invalid header must not fall back to valid cookie (header-first precedence)."""
 
     exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert exchange.status_code == 200
 
@@ -99,27 +113,28 @@ def test_header_has_precedence_over_cookie(isolated_client: TestClient) -> None:
         headers={"X-API-Key": "invalid_key"},
     )
     assert response.status_code == 403
-    assert "PRO tier" in response.json()["detail"]
+    assert "PRO tier" in _assert_json_response(response)["detail"]
 
 
-def test_refresh_and_logout_flow(isolated_client: TestClient) -> None:
+def test_refresh_and_logout_flow(isolated_client: TestClient, pro_headers: dict[str, str]) -> None:
     """Refresh keeps auth valid; logout clears cookie and blocks cookie-only status."""
 
     exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert exchange.status_code == 200
 
     refreshed = isolated_client.post("/api/v1/pro/session/refresh")
     assert refreshed.status_code == 200
-    assert refreshed.json()["status"] == "ok"
-    assert refreshed.json()["auth_source"] == "cookie"
+    refreshed_body = _assert_json_response(refreshed)
+    assert refreshed_body["status"] == "ok"
+    assert refreshed_body["auth_source"] == "cookie"
     assert f"{WEB_SESSION_COOKIE_NAME}=" in refreshed.headers.get("set-cookie", "")
 
     logout = isolated_client.post("/api/v1/pro/session/logout")
     assert logout.status_code == 200
-    assert logout.json() == {"status": "ok", "logged_out": True}
+    assert _assert_json_response(logout) == {"status": "ok", "logged_out": True}
     clear_cookie = logout.headers.get("set-cookie", "").lower()
     assert f"{WEB_SESSION_COOKIE_NAME}=" in clear_cookie
     assert "max-age=0" in clear_cookie
@@ -141,7 +156,7 @@ def test_expired_cookie_is_rejected(isolated_client: TestClient) -> None:
 
     response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 401
-    assert "API key required" in response.json()["detail"]
+    assert "API key required" in _assert_json_response(response)["detail"]
 
 
 def test_invalid_cookie_is_rejected(isolated_client: TestClient) -> None:
@@ -150,21 +165,23 @@ def test_invalid_cookie_is_rejected(isolated_client: TestClient) -> None:
     isolated_client.cookies.set(WEB_SESSION_COOKIE_NAME, "bad-token-value", path="/")
     response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 401
-    assert "API key required" in response.json()["detail"]
+    assert "API key required" in _assert_json_response(response)["detail"]
 
 
-def test_vip_endpoint_rejects_pro_cookie(isolated_client: TestClient) -> None:
+def test_vip_endpoint_rejects_pro_cookie(
+    isolated_client: TestClient, pro_headers: dict[str, str]
+) -> None:
     """VIP endpoint must reject PRO-tier cookie (no privilege escalation)."""
 
     exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert exchange.status_code == 200
 
     response = isolated_client.get("/api/v1/vip/health")
     assert response.status_code == 403
-    assert "VIP access required" in response.json()["detail"]
+    assert "VIP access required" in _assert_json_response(response)["detail"]
 
 
 def test_get_cached_context_missing_returns_500() -> None:
@@ -203,7 +220,9 @@ def test_issue_and_set_cookie_rejects_unexpected_tier() -> None:
 
 
 def test_exchange_returns_503_when_cookie_issue_fails(
-    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    pro_headers: dict[str, str],
 ) -> None:
     """Exchange endpoint must return deterministic 503 on cookie issuance runtime errors."""
 
@@ -214,14 +233,16 @@ def test_exchange_returns_503_when_cookie_issue_fails(
     )
     response = isolated_client.post(
         "/api/v1/pro/session/exchange",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert response.status_code == 503
-    assert response.json()["detail"] == "Web session is unavailable"
+    assert _assert_json_response(response)["detail"] == "Web session is unavailable"
 
 
 def test_refresh_returns_503_when_cookie_issue_fails(
-    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    pro_headers: dict[str, str],
 ) -> None:
     """Refresh endpoint must return deterministic 503 on cookie issuance runtime errors."""
 
@@ -232,7 +253,7 @@ def test_refresh_returns_503_when_cookie_issue_fails(
     )
     response = isolated_client.post(
         "/api/v1/pro/session/refresh",
-        headers={"X-API-Key": TEST_KEY_PRO},
+        headers=pro_headers,
     )
     assert response.status_code == 503
-    assert response.json()["detail"] == "Web session is unavailable"
+    assert _assert_json_response(response)["detail"] == "Web session is unavailable"

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from fastapi import HTTPException, Response
 from fastapi.testclient import TestClient
+from httpx import Response as HTTPXResponse
 from starlette.requests import Request
 
 import app.routers.pro_session as pro_session_mod
@@ -32,7 +34,7 @@ def isolated_client() -> TestClient:
         yield test_client
 
 
-def _assert_json_response(response) -> dict:
+def _assert_json_response(response: HTTPXResponse) -> dict[str, Any]:
     """Assert JSON content type before parsing response body."""
 
     content_type = response.headers.get("content-type", "").lower()

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 import app.routers.pro_session as pro_session_mod
+from app.main import app as main_app
 from app.middleware.api_tiers import AuthSource, SubscriptionTier, TEST_KEY_PRO, TierAuthContext
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
 
@@ -23,10 +24,18 @@ def _session_cookie_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DEBUG", "true")
 
 
-def test_exchange_success_sets_hardened_cookie(client: TestClient) -> None:
+@pytest.fixture
+def isolated_client() -> TestClient:
+    """Isolated TestClient without shared fixture overrides."""
+
+    with TestClient(main_app) as test_client:
+        yield test_client
+
+
+def test_exchange_success_sets_hardened_cookie(isolated_client: TestClient) -> None:
     """Exchange should issue HttpOnly Lax cookie in local mode (Secure off)."""
 
-    response = client.post(
+    response = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
@@ -47,10 +56,10 @@ def test_exchange_success_sets_hardened_cookie(client: TestClient) -> None:
     assert "secure" not in set_cookie.lower()
 
 
-def test_exchange_fail_invalid_key(client: TestClient) -> None:
+def test_exchange_fail_invalid_key(isolated_client: TestClient) -> None:
     """Invalid header key should be rejected at exchange."""
 
-    response = client.post(
+    response = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": "invalid_key"},
     )
@@ -58,16 +67,16 @@ def test_exchange_fail_invalid_key(client: TestClient) -> None:
     assert "PRO tier" in response.json()["detail"]
 
 
-def test_status_uses_cookie_after_exchange(client: TestClient) -> None:
+def test_status_uses_cookie_after_exchange(isolated_client: TestClient) -> None:
     """Status should authenticate with cookie when header is absent."""
 
-    exchange = client.post(
+    exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
     assert exchange.status_code == 200
 
-    response = client.get("/api/v1/pro/session")
+    response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 200
     body = response.json()
     assert body["authenticated"] is True
@@ -76,16 +85,16 @@ def test_status_uses_cookie_after_exchange(client: TestClient) -> None:
     assert body["expires_at_epoch"] >= 1
 
 
-def test_header_has_precedence_over_cookie(client: TestClient) -> None:
+def test_header_has_precedence_over_cookie(isolated_client: TestClient) -> None:
     """Invalid header must not fall back to valid cookie (header-first precedence)."""
 
-    exchange = client.post(
+    exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
     assert exchange.status_code == 200
 
-    response = client.get(
+    response = isolated_client.get(
         "/api/v1/pro/session",
         headers={"X-API-Key": "invalid_key"},
     )
@@ -93,33 +102,33 @@ def test_header_has_precedence_over_cookie(client: TestClient) -> None:
     assert "PRO tier" in response.json()["detail"]
 
 
-def test_refresh_and_logout_flow(client: TestClient) -> None:
+def test_refresh_and_logout_flow(isolated_client: TestClient) -> None:
     """Refresh keeps auth valid; logout clears cookie and blocks cookie-only status."""
 
-    exchange = client.post(
+    exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
     assert exchange.status_code == 200
 
-    refreshed = client.post("/api/v1/pro/session/refresh")
+    refreshed = isolated_client.post("/api/v1/pro/session/refresh")
     assert refreshed.status_code == 200
     assert refreshed.json()["status"] == "ok"
     assert refreshed.json()["auth_source"] == "cookie"
     assert f"{WEB_SESSION_COOKIE_NAME}=" in refreshed.headers.get("set-cookie", "")
 
-    logout = client.post("/api/v1/pro/session/logout")
+    logout = isolated_client.post("/api/v1/pro/session/logout")
     assert logout.status_code == 200
     assert logout.json() == {"status": "ok", "logged_out": True}
     clear_cookie = logout.headers.get("set-cookie", "").lower()
     assert f"{WEB_SESSION_COOKIE_NAME}=" in clear_cookie
     assert "max-age=0" in clear_cookie
 
-    status_after_logout = client.get("/api/v1/pro/session")
+    status_after_logout = isolated_client.get("/api/v1/pro/session")
     assert status_after_logout.status_code == 401
 
 
-def test_expired_cookie_is_rejected(client: TestClient) -> None:
+def test_expired_cookie_is_rejected(isolated_client: TestClient) -> None:
     """Expired cookie must be rejected fail-closed."""
 
     issued = issue_web_session(
@@ -128,32 +137,32 @@ def test_expired_cookie_is_rejected(client: TestClient) -> None:
         now=datetime(2020, 1, 1, tzinfo=timezone.utc),
         ttl_seconds=1,
     )
-    client.cookies.set(WEB_SESSION_COOKIE_NAME, issued.token, path="/")
+    isolated_client.cookies.set(WEB_SESSION_COOKIE_NAME, issued.token, path="/")
 
-    response = client.get("/api/v1/pro/session")
+    response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 401
     assert "API key required" in response.json()["detail"]
 
 
-def test_invalid_cookie_is_rejected(client: TestClient) -> None:
+def test_invalid_cookie_is_rejected(isolated_client: TestClient) -> None:
     """Malformed/invalid signature cookie must be rejected fail-closed."""
 
-    client.cookies.set(WEB_SESSION_COOKIE_NAME, "bad-token-value", path="/")
-    response = client.get("/api/v1/pro/session")
+    isolated_client.cookies.set(WEB_SESSION_COOKIE_NAME, "bad-token-value", path="/")
+    response = isolated_client.get("/api/v1/pro/session")
     assert response.status_code == 401
     assert "API key required" in response.json()["detail"]
 
 
-def test_vip_endpoint_rejects_pro_cookie(client: TestClient) -> None:
+def test_vip_endpoint_rejects_pro_cookie(isolated_client: TestClient) -> None:
     """VIP endpoint must reject PRO-tier cookie (no privilege escalation)."""
 
-    exchange = client.post(
+    exchange = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
     assert exchange.status_code == 200
 
-    response = client.get("/api/v1/vip/health")
+    response = isolated_client.get("/api/v1/vip/health")
     assert response.status_code == 403
     assert "VIP access required" in response.json()["detail"]
 
@@ -180,8 +189,8 @@ def test_get_cached_context_missing_returns_500() -> None:
     assert exc_info.value.detail == "Missing authentication context"
 
 
-def test_issue_and_set_cookie_normalizes_non_pro_tier_to_pro() -> None:
-    """Defensive normalization should downgrade unexpected tiers to PRO."""
+def test_issue_and_set_cookie_rejects_unexpected_tier() -> None:
+    """Unexpected tier should fail closed (no silent upgrade)."""
 
     response = Response()
     context = TierAuthContext(
@@ -189,14 +198,12 @@ def test_issue_and_set_cookie_normalizes_non_pro_tier_to_pro() -> None:
         tier=SubscriptionTier.FREE,
         source=AuthSource.HEADER,
     )
-    payload = pro_session_mod._issue_and_set_cookie(response=response, context=context)
-    assert payload.tier == "PRO"
-    assert payload.auth_source == "header"
-    assert payload.ttl_seconds >= 1
+    with pytest.raises(RuntimeError):
+        pro_session_mod._issue_and_set_cookie(response=response, context=context)
 
 
 def test_exchange_returns_503_when_cookie_issue_fails(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Exchange endpoint must return deterministic 503 on cookie issuance runtime errors."""
 
@@ -205,7 +212,7 @@ def test_exchange_returns_503_when_cookie_issue_fails(
         "_issue_and_set_cookie",
         lambda **_: (_ for _ in ()).throw(RuntimeError("session unavailable")),
     )
-    response = client.post(
+    response = isolated_client.post(
         "/api/v1/pro/session/exchange",
         headers={"X-API-Key": TEST_KEY_PRO},
     )
@@ -214,7 +221,7 @@ def test_exchange_returns_503_when_cookie_issue_fails(
 
 
 def test_refresh_returns_503_when_cookie_issue_fails(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Refresh endpoint must return deterministic 503 on cookie issuance runtime errors."""
 
@@ -223,7 +230,7 @@ def test_refresh_returns_503_when_cookie_issue_fails(
         "_issue_and_set_cookie",
         lambda **_: (_ for _ in ()).throw(RuntimeError("session unavailable")),
     )
-    response = client.post(
+    response = isolated_client.post(
         "/api/v1/pro/session/refresh",
         headers={"X-API-Key": TEST_KEY_PRO},
     )

--- a/tests/test_web_session_security.py
+++ b/tests/test_web_session_security.py
@@ -1,0 +1,222 @@
+"""Unit tests for web session cookie security helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import Response
+
+from app.security import web_session
+
+TEST_PRO_KEY = "test_pro_key"  # pragma: allowlist secret
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(encoded: str) -> bytes:
+    pad_len = (-len(encoded)) % 4
+    return base64.urlsafe_b64decode(encoded + ("=" * pad_len))
+
+
+def _derived_key(server_salt: str) -> bytes:
+    return hashlib.sha256(f"web_session_v1::{server_salt}".encode("utf-8")).digest()
+
+
+def _sign_payload(payload_b64: str, *, server_salt: str) -> str:
+    return hmac.new(
+        _derived_key(server_salt),
+        payload_b64.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def test_require_web_session_ttl_seconds_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset TTL should use safe default."""
+
+    monkeypatch.delenv(web_session.WEB_SESSION_TTL_ENV, raising=False)
+    assert (
+        web_session.require_web_session_ttl_seconds() == web_session.DEFAULT_WEB_SESSION_TTL_SECONDS
+    )
+
+
+def test_require_web_session_ttl_seconds_valid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TTL env should be parsed when valid."""
+
+    monkeypatch.setenv(web_session.WEB_SESSION_TTL_ENV, "123")
+    assert web_session.require_web_session_ttl_seconds() == 123
+
+
+def test_require_web_session_ttl_seconds_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid TTL env should fail closed."""
+
+    monkeypatch.setenv(web_session.WEB_SESSION_TTL_ENV, "abc")
+    with pytest.raises(RuntimeError):
+        web_session.require_web_session_ttl_seconds()
+
+    monkeypatch.setenv(web_session.WEB_SESSION_TTL_ENV, "0")
+    with pytest.raises(RuntimeError):
+        web_session.require_web_session_ttl_seconds()
+
+
+def test_issue_and_verify_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issued token should verify and keep core claims."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    issued = web_session.issue_web_session(
+        api_key=TEST_PRO_KEY,
+        tier="PRO",
+        now=now,
+        ttl_seconds=120,
+    )
+    claims = web_session.verify_web_session(issued.token, now=now + timedelta(seconds=60))
+
+    assert claims is not None
+    assert claims.api_key == TEST_PRO_KEY
+    assert claims.tier == "PRO"
+    assert claims.issued_at_epoch == int(now.timestamp())
+    assert claims.expires_at_epoch == int((now + timedelta(seconds=120)).timestamp())
+
+
+def test_issue_rejects_invalid_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue path must fail closed for malformed inputs."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+
+    with pytest.raises(ValueError):
+        web_session.issue_web_session(api_key="", tier="PRO")
+    with pytest.raises(ValueError):
+        web_session.issue_web_session(api_key="k", tier="FREE")
+    with pytest.raises(ValueError):
+        web_session.issue_web_session(api_key="k", tier="PRO", ttl_seconds=0)
+
+
+def test_issue_rejects_empty_explicit_secret() -> None:
+    """Explicit empty secret is forbidden."""
+
+    with pytest.raises(RuntimeError):
+        web_session.issue_web_session(api_key="k", tier="PRO", secret="   ")
+
+
+def test_verify_rejects_malformed_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed token formats should return None."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    assert web_session.verify_web_session("") is None
+    assert web_session.verify_web_session("abc") is None
+    assert web_session.verify_web_session("a.b.c") is None
+    assert web_session.verify_web_session("a.") is None
+    assert web_session.verify_web_session(".b") is None
+
+
+def test_verify_rejects_bad_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tampered signature must fail verification."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    issued = web_session.issue_web_session(api_key="k", tier="PRO", ttl_seconds=100)
+    payload, _sig = issued.token.split(".", 1)
+    assert web_session.verify_web_session(f"{payload}.deadbeef") is None
+
+
+def test_verify_rejects_wrong_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unsupported version must be rejected."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    issued = web_session.issue_web_session(api_key="k", tier="PRO", ttl_seconds=100)
+    payload, _sig = issued.token.split(".", 1)
+    payload_raw = _b64url_decode(payload)
+    tampered = payload_raw.replace(b'"v":1', b'"v":2')
+    tampered_payload = _b64url_encode(tampered)
+    tampered_sig = _sign_payload(tampered_payload, server_salt="session-secret")
+    bad_token = f"{tampered_payload}.{tampered_sig}"
+    assert web_session.verify_web_session(bad_token) is None
+
+
+def test_verify_rejects_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expired token should be rejected deterministically."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    issued = web_session.issue_web_session(
+        api_key="k",
+        tier="PRO",
+        now=now,
+        ttl_seconds=10,
+    )
+    assert web_session.verify_web_session(issued.token, now=now + timedelta(seconds=11)) is None
+
+
+def test_verify_rejects_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verification should reject non-object payload and invalid claims."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    expires_epoch = now_epoch + 100
+
+    bad_payloads = [
+        b"[]",
+        b'{"api_key":"","tier":"PRO","iat":1,"exp":2,"v":1}',
+        b'{"api_key":"k","tier":"UNKNOWN","iat":1,"exp":2,"v":1}',
+        b'{"api_key":"k","tier":"PRO","iat":"1","exp":2,"v":1}',
+        b'{"api_key":"k","tier":"PRO","iat":1,"exp":"2","v":1}',
+        b'{"api_key":"k","tier":"PRO","iat":-1,"exp":2,"v":1}',
+        b'{"api_key":"k","tier":"PRO","iat":2,"exp":2,"v":1}',
+        (
+            f'{{"api_key":"k","tier":"PRO","iat":{now_epoch},"exp":{expires_epoch},"v":"1"}}'.encode(
+                "utf-8"
+            )
+        ),
+    ]
+    for payload_raw in bad_payloads:
+        payload = _b64url_encode(payload_raw)
+        sig = _sign_payload(payload, server_salt="session-secret")
+        assert web_session.verify_web_session(f"{payload}.{sig}") is None
+
+
+def test_cookie_helpers_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local mode should set hardened cookie without Secure flag."""
+
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv(web_session.WEB_SESSION_TTL_ENV, "90")
+    response = Response()
+
+    web_session.set_web_session_cookie(response=response, token="abc")
+    header = response.headers.get("set-cookie", "")
+    assert f"{web_session.WEB_SESSION_COOKIE_NAME}=abc" in header
+    assert "HttpOnly" in header
+    assert "Path=/" in header
+    assert "samesite=lax" in header.lower()
+    assert "max-age=90" in header.lower()
+    assert "secure" not in header.lower()
+
+
+def test_cookie_helpers_prod_and_clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prod mode should set Secure and clear should expire cookie."""
+
+    monkeypatch.setenv("APP_ENV", "production")
+    response = Response()
+
+    web_session.set_web_session_cookie(response=response, token="abc", ttl_seconds=30)
+    set_headers = [
+        value.decode("latin-1").lower()
+        for key, value in response.raw_headers
+        if key.lower() == b"set-cookie"
+    ]
+    assert any("secure" in header for header in set_headers)
+    assert any("max-age=30" in header for header in set_headers)
+
+    web_session.clear_web_session_cookie(response=response)
+    clear_headers = [
+        value.decode("latin-1").lower()
+        for key, value in response.raw_headers
+        if key.lower() == b"set-cookie"
+    ]
+    assert any(f"{web_session.WEB_SESSION_COOKIE_NAME}=" in header for header in clear_headers)
+    assert any("max-age=0" in header for header in clear_headers)

--- a/tests/test_web_session_security.py
+++ b/tests/test_web_session_security.py
@@ -105,6 +105,27 @@ def test_issue_rejects_empty_explicit_secret() -> None:
         web_session.issue_web_session(api_key="k", tier="PRO", secret="   ")
 
 
+def test_issue_and_verify_with_explicit_secret() -> None:
+    """Explicit secret path should work without relying on SERVER_SALT env."""
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    issued = web_session.issue_web_session(
+        api_key=TEST_PRO_KEY,
+        tier="PRO",
+        now=now,
+        ttl_seconds=120,
+        secret="explicit-session-secret",  # pragma: allowlist secret
+    )
+    claims = web_session.verify_web_session(
+        issued.token,
+        now=now + timedelta(seconds=30),
+        secret="explicit-session-secret",  # pragma: allowlist secret
+    )
+    assert claims is not None
+    assert claims.api_key == TEST_PRO_KEY
+    assert claims.tier == "PRO"
+
+
 def test_verify_rejects_malformed_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     """Malformed token formats should return None."""
 
@@ -114,6 +135,17 @@ def test_verify_rejects_malformed_tokens(monkeypatch: pytest.MonkeyPatch) -> Non
     assert web_session.verify_web_session("a.b.c") is None
     assert web_session.verify_web_session("a.") is None
     assert web_session.verify_web_session(".b") is None
+
+
+def test_verify_rejects_invalid_base64_payload_with_valid_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Signed token with undecodable payload must fail closed."""
+
+    monkeypatch.setenv("SERVER_SALT", "session-secret")
+    payload = "@@@"
+    sig = _sign_payload(payload, server_salt="session-secret")
+    assert web_session.verify_web_session(f"{payload}.{sig}") is None
 
 
 def test_verify_rejects_bad_signature(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -164,6 +196,7 @@ def test_verify_rejects_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
         b"[]",
         b'{"api_key":"","tier":"PRO","iat":1,"exp":2,"v":1}',
         b'{"api_key":"k","tier":"UNKNOWN","iat":1,"exp":2,"v":1}',
+        b'{"api_key":"k","tier":123,"iat":1,"exp":2,"v":1}',
         b'{"api_key":"k","tier":"PRO","iat":"1","exp":2,"v":1}',
         b'{"api_key":"k","tier":"PRO","iat":1,"exp":"2","v":1}',
         b'{"api_key":"k","tier":"PRO","iat":-1,"exp":2,"v":1}',

--- a/tests/test_web_session_security.py
+++ b/tests/test_web_session_security.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import hmac
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -25,15 +24,17 @@ def _b64url_decode(encoded: str) -> bytes:
 
 
 def _derived_key(server_salt: str) -> bytes:
-    return hashlib.sha256(f"web_session_v1::{server_salt}".encode("utf-8")).digest()
+    return hashlib.blake2s(f"web_session_v1::{server_salt}".encode("utf-8")).digest()
 
 
 def _sign_payload(payload_b64: str, *, server_salt: str) -> str:
-    return hmac.new(
-        _derived_key(server_salt),
+    return hashlib.pbkdf2_hmac(
+        "sha256",
         payload_b64.encode("ascii"),
-        hashlib.sha256,
-    ).hexdigest()
+        _derived_key(server_salt),
+        web_session._SESSION_SIGNATURE_ITERATIONS,
+        dklen=32,
+    ).hex()
 
 
 def test_require_web_session_ttl_seconds_default(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Implements `P0` session transport hardening W1: web auth now uses server-issued `HttpOnly` signed cookie instead of browser key persistence.
- Preserves backward compatibility: `X-API-Key` flow remains valid (header-first), cookie auth is additive fallback for web.
- Adds canonical PRO session endpoints under `/api/v1/pro/session*` and updates frontend auth flow to exchange key -> session.

## Scope
### Backend / Security
- Added stateless signed web session module: `app/security/web_session.py`.
- Added PRO session endpoints:
  - `POST /api/v1/pro/session/exchange`
  - `GET /api/v1/pro/session`
  - `POST /api/v1/pro/session/refresh`
  - `POST /api/v1/pro/session/logout`
- Updated tier guards in `app/middleware/api_tiers.py`:
  - header-first auth precedence
  - cookie fallback (`HttpOnly` session cookie)
  - fail-closed behavior on invalid/expired/misconfigured cookie
- Registered new router in `app/routers/pro_registration.py`.
- Added env contract in `.env.example`: `WEB_SESSION_TTL_SECONDS`.
- Synced OpenAPI and generated frontend schema.

### Frontend
- Disabled API key persistence in browser storage (`frontend/src/auth/storage.ts`).
- Added server-session helpers in `frontend/src/api/client.ts` (`checkProSession`, `exchangeApiKeyForSession`, `clearProSession`).
- Auth context now bootstraps from server session status (`frontend/src/lib/auth.tsx`).
- Added one-time migration path: legacy stored key -> exchange -> clear storage.
- Updated Enter Key flow for async session exchange and logout.

### Tests
- Added backend tests:
  - `tests/test_web_session_security.py`
  - `tests/test_pro_session_cookie_auth.py`
- Extended tier tests in `tests/test_api_tiers.py` for cookie fallback, precedence, and fail-closed branches.
- Added frontend tests:
  - `frontend/src/lib/__tests__/auth.session.test.tsx`
  - updated API/auth onboarding tests for cookie-session behavior.

## Ledger
- Updated `docs/roadmap/BACKLOG_LEDGER.md`:
  - `P0 session token hardening` -> `🟡 In progress (W1)`
  - `P0 PRO/VIP Depends guard` -> `✅ Merged (PR #994)`

## Validation
- `pre-commit run --all-files` ✅
- `make verify` ✅
- `make openapi-check` ✅
- `npm --prefix frontend run test -- --run src/api/__tests__/client.test.ts src/api/__tests__/client.fetchBlob.test.ts src/lib/__tests__/auth.session.test.tsx src/pages/Onboarding/__tests__/EnterKey.test.tsx` ✅

## Security Notes
- Cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`.
- `Secure=true` for staging/production, disabled in local dev.
- No new external network calls in auth guard logic.
- Tier checks stay fail-closed for invalid header/cookie/auth context.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3905918036 -> c22e5102
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3903823202 -> 3b8084f0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895871147 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3903855878 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895905793 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895905801 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895905806 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895905809 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2895905815 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3904091257 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896128551 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896128568 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896128574 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896128579 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140335 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140343 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140348 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140355 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140360 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896140363 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3904105419 -> 49e691a7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896380457 -> 9edd40e7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896380464 -> 9edd40e7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896380472 -> 9edd40e7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3904370224 -> 9edd40e7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2896352395 -> 9edd40e7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2897665519 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3905802996 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3905818982 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2897679129 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2897704024 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#discussion_r2897704030 -> bba50b0f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/995#pullrequestreview-3905843973 -> bba50b0f

## Merge Readiness
- [x] Scope is focused and non-breaking for existing API clients
- [x] Required quality gates passed locally
- [x] OpenAPI + frontend schema synchronized
- [x] Backlog ledger updated for traceability



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-backed HttpOnly PRO/VIP sessions with exchange, status, refresh, and logout endpoints; configurable TTL via WEB_SESSION_TTL_SECONDS.
  * Client APIs for session management (check/exchange/clear) and session-first auth flow.

* **Bug Fixes & Improvements**
  * Migrate away from persisted browser API keys; API key headers omitted for external URLs.
  * Clearer session/auth error messages and safer cookie defaults (HttpOnly, SameSite, Secure per env).

* **Tests**
  * Extensive unit and end-to-end tests covering issuance, verification, refresh, logout, precedence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



