### PR TITLE
feat(sandbox): stream output budget enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,4 +87,4 @@ AGENT_EXECUTION_SANDBOX_ROOT=.
 AGENT_EXECUTION_SANDBOX_TIMEOUT_SECONDS=30
 AGENT_EXECUTION_SANDBOX_MAX_OUTPUT_BYTES=32768
 # Explicit local opt-in allowlist; keep minimal per machine/task.
-AGENT_EXECUTION_SANDBOX_ALLOWED_BINARIES=pytest,mypy,coverage,diff-cover,ruff,flake8,git
+AGENT_EXECUTION_SANDBOX_ALLOWED_BINARIES=pytest,mypy,ruff,flake8,git

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1014,7 +1014,7 @@
         "filename": "tests/test_food_apis_basic_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 25
       }
     ],
     "tests/test_food_apis_comprehensive_coverage.py": [
@@ -1023,14 +1023,14 @@
         "filename": "tests/test_food_apis_comprehensive_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 30
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_food_apis_comprehensive_coverage.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1137
+        "line_number": 1148
       }
     ],
     "tests/test_food_merge_coverage_96.py": [
@@ -1607,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T20:59:23Z"
+  "generated_at": "2026-03-08T21:00:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -998,14 +998,14 @@
         "filename": "tests/test_food_apis.py",
         "hashed_secret": "cbaf17f4a200f6a2d5a748efa7601497d328d950",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 55
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_food_apis.py",
         "hashed_secret": "7bac3a781f4b9606796e1a61bc27b0966b884cdc",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 61
       }
     ],
     "tests/test_food_apis_basic_coverage.py": [
@@ -1607,5 +1607,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T07:34:18Z"
+  "generated_at": "2026-03-08T20:59:23Z"
 }

--- a/app/security/execution_sandbox.py
+++ b/app/security/execution_sandbox.py
@@ -9,12 +9,14 @@ timeout, and output limits.
 from __future__ import annotations
 
 import os
+import signal
 import shutil
 import subprocess  # nosec B404: subprocess is required for bounded local sandbox execution (remove-by: 2026-07-31, ref: PR-1010)
 import threading
+from typing import IO
+from typing import Final
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO
 from typing import Mapping
 
 from app.security.agent_control_plane import EXECUTION_MODE_AUTO_SAFE
@@ -73,6 +75,8 @@ _EXECUTION_MODE_PRIORITY = {
     EXECUTION_MODE_REVIEW_REQUIRED: 1,
     EXECUTION_MODE_BLOCKED: 2,
 }
+_WINDOWS_PROCESS_GROUP_FLAG = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+_STREAM_JOIN_GRACE_SECONDS: Final[float] = 0.1
 
 
 @dataclass(frozen=True)
@@ -296,23 +300,46 @@ def _coerce_output(value: bytes | str | None) -> str:
 
 
 @dataclass
+class _SharedOutputBudget:
+    """Thread-safe total output budget shared across stdout and stderr."""
+
+    max_bytes: int
+    _consumed: int = 0
+    _lock: threading.Lock | None = None
+
+    def __post_init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def consume(self, chunk: bytes) -> int:
+        if self._lock is None:
+            self._lock = threading.Lock()
+        with self._lock:
+            remaining = self.max_bytes - self._consumed
+            if remaining <= 0:
+                return 0
+            accepted = min(len(chunk), remaining)
+            self._consumed += accepted
+            return accepted
+
+
+@dataclass
 class _StreamingOutputBuffer:
     """Bounded streaming output collector."""
 
-    max_bytes: int
+    budget: _SharedOutputBudget
     _buffer: bytearray
     truncated: bool = False
 
-    def __init__(self, *, max_bytes: int) -> None:
-        self.max_bytes = max_bytes
+    def __init__(self, *, budget: _SharedOutputBudget) -> None:
+        self.budget = budget
         self._buffer = bytearray()
         self.truncated = False
 
     def append(self, chunk: bytes) -> None:
-        remaining = self.max_bytes - len(self._buffer)
-        if remaining > 0:
-            self._buffer.extend(chunk[:remaining])
-        if len(chunk) > max(remaining, 0):
+        accepted = self.budget.consume(chunk)
+        if accepted > 0:
+            self._buffer.extend(chunk[:accepted])
+        if accepted < len(chunk):
             self.truncated = True
 
     def to_text(self) -> str:
@@ -320,7 +347,7 @@ class _StreamingOutputBuffer:
 
 
 def _drain_stream(
-    stream: BinaryIO,
+    stream: IO[bytes],
     *,
     collector: _StreamingOutputBuffer,
 ) -> None:
@@ -332,8 +359,35 @@ def _drain_stream(
             if not chunk:
                 break
             collector.append(chunk)
+    except OSError:
+        # The controller may close a pipe during timeout cleanup.
+        return
     finally:
         stream.close()
+
+
+def _terminate_sandbox_process(process: subprocess.Popen[bytes]) -> None:
+    """Terminate sandbox process without leaving stdio-holding descendants alive."""
+
+    if os.name == "posix":
+        os.killpg(process.pid, signal.SIGKILL)
+        return
+    process.kill()
+
+
+def _join_drain_thread(
+    thread: threading.Thread,
+    *,
+    stream: IO[bytes],
+    timeout_seconds: int,
+) -> None:
+    """Bound drain-thread joins so timeout cleanup cannot block indefinitely."""
+
+    thread.join(timeout=timeout_seconds)
+    if not thread.is_alive():
+        return
+    stream.close()
+    thread.join(timeout=_STREAM_JOIN_GRACE_SECONDS)
 
 
 def run_local_sandbox(
@@ -354,8 +408,9 @@ def run_local_sandbox(
     max_output_bytes = require_sandbox_max_output_bytes()
     env = sanitize_sandbox_env(request.env)
     argv = (binary_path, *request.args)
-    stdout_collector = _StreamingOutputBuffer(max_bytes=max_output_bytes)
-    stderr_collector = _StreamingOutputBuffer(max_bytes=max_output_bytes)
+    output_budget = _SharedOutputBudget(max_bytes=max_output_bytes)
+    stdout_collector = _StreamingOutputBuffer(budget=output_budget)
+    stderr_collector = _StreamingOutputBuffer(budget=output_budget)
 
     process = subprocess.Popen(  # nosec B603: absolute allowlisted binary; argv bounded by sandbox API (remove-by: 2026-07-31, ref: PR-1010)
         argv,
@@ -363,6 +418,8 @@ def run_local_sandbox(
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=(os.name == "posix"),
+        creationflags=_WINDOWS_PROCESS_GROUP_FLAG if os.name == "nt" else 0,
     )
     if process.stdout is None or process.stderr is None:
         raise RuntimeError("Sandbox subprocess must expose stdout/stderr pipes.")
@@ -386,12 +443,12 @@ def run_local_sandbox(
         returncode = process.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
-        process.kill()
+        _terminate_sandbox_process(process)
         process.wait()
         returncode = 124
 
-    stdout_thread.join()
-    stderr_thread.join()
+    _join_drain_thread(stdout_thread, stream=process.stdout, timeout_seconds=timeout_seconds)
+    _join_drain_thread(stderr_thread, stream=process.stderr, timeout_seconds=timeout_seconds)
     return SandboxResult(
         argv=argv,
         returncode=returncode,

--- a/app/security/execution_sandbox.py
+++ b/app/security/execution_sandbox.py
@@ -370,7 +370,10 @@ def _terminate_sandbox_process(process: subprocess.Popen[bytes]) -> None:
     """Terminate sandbox process without leaving stdio-holding descendants alive."""
 
     if os.name == "posix":
-        os.killpg(process.pid, signal.SIGKILL)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         return
     process.kill()
 

--- a/app/security/execution_sandbox.py
+++ b/app/security/execution_sandbox.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess  # nosec B404: subprocess is required for bounded local sandbox execution (remove-by: 2026-07-31, ref: PR-1010)
+import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 from typing import Mapping
 
 from app.security.agent_control_plane import EXECUTION_MODE_AUTO_SAFE
@@ -31,14 +33,13 @@ SANDBOX_ALLOWED_BINARIES_ENV = "AGENT_EXECUTION_SANDBOX_ALLOWED_BINARIES"
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 30
 DEFAULT_SANDBOX_MAX_OUTPUT_BYTES = 32_768
 DEFAULT_ALLOWED_BINARIES = (
-    "coverage",
-    "diff-cover",
     "flake8",
     "git",
     "mypy",
     "pytest",
     "ruff",
 )
+_STREAM_READ_CHUNK_BYTES = 4_096
 _DEFAULT_ENV_KEYS = (
     "HOME",
     "LANG",
@@ -294,15 +295,45 @@ def _coerce_output(value: bytes | str | None) -> str:
     return value
 
 
-def _truncate_output(value: bytes | str | None, *, max_bytes: int) -> tuple[str, bool]:
-    """Truncate text to deterministic byte budget."""
+@dataclass
+class _StreamingOutputBuffer:
+    """Bounded streaming output collector."""
 
-    normalized = _coerce_output(value)
-    encoded = normalized.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return normalized, False
-    truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
-    return truncated, True
+    max_bytes: int
+    _buffer: bytearray
+    truncated: bool = False
+
+    def __init__(self, *, max_bytes: int) -> None:
+        self.max_bytes = max_bytes
+        self._buffer = bytearray()
+        self.truncated = False
+
+    def append(self, chunk: bytes) -> None:
+        remaining = self.max_bytes - len(self._buffer)
+        if remaining > 0:
+            self._buffer.extend(chunk[:remaining])
+        if len(chunk) > max(remaining, 0):
+            self.truncated = True
+
+    def to_text(self) -> str:
+        return self._buffer.decode("utf-8", errors="ignore")
+
+
+def _drain_stream(
+    stream: BinaryIO,
+    *,
+    collector: _StreamingOutputBuffer,
+) -> None:
+    """Read a subprocess stream into a bounded collector."""
+
+    try:
+        while True:
+            chunk = stream.read(_STREAM_READ_CHUNK_BYTES)
+            if not chunk:
+                break
+            collector.append(chunk)
+    finally:
+        stream.close()
 
 
 def run_local_sandbox(
@@ -323,43 +354,50 @@ def run_local_sandbox(
     max_output_bytes = require_sandbox_max_output_bytes()
     env = sanitize_sandbox_env(request.env)
     argv = (binary_path, *request.args)
+    stdout_collector = _StreamingOutputBuffer(max_bytes=max_output_bytes)
+    stderr_collector = _StreamingOutputBuffer(max_bytes=max_output_bytes)
 
+    process = subprocess.Popen(  # nosec B603: absolute allowlisted binary; argv bounded by sandbox API (remove-by: 2026-07-31, ref: PR-1010)
+        argv,
+        cwd=str(sandbox_cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if process.stdout is None or process.stderr is None:
+        raise RuntimeError("Sandbox subprocess must expose stdout/stderr pipes.")
+    stdout_thread = threading.Thread(
+        target=_drain_stream,
+        args=(process.stdout,),
+        kwargs={"collector": stdout_collector},
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_drain_stream,
+        args=(process.stderr,),
+        kwargs={"collector": stderr_collector},
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+
+    timed_out = False
     try:
-        completed = subprocess.run(  # nosec B603: absolute allowlisted binary; argv bounded by sandbox API (remove-by: 2026-07-31, ref: PR-1010)
-            argv,
-            cwd=str(sandbox_cwd),
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
-        stdout, stdout_truncated = _truncate_output(completed.stdout, max_bytes=max_output_bytes)
-        stderr, stderr_truncated = _truncate_output(completed.stderr, max_bytes=max_output_bytes)
-        return SandboxResult(
-            argv=argv,
-            returncode=completed.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=False,
-            truncated=stdout_truncated or stderr_truncated,
-            cwd=str(sandbox_cwd),
-        )
-    except subprocess.TimeoutExpired as exc:
-        stdout, stdout_truncated = _truncate_output(
-            exc.stdout,
-            max_bytes=max_output_bytes,
-        )
-        stderr, stderr_truncated = _truncate_output(
-            exc.stderr,
-            max_bytes=max_output_bytes,
-        )
-        return SandboxResult(
-            argv=argv,
-            returncode=124,
-            stdout=stdout,
-            stderr=stderr,
-            timed_out=True,
-            truncated=stdout_truncated or stderr_truncated,
-            cwd=str(sandbox_cwd),
-        )
+        returncode = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        process.kill()
+        process.wait()
+        returncode = 124
+
+    stdout_thread.join()
+    stderr_thread.join()
+    return SandboxResult(
+        argv=argv,
+        returncode=returncode,
+        stdout=stdout_collector.to_text(),
+        stderr=stderr_collector.to_text(),
+        timed_out=timed_out,
+        truncated=stdout_collector.truncated or stderr_collector.truncated,
+        cwd=str(sandbox_cwd),
+    )

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -5,9 +5,6 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
 Disposition: FIXED
 Commit: see mapping entries below
 Evidence: app/security/execution_sandbox.py:303
@@ -16,6 +13,9 @@ Evidence: app/security/execution_sandbox.py:378
 Evidence: tests/test_execution_sandbox.py:197
 Evidence: tests/test_execution_sandbox.py:214
 Evidence: tests/test_execution_sandbox.py:421
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -10,14 +10,17 @@ Commit: see mapping entries below
 Evidence: app/security/execution_sandbox.py:303
 Evidence: app/security/execution_sandbox.py:349
 Evidence: app/security/execution_sandbox.py:378
+Evidence: app/security/execution_sandbox.py:373
 Evidence: tests/test_execution_sandbox.py:197
 Evidence: tests/test_execution_sandbox.py:214
 Evidence: tests/test_execution_sandbox.py:421
+Evidence: tests/test_execution_sandbox.py:243
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911647600 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902132260 -> a074fcec
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1041 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -5,7 +5,17 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: app/security/execution_sandbox.py:303
+Evidence: app/security/execution_sandbox.py:349
+Evidence: app/security/execution_sandbox.py:378
+Evidence: tests/test_execution_sandbox.py:197
+Evidence: tests/test_execution_sandbox.py:214
+Evidence: tests/test_execution_sandbox.py:421
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -11,6 +11,10 @@ Evidence: app/security/execution_sandbox.py:303
 Evidence: app/security/execution_sandbox.py:349
 Evidence: app/security/execution_sandbox.py:378
 Evidence: app/security/execution_sandbox.py:373
+Evidence: tests/test_execution_sandbox.py:224
+Evidence: tests/test_execution_sandbox.py:241
+Evidence: tests/test_execution_sandbox.py:256
+Evidence: tests/test_execution_sandbox.py:279
 Evidence: tests/test_execution_sandbox.py:197
 Evidence: tests/test_execution_sandbox.py:214
 Evidence: tests/test_execution_sandbox.py:421
@@ -22,6 +26,7 @@ Evidence: tests/test_execution_sandbox.py:243
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911647600 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902132260 -> a074fcec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911763420 -> a074fcec
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902183357 -> 29f20a02
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -27,6 +27,7 @@ Evidence: tests/test_execution_sandbox.py:243
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902132260 -> a074fcec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911763420 -> a074fcec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902183357 -> 29f20a02
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911817997 -> 29f20a02
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -17,6 +17,7 @@ Evidence: tests/test_execution_sandbox.py:421
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911647600 -> f7b5daf0
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -7,12 +7,7 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: app/security/execution_sandbox.py:303
-Evidence: app/security/execution_sandbox.py:349
-Evidence: app/security/execution_sandbox.py:378
-Evidence: tests/test_execution_sandbox.py:197
-Evidence: tests/test_execution_sandbox.py:214
-Evidence: tests/test_execution_sandbox.py:421
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -7,6 +7,12 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
+Evidence: app/security/execution_sandbox.py:303
+Evidence: app/security/execution_sandbox.py:349
+Evidence: app/security/execution_sandbox.py:378
+Evidence: tests/test_execution_sandbox.py:197
+Evidence: tests/test_execution_sandbox.py:214
+Evidence: tests/test_execution_sandbox.py:421
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0

--- a/docs/review/PR_1041_FIXED_MAPPING.md
+++ b/docs/review/PR_1041_FIXED_MAPPING.md
@@ -21,6 +21,7 @@ Evidence: tests/test_execution_sandbox.py:243
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911647600 -> f7b5daf0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902132260 -> a074fcec
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911763420 -> a074fcec
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/tests/test_execution_sandbox.py
+++ b/tests/test_execution_sandbox.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from typing import IO
+from typing import cast
 
 import pytest
 
@@ -219,7 +221,7 @@ def test_drain_stream_ignores_oserror_and_closes_stream() -> None:
 
     stream = _BrokenStream()
     collector = sandbox._StreamingOutputBuffer(budget=sandbox._SharedOutputBudget(max_bytes=8))
-    sandbox._drain_stream(stream, collector=collector)  # type: ignore[arg-type]
+    sandbox._drain_stream(cast(IO[bytes], stream), collector=collector)
     assert stream.closed is True
 
 
@@ -236,7 +238,7 @@ def test_terminate_sandbox_process_uses_kill_on_non_posix(
 
     process = _DummyProcess()
     monkeypatch.setattr(sandbox.os, "name", "nt", raising=False)
-    sandbox._terminate_sandbox_process(process)  # type: ignore[arg-type]
+    sandbox._terminate_sandbox_process(cast(subprocess.Popen[bytes], process))
     assert process.killed is True
 
 
@@ -251,7 +253,7 @@ def test_terminate_sandbox_process_ignores_missing_posix_process_group(
 
     monkeypatch.setattr(sandbox.os, "name", "posix", raising=False)
     monkeypatch.setattr(sandbox.os, "killpg", _raise_process_lookup)
-    sandbox._terminate_sandbox_process(_DummyProcess())  # type: ignore[arg-type]
+    sandbox._terminate_sandbox_process(cast(subprocess.Popen[bytes], _DummyProcess()))
 
 
 def test_join_drain_thread_closes_stream_when_reader_stays_alive() -> None:
@@ -274,7 +276,11 @@ def test_join_drain_thread_closes_stream_when_reader_stays_alive() -> None:
 
     thread = _DummyThread()
     stream = _DummyStream()
-    sandbox._join_drain_thread(thread, stream=stream, timeout_seconds=2)  # type: ignore[arg-type]
+    sandbox._join_drain_thread(
+        cast(sandbox.threading.Thread, thread),
+        stream=cast(IO[bytes], stream),
+        timeout_seconds=2,
+    )
     assert thread.join_calls == [2.0, sandbox._STREAM_JOIN_GRACE_SECONDS]
     assert stream.closed is True
 

--- a/tests/test_execution_sandbox.py
+++ b/tests/test_execution_sandbox.py
@@ -194,6 +194,77 @@ def test_coerce_output_decodes_bytes() -> None:
     assert sandbox._coerce_output(b"hello") == "hello"
 
 
+def test_coerce_output_preserves_text() -> None:
+    assert sandbox._coerce_output("hello") == "hello"
+
+
+def test_shared_output_budget_recreates_lock_and_stops_after_budget_exhaustion() -> None:
+    budget = sandbox._SharedOutputBudget(max_bytes=1)
+    budget._lock = None
+    assert budget.consume(b"a") == 1
+    budget._lock = None
+    assert budget.consume(b"b") == 0
+
+
+def test_drain_stream_ignores_oserror_and_closes_stream() -> None:
+    class _BrokenStream:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def read(self, _size: int) -> bytes:
+            raise OSError("stream closed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    stream = _BrokenStream()
+    collector = sandbox._StreamingOutputBuffer(budget=sandbox._SharedOutputBudget(max_bytes=8))
+    sandbox._drain_stream(stream, collector=collector)  # type: ignore[arg-type]
+    assert stream.closed is True
+
+
+def test_terminate_sandbox_process_uses_kill_on_non_posix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _DummyProcess:
+        def __init__(self) -> None:
+            self.pid = 123
+            self.killed = False
+
+        def kill(self) -> None:
+            self.killed = True
+
+    process = _DummyProcess()
+    monkeypatch.setattr(sandbox.os, "name", "nt", raising=False)
+    sandbox._terminate_sandbox_process(process)  # type: ignore[arg-type]
+    assert process.killed is True
+
+
+def test_join_drain_thread_closes_stream_when_reader_stays_alive() -> None:
+    class _DummyThread:
+        def __init__(self) -> None:
+            self.join_calls: list[float] = []
+
+        def join(self, timeout: float | None = None) -> None:
+            self.join_calls.append(float(timeout or 0))
+
+        def is_alive(self) -> bool:
+            return len(self.join_calls) == 1
+
+    class _DummyStream:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    thread = _DummyThread()
+    stream = _DummyStream()
+    sandbox._join_drain_thread(thread, stream=stream, timeout_seconds=2)  # type: ignore[arg-type]
+    assert thread.join_calls == [2.0, sandbox._STREAM_JOIN_GRACE_SECONDS]
+    assert stream.closed is True
+
+
 def test_run_local_sandbox_executes_allowlisted_python(
     sandbox_root: Path,
 ) -> None:
@@ -263,6 +334,26 @@ def test_run_local_sandbox_request_mode_can_tighten_runtime(
         )
 
 
+def test_run_local_sandbox_rejects_missing_pipes(
+    sandbox_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _DummyProcess:
+        def __init__(self) -> None:
+            self.stdout = None
+            self.stderr = None
+
+    monkeypatch.setattr(sandbox.subprocess, "Popen", lambda *args, **kwargs: _DummyProcess())
+    with pytest.raises(RuntimeError, match="stdout/stderr pipes"):
+        sandbox.run_local_sandbox(
+            sandbox.SandboxRequest(
+                binary="python3",
+                args=("-c", "print('x')"),
+                cwd=sandbox_root,
+            )
+        )
+
+
 def test_run_local_sandbox_times_out(
     sandbox_root: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -272,6 +363,29 @@ def test_run_local_sandbox_times_out(
         sandbox.SandboxRequest(
             binary="python3",
             args=("-c", "import signal; signal.pause()"),
+            cwd=sandbox_root,
+        )
+    )
+    assert result.returncode == 124
+    assert result.timed_out is True
+
+
+def test_run_local_sandbox_timeout_kills_descendants_holding_stdio(
+    sandbox_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(sandbox.SANDBOX_TIMEOUT_ENV, "1")
+    result = sandbox.run_local_sandbox(
+        sandbox.SandboxRequest(
+            binary="python3",
+            args=(
+                "-c",
+                (
+                    "import subprocess, sys, time;"
+                    "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']);"
+                    "time.sleep(30)"
+                ),
+            ),
             cwd=sandbox_root,
         )
     )
@@ -331,6 +445,35 @@ def test_run_local_sandbox_stream_limits_stderr_during_execution(
     assert result.returncode == 0
     assert result.truncated is True
     assert len(result.stderr.encode("utf-8")) <= 8
+
+
+def test_run_local_sandbox_stream_limit_applies_across_stdout_and_stderr(
+    sandbox_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(sandbox.SANDBOX_MAX_OUTPUT_ENV, "8")
+    result = sandbox.run_local_sandbox(
+        sandbox.SandboxRequest(
+            binary="python3",
+            args=(
+                "-c",
+                (
+                    "import sys;"
+                    "sys.stdout.write('abcd');"
+                    "sys.stdout.flush();"
+                    "sys.stderr.write('efgh');"
+                    "sys.stderr.flush();"
+                    "sys.stdout.write('ijkl');"
+                    "sys.stdout.flush()"
+                ),
+            ),
+            cwd=sandbox_root,
+        )
+    )
+    combined_bytes = len(result.stdout.encode("utf-8")) + len(result.stderr.encode("utf-8"))
+    assert result.returncode == 0
+    assert result.truncated is True
+    assert combined_bytes <= 8
 
 
 def test_run_local_sandbox_cli_emits_deterministic_json(sandbox_root: Path) -> None:

--- a/tests/test_execution_sandbox.py
+++ b/tests/test_execution_sandbox.py
@@ -240,6 +240,20 @@ def test_terminate_sandbox_process_uses_kill_on_non_posix(
     assert process.killed is True
 
 
+def test_terminate_sandbox_process_ignores_missing_posix_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _DummyProcess:
+        pid = 123
+
+    def _raise_process_lookup(_pid: int, _signal: int) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(sandbox.os, "name", "posix", raising=False)
+    monkeypatch.setattr(sandbox.os, "killpg", _raise_process_lookup)
+    sandbox._terminate_sandbox_process(_DummyProcess())  # type: ignore[arg-type]
+
+
 def test_join_drain_thread_closes_stream_when_reader_stays_alive() -> None:
     class _DummyThread:
         def __init__(self) -> None:

--- a/tests/test_execution_sandbox.py
+++ b/tests/test_execution_sandbox.py
@@ -51,6 +51,11 @@ def test_default_allowed_binaries_exclude_python_interpreters() -> None:
     assert "python3" not in sandbox.DEFAULT_ALLOWED_BINARIES
 
 
+def test_default_allowed_binaries_keep_full_gates_opt_in() -> None:
+    assert "coverage" not in sandbox.DEFAULT_ALLOWED_BINARIES
+    assert "diff-cover" not in sandbox.DEFAULT_ALLOWED_BINARIES
+
+
 def test_parse_allowed_binaries_skips_duplicates() -> None:
     parsed = sandbox.parse_allowed_binaries("python3,\npython3,pytest")
     assert parsed == ("python3", "pytest")
@@ -274,7 +279,7 @@ def test_run_local_sandbox_times_out(
     assert result.timed_out is True
 
 
-def test_run_local_sandbox_truncates_output(
+def test_run_local_sandbox_stream_limits_stdout_during_execution(
     sandbox_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -282,13 +287,50 @@ def test_run_local_sandbox_truncates_output(
     result = sandbox.run_local_sandbox(
         sandbox.SandboxRequest(
             binary="python3",
-            args=("-c", "print('0123456789abcdef')"),
+            args=(
+                "-c",
+                (
+                    "import sys, time;"
+                    "sys.stdout.write('01234567');"
+                    "sys.stdout.flush();"
+                    "time.sleep(0.05);"
+                    "sys.stdout.write('89abcdef');"
+                    "sys.stdout.flush()"
+                ),
+            ),
             cwd=sandbox_root,
         )
     )
     assert result.returncode == 0
     assert result.truncated is True
     assert len(result.stdout.encode("utf-8")) <= 8
+
+
+def test_run_local_sandbox_stream_limits_stderr_during_execution(
+    sandbox_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(sandbox.SANDBOX_MAX_OUTPUT_ENV, "8")
+    result = sandbox.run_local_sandbox(
+        sandbox.SandboxRequest(
+            binary="python3",
+            args=(
+                "-c",
+                (
+                    "import sys, time;"
+                    "sys.stderr.write('abcdefgh');"
+                    "sys.stderr.flush();"
+                    "time.sleep(0.05);"
+                    "sys.stderr.write('ijklmnop');"
+                    "sys.stderr.flush()"
+                ),
+            ),
+            cwd=sandbox_root,
+        )
+    )
+    assert result.returncode == 0
+    assert result.truncated is True
+    assert len(result.stderr.encode("utf-8")) <= 8
 
 
 def test_run_local_sandbox_cli_emits_deterministic_json(sandbox_root: Path) -> None:

--- a/tests/test_food_apis.py
+++ b/tests/test_food_apis.py
@@ -14,6 +14,12 @@ from core.food_apis.update_manager import DatabaseUpdateManager, UpdateResult
 from core.food_apis.usda_client import USDAClient, USDAFoodItem
 
 
+@pytest.fixture(autouse=True)
+def disable_default_off_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable live OFF client by default; tests may override with explicit mocks."""
+    monkeypatch.setattr("core.food_apis.unified_db.OFFClient", None)
+
+
 class TestUSDAClient:
     """Test USDA FoodData Central API client."""
 
@@ -569,6 +575,7 @@ class TestUnifiedFoodDatabase:
     async def test_unified_database_initialization(self):
         """Test unified database initialization."""
         db = UnifiedFoodDatabase("test_cache")
+        db.off_client = None
 
         # Should initialize without errors
         assert db.cache_dir.name == "test_cache"
@@ -578,10 +585,8 @@ class TestUnifiedFoodDatabase:
         await db.close()
 
     @pytest.mark.asyncio
-    @patch("core.food_apis.usda_client.get_common_foods_database")
-    async def test_unified_database_get_foods(self, mock_get_foods):
+    async def test_unified_database_get_foods(self):
         """Test getting foods from unified database."""
-        # Mock USDA response
         mock_usda_food = USDAFoodItem(
             fdc_id=123,
             description="Test Chicken",
@@ -596,10 +601,13 @@ class TestUnifiedFoodDatabase:
             publication_date="2024-01-01",
         )
 
-        mock_get_foods.return_value = {"chicken_breast": mock_usda_food}
-
         db = UnifiedFoodDatabase("test_cache")
-        foods = await db.get_common_foods_database()
+        db.off_client = None
+        db.usda_client = AsyncMock()
+        db.usda_client.search_foods.return_value = [mock_usda_food]
+
+        with patch("core.food_apis.unified_db.asyncio.sleep", new=AsyncMock()):
+            foods = await db.get_common_foods_database()
 
         assert "chicken_breast" in foods
         assert isinstance(foods["chicken_breast"], UnifiedFoodItem)

--- a/tests/test_food_apis_basic_coverage.py
+++ b/tests/test_food_apis_basic_coverage.py
@@ -10,6 +10,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def disable_default_off_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable live OFF client by default; tests may override with explicit mocks."""
+    monkeypatch.setattr("core.food_apis.unified_db.OFFClient", None)
+
+
 # Test unified_db module
 class TestUnifiedFoodDatabase:
     """Basic tests for UnifiedFoodDatabase to improve coverage."""
@@ -73,6 +79,7 @@ class TestUnifiedFoodDatabase:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             db = UnifiedFoodDatabase(cache_dir=temp_dir)
+            db.off_client = None
             results = await db.search_food("chicken")
 
             # Should return some results (fallback data or cached)

--- a/tests/test_food_apis_comprehensive_coverage.py
+++ b/tests/test_food_apis_comprehensive_coverage.py
@@ -14,6 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def disable_default_off_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable live OFF client by default; tests may override with explicit mocks."""
+    monkeypatch.setattr("core.food_apis.unified_db.OFFClient", None)
+
+
 # Test scheduler module comprehensively
 @pytest.mark.slow
 class TestDatabaseUpdateSchedulerComprehensive:
@@ -343,6 +349,7 @@ class TestUnifiedFoodDatabaseComprehensive:
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 db = UnifiedFoodDatabase(cache_dir=temp_dir)
+                db.off_client = None
 
                 # Test with prefer_source='openfoodfacts'
                 # Currently this will fall back to USDA since OFF is not implemented
@@ -372,6 +379,7 @@ class TestUnifiedFoodDatabaseComprehensive:
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 db = UnifiedFoodDatabase(cache_dir=temp_dir)
+                db.off_client = None
 
                 results = await db.search_food("chicken")
 
@@ -451,6 +459,7 @@ class TestUnifiedFoodDatabaseComprehensive:
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 db = UnifiedFoodDatabase(cache_dir=temp_dir)
+                db.off_client = None
 
                 # Create an invalid cache file
                 cache_file = db.cache_dir / "common_foods.json"
@@ -474,6 +483,7 @@ class TestUnifiedFoodDatabaseComprehensive:
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 db = UnifiedFoodDatabase(cache_dir=temp_dir)
+                db.off_client = None
 
                 # Make the cache directory read-only to cause save exception
                 _ = db.cache_dir / "common_foods.json"
@@ -498,6 +508,7 @@ class TestUnifiedFoodDatabaseComprehensive:
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 db = UnifiedFoodDatabase(cache_dir=temp_dir)
+                db.off_client = None
 
                 # Should handle the exception and continue with other searches
                 foods_db = await db.get_common_foods_database()

--- a/tests/test_food_apis_coverage_errors.py
+++ b/tests/test_food_apis_coverage_errors.py
@@ -7,7 +7,7 @@ Targets ~40 lines in update_manager.py (15% coverage) and unified_db.py (19% cov
 import json
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from core.food_apis.update_manager import DatabaseUpdateManager, UpdateResult
@@ -274,27 +274,36 @@ class TestFoodAPIsUpdatePipeline:
     @pytest.mark.asyncio
     async def test_update_usda_database_no_force_same_checksum(self, update_manager):
         """Test _update_usda_database with same checksum, no force (line 308)."""
-        # Mock current version with same checksum
-        current_version = type(
-            "Version", (), {"checksum": "same_checksum_123", "timestamp": "2023-01-01T00:00:00Z"}
-        )()
+        from core.food_apis.update_manager import DatabaseVersion
 
-        with patch.object(update_manager, "_load_versions", return_value={"usda": current_version}):
-            with patch("core.food_apis.update_manager.USDAClient") as mock_usda:
-                mock_usda.return_value.get_all_foods.return_value = []
+        current_version = DatabaseVersion(
+            source="usda",
+            version="20230101_000000",
+            last_updated="2023-01-01T00:00:00Z",
+            record_count=1,
+            checksum="same_checksum_123",
+            metadata={},
+        )
+        update_manager.versions["usda"] = current_version
 
-                # Mock checksum calculation to return same value
-                with patch("core.food_apis.update_manager.hashlib.sha256") as mock_hash:
-                    mock_hash.return_value.hexdigest.return_value = "same_checksum_123"
-
+        with patch.object(
+            update_manager.unified_db,
+            "get_common_foods_database",
+            return_value={},
+        ):
+            with patch.object(
+                update_manager,
+                "_calculate_checksum",
+                return_value="same_checksum_123",
+            ):
+                with patch.object(update_manager, "_create_backup", new=AsyncMock()) as mock_backup:
                     result = await update_manager._update_usda_database(force=False)
 
-                    # Should skip update due to same checksum (or fail gracefully if API rate limited)
-                    assert result is not None
-                    assert isinstance(result.success, bool)
-                    # If successful, should have 0 records updated (same checksum)
-                    if result.success:
-                        assert result.records_updated == 0
+        assert result is not None
+        assert result.success is True
+        assert result.new_version == current_version.version
+        assert result.records_updated == 0
+        mock_backup.assert_awaited_once_with("usda", current_version.version)
 
     @pytest.mark.asyncio
     async def test_update_usda_database_old_data_load_error(

--- a/tests/test_unified_db_advanced.py
+++ b/tests/test_unified_db_advanced.py
@@ -59,6 +59,7 @@ class TestUnifiedFoodDatabaseCommonFoods:
     async def test_get_common_foods_database_from_cache(self, temp_cache_dir):
         """Test getting common foods from cache."""
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
+        db.off_client = None
 
         # Write cache file using mock_open and mock Path.exists separately
         with patch(
@@ -93,6 +94,7 @@ class TestUnifiedFoodDatabaseCommonFoods:
 
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
         db.usda_client = mock_usda_client
+        db.off_client = None
 
         # Mock asyncio.sleep to speed up test
         with patch("asyncio.sleep", new_callable=AsyncMock):
@@ -125,6 +127,7 @@ class TestUnifiedFoodDatabaseCommonFoods:
     async def test_get_common_foods_database_cache_error(self, temp_cache_dir):
         """Test common foods database with cache loading error."""
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
+        db.off_client = None
 
         # Mock file exists but reading fails
         with patch("pathlib.Path.exists", return_value=True):
@@ -149,6 +152,7 @@ class TestUnifiedFoodDatabaseCommonFoods:
 
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
         db.usda_client = mock_usda_client
+        db.off_client = None
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             foods_db = await db.get_common_foods_database()
@@ -175,6 +179,7 @@ class TestUnifiedFoodDatabaseCommonFoods:
 
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
         db.usda_client = mock_usda_client
+        db.off_client = None
 
         # Mock file operations to fail on write
         with patch("builtins.open", side_effect=PermissionError("Cannot write")):

--- a/tests/test_unified_db_basics.py
+++ b/tests/test_unified_db_basics.py
@@ -314,6 +314,7 @@ class TestUnifiedFoodDatabaseSearch:
         """Test food search with USDA preferred."""
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
         db.usda_client = mock_usda_client
+        db.off_client = None
 
         results = await db.search_food("chicken breast", prefer_source="usda")
 
@@ -370,6 +371,7 @@ class TestUnifiedFoodDatabaseSearch:
     async def test_search_food_cached_result(self, temp_cache_dir):
         """Test search returns cached result."""
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
+        db.off_client = None
 
         # Add cached item
         cached_item = UnifiedFoodItem(
@@ -435,6 +437,7 @@ class TestUnifiedFoodDatabaseGetById:
 
         db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
         db.usda_client = mock_usda_client
+        db.off_client = None
 
         result = await db.get_food_by_id("usda", "12345")
 

--- a/tests/test_unified_db_coverage.py
+++ b/tests/test_unified_db_coverage.py
@@ -68,6 +68,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase()
+            db.off_client = None
             results = await db.search_food("test query")
 
             # Проверяем, что данные были обработаны
@@ -91,6 +92,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase()
+            db.off_client = None
 
             # Тестируем метод close
             if hasattr(db, "close"):
@@ -129,6 +131,7 @@ class TestUnifiedDBCoverage:
 
             # Create database with custom cache directory
             db = UnifiedFoodDatabase(cache_dir=str(tmp_path))
+            db.off_client = None
             cache_file = tmp_path / "unified_food_cache.json"
 
             # Verify cache doesn't exist initially
@@ -176,6 +179,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase(cache_dir=str(tmp_path))
+            db.off_client = None
             cache_file = tmp_path / "unified_food_cache.json"
 
             # Call search_food with save_cache=False
@@ -215,6 +219,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase(cache_dir=str(tmp_path))
+            db.off_client = None
             cache_file = tmp_path / "unified_food_cache.json"
 
             # Call search_food WITHOUT save_cache arg (should default to True)
@@ -268,6 +273,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase(cache_dir=str(tmp_path))
+            db.off_client = None
             cache_file = tmp_path / "unified_food_cache.json"
 
             # Sequence 1: save_cache=True, then save_cache=False
@@ -330,6 +336,7 @@ class TestUnifiedDBCoverage:
             from core.food_apis.unified_db import UnifiedFoodDatabase
 
             db = UnifiedFoodDatabase(cache_dir=str(tmp_path))
+            db.off_client = None
             cache_file = tmp_path / "unified_food_cache.json"
 
             # Create initial cache with save_cache=True


### PR DESCRIPTION
# Pull Request

## Summary

Implements the deferred sandbox hardening follow-up from PR #1013 by switching local execution output enforcement from post-capture truncation to streaming bounded collection. The PR also reduces the default sandbox binary baseline so full-gate tooling stays explicit opt-in instead of part of the runtime default allowlist.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [x] Linked issues/PRs: follow-up to #1013; backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-pr1013-sandbox-hardening-followups`

## Risk & Impact

Internal runtime/security hardening only. No public API, schema, or client behavior changes.

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [x] Integration/slow tests (if applicable)
- [x] Manual verification steps

Validation run locally:
- `pytest -q tests/test_execution_sandbox.py`
- `pre-commit run --all-files`
- `make verify`

Raw validation results:
- `pytest -q tests/test_execution_sandbox.py` -> `45 passed`
- `pre-commit run --all-files` -> passed
- `make verify` -> passed; diff-cover reported `app/security/execution_sandbox.py (100%)`, total diff coverage `100%`

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Disposition: FIXED
Commit: see mapping entries below
Evidence: app/security/execution_sandbox.py:303
Evidence: app/security/execution_sandbox.py:349
Evidence: app/security/execution_sandbox.py:378
Evidence: app/security/execution_sandbox.py:373
Evidence: tests/test_execution_sandbox.py:197
Evidence: tests/test_execution_sandbox.py:214
Evidence: tests/test_execution_sandbox.py:243
Evidence: tests/test_execution_sandbox.py:421

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902025937 -> f7b5daf0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034064 -> f7b5daf0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902034065 -> f7b5daf0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911647600 -> f7b5daf0
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902132260 -> a074fcec
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911763420 -> a074fcec
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#discussion_r2902183357 -> 29f20a02
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1041#pullrequestreview-3911817997 -> 29f20a02

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [x] No unresolved review threads
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): `docs/roadmap/BACKLOG_LEDGER.md#ledger-pr1013-fitchef-phase2-scope` remains explicitly out of scope for this PR
- [x] GitHub issue(s): None

## Notes

### For Simple Changes

- [x] No database/schema/migration changes
- [x] No public API contract changes (endpoints, request/response, events)
- [x] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [x] No user-facing performance impact

Rollback / Feature flag (brief):

- How to revert: revert commit `bab053b9`
- Feature flag/toggle (if any): `AGENT_EXECUTION_SANDBOX_ENABLED` remains the runtime gate
- Owner for emergency contact: @katsiaryna_kavaleuskaya

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams sandbox stdout/stderr into bounded buffers with a shared budget to enforce output limits during execution. Hardens timeout cleanup and process-group handling, tightens the default allowlist, adds the PR 1041 fixed-mapping proof doc, and replaces test arg-type ignores with `typing.cast`.

- **Bug Fixes**
  - Stream stdout/stderr with a shared budget; enforce limits mid-run and set `truncated` on overflow.
  - Start a new session/process group (`CREATE_NEW_PROCESS_GROUP` on Windows); on timeout, kill the whole group, ignore `killpg` races, and return `124`.
  - Drain pipes in background threads with bounded joins; close pipes to avoid hangs, reject missing pipes, and ignore `OSError` while draining.

- **Migration**
  - `coverage` and `diff-cover` were removed from defaults; add them to `AGENT_EXECUTION_SANDBOX_ALLOWED_BINARIES` if needed.

<sup>Written for commit 0a446c6b90da9da84de23dcb261603b346b54f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming output capture with global size limits and more robust timeout/termination for sandboxed subprocesses.

* **Chores**
  * Default allowed binaries updated (removed two entries).
  * Secret baseline regenerated with updated timestamps/locations.

* **Tests**
  * Extensive sandbox tests for streaming, budgeting, timeouts, termination, and allowlist.
  * Tests updated to disable live external client by default and adjust related mocks/fixtures.

* **Documentation**
  * Added a review/merge-readiness document summarizing fixes and mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->








