### PR TITLE
fix: scope vector RAG retrieval by subject

### DIFF
--- a/app/routers/cbt_insight.py
+++ b/app/routers/cbt_insight.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
-from app.middleware.api_tiers import require_pro_tier
+from app.middleware.api_tiers import derive_subject_id_from_api_key, require_pro_tier
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,
@@ -179,6 +179,7 @@ async def cbt_insight(
             max_chunks=5,
             agent_id="cbt-agent",
             user_tier="PRO",
+            subject_id=derive_subject_id_from_api_key(_api_key),
         )
 
         if rag_ctx.chunks:

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -91,6 +91,12 @@ async def retrieve_and_validate_rag(
         Whether to run philosophy validation on chunks (feature flag).
     recursive_rag_enabled:
         Whether to run recursive multi-hop retrieval path.
+    subject_id:
+        Authenticated tenant/user identifier for personalized retrieval.
+        Pass a concrete value for tenant-scoped `user_knowledge` access.
+        Passing `None` is fail-closed: vector retrieval must not read
+        tenant-scoped data and the pipeline falls back to non-personal
+        retrieval only.
 
     Returns
     -------
@@ -103,6 +109,8 @@ async def retrieve_and_validate_rag(
     - Caller passes feature flag state (keeps core/ decoupled from app/)
     - Lazy imports preserve fail-safe behavior (missing modules don't crash)
     - Confidence is recalculated from filtered chunks when validation enabled
+    - `recursive_rag_enabled` and `philo_validation_enabled` do not weaken
+      tenant isolation; both paths propagate the same `subject_id`
     """
     try:
         return await _run_orchestration(

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -74,6 +74,7 @@ async def retrieve_and_validate_rag(
     *,
     philo_validation_enabled: bool = False,
     recursive_rag_enabled: bool = False,
+    subject_id: int | None = None,
 ) -> RAGOrchestrationResult:
     """Orchestrate RAG retrieval + philosophy validation.
 
@@ -109,6 +110,7 @@ async def retrieve_and_validate_rag(
             max_chunks,
             philo_validation_enabled,
             recursive_rag_enabled,
+            subject_id,
         )
     except Exception:
         logger.warning(
@@ -123,6 +125,7 @@ async def _run_orchestration(
     max_chunks: int,
     philo_enabled: bool,
     recursive_enabled: bool,
+    subject_id: int | None,
 ) -> RAGOrchestrationResult:
     """Execute RAG retrieval + validation pipeline."""
     # Lazy imports to preserve fail-safe behavior (missing modules don't crash)
@@ -135,13 +138,17 @@ async def _run_orchestration(
             retrieve_recursive_context_structured,
             prompt_input,
             max_chunks=max_chunks,
+            subject_id=subject_id,
             philo_validation_enabled=False,
         )
     else:
         from core.rag.vector_rag import retrieve_context_structured
 
         rag_ctx = await asyncio.to_thread(
-            retrieve_context_structured, prompt_input, max_chunks=max_chunks
+            retrieve_context_structured,
+            prompt_input,
+            max_chunks=max_chunks,
+            subject_id=subject_id,
         )
 
     if not rag_ctx.chunks:

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -116,6 +116,7 @@ def retrieve_recursive_context_structured(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
     *,
     philo_validation_enabled: bool = False,
 ) -> RAGContext:
@@ -156,6 +157,7 @@ def retrieve_recursive_context_structured(
                 max_chunks=limit,
                 agent_id=agent_id,
                 user_tier=user_tier,
+                subject_id=subject_id,
             )
             if not hop_ctx.chunks:
                 break

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -60,7 +60,7 @@ def _tokenize(text: str) -> List[str]:
 def _compute_confidence(chunks: List[RAGChunk]) -> float:
     if not chunks:
         return 0.0
-    return round(sum(chunk.score for chunk in chunks) / len(chunks), 4)
+    return float(round(sum(chunk.score for chunk in chunks) / len(chunks), 4))
 
 
 def _rank_chunks(chunks: Iterable[RAGChunk], limit: int) -> List[RAGChunk]:
@@ -101,14 +101,15 @@ def _apply_verification(
     """Apply deterministic chunk verification pipeline."""
     from core.rag.validation import validate_rag_chunks
 
-    validated = validate_rag_chunks(chunks, agent_id=agent_id).filtered_chunks
+    validated: List[RAGChunk] = validate_rag_chunks(chunks, agent_id=agent_id).filtered_chunks
 
     if not philo_validation_enabled or not validated:
         return validated
 
     from core.rag.philosophy_pipeline import run_pipeline
 
-    return run_pipeline(validated, query=query).filtered_chunks
+    filtered: List[RAGChunk] = run_pipeline(validated, query=query).filtered_chunks
+    return filtered
 
 
 def retrieve_recursive_context_structured(

--- a/core/rag/vector_rag.py
+++ b/core/rag/vector_rag.py
@@ -87,6 +87,7 @@ def _retrieve_vector_postgres(
     query_embedding: list[float],
     limit: int,
     session: Any,
+    subject_id: int,
     corpus_prefixes: list[str] | None = None,
 ) -> list[tuple[Any, float]]:
     """Retrieve similar rows via pgvector cosine distance operator.
@@ -101,8 +102,12 @@ def _retrieve_vector_postgres(
     qvec_text = "[" + ",".join(str(x) for x in query_embedding) + "]"
 
     # Build WHERE clause with optional corpus filtering
-    where_clause = "WHERE embedding IS NOT NULL"
-    params: dict[str, Any] = {"qvec": qvec_text, "lim": limit}
+    where_clause = "WHERE embedding IS NOT NULL AND user_id = :subject_id"
+    params: dict[str, Any] = {
+        "qvec": qvec_text,
+        "lim": limit,
+        "subject_id": subject_id,
+    }
 
     if corpus_prefixes:
         # Build OR conditions for each prefix using LIKE
@@ -115,7 +120,7 @@ def _retrieve_vector_postgres(
             where_clause += " AND (" + " OR ".join(prefix_conditions) + ")"
 
     # Safe: where_clause built from hardcoded AGENT_CORPUS_MAP, values use placeholders
-    sql = f"SELECT id, content, source, 1 - (embedding <=> :qvec::vector) AS similarity FROM user_knowledge {where_clause} ORDER BY embedding <=> :qvec::vector LIMIT :lim"  # nosec B608
+    sql = f"SELECT id, content, source, 1 - (embedding <=> :qvec::vector) AS similarity FROM user_knowledge {where_clause} ORDER BY embedding <=> :qvec::vector LIMIT :lim"  # nosec B608: where_clause is built from fixed predicates and bound params only (remove-by: 2026-04-30, ref: PR-TBD-RAG-TENANT-SCOPE)
     stmt = text(sql)
     rows = session.execute(stmt, params).fetchall()
     return [(row, row.similarity) for row in rows]
@@ -125,6 +130,7 @@ def _retrieve_vector_sqlite(
     query_embedding: list[float],
     limit: int,
     session: Any,
+    subject_id: int,
     corpus_prefixes: list[str] | None = None,
 ) -> list[tuple[Any, float]]:
     """Retrieve similar rows via application-level cosine (SQLite tests).
@@ -135,8 +141,8 @@ def _retrieve_vector_sqlite(
     from sqlalchemy import text
 
     # Build WHERE clause with optional corpus filtering
-    where_clause = "WHERE embedding IS NOT NULL"
-    params: dict[str, Any] = {}
+    where_clause = "WHERE embedding IS NOT NULL AND user_id = :subject_id"
+    params: dict[str, Any] = {"subject_id": subject_id}
 
     if corpus_prefixes:
         prefix_conditions = []
@@ -148,7 +154,7 @@ def _retrieve_vector_sqlite(
             where_clause += " AND (" + " OR ".join(prefix_conditions) + ")"
 
     # Safe: where_clause built from hardcoded AGENT_CORPUS_MAP, values use placeholders
-    sql = f"SELECT id, content, source, embedding FROM user_knowledge {where_clause}"  # nosec B608
+    sql = f"SELECT id, content, source, embedding FROM user_knowledge {where_clause}"  # nosec B608: where_clause is built from fixed predicates and bound params only (remove-by: 2026-04-30, ref: PR-TBD-RAG-TENANT-SCOPE)
     rows = session.execute(
         text(sql),
         params,
@@ -183,6 +189,7 @@ def _retrieve_vector_from_db(
     max_chunks: int,
     agent_id: str | None,
     user_tier: str | None,
+    subject_id: int | None,
 ) -> RAGContext:
     """Core vector retrieval: encode query, search DB, return RAGContext.
 
@@ -190,6 +197,10 @@ def _retrieve_vector_from_db(
     corpus paths. Otherwise, queries all indexed content.
     """
     start = time.perf_counter()
+
+    if subject_id is None:
+        logger.debug("Vector retrieval skipped because subject_id is missing")
+        return _empty_context(query, agent_id, user_tier, start)
 
     # Get corpus prefixes for agent-specific filtering
     corpus_prefixes = AGENT_CORPUS_MAP.get(agent_id) if agent_id else None
@@ -207,9 +218,21 @@ def _retrieve_vector_from_db(
         limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
 
         if dialect == "postgresql":
-            results = _retrieve_vector_postgres(query_embedding, limit, session, corpus_prefixes)
+            results = _retrieve_vector_postgres(
+                query_embedding,
+                limit,
+                session,
+                subject_id=subject_id,
+                corpus_prefixes=corpus_prefixes,
+            )
         else:
-            results = _retrieve_vector_sqlite(query_embedding, limit, session, corpus_prefixes)
+            results = _retrieve_vector_sqlite(
+                query_embedding,
+                limit,
+                session,
+                subject_id=subject_id,
+                corpus_prefixes=corpus_prefixes,
+            )
 
     # Filter by minimum score and build RAGChunks
     chunks: list[RAGChunk] = []
@@ -278,6 +301,7 @@ def retrieve_context_structured(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> RAGContext:
     """Vector retrieval with automatic fallback to Jaccard.
 
@@ -290,7 +314,13 @@ def retrieve_context_structured(
     """
     if is_rag_vector_enabled():
         try:
-            ctx = _retrieve_vector_from_db(query, max_chunks, agent_id, user_tier)
+            ctx = _retrieve_vector_from_db(
+                query,
+                max_chunks,
+                agent_id,
+                user_tier,
+                subject_id,
+            )
             # If vector found results, return them
             if ctx.chunks:
                 return ctx

--- a/docs/contracts/RAG_CONTRACT.md
+++ b/docs/contracts/RAG_CONTRACT.md
@@ -168,7 +168,8 @@ MAX_CHUNK_SIZE_CHARS: int = 800
 - `core/rag/vector_rag.py:86` — `_retrieve_vector_postgres()` corpus filtering via parameterized LIKE
 - `core/rag/vector_rag.py:124` — `_retrieve_vector_sqlite()` corpus filtering via parameterized LIKE
 - `core/rag/vector_rag.py:181` — `_retrieve_vector_from_db()` resolves `agent_id` → `corpus_prefixes`
-- `core/rag/vector_rag.py` — vector retrieval from `user_knowledge` requires authenticated `subject_id`; missing subject context must fail closed to non-personal fallback
+- `core/rag/vector_rag.py:201` — vector retrieval fails closed when `subject_id` is missing
+- `core/rag/vector_rag.py:317` — public vector path falls back to non-personal Jaccard retrieval when vector path returns no chunks or errors
 - `core/rag/simple_rag.py:157` — Jaccard fallback with `startswith` corpus filtering
 - `app/routers/cbt_insight.py:134` — PRO-gated endpoint using `agent_id="cbt-agent"`
 
@@ -223,8 +224,8 @@ ALTER TABLE user_knowledge ENABLE ROW LEVEL SECURITY;
 Evidence anchors (audit policy: architecture docs must cite `file:line` or mark target-state):
 
 - `sources[].preview` проходит через `redact_rag_context_for_insight` перед отправкой клиенту. **Evidence:** `core/insight/safety.py:10` (реализация); при добавлении `sources[]` в response — вызывать перед сериализацией (target-state).
-- `user_knowledge` разрешён только при authenticated `subject_id`; если subject context отсутствует, vector retrieval обязан fail-closed и перейти на non-personal fallback. **Evidence:** `core/rag/vector_rag.py` (subject_id-gated retrieval path), `core/rag/orchestration.py` (subject propagation), `legacy_app.py` (legacy `/insight` safe fallback).
-- `user_knowledge.embedding` изолирован по `user_id` через RLS. **Target-state:** DDL в §7 включает `ENABLE ROW LEVEL SECURITY`; при миграции добавить политику `USING (auth.uid() = user_id)` (или аналог).
+- `user_knowledge` разрешён только при authenticated `subject_id`; если subject context отсутствует, vector retrieval обязан fail-closed и перейти на non-personal fallback. **Evidence:** `core/rag/vector_rag.py:201` (fail-closed on missing `subject_id`), `core/rag/vector_rag.py:317` (fallback to Jaccard on empty/error vector path), `core/rag/orchestration.py:137` and `core/rag/orchestration.py:147` (subject propagation into recursive/vector retrieval), `legacy_app.py:2202` and `legacy_app.py:2332` (authenticated `/api/v1/insight` derives and forwards `subject_id`), `legacy_app.py:2274` (legacy `/insight` passes `subject_id=None`), `app/routers/cbt_insight.py:176` (PRO CBT endpoint derives and forwards `subject_id`).
+- `user_knowledge.embedding` изолирован по `user_id` через RLS. **Target-state:** DDL в §7 включает `ENABLE ROW LEVEL SECURITY`; при миграции добавить политику `USING (auth.uid() = user_id)` (или аналог). **Tracking:** `docs/roadmap/BACKLOG_LEDGER.md:2040`.
 - `rag_feedback.llm_response` не хранится без редактирования (PII). **Target-state:** при реализации записи в `rag_feedback` применять redaction (тот же `core/insight/safety.py` или отдельный redactor) перед сохранением.
 - Rate limit на RAG-эндпоинты (insight) сохраняется. **Evidence:** детерминированные 429-тесты — `tests/test_rate_limit_llm_and_exports_api.py:95-108` (`/api/v1/insight`), `:117-130` (`/insight`); tier-guard — `tests/test_insight_vip_guard_api.py:50-78`.
 

--- a/docs/contracts/RAG_CONTRACT.md
+++ b/docs/contracts/RAG_CONTRACT.md
@@ -115,9 +115,13 @@ def retrieve_context(
     max_hops: int = 1,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> RAGContext:
     ...
 ```
+
+`subject_id` обязателен для любого retrieval из `user_knowledge`. Если `subject_id` отсутствует,
+vector path должен fail-closed и перейти на non-personal fallback, не читая персональный corpus.
 
 ---
 
@@ -164,6 +168,7 @@ MAX_CHUNK_SIZE_CHARS: int = 800
 - `core/rag/vector_rag.py:86` — `_retrieve_vector_postgres()` corpus filtering via parameterized LIKE
 - `core/rag/vector_rag.py:124` — `_retrieve_vector_sqlite()` corpus filtering via parameterized LIKE
 - `core/rag/vector_rag.py:181` — `_retrieve_vector_from_db()` resolves `agent_id` → `corpus_prefixes`
+- `core/rag/vector_rag.py` — vector retrieval from `user_knowledge` requires authenticated `subject_id`; missing subject context must fail closed to non-personal fallback
 - `core/rag/simple_rag.py:157` — Jaccard fallback with `startswith` corpus filtering
 - `app/routers/cbt_insight.py:134` — PRO-gated endpoint using `agent_id="cbt-agent"`
 
@@ -218,6 +223,7 @@ ALTER TABLE user_knowledge ENABLE ROW LEVEL SECURITY;
 Evidence anchors (audit policy: architecture docs must cite `file:line` or mark target-state):
 
 - `sources[].preview` проходит через `redact_rag_context_for_insight` перед отправкой клиенту. **Evidence:** `core/insight/safety.py:10` (реализация); при добавлении `sources[]` в response — вызывать перед сериализацией (target-state).
+- `user_knowledge` разрешён только при authenticated `subject_id`; если subject context отсутствует, vector retrieval обязан fail-closed и перейти на non-personal fallback. **Evidence:** `core/rag/vector_rag.py` (subject_id-gated retrieval path), `core/rag/orchestration.py` (subject propagation), `legacy_app.py` (legacy `/insight` safe fallback).
 - `user_knowledge.embedding` изолирован по `user_id` через RLS. **Target-state:** DDL в §7 включает `ENABLE ROW LEVEL SECURITY`; при миграции добавить политику `USING (auth.uid() = user_id)` (или аналог).
 - `rag_feedback.llm_response` не хранится без редактирования (PII). **Target-state:** при реализации записи в `rag_feedback` применять redaction (тот же `core/insight/safety.py` или отдельный redactor) перед сохранением.
 - Rate limit на RAG-эндпоинты (insight) сохраняется. **Evidence:** детерминированные 429-тесты — `tests/test_rate_limit_llm_and_exports_api.py:95-108` (`/api/v1/insight`), `:117-130` (`/insight`); tier-guard — `tests/test_insight_vip_guard_api.py:50-78`.

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_body_phase2_gates.py:180`, `scripts/orchestration/review_mapping_artifact.py:131`, `scripts/orchestration/review_mapping_artifact.py:151`, `tests/test_pr_body_phase2_gates.py:195`, `tests/test_pr_body_phase2_gates.py:231`, `tests/test_review_mapping_artifact.py:144`, `tests/test_review_mapping_artifact.py:166`
+Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_body_phase2_gates.py:188`, `scripts/orchestration/review_mapping_artifact.py:131`, `scripts/orchestration/review_mapping_artifact.py:151`, `tests/test_pr_body_phase2_gates.py:195`, `tests/test_pr_body_phase2_gates.py:265`, `tests/test_review_mapping_artifact.py:144`, `tests/test_review_mapping_artifact.py:166`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
@@ -19,3 +19,5 @@ Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899060242 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907615629 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907626291 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907674786 -> f61600e0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907678300 -> f61600e0

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_body_phase2_gates.py:188`, `scripts/orchestration/review_mapping_artifact.py:131`, `scripts/orchestration/review_mapping_artifact.py:151`, `tests/test_pr_body_phase2_gates.py:195`, `tests/test_pr_body_phase2_gates.py:265`, `tests/test_review_mapping_artifact.py:144`, `tests/test_review_mapping_artifact.py:166`
+Evidence: `scripts/ci/check_pr_body_phase2_gates.py:60`, `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_body_phase2_gates.py:188`, `scripts/orchestration/review_mapping_artifact.py:131`, `scripts/orchestration/review_mapping_artifact.py:151`, `tests/test_pr_body_phase2_gates.py:196`, `tests/test_pr_body_phase2_gates.py:265`, `tests/test_review_mapping_artifact.py:144`, `tests/test_review_mapping_artifact.py:166`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
@@ -17,7 +17,10 @@ Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899055272 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899055273 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899060242 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899075633 -> f61600e0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907615629 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907626291 -> ae46cf08
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907674786 -> f61600e0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907678300 -> f61600e0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899097191 -> c1ce5ccb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907732593 -> c1ce5ccb

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -7,4 +7,7 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
+  - Disposition: FIXED
+  - Commit: `d38b5c9b`
+  - Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -8,7 +8,9 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`, `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`
+Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`, `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`, `tests/test_review_mapping_artifact.py:38`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899052211 -> 068a6c51
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907606899 -> 068a6c51

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -11,3 +11,7 @@
   - Disposition: FIXED
   - Commit: `d38b5c9b`
   - Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
+  - Disposition: FIXED
+  - Commit: `41b03fbc`
+  - Evidence: `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -6,12 +6,9 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`, `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
-  - Disposition: FIXED
-  - Commit: `d38b5c9b`
-  - Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
-  - Disposition: FIXED
-  - Commit: `41b03fbc`
-  - Evidence: `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -8,9 +8,14 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`, `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`, `tests/test_review_mapping_artifact.py:38`
+Evidence: `scripts/ci/check_pr_body_phase2_gates.py:167`, `scripts/ci/check_pr_body_phase2_gates.py:180`, `scripts/orchestration/review_mapping_artifact.py:131`, `scripts/orchestration/review_mapping_artifact.py:151`, `tests/test_pr_body_phase2_gates.py:195`, `tests/test_pr_body_phase2_gates.py:231`, `tests/test_review_mapping_artifact.py:144`, `tests/test_review_mapping_artifact.py:166`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899052211 -> 068a6c51
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907606899 -> 068a6c51
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899055272 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899055273 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2899060242 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907615629 -> ae46cf08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3907626291 -> ae46cf08

--- a/docs/review/PR_1002_FIXED_MAPPING.md
+++ b/docs/review/PR_1002_FIXED_MAPPING.md
@@ -1,0 +1,10 @@
+# PR 1002 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2037,6 +2037,23 @@ If it is not recorded here — it does not exist.
     - docs/db schema doc created
     - `make verify` passes
 
+- [ ] P1: `user_knowledge` DB-level RLS / policy hardening
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (security / defense-in-depth)
+  - Target PR: PR-TBD-USER-KNOWLEDGE-RLS
+  - Status: 📋 Planned
+  - Reason (EN): Application-layer tenant scoping prevents cross-tenant leaks in runtime retrieval, but `user_knowledge` still needs explicit DB-level RLS/policy enforcement as defense in depth.
+  - Links:
+    - `docs/contracts/RAG_CONTRACT.md` (§7, §8)
+    - `app/models/rag_feedback.py`
+    - `core/rag/vector_rag.py`
+    - `alembic/versions/202602280001_add_rag_feedback_tables.py`
+  - DoD:
+    - Postgres RLS policy exists for `user_knowledge` (and companion policy for `rag_feedback` if required)
+    - Migration + rollback path documented
+    - Tests or audit evidence cover deny-by-default cross-tenant access at DB layer
+    - Runtime app-layer filtering remains in place (no regression to code-level scoping)
+
 - [ ] P1: `simple_rag` shared index thread-safety hardening
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (runtime reliability)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -117,7 +117,7 @@ from app.scheduler_helpers import (
 )
 from app.utils.helpers import _resolve_app_callable, _short_git_sha
 from app.utils.feature_flags import _is_truthy
-from app.middleware.api_tiers import require_vip_tier
+from app.middleware.api_tiers import derive_subject_id_from_api_key, require_vip_tier
 from app.security.llm_monthly_quota import (
     attempt_consume_vip_llm_monthly_quota,
     require_server_salt,
@@ -2157,7 +2157,11 @@ def _build_rag_source_items(chunks: list[Any]) -> list[RAGSourceItem]:
     return [RAGSourceItem(**d) for d in build_rag_source_dicts(chunks)]
 
 
-async def insight_v1(req: InsightRequest) -> InsightResponse:
+async def insight_v1(
+    req: InsightRequest,
+    *,
+    subject_id: int | None = None,
+) -> InsightResponse:
     """Generate insight using LLM provider (v1 with API key).
 
     Privacy: user text may be sent to external providers; see /privacy.
@@ -2200,6 +2204,7 @@ async def insight_v1(req: InsightRequest) -> InsightResponse:
             max_chunks=3,
             philo_validation_enabled=is_philosophy_validation_enabled(),
             recursive_rag_enabled=is_recursive_rag_enabled(),
+            subject_id=subject_id,
         )
         rag_hops = rag_result.hops
         rag_latency_ms = rag_result.latency_ms
@@ -2271,6 +2276,7 @@ async def insight(req: InsightRequest) -> InsightResponse:
             max_chunks=3,
             philo_validation_enabled=is_philosophy_validation_enabled(),
             recursive_rag_enabled=is_recursive_rag_enabled(),
+            subject_id=None,
         )
         rag_hops = rag_result.hops
         rag_latency_ms = rag_result.latency_ms
@@ -2323,7 +2329,8 @@ async def insight_v1_route(
     if not _is_truthy(os.getenv("FEATURE_INSIGHT", "false")):
         raise HTTPException(status_code=503, detail="FEATURE_INSIGHT is disabled")
     await run_in_threadpool(_enforce_vip_llm_monthly_quota, vip_key)
-    return await insight_v1(req)
+    subject_id = derive_subject_id_from_api_key(vip_key)
+    return await insight_v1(req, subject_id=subject_id)
 
 
 # Backward-compatible simple insight endpoint (no API key)

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration.review_mapping_artifact import (
+    read_mapping_artifact,
+    validate_mapping_artifact_text,
+)
 
 # Phase2 contract: headings and checkbox labels (single source for parser and docs).
 # Changing template wording requires updating these constants and re-running tests.
@@ -26,10 +36,10 @@ def _checkbox_re(label: str) -> re.Pattern[str]:
     return re.compile(rf"(?im)^\s*-\s*\[(?P<checked>[ xX])\]\s*{escaped}\s*$")
 
 
-DISCUSSION_SECTION_RE = _section_heading_re("##", PHASE2_CONFIG["discussion_heading"])
-MAPPING_SECTION_RE = _section_heading_re("###", PHASE2_CONFIG["mapping_heading"])
-DISCUSSION_CHECKBOX_RE = _checkbox_re(PHASE2_CONFIG["discussion_checkbox_label"])
-MAPPING_CHECKBOX_RE = _checkbox_re(PHASE2_CONFIG["mapping_checkbox_label"])
+DISCUSSION_SECTION_RE = _section_heading_re("##", str(PHASE2_CONFIG["discussion_heading"]))
+MAPPING_SECTION_RE = _section_heading_re("###", str(PHASE2_CONFIG["mapping_heading"]))
+DISCUSSION_CHECKBOX_RE = _checkbox_re(str(PHASE2_CONFIG["discussion_checkbox_label"]))
+MAPPING_CHECKBOX_RE = _checkbox_re(str(PHASE2_CONFIG["mapping_checkbox_label"]))
 
 MAPPING_ENTRY_RE = re.compile(
     r"(?im)^\s*-\s*`?(https?://[^\s`]+)`?\s*->\s*`?([0-9a-f]{7,40})`?\s*$"
@@ -47,14 +57,31 @@ def _extract_checked(match: re.Match[str] | None) -> bool:
     return bool(match and match.group("checked").lower() == "x")
 
 
-def _extract_pr_body(event_path: Path) -> str:
+def _load_event_pull_request(event_path: Path) -> dict:
+    """Load pull_request dict from GitHub event payload."""
     try:
         payload = json.loads(event_path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return ""
-    except json.JSONDecodeError:
-        return ""
-    return str(payload.get("pull_request", {}).get("body", ""))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    return payload.get("pull_request") or {}
+
+
+def _extract_pr_number(event_path: Path) -> int | None:
+    """Extract PR number from GitHub event payload."""
+    pr = _load_event_pull_request(event_path)
+    num = pr.get("number")
+    if num is None:
+        return None
+    try:
+        return int(num)
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_pr_body(event_path: Path) -> str:
+    """Extract PR body from GitHub event payload."""
+    pr = _load_event_pull_request(event_path)
+    return str(pr.get("body", ""))
 
 
 def _extract_mapping_section(text: str) -> str:
@@ -100,6 +127,11 @@ def check_pr_body_phase2_gates(body: str) -> list[str]:
             "Add at least one mapping entry "
             "(`- <review-comment-url> -> <commit-sha>`) or `- No actionable review comments`."
         )
+    if has_mapping_entries and has_na_mapping:
+        errors.append(
+            "Invalid mixed mode: 'No actionable review comments' cannot appear "
+            "together with SHA mappings (use one or the other)."
+        )
 
     return errors
 
@@ -116,12 +148,38 @@ def main() -> int:
         default="",
         help="Explicit PR body text (optional, overrides event body if provided).",
     )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="PR number for artifact lookup (optional, extracted from event-path if not set).",
+    )
     args = parser.parse_args()
 
     body = args.body
     if not body and args.event_path:
         body = _extract_pr_body(Path(args.event_path))
 
+    # Canonical SoT: repo artifact (docs/review/PR_<N>_FIXED_MAPPING.md)
+    pr_number = args.pr_number
+    if pr_number is None and args.event_path:
+        pr_number = _extract_pr_number(Path(args.event_path))
+
+    if pr_number is not None:
+        try:
+            artifact_text = read_mapping_artifact(pr_number)
+            errors = validate_mapping_artifact_text(artifact_text)
+            if errors:
+                print("ERROR: phase2 canonical mapping artifact failed:")
+                for item in errors:
+                    print(f"- {item}")
+                return 1
+            print("phase2-pr-body-gates: canonical mapping artifact passed.")
+            return 0
+        except FileNotFoundError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+
+    # Fallback: PR body (when no event-path / pr-number, e.g. local testing)
     if not body.strip():
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -73,12 +73,16 @@ def _extract_pr_number(event_path: Path) -> int | None:
     """Extract PR number from GitHub event payload."""
     pr = _load_event_pull_request(event_path)
     num = pr.get("number")
-    if num is None:
+    if isinstance(num, bool) or num is None:
         return None
-    try:
-        return int(num)
-    except (ValueError, TypeError):
-        return None
+    if isinstance(num, int):
+        return num
+    if isinstance(num, str):
+        try:
+            return int(num)
+        except ValueError:
+            return None
+    return None
 
 
 def _extract_pr_body(event_path: Path) -> str:

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -57,13 +57,16 @@ def _extract_checked(match: re.Match[str] | None) -> bool:
     return bool(match and match.group("checked").lower() == "x")
 
 
-def _load_event_pull_request(event_path: Path) -> dict:
+def _load_event_pull_request(event_path: Path) -> dict[str, object]:
     """Load pull_request dict from GitHub event payload."""
     try:
         payload = json.loads(event_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
-    return payload.get("pull_request") or {}
+    if not isinstance(payload, dict):
+        return {}
+    pull_request = payload.get("pull_request")
+    return pull_request if isinstance(pull_request, dict) else {}
 
 
 def _extract_pr_number(event_path: Path) -> int | None:
@@ -81,7 +84,8 @@ def _extract_pr_number(event_path: Path) -> int | None:
 def _extract_pr_body(event_path: Path) -> str:
     """Extract PR body from GitHub event payload."""
     pr = _load_event_pull_request(event_path)
-    return str(pr.get("body", ""))
+    body = pr.get("body")
+    return body if isinstance(body, str) else ""
 
 
 def _extract_mapping_section(text: str) -> str:

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -166,7 +166,8 @@ def main() -> int:
 
     artifact_checked = False
     body_checked = False
-    errors: list[str] = []
+    artifact_errors: list[str] = []
+    body_errors: list[str] = []
 
     if pr_number is not None:
         try:
@@ -175,20 +176,21 @@ def main() -> int:
             print(f"ERROR: {exc}")
             return 1
         artifact_checked = True
-        errors.extend(validate_mapping_artifact_text(artifact_text))
+        artifact_errors.extend(validate_mapping_artifact_text(artifact_text))
 
     if body.strip():
         body_checked = True
-        errors.extend(check_pr_body_phase2_gates(body=body))
+        body_errors.extend(check_pr_body_phase2_gates(body=body))
     elif pr_number is None:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
 
+    errors = [*artifact_errors, *body_errors]
     if errors:
         print("ERROR: phase2 gates failed:")
-        if artifact_checked:
+        if artifact_checked and artifact_errors:
             print("- canonical mapping artifact validation failed")
-        if body_checked:
+        if body_checked and body_errors:
             print("- PR body validation failed")
         for item in errors:
             print(f"- {item}")

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -164,32 +164,42 @@ def main() -> int:
     if pr_number is None and args.event_path:
         pr_number = _extract_pr_number(Path(args.event_path))
 
+    artifact_checked = False
+    body_checked = False
+    errors: list[str] = []
+
     if pr_number is not None:
         try:
             artifact_text = read_mapping_artifact(pr_number)
-            errors = validate_mapping_artifact_text(artifact_text)
-            if errors:
-                print("ERROR: phase2 canonical mapping artifact failed:")
-                for item in errors:
-                    print(f"- {item}")
-                return 1
-            print("phase2-pr-body-gates: canonical mapping artifact passed.")
-            return 0
         except FileNotFoundError as exc:
             print(f"ERROR: {exc}")
             return 1
+        artifact_checked = True
+        errors.extend(validate_mapping_artifact_text(artifact_text))
 
-    # Fallback: PR body (when no event-path / pr-number, e.g. local testing)
-    if not body.strip():
+    if body.strip():
+        body_checked = True
+        errors.extend(check_pr_body_phase2_gates(body=body))
+    elif pr_number is None:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
 
-    errors = check_pr_body_phase2_gates(body=body)
     if errors:
-        print("ERROR: phase2 PR body gates failed:")
+        print("ERROR: phase2 gates failed:")
+        if artifact_checked:
+            print("- canonical mapping artifact validation failed")
+        if body_checked:
+            print("- PR body validation failed")
         for item in errors:
             print(f"- {item}")
         return 1
+
+    if artifact_checked and body_checked:
+        print("phase2-pr-body-gates: canonical mapping artifact and PR body passed.")
+        return 0
+    if artifact_checked:
+        print("phase2-pr-body-gates: canonical mapping artifact passed.")
+        return 0
 
     print("phase2-pr-body-gates: passed.")
     return 0

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import http.client
+import sys
 import json
 import os
 import re
@@ -13,6 +14,17 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration.review_mapping_artifact import (
+    extract_fixed_mapping_section,
+    has_no_actionable_marker,
+    parse_fixed_mapping_entries,
+    read_mapping_artifact,
+)
 
 ACTIONABLE_MARKERS = (
     "Actionable comments posted",
@@ -352,18 +364,27 @@ def main() -> int:
         print(f"ERROR: cannot query bot comments/reviews: HTTP {exc.code}")
         return 1
 
-    mapped_urls, no_actionable_marker = _mapped_urls(pr_body=pr_body)
+    # Canonical SoT: repo artifact (docs/review/PR_<N>_FIXED_MAPPING.md)
+    try:
+        artifact_text = read_mapping_artifact(pr_number)
+        fixed_mapping_section = extract_fixed_mapping_section(artifact_text)
+        mapping_entries = parse_fixed_mapping_entries(fixed_mapping_section)
+        mapped_urls = set(mapping_entries.keys())
+        no_actionable_marker = has_no_actionable_marker(fixed_mapping_section)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        return 1
 
     if actionable_items:
         if no_actionable_marker:
             errors.append(
-                "PR body claims `No actionable review comments` but actionable bot findings were detected."
+                "Canonical artifact claims `No actionable review comments` but actionable bot findings were detected."
             )
         unmapped = [item for item in actionable_items if item.url not in mapped_urls]
         if unmapped:
             errors.append(
-                "Unmapped actionable bot comments found in `### Fixed in Commit Mapping` "
-                "(add `<review-comment-url> -> <commit-sha>` entries)."
+                "Unmapped actionable bot comments found in canonical artifact "
+                "`docs/review/PR_<N>_FIXED_MAPPING.md` (add `<review-comment-url> -> <commit-sha>` entries)."
             )
             for item in unmapped:
                 print(f"UNMAPPED: {item.author} [{item.kind}] {item.url} ({item.created_at})")
@@ -375,7 +396,9 @@ def main() -> int:
         return 1
 
     print("merge-readiness-gate: passed.")
-    print("Zero comments: 0 unresolved threads, all actionable bot comments mapped in PR body.")
+    print(
+        "Zero comments: 0 unresolved threads, all actionable bot comments mapped in canonical artifact."
+    )
     return 0
 
 

--- a/scripts/orchestration/check_review_threads_disposition.py
+++ b/scripts/orchestration/check_review_threads_disposition.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Guard: resolved review threads must have explicit Disposition records in PR body.
+Guard: resolved review threads must have explicit Disposition records in canonical artifact.
 
 Strict mode: every resolved thread must be listed under **Fixed in Commit Mapping**
-with Disposition (FIXED | NOT-A-BUG | DEFERRED) and proof (Commit / Evidence / Backlog).
+in docs/review/PR_<N>_FIXED_MAPPING.md with Disposition (FIXED | NOT-A-BUG | DEFERRED)
+and proof (Commit / Evidence / Backlog).
 
 Requires: GitHub CLI `gh` authenticated. **Canonical token: GH_TOKEN.** In CI use --require-auth and
 export GH_TOKEN from secrets.GITHUB_TOKEN. GITHUB_TOKEN alone is not sufficient — gh reads GH_TOKEN.
@@ -22,12 +23,20 @@ import subprocess  # nosec B404: fixed gh CLI only (remove-by: 2026-04-30, ref: 
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from pathlib import Path
+from typing import Any, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration.review_mapping_artifact import (
+    extract_fixed_mapping_section as _artifact_extract_fixed_mapping,
+    read_mapping_artifact,
+)
 
 DISPOSITION_RE = re.compile(r"Disposition:\s*(FIXED|NOT-A-BUG|DEFERRED)", re.IGNORECASE)
 PROOF_RE = re.compile(r"(Commit:|Evidence:|Backlog:)", re.IGNORECASE)
-# Match Fixed in Commit Mapping heading; section content extracted by level-aware parse (Cubic: avoid stop at ####)
-_FIXED_MAPPING_HEADING_RE = re.compile(r"(?im)^(#+)\s*Fixed in Commit Mapping\s*$")
 
 
 @dataclass(frozen=True)
@@ -44,6 +53,8 @@ _GIT_TIMEOUT_SEC = 15
 
 # Mapping line: "- https://... -> sha" or "- https://...#anchor -> sha"
 _MAPPING_LINE_RE = re.compile(r"^\s*-\s*(https://[^\s]+)\s*->\s*([a-f0-9]{7,40})\b", re.IGNORECASE)
+# Relaxed: match mapping-like lines to validate SHA (catches "- url -> notasha")
+_MAPPING_LINE_RELAXED_RE = re.compile(r"^\s*-\s*(https://[^\s]+)\s*->\s*(\S+)", re.IGNORECASE)
 
 
 def _gh_path() -> str:
@@ -59,7 +70,7 @@ def _run(cmd: list[str]) -> str:
     argv = list(cmd)
     if argv and argv[0] == "gh":
         argv = [_gh_path()] + argv[1:]
-    result = subprocess.run(  # nosec B603 — argv from _gh_path()+static; no user input (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: argv from _gh_path()+static; no user input (remove-by: 2026-04-30, ref: PR-985)
         argv,
         capture_output=True,
         text=True,
@@ -106,7 +117,7 @@ def _git_commit_time_iso(commit_sha: str) -> str:
     git_path = shutil.which("git")
     if not git_path:
         raise RuntimeError("git not found in PATH; required for commit-after-comment guard")
-    result = subprocess.run(  # nosec B603 — git_path from which(); commit_sha validated by _GIT_SHA_RE (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: git_path from which(); commit_sha validated by _GIT_SHA_RE (remove-by: 2026-04-30, ref: PR-985)
         [git_path, "show", "-s", "--format=%cI", commit_sha.strip()],
         capture_output=True,
         text=True,
@@ -131,7 +142,7 @@ def _git_commit_subject(commit_sha: str) -> str:
     git_path = shutil.which("git")
     if not git_path:
         raise RuntimeError("git not found in PATH; required for trigger-only mapping guard")
-    result = subprocess.run(  # nosec B603 — fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
         [git_path, "show", "-s", "--format=%s", sha],
         capture_output=True,
         text=True,
@@ -153,7 +164,7 @@ def _git_changed_files(commit_sha: str) -> list[str]:
     git_path = shutil.which("git")
     if not git_path:
         raise RuntimeError("git not found in PATH; required for trigger-only mapping guard")
-    result = subprocess.run(  # nosec B603 — fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: fixed argv, sha validated (remove-by: 2026-04-30, ref: PR-985)
         [git_path, "show", "--name-only", "--pretty=format:", sha],
         capture_output=True,
         text=True,
@@ -258,14 +269,10 @@ def _get_pr_number() -> int:
     return int(out)
 
 
-def _get_pr_body() -> str:
-    return _run(["gh", "pr", "view", "--json", "body", "-q", ".body"])
-
-
 def _graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
     # Sourcery: no dynamic argv — pass body via stdin (static argv only)
     body = json.dumps({"query": query, "variables": variables})
-    result = subprocess.run(  # nosec B603 — argv static; body via stdin only (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: argv static; body via stdin only (remove-by: 2026-04-30, ref: PR-985)
         [_gh_path(), "api", "graphql", "--input", "-"],
         input=body,
         capture_output=True,
@@ -277,7 +284,7 @@ def _graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
     data = json.loads(result.stdout)
     if "errors" in data:
         raise RuntimeError(f"GraphQL errors: {data['errors']}")
-    return data["data"]
+    return cast(dict[str, Any], data["data"])
 
 
 def _get_owner_repo() -> tuple[str, str]:
@@ -288,37 +295,19 @@ def _get_owner_repo() -> tuple[str, str]:
     return owner, name
 
 
-def _extract_fixed_mapping_section(body: str) -> str:
-    """
-    Extract content under Fixed in Commit Mapping. Stops at next heading of same or higher level
-    (so #### inside section does not end extraction; Cubic P2).
-    """
-    match = _FIXED_MAPPING_HEADING_RE.search(body)
-    if not match:
-        return ""
-    level = len(match.group(1))
-    start = match.end()
-    lines = body[start:].splitlines()
-    content_lines: list[str] = []
-    for line in lines:
-        m = re.match(r"^\s*(#+)\s", line)
-        if m and len(m.group(1)) <= level:
-            break
-        content_lines.append(line)
-    return "\n".join(content_lines).strip()
-
-
 def _find_disposition_block_in_section(section: str, url: str) -> bool:
     """
     Thread-specific URL (full URL with anchor) must appear in section with Disposition + proof
-    (Commit/Evidence/Backlog) nearby (±12 lines). Scan only lines containing this thread URL
-    so one mapping does not satisfy multiple threads (CodeRabbit/Sourcery/Cubic).
+    (Commit/Evidence/Backlog). For single-block artifacts, Disposition+Proof at top applies to
+    all mapping lines; use ±25 line window to cover typical artifact layout.
+    Use exact URL match to avoid substring false positives (e.g. discussion_r1 vs discussion_r10).
     """
     lines = section.splitlines()
+    url_pattern = re.escape(url) + r"(?![0-9a-zA-Z])"
     for i, line in enumerate(lines):
-        if url in line:
-            start = max(0, i - 12)
-            end = min(len(lines), i + 13)
+        if re.search(url_pattern, line):
+            start = max(0, i - 25)
+            end = min(len(lines), i + 26)
             window = "\n".join(lines[start:end])
             if DISPOSITION_RE.search(window) and PROOF_RE.search(window):
                 return True
@@ -383,7 +372,7 @@ def _has_gh_auth() -> bool:
         return True
     # Sourcery/B607: use resolved path only; argv is static
     try:
-        result = subprocess.run(  # nosec B603 — argv [_gh_path(), "auth", "status"]; no user input (remove-by: 2026-04-30, ref: PR-985)
+        result = subprocess.run(  # nosec B603: argv [_gh_path(), "auth", "status"]; no user input (remove-by: 2026-04-30, ref: PR-985)
             [_gh_path(), "auth", "status"],
             capture_output=True,
             text=True,
@@ -425,7 +414,7 @@ def _require_gh_token_preflight(require_auth: bool, in_ci: bool) -> None:
     except RuntimeError:
         print("ERROR: gh CLI not found in PATH; required when GH_TOKEN is set.")
         sys.exit(1)
-    result = subprocess.run(  # nosec B603 — argv from _gh_path()+static; no user input (remove-by: 2026-04-30, ref: PR-985)
+    result = subprocess.run(  # nosec B603: argv from _gh_path()+static; no user input (remove-by: 2026-04-30, ref: PR-985)
         argv,
         capture_output=True,
         text=True,
@@ -441,7 +430,7 @@ def _require_gh_token_preflight(require_auth: bool, in_ci: bool) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Check resolved review threads have disposition in PR body."
+        description="Check resolved review threads have disposition in canonical artifact."
     )
     parser.add_argument(
         "--require-auth",
@@ -460,12 +449,45 @@ def main() -> None:
             sys.exit(0)
 
     pr_number = _get_pr_number()
-    body = _get_pr_body()
-    section = _extract_fixed_mapping_section(body)
+    try:
+        artifact_text = read_mapping_artifact(pr_number)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+    section = _artifact_extract_fixed_mapping(artifact_text)
 
     if not section:
-        print("ERROR: Missing 'Fixed in Commit Mapping' section in PR body.")
+        print(
+            f"ERROR: Missing '## Fixed in Commit Mapping' section in canonical artifact "
+            f"docs/review/PR_{pr_number}_FIXED_MAPPING.md"
+        )
         sys.exit(1)
+
+    # Reject invalid FIXED mappings: validate raw section for any "- url -> X" lines
+    for line in section.splitlines():
+        m = _MAPPING_LINE_RELAXED_RE.search(line.strip())
+        if m:
+            url_part, sha_part = m.group(1), m.group(2).strip()
+            if not _GIT_SHA_RE.match(sha_part):
+                print(
+                    f"ERROR: Invalid FIXED mapping in artifact: {url_part} -> {sha_part!r} "
+                    "(SHA must be 7–40 hex chars)"
+                )
+                sys.exit(1)
+
+    # Reject invalid FIXED blocks: Commit: value must be valid SHA or known placeholder
+    if re.search(r"Disposition:\s*FIXED\b", section, re.IGNORECASE):
+        commit_re = re.compile(r"Commit:\s*(.+)$", re.IGNORECASE)
+        for line in section.splitlines():
+            mo = commit_re.search(line.strip())
+            if mo:
+                val = mo.group(1).strip()
+                if not _GIT_SHA_RE.match(val) and val.lower() != "see mapping entries below":
+                    print(
+                        f"ERROR: Invalid Commit value in FIXED block: {val!r} "
+                        "(must be 7–40 hex chars or 'see mapping entries below')"
+                    )
+                    sys.exit(1)
 
     resolved_threads = _collect_resolved_threads(pr_number)
 
@@ -477,7 +499,8 @@ def main() -> None:
     missing_disposition: list[str] = []
 
     for t in resolved_threads:
-        if t.url not in section:
+        # Use exact URL match to avoid substring false positives (e.g. discussion_r1 vs r10)
+        if not re.search(re.escape(t.url) + r"(?![0-9a-zA-Z])", section):
             missing_refs.append(t.url)
             continue
         if not _find_disposition_block_in_section(section, t.url):

--- a/scripts/orchestration/review_mapping_artifact.py
+++ b/scripts/orchestration/review_mapping_artifact.py
@@ -1,0 +1,186 @@
+"""Canonical Fixed in Commit Mapping artifact: repo file as source of truth."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REVIEW_DIR = REPO_ROOT / "docs" / "review"
+
+
+def _review_dir() -> Path:
+    """Return review dir; override via REVIEW_MAPPING_ARTIFACT_DIR for tests only."""
+    override = os.environ.get("REVIEW_MAPPING_ARTIFACT_DIR")
+    if not override:
+        return REVIEW_DIR
+    base = Path(override).resolve()
+    if not base.is_dir():
+        raise RuntimeError(f"REVIEW_MAPPING_ARTIFACT_DIR must be an existing directory: {base}")
+    return base
+
+
+DISCUSSION_THREAD_PASS_HEADING = (
+    "## Discussion Thread Pass"  # nosec B105: doc heading (remove-by: 2026-06-30, ref: PR-998)
+)
+# Canonical artifact uses ##; PR-body mirror/fallback may use ### (AGENTS.md)
+FIXED_MAPPING_HEADINGS = ("## Fixed in Commit Mapping", "### Fixed in Commit Mapping")
+
+CHECKBOX_DISCUSSION_PASS = "- [x] Discussion-thread pass completed"  # nosec B105: checkbox label (remove-by: 2026-06-30, ref: PR-998)
+CHECKBOX_FIXED_MAPPING = "- [x] Fixed in commit mapping completed"
+
+MAPPING_LINE_RE = re.compile(r"^\s*-\s+(https://github\.com/\S+)\s+->\s+([0-9a-f]{7,40})\s*$")
+NO_ACTIONABLE_LINE = "- No actionable review comments"
+# Disposition/proof lines allowed in section (disposition guard format)
+DETAIL_PREFIXES = ("Disposition:", "Commit:", "Evidence:", "Backlog:")
+
+
+def mapping_artifact_path(pr_number: int) -> Path:
+    """Return canonical review mapping artifact path for a PR number."""
+    return _review_dir() / f"PR_{pr_number}_FIXED_MAPPING.md"
+
+
+def read_mapping_artifact(pr_number: int) -> str:
+    """Read canonical review mapping artifact text."""
+    path = mapping_artifact_path(pr_number)
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing canonical review mapping artifact: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def extract_section(markdown_text: str, heading: str) -> str:
+    """
+    Extract section body for a markdown heading (## or ###).
+    Returns content after heading until next heading at same or higher level.
+    """
+    lines = markdown_text.splitlines()
+    inside = False
+    collected: list[str] = []
+    heading_level = len(heading) - len(heading.lstrip("#"))
+
+    for line in lines:
+        # Normalize multiple spaces (markdown allows "##  Title")
+        if re.sub(r"\s+", " ", line.strip()) == re.sub(r"\s+", " ", heading):
+            inside = True
+            continue
+
+        if inside:
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                next_level = len(stripped) - len(stripped.lstrip("#"))
+                if next_level <= heading_level:
+                    break
+            collected.append(line)
+
+    return "\n".join(collected).strip()
+
+
+def extract_discussion_thread_pass_section(markdown_text: str) -> str:
+    """Extract ## Discussion Thread Pass section."""
+    return extract_section(markdown_text, DISCUSSION_THREAD_PASS_HEADING)
+
+
+def extract_fixed_mapping_section(markdown_text: str) -> str:
+    """Extract Fixed in Commit Mapping section (## or ###)."""
+    for heading in FIXED_MAPPING_HEADINGS:
+        section = extract_section(markdown_text, heading)
+        if section:
+            return section
+    return ""
+
+
+def validate_discussion_thread_pass_section(section: str) -> list[str]:
+    """Validate Discussion Thread Pass section; return list of errors."""
+    errors: list[str] = []
+
+    if not section:
+        errors.append("Missing '## Discussion Thread Pass' section.")
+        return errors
+
+    if CHECKBOX_DISCUSSION_PASS not in section:
+        errors.append("Missing checkbox: '- [x] Discussion-thread pass completed'.")
+
+    if CHECKBOX_FIXED_MAPPING not in section:
+        errors.append("Missing checkbox: '- [x] Fixed in commit mapping completed'.")
+
+    return errors
+
+
+def validate_fixed_mapping_section(section: str) -> list[str]:
+    """Validate Fixed in Commit Mapping section; return list of errors."""
+    errors: list[str] = []
+
+    if not section:
+        errors.append("Missing '## Fixed in Commit Mapping' section.")
+        return errors
+
+    lines = [ln.strip() for ln in section.splitlines() if ln.strip()]
+    if not lines:
+        errors.append("'## Fixed in Commit Mapping' section is empty.")
+        return errors
+
+    if NO_ACTIONABLE_LINE in lines:
+        if len(lines) > 1:
+            errors.append(
+                "Invalid mixed mode: 'No actionable review comments' "
+                "cannot appear together with SHA mappings."
+            )
+        return errors
+
+    saw_mapping_line = False
+    for line in lines:
+        if any(line.startswith(prefix) for prefix in DETAIL_PREFIXES):
+            continue
+        if MAPPING_LINE_RE.match(line):
+            saw_mapping_line = True
+            continue
+        errors.append(f"Invalid mapping line format in canonical artifact: {line}")
+
+    if not errors and not saw_mapping_line:
+        errors.append(
+            "Fixed in Commit Mapping must contain at least one '- <url> -> <sha>' line "
+            "or '- No actionable review comments'."
+        )
+
+    return errors
+
+
+def validate_mapping_artifact_text(markdown_text: str) -> list[str]:
+    """Validate full artifact text; return list of errors."""
+    errors: list[str] = []
+
+    discussion_section = extract_discussion_thread_pass_section(markdown_text)
+    fixed_mapping_section = extract_fixed_mapping_section(markdown_text)
+
+    errors.extend(validate_discussion_thread_pass_section(discussion_section))
+    errors.extend(validate_fixed_mapping_section(fixed_mapping_section))
+
+    return errors
+
+
+def parse_fixed_mapping_entries(section: str) -> dict[str, str]:
+    """
+    Parse mapping lines: - <url> -> <sha>
+    Returns {url: sha}
+    """
+    entries: dict[str, str] = {}
+
+    for raw_line in section.splitlines():
+        line = raw_line.strip()
+        if not line or line == NO_ACTIONABLE_LINE:
+            continue
+
+        match = MAPPING_LINE_RE.match(line)
+        if not match:
+            continue
+
+        url, sha = match.groups()
+        entries[url] = sha
+
+    return entries
+
+
+def has_no_actionable_marker(section: str) -> bool:
+    """True if section contains 'No actionable review comments'."""
+    return NO_ACTIONABLE_LINE in section

--- a/scripts/orchestration/review_mapping_artifact.py
+++ b/scripts/orchestration/review_mapping_artifact.py
@@ -129,8 +129,14 @@ def validate_fixed_mapping_section(section: str) -> list[str]:
         return errors
 
     saw_mapping_line = False
+    saw_disposition = False
+    saw_proof = False
     for line in lines:
-        if any(line.startswith(prefix) for prefix in DETAIL_PREFIXES):
+        if line.startswith("Disposition:"):
+            saw_disposition = True
+            continue
+        if any(line.startswith(prefix) for prefix in ("Commit:", "Evidence:", "Backlog:")):
+            saw_proof = True
             continue
         if MAPPING_LINE_RE.match(line):
             saw_mapping_line = True
@@ -141,6 +147,12 @@ def validate_fixed_mapping_section(section: str) -> list[str]:
         errors.append(
             "Fixed in Commit Mapping must contain at least one '- <url> -> <sha>' line "
             "or '- No actionable review comments'."
+        )
+    if not errors and saw_mapping_line and not saw_disposition:
+        errors.append("Missing 'Disposition:' when SHA mappings are present.")
+    if not errors and saw_mapping_line and not saw_proof:
+        errors.append(
+            "Missing proof detail (Commit:/Evidence:/Backlog:) when SHA mappings are present."
         )
 
     return errors

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from app.middleware.api_tiers import TEST_KEY_PRO, derive_subject_id_from_api_key
+
 if TYPE_CHECKING:
     from core.rag.contracts import RAGContext
 
@@ -206,6 +208,39 @@ class TestCBTInsightFeatureFlag:
             "llm.get_provider",
             lambda: mock_provider,
         )
+
+
+class TestCBTInsightSubjectIdPropagation:
+    """Tests that CBT endpoint keeps user_knowledge retrieval scoped per subject."""
+
+    def test_cbt_insight_passes_subject_id(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """CBT insight derives subject_id from authenticated PRO API key."""
+        monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+        observed: dict[str, int | None] = {"subject_id": None}
+
+        def _retrieve(*args: object, **kwargs: object) -> object:
+            observed["subject_id"] = kwargs.get("subject_id")
+            return _make_rag_context()
+
+        mock_provider = MagicMock()
+        mock_provider.generate.return_value = "CBT response"
+
+        monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _retrieve)
+        monkeypatch.setattr("llm.get_provider", lambda: mock_provider)
+
+        response = client.post(
+            "/api/v1/pro/cbt/insight",
+            json={"query": "How do I handle negative thoughts?"},
+            headers=pro_headers,
+        )
+
+        assert response.status_code == 200
+        assert observed["subject_id"] == derive_subject_id_from_api_key(TEST_KEY_PRO)
 
 
 class TestCBTInsightValidation:

--- a/tests/test_insight_error_hygiene.py
+++ b/tests/test_insight_error_hygiene.py
@@ -87,7 +87,9 @@ def test_insight_redacts_rag_source_headers(
         max_chunks: int = 3,
         agent_id: str | None = None,
         user_tier: str | None = None,
+        subject_id: int | None = None,
     ) -> _FakeCtx:
+        del subject_id
         return _FakeCtx(
             query=query,
             refined_queries=[query],

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -40,8 +40,10 @@ def _make_fake_structured(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeRAGContext:
     """Fake retrieve_context_structured that returns two chunks."""
+    del subject_id
     chunks = [
         _FakeRAGChunk(
             chunk_id="readme.md:1",
@@ -75,8 +77,10 @@ def _make_empty_structured(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeRAGContext:
     """Fake retrieve_context_structured that returns zero chunks."""
+    del subject_id
     return _FakeRAGContext(
         query=query,
         refined_queries=[query],
@@ -94,11 +98,12 @@ def _make_fake_recursive_structured(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
     philo_validation_enabled: bool = False,
 ) -> _FakeRAGContext:
     """Fake recursive retriever with deeper hops and refined query chain."""
     # Intentionally unused: keep signature parity with real recursive retriever.
-    _ = philo_validation_enabled
+    _ = (philo_validation_enabled, subject_id)
     chunks = [
         _FakeRAGChunk(
             chunk_id="recursive.md:1",

--- a/tests/test_philosophy_validation_integration.py
+++ b/tests/test_philosophy_validation_integration.py
@@ -44,8 +44,10 @@ def _rag_with_medical(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeCtx:
     """Fake RAG returning one medical chunk and one clean chunk."""
+    del subject_id
     return _FakeCtx(
         query=query,
         refined_queries=[query],
@@ -64,8 +66,10 @@ def _rag_all_clean(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeCtx:
     """Fake RAG returning only clean chunks."""
+    del subject_id
     return _FakeCtx(
         query=query,
         refined_queries=[query],

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -194,8 +195,6 @@ def test_extract_pr_body_returns_empty_on_invalid_json(tmp_path: Path) -> None:
 
 def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
     """When event has pr_number, Phase2 validates artifact and mirrored PR body."""
-    import subprocess
-
     event = {"pull_request": {"number": 998, "body": VALID_BODY_WITH_MAPPING}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
@@ -230,8 +229,6 @@ Commit: abc1234
 
 def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
     """Artifact success must not bypass PR body validation."""
-    import subprocess
-
     event = {"pull_request": {"number": 998, "body": "minimal"}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
@@ -263,3 +260,38 @@ Commit: abc1234
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
     assert "Missing required section" in result.stdout
+
+
+def test_phase2_failure_output_only_reports_failing_scope(tmp_path: Path) -> None:
+    """Failure summary should mention only the scope that actually failed."""
+    event = {"pull_request": {"number": 998, "body": "minimal"}}
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "PR body validation failed" in result.stdout
+    assert "canonical mapping artifact validation failed" not in result.stdout

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -193,6 +193,20 @@ def test_extract_pr_body_returns_empty_on_invalid_json(tmp_path: Path) -> None:
     assert result == ""
 
 
+def test_extract_pr_body_returns_empty_for_non_object_payload(tmp_path: Path) -> None:
+    payload_path = tmp_path / "event.json"
+    payload_path.write_text("[]", encoding="utf-8")
+    assert gates._extract_pr_body(payload_path) == ""
+    assert gates._extract_pr_number(payload_path) is None
+
+
+def test_extract_pr_body_returns_empty_for_non_object_pull_request(tmp_path: Path) -> None:
+    payload_path = tmp_path / "event.json"
+    payload_path.write_text(json.dumps({"pull_request": []}), encoding="utf-8")
+    assert gates._extract_pr_body(payload_path) == ""
+    assert gates._extract_pr_number(payload_path) is None
+
+
 def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
     """When event has pr_number, Phase2 validates artifact and mirrored PR body."""
     event = {"pull_request": {"number": 998, "body": VALID_BODY_WITH_MAPPING}}

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -193,10 +193,10 @@ def test_extract_pr_body_returns_empty_on_invalid_json(tmp_path: Path) -> None:
 
 
 def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
-    """When event has pr_number, Phase2 reads canonical artifact from temp dir."""
+    """When event has pr_number, Phase2 validates artifact and mirrored PR body."""
     import subprocess
 
-    event = {"pull_request": {"number": 998, "body": "minimal"}}
+    event = {"pull_request": {"number": 998, "body": VALID_BODY_WITH_MAPPING}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
 
@@ -205,6 +205,8 @@ def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
 - https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -223,4 +225,41 @@ def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
         env=env,
     )
     assert result.returncode == 0
-    assert "canonical mapping artifact passed" in result.stdout
+    assert "canonical mapping artifact and PR body passed" in result.stdout
+
+
+def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
+    """Artifact success must not bypass PR body validation."""
+    import subprocess
+
+    event = {"pull_request": {"number": 998, "body": "minimal"}}
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "PR body validation failed" in result.stdout
+    assert "Missing required section" in result.stdout

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 
 import scripts.ci.check_pr_body_phase2_gates as gates
@@ -92,14 +94,15 @@ def test_phase2_guard_rejects_missing_mapping_details() -> None:
     assert any("Add at least one mapping entry" in error for error in errors)
 
 
-def test_phase2_guard_allows_mapping_and_na_marker_together() -> None:
+def test_phase2_guard_rejects_mixed_mapping_and_na_marker() -> None:
+    """Mixed mode (mapping + No actionable) is invalid; align with artifact contract."""
     body = VALID_BODY_WITH_MAPPING.replace(
         "- https://github.com/org/repo/pull/719#issuecomment-123 -> 28069fd4",
         "- https://github.com/org/repo/pull/719#issuecomment-123 -> 28069fd4\n"
         "- No actionable review comments",
     )
     errors = gates.check_pr_body_phase2_gates(body=body)
-    assert errors == []
+    assert any("mixed mode" in e.lower() or "cannot appear together" in e.lower() for e in errors)
 
 
 def test_phase2_guard_rejects_malformed_mapping_line() -> None:
@@ -187,3 +190,37 @@ def test_extract_pr_body_returns_empty_on_invalid_json(tmp_path: Path) -> None:
     payload_path.write_text("not valid json", encoding="utf-8")
     result = gates._extract_pr_body(payload_path)
     assert result == ""
+
+
+def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
+    """When event has pr_number, Phase2 reads canonical artifact from temp dir."""
+    import subprocess
+
+    event = {"pull_request": {"number": 998, "body": "minimal"}}
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "canonical mapping artifact passed" in result.stdout

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -165,12 +165,45 @@ class TestRetrieveAndValidateRag:
                 "test prompt",
                 philo_validation_enabled=False,
                 recursive_rag_enabled=True,
+                subject_id=55,
             )
 
         assert to_thread_mock.call_count == 1
         assert to_thread_mock.call_args.args[0] is recursive
+        assert to_thread_mock.call_args.kwargs["subject_id"] == 55
         assert result.rag_actually_used is True
         assert result.hops == 2
+
+    @pytest.mark.asyncio
+    async def test_vector_path_propagates_subject_id(self) -> None:
+        """Vector orchestration passes authenticated subject_id to retriever."""
+        rag_ctx = _make_rag_context(chunks=[_make_chunk("c1", score=0.9)], confidence=0.9)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ) as to_thread_mock,
+            patch("core.rag.vector_rag.retrieve_context_structured") as retrieve_mock,
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "test prompt",
+                philo_validation_enabled=False,
+                subject_id=77,
+            )
+
+        assert to_thread_mock.call_args.args[0] is retrieve_mock
+        assert to_thread_mock.call_args.kwargs["subject_id"] == 77
+        assert result.rag_actually_used is True
 
     @pytest.mark.asyncio
     async def test_recursive_with_philo_enabled_runs_pipeline_without_double_filter(self) -> None:

--- a/tests/test_rag_vector_feature_flag_guard.py
+++ b/tests/test_rag_vector_feature_flag_guard.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
+
+from app.middleware.api_tiers import TEST_KEY_VIP, derive_subject_id_from_api_key
+from core.rag.orchestration import RAGOrchestrationResult
 
 
 @dataclass
@@ -42,6 +46,7 @@ def _vector_fake(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeCtx:
     """Fake that simulates vector retrieval (distinct chunk_id prefix)."""
     return _FakeCtx(
@@ -174,6 +179,7 @@ class TestFeatureFlagIntegration:
             max_chunks: int = 3,
             agent_id: str | None = None,
             user_tier: str | None = None,
+            subject_id: int | None = None,
         ) -> _FakeCtx:
             return _FakeCtx(
                 query=query,
@@ -196,3 +202,69 @@ class TestFeatureFlagIntegration:
         data = resp.json()
         assert data["rag_used"] is True
         assert data["sources"][0]["chunk_id"] == "j:1"
+
+    def test_api_v1_insight_passes_authenticated_subject_id(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        """Authenticated /api/v1/insight propagates derived subject_id into RAG orchestration."""
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        rag_result = AsyncMock()
+        rag_result.return_value = RAGOrchestrationResult(
+            chunks=[],
+            formatted_prompt="test",
+            rag_actually_used=False,
+            confidence=None,
+            hops=0,
+            latency_ms=0,
+        )
+        monkeypatch.setattr(
+            "core.rag.orchestration.retrieve_and_validate_rag",
+            rag_result,
+            raising=True,
+        )
+
+        resp = client.post("/api/v1/insight", json={"text": "test"}, headers=vip_headers)
+
+        assert resp.status_code == 200
+        assert rag_result.await_args.kwargs["subject_id"] == derive_subject_id_from_api_key(
+            TEST_KEY_VIP
+        )
+
+    def test_legacy_insight_uses_safe_fallback_without_subject_id(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        """Legacy /insight keeps vector user corpus disabled by omitting subject_id."""
+        import llm
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: _EchoProvider(), raising=True)
+        rag_result = AsyncMock()
+        rag_result.return_value = RAGOrchestrationResult(
+            chunks=[],
+            formatted_prompt="test",
+            rag_actually_used=False,
+            confidence=None,
+            hops=0,
+            latency_ms=0,
+        )
+        monkeypatch.setattr(
+            "core.rag.orchestration.retrieve_and_validate_rag",
+            rag_result,
+            raising=True,
+        )
+
+        resp = client.post("/insight", json={"text": "test"}, headers=vip_headers)
+
+        assert resp.status_code == 200
+        assert rag_result.await_args.kwargs["subject_id"] is None

--- a/tests/test_review_mapping_artifact.py
+++ b/tests/test_review_mapping_artifact.py
@@ -15,6 +15,8 @@ FIXTURE_ARTIFACT = """# PR 998 — Fixed in Commit Mapping
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
 - https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
 """
 
@@ -114,7 +116,9 @@ def test_validate_mapping_artifact_text_valid() -> None:
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
 """
     errors = artifact.validate_mapping_artifact_text(text)
     assert errors == []
@@ -137,6 +141,19 @@ def test_validate_fixed_mapping_section_invalid_line() -> None:
     assert any("Invalid mapping line" in e for e in errors)
 
 
+def test_validate_fixed_mapping_section_empty() -> None:
+    errors = artifact.validate_fixed_mapping_section("")
+    assert any("Missing" in error for error in errors)
+
+
+def test_validate_fixed_mapping_section_mixed_mode() -> None:
+    section = """- No actionable review comments
+- https://github.com/org/repo/pull/1#discussion_r1 -> abc1234
+"""
+    errors = artifact.validate_fixed_mapping_section(section)
+    assert any("mixed mode" in error.lower() for error in errors)
+
+
 def test_validate_fixed_mapping_section_requires_mapping_or_no_actionable() -> None:
     """Section with only Disposition/Commit lines must have at least one mapping."""
     section = """Disposition: FIXED
@@ -144,3 +161,19 @@ Commit: abc1234
 """
     errors = artifact.validate_fixed_mapping_section(section)
     assert any("at least one" in e for e in errors)
+
+
+def test_validate_fixed_mapping_section_requires_disposition_for_sha_mappings() -> None:
+    section = """Commit: abc1234
+- https://github.com/org/repo/pull/1#discussion_r1 -> abc1234
+"""
+    errors = artifact.validate_fixed_mapping_section(section)
+    assert "Missing 'Disposition:' when SHA mappings are present." in errors
+
+
+def test_validate_fixed_mapping_section_requires_proof_for_sha_mappings() -> None:
+    section = """Disposition: FIXED
+- https://github.com/org/repo/pull/1#discussion_r1 -> abc1234
+"""
+    errors = artifact.validate_fixed_mapping_section(section)
+    assert any("Missing proof detail" in error for error in errors)

--- a/tests/test_review_mapping_artifact.py
+++ b/tests/test_review_mapping_artifact.py
@@ -35,6 +35,17 @@ def test_read_mapping_artifact_existing(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert "->" in text
 
 
+def test_mapping_artifact_path_invalid_override_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-existent override dir should fail with a clear RuntimeError."""
+    bad_dir = tmp_path / "nonexistent_dir"
+    monkeypatch.setenv("REVIEW_MAPPING_ARTIFACT_DIR", str(bad_dir))
+
+    with pytest.raises(RuntimeError, match="REVIEW_MAPPING_ARTIFACT_DIR"):
+        artifact.mapping_artifact_path(998)
+
+
 def test_read_mapping_artifact_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Ensure FileNotFoundError when artifact absent; isolate from REVIEW_MAPPING_ARTIFACT_DIR."""
     monkeypatch.delenv("REVIEW_MAPPING_ARTIFACT_DIR", raising=False)

--- a/tests/test_review_mapping_artifact.py
+++ b/tests/test_review_mapping_artifact.py
@@ -1,0 +1,135 @@
+"""Deterministic tests for canonical review mapping artifact module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import review_mapping_artifact as artifact
+
+FIXTURE_ARTIFACT = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+
+
+def test_mapping_artifact_path() -> None:
+    p998 = artifact.mapping_artifact_path(998)
+    assert p998.name == "PR_998_FIXED_MAPPING.md"
+    assert "docs" in str(p998) and "review" in str(p998)
+
+
+def test_read_mapping_artifact_existing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Read artifact from temp dir to avoid coupling to real repo file."""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(FIXTURE_ARTIFACT, encoding="utf-8")
+    monkeypatch.setattr(artifact, "_review_dir", lambda: tmp_path)
+    text = artifact.read_mapping_artifact(998)
+    assert "## Discussion Thread Pass" in text
+    assert "## Fixed in Commit Mapping" in text
+    assert "->" in text
+
+
+def test_read_mapping_artifact_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Ensure FileNotFoundError when artifact absent; isolate from REVIEW_MAPPING_ARTIFACT_DIR."""
+    monkeypatch.delenv("REVIEW_MAPPING_ARTIFACT_DIR", raising=False)
+    monkeypatch.setattr(artifact, "_review_dir", lambda: tmp_path)
+    with pytest.raises(FileNotFoundError, match="Missing canonical review mapping artifact"):
+        artifact.read_mapping_artifact(99999)
+
+
+def test_extract_fixed_mapping_section() -> None:
+    text = """# PR 1
+
+## Discussion Thread Pass
+- [x] done
+
+## Fixed in Commit Mapping
+- https://github.com/org/repo/pull/1#discussion_r1 -> abc1234
+"""
+    section = artifact.extract_fixed_mapping_section(text)
+    assert "https://github.com/org/repo/pull/1#discussion_r1" in section
+    assert "abc1234" in section
+
+
+def test_extract_fixed_mapping_section_no_actionable() -> None:
+    text = """## Fixed in Commit Mapping
+- No actionable review comments
+"""
+    section = artifact.extract_fixed_mapping_section(text)
+    assert "No actionable review comments" in section
+
+
+def test_extract_fixed_mapping_section_accepts_triple_hash() -> None:
+    """PR-body fallback uses ### Fixed in Commit Mapping."""
+    text = """## Discussion Thread Pass
+- [x] done
+
+### Fixed in Commit Mapping
+- https://github.com/org/repo/pull/1#d1 -> abc1234
+"""
+    section = artifact.extract_fixed_mapping_section(text)
+    assert "abc1234" in section
+
+
+def test_parse_fixed_mapping_entries() -> None:
+    section = """- https://github.com/org/repo/pull/1#discussion_r1 -> abc1234
+- https://github.com/org/repo/pull/1#issuecomment-2 -> deadbeef
+"""
+    entries = artifact.parse_fixed_mapping_entries(section)
+    assert entries["https://github.com/org/repo/pull/1#discussion_r1"] == "abc1234"
+    assert entries["https://github.com/org/repo/pull/1#issuecomment-2"] == "deadbeef"
+
+
+def test_parse_fixed_mapping_entries_no_actionable() -> None:
+    section = "- No actionable review comments"
+    entries = artifact.parse_fixed_mapping_entries(section)
+    assert entries == {}
+
+
+def test_has_no_actionable_marker() -> None:
+    assert artifact.has_no_actionable_marker("- No actionable review comments") is True
+    assert artifact.has_no_actionable_marker("- https://x -> abc1234") is False
+
+
+def test_validate_mapping_artifact_text_valid() -> None:
+    text = """## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+"""
+    errors = artifact.validate_mapping_artifact_text(text)
+    assert errors == []
+
+
+def test_validate_mapping_artifact_text_missing_checkbox() -> None:
+    text = """## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+"""
+    errors = artifact.validate_mapping_artifact_text(text)
+    assert any("Discussion-thread pass completed" in e for e in errors)
+
+
+def test_validate_fixed_mapping_section_invalid_line() -> None:
+    section = "- invalid mapping line"
+    errors = artifact.validate_fixed_mapping_section(section)
+    assert any("Invalid mapping line" in e for e in errors)
+
+
+def test_validate_fixed_mapping_section_requires_mapping_or_no_actionable() -> None:
+    """Section with only Disposition/Commit lines must have at least one mapping."""
+    section = """Disposition: FIXED
+Commit: abc1234
+"""
+    errors = artifact.validate_fixed_mapping_section(section)
+    assert any("at least one" in e for e in errors)

--- a/tests/test_review_threads_disposition_strict.py
+++ b/tests/test_review_threads_disposition_strict.py
@@ -10,20 +10,20 @@ import pytest
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
-# Section extraction and auth only; no gh/GraphQL mocks
+# Section extraction from artifact; auth from disposition
 import scripts.orchestration.check_review_threads_disposition as _disposition_mod
 from scripts.orchestration.check_review_threads_disposition import (
     ResolvedThreadRef,
     _check_commit_after_comment,
     _check_trigger_only_mapping,
     _env_diagnostic,
-    _extract_fixed_mapping_section,
     _find_disposition_block_in_section,
     _has_gh_auth,
     _parse_iso_datetime,
     _parse_mapping_section,
     _require_gh_token_preflight,
 )
+from scripts.orchestration.review_mapping_artifact import extract_fixed_mapping_section
 
 
 def test_extract_fixed_mapping_section_finds_section() -> None:
@@ -34,20 +34,20 @@ text
 ## Discussion Thread Pass
 - [x] done
 
-### Fixed in Commit Mapping
+## Fixed in Commit Mapping
 Thread: https://example.com/1
 Disposition: FIXED
 Commit: abc123
 
 ## Merge Readiness
 """
-    section = _extract_fixed_mapping_section(body)
+    section = extract_fixed_mapping_section(body)
     assert "https://example.com/1" in section
     assert re.search(r"Disposition:\s*FIXED", section)
 
 
 def test_extract_fixed_mapping_section_accepts_double_hash_heading() -> None:
-    """Section may use ## Fixed in Commit Mapping (any heading level)."""
+    """Section uses ## Fixed in Commit Mapping (artifact format)."""
     body = """
 ## Summary
 ## Fixed in Commit Mapping
@@ -57,7 +57,7 @@ Commit: abc
 
 ## Discussion Thread Pass
 """
-    section = _extract_fixed_mapping_section(body)
+    section = extract_fixed_mapping_section(body)
     assert "https://github.com/org/repo/pull/99" in section
     assert re.search(r"Disposition:\s*FIXED", section)
 
@@ -68,13 +68,13 @@ def test_extract_fixed_mapping_section_empty_when_missing() -> None:
 ## Discussion Thread Pass
 ## Merge Readiness
 """
-    section = _extract_fixed_mapping_section(body)
+    section = extract_fixed_mapping_section(body)
     assert section == ""
 
 
 def test_extract_fixed_mapping_section_stops_at_next_heading() -> None:
     body = """
-### Fixed in Commit Mapping
+## Fixed in Commit Mapping
 - https://github.com/org/repo/pull/1#discussion_r123 -> abc1234
 Disposition: FIXED
 Evidence: file.md:10
@@ -82,7 +82,7 @@ Evidence: file.md:10
 ## Discussion Thread Pass
 - [x] done
 """
-    section = _extract_fixed_mapping_section(body)
+    section = extract_fixed_mapping_section(body)
     assert "https://github.com/org/repo/pull/1" in section
     assert "Discussion Thread Pass" not in section
 

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -47,6 +47,7 @@ def _fake_jaccard(
     max_chunks: int = 3,
     agent_id: str | None = None,
     user_tier: str | None = None,
+    subject_id: int | None = None,
 ) -> _FakeContext:
     return _FakeContext(
         query=query,
@@ -179,7 +180,7 @@ class TestVectorRetrievalSQLite:
         fake_session = MagicMock()
         fake_session.execute.return_value.fetchall.return_value = rows
 
-        results = vector_rag._retrieve_vector_sqlite(query_vec, 5, fake_session)
+        results = vector_rag._retrieve_vector_sqlite(query_vec, 5, fake_session, subject_id=7)
 
         # Should have 2 valid results (3rd row has bad JSON)
         assert len(results) == 2
@@ -206,7 +207,7 @@ class TestVectorRetrievalSQLite:
         fake_session = MagicMock()
         fake_session.execute.return_value.fetchall.return_value = rows
 
-        results = vector_rag._retrieve_vector_sqlite(query_vec, 3, fake_session)
+        results = vector_rag._retrieve_vector_sqlite(query_vec, 3, fake_session, subject_id=7)
         assert len(results) == 3
 
     def test_retrieve_vector_sqlite_skips_wrong_dimensions(
@@ -232,8 +233,45 @@ class TestVectorRetrievalSQLite:
         fake_session = MagicMock()
         fake_session.execute.return_value.fetchall.return_value = rows
 
-        results = vector_rag._retrieve_vector_sqlite(query_vec, 5, fake_session)
+        results = vector_rag._retrieve_vector_sqlite(query_vec, 5, fake_session, subject_id=7)
         assert len(results) == 0
+
+    def test_retrieve_vector_sqlite_binds_subject_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SQLite retrieval binds subject_id to prevent cross-tenant leaks."""
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        class _Row:
+            def __init__(self, id: int, embedding: str) -> None:
+                self.id = id
+                self.content = f"doc {id}"
+                self.source = "src"
+                self.embedding = embedding
+
+        captured_params: list[dict[str, int]] = []
+
+        class _Result:
+            def fetchall(self) -> list[_Row]:
+                return [_Row(1, json.dumps([1.0, 0.0, 0.0]))]
+
+        def _execute(stmt: Any, params: dict[str, int] | None = None) -> _Result:
+            assert "user_id = :subject_id" in str(stmt)
+            captured_params.append(params or {})
+            return _Result()
+
+        fake_session = MagicMock()
+        fake_session.execute = _execute
+
+        results = vector_rag._retrieve_vector_sqlite(
+            [1.0, 0.0, 0.0],
+            5,
+            fake_session,
+            subject_id=42,
+        )
+
+        assert len(results) == 1
+        assert captured_params[0]["subject_id"] == 42
 
 
 class TestEmptyContext:
@@ -317,7 +355,7 @@ class TestRetrieveVectorPostgres:
         fake_session = MagicMock()
         fake_session.execute.return_value.fetchall.return_value = [fake_row]
 
-        results = _retrieve_vector_postgres([1.0, 2.0, 3.0], 5, fake_session)
+        results = _retrieve_vector_postgres([1.0, 2.0, 3.0], 5, fake_session, subject_id=17)
 
         assert len(results) == 1
         assert results[0][0] is fake_row
@@ -328,6 +366,8 @@ class TestRetrieveVectorPostgres:
         params = call_args[1] if call_args[1] else call_args[0][1]
         assert params["qvec"] == "[1.0,2.0,3.0]"
         assert params["lim"] == 5
+        assert params["subject_id"] == 17
+        assert "user_id = :subject_id" in str(call_args[0][0])
 
 
 class TestRetrieveVectorFromDb:
@@ -366,7 +406,7 @@ class TestRetrieveVectorFromDb:
 
         monkeypatch.setattr("core.db.session_scope", _fake_session_scope)
 
-        ctx = vector_rag._retrieve_vector_from_db("test", 3, "agent-1", "PRO")
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, "agent-1", "PRO", 21)
         assert isinstance(ctx, RAGContext)
         assert len(ctx.chunks) == 1
         assert ctx.chunks[0].file == "notes.md"
@@ -385,11 +425,27 @@ class TestRetrieveVectorFromDb:
         fake_provider.encode.return_value = []
         vector_rag._embedding_provider = fake_provider
 
-        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None)
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, 21)
         assert isinstance(ctx, RAGContext)
         assert ctx.chunks == []
 
         # Cleanup
+        vector_rag._embedding_provider = None
+
+    def test_missing_subject_id_returns_empty_without_encoding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Vector retrieval must fail closed when subject_id is absent."""
+        from core.rag import vector_rag
+
+        fake_provider = MagicMock()
+        vector_rag._embedding_provider = fake_provider
+
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, None)
+
+        assert ctx.chunks == []
+        fake_provider.encode.assert_not_called()
+
         vector_rag._embedding_provider = None
 
     def test_postgres_dialect_calls_postgres_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -420,10 +476,10 @@ class TestRetrieveVectorFromDb:
         monkeypatch.setattr(
             vector_rag,
             "_retrieve_vector_postgres",
-            lambda q, lim, s, corpus_prefixes=None: [(fake_row, 0.9)],
+            lambda q, lim, s, subject_id, corpus_prefixes=None: [(fake_row, 0.9)],
         )
 
-        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None)
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, 21)
         assert len(ctx.chunks) == 1
         assert ctx.chunks[0].file == "pg.md"
 
@@ -464,7 +520,7 @@ class TestRetrieveVectorFromDb:
         monkeypatch.setattr("core.db.session_scope", _fake_session_scope)
         monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
 
-        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None)
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, 21)
         assert ctx.chunks == []
         assert ctx.confidence == 0.0
 
@@ -531,7 +587,7 @@ class TestQueryEmbeddingValidation:
         ]
 
         # 2-dim query vs 3-dim expected — guard should reject
-        results = vector_rag._retrieve_vector_sqlite([1.0, 0.0], 5, fake_session)
+        results = vector_rag._retrieve_vector_sqlite([1.0, 0.0], 5, fake_session, subject_id=7)
         assert results == []
 
 
@@ -564,7 +620,7 @@ class TestCorpusFilteringVectorRag:
         corpus_prefixes = ["docs/cbt/", "docs/psychology/"]
 
         vector_rag._retrieve_vector_postgres(
-            query_embedding, 5, fake_session, corpus_prefixes=corpus_prefixes
+            query_embedding, 5, fake_session, subject_id=99, corpus_prefixes=corpus_prefixes
         )
 
         # Verify SQL contains LIKE clauses for prefixes
@@ -578,6 +634,7 @@ class TestCorpusFilteringVectorRag:
         params = captured_params[0]
         assert params.get("prefix_0") == "docs/cbt/%"
         assert params.get("prefix_1") == "docs/psychology/%"
+        assert params.get("subject_id") == 99
 
     def test_sqlite_corpus_filtering_builds_where_clause(
         self, monkeypatch: pytest.MonkeyPatch
@@ -606,7 +663,7 @@ class TestCorpusFilteringVectorRag:
 
         monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
         vector_rag._retrieve_vector_sqlite(
-            query_embedding, 5, fake_session, corpus_prefixes=corpus_prefixes
+            query_embedding, 5, fake_session, subject_id=99, corpus_prefixes=corpus_prefixes
         )
 
         # Verify SQL contains LIKE clauses for prefixes
@@ -618,6 +675,7 @@ class TestCorpusFilteringVectorRag:
         # Verify params contain prefix patterns
         params = captured_params[0]
         assert params.get("prefix_0") == "docs/cbt/%"
+        assert params.get("subject_id") == 99
 
     def test_retrieve_from_db_logs_warning_when_corpus_empty(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -645,12 +703,12 @@ class TestCorpusFilteringVectorRag:
         monkeypatch.setattr(
             vector_rag,
             "_retrieve_vector_postgres",
-            lambda q, lim, s, corpus_prefixes=None: [],  # Empty results
+            lambda q, lim, s, subject_id, corpus_prefixes=None: [],  # Empty results
         )
 
         with caplog.at_level(logging.WARNING, logger="core.rag.vector_rag"):
             ctx = vector_rag._retrieve_vector_from_db(
-                "test", 3, agent_id="cbt-agent", user_tier="PRO"
+                "test", 3, agent_id="cbt-agent", user_tier="PRO", subject_id=21
             )
 
         # Should return empty context


### PR DESCRIPTION
# Pull Request

## Summary

Fix vector RAG tenant scoping so personalized `user_knowledge` retrieval is constrained by authenticated `subject_id`, and fail closed to non-personal fallback when no authenticated subject context exists.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

Closes a cross-tenant disclosure in vector retrieval by threading authenticated subject context through vector/recursive RAG and VIP/PRO insight callers. Legacy `/insight` intentionally remains fallback-only without personalized vector corpus.

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [x] Integration/slow tests (if applicable)
- [x] Manual verification steps

Manual verification performed:
- `pytest -q tests/test_vector_rag.py tests/test_rag_orchestration.py tests/test_rag_vector_feature_flag_guard.py tests/test_cbt_insight_api.py`
- `pytest -q tests/test_insight_rag_response_fields.py tests/test_philosophy_validation_integration.py tests/test_insight_error_hygiene.py`
- `pre-commit run --all-files`
- `make verify`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$BODY"` against the current PR body mirror

## CI Gates

- [x] PR tests green (lint, type, unit)
- [x] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Disposition: FIXED
Commit: see mapping entries below
Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`, `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#discussion_r2898456843 -> d38b5c9b
  - Disposition: FIXED
  - Commit: `d38b5c9b`
  - Evidence: `docs/contracts/RAG_CONTRACT.md:171`, `docs/contracts/RAG_CONTRACT.md:227`, `docs/contracts/RAG_CONTRACT.md:228`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1002#pullrequestreview-3906682857 -> 41b03fbc
  - Disposition: FIXED
  - Commit: `41b03fbc`
  - Evidence: `core/rag/orchestration.py:94`, `core/rag/orchestration.py:112`
## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): `docs/roadmap/BACKLOG_LEDGER.md` entry for `user_knowledge DB-level RLS / policy hardening`
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Complex/High-Risk Changes

#### Deployment Strategy

- [x] Feature flag configuration (enable/disable without redeploy)

#### Database & Data Changes

- [x] Database migrations required (Alembic version, backwards compatibility)

Details: no schema migration is required for this hotfix.

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [x] Manual verification checklist (specific endpoints, user flows)
- [x] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [x] Rollback triggers (what conditions require immediate rollback)

Rollback / Feature flag (brief):

- How to revert: revert commits `19e957ad` and `d840290a`
- Feature flag/toggle (if any): `FEATURE_RAG_VECTOR`; disabling it turns off vector retrieval path
- Owner for emergency contact: @katsiarynakavaleuskaya

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [x] Documentation updates needed (README, API docs, runbooks)

## Summary by Sourcery

Ограничить векторный RAG‑поиск аутентифицированными субъектами и сделать учёт арендатора (tenant-aware) поведением по умолчанию, одновременно централизовав управление сопоставлением обзоров в каноническом артефакте, используемом CI и гейтами готовности к слиянию.

Bug Fixes:
- Ограничить векторный поиск `user_knowledge` в Postgres и SQLite аутентифицированным `subject_id` и при отсутствии контекста субъекта переходить в режим «fail closed» к неперсонализированному варианту по умолчанию.
- Прокинуть `subject_id` через оркестрацию RAG, рекурсивный поиск и эндпоинты insight/CBT, чтобы персонализация на уровне арендатора не могла выходить за границы соответствующего арендатора.

Enhancements:
- Ввести канонический артефакт Fixed in Commit Mapping в `docs/review` и обновить скрипты CI/disposition так, чтобы они читали, валидировали и обеспечивали соблюдение его структуры вместо того, чтобы полагаться на тело PR.
- Ужесточить Phase2 CI и гейты готовности к слиянию, чтобы отклонять некорректные или смешанные записи сопоставления и гарантировать, что все действенные комментарии бота и разрешённые треды корректно сопоставлены.
- Уточнить документацию по контракту RAG относительно требований к `subject_id` и поведения fail-closed, а также зафиксировать последующую задачу в бэклоге по усилению RLS на уровне БД для `user_knowledge`.

Tests:
- Расширить тесты для векторного RAG, оркестрации, insight и governance, чтобы покрыть прокидывание `subject_id`, поведение fail-closed при отсутствии контекста субъекта и валидацию канонического артефакта сопоставления.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope vector RAG retrieval to authenticated subjects and make tenant-aware access the default, while centralizing review mapping governance in a canonical artifact used by CI and merge readiness gates.

Bug Fixes:
- Constrain vector-based user_knowledge retrieval in Postgres and SQLite to the authenticated subject_id and fail closed to non-personal fallback when no subject context is available.
- Propagate subject_id through RAG orchestration, recursive retrieval, and insight/CBT endpoints so per-tenant personalization cannot cross tenant boundaries.

Enhancements:
- Introduce a canonical Fixed in Commit Mapping artifact under docs/review and update CI/disposition scripts to read, validate, and enforce its structure instead of relying on the PR body.
- Tighten CI Phase2 and merge-readiness gates to reject malformed or mixed mapping entries and ensure all actionable bot comments and resolved threads are correctly mapped.
- Clarify RAG contract documentation around subject_id requirements and fail-closed behavior, and record a follow-up backlog item for DB-level RLS hardening of user_knowledge.

Tests:
- Extend vector RAG, orchestration, insight, and governance tests to cover subject_id propagation, fail-closed behavior without subject context, and validation of the canonical mapping artifact.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ограничить векторный RAG‑поиск аутентифицированными субъектами и сделать учёт арендатора (tenant-aware) поведением по умолчанию, одновременно централизовав управление сопоставлением обзоров в каноническом артефакте, используемом CI и гейтами готовности к слиянию.

Bug Fixes:
- Ограничить векторный поиск `user_knowledge` в Postgres и SQLite аутентифицированным `subject_id` и при отсутствии контекста субъекта переходить в режим «fail closed» к неперсонализированному варианту по умолчанию.
- Прокинуть `subject_id` через оркестрацию RAG, рекурсивный поиск и эндпоинты insight/CBT, чтобы персонализация на уровне арендатора не могла выходить за границы соответствующего арендатора.

Enhancements:
- Ввести канонический артефакт Fixed in Commit Mapping в `docs/review` и обновить скрипты CI/disposition так, чтобы они читали, валидировали и обеспечивали соблюдение его структуры вместо того, чтобы полагаться на тело PR.
- Ужесточить Phase2 CI и гейты готовности к слиянию, чтобы отклонять некорректные или смешанные записи сопоставления и гарантировать, что все действенные комментарии бота и разрешённые треды корректно сопоставлены.
- Уточнить документацию по контракту RAG относительно требований к `subject_id` и поведения fail-closed, а также зафиксировать последующую задачу в бэклоге по усилению RLS на уровне БД для `user_knowledge`.

Tests:
- Расширить тесты для векторного RAG, оркестрации, insight и governance, чтобы покрыть прокидывание `subject_id`, поведение fail-closed при отсутствии контекста субъекта и валидацию канонического артефакта сопоставления.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope vector RAG retrieval to authenticated subjects and make tenant-aware access the default, while centralizing review mapping governance in a canonical artifact used by CI and merge readiness gates.

Bug Fixes:
- Constrain vector-based user_knowledge retrieval in Postgres and SQLite to the authenticated subject_id and fail closed to non-personal fallback when no subject context is available.
- Propagate subject_id through RAG orchestration, recursive retrieval, and insight/CBT endpoints so per-tenant personalization cannot cross tenant boundaries.

Enhancements:
- Introduce a canonical Fixed in Commit Mapping artifact under docs/review and update CI/disposition scripts to read, validate, and enforce its structure instead of relying on the PR body.
- Tighten CI Phase2 and merge-readiness gates to reject malformed or mixed mapping entries and ensure all actionable bot comments and resolved threads are correctly mapped.
- Clarify RAG contract documentation around subject_id requirements and fail-closed behavior, and record a follow-up backlog item for DB-level RLS hardening of user_knowledge.

Tests:
- Extend vector RAG, orchestration, insight, and governance tests to cover subject_id propagation, fail-closed behavior without subject context, and validation of the canonical mapping artifact.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes vector RAG retrieval to the authenticated subject and fails closed to a non-personal fallback when no subject context exists. CI review gates now validate the canonical mapping artifact and the mirrored PR body with clear, scoped failure messages.

- **Bug Fixes**
  - Subject-scoped vector queries: filter user_knowledge by user_id = :subject_id; if None, skip encode/DB reads and use Jaccard fallback.
  - Propagate subject_id across orchestration, vector, and recursive paths; VIP/PRO (including CBT) derive it from API keys, legacy /insight sends None.
  - Governance: Phase2 and merge-readiness gates read docs/review/PR_<N>_FIXED_MAPPING.md, validate SHAs, require Disposition and proof (Commit/Evidence/Backlog) with SHA mappings, reject mixed “No actionable” + SHA modes, validate the PR body mirror, harden GitHub event JSON/PR-number parsing, and report whether the artifact or PR body failed.

- **Docs**
  - Clarified RAG contract for subject isolation and fail-closed behavior; added evidence anchors and the PR_1002 Fixed in Commit Mapping artifact.
  - Logged DB-level RLS hardening for user_knowledge in the backlog.

<sup>Written for commit 5a6dc6c908bcea200ad2f14cc443e2b93416b25f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insight/RAG retrievals now respect an authenticated per-subject ID when available; retrievals safely fall back to non-personal paths if absent.

* **Documentation**
  * Retrieval API contract updated; added canonical review-mapping artifact guidance and backlog/security ledger entry.

* **Tests**
  * Expanded coverage for subject propagation, vector-retrieval guards, orchestration, and mapping-artifact parsing/validation.

* **Chores**
  * CI and review tooling enhanced to validate canonical mapping artifacts during PR checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


