### PR TITLE
fix(security): require API key for users CRUD surface

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -6,20 +6,56 @@ import logging
 import time
 from typing import Callable, List, TypeVar, cast
 
-from fastapi import APIRouter, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from starlette.concurrency import run_in_threadpool
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
+from app.routers.api_key import api_key_header
 from app.schemas.users import UserCreate, UserRead
 from core import db as db_module
 from core.models import User
+from core.utils import resolve_attr
 
-router = APIRouter(prefix="/api/v1/users", tags=["users"])
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _require_users_api_key(api_key: str = Depends(api_key_header)) -> str:
+    """Validate app-level API key access for the users CRUD surface."""
+
+    app_get_api_key = resolve_attr("get_api_key", None)
+    if not callable(app_get_api_key):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        )
+    try:
+        result = app_get_api_key(api_key)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception("Users API key validation failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        ) from exc
+    if not isinstance(result, str):
+        logger.error("Users API key guard returned non-string result")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        )
+    return result
+
+
+router = APIRouter(
+    prefix="/api/v1/users",
+    tags=["users"],
+    dependencies=[Depends(_require_users_api_key)],
+)
 
 
 def _to_user_read(model: User) -> UserRead:

--- a/docs/review/PR_1014_FIXED_MAPPING.md
+++ b/docs/review/PR_1014_FIXED_MAPPING.md
@@ -14,3 +14,23 @@ Evidence: tests/_helpers/api_headers.py:1; tests/test_users_api.py:8; tests/test
 Disposition: FIXED
 Commit: 675a93c8
 Evidence: tests/test_users_router.py:198
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900440859 -> 77291ec7
+Disposition: FIXED
+Commit: 77291ec7
+Evidence: docs/review/PR_1014_FIXED_MAPPING.md:7
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909546766 -> 77291ec7
+Disposition: FIXED
+Commit: 77291ec7
+Evidence: docs/review/PR_1014_FIXED_MAPPING.md:7
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900443041 -> d70a1761
+Disposition: FIXED
+Commit: d70a1761
+Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:118
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909549599 -> d70a1761
+Disposition: FIXED
+Commit: d70a1761
+Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:118

--- a/docs/review/PR_1014_FIXED_MAPPING.md
+++ b/docs/review/PR_1014_FIXED_MAPPING.md
@@ -5,4 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909538850 -> 675a93c8
+Disposition: FIXED
+Commit: 675a93c8
+Evidence: tests/_helpers/api_headers.py:1; tests/test_users_api.py:8; tests/test_simple_coverage_boost.py:9
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909541847 -> 675a93c8
+Disposition: FIXED
+Commit: 675a93c8
+Evidence: tests/test_users_router.py:198

--- a/docs/review/PR_1014_FIXED_MAPPING.md
+++ b/docs/review/PR_1014_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1014 Fixed Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1014_FIXED_MAPPING.md
+++ b/docs/review/PR_1014_FIXED_MAPPING.md
@@ -34,3 +34,28 @@ Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclus
 Disposition: FIXED
 Commit: d70a1761
 Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:118
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900468135 -> 059a6daf
+Disposition: FIXED
+Commit: 059a6daf
+Evidence: tests/test_simple_coverage_boost.py:64
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909576475 -> 059a6daf
+Disposition: FIXED
+Commit: 059a6daf
+Evidence: tests/test_simple_coverage_boost.py:64
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900510761 -> 184a2f64
+Disposition: FIXED
+Commit: 184a2f64
+Evidence: tests/test_app_endpoints_coverage.py:145
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900510762 -> 184a2f64
+Disposition: FIXED
+Commit: 184a2f64
+Evidence: tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router_inclusion_coverage.py:124
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909615592 -> 184a2f64
+Disposition: FIXED
+Commit: 184a2f64
+Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router_inclusion_coverage.py:124

--- a/docs/review/PR_1014_FIXED_MAPPING.md
+++ b/docs/review/PR_1014_FIXED_MAPPING.md
@@ -59,3 +59,8 @@ Evidence: tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router
 Disposition: FIXED
 Commit: 184a2f64
 Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router_inclusion_coverage.py:124
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909741350 -> 28777741
+Disposition: FIXED
+Commit: 28777741
+Evidence: tests/test_app_router_inclusion_coverage.py:126

--- a/tests/_helpers/api_headers.py
+++ b/tests/_helpers/api_headers.py
@@ -1,0 +1,3 @@
+"""Shared test headers for app-level API key auth paths."""
+
+API_KEY_HEADERS = {"X-API-Key": "test_key"}

--- a/tests/test_app_endpoints_coverage.py
+++ b/tests/test_app_endpoints_coverage.py
@@ -141,8 +141,8 @@ class TestAppEndpointsCoverage:
         """Тест покрытия app.py users endpoint"""
         # Тестируем users endpoint
         response = client.get("/api/v1/users")
-        # 403: auth required, 200: success, 404/405: endpoint not found, 500: DB not initialized
-        assert response.status_code in [200, 403, 404, 405, 500]
+        # 403: auth required, 404/405: endpoint not found, 500: DB not initialized
+        assert response.status_code in [403, 404, 405, 500]
 
     def test_app_premium_week_endpoint_coverage(self, client):
         """Тест покрытия app.py premium week endpoint"""

--- a/tests/test_app_endpoints_coverage.py
+++ b/tests/test_app_endpoints_coverage.py
@@ -141,8 +141,7 @@ class TestAppEndpointsCoverage:
         """Тест покрытия app.py users endpoint"""
         # Тестируем users endpoint
         response = client.get("/api/v1/users")
-        # 403: auth required, 404/405: endpoint not found, 500: DB not initialized
-        assert response.status_code in [403, 404, 405, 500]
+        assert response.status_code == 403
 
     def test_app_premium_week_endpoint_coverage(self, client):
         """Тест покрытия app.py premium week endpoint"""

--- a/tests/test_app_endpoints_coverage.py
+++ b/tests/test_app_endpoints_coverage.py
@@ -141,8 +141,8 @@ class TestAppEndpointsCoverage:
         """Тест покрытия app.py users endpoint"""
         # Тестируем users endpoint
         response = client.get("/api/v1/users")
-        # 200: success, 404/405: endpoint not found, 500: DB not initialized
-        assert response.status_code in [200, 404, 405, 500]
+        # 403: auth required, 200: success, 404/405: endpoint not found, 500: DB not initialized
+        assert response.status_code in [200, 403, 404, 405, 500]
 
     def test_app_premium_week_endpoint_coverage(self, client):
         """Тест покрытия app.py premium week endpoint"""

--- a/tests/test_app_router_inclusion_coverage.py
+++ b/tests/test_app_router_inclusion_coverage.py
@@ -115,10 +115,10 @@ class TestAppRouterInclusionCoverage:
         """Тест покрытия app.py users router inclusion"""
         # Тестируем users router inclusion
         response = client.get("/api/v1/users")
-        assert response.status_code in [200, 404, 405]
+        assert response.status_code in [200, 403, 404, 405]
 
         response = client.post("/api/v1/users", json={})
-        assert response.status_code in [200, 404, 405, 422]
+        assert response.status_code in [200, 403, 404, 405, 422]
 
     def test_app_router_inclusion_premium_week_coverage(self, client):
         """Тест покрытия app.py premium week router inclusion"""

--- a/tests/test_app_router_inclusion_coverage.py
+++ b/tests/test_app_router_inclusion_coverage.py
@@ -123,6 +123,7 @@ class TestAppRouterInclusionCoverage:
         assert response.status_code == 422
 
     def test_app_router_inclusion_users_requires_api_key(self, client: TestClient) -> None:
+        """Тестирует требование API key для users endpoint."""
         response = client.get("/api/v1/users")
         assert response.status_code == 403
 

--- a/tests/test_app_router_inclusion_coverage.py
+++ b/tests/test_app_router_inclusion_coverage.py
@@ -9,6 +9,8 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
+from tests._helpers.api_headers import API_KEY_HEADERS
+
 
 @pytest.fixture()
 def client(test_environment):
@@ -111,14 +113,18 @@ class TestAppRouterInclusionCoverage:
         response = client.post("/api/v1/recipes", json={})
         assert response.status_code in [200, 404, 405, 422]
 
-    def test_app_router_inclusion_users_coverage(self, client):
+    def test_app_router_inclusion_users_coverage(self, client: TestClient) -> None:
         """Тест покрытия app.py users router inclusion"""
         # Тестируем users router inclusion
-        response = client.get("/api/v1/users")
-        assert response.status_code in [403, 404, 405]
+        response = client.get("/api/v1/users", headers=API_KEY_HEADERS)
+        assert response.status_code == 200
 
-        response = client.post("/api/v1/users", json={})
-        assert response.status_code in [403, 404, 405]
+        response = client.post("/api/v1/users", json={}, headers=API_KEY_HEADERS)
+        assert response.status_code == 422
+
+    def test_app_router_inclusion_users_requires_api_key(self, client: TestClient) -> None:
+        response = client.get("/api/v1/users")
+        assert response.status_code == 403
 
     def test_app_router_inclusion_premium_week_coverage(self, client):
         """Тест покрытия app.py premium week router inclusion"""

--- a/tests/test_app_router_inclusion_coverage.py
+++ b/tests/test_app_router_inclusion_coverage.py
@@ -115,10 +115,10 @@ class TestAppRouterInclusionCoverage:
         """Тест покрытия app.py users router inclusion"""
         # Тестируем users router inclusion
         response = client.get("/api/v1/users")
-        assert response.status_code in [200, 403, 404, 405]
+        assert response.status_code in [403, 404, 405]
 
         response = client.post("/api/v1/users", json={})
-        assert response.status_code in [200, 403, 404, 405, 422]
+        assert response.status_code in [403, 404, 405]
 
     def test_app_router_inclusion_premium_week_coverage(self, client):
         """Тест покрытия app.py premium week router inclusion"""

--- a/tests/test_simple_coverage_boost.py
+++ b/tests/test_simple_coverage_boost.py
@@ -62,6 +62,7 @@ class TestSimpleCoverageBoost:
         client = TestClient(app)
         response = client.get("/api/v1/users", headers=API_KEY_HEADERS)
         assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
         data = response.json()
         assert isinstance(data, list)
 

--- a/tests/test_simple_coverage_boost.py
+++ b/tests/test_simple_coverage_boost.py
@@ -59,7 +59,7 @@ class TestSimpleCoverageBoost:
     def test_users_endpoint(self) -> None:
         """Test users endpoint."""
         client = TestClient(app)
-        response = client.get("/api/v1/users")
+        response = client.get("/api/v1/users", headers={"X-API-Key": "test_key"})
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)

--- a/tests/test_simple_coverage_boost.py
+++ b/tests/test_simple_coverage_boost.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app import app
+from tests._helpers.api_headers import API_KEY_HEADERS
 
 
 class TestSimpleCoverageBoost:
@@ -59,7 +60,7 @@ class TestSimpleCoverageBoost:
     def test_users_endpoint(self) -> None:
         """Test users endpoint."""
         client = TestClient(app)
-        response = client.get("/api/v1/users", headers={"X-API-Key": "test_key"})
+        response = client.get("/api/v1/users", headers=API_KEY_HEADERS)
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -5,21 +5,21 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-USER_HEADERS = {"X-API-Key": "test_key"}
+from tests._helpers.api_headers import API_KEY_HEADERS
 
 
 def test_create_and_get_user(client: TestClient) -> None:
     response = client.post(
         "/api/v1/users",
         json={"email": "ann@example.com", "name": "Ann"},
-        headers=USER_HEADERS,
+        headers=API_KEY_HEADERS,
     )
     assert response.status_code == 201
     payload = response.json()
     assert payload["email"] == "ann@example.com"
     user_id = payload["id"]
 
-    fetched = client.get(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
+    fetched = client.get(f"/api/v1/users/{user_id}", headers=API_KEY_HEADERS)
     assert fetched.status_code == 200
     assert fetched.json()["name"] == "Ann"
 
@@ -36,14 +36,18 @@ def test_list_users_pagination(client: TestClient) -> None:
         resp = client.post(
             "/api/v1/users",
             json={"email": f"{prefix}_user{idx}@example.com", "name": f"User {idx}"},
-            headers=USER_HEADERS,
+            headers=API_KEY_HEADERS,
         )
         created_ids.append(resp.json()["id"])
 
     # Query with offset=1, limit=2 - should skip first user and get next 2
     # But since other tests may have created users, we need to find our users by ID
     # The endpoint returns users ordered by ID, so our 3 users should be consecutive
-    page = client.get("/api/v1/users", params={"limit": 100, "offset": 0}, headers=USER_HEADERS)
+    page = client.get(
+        "/api/v1/users",
+        params={"limit": 100, "offset": 0},
+        headers=API_KEY_HEADERS,
+    )
     assert page.status_code == 200
     all_users = page.json()
 
@@ -66,12 +70,12 @@ def test_create_user_conflict(client: TestClient) -> None:
     client.post(
         "/api/v1/users",
         json={"email": "dup@example.com", "name": "One"},
-        headers=USER_HEADERS,
+        headers=API_KEY_HEADERS,
     )
     duplicate = client.post(
         "/api/v1/users",
         json={"email": "dup@example.com", "name": "Two"},
-        headers=USER_HEADERS,
+        headers=API_KEY_HEADERS,
     )
     assert duplicate.status_code == 409
     assert "Data conflict" in duplicate.json()["detail"]
@@ -79,7 +83,7 @@ def test_create_user_conflict(client: TestClient) -> None:
 
 
 def test_get_user_not_found(client: TestClient) -> None:
-    response = client.get("/api/v1/users/9999", headers=USER_HEADERS)
+    response = client.get("/api/v1/users/9999", headers=API_KEY_HEADERS)
     assert response.status_code == 404
 
 
@@ -88,15 +92,15 @@ def test_delete_user_success_and_idempotent(client: TestClient) -> None:
     created = client.post(
         "/api/v1/users",
         json={"email": "del@example.com", "name": "Del"},
-        headers=USER_HEADERS,
+        headers=API_KEY_HEADERS,
     )
     user_id = created.json()["id"]
 
-    delete_resp = client.delete(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
+    delete_resp = client.delete(f"/api/v1/users/{user_id}", headers=API_KEY_HEADERS)
     assert delete_resp.status_code == 204
 
     # Second delete should also return 204 (idempotent behavior)
-    missing = client.delete(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
+    missing = client.delete(f"/api/v1/users/{user_id}", headers=API_KEY_HEADERS)
     assert missing.status_code == 204
 
 
@@ -105,7 +109,7 @@ def test_create_user_validation_error(client: TestClient) -> None:
     bad = client.post(
         "/api/v1/users",
         json={"email": "not-an-email", "name": ""},
-        headers=USER_HEADERS,
+        headers=API_KEY_HEADERS,
     )
     assert bad.status_code == 422
     # Verify FastAPI validation error structure

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+USER_HEADERS = {"X-API-Key": "test_key"}
+
 
 def test_create_and_get_user(client: TestClient) -> None:
-    response = client.post("/api/v1/users", json={"email": "ann@example.com", "name": "Ann"})
+    response = client.post(
+        "/api/v1/users",
+        json={"email": "ann@example.com", "name": "Ann"},
+        headers=USER_HEADERS,
+    )
     assert response.status_code == 201
     payload = response.json()
     assert payload["email"] == "ann@example.com"
     user_id = payload["id"]
 
-    fetched = client.get(f"/api/v1/users/{user_id}")
+    fetched = client.get(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
     assert fetched.status_code == 200
     assert fetched.json()["name"] == "Ann"
 
@@ -30,13 +36,14 @@ def test_list_users_pagination(client: TestClient) -> None:
         resp = client.post(
             "/api/v1/users",
             json={"email": f"{prefix}_user{idx}@example.com", "name": f"User {idx}"},
+            headers=USER_HEADERS,
         )
         created_ids.append(resp.json()["id"])
 
     # Query with offset=1, limit=2 - should skip first user and get next 2
     # But since other tests may have created users, we need to find our users by ID
     # The endpoint returns users ordered by ID, so our 3 users should be consecutive
-    page = client.get("/api/v1/users", params={"limit": 100, "offset": 0})
+    page = client.get("/api/v1/users", params={"limit": 100, "offset": 0}, headers=USER_HEADERS)
     assert page.status_code == 200
     all_users = page.json()
 
@@ -56,34 +63,50 @@ def test_list_users_pagination(client: TestClient) -> None:
 
 
 def test_create_user_conflict(client: TestClient) -> None:
-    client.post("/api/v1/users", json={"email": "dup@example.com", "name": "One"})
-    duplicate = client.post("/api/v1/users", json={"email": "dup@example.com", "name": "Two"})
+    client.post(
+        "/api/v1/users",
+        json={"email": "dup@example.com", "name": "One"},
+        headers=USER_HEADERS,
+    )
+    duplicate = client.post(
+        "/api/v1/users",
+        json={"email": "dup@example.com", "name": "Two"},
+        headers=USER_HEADERS,
+    )
     assert duplicate.status_code == 409
     assert "Data conflict" in duplicate.json()["detail"]
     assert "constraints" in duplicate.json()["detail"]
 
 
 def test_get_user_not_found(client: TestClient) -> None:
-    response = client.get("/api/v1/users/9999")
+    response = client.get("/api/v1/users/9999", headers=USER_HEADERS)
     assert response.status_code == 404
 
 
 def test_delete_user_success_and_idempotent(client: TestClient) -> None:
     """DELETE should be idempotent - return 204 even if user doesn't exist."""
-    created = client.post("/api/v1/users", json={"email": "del@example.com", "name": "Del"})
+    created = client.post(
+        "/api/v1/users",
+        json={"email": "del@example.com", "name": "Del"},
+        headers=USER_HEADERS,
+    )
     user_id = created.json()["id"]
 
-    delete_resp = client.delete(f"/api/v1/users/{user_id}")
+    delete_resp = client.delete(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
     assert delete_resp.status_code == 204
 
     # Second delete should also return 204 (idempotent behavior)
-    missing = client.delete(f"/api/v1/users/{user_id}")
+    missing = client.delete(f"/api/v1/users/{user_id}", headers=USER_HEADERS)
     assert missing.status_code == 204
 
 
 def test_create_user_validation_error(client: TestClient) -> None:
     """Test user creation with validation errors."""
-    bad = client.post("/api/v1/users", json={"email": "not-an-email", "name": ""})
+    bad = client.post(
+        "/api/v1/users",
+        json={"email": "not-an-email", "name": ""},
+        headers=USER_HEADERS,
+    )
     assert bad.status_code == 422
     # Verify FastAPI validation error structure
     error_data = bad.json()
@@ -97,3 +120,8 @@ def test_create_user_validation_error(client: TestClient) -> None:
             field_name = loc[-1]
             error_fields.append(field_name)
     assert "email" in error_fields
+
+
+def test_users_surface_rejects_missing_api_key(client: TestClient) -> None:
+    response = client.get("/api/v1/users")
+    assert response.status_code == 403

--- a/tests/test_users_router.py
+++ b/tests/test_users_router.py
@@ -23,6 +23,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.exc import OperationalError
 
 import app.routers.users as users_mod
+from tests._helpers.api_headers import API_KEY_HEADERS
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +44,7 @@ class TestUsersRouter:
         self.app = FastAPI()
         self.app.include_router(router)
         self.client = TestClient(self.app)
-        self.headers = {"X-API-Key": "test_key"}
+        self.headers = API_KEY_HEADERS
 
     def teardown_method(self) -> None:
         """Clean up test client."""
@@ -204,18 +205,10 @@ class TestUsersRouter:
         resp = self.client.get("/api/v1/users")
         assert resp.status_code == 403
 
-    def test_users_api_key_guard_returns_500_when_validator_missing(self) -> None:
-        with patch.object(users_mod, "resolve_attr", return_value=None):
-            with pytest.raises(users_mod.HTTPException) as exc_info:
-                users_mod._require_users_api_key("test_key")
+    @pytest.mark.parametrize("validator", [None, lambda _: object()])
+    def test_users_api_key_guard_fail_closed_behavior(self, validator: object) -> None:
+        with patch.object(users_mod, "resolve_attr", return_value=validator):
+            resp = self.client.get("/api/v1/users", headers=self.headers)
 
-        assert exc_info.value.status_code == 500
-        assert exc_info.value.detail == "API key validation unavailable"
-
-    def test_users_api_key_guard_returns_500_when_validator_returns_non_string(self) -> None:
-        with patch.object(users_mod, "resolve_attr", return_value=lambda _: object()):
-            with pytest.raises(users_mod.HTTPException) as exc_info:
-                users_mod._require_users_api_key("test_key")
-
-        assert exc_info.value.status_code == 500
-        assert exc_info.value.detail == "API key validation unavailable"
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "API key validation unavailable"

--- a/tests/test_users_router.py
+++ b/tests/test_users_router.py
@@ -43,6 +43,7 @@ class TestUsersRouter:
         self.app = FastAPI()
         self.app.include_router(router)
         self.client = TestClient(self.app)
+        self.headers = {"X-API-Key": "test_key"}
 
     def teardown_method(self) -> None:
         """Clean up test client."""
@@ -55,7 +56,7 @@ class TestUsersRouter:
             mock_session.execute.return_value.scalars.return_value.all.return_value = []
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users")
+            resp = self.client.get("/api/v1/users", headers=self.headers)
 
             assert resp.status_code == 200
             data = resp.json()
@@ -68,18 +69,18 @@ class TestUsersRouter:
             mock_session.execute.return_value.scalars.return_value.all.return_value = []
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users?limit=10&offset=5")
+            resp = self.client.get("/api/v1/users?limit=10&offset=5", headers=self.headers)
 
             assert resp.status_code == 200
 
     def test_list_users_invalid_pagination_422(self) -> None:
         """GET /api/v1/users with invalid pagination returns 422."""
         # limit too high
-        resp = self.client.get("/api/v1/users?limit=2000")
+        resp = self.client.get("/api/v1/users?limit=2000", headers=self.headers)
         assert resp.status_code == 422
 
         # negative offset
-        resp = self.client.get("/api/v1/users?offset=-1")
+        resp = self.client.get("/api/v1/users?offset=-1", headers=self.headers)
         assert resp.status_code == 422
 
     def test_create_user_success(self) -> None:
@@ -99,18 +100,19 @@ class TestUsersRouter:
                 resp = self.client.post(
                     "/api/v1/users",
                     json={"email": "test@example.com", "name": "Test User"},
+                    headers=self.headers,
                 )
 
                 assert resp.status_code == 201
 
     def test_create_user_missing_email_422(self) -> None:
         """POST /api/v1/users without email returns 422."""
-        resp = self.client.post("/api/v1/users", json={"name": "Test User"})
+        resp = self.client.post("/api/v1/users", json={"name": "Test User"}, headers=self.headers)
         assert resp.status_code == 422
 
     def test_create_user_empty_payload_422(self) -> None:
         """POST /api/v1/users with empty payload returns 422."""
-        resp = self.client.post("/api/v1/users", json={})
+        resp = self.client.post("/api/v1/users", json={}, headers=self.headers)
         assert resp.status_code == 422
 
     def test_get_user_not_found_404(self) -> None:
@@ -120,7 +122,7 @@ class TestUsersRouter:
             mock_session.get.return_value = None  # User not found
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users/999")
+            resp = self.client.get("/api/v1/users/999", headers=self.headers)
 
             assert resp.status_code == 404
             assert "not found" in resp.json()["detail"].lower()
@@ -136,7 +138,7 @@ class TestUsersRouter:
             mock_session.get.return_value = mock_user
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users/1")
+            resp = self.client.get("/api/v1/users/1", headers=self.headers)
 
             assert resp.status_code == 200
             data = resp.json()
@@ -152,7 +154,7 @@ class TestUsersRouter:
             mock_session.get.return_value = mock_user
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.delete("/api/v1/users/1")
+            resp = self.client.delete("/api/v1/users/1", headers=self.headers)
 
             assert resp.status_code == 204
 
@@ -163,7 +165,7 @@ class TestUsersRouter:
             mock_session.get.return_value = None  # User not found
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.delete("/api/v1/users/999")
+            resp = self.client.delete("/api/v1/users/999", headers=self.headers)
 
             # Idempotent delete design per docstring
             assert resp.status_code == 204
@@ -176,7 +178,7 @@ class TestUsersRouter:
             mock_session.execute.side_effect = OperationalError("DB locked", None, None)
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users")
+            resp = self.client.get("/api/v1/users", headers=self.headers)
 
             assert resp.status_code == 503
             assert "unavailable" in resp.json()["detail"].lower()
@@ -193,7 +195,27 @@ class TestUsersRouter:
             ]
             mock_factory.return_value = lambda: mock_session
 
-            resp = self.client.get("/api/v1/users")
+            resp = self.client.get("/api/v1/users", headers=self.headers)
 
             assert resp.status_code == 200
             assert resp.json() == []
+
+    def test_users_surface_requires_api_key(self) -> None:
+        resp = self.client.get("/api/v1/users")
+        assert resp.status_code == 403
+
+    def test_users_api_key_guard_returns_500_when_validator_missing(self) -> None:
+        with patch.object(users_mod, "resolve_attr", return_value=None):
+            with pytest.raises(users_mod.HTTPException) as exc_info:
+                users_mod._require_users_api_key("test_key")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "API key validation unavailable"
+
+    def test_users_api_key_guard_returns_500_when_validator_returns_non_string(self) -> None:
+        with patch.object(users_mod, "resolve_attr", return_value=lambda _: object()):
+            with pytest.raises(users_mod.HTTPException) as exc_info:
+                users_mod._require_users_api_key("test_key")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "API key validation unavailable"

--- a/tests/test_users_router_retry_logic.py
+++ b/tests/test_users_router_retry_logic.py
@@ -13,6 +13,8 @@ from unittest.mock import patch, MagicMock, call
 from fastapi import HTTPException
 from sqlalchemy.exc import OperationalError, IntegrityError
 
+from tests._helpers.api_headers import API_KEY_HEADERS
+
 
 def _wire_session_factory(mock_db: MagicMock, mock_session: MagicMock) -> MagicMock:
     """Make db_module.get_session_factory() return a callable factory.
@@ -244,7 +246,7 @@ class TestUsersEndpointRetryIntegration:
 
         monkeypatch.setattr("app.routers.users._execute_with_retry", always_fail)
 
-        response = test_client.get("/api/v1/users", headers={"X-API-Key": "test_key"})
+        response = test_client.get("/api/v1/users", headers=API_KEY_HEADERS)
 
         # Should fail with 503 (no fallback for list operation)
         assert response.status_code == 503

--- a/tests/test_users_router_retry_logic.py
+++ b/tests/test_users_router_retry_logic.py
@@ -244,7 +244,7 @@ class TestUsersEndpointRetryIntegration:
 
         monkeypatch.setattr("app.routers.users._execute_with_retry", always_fail)
 
-        response = test_client.get("/api/v1/users")
+        response = test_client.get("/api/v1/users", headers={"X-API-Key": "test_key"})
 
         # Should fail with 503 (no fallback for list operation)
         assert response.status_code == 503


### PR DESCRIPTION
## Summary
- require app-level API key validation on `/api/v1/users/*`
- preserve existing FREE-tier semantics while removing unauthenticated CRUD access
- align users tests and generic coverage tests with the new 403 boundary

## Security Notes
- closes the audit finding that users CRUD was publicly reachable without bearer material
- uses the existing app-level API key guard instead of adding a new auth contract
- fails closed with 500 if validator wiring is unavailable or returns an invalid type

## Validation
- `pytest -q tests/test_users_api.py`
- `pytest -q tests/test_users_router.py`
- `pytest -q tests/test_users_router_retry_logic.py`
- `pre-commit run --all-files`
- `make verify`

## Backlog
- addresses `docs/roadmap/BACKLOG_LEDGER.md` item `P1: Public users CRUD surface must be authenticated or explicitly retired`

## Summary by Sourcery

Принудительно применена защита на уровне API-ключа приложения для CRUD API пользователей и согласованы тесты и ожидания по покрытию с новой границей авторизации.

Исправления ошибок:
- Закрыто неаутентифицированное публичное раскрытие CRUD-интерфейса пользователей за счёт требования API-ключа приложения для всех эндпоинтов `/api/v1/users`.

Улучшения:
- Введён многократно используемый guard для API пользователей по API-ключу, который интегрируется с существующим валидатором API-ключей на уровне приложения и переходит в режим «fail closed», когда валидация недоступна или неправильно сконфигурирована.
- Обновлены API пользователей, роутер, логика повторных попыток и тесты покрытия приложения, чтобы отправлять необходимый заголовок с API-ключом и проверять ответы 403 при отсутствии авторизации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce app-level API key protection on the users CRUD API and align tests and coverage expectations with the new authorization boundary.

Bug Fixes:
- Close the unauthenticated public exposure of the users CRUD surface by requiring an app-level API key on all /api/v1/users endpoints.

Enhancements:
- Introduce a reusable users API key guard that integrates with the existing app-level API key validator and fails closed when validation is unavailable or misconfigured.
- Update users API, router, retry-logic, and app coverage tests to send the required API key header and to assert 403 responses when authorization is missing.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an app-level API key for all /api/v1/users endpoints to close public CRUD access and enforce auth. Adds a review mapping doc with fixed-in-commit references and documents users auth coverage in tests.

- **Bug Fixes**
  - Enforced a router-level Depends guard using the existing API key validator for every users route.
  - Missing/invalid keys return 403; unavailable/misconfigured validator returns 500.
  - Updated tests to use a shared X-API-Key header, added reject/fail-closed cases, tightened router inclusion and endpoint coverage to expect 403, and asserted JSON content type.

- **Migration**
  - Send the X-API-Key header with all /api/v1/users requests.

<sup>Written for commit 654d83556d802eafc0d5cacbcfb569906eaebac2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909538850 -> 675a93c8
Disposition: FIXED
Commit: 675a93c8
Evidence: tests/_helpers/api_headers.py:1; tests/test_users_api.py:8; tests/test_simple_coverage_boost.py:9

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909541847 -> 675a93c8
Disposition: FIXED
Commit: 675a93c8
Evidence: tests/test_users_router.py:198

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900440859 -> 77291ec7
Disposition: FIXED
Commit: 77291ec7
Evidence: docs/review/PR_1014_FIXED_MAPPING.md:7

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909546766 -> 77291ec7
Disposition: FIXED
Commit: 77291ec7
Evidence: docs/review/PR_1014_FIXED_MAPPING.md:7

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900443041 -> d70a1761
Disposition: FIXED
Commit: d70a1761
Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:118

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909549599 -> d70a1761
Disposition: FIXED
Commit: d70a1761
Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:118

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900468135 -> 059a6daf
Disposition: FIXED
Commit: 059a6daf
Evidence: tests/test_simple_coverage_boost.py:64

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909576475 -> 059a6daf
Disposition: FIXED
Commit: 059a6daf
Evidence: tests/test_simple_coverage_boost.py:64

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900510761 -> 184a2f64
Disposition: FIXED
Commit: 184a2f64
Evidence: tests/test_app_endpoints_coverage.py:145

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#discussion_r2900510762 -> 184a2f64
Disposition: FIXED
Commit: 184a2f64
Evidence: tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router_inclusion_coverage.py:124

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909615592 -> 184a2f64
Disposition: FIXED
Commit: 184a2f64
Evidence: tests/test_app_endpoints_coverage.py:145; tests/test_app_router_inclusion_coverage.py:117; tests/test_app_router_inclusion_coverage.py:124

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1014#pullrequestreview-3909741350 -> 28777741
Disposition: FIXED
Commit: 28777741
Evidence: tests/test_app_router_inclusion_coverage.py:126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All users API endpoints now require API key-based authentication for access.

* **Tests**
  * Comprehensive test suite updates validating API key authentication requirements across all users endpoint operations.
  * Added tests verifying proper rejection of requests lacking authentication credentials.

* **Documentation**
  * Added documentation providing detailed mapping of PR changes and related fixes implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
