### PR TITLE
docs: add Wellness Explainers + Learning Cycles MVP PRD

### DIFF
--- a/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
+++ b/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
@@ -1,7 +1,7 @@
 # Wellness Explainers + Learning Cycles (Mini-PRD)
 
 **Status:** Proposed
-**Last updated:** 8 March 2026
+**Last updated:** 7 March 2026
 **Scope:** Product specification for a rules-first MVP
 
 ---
@@ -58,7 +58,7 @@ use into visible learning progress, and strengthens the trust-based funnel.
 ### Non-goals
 
 - No ML curriculum, algorithm catalog, or external educational track.
-- No diagnosis, treatment, or medical claims.
+- No clinical or curative positioning.
 - No new public heavy LLM endpoint for explainers.
 - No leaderboard, social pressure, or anxiety-producing streak mechanics in MVP.
 - No client-side business logic duplication.
@@ -69,8 +69,8 @@ use into visible learning progress, and strengthens the trust-based funnel.
 
 ### 1. Wellness-only language
 
-Explainers must stay educational and wellness-safe. They must not claim diagnosis,
-treatment, cure, or guaranteed outcomes.
+Explainers must stay educational and wellness-safe. They must not use clinical,
+curative, or guaranteed-outcome framing.
 Use the canonical disclaimer in `docs/safety/WELLNESS_DISCLAIMER_CANONICAL.md`.
 
 ### 2. Scientific clarity without false precision
@@ -135,6 +135,15 @@ Each cycle should answer:
 - which existing signals unlocked the cycle,
 - what the next useful action is.
 
+### Learning cycle rule table
+
+| Cycle ID | Label | Required signals | Deterministic unlock rule |
+| --- | --- | --- | --- |
+| `baseline` | Baseline | BMI result rendered | Unlock when a valid FREE result is produced. |
+| `risk_context` | Risk Context | BMI interpretation plus at least one PRO context field | Unlock when `interpretation_v1` or `waist_risk` is present. |
+| `consistency_pattern` | Consistency Pattern | Adherence event history or weekly adherence score | Unlock when adherence data exists and confidence is not marked as low-data only. |
+| `plan_adjustment` | Plan Adjustment | VIP weekly-plan output plus plan-fit explanation | Unlock when a weekly plan and its explainer payload are both available. |
+
 ### Surface C: Progress Signals
 
 Represent progress as:
@@ -184,6 +193,15 @@ MVP progress must be local to the product journey. No public ranking and no soci
 - Confidence should be surfaced carefully: low-confidence states should say "needs more
   data", not imply certainty.
 
+#### Score normalization rule
+
+- Event-level adherence from `app/schemas/nutrition_log.py` uses a `0.0..1.0` scale.
+- Weekly-plan adherence from `core/menu_engine.py` and `core/weekly_plan_new.py` uses a
+  `0..100` scale.
+- Any shared explainer or learning-cycle threshold must normalize these sources before
+  comparison. Canonical MVP rule: convert weekly-plan scores to `0.0..1.0` before using
+  shared progression logic.
+
 ---
 
 ## Rules-First MVP Contract
@@ -210,6 +228,27 @@ If a future version uses AI-assisted rewriting for tone or personalization, it m
 - pass wellness-safe validation,
 - obey quota / rate-limit / cost guardrails,
 - degrade safely to deterministic copy.
+
+### Minimal explainer payload example
+
+```json
+{
+  "entity": "bmi_result",
+  "tier": "free",
+  "title": "BMI is a starting point",
+  "what_this_means": "This result gives a broad orientation based on height and weight.",
+  "what_is_missing": [
+    "fat_distribution",
+    "muscle_context"
+  ],
+  "next_step": "pro",
+  "learning_cycle_id": "baseline",
+  "signals": {
+    "bmi": 26.4,
+    "category": "overweight"
+  }
+}
+```
 
 ---
 

--- a/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
+++ b/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
@@ -140,7 +140,7 @@ Each cycle should answer:
 | Cycle ID | Label | Required signals | Deterministic unlock rule |
 | --- | --- | --- | --- |
 | `baseline` | Baseline | BMI result rendered | Unlock when a valid FREE result is produced. |
-| `risk_context` | Risk Context | BMI interpretation plus at least one PRO context field | Unlock when `interpretation_v1` or `waist_risk` is present. |
+| `risk_context` | Risk Context | BMI interpretation plus at least one PRO context field | Unlock when `interpretation_v1` is present and at least one PRO context field (for example `waist_risk`) is present. |
 | `consistency_pattern` | Consistency Pattern | Adherence event history or weekly adherence score | Unlock when adherence data exists and confidence is not marked as low-data only. |
 | `plan_adjustment` | Plan Adjustment | VIP weekly-plan output plus plan-fit explanation | Unlock when a weekly plan and its explainer payload are both available. |
 

--- a/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
+++ b/docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
@@ -1,0 +1,330 @@
+# Wellness Explainers + Learning Cycles (Mini-PRD)
+
+**Status:** Proposed
+**Last updated:** 8 March 2026
+**Scope:** Product specification for a rules-first MVP
+
+---
+
+## Summary
+
+PulsePlate should adopt the strongest product patterns from modern interactive learning
+platforms without turning into an ML school. The fit is not "200 algorithms" or
+"architecture recreations". The fit is:
+
+- interactive explainers for user-facing wellness logic,
+- progression through learning cycles instead of fragile streaks,
+- science-backed framing that improves trust, retention, and upsell clarity.
+
+This MVP must remain consistent with PulsePlate's existing product contract:
+
+- FREE = orientation,
+- PRO = interpretation,
+- VIP = daily action support.
+
+The MVP is explicitly scoped to existing product entities, deterministic rules, and
+existing backend data. It must not introduce a new heavy LLM surface.
+
+---
+
+## Problem
+
+PulsePlate already has meaningful calculations, tier progression, and adherence signals,
+but the user journey still has a comprehension gap:
+
+- FREE tells the user where they are, but not always why the result is limited.
+- PRO adds interpretation, but the learning value is not packaged as a progressive system.
+- VIP adds action, but the app can explain the "why this plan" layer more clearly.
+
+This creates three product risks:
+
+1. Trust is lower than it could be because the app computes more than it teaches.
+2. Retention depends too much on utility alone and not enough on self-understanding.
+3. Upsell can drift toward generic conversion copy instead of educational progression.
+
+---
+
+## Goal
+
+Create a compact product layer that explains the user's current result, turns repeated
+use into visible learning progress, and strengthens the trust-based funnel.
+
+### Primary goals
+
+- Increase comprehension of BMI / risk / adherence / plan outputs.
+- Reframe progress around learning cycles, not "success vs failure".
+- Improve FREE -> PRO and PRO -> VIP progression with educational, wellness-safe logic.
+
+### Non-goals
+
+- No ML curriculum, algorithm catalog, or external educational track.
+- No diagnosis, treatment, or medical claims.
+- No new public heavy LLM endpoint for explainers.
+- No leaderboard, social pressure, or anxiety-producing streak mechanics in MVP.
+- No client-side business logic duplication.
+
+---
+
+## Product Principles
+
+### 1. Wellness-only language
+
+Explainers must stay educational and wellness-safe. They must not claim diagnosis,
+treatment, cure, or guaranteed outcomes.
+Use the canonical disclaimer in `docs/safety/WELLNESS_DISCLAIMER_CANONICAL.md`.
+
+### 2. Scientific clarity without false precision
+
+The product should explain limits, uncertainty, and contributing factors instead of
+pretending to know more than it does.
+
+### 3. Learning cycles over streaks
+
+The user should feel "I am learning what works for me", not "I broke my streak".
+
+### 4. Rules-first MVP
+
+For the first release, explainer assembly should be deterministic and sourced from
+existing payloads and rules. If AI-assisted copy is ever added later, it must remain
+optional and guarded.
+
+### 5. Thin-client delivery
+
+The backend owns explainer logic; frontend and iOS remain presentation adapters.
+
+---
+
+## User Outcomes
+
+### FREE outcome
+
+"I understand what this result means and what it does not mean."
+
+### PRO outcome
+
+"I understand why my risk/interpretation looks this way for me."
+
+### VIP outcome
+
+"I understand why the app recommends these actions and what pattern I am improving."
+
+---
+
+## MVP Scope
+
+### Surface A: Context Explainers
+
+Add short, structured explanations on top of existing outputs:
+
+- FREE: explain BMI as a starting point and state what is missing.
+- PRO: explain which factors increase or reduce interpretation depth.
+- VIP: explain why this plan/target/action is suggested and what pattern it supports.
+
+### Surface B: Learning Cycles
+
+Introduce a lightweight progression model based on repeated understanding and behavior:
+
+- Cycle 1: Baseline
+- Cycle 2: Risk Context
+- Cycle 3: Consistency Pattern
+- Cycle 4: Plan Adjustment
+
+Each cycle should answer:
+
+- what the user learned,
+- which existing signals unlocked the cycle,
+- what the next useful action is.
+
+### Surface C: Progress Signals
+
+Represent progress as:
+
+- completed explainers,
+- unlocked learning cycles,
+- repeated evidence of adherence or plan understanding,
+- next recommended educational action.
+
+MVP progress must be local to the product journey. No public ranking and no social comparison.
+
+---
+
+## Entity Mapping To Existing Product Objects
+
+| Product surface | Existing entity or signal | Current source |
+| --- | --- | --- |
+| FREE explainer | `bmi`, `category`, `interpretation_v1`, `soft_paywall` | `app/schemas/bmi.py` |
+| PRO explainer | `waist_risk`, `notes`, combined interpretation fields | `app/schemas/bmi.py`, BMI Pro contract |
+| Adherence explainer | `adherence_score`, slip risk, confidence | `app/schemas/nutrition_log.py`, `core/bayes/adherence_model.py` |
+| Weekly plan explainer | weekly `adherence_score`, nutrient target fit | `core/menu_engine.py`, `core/weekly_plan_new.py` |
+| CBT reframing copy | existing CBT insight and wellness-safe messaging direction | `app/routers/cbt_insight.py`, `docs/analysis/SCIENTIFIC_INNOVATION_ANALYSIS.md` |
+
+### Binding notes
+
+#### FREE
+
+- Use current BMI result fields to explain "what this number captures" and "what it omits".
+- Reuse soft-paywall logic as an educational continuation, not as a sales interruption.
+
+#### PRO
+
+- Use current interpretation and waist-risk data to explain why the user sees a broader
+  risk picture than BMI alone.
+- Package this as understanding, not fear.
+
+#### VIP
+
+- Use current weekly plan and adherence signals to explain why a recommendation exists.
+- The learning unit is not "perfect compliance". The learning unit is "pattern detection
+  and adjustment".
+
+#### Adherence
+
+- Use the existing Beta-Binomial adherence model and current adherence score fields as
+  the first source of "consistency pattern" messaging.
+- Confidence should be surfaced carefully: low-confidence states should say "needs more
+  data", not imply certainty.
+
+---
+
+## Rules-First MVP Contract
+
+### Allowed data sources
+
+- Existing backend response fields
+- Existing domain models and deterministic rules
+- Existing adherence signals
+- Existing plan-generation outputs
+
+### Forbidden in MVP
+
+- New external datasets
+- New vector search / RAG requirement for explainers
+- New always-on LLM endpoint for educational copy
+- Copy that depends on hidden client-side heuristics
+
+### Optional future extension
+
+If a future version uses AI-assisted rewriting for tone or personalization, it must:
+
+- sit behind the existing tier model,
+- pass wellness-safe validation,
+- obey quota / rate-limit / cost guardrails,
+- degrade safely to deterministic copy.
+
+---
+
+## UX Shape
+
+### Explainer card
+
+Each explainer card should contain:
+
+- `title`
+- `what_this_means`
+- `what_is_missing` or `why_this_matters`
+- `next_step`
+- `learning_cycle_id` (optional)
+
+### Learning cycle card
+
+Each learning cycle should contain:
+
+- `cycle_id`
+- `label`
+- `unlocked_by`
+- `what_you_learned`
+- `next_action`
+
+### Tone
+
+- calm,
+- educational,
+- non-judgmental,
+- specific,
+- not salesy.
+
+### Default behavior
+
+- If required source data is missing, do not invent an explanation. Show a short neutral
+  fallback and omit the learning-cycle unlock.
+- If confidence is low, say "needs more data" rather than implying certainty.
+- If a tier does not expose the needed entity, do not emulate it on the client.
+
+---
+
+## Acceptance Criteria
+
+- A deterministic explainer payload is defined for at least one FREE and one PRO or VIP surface.
+- Every explainer field maps to an existing backend entity or rule already present in the repo.
+- MVP logic does not require a new public LLM or RAG endpoint.
+- Copy remains wellness-safe and compatible with the canonical disclaimer.
+- Frontend and iOS are specified as render-only consumers of backend explainer payloads.
+- Learning-cycle progression uses non-coercive rules and does not depend on streak-shame.
+
+---
+
+## Success Metrics
+
+### Product metrics
+
+- Increased interaction rate with explainers after result screens
+- Increased return usage for users who unlocked at least one learning cycle
+- Higher conversion from FREE -> PRO and/or PRO -> VIP on educational surfaces
+
+### Safety metrics
+
+- Zero medical-claim regressions in explainer copy
+- Zero new expensive AI calls on the MVP path
+- No business-logic drift into frontend or iOS
+
+---
+
+## Deferred Follow-Ups
+
+- Richer progress memory across sessions
+- Additional entity types beyond BMI / risk / adherence / weekly plan
+- Optional AI-assisted tone rewriting with explicit safety/economics gates
+- More advanced personalization beyond existing deterministic and Bayesian signals
+- Any standalone endpoint/runtime expansion for explainers
+
+---
+
+## Delivery Plan
+
+### Phase 1: Contract + copy system
+
+- Define deterministic explainer payload shape
+- Define learning cycle IDs and unlock conditions
+- Approve wellness-safe copy patterns
+
+### Phase 2: Backend assembly
+
+- Assemble explainer payloads from existing BMI / risk / adherence / plan data
+- Keep logic in backend/domain layer
+- No new public heavy AI endpoints
+
+### Phase 3: Frontend surfaces
+
+- Render explainer cards on existing result and progress surfaces
+- Render learning-cycle progress using backend payloads only
+
+---
+
+## Explicit Guardrails
+
+- Do not turn PulsePlate into an ML education product.
+- Do not promise better health outcomes because a cycle was unlocked.
+- Do not use streak-shame or "failure recovery" framing.
+- Do not add implementation that requires a new expensive provider call on every result.
+- Do not bypass the current tier progression contract.
+
+---
+
+## Open Questions
+
+- Should the first shipping surface be BMI result only, or BMI + Progress together?
+- Should learning cycles unlock passively from usage, or require explicit "mark as understood" events?
+- Should CBT insight remain separate from explainers in MVP to keep cost and complexity low?
+
+Current recommendation: ship BMI + PRO interpretation explainers first, then extend to
+adherence and weekly-plan flows.

--- a/docs/review/PR_1019_FIXED_MAPPING.md
+++ b/docs/review/PR_1019_FIXED_MAPPING.md
@@ -14,3 +14,10 @@ Evidence: `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:4`, `doc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632195 -> b1b9e2f7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632196 -> b1b9e2f7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909891685 -> b1b9e2f7
+
+Disposition: FIXED
+Commit: bffeb1d2
+Evidence: `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:143`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909917846 -> bffeb1d2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900645863 -> bffeb1d2

--- a/docs/review/PR_1019_FIXED_MAPPING.md
+++ b/docs/review/PR_1019_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1019 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: b1b9e2f7
+Evidence: `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:4`, `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:61`, `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:72`, `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:138`, `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:196`, `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md:232`, `docs/roadmap/BACKLOG_LEDGER.md:3996`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909875043 -> b1b9e2f7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900631134 -> b1b9e2f7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632195 -> b1b9e2f7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632196 -> b1b9e2f7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909891685 -> b1b9e2f7

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3993,6 +3993,25 @@ If it is not recorded here — it does not exist.
     - Decision documented: pursue / defer / won't do for publication track
     - If pursue: venue + outline for one paper; no mandatory timeline
 
+- [ ] P2: Wellness Explainers + Learning Cycles MVP (rules-first)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (product differentiation + trust/retention)
+  - Target PR: TBD (implementation after mini-PRD approval)
+  - Status: 📋 Planned
+  - Reason (EN): Adopt the strongest fit from modern interactive learning products without turning PulsePlate into an ML academy. The product fit is interactive explainers, learning-cycle progression, and science-backed clarity around existing wellness outputs. MVP must remain deterministic, wellness-safe, and grounded in existing BMI / risk / adherence / weekly-plan data. No new heavy LLM endpoint is allowed on the core path. (RU: Интегрировать понятные explainers и learning cycles поверх текущих wellness-сущностей; без копирования чужого контента, без ML-куррикулума внутри продукта и без нового дорогого AI-контура.)
+  - Links:
+    - docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md
+    - docs/audience_pack/FACTS_CANONICAL.md
+    - docs/analysis/SCIENTIFIC_INNOVATION_ANALYSIS.md
+    - core/insight/philosophy_validator.py
+    - docs/policy/LLM_UNIT_ECONOMICS_GUARDRAILS.md
+  - DoD:
+    - Backend contract for explainer payloads is documented and implemented using existing product entities only
+    - At least one FREE/PRO explainer surface ships without client-side business logic duplication
+    - Learning cycle unlock rules are deterministic and do not depend on streak-shame mechanics
+    - MVP path introduces no new heavy LLM endpoint; any optional AI-assisted copy remains guarded by existing safety/economics rules
+    - Product copy remains wellness-safe and evidence-aligned
+
 - [ ] P1: Agent knowledge library template packs (domain-specific)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (process scalability)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3993,6 +3993,7 @@ If it is not recorded here — it does not exist.
     - Decision documented: pursue / defer / won't do for publication track
     - If pursue: venue + outline for one paper; no mandatory timeline
 
+<a id="ledger-p2-wellness-explainers-learning-cycles"></a>
 - [ ] P2: Wellness Explainers + Learning Cycles MVP (rules-first)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (product differentiation + trust/retention)


### PR DESCRIPTION
## Summary
This PR adds a docs-only product direction for Wellness Explainers + Learning Cycles.

Why this exists:
- strengthen trust-based educational progression
- package existing wellness logic into explainers and learning cycles
- define a rules-first MVP without widening runtime scope

Included:
- `docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md`
- one backlog item in `docs/roadmap/BACKLOG_LEDGER.md`
- canonical review mapping artifact `docs/review/PR_1019_FIXED_MAPPING.md`

Excluded:
- runtime changes
- schema changes
- new AI endpoint work
- frontend/iOS implementation

## Validation
- `PYTHONPATH=. python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files`
- `git diff --stat origin/main...HEAD`
- `git diff -- docs/product/WELLNESS_EXPLAINERS_LEARNING_CYCLES_MINI_PRD.md docs/roadmap/BACKLOG_LEDGER.md`

## Follow-up
A later implementation PR will define the explainer payload contract and first rendered surface.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909875043 -> b1b9e2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900631134 -> b1b9e2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632195 -> b1b9e2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900632196 -> b1b9e2f7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909891685 -> b1b9e2f7

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#pullrequestreview-3909917846 -> bffeb1d2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1019#discussion_r2900645863 -> bffeb1d2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added product specification for Wellness Explainers and Learning Cycles MVP, including user outcomes, design specifications, and success metrics.
  * Updated backlog ledger with new priority item.
  * Added internal review documentation for commit tracking and mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->