### PR TITLE
feat(orchestration): add canonical merge-check entrypoint

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -243,13 +243,16 @@ Run before merge after latest commit and latest bot/review activity:
 - Under **### Fixed in Commit Mapping**: either list each bot comment as `- <comment-url> -> <commit-sha>`, or use exactly (no extra text): `- No actionable review comments`.
 - Local check (no API): `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"` (use the same body as on the PR).
 
-**Canonical verification (required before claiming "0 comments" or "ready to merge"):** Run the merge-readiness script so both unresolved threads and unmapped actionable bot comments are checked. Policy: see `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`.
+**Canonical verification (required before claiming "0 comments" or "ready to merge"):** Run the orchestration wrapper so Phase 2, merge-readiness, and disposition proof are checked together. Policy: see `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`.
 
 ```bash
-# From repo root; requires GITHUB_TOKEN (e.g. gh auth token).
-python scripts/ci/check_pr_merge_readiness.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate
+# From repo root; requires GITHUB_TOKEN and GH_TOKEN for full strict coverage.
+python scripts/orchestration/check_merge_ready.py \
+  --pr-number <PR_NUMBER> \
+  --repo Katsiarynakavaleuskaya/PulsePlate \
+  --require-auth
 ```
-Exit 0 = zero comments (0 unresolved threads + all actionables mapped). Exit 1 = do not merge; fix and re-run.
+Exit 0 = Phase 2 + merge-readiness + disposition proof all pass. Exit 1 = do not merge; fix and re-run.
 
 **Optional: unresolved thread count only** (not sufficient alone):
 
@@ -268,7 +271,7 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
 
 1. **Commit** (fixes for code/docs); **push** to PR branch.
 2. **Watch CI:** `gh run list --branch "$(git branch --show-current)" --limit 3` then `gh run watch <RUN_ID> --exit-status` (or wait for run completion).
-3. **Check comments:** `python scripts/ci/check_pr_merge_readiness.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate`. If exit 1 → unmapped actionables and/or unresolved threads.
+3. **Check comments/governance:** `python scripts/orchestration/check_merge_ready.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`. If exit 1 → inspect the failing sub-gate output and fix before re-running.
 4. **Fix:** Resolve each new review thread (GitHub UI or GraphQL `resolveReviewThread`); add every UNMAPPED comment URL to PR body under `### Fixed in Commit Mapping` as `- <url> -> <commit-sha>`; if the bot asked for a code/docs change, implement it, commit, push, and use that commit sha in the mapping.
 5. **Re-run** step 3. If exit 0 and CI green → zero comments; only then is the PR ready for merge per AGENTS.md.
 

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -30,27 +30,37 @@
 
 ## 3. Verification script (canonical)
 
-The **only** authoritative check for "zero comments" in this repo is:
+The canonical operator entrypoint for merge governance in this repo is:
 
 ```bash
-# From repo root, with GITHUB_TOKEN set (e.g. gh auth token or fine-grained PAT with repo read).
+# From repo root, with GITHUB_TOKEN and GH_TOKEN set for strict local parity.
 export GITHUB_TOKEN="..."
-python scripts/ci/check_pr_merge_readiness.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate
+export GH_TOKEN="${GITHUB_TOKEN}"
+python scripts/orchestration/check_merge_ready.py \
+  --pr-number <PR_NUMBER> \
+  --repo Katsiarynakavaleuskaya/PulsePlate \
+  --require-auth
 ```
 
-- **Exit 0:** Zero unresolved threads and all actionable bot comments are mapped → PR satisfies "0 comments" policy.
-- **Exit 1:** Either unresolved threads exist or unmapped actionable comments exist → PR must **not** be merged until fixed; script prints what is missing (e.g. `UNMAPPED: ...`).
+- **Exit 0:** Phase 2 body/artifact contract, merge-readiness checks, and disposition proof all pass → PR satisfies merge-governance policy at the time of the run.
+- **Exit 1:** At least one sub-gate failed → PR must **not** be merged until fixed; wrapper prints the failing gate names and their output.
 
-**CI:** The same script runs in CI with `--event-path "$GITHUB_EVENT_PATH"`. For local/agent usage, use `--pr-number` and `--repo` instead.
+Underlying enforcement scripts remain canonical for their own domains:
+
+- `scripts/ci/check_pr_body_phase2_gates.py`
+- `scripts/ci/check_pr_merge_readiness.py`
+- `scripts/orchestration/check_review_threads_disposition.py`
+
+**CI:** The same wrapper runs with `--event-path "$GITHUB_EVENT_PATH"`. For local/agent usage, use `--pr-number` and `--repo` instead.
 
 ---
 
 ## 4. Coordinator orchestration checklist (before saying "ready to merge" or "0 comments")
 
-1. **Run the script** (section 3) for the PR.
+1. **Run the wrapper** (section 3) for the PR.
 2. **If exit code is not 0:** Do **not** report "0 comments" or "ready to merge". Report the script output (unresolved count, UNMAPPED comment URLs) and instruct to fix and re-run.
-3. **If exit code is 0:** You may state that the PR satisfies the zero-comments policy **at the time of the run**. Prefer: "Merge-readiness script passed: 0 unresolved threads, all actionables mapped."
-4. **After new bot activity:** If the user or system reports new bot comments (e.g. CodeRabbit, Sourcery), **re-run the script** before any merge decision; do not assume previous pass still holds.
+3. **If exit code is 0:** You may state that the PR satisfies the zero-comments policy **at the time of the run**. Prefer: "Orchestration merge-check passed: Phase 2, merge-readiness, and disposition proof are all green."
+4. **After new bot activity:** If the user or system reports new bot comments (e.g. CodeRabbit, Sourcery), **re-run the wrapper** before any merge decision; do not assume previous pass still holds.
 
 **Loop until zero:** Full cycle (commit → push → watch CI → new comment → fix → re-check) is in `RUNBOOK_AGENT.md` (sections "Pre-merge readiness pass" ~line 121, "Loop until zero comments (canonical cycle)" ~line 160). Repeat until script exit 0 and CI green.
 
@@ -72,5 +82,6 @@ See `RUNBOOK_AGENT.md` (Pre-merge readiness pass ~line 121, Phase2 PR body gates
 
 - **Policy:** `AGENTS.md` (PR merge readiness hard rule, ~line 31).
 - **Procedure:** `RUNBOOK_AGENT.md` (Pre-merge readiness pass ~line 121, Loop until zero ~line 160, Verify zero unresolved review threads).
-- **CI gate:** `scripts/ci/check_pr_merge_readiness.py` (exit 0/1: main() return and merge-readiness checks; same logic for CI and local/agent).
+- **Canonical operator entrypoint:** `scripts/orchestration/check_merge_ready.py`.
+- **CI gate:** `scripts/ci/check_pr_merge_readiness.py` (merge-readiness sub-gate).
 - **Phase2 body check:** `scripts/ci/check_pr_body_phase2_gates.py`.

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -33,6 +33,11 @@ Evidence:
 | Phase 3 | Merge readiness   | unresolved threads + actionable mapping | yes          |
 | Phase 4 | Disposition proof | script semantics                        | yes          |
 
+Canonical operator entrypoint:
+
+- `scripts/orchestration/check_merge_ready.py` runs Phase 2, merge-readiness, and disposition proof as one verdict.
+- Underlying gate scripts remain authoritative for their own contract semantics.
+
 ## 4. Phase 2 Contract (Canonical Artifact)
 
 Canonical source: `docs/review/PR_<N>_FIXED_MAPPING.md`.

--- a/docs/review/PR_1007_FIXED_MAPPING.md
+++ b/docs/review/PR_1007_FIXED_MAPPING.md
@@ -5,4 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: f9d31d59
+Evidence: `scripts/orchestration/check_merge_ready.py:89`, `scripts/orchestration/check_merge_ready.py:113`, `tests/test_orchestration_merge_ready.py:54`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908136912 -> f9d31d59

--- a/docs/review/PR_1007_FIXED_MAPPING.md
+++ b/docs/review/PR_1007_FIXED_MAPPING.md
@@ -7,6 +7,17 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: f9d31d59
-Evidence: `scripts/orchestration/check_merge_ready.py:89`, `scripts/orchestration/check_merge_ready.py:113`, `tests/test_orchestration_merge_ready.py:54`
+Evidence: `scripts/orchestration/check_merge_ready.py:101`, `scripts/orchestration/check_merge_ready.py:125`, `tests/test_orchestration_merge_ready.py:54`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908136912 -> f9d31d59
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899289402 -> f9d31d59
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899292302 -> f9d31d59
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294607 -> f9d31d59
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295974 -> f9d31d59
+
+Disposition: FIXED
+Commit: 2535cb06
+Evidence: `scripts/orchestration/check_merge_ready.py:20`, `scripts/orchestration/check_merge_ready.py:55`, `scripts/orchestration/check_review_threads_disposition.py:426`, `tests/test_orchestration_merge_ready.py:146`, `tests/test_review_threads_disposition_strict.py:57`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294608 -> 2535cb06
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295973 -> 2535cb06

--- a/docs/review/PR_1007_FIXED_MAPPING.md
+++ b/docs/review/PR_1007_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1007 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1007_FIXED_MAPPING.md
+++ b/docs/review/PR_1007_FIXED_MAPPING.md
@@ -8,16 +8,20 @@
 Disposition: FIXED
 Commit: f9d31d59
 Evidence: `scripts/orchestration/check_merge_ready.py:101`, `scripts/orchestration/check_merge_ready.py:125`, `tests/test_orchestration_merge_ready.py:54`
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908136912 -> f9d31d59
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899289402 -> f9d31d59
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899292302 -> f9d31d59
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294607 -> f9d31d59
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295974 -> f9d31d59
+
+Disposition: FIXED
+Commit: 9ae47880
+Evidence: `tests/test_orchestration_merge_ready.py:82`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899292302 -> 9ae47880
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294607 -> 9ae47880
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295974 -> 9ae47880
 
 Disposition: FIXED
 Commit: 2535cb06
 Evidence: `scripts/orchestration/check_merge_ready.py:20`, `scripts/orchestration/check_merge_ready.py:55`, `scripts/orchestration/check_review_threads_disposition.py:426`, `tests/test_orchestration_merge_ready.py:146`, `tests/test_review_threads_disposition_strict.py:57`
-
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908146488 -> 2535cb06
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908148467 -> 2535cb06
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294608 -> 2535cb06
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295973 -> 2535cb06

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess  # nosec B404: wrapper executes fixed repo scripts only (remove-by: 2026-06-30, ref: PR-1005)
 import sys
 from dataclasses import dataclass
@@ -85,10 +86,37 @@ def _merge_gate_args(args: argparse.Namespace) -> list[str]:
     return ["--pr-number", str(args.pr_number), "--repo", args.repo]
 
 
+def _event_pr_number(event_path: str) -> int | None:
+    """Extract PR number from a GitHub event payload for deterministic CI routing."""
+
+    if not event_path.strip():
+        return None
+    try:
+        payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return None
+    pr_number = pull_request.get("number")
+    if isinstance(pr_number, bool) or pr_number is None:
+        return None
+    if isinstance(pr_number, int):
+        return pr_number
+    if isinstance(pr_number, str) and pr_number.isdigit():
+        return int(pr_number)
+    return None
+
+
 def _disposition_args(args: argparse.Namespace) -> list[str]:
     disposition_args: list[str] = []
-    if args.pr_number is not None:
-        disposition_args.extend(["--pr-number", str(args.pr_number)])
+    disposition_pr_number = args.pr_number
+    if disposition_pr_number is None:
+        disposition_pr_number = _event_pr_number(args.event_path)
+    if disposition_pr_number is not None:
+        disposition_args.extend(["--pr-number", str(disposition_pr_number)])
     if args.require_auth:
         disposition_args.append("--require-auth")
     return disposition_args

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 PHASE2_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_body_phase2_gates.py"
 MERGE_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_merge_readiness.py"
 DISPOSITION_GATE = REPO_ROOT / "scripts" / "orchestration" / "check_review_threads_disposition.py"
+RUN_TIMEOUT_SEC = 120
 
 
 @dataclass(frozen=True)
@@ -55,13 +56,24 @@ def _run_gate(name: str, script_path: Path, extra_args: list[str]) -> GateResult
     """Run a gate script and capture its output without mutating its behavior."""
 
     argv = [sys.executable, str(script_path), *extra_args]
-    result = subprocess.run(  # nosec B603: fixed interpreter/script paths; args validated by parser (remove-by: 2026-06-30, ref: PR-1005)
-        argv,
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(  # nosec B603: fixed interpreter/script paths; args validated by parser (remove-by: 2026-06-30, ref: PR-1005)
+            argv,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=RUN_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
+        return GateResult(
+            name=name,
+            argv=argv,
+            returncode=1,
+            stdout=stdout,
+            stderr=f"Timed out after {RUN_TIMEOUT_SEC}s while running {script_path.name}: {exc}",
+        )
     return GateResult(
         name=name,
         argv=argv,

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Canonical orchestration wrapper for merge-readiness gates."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess  # nosec B404: wrapper executes fixed repo scripts only (remove-by: 2026-06-30, ref: PR-1005)
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+PHASE2_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_body_phase2_gates.py"
+MERGE_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_merge_readiness.py"
+DISPOSITION_GATE = REPO_ROOT / "scripts" / "orchestration" / "check_review_threads_disposition.py"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Result of one gate subprocess."""
+
+    name: str
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Enforce CI vs local mode contract for the wrapper CLI."""
+
+    has_event = bool((args.event_path or "").strip())
+    has_local_pr = args.pr_number is not None or bool((args.repo or "").strip())
+
+    if has_event and has_local_pr:
+        parser.error(
+            "Use either --event-path (CI) or both --pr-number and --repo (local), not both."
+        )
+
+    if has_event:
+        return
+
+    if (args.pr_number is not None) != bool((args.repo or "").strip()):
+        parser.error("For local mode provide both --pr-number and --repo.")
+
+    if args.pr_number is None and not (args.repo or "").strip():
+        parser.error("Provide either --event-path (CI) or both --pr-number and --repo (local).")
+
+
+def _run_gate(name: str, script_path: Path, extra_args: list[str]) -> GateResult:
+    """Run a gate script and capture its output without mutating its behavior."""
+
+    argv = [sys.executable, str(script_path), *extra_args]
+    result = subprocess.run(  # nosec B603: fixed interpreter/script paths; args validated by parser (remove-by: 2026-06-30, ref: PR-1005)
+        argv,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return GateResult(
+        name=name,
+        argv=argv,
+        returncode=result.returncode,
+        stdout=result.stdout.strip(),
+        stderr=result.stderr.strip(),
+    )
+
+
+def _phase2_args(args: argparse.Namespace) -> list[str]:
+    if args.event_path:
+        return ["--event-path", args.event_path]
+    phase2_args = ["--pr-number", str(args.pr_number)]
+    if args.body:
+        phase2_args.extend(["--body", args.body])
+    return phase2_args
+
+
+def _merge_gate_args(args: argparse.Namespace) -> list[str]:
+    if args.event_path:
+        return ["--event-path", args.event_path]
+    return ["--pr-number", str(args.pr_number), "--repo", args.repo]
+
+
+def _disposition_args(args: argparse.Namespace) -> list[str]:
+    disposition_args: list[str] = []
+    if args.pr_number is not None:
+        disposition_args.extend(["--pr-number", str(args.pr_number)])
+    if args.require_auth:
+        disposition_args.append("--require-auth")
+    return disposition_args
+
+
+def _print_gate_output(result: GateResult) -> None:
+    """Render one gate block for deterministic local/CI diagnostics."""
+
+    status = "PASS" if result.returncode == 0 else "FAIL"
+    print(f"[{status}] {result.name}")
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run canonical PR governance gates and emit a single merge verdict."
+    )
+    parser.add_argument(
+        "--event-path",
+        default="",
+        help="Path to GitHub event payload JSON for CI mode.",
+    )
+    parser.add_argument(
+        "--body",
+        default="",
+        help="Explicit PR body text for local Phase2 validation.",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="PR number for local mode (must be paired with --repo).",
+    )
+    parser.add_argument(
+        "--repo",
+        default="",
+        help="Repo full name owner/repo for local mode.",
+    )
+    parser.add_argument(
+        "--require-auth",
+        action="store_true",
+        help="Require GH_TOKEN for disposition guard even outside CI.",
+    )
+    parsed = parser.parse_args(argv)
+    _validate_args(parsed, parser)
+
+    gate_results = [
+        _run_gate("phase2-pr-body-gates", PHASE2_GATE, _phase2_args(parsed)),
+        _run_gate("merge-readiness-gate", MERGE_GATE, _merge_gate_args(parsed)),
+        _run_gate(
+            "review-threads-disposition",
+            DISPOSITION_GATE,
+            _disposition_args(parsed),
+        ),
+    ]
+
+    failed = [result.name for result in gate_results if result.returncode != 0]
+    for result in gate_results:
+        _print_gate_output(result)
+
+    if failed:
+        print("ERROR: orchestration merge-check failed.")
+        print(f"Failing gates: {', '.join(failed)}")
+        return 1
+
+    print("orchestration-merge-check: passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/check_review_threads_disposition.py
+++ b/scripts/orchestration/check_review_threads_disposition.py
@@ -425,6 +425,8 @@ def _check_commit_after_comment(
 
 def _get_pr_number(pr_number: int | None = None) -> int:
     if pr_number is not None:
+        if pr_number <= 0:
+            raise RuntimeError(f"Invalid PR number: {pr_number!r} (must be > 0)")
         return pr_number
     out = _run(["gh", "pr", "view", "--json", "number", "-q", ".number"])
     out = out.strip()

--- a/scripts/orchestration/check_review_threads_disposition.py
+++ b/scripts/orchestration/check_review_threads_disposition.py
@@ -423,7 +423,9 @@ def _check_commit_after_comment(
     return violations
 
 
-def _get_pr_number() -> int:
+def _get_pr_number(pr_number: int | None = None) -> int:
+    if pr_number is not None:
+        return pr_number
     out = _run(["gh", "pr", "view", "--json", "number", "-q", ".number"])
     out = out.strip()
     if not out.isdigit():
@@ -608,6 +610,11 @@ def main() -> None:
         description="Check resolved review threads have disposition in canonical artifact."
     )
     parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="Explicit PR number for local/agent runs (otherwise use gh pr view on current branch).",
+    )
+    parser.add_argument(
         "--require-auth",
         action="store_true",
         help="In CI: fail if GH_TOKEN not set. Otherwise without auth we SKIP (exit 0).",
@@ -623,7 +630,7 @@ def main() -> None:
             print("SKIP: no gh auth (set GH_TOKEN or run gh auth login for full check).")
             sys.exit(0)
 
-    pr_number = _get_pr_number()
+    pr_number = _get_pr_number(args.pr_number)
     try:
         artifact_text = read_mapping_artifact(pr_number)
     except FileNotFoundError as e:

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -1,0 +1,138 @@
+"""Tests for canonical orchestration merge-check wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.orchestration import check_merge_ready as merge_ready
+
+
+def _ok_result(name: str, argv: list[str]) -> merge_ready.GateResult:
+    return merge_ready.GateResult(
+        name=name,
+        argv=argv,
+        returncode=0,
+        stdout=f"{name}: ok",
+        stderr="",
+    )
+
+
+def test_local_mode_runs_all_gates_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_run_gate(name: str, script_path, extra_args: list[str]) -> merge_ready.GateResult:
+        calls.append((name, extra_args))
+        return _ok_result(name, [str(script_path), *extra_args])
+
+    monkeypatch.setattr(merge_ready, "_run_gate", fake_run_gate)
+
+    exit_code = merge_ready.main(
+        [
+            "--pr-number",
+            "1005",
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--body",
+            "## Summary\nmirror",
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls == [
+        ("phase2-pr-body-gates", ["--pr-number", "1005", "--body", "## Summary\nmirror"]),
+        (
+            "merge-readiness-gate",
+            ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"],
+        ),
+        ("review-threads-disposition", ["--pr-number", "1005"]),
+    ]
+
+
+def test_event_mode_passes_require_auth_only_to_disposition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_run_gate(name: str, script_path, extra_args: list[str]) -> merge_ready.GateResult:
+        calls.append((name, extra_args))
+        return _ok_result(name, [str(script_path), *extra_args])
+
+    monkeypatch.setattr(merge_ready, "_run_gate", fake_run_gate)
+
+    exit_code = merge_ready.main(
+        [
+            "--event-path",
+            "/tmp/github-event.json",
+            "--require-auth",
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls == [
+        ("phase2-pr-body-gates", ["--event-path", "/tmp/github-event.json"]),
+        ("merge-readiness-gate", ["--event-path", "/tmp/github-event.json"]),
+        ("review-threads-disposition", ["--require-auth"]),
+    ]
+
+
+def test_wrapper_surfaces_failing_gate_names(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = {
+        "phase2-pr-body-gates": merge_ready.GateResult(
+            name="phase2-pr-body-gates",
+            argv=[],
+            returncode=0,
+            stdout="phase2 ok",
+            stderr="",
+        ),
+        "merge-readiness-gate": merge_ready.GateResult(
+            name="merge-readiness-gate",
+            argv=[],
+            returncode=1,
+            stdout="ERROR: unresolved review threads",
+            stderr="",
+        ),
+        "review-threads-disposition": merge_ready.GateResult(
+            name="review-threads-disposition",
+            argv=[],
+            returncode=0,
+            stdout="disposition ok",
+            stderr="",
+        ),
+    }
+
+    monkeypatch.setattr(
+        merge_ready,
+        "_run_gate",
+        lambda name, script_path, extra_args: results[name],
+    )
+
+    exit_code = merge_ready.main(
+        ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "ERROR: orchestration merge-check failed." in captured.out
+    assert "Failing gates: merge-readiness-gate" in captured.out
+    assert "ERROR: unresolved review threads" in captured.out
+
+
+def test_wrapper_requires_complete_local_context() -> None:
+    with pytest.raises(SystemExit):
+        merge_ready.main(["--pr-number", "1005"])
+
+
+def test_wrapper_rejects_mixed_event_and_local_modes() -> None:
+    with pytest.raises(SystemExit):
+        merge_ready.main(
+            [
+                "--event-path",
+                "/tmp/github-event.json",
+                "--pr-number",
+                "1005",
+                "--repo",
+                "Katsiarynakavaleuskaya/PulsePlate",
+            ]
+        )

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -141,3 +141,27 @@ def test_wrapper_rejects_mixed_event_and_local_modes() -> None:
                 "Katsiarynakavaleuskaya/PulsePlate",
             ]
         )
+
+
+def test_run_gate_returns_failure_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_timeout(*args, **kwargs) -> None:
+        raise merge_ready.subprocess.TimeoutExpired(
+            cmd=["python3", "scripts/orchestration/check_merge_ready.py"],
+            timeout=merge_ready.RUN_TIMEOUT_SEC,
+            output="partial output",
+        )
+
+    monkeypatch.setattr(merge_ready.subprocess, "run", raise_timeout)
+
+    result = merge_ready._run_gate(
+        "merge-readiness-gate",
+        merge_ready.MERGE_GATE,
+        ["--pr-number", "1007", "--repo", "Katsiarynakavaleuskaya/PulsePlate"],
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == "partial output"
+    assert "Timed out after" in result.stderr
+    assert merge_ready.MERGE_GATE.name in result.stderr

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -80,6 +80,20 @@ def test_event_mode_passes_require_auth_only_to_disposition(
     ]
 
 
+def test_event_pr_number_accepts_numeric_string(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"number": "1008"}}), encoding="utf-8")
+
+    assert merge_ready._event_pr_number(str(event_path)) == 1008
+
+
+def test_event_pr_number_returns_none_for_invalid_payload(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"number": "bad"}}), encoding="utf-8")
+
+    assert merge_ready._event_pr_number(str(event_path)) is None
+
+
 def test_wrapper_surfaces_failing_gate_names(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from scripts.orchestration import check_merge_ready as merge_ready
@@ -49,9 +52,11 @@ def test_local_mode_runs_all_gates_in_order(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_event_mode_passes_require_auth_only_to_disposition(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: list[tuple[str, list[str]]] = []
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"number": 1007}}), encoding="utf-8")
 
     def fake_run_gate(name: str, script_path, extra_args: list[str]) -> merge_ready.GateResult:
         calls.append((name, extra_args))
@@ -62,16 +67,16 @@ def test_event_mode_passes_require_auth_only_to_disposition(
     exit_code = merge_ready.main(
         [
             "--event-path",
-            "/tmp/github-event.json",
+            str(event_path),
             "--require-auth",
         ]
     )
 
     assert exit_code == 0
     assert calls == [
-        ("phase2-pr-body-gates", ["--event-path", "/tmp/github-event.json"]),
-        ("merge-readiness-gate", ["--event-path", "/tmp/github-event.json"]),
-        ("review-threads-disposition", ["--require-auth"]),
+        ("phase2-pr-body-gates", ["--event-path", str(event_path)]),
+        ("merge-readiness-gate", ["--event-path", str(event_path)]),
+        ("review-threads-disposition", ["--pr-number", "1007", "--require-auth"]),
     ]
 
 

--- a/tests/test_review_threads_disposition_strict.py
+++ b/tests/test_review_threads_disposition_strict.py
@@ -49,6 +49,11 @@ Commit: abc123
     assert re.search(r"Disposition:\s*FIXED", section)
 
 
+def test_get_pr_number_prefers_explicit_cli_value(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(_disposition_mod, "_run", lambda cmd: "999")
+    assert _disposition_mod._get_pr_number(1005) == 1005
+
+
 def test_extract_fixed_mapping_section_accepts_double_hash_heading() -> None:
     """Section uses ## Fixed in Commit Mapping (artifact format)."""
     body = """

--- a/tests/test_review_threads_disposition_strict.py
+++ b/tests/test_review_threads_disposition_strict.py
@@ -54,6 +54,11 @@ def test_get_pr_number_prefers_explicit_cli_value(monkeypatch: MonkeyPatch) -> N
     assert _disposition_mod._get_pr_number(1005) == 1005
 
 
+def test_get_pr_number_rejects_non_positive_cli_value() -> None:
+    with pytest.raises(RuntimeError, match="must be > 0"):
+        _disposition_mod._get_pr_number(0)
+
+
 def test_extract_fixed_mapping_section_accepts_double_hash_heading() -> None:
     """Section uses ## Fixed in Commit Mapping (artifact format)."""
     body = """


### PR DESCRIPTION
## Summary
Add a canonical orchestration merge-check entrypoint that composes Phase 2, merge-readiness, and disposition proof into one operator-facing verdict.

## Scope
- add `scripts/orchestration/check_merge_ready.py` wrapper
- pass explicit PR context into disposition guard for deterministic local and CI checks
- harden child-gate subprocess execution with bounded timeout handling
- document the canonical operator command in orchestration runbooks

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pytest -q tests/test_orchestration_merge_ready.py tests/test_review_threads_disposition_strict.py tests/test_pr_body_phase2_gates.py tests/test_orchestration_preflight.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908136912 -> f9d31d59
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899289402 -> f9d31d59
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899292302 -> 9ae47880
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294607 -> 9ae47880
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295974 -> 9ae47880
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908146488 -> 2535cb06
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#pullrequestreview-3908148467 -> 2535cb06
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899294608 -> 2535cb06
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1007#discussion_r2899295973 -> 2535cb06

## Merge Readiness
- [x] Local hard gates passed (`pre-commit run --all-files`, `make verify`)
- [x] PR body includes canonical governance sections
- [x] Sourcery / Cubic / CodeRabbit findings addressed in post-comment commits and mirrored in artifact
