### PR TITLE
feat(recovery): seed top20 queue and legal terms

### DIFF
--- a/docs/orchestration/TOP20_PR_RECOVERY_TASK_PACKETS_2026-03-08.md
+++ b/docs/orchestration/TOP20_PR_RECOVERY_TASK_PACKETS_2026-03-08.md
@@ -1,0 +1,46 @@
+# Top-20 PR Recovery Task Packets (2026-03-08)
+
+Canonical execution artifact for the normalized recovery queue.
+
+Mandatory entry gates before any listed PR starts:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/route_with_telemetry.py --domain <domain> --task-type "<task type>"
+```
+
+Coordinator-first rule still applies. If agent connectivity is degraded, use the same routing manually and record the decision in the PR artifact / ledger.
+
+## Active Queue
+
+| # | Target PR | Wave | Domain | Primary | Secondary | Reviewer | Minimum DoD |
+|---|---|---|---|---|---|---|---|
+| 1 | `PR-TBD-SESSION-COOKIE-HARDENING-W1` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Remove browser-stored auth secrets; use canonical `/api/v1/pro/session/*` cookie flow; add auth regression tests |
+| 2 | `PR-TBD-INSIGHT-FALLBACK-CHAIN` | 3 | ml | `ai-innovation-specialist` | `rag-systems-agent` | `architecture-specialist` | Deterministic provider fallback order; `/ready` reports fallback/echo state safely; response contract remains additive |
+| 3 | `PR-TBD-RAG-INPUT-SANITIZER` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Sanitizer runs before RAG indexing/retrieval; prompt-injection regressions added |
+| 4 | `PR-TBD-IOS-KEYCHAIN-CONFORMANCE` | 2 | ios | `frontend-engineer` | `creative-designer` | `qa-engineer-agent` | Keychain-only secret storage verified; no insecure release fallback |
+| 5 | `PR-TBD-PAYMENTS-RUBY-IOS-BASELINE-RUNTIME-W1` | 2 | backend | `architecture-specialist` | `backend-engineer` | `security-auditor` | Runtime billing flow for `ios_app_store`, `erip_qr`, `swift_manual`; activation contract tested |
+| 6 | `PR-TBD-BILLING-APPLE-VERIFY` | 2 | backend | `architecture-specialist` | `backend-engineer` | `security-auditor` | Server-side Apple receipt verification normalizes into billing activation |
+| 7 | `PR-TBD-IOS-SUBSCRIPTION-MANAGER` | 2 | ios | `frontend-engineer` | `creative-designer` | `qa-engineer-agent` | Dedicated iOS subscription orchestration stays thin and backend-driven |
+| 8 | `PR-TBD-DIET-FLAGS-CONTRACT-SYNC` | 3 | frontend | `frontend-engineer` | `creative-designer` | `qa-engineer-agent` | One canonical enum/normalization table across schemas, UI, and generated types |
+| 9 | `PR-TBD-LEGAL-POLICY-PUBLISH` | 1 | docs | `web-research-agent` | `cursor-specialist-agent` | `qa-engineer-agent` | Canonical privacy/terms publication paths exist and client links are aligned |
+| 10 | `PR-TBD-EXPORT-SIGNING-HARDENING` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Default secret fails closed; signable export paths are allowlisted |
+| 11 | `PR-TBD-USERS-SURFACE-HARDENING` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | `/api/v1/users` is authenticated, internalized, or retired explicitly |
+| 12 | `PR-TBD-API-KEY-TOGGLE-GUARD` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Production/staging fail closed on anonymous or dev API-key toggles |
+| 13 | `PR-TBD-WORKER-PROXY-HARDENING` | 1 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Worker path scope, CORS, and forwarded headers are bounded |
+| 14 | `PR-TBD (fix/orch-ban-trigger-commit-mapping)` | 4 | orchestration | `cursor-specialist-agent` | `dev-operator` | `architecture-specialist` | Trigger-only commits cannot satisfy FIXED proof mapping |
+| 15 | `PR-TBD (required-check truth)` | 4 | orchestration | `cursor-specialist-agent` | `dev-operator` | `architecture-specialist` | Merge truth is current-HEAD required checks only |
+| 16 | `PR-TBD (CI hard/soft/external)` | 4 | orchestration | `cursor-specialist-agent` | `dev-operator` | `architecture-specialist` | CI check classes documented and aligned with merge-readiness rules |
+| 17 | `PR-TBD-STAGING-SEAM-REMOVAL` | 4 | infra | `dev-operator` | `architecture-specialist` | `security-auditor` | Temporary staging TLS fallback removed only after direct staging runtime is primary |
+| 18 | `PR-TBD-NOSEC-ALLOWLIST-PHASE2` | 4 | security | `security-auditor` | `architecture-specialist` | `agent-coordinator` | Legacy allowlist entries removed or converted to fully compliant inline suppressions |
+| 19 | `PR-TBD-AI-BOUNDED-CONTEXT` | 3 | ml | `ai-innovation-specialist` | `rag-systems-agent` | `architecture-specialist` | AI runtime extracted after fallback-chain behavior is locked |
+| 20 | `PR-TBD-IOS-STOREKIT-PRODUCTS` | 2 | release | `app-store-release-agent` | `marketing-strategist` | `qa-engineer-agent` | Canonical StoreKit product contract and setup checklist are versioned |
+
+## Sequencing Rules
+
+1. Wave 1 security/release blockers land before public growth or store-release pushes.
+2. In Wave 2, implement `PR-TBD-PAYMENTS-RUBY-IOS-BASELINE-RUNTIME-W1` before Apple verify or iOS SubscriptionManager work.
+3. `PR-TBD-IOS-STOREKIT-PRODUCTS` may run in parallel with `PR-TBD-IOS-SUBSCRIPTION-MANAGER` only after the billing baseline contract is runtime-backed.
+4. `PR-TBD-AI-BOUNDED-CONTEXT` must not start before `PR-TBD-INSIGHT-FALLBACK-CHAIN` is behaviorally complete.
+5. Governance cleanup PRs in Wave 4 must not block active release/security remediation unless they directly affect merge-readiness policy.

--- a/docs/review/PR_1029_FIXED_MAPPING.md
+++ b/docs/review/PR_1029_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1029 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3713,6 +3713,54 @@ If it is not recorded here — it does not exist.
     - Injection-pattern regression tests are added and green
     - No contract break for current insight endpoints
 
+<a id="ledger-top20-pr-recovery-queue"></a>
+### Active top-20 PR recovery queue (2026-03-08)
+
+Canonical basis: repo truth wins over external snapshots. `PR-TBD-PRO-VIP-DEPENDS-GUARD` is removed from the active queue because it is already closed by `PR #994`. Replacement slot `#20` is `PR-TBD-IOS-STOREKIT-PRODUCTS`.
+
+1. `PR-TBD-SESSION-COOKIE-HARDENING-W1`
+2. `PR-TBD-INSIGHT-FALLBACK-CHAIN`
+3. `PR-TBD-RAG-INPUT-SANITIZER`
+4. `PR-TBD-IOS-KEYCHAIN-CONFORMANCE`
+5. `PR-TBD-PAYMENTS-RUBY-IOS-BASELINE-RUNTIME-W1`
+6. `PR-TBD-BILLING-APPLE-VERIFY`
+7. `PR-TBD-IOS-SUBSCRIPTION-MANAGER`
+8. `PR-TBD-DIET-FLAGS-CONTRACT-SYNC`
+9. `PR-TBD-LEGAL-POLICY-PUBLISH`
+10. `PR-TBD-EXPORT-SIGNING-HARDENING`
+11. `PR-TBD-USERS-SURFACE-HARDENING`
+12. `PR-TBD-API-KEY-TOGGLE-GUARD`
+13. `PR-TBD-WORKER-PROXY-HARDENING`
+14. `PR-TBD (fix/orch-ban-trigger-commit-mapping)`
+15. `PR-TBD (required-check truth)`
+16. `PR-TBD (CI hard/soft/external)`
+17. `PR-TBD-STAGING-SEAM-REMOVAL`
+18. `PR-TBD-NOSEC-ALLOWLIST-PHASE2`
+19. `PR-TBD-AI-BOUNDED-CONTEXT`
+20. `PR-TBD-IOS-STOREKIT-PRODUCTS`
+
+Execution artifact:
+- `docs/orchestration/TOP20_PR_RECOVERY_TASK_PACKETS_2026-03-08.md`
+
+<a id="ledger-p0-billing-apple-verify"></a>
+- [ ] P0: Apple receipt verification backend
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (billing automation / release blocker)
+  - Target PR: PR-TBD-BILLING-APPLE-VERIFY
+  - Status: 📋 Planned
+  - Reason (EN): The payment baseline contract already reserves Apple receipt verification as the only automated iOS billing path. Runtime verification must land before SubscriptionManager can delegate entitlement truth to backend services.
+  - Links:
+    - docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
+    - docs/IOS_API_INTEGRATION.md
+    - app/routers/pro_payments.py
+    - app/services/payments_activation.py
+    - tests/test_pro_payments_api.py
+  - DoD:
+    - Backend exposes canonical Apple verification route on the additive billing surface
+    - Verification result is normalized into the shared activation contract without client-side entitlement logic
+    - Failure paths are deterministic and use canonical billing error envelopes
+    - `tests/test_ios_receipt_verification_api.py` exists and is green
+
 <a id="ledger-p1-mobile-secret-conformance"></a>
 - [ ] P1: Mobile secret storage conformance (iOS Keychain now, Android Keystore deferred)
   - Owner: @katsiaryna_kavaleuskaya
@@ -3728,6 +3776,81 @@ If it is not recorded here — it does not exist.
   - DoD:
     - iOS secret paths are verified to use Keychain storage only
     - Guard tests prevent regression to insecure storage
+
+<a id="ledger-p1-ios-subscription-manager"></a>
+- [ ] P1: iOS SubscriptionManager thin-client integration
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (iOS monetization correctness)
+  - Target PR: PR-TBD-IOS-SUBSCRIPTION-MANAGER
+  - Status: 📋 Planned
+  - Reason (EN): The current `StoreKitManager` handles purchases directly, but the roadmap requires a dedicated iOS orchestration layer that delegates entitlement truth to backend billing contracts and keeps business logic off the client.
+  - Links:
+    - docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
+    - docs/IOS_API_INTEGRATION.md
+    - ios/PulsePlate/Models/StoreKitManager.swift
+    - ios/PulsePlate/Screens/PaywallScreen.swift
+    - ios/PulsePlate/Services/ProKeyProvider.swift
+  - DoD:
+    - A dedicated iOS subscription orchestration layer exists without duplicating backend billing decisions
+    - Purchase, restore, and verification states are delegated to backend billing contracts where required
+    - Thin-client guardrails remain green (no client-side tier or receipt business logic)
+    - Unit tests cover happy-path, pending, and failure states
+
+<a id="ledger-p1-ios-storekit-products"></a>
+- [ ] P1: StoreKit product contract and operational setup for iOS monetization
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (release operations dependency)
+  - Target PR: PR-TBD-IOS-STOREKIT-PRODUCTS
+  - Status: 📋 Planned
+  - Reason (EN): The active monetization queue needs a canonical StoreKit product-id contract and release-operations checklist so iOS purchase flows do not depend on ad hoc identifiers or manual tribal knowledge.
+  - Links:
+    - docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
+    - ios/PulsePlate/Models/StoreKitManager.swift
+    - ios/PulsePlate/Screens/PaywallScreen.swift
+    - docs/roadmap/P0_MASTER_CHECKLIST_PHASE_FIT_TRIAGE_2026-03-05.md
+  - DoD:
+    - Canonical StoreKit product identifiers are documented and referenced from iOS runtime code
+    - Release/setup steps for StoreKit products are versioned in-repo
+    - Product-list loading aligns with the documented contract and fails safely when products are unavailable
+    - Follow-on App Store release work has an explicit source of truth
+
+<a id="ledger-p1-diet-flags-contract-sync"></a>
+- [ ] P1: Diet flags contract sync across backend, frontend, and thin clients
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (product correctness / contract parity)
+  - Target PR: PR-TBD-DIET-FLAGS-CONTRACT-SYNC
+  - Status: 📋 Planned
+  - Reason (EN): The web Nutrition Setup surface exposes a broader diet-flags set than one backend contract currently accepts, which creates drift in generated types, API normalization, and client expectations.
+  - Links:
+    - frontend/src/pages/NutritionSetup/schema.ts
+    - frontend/src/pages/NutritionSetup/hooks.ts
+    - frontend/src/api/schema.ts
+    - app/schemas/premium_contracts.py
+    - app/schemas/nutrition_recommendations.py
+  - DoD:
+    - One canonical diet-flags enum/normalization table is defined and documented
+    - Frontend form schema, backend schemas, and generated API types use the same contract
+    - Thin clients do not implement divergent diet-flags business logic
+    - Contract and normalization tests are green before OpenAPI sync is claimed complete
+
+<a id="ledger-p0-legal-policy-publish"></a>
+- [ ] P0: Privacy Policy + Terms publication and client-link alignment
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (release / compliance blocker)
+  - Target PR: PR-TBD-LEGAL-POLICY-PUBLISH
+  - Status: 🟡 In progress (runtime legal surface normalization)
+  - Reason (EN): `/privacy` already exists, but release readiness still lacks a canonical Terms publication path and a repo-tracked contract that web/iOS can link to consistently before App Store and billing rollout.
+  - Links:
+    - legacy_app.py
+    - ios/PulsePlate/Views/ProfileView.swift
+    - frontend/src/locales/en.json
+    - frontend/src/locales/ru.json
+    - frontend/src/locales/es.json
+  - DoD:
+    - Canonical privacy and terms publication paths exist and are stable
+    - iOS/web legal links point to the published canonical paths
+    - Legal copy keeps wellness-safe, non-medical boundaries
+    - Tests cover legal endpoint shape and basic release-safety assertions
 
 <a id="ledger-p2-android-keystore-conformance"></a>
 - [ ] P2: Android Keystore secret storage conformance (deferred track)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1747,6 +1747,50 @@ async def privacy() -> Dict[str, Any]:
     }
 
 
+@app.get("/terms", include_in_schema=False)
+async def terms() -> Dict[str, Any]:
+    """Terms of use endpoint for release-safe legal publication.
+
+    RU: Эндпоинт условий использования для канонической legal-публикации.
+    EN: Terms of use endpoint for canonical legal publication.
+    """
+
+    return {
+        "terms_of_use": (
+            "PulsePlate provides wellness-oriented planning, nutrition, and coaching-style features. "
+            "It does not provide medical diagnosis, treatment, emergency response, or licensed clinical services."
+        ),
+        "service_scope": {
+            "category": "wellness / nutrition planning / coaching support",
+            "medical_boundary": (
+                "Content is informational and product-guidance only. Users must not treat the service as "
+                "medical, psychiatric, or emergency advice."
+            ),
+            "age_requirement": "The service is intended for adults unless a specific flow states otherwise.",
+        },
+        "billing_and_subscriptions": {
+            "ios_app_store": "Apple-managed digital subscription flow with server-side verification.",
+            "manual_rails": "Operational fallback rails may include ERIP QR or SWIFT manual reconciliation.",
+            "cancellation": "Users manage subscription cancellation in the original purchase channel.",
+            "entitlement_truth": "Subscription entitlement is determined by backend verification and audit state.",
+        },
+        "acceptable_use": {
+            "forbidden": [
+                "attempting to bypass tier controls or payment verification",
+                "submitting unlawful, abusive, or malicious content",
+                "using the service for medical triage or emergency decisions",
+            ],
+            "security_note": "Abuse-prevention and platform-protection controls may block unsafe or fraudulent use.",
+        },
+        "liability_boundary": (
+            "The service is provided on a best-effort basis for wellness support. "
+            "Users remain responsible for critical health, legal, and financial decisions."
+        ),
+        "contact": "For legal or billing questions, please contact the application administrator.",
+        "effective_date": "2026-03-08",
+    }
+
+
 @app.post("/admin/logs/cleanup", dependencies=[Depends(_get_api_key_dynamic)])
 async def cleanup_expired_logs(
     data_class: Optional[str] = None,

--- a/tests/test_app_endpoints_1383_1401.py
+++ b/tests/test_app_endpoints_1383_1401.py
@@ -5,6 +5,7 @@ Covers:
 - /api/v1/health endpoint
 - /metrics endpoint (Prometheus)
 - /privacy endpoint
+- /terms endpoint
 """
 
 from typing import Any
@@ -113,3 +114,36 @@ class TestAppEndpoints1383_1401:
 
         # Verify it's mentioned in data_retention string
         assert str(retention_days) in data["data_retention"]
+
+    def test_terms_endpoint_structure(self, client: TestClient) -> None:
+        """/terms returns canonical legal publication structure."""
+        response = client.get("/terms")
+        assert response.status_code == 200
+        data: dict[str, Any] = response.json()
+
+        assert "terms_of_use" in data
+        assert "service_scope" in data
+        assert "billing_and_subscriptions" in data
+        assert "acceptable_use" in data
+        assert "liability_boundary" in data
+        assert "contact" in data
+        assert data["effective_date"] == "2026-03-08"
+
+        service_scope = data["service_scope"]
+        assert service_scope["category"] == "wellness / nutrition planning / coaching support"
+        assert "medical" in service_scope["medical_boundary"].lower()
+
+        billing = data["billing_and_subscriptions"]
+        assert "Apple" in billing["ios_app_store"]
+        assert "backend" in billing["entitlement_truth"].lower()
+
+    def test_terms_endpoint_keeps_wellness_boundaries(self, client: TestClient) -> None:
+        """/terms must preserve non-medical product framing."""
+        response = client.get("/terms")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "wellness" in data["terms_of_use"].lower()
+        assert "does not provide medical diagnosis" in data["terms_of_use"].lower()
+        forbidden = data["acceptable_use"]["forbidden"]
+        assert "using the service for medical triage or emergency decisions" in forbidden


### PR DESCRIPTION
## Summary
- normalize the canonical Top-20 PR recovery queue in the backlog using repo truth
- add a coordinator-first task-packet artifact for the normalized queue
- publish a canonical `/terms` legal endpoint and cover it with tests

## Scope
- Wave 0 queue normalization
- first legal/runtime gap from `PR-TBD-LEGAL-POLICY-PUBLISH`
- coordinator-first recovery execution packet for the active Top-20 queue

## Carryover
- This PR supersedes the earlier draft branch after rebasing the work onto `origin/main` and removing unrelated branch history from the diff.

## Why This PR
- `PR #994` already closed the PRO/VIP depends guard item, so the active queue required canonical normalization
- several planned PRs had triage references but no ledger-grade entries or routing artifact
- `/privacy` existed, but `/terms` was still missing as a canonical legal publication path

## Validation
- `python3 -m scripts.orchestration.check_preflight`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type feature`
- `pytest -q tests/test_app_endpoints_1383_1401.py`
- `pytest -q tests/test_openapi_determinism.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Notes
- Draft PR on purpose: this is Wave 0 only, not the full roadmap series
- no OpenAPI artifact carryover remains in this branch diff

## Summary by Sourcery

Нормализовать активную очередь восстановления топ-20 PR, добавить для неё артефакт выполнения и ввести каноничный эндпоинт с юридическими условиями, покрытый тестами.

New Features:
- Добавить каноничный юридический эндпоинт `/terms`, который документирует границы сервиса, поведение биллинга, допустимое использование и ограничения ответственности.
- Ввести документ «execution packet» с приоритетом координатора для нормализованной очереди восстановления активных топ-20 PR.

Enhancements:
- Обновить реестр беклога с нормализованной активной очередью восстановления топ-20 PR и детализированными записями для ключевых пунктов по iOS, биллингу, diet-flags и юридическому роадмапу.

Documentation:
- Задокументировать активную очередь восстановления топ-20 PR и её правила выполнения, включая порядок волн, роли и минимальные определения «готово» (definition of done) для каждого целевого PR.
- Расширить реестр дорожной карты (roadmap backlog ledger) новыми записями, описывающими задачи P0/P1 по биллингу, монетизацию iOS, синхронизацию контракта diet-flags и работу по публикации юридических политик.
- Добавить документ сопоставления «fixed-in-commit» для PR 1029, указывающий, что нет применимых комментариев к ревью.

Tests:
- Добавить тесты для проверки структуры эндпоинта `/terms`, даты вступления в силу и ориентированной на wellness, немедицинской юридической формулировки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize the active top-20 PR recovery queue, add an execution artifact for it, and introduce a canonical legal terms endpoint covered by tests.

New Features:
- Add a canonical `/terms` legal endpoint that documents service scope, billing behavior, acceptable use, and liability boundaries.
- Introduce a coordinator-first execution packet document for the normalized top-20 PR recovery queue.

Enhancements:
- Update the backlog ledger with a normalized active top-20 PR recovery queue and detailed entries for key iOS, billing, diet-flags, and legal roadmap items.

Documentation:
- Document the active top-20 PR recovery queue and its execution rules, including wave ordering, roles, and minimum definitions of done for each target PR.
- Extend the roadmap backlog ledger with new entries describing P0/P1 billing, iOS monetization, diet-flags contract sync, and legal policy publication work.
- Add a fixed-in-commit mapping document for PR 1029 indicating no actionable review comments.

Tests:
- Add tests to validate the `/terms` endpoint structure, effective date, and wellness-focused, non-medical legal framing.

</details>