### PR TITLE
docs(ledger): close PR 1035 backlog item

### DIFF
--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2987,19 +2987,20 @@ If it is not recorded here — it does not exist.
     - Consistent error handling via APIError
     - No dual-path networking
 
-- [ ] OpenAPI debt for `/api/v1/export/sign` reclassified as internal contract
+- [x] OpenAPI debt for `/api/v1/export/sign` reclassified as internal contract — completed in PR #1035 (merged 2026-03-08)
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: PR `#1035` (`feat/export-signing-hardening`)
-  - Status: In progress
+  - Status: ✅ Merged
   - Priority: P2
   - Area: backend / OpenAPI / frontend contract
   - Finding Type: contract-clarification
   - Location: `app/routers/plan_export.py`, `frontend/src/lib/sharedLinks.ts`
-  - Reason: `/api/v1/export/sign` is intentionally hidden from canonical public OpenAPI, so forcing generated public-schema typing would widen the public contract incorrectly. PR `#1035` moved export signing away from static `EXPORT_TOKEN_SECRET` import-time access to the runtime accessor in `settings.py`; the remaining requirement is to keep the runtime JSON shape stable and document why web uses a local internal type. Ledger policy keeps this item open until the implementing PR is merged or explicitly closed as won't-do.
+  - Reason: `/api/v1/export/sign` remains intentionally hidden from canonical public OpenAPI, so public-schema typing would widen the contract incorrectly. PR `#1035` moved export signing away from static `EXPORT_TOKEN_SECRET` import-time access to the runtime accessor in `settings.py`, preserved the stable signed-link JSON shape, and documented the internal web adapter boundary.
   - Links:
     - `app/routers/plan_export.py`
     - `frontend/src/lib/sharedLinks.ts`
     - `legacy_app.py`
+    - <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1035>
   - DoD:
     - Backend keeps `SignedLinkResponse` as the runtime response model
     - `POST /api/v1/export/sign` keeps the stable JSON shape `{url, exp, ttl}` with regression coverage


### PR DESCRIPTION
## Summary
- mark the export-signing internal-contract backlog item complete after merged PR #1035
- update the ledger reason to reflect post-merge truth
- keep this PR docs-only and scoped to ledger closure

## Testing
- pre-commit run --all-files

## Notes
- Carryover: none
- This PR intentionally contains docs-only post-merge ledger hygiene.

## Summary by Sourcery

Документация:
- Обновить запись в журнале невыполненных задач для внутреннего контракта `/api/v1/export/sign`, чтобы отметить его как завершённый, обновить обоснование и добавить ссылку на PR №1035.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the backlog ledger entry for the `/api/v1/export/sign` internal contract to mark it as completed, refresh the rationale, and add a reference link to PR #1035.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the `/api/v1/export/sign` backlog item as completed in `docs/roadmap/BACKLOG_LEDGER.md` after PR `#1035` merged, updating status, reason, and links to reflect the post-merge state. Docs-only; no API or runtime changes.

<sup>Written for commit f7af322adc85c5c6c360171df39739a1b438c931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal backlog tracking documentation with status updates and PR reference links for development item tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->