### PR TITLE
feat(compliance): add internal DSAR helpers for direct-user artifacts

### DIFF
--- a/core/compliance/__init__.py
+++ b/core/compliance/__init__.py
@@ -9,6 +9,11 @@ from core.compliance.dsar import (
     get_dsar_artifact_map,
     summarize_dsar_support,
 )
+from core.compliance.dsar_service import (
+    build_direct_user_deletion_plan,
+    delete_direct_user_artifacts,
+    export_direct_user_artifacts,
+)
 from core.compliance.minimization import (
     SensitiveFieldPolicy,
     get_sensitive_field_taxonomy,
@@ -32,8 +37,11 @@ __all__ = [
     "PRIVACY_POLICY_LAST_UPDATED",
     "PRIVACY_POLICY_VERSION",
     "SensitiveFieldPolicy",
+    "build_direct_user_deletion_plan",
     "build_dsar_rights_summary",
     "build_privacy_endpoint_payload",
+    "delete_direct_user_artifacts",
+    "export_direct_user_artifacts",
     "get_blocked_regulated_lane",
     "get_dsar_artifact_map",
     "get_processing_categories",

--- a/core/compliance/dsar_service.py
+++ b/core/compliance/dsar_service.py
@@ -6,10 +6,13 @@ EN: Internal DSAR helpers for support-led export/delete of direct user-bound art
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 
 def _serialize_timestamp(value: datetime | None) -> str | None:
@@ -100,14 +103,12 @@ def build_direct_user_deletion_plan(*, session: Session, user_id: int) -> dict[s
     from core.models import User
 
     user_exists = session.get(User, user_id) is not None
-    feedback_records = (
-        session.execute(select(RAGFeedback).where(RAGFeedback.user_id == user_id)).scalars().all()
-    )
-    knowledge_records = (
-        session.execute(select(UserKnowledge).where(UserKnowledge.user_id == user_id))
-        .scalars()
-        .all()
-    )
+    feedback_count = session.execute(
+        select(func.count()).select_from(RAGFeedback).where(RAGFeedback.user_id == user_id)
+    ).scalar_one()
+    knowledge_count = session.execute(
+        select(func.count()).select_from(UserKnowledge).where(UserKnowledge.user_id == user_id)
+    ).scalar_one()
 
     return {
         "user_id": user_id,
@@ -118,11 +119,11 @@ def build_direct_user_deletion_plan(*, session: Session, user_id: int) -> dict[s
                 "notes": "Account-row deletion stays on the dedicated user deletion path, not this helper.",
             },
             "rag_feedback": {
-                "present_count": len(feedback_records),
+                "present_count": feedback_count,
                 "helper_action": "delete_now",
             },
             "user_knowledge": {
-                "present_count": len(knowledge_records),
+                "present_count": knowledge_count,
                 "helper_action": "delete_now",
             },
         },
@@ -136,18 +137,21 @@ def delete_direct_user_artifacts(*, session: Session, user_id: int) -> dict[str,
     from core.models import User
 
     user_exists = session.get(User, user_id) is not None
-    feedback_deleted = len(
-        session.execute(select(RAGFeedback.id).where(RAGFeedback.user_id == user_id)).all()
-    )
-    knowledge_deleted = len(
-        session.execute(select(UserKnowledge.id).where(UserKnowledge.user_id == user_id)).all()
-    )
     try:
-        session.execute(delete(RAGFeedback).where(RAGFeedback.user_id == user_id))
-        session.execute(delete(UserKnowledge).where(UserKnowledge.user_id == user_id))
+        feedback_result = session.execute(
+            delete(RAGFeedback).where(RAGFeedback.user_id == user_id).returning(RAGFeedback.id)
+        )
+        knowledge_result = session.execute(
+            delete(UserKnowledge)
+            .where(UserKnowledge.user_id == user_id)
+            .returning(UserKnowledge.id)
+        )
+        feedback_deleted = len(feedback_result.scalars().all())
+        knowledge_deleted = len(knowledge_result.scalars().all())
         session.commit()
     except Exception:
         session.rollback()
+        logger.exception("DSAR direct-user artifact delete failed")
         raise
 
     pending_manual_artifacts: list[str] = []

--- a/core/compliance/dsar_service.py
+++ b/core/compliance/dsar_service.py
@@ -1,0 +1,166 @@
+"""Internal DSAR helper services for direct-user artifacts.
+
+RU: Внутренние DSAR-хелперы для support-led export/delete прямых user-bound артефактов.
+EN: Internal DSAR helpers for support-led export/delete of direct user-bound artifacts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+
+def _serialize_timestamp(value: datetime | None) -> str | None:
+    """Return an ISO timestamp with explicit UTC fallback for naive datetimes."""
+
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc).isoformat()
+    return value.isoformat()
+
+
+def export_direct_user_artifacts(*, session: Session, user_id: int) -> dict[str, object]:
+    """Export direct-user SQL artifacts for internal support-led DSAR handling."""
+
+    from app.models.rag_feedback import RAGFeedback, UserKnowledge
+    from core.models import User
+
+    user = session.get(User, user_id)
+    feedback_rows = (
+        session.execute(
+            select(RAGFeedback).where(RAGFeedback.user_id == user_id).order_by(RAGFeedback.id.asc())
+        )
+        .scalars()
+        .all()
+    )
+    knowledge_rows = (
+        session.execute(
+            select(UserKnowledge)
+            .where(UserKnowledge.user_id == user_id)
+            .order_by(UserKnowledge.id.asc())
+        )
+        .scalars()
+        .all()
+    )
+
+    user_payload = None
+    if user is not None:
+        user_payload = {
+            "id": user.id,
+            "email": user.email,
+            "name": user.name,
+            "created_at": _serialize_timestamp(user.created_at),
+        }
+
+    return {
+        "user_id": user_id,
+        "artifacts": {
+            "account_user_record": user_payload,
+            "rag_feedback": [
+                {
+                    "id": row.id,
+                    "agent_id": row.agent_id,
+                    "query": row.query,
+                    "retrieved_chunks": row.retrieved_chunks,
+                    "llm_response": row.llm_response,
+                    "user_rating": row.user_rating,
+                    "user_correction": row.user_correction,
+                    "confidence": row.confidence,
+                    "hops": row.hops,
+                    "created_at": _serialize_timestamp(row.created_at),
+                }
+                for row in feedback_rows
+            ],
+            "user_knowledge": [
+                {
+                    "id": row.id,
+                    "content": row.content,
+                    "embedding": row.embedding,
+                    "source": row.source,
+                    "created_at": _serialize_timestamp(row.created_at),
+                }
+                for row in knowledge_rows
+            ],
+        },
+        "artifact_counts": {
+            "account_user_record": 1 if user_payload is not None else 0,
+            "rag_feedback": len(feedback_rows),
+            "user_knowledge": len(knowledge_rows),
+        },
+    }
+
+
+def build_direct_user_deletion_plan(*, session: Session, user_id: int) -> dict[str, object]:
+    """Return the bounded DSAR deletion plan for direct-user artifacts."""
+
+    from app.models.rag_feedback import RAGFeedback, UserKnowledge
+    from core.models import User
+
+    user_exists = session.get(User, user_id) is not None
+    feedback_records = (
+        session.execute(select(RAGFeedback).where(RAGFeedback.user_id == user_id)).scalars().all()
+    )
+    knowledge_records = (
+        session.execute(select(UserKnowledge).where(UserKnowledge.user_id == user_id))
+        .scalars()
+        .all()
+    )
+
+    return {
+        "user_id": user_id,
+        "artifacts": {
+            "account_user_record": {
+                "present": user_exists,
+                "helper_action": "manual_existing_user_delete_flow",
+                "notes": "Account-row deletion stays on the dedicated user deletion path, not this helper.",
+            },
+            "rag_feedback": {
+                "present_count": len(feedback_records),
+                "helper_action": "delete_now",
+            },
+            "user_knowledge": {
+                "present_count": len(knowledge_records),
+                "helper_action": "delete_now",
+            },
+        },
+    }
+
+
+def delete_direct_user_artifacts(*, session: Session, user_id: int) -> dict[str, object]:
+    """Delete bounded direct-user SQL artifacts for support-led DSAR handling."""
+
+    from app.models.rag_feedback import RAGFeedback, UserKnowledge
+    from core.models import User
+
+    user_exists = session.get(User, user_id) is not None
+    feedback_deleted = len(
+        session.execute(select(RAGFeedback.id).where(RAGFeedback.user_id == user_id)).all()
+    )
+    knowledge_deleted = len(
+        session.execute(select(UserKnowledge.id).where(UserKnowledge.user_id == user_id)).all()
+    )
+    try:
+        session.execute(delete(RAGFeedback).where(RAGFeedback.user_id == user_id))
+        session.execute(delete(UserKnowledge).where(UserKnowledge.user_id == user_id))
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    pending_manual_artifacts: list[str] = []
+    if user_exists:
+        pending_manual_artifacts.append("account_user_record")
+
+    return {
+        "user_id": user_id,
+        "deleted": {
+            "account_user_record": 0,
+            "rag_feedback": feedback_deleted,
+            "user_knowledge": knowledge_deleted,
+        },
+        "deleted_any": any((feedback_deleted, knowledge_deleted)),
+        "pending_manual_artifacts": pending_manual_artifacts,
+    }

--- a/docs/compliance/DSAR_AND_DELETION_MAP.md
+++ b/docs/compliance/DSAR_AND_DELETION_MAP.md
@@ -18,5 +18,6 @@ direct-user artifacts without promising a public self-service endpoint.
 ## Current DSAR Posture
 
 - Support can service access/export/delete requests for direct-user SQL artifacts.
+- Internal runtime helpers now provide deterministic export coverage for `users`, plus bounded delete execution for `rag_feedback` and `user_knowledge` with an explicit account-delete plan.
 - Pseudonymous security artifacts and minimized audit artifacts are not exposed as public self-service assets.
 - Deletion is implemented as row removal or retention-driven cleanup, not arbitrary in-place editing.

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -26,6 +26,7 @@ PulsePlate wellness runtime.
 - `core/compliance/transparency.py`
 - `core/compliance/minimization.py`
 - `core/compliance/dsar.py`
+- `core/compliance/dsar_service.py`
 - `legacy_app.py`
 
 ## Legal Publication Endpoints

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -17,6 +17,12 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 3ea26eeb
   Disposition: FIXED
   Evidence: tests/test_compliance_control_plane.py:307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581742
+  Disposition: DEFERRED
+  Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:106
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 3ea26eeb
   Disposition: FIXED
   Evidence: tests/test_compliance_control_plane.py:176

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1049 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Scope tied to PR objective
+- [x] Docs/runtime changes applied
+- [x] Verification completed
+- [ ] Required GitHub checks PASS with no pending required jobs
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] No unresolved review threads or actionable bot comments remain
+- [ ] Review wait-window completed

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -7,33 +7,42 @@
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:106
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:141
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: tests/test_compliance_control_plane.py:307
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581742
   Disposition: DEFERRED
   Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:106
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: tests/test_compliance_control_plane.py:176
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: tests/test_compliance_control_plane.py:176
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589271
   Disposition: NOT-A-BUG
@@ -41,6 +50,7 @@
   Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 61988053
   Disposition: FIXED
+  Commit: 61988053
   Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917801490
   Disposition: NOT-A-BUG

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -42,6 +42,10 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 3ea26eeb
   Disposition: FIXED
   Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917801490
+  Disposition: NOT-A-BUG
+  Evidence: tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
+  Reason: The test already starts with deterministic stale-record cleanup and removes the dedicated account row before exit; a mid-test assertion failure would not leak cross-test state beyond this isolated email-specific fixture path.
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -6,60 +6,73 @@
 
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:106
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:106
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:141
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:141
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: tests/test_compliance_control_plane.py:307
+Disposition: FIXED
+Commit: 61988053
+Evidence: tests/test_compliance_control_plane.py:307
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581742
-  Disposition: DEFERRED
-  Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:106
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:106
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: tests/test_compliance_control_plane.py:176
+Disposition: FIXED
+Commit: 61988053
+Evidence: tests/test_compliance_control_plane.py:176
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: tests/test_compliance_control_plane.py:176
+Disposition: FIXED
+Commit: 61988053
+Evidence: tests/test_compliance_control_plane.py:176
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
+Disposition: FIXED
+Commit: 61988053
+Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589271
-  Disposition: NOT-A-BUG
-  Evidence: scripts/ci/check_pr_body_phase2_gates.py:119; scripts/orchestration/review_mapping_artifact.py:102
-  Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
+Disposition: NOT-A-BUG
+Evidence: scripts/ci/check_pr_body_phase2_gates.py:119; scripts/orchestration/review_mapping_artifact.py:102
+Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 61988053
-  Disposition: FIXED
-  Commit: 61988053
-  Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
+Disposition: FIXED
+Commit: 61988053
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917801490
-  Disposition: NOT-A-BUG
-  Evidence: tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
-  Reason: The test already starts with deterministic stale-record cleanup and removes the dedicated account row before exit; a mid-test assertion failure would not leak cross-test state beyond this isolated email-specific fixture path.
+Disposition: NOT-A-BUG
+Evidence: tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
+Reason: The test already starts with deterministic stale-record cleanup and removes the dedicated account row before exit; a mid-test assertion failure would not leak cross-test state beyond this isolated email-specific fixture path.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917985096
-  Disposition: NOT-A-BUG
-  Evidence: core/compliance/dsar_service.py:28; core/compliance/dsar_service.py:99; core/compliance/dsar_service.py:133; tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
-  Reason: The review suggests follow-up refactors for stricter `TypedDict` contracts and a shared DSAR fixture, but the current helper shapes and tests are deterministic, mypy-clean, and scoped intentionally to this internal helper PR rather than a broader typing/fixture cleanup slice.
+Disposition: NOT-A-BUG
+Evidence: core/compliance/dsar_service.py:28; core/compliance/dsar_service.py:99; core/compliance/dsar_service.py:133; tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
+Reason: The review suggests follow-up refactors for stricter `TypedDict` contracts and a shared DSAR fixture, but the current helper shapes and tests are deterministic, mypy-clean, and scoped intentionally to this internal helper PR rather than a broader typing/fixture cleanup slice.
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -46,6 +46,10 @@
   Disposition: NOT-A-BUG
   Evidence: tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
   Reason: The test already starts with deterministic stale-record cleanup and removes the dedicated account row before exit; a mid-test assertion failure would not leak cross-test state beyond this isolated email-specific fixture path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917985096
+  Disposition: NOT-A-BUG
+  Evidence: core/compliance/dsar_service.py:28; core/compliance/dsar_service.py:99; core/compliance/dsar_service.py:133; tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
+  Reason: The review suggests follow-up refactors for stricter `TypedDict` contracts and a shared DSAR fixture, but the current helper shapes and tests are deterministic, mypy-clean, and scoped intentionally to this internal helper PR rather than a broader typing/fixture cleanup slice.
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -5,41 +5,41 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:106
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:141
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 61988053
   Disposition: FIXED
   Evidence: tests/test_compliance_control_plane.py:307
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581742
   Disposition: DEFERRED
   Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:106
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 61988053
   Disposition: FIXED
   Evidence: tests/test_compliance_control_plane.py:176
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 61988053
   Disposition: FIXED
   Evidence: tests/test_compliance_control_plane.py:176
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 61988053
   Disposition: FIXED
   Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589271
   Disposition: NOT-A-BUG
   Evidence: scripts/ci/check_pr_body_phase2_gates.py:119; scripts/orchestration/review_mapping_artifact.py:102
   Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 3ea26eeb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 61988053
   Disposition: FIXED
   Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917801490

--- a/docs/review/PR_1049_FIXED_MAPPING.md
+++ b/docs/review/PR_1049_FIXED_MAPPING.md
@@ -5,7 +5,37 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:141
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: tests/test_compliance_control_plane.py:307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: tests/test_compliance_control_plane.py:176
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: tests/test_compliance_control_plane.py:176
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589271
+  Disposition: NOT-A-BUG
+  Evidence: scripts/ci/check_pr_body_phase2_gates.py:119; scripts/orchestration/review_mapping_artifact.py:102
+  Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 3ea26eeb
+  Disposition: FIXED
+  Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -996,6 +996,23 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P2
 
+<a id="ledger-p2-dsar-transaction-neutral-helper"></a>
+- [ ] P2: Make internal DSAR delete helper transaction-neutral
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR-TBD-DSAR-TRANSACTION-NEUTRAL-HELPER
+  - Area: backend / privacy
+  - Finding Type: transaction-boundary hardening
+  - Reason: `delete_direct_user_artifacts()` currently owns `commit()` / `rollback()` while accepting a caller-provided SQLAlchemy `Session`. That is acceptable for the current support-led standalone helper contract, but a future support/admin workflow may batch DSAR artifact deletion with other writes on the same session. The helper should eventually declare or narrow its transaction ownership explicitly instead of implicitly committing caller-owned work.
+  - Links:
+    - `core/compliance/dsar_service.py`
+    - `tests/test_compliance_control_plane.py`
+    - `docs/compliance/DSAR_AND_DELETION_MAP.md`
+  - DoD:
+    - The DSAR helper either becomes transaction-neutral or moves to an explicit session/transaction ownership contract
+    - Tests cover caller-owned session behavior for batched writes and rollback semantics
+    - Support-led DSAR docs stay aligned with the final ownership contract
+
 - [ ] P2 Optional: Evaluate Lenny's Podcast Transcripts for insights, marketing, and Bayesian context
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (optional; after P0/P1 hardening and insight/coach work stable)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -116,6 +116,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Canonical privacy and terms publication paths exist in-repo
     - Web and iOS clients link to the published policy paths consistently
     - Published text stays aligned with runtime wellness/compliance posture
+<a id="ledger-p1-dsar-direct-user-helper-contract"></a>
+- [ ] P1: Internal DSAR direct-user helper contract
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-DSAR-DIRECT-USER-HELPERS
+  - Area: backend / privacy
+  - Finding Type: compliance runtime hardening
+  - Reason: The compliance control plane now documents support-led DSAR handling, but the runtime still needs deterministic helper functions that export direct-user SQL artifacts and execute bounded deletion without exposing a public endpoint. This slice keeps DSAR execution consistent for `users`, `rag_feedback`, and `user_knowledge` while keeping account-row deletion on the dedicated existing path.
+  - Links:
+    - `core/compliance/dsar.py`
+    - `core/compliance/dsar_service.py`
+    - `docs/compliance/DSAR_AND_DELETION_MAP.md`
+    - `docs/legal/Privacy.md`
+  - DoD:
+    - Internal helper functions export direct-user SQL artifacts in a deterministic, serializable format
+    - Internal helper functions delete `rag_feedback` and `user_knowledge` idempotently and report per-artifact counts
+    - Internal helper functions expose an explicit deletion plan for the `users` row instead of silently widening into full account deletion
+    - No public DSAR endpoint is introduced before an explicit auth/ownership contract exists
+    - Deterministic tests cover export + delete paths for `users`, `rag_feedback`, and `user_knowledge`
 
 
 <a id="ledger-p0-insight-fallback-chain"></a>

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -116,27 +116,6 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Canonical privacy and terms publication paths exist in-repo
     - Web and iOS clients link to the published policy paths consistently
     - Published text stays aligned with runtime wellness/compliance posture
-<a id="ledger-p1-dsar-direct-user-helper-contract"></a>
-- [ ] P1: Internal DSAR direct-user helper contract
-  - Owner: @katsiaryna_kavaleuskaya
-  - Priority: P1
-  - Target PR: PR #1049
-  - Area: backend / privacy
-  - Finding Type: compliance runtime hardening
-  - Reason: The compliance control plane now documents support-led DSAR handling, but the runtime still needs deterministic helper functions that export direct-user SQL artifacts and execute bounded deletion without exposing a public endpoint. This slice keeps DSAR execution consistent for `users`, `rag_feedback`, and `user_knowledge` while keeping account-row deletion on the dedicated existing path.
-  - Links:
-    - `core/compliance/dsar.py`
-    - `core/compliance/dsar_service.py`
-    - `docs/compliance/DSAR_AND_DELETION_MAP.md`
-    - `docs/legal/Privacy.md`
-  - DoD:
-    - Internal helper functions export direct-user SQL artifacts in a deterministic, serializable format
-    - Internal helper functions delete `rag_feedback` and `user_knowledge` idempotently and report per-artifact counts
-    - Internal helper functions expose an explicit deletion plan for the `users` row instead of silently widening into full account deletion
-    - No public DSAR endpoint is introduced before an explicit auth/ownership contract exists
-    - Deterministic tests cover export + delete paths for `users`, `rag_feedback`, and `user_knowledge`
-
-
 <a id="ledger-p0-insight-fallback-chain"></a>
 - [ ] P0: Insight fallback chain + echo-mode readiness visibility
   - Owner: @katsiaryna_kavaleuskaya
@@ -196,6 +175,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 
 ### P1
+
+<a id="ledger-p1-dsar-direct-user-helper-contract"></a>
+- [ ] P1: Internal DSAR direct-user helper contract
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR #1049
+  - Area: backend / privacy
+  - Finding Type: compliance runtime hardening
+  - Reason: The compliance control plane now documents support-led DSAR handling, but the runtime still needs deterministic helper functions that export direct-user SQL artifacts and execute bounded deletion without exposing a public endpoint. This slice keeps DSAR execution consistent for `users`, `rag_feedback`, and `user_knowledge` while keeping account-row deletion on the dedicated existing path.
+  - Links:
+    - `core/compliance/dsar.py`
+    - `core/compliance/dsar_service.py`
+    - `docs/compliance/DSAR_AND_DELETION_MAP.md`
+    - `docs/legal/Privacy.md`
+  - DoD:
+    - Internal helper functions export direct-user SQL artifacts in a deterministic, serializable format
+    - Internal helper functions delete `rag_feedback` and `user_knowledge` idempotently and report per-artifact counts
+    - Internal helper functions expose an explicit deletion plan for the `users` row instead of silently widening into full account deletion
+    - No public DSAR endpoint is introduced before an explicit auth/ownership contract exists
+    - Deterministic tests cover export + delete paths for `users`, `rag_feedback`, and `user_knowledge`
 
 <a id="ledger-p1-token-expansion-activation"></a>
 - [ ] P1: Semantic/product token expansion + Tokens Studio activation + optional figma-manifest schema unification

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -120,7 +120,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Internal DSAR direct-user helper contract
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DSAR-DIRECT-USER-HELPERS
+  - Target PR: PR #1049
   - Area: backend / privacy
   - Finding Type: compliance runtime hardening
   - Reason: The compliance control plane now documents support-led DSAR handling, but the runtime still needs deterministic helper functions that export direct-user SQL artifacts and execute bounded deletion without exposing a public endpoint. This slice keeps DSAR execution consistent for `users`, `rag_feedback`, and `user_knowledge` while keeping account-row deletion on the dedicated existing path.

--- a/tests/test_compliance_control_plane.py
+++ b/tests/test_compliance_control_plane.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import cast
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
+from core.compliance import dsar_service
 from core.compliance import (
     build_privacy_endpoint_payload,
     build_direct_user_deletion_plan,
@@ -97,6 +100,18 @@ def test_provider_inventory_includes_local_and_conditional_ai_families() -> None
     assert "xai_grok" in provider_ids
 
 
+def test_dsar_timestamp_serializer_covers_none_and_aware_values() -> None:
+    aware_dt = datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc)
+    naive_dt = datetime(2026, 3, 9, 12, 0)
+
+    assert dsar_service._serialize_timestamp(None) is None
+    assert dsar_service._serialize_timestamp(aware_dt) == aware_dt.isoformat()
+    assert (
+        dsar_service._serialize_timestamp(naive_dt)
+        == naive_dt.replace(tzinfo=timezone.utc).isoformat()
+    )
+
+
 def test_minimization_fallback_and_drop_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -160,6 +175,8 @@ def test_dsar_helpers_export_and_delete_direct_user_artifacts() -> None:
         ).scalar_one_or_none()
         if existing_user is not None:
             delete_direct_user_artifacts(session=session, user_id=existing_user.id)
+            session.delete(existing_user)
+            session.commit()
 
         user = User(email="dsar-direct@example.com", name="DSAR Direct User")
         session.add(user)
@@ -285,3 +302,66 @@ def test_dsar_deletion_plan_handles_user_without_direct_artifacts() -> None:
 
         session.delete(user)
         session.commit()
+
+
+def test_dsar_delete_helper_preserves_account_row_without_direct_artifacts() -> None:
+    from core.db import SessionLocal
+    from core.models import User
+
+    assert SessionLocal is not None
+
+    with SessionLocal() as session:
+        existing_user = session.execute(
+            select(User).where(User.email == "dsar-no-artifacts@example.com")
+        ).scalar_one_or_none()
+        if existing_user is not None:
+            session.delete(existing_user)
+            session.commit()
+
+        user = User(email="dsar-no-artifacts@example.com", name="DSAR No Artifacts User")
+        session.add(user)
+        session.commit()
+
+        deleted = delete_direct_user_artifacts(session=session, user_id=user.id)
+
+        assert deleted == {
+            "user_id": user.id,
+            "deleted": {
+                "account_user_record": 0,
+                "rag_feedback": 0,
+                "user_knowledge": 0,
+            },
+            "deleted_any": False,
+            "pending_manual_artifacts": ["account_user_record"],
+        }
+
+        cleanup = session.get(User, user.id)
+        if cleanup is not None:
+            session.delete(cleanup)
+            session.commit()
+
+
+def test_dsar_delete_helper_rolls_back_and_logs_on_delete_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class BrokenSession:
+        def __init__(self) -> None:
+            self.rollback_called = False
+
+        def get(self, _model: object, _user_id: int) -> object:
+            return object()
+
+        def execute(self, _statement: object) -> object:
+            raise RuntimeError("delete boom")
+
+        def rollback(self) -> None:
+            self.rollback_called = True
+
+    broken_session = BrokenSession()
+
+    with caplog.at_level("ERROR", logger="core.compliance.dsar_service"):
+        with pytest.raises(RuntimeError, match="delete boom"):
+            delete_direct_user_artifacts(session=cast(Session, broken_session), user_id=7)
+
+    assert broken_session.rollback_called is True
+    assert "DSAR direct-user artifact delete failed" in caplog.text

--- a/tests/test_compliance_control_plane.py
+++ b/tests/test_compliance_control_plane.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from typing import cast
 
 import pytest
+from sqlalchemy import select
 
 from core.compliance import (
     build_privacy_endpoint_payload,
+    build_direct_user_deletion_plan,
+    delete_direct_user_artifacts,
+    export_direct_user_artifacts,
     get_dsar_artifact_map,
     get_provider_inventory,
     get_sensitive_field_taxonomy,
@@ -100,8 +104,8 @@ def test_minimization_fallback_and_drop_paths(
 
     unknown_minimized = minimize_free_text("plain text", field_name="unmapped_field")
     audit_marker = sanitize_audit_string("unmapped_field", "plain text")
-    assert unknown_minimized == audit_marker["sha256"]
     assert isinstance(audit_marker, dict)
+    assert unknown_minimized == audit_marker["sha256"]
     assert audit_marker["length"] == len("plain text")
     assert audit_marker["sha256"]
 
@@ -141,3 +145,143 @@ def test_canonical_field_name_avoids_loose_substring_matches() -> None:
     assert aliased == canonical
     assert unmatched is not None
     assert len(unmatched) == 64
+
+
+def test_dsar_helpers_export_and_delete_direct_user_artifacts() -> None:
+    from app.models.rag_feedback import RAGFeedback, UserKnowledge
+    from core.db import SessionLocal
+    from core.models import User
+
+    assert SessionLocal is not None
+
+    with SessionLocal() as session:
+        existing_user = session.execute(
+            select(User).where(User.email == "dsar-direct@example.com")
+        ).scalar_one_or_none()
+        if existing_user is not None:
+            delete_direct_user_artifacts(session=session, user_id=existing_user.id)
+
+        user = User(email="dsar-direct@example.com", name="DSAR Direct User")
+        session.add(user)
+        session.flush()
+        user_id = user.id
+
+        session.add(
+            RAGFeedback(
+                user_id=user_id,
+                agent_id="insight",
+                query="[EMAIL_REDACTED] wants a plate",
+                retrieved_chunks=[{"chunk_id": "c1", "preview": "lean protein", "score": 0.9}],
+                llm_response="balanced plan",
+                user_rating=5,
+                user_correction="more fiber",
+                confidence=0.91,
+                hops=2,
+            )
+        )
+        session.add(
+            UserKnowledge(
+                user_id=user_id,
+                content="prefers oatmeal breakfasts",
+                embedding="[0.1,0.2]",
+                source="manual_note",
+            )
+        )
+        session.commit()
+
+        exported = export_direct_user_artifacts(session=session, user_id=user_id)
+
+        counts = cast(dict[str, int], exported["artifact_counts"])
+        artifacts = cast(dict[str, object], exported["artifacts"])
+        user_record = cast(dict[str, object], artifacts["account_user_record"])
+        feedback_records = cast(list[dict[str, object]], artifacts["rag_feedback"])
+        knowledge_records = cast(list[dict[str, object]], artifacts["user_knowledge"])
+
+        assert counts == {
+            "account_user_record": 1,
+            "rag_feedback": 1,
+            "user_knowledge": 1,
+        }
+        assert user_record["email"] == "dsar-direct@example.com"
+        assert feedback_records[0]["query"] == "[EMAIL_REDACTED] wants a plate"
+        assert knowledge_records[0]["content"] == "prefers oatmeal breakfasts"
+
+        deletion_plan = build_direct_user_deletion_plan(session=session, user_id=user_id)
+        plan_artifacts = cast(dict[str, dict[str, object]], deletion_plan["artifacts"])
+        assert (
+            plan_artifacts["account_user_record"]["helper_action"]
+            == "manual_existing_user_delete_flow"
+        )
+        assert plan_artifacts["rag_feedback"]["present_count"] == 1
+        assert plan_artifacts["user_knowledge"]["present_count"] == 1
+
+        deleted = delete_direct_user_artifacts(session=session, user_id=user_id)
+
+        deleted_counts = cast(dict[str, int], deleted["deleted"])
+        assert deleted_counts == {
+            "account_user_record": 0,
+            "rag_feedback": 1,
+            "user_knowledge": 1,
+        }
+        assert deleted["deleted_any"] is True
+        assert deleted["pending_manual_artifacts"] == ["account_user_record"]
+        assert export_direct_user_artifacts(session=session, user_id=user_id)[
+            "artifact_counts"
+        ] == {
+            "account_user_record": 1,
+            "rag_feedback": 0,
+            "user_knowledge": 0,
+        }
+        cleanup = session.get(User, user_id)
+        if cleanup is not None:
+            session.delete(cleanup)
+            session.commit()
+
+
+def test_dsar_delete_helper_is_idempotent_for_missing_user() -> None:
+    from core.db import SessionLocal
+
+    assert SessionLocal is not None
+
+    with SessionLocal() as session:
+        deleted = delete_direct_user_artifacts(session=session, user_id=999_999)
+
+    assert deleted == {
+        "user_id": 999_999,
+        "deleted": {
+            "account_user_record": 0,
+            "rag_feedback": 0,
+            "user_knowledge": 0,
+        },
+        "deleted_any": False,
+        "pending_manual_artifacts": [],
+    }
+
+
+def test_dsar_deletion_plan_handles_user_without_direct_artifacts() -> None:
+    from core.db import SessionLocal
+    from core.models import User
+
+    assert SessionLocal is not None
+
+    with SessionLocal() as session:
+        existing_user = session.execute(
+            select(User).where(User.email == "dsar-empty@example.com")
+        ).scalar_one_or_none()
+        if existing_user is not None:
+            session.delete(existing_user)
+            session.commit()
+
+        user = User(email="dsar-empty@example.com", name="DSAR Empty User")
+        session.add(user)
+        session.commit()
+
+        deletion_plan = build_direct_user_deletion_plan(session=session, user_id=user.id)
+        plan_artifacts = cast(dict[str, dict[str, object]], deletion_plan["artifacts"])
+
+        assert plan_artifacts["account_user_record"]["present"] is True
+        assert plan_artifacts["rag_feedback"]["present_count"] == 0
+        assert plan_artifacts["user_knowledge"]["present_count"] == 0
+
+        session.delete(user)
+        session.commit()


### PR DESCRIPTION
## Summary
- add internal-only DSAR helper services for direct-user SQL artifacts
- keep account-row deletion on the existing dedicated user-deletion path
- extend compliance docs and deterministic tests without adding a public DSAR endpoint

## What Changed
- add `core/compliance/dsar_service.py` with deterministic export, delete-plan, and bounded delete helpers for `users`, `rag_feedback`, and `user_knowledge`
- re-export DSAR helper functions through `core/compliance/__init__.py`
- update compliance docs and ledger to reflect the support-led DSAR runtime contract
- add deterministic tests for export/delete/idempotence paths and review follow-up coverage branches

## Validation
- `pre-commit run --all-files`
- `make verify`

## Security Notes
- no public DSAR/export/delete API is introduced in this PR
- raw account-row deletion is intentionally blocked from this helper surface
- bounded deletion covers only `rag_feedback` and `user_knowledge`; account deletion remains explicit and separate

## Deferred / Follow-ups
- [P0: EU-first compliance control plane follow-through](docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-eu-compliance-control-plane-follow-through)
- [P1: Internal DSAR direct-user helper contract](docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-dsar-direct-user-helper-contract)
- [P2: Make internal DSAR delete helper transaction-neutral](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912164903 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:106; core/compliance/dsar_service.py:141; tests/test_compliance_control_plane.py:307
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579318 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:106
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579320 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:141
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902579322 -> 61988053
  Disposition: FIXED
  Evidence: tests/test_compliance_control_plane.py:307
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581742
  Disposition: DEFERRED
  Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dsar-transaction-neutral-helper
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902581747 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:106
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912168779 -> 61988053
  Disposition: FIXED
  Evidence: tests/test_compliance_control_plane.py:176
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902583110 -> 61988053
  Disposition: FIXED
  Evidence: tests/test_compliance_control_plane.py:176
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3912175286 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:154; docs/roadmap/BACKLOG_LEDGER.md:163; tests/test_compliance_control_plane.py:176
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589269 -> 61988053
  Disposition: FIXED
  Evidence: core/compliance/dsar_service.py:141; core/compliance/dsar_service.py:154; tests/test_compliance_control_plane.py:344
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589271
  Disposition: NOT-A-BUG
  Evidence: scripts/ci/check_pr_body_phase2_gates.py:119; scripts/orchestration/review_mapping_artifact.py:102
  Reason: The repository Phase 2 contract requires these two checkboxes to stay checked for artifact/body validation; unchecking them would fail the canonical gate.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#discussion_r2902589273 -> 61988053
  Disposition: FIXED
  Evidence: docs/roadmap/BACKLOG_LEDGER.md:163
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917801490
  Disposition: NOT-A-BUG
  Evidence: tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
  Reason: The test already starts with deterministic stale-record cleanup and removes the dedicated account row before exit; a mid-test assertion failure would not leak cross-test state beyond this isolated email-specific fixture path.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1049#pullrequestreview-3917985096
  Disposition: NOT-A-BUG
  Evidence: core/compliance/dsar_service.py:28; core/compliance/dsar_service.py:99; core/compliance/dsar_service.py:133; tests/test_compliance_control_plane.py:172; tests/test_compliance_control_plane.py:252
  Reason: The review suggests follow-up refactors for stricter TypedDict contracts and a shared DSAR fixture, but the current helper shapes and tests are deterministic, mypy-clean, and scoped intentionally to this internal helper PR rather than a broader typing/fixture cleanup slice.

## Merge Readiness
- [x] Scope tied to PR objective
- [x] Docs/runtime changes applied
- [x] Verification completed
- [ ] Required GitHub checks PASS with no pending required jobs
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] No unresolved review threads or actionable bot comments remain
- [ ] Review wait-window completed
