### PR TITLE
test(orchestration): lock preflight cli contract

### DIFF
--- a/docs/review/PR_1004_FIXED_MAPPING.md
+++ b/docs/review/PR_1004_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1004 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1004_FIXED_MAPPING.md
+++ b/docs/review/PR_1004_FIXED_MAPPING.md
@@ -5,4 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: b718df76
+Evidence: tests/test_orchestration_preflight.py:14
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1004#pullrequestreview-3907945051 -> b718df76

--- a/tests/test_orchestration_preflight.py
+++ b/tests/test_orchestration_preflight.py
@@ -11,6 +11,9 @@ import pytest
 
 from scripts.orchestration import check_preflight as preflight
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT_CLI_PATH = REPO_ROOT / "scripts" / "orchestration" / "check_preflight.py"
+
 
 def test_analyze_mode_allows_dirty_tree(monkeypatch: pytest.MonkeyPatch) -> None:
     """Analyze mode must pass with dirty tree when other checks pass."""
@@ -168,15 +171,13 @@ def test_check_gate_evidence_resolves_relative_paths_against_root(
     assert preflight.check_gate_evidence(["evidence.log"]) is True
 
 
+@pytest.mark.slow
 def test_cli_invocation_works_without_pythonpath() -> None:
     """Plain script invocation must work from repo root without PYTHONPATH."""
 
-    repo_root = Path(__file__).resolve().parents[1]
-    script_path = repo_root / "scripts" / "orchestration" / "check_preflight.py"
-
     result = subprocess.run(
-        [sys.executable, str(script_path)],
-        cwd=repo_root,
+        [sys.executable, str(PREFLIGHT_CLI_PATH)],
+        cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_orchestration_preflight.py
+++ b/tests/test_orchestration_preflight.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -163,3 +166,21 @@ def test_check_gate_evidence_resolves_relative_paths_against_root(
     monkeypatch.chdir(tmp_path.parent)
 
     assert preflight.check_gate_evidence(["evidence.log"]) is True
+
+
+def test_cli_invocation_works_without_pythonpath() -> None:
+    """Plain script invocation must work from repo root without PYTHONPATH."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "orchestration" / "check_preflight.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={k: v for k, v in os.environ.items() if k != "PYTHONPATH"},
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr


### PR DESCRIPTION
## Summary
Lock the documented `check_preflight.py` CLI contract with a regression test so repo-root invocation remains valid without `PYTHONPATH`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: b718df76
Evidence: tests/test_orchestration_preflight.py:14

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1004#pullrequestreview-3907945051 -> b718df76

## Merge Readiness
- Local validation completed on the stacked branch:
  - `python3 scripts/orchestration/check_preflight.py`
  - `pytest -q tests/test_orchestration_preflight.py`
  - `pre-commit run --all-files`
  - `make verify`
- Stacked PR base: `feat/agent-orchestration-2-0`
- Canonical review artifact committed: `docs/review/PR_1004_FIXED_MAPPING.md`