### PR TITLE
fix(openapi): type weekly plan contract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
       # frontend tests — run on pre-commit if frontend files changed
       - id: frontend-tests
         name: frontend tests (vitest)
-        entry: bash -c "cd frontend && npm run test:ci || (echo '⚠️  Frontend tests failed or test:ci not configured'; exit 0)"
+        entry: bash -c "cd frontend && npm run test:precommit || (echo '⚠️  Frontend tests failed or test:precommit not configured'; exit 0)"
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1277,7 +1277,7 @@
         "filename": "tests/test_premium_week_endpoint_96.py",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 60
       }
     ],
     "tests/test_premium_week_endpoint_simple_96.py": [
@@ -1286,7 +1286,7 @@
         "filename": "tests/test_premium_week_endpoint_simple_96.py",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 58
       }
     ],
     "tests/test_product_finder_simple_coverage.py": [
@@ -1598,5 +1598,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T21:42:27Z"
+  "generated_at": "2026-03-09T15:49:10Z"
 }

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -21,6 +21,7 @@ from app.middleware.api_tiers import require_pro_tier
 from app.schemas.nutrition_targets import TargetsIn
 from app.schemas.weekly_plan import (
     WeeklyMealPlanResponse,
+    require_weekly_plan_payload_shape,
     normalize_weekly_plan_payload,
 )
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
@@ -272,7 +273,8 @@ async def generate_week_plan(
 
     # Wrap PremiumWeekPlanResponse constructor to match postprocess_fn signature
     def _postprocess_week(week: dict[str, Any]) -> PremiumWeekPlanResponse:
-        normalized_week = normalize_weekly_plan_payload(week)
+        validated_week = require_weekly_plan_payload_shape(week)
+        normalized_week = normalize_weekly_plan_payload(validated_week)
         return PremiumWeekPlanResponse(**normalized_week)
 
     result = run_weekly_pipeline_guarded(

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -19,6 +19,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.middleware.api_tiers import require_pro_tier
 from app.schemas.nutrition_targets import TargetsIn
+from app.schemas.weekly_plan import (
+    WeeklyMealPlanResponse,
+    normalize_weekly_plan_payload,
+)
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
 from core.food_db_new import FoodDB
@@ -85,14 +89,7 @@ class PremiumWeekPlanRequest(BaseModel):
     model_config = ConfigDict(title="PremiumWeekPlanRequest")
 
 
-class PremiumWeekPlanResponse(BaseModel):
-    model_config = ConfigDict(title="PremiumWeekPlanResponse")
-
-    daily_menus: List[Dict[str, Any]]
-    weekly_coverage: Dict[str, float]
-    shopping_list: Dict[str, float]
-    total_cost: float
-    adherence_score: float
+PremiumWeekPlanResponse = WeeklyMealPlanResponse
 
 
 def _missing_profile_detail(field: str) -> str:
@@ -275,7 +272,8 @@ async def generate_week_plan(
 
     # Wrap PremiumWeekPlanResponse constructor to match postprocess_fn signature
     def _postprocess_week(week: dict[str, Any]) -> PremiumWeekPlanResponse:
-        return PremiumWeekPlanResponse(**week)
+        normalized_week = normalize_weekly_plan_payload(week)
+        return PremiumWeekPlanResponse(**normalized_week)
 
     result = run_weekly_pipeline_guarded(
         generation_fn=build_week,

--- a/app/routers/pro.py
+++ b/app/routers/pro.py
@@ -25,6 +25,7 @@ from app.middleware.api_tiers import require_pro_tier
 from app.schemas.nutrition_targets import TargetsIn
 from app.schemas.weekly_plan import (
     WeeklyMealPlanResponse,
+    require_weekly_plan_payload_shape,
     normalize_weekly_plan_payload,
 )
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
@@ -318,7 +319,8 @@ async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanRespon
 
     # Wrap ProWeekPlanResponse constructor to match postprocess_fn signature
     def _postprocess_week(week: Dict[str, Any]) -> ProWeekPlanResponse:
-        normalized_week = normalize_weekly_plan_payload(week)
+        validated_week = require_weekly_plan_payload_shape(week)
+        normalized_week = normalize_weekly_plan_payload(validated_week)
         return ProWeekPlanResponse(**normalized_week)
 
     result = run_weekly_pipeline_guarded(

--- a/app/routers/pro.py
+++ b/app/routers/pro.py
@@ -23,6 +23,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.middleware.api_tiers import require_pro_tier
 from app.schemas.nutrition_targets import TargetsIn
+from app.schemas.weekly_plan import (
+    WeeklyMealPlanResponse,
+    normalize_weekly_plan_payload,
+)
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
 from core.food_db_new import FoodDB
@@ -107,16 +111,7 @@ class ProWeekPlanRequest(BaseModel):
     lang: Language = "en"
 
 
-class ProWeekPlanResponse(BaseModel):
-    """Response model for weekly meal plan."""
-
-    model_config = ConfigDict(title="ProWeekPlanResponse")
-
-    daily_menus: List[Dict]
-    weekly_coverage: Dict[str, float]
-    shopping_list: Dict[str, float]
-    total_cost: float
-    adherence_score: float
+ProWeekPlanResponse = WeeklyMealPlanResponse
 
 
 class NutritionSegmentData(BaseModel):
@@ -323,7 +318,8 @@ async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanRespon
 
     # Wrap ProWeekPlanResponse constructor to match postprocess_fn signature
     def _postprocess_week(week: Dict[str, Any]) -> ProWeekPlanResponse:
-        return ProWeekPlanResponse(**week)
+        normalized_week = normalize_weekly_plan_payload(week)
+        return ProWeekPlanResponse(**normalized_week)
 
     result = run_weekly_pipeline_guarded(
         generation_fn=build_week,

--- a/app/schemas/weekly_plan.py
+++ b/app/schemas/weekly_plan.py
@@ -1,0 +1,146 @@
+"""Canonical weekly-plan DTOs and payload normalization helpers."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Convert supported numeric-like values to float; reject invalid values."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric_value):
+        return None
+    return numeric_value
+
+
+def _normalize_numeric_map(raw_value: Any) -> dict[str, float]:
+    """Keep only string->float pairs for OpenAPI-stable numeric maps."""
+    if not isinstance(raw_value, Mapping):
+        return {}
+
+    normalized: dict[str, float] = {}
+    for key, value in raw_value.items():
+        if not isinstance(key, str):
+            continue
+        numeric_value = _coerce_float(value)
+        if numeric_value is None:
+            continue
+        normalized[key] = numeric_value
+    return normalized
+
+
+def _normalize_meal_item(raw_value: Any) -> dict[str, Any]:
+    """Normalize one meal entry into the canonical typed payload."""
+    payload = raw_value if isinstance(raw_value, Mapping) else {}
+    title = str(payload.get("title") or "")
+    title_translated = str(payload.get("title_translated") or title)
+
+    return {
+        "title": title,
+        "title_translated": title_translated,
+        "grams": _normalize_numeric_map(payload.get("grams")),
+        "kcal": _coerce_float(payload.get("kcal")) or 0.0,
+        "macros": _normalize_numeric_map(payload.get("macros")),
+        "micros": _normalize_numeric_map(payload.get("micros")),
+        "price_est": _coerce_float(payload.get("price_est")),
+    }
+
+
+def _normalize_day_menu(raw_value: Any) -> dict[str, Any]:
+    """Normalize one day menu into the canonical typed payload."""
+    payload = raw_value if isinstance(raw_value, Mapping) else {}
+    raw_meals = payload.get("meals")
+    meals = (
+        [_normalize_meal_item(meal) for meal in raw_meals] if isinstance(raw_meals, list) else []
+    )
+
+    raw_tips = payload.get("tips")
+    tips = [str(tip) for tip in raw_tips] if isinstance(raw_tips, list) else []
+
+    total_cost = _coerce_float(payload.get("total_cost"))
+    if total_cost is None:
+        total_cost = round(
+            sum(meal["price_est"] or 0.0 for meal in meals),
+            2,
+        )
+
+    return {
+        "meals": meals,
+        "kcal": _coerce_float(payload.get("kcal")) or 0.0,
+        "macros": _normalize_numeric_map(payload.get("macros")),
+        "micros": _normalize_numeric_map(payload.get("micros")),
+        "coverage": _normalize_numeric_map(payload.get("coverage")),
+        "tips": tips,
+        "total_cost": total_cost,
+    }
+
+
+def normalize_weekly_plan_payload(raw_value: Any) -> dict[str, Any]:
+    """Normalize build_week output before validating with typed DTOs."""
+    payload = raw_value if isinstance(raw_value, Mapping) else {}
+    raw_daily_menus = payload.get("daily_menus")
+    daily_menus = (
+        [_normalize_day_menu(day) for day in raw_daily_menus]
+        if isinstance(raw_daily_menus, list)
+        else []
+    )
+
+    total_cost = _coerce_float(payload.get("total_cost"))
+    if total_cost is None:
+        total_cost = round(sum(day["total_cost"] for day in daily_menus), 2)
+
+    return {
+        "daily_menus": daily_menus,
+        "weekly_coverage": _normalize_numeric_map(payload.get("weekly_coverage")),
+        "shopping_list": _normalize_numeric_map(payload.get("shopping_list")),
+        "total_cost": total_cost,
+        "adherence_score": _coerce_float(payload.get("adherence_score")) or 0.0,
+    }
+
+
+class WeeklyMealPlanItem(BaseModel):
+    """Typed representation of one generated meal entry."""
+
+    model_config = ConfigDict(title="WeeklyMealPlanItem")
+
+    title: str
+    title_translated: str
+    grams: dict[str, float]
+    kcal: float
+    macros: dict[str, float]
+    micros: dict[str, float]
+    price_est: float | None = None
+
+
+class WeeklyMealPlanDayMenu(BaseModel):
+    """Typed representation of one generated day menu."""
+
+    model_config = ConfigDict(title="WeeklyMealPlanDayMenu")
+
+    meals: list[WeeklyMealPlanItem]
+    kcal: float
+    macros: dict[str, float]
+    micros: dict[str, float]
+    coverage: dict[str, float]
+    tips: list[str]
+    total_cost: float
+
+
+class WeeklyMealPlanResponse(BaseModel):
+    """Typed canonical response for PRO/premium weekly-plan endpoints."""
+
+    model_config = ConfigDict(title="WeeklyMealPlanResponse")
+
+    daily_menus: list[WeeklyMealPlanDayMenu]
+    weekly_coverage: dict[str, float]
+    shopping_list: dict[str, float]
+    total_cost: float
+    adherence_score: float

--- a/app/schemas/weekly_plan.py
+++ b/app/schemas/weekly_plan.py
@@ -106,6 +106,18 @@ def normalize_weekly_plan_payload(raw_value: Any) -> dict[str, Any]:
     }
 
 
+def require_weekly_plan_payload_shape(raw_value: Any) -> Mapping[str, Any]:
+    """Fail closed when build_week returns a payload outside the public contract."""
+    if not isinstance(raw_value, Mapping):
+        raise ValueError("weekly plan payload must be a mapping")
+
+    raw_daily_menus = raw_value.get("daily_menus")
+    if not isinstance(raw_daily_menus, list):
+        raise ValueError("weekly plan payload missing required daily_menus list")
+
+    return raw_value
+
+
 class WeeklyMealPlanItem(BaseModel):
     """Typed representation of one generated meal entry."""
 

--- a/app/schemas/weekly_plan.py
+++ b/app/schemas/weekly_plan.py
@@ -21,63 +21,105 @@ def _coerce_float(value: Any) -> float | None:
     return numeric_value
 
 
-def _normalize_numeric_map(raw_value: Any) -> dict[str, float]:
-    """Keep only string->float pairs for OpenAPI-stable numeric maps."""
+def _require_mapping(raw_value: Any, field_name: str) -> Mapping[str, Any]:
+    """Require a mapping payload for typed weekly-plan normalization."""
     if not isinstance(raw_value, Mapping):
+        raise ValueError(f"{field_name} must be a mapping")
+    return raw_value
+
+
+def _require_non_empty_string(value: Any, field_name: str) -> str:
+    """Require a non-empty string for canonical typed fields."""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a non-empty string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return normalized
+
+
+def _require_float(value: Any, field_name: str) -> float:
+    """Require a finite numeric value for canonical typed fields."""
+    numeric_value = _coerce_float(value)
+    if numeric_value is None:
+        raise ValueError(f"{field_name} must be a finite number")
+    return numeric_value
+
+
+def _normalize_numeric_map(raw_value: Any, field_name: str) -> dict[str, float]:
+    """Keep only string->float pairs for OpenAPI-stable numeric maps."""
+    if raw_value is None:
         return {}
+    mapping = _require_mapping(raw_value, field_name)
 
     normalized: dict[str, float] = {}
-    for key, value in raw_value.items():
+    for key, value in mapping.items():
         if not isinstance(key, str):
-            continue
-        numeric_value = _coerce_float(value)
-        if numeric_value is None:
-            continue
+            raise ValueError(f"{field_name} keys must be strings")
+        numeric_value = _require_float(value, f"{field_name}.{key}")
         normalized[key] = numeric_value
     return normalized
 
 
 def _normalize_meal_item(raw_value: Any) -> dict[str, Any]:
     """Normalize one meal entry into the canonical typed payload."""
-    payload = raw_value if isinstance(raw_value, Mapping) else {}
-    title = str(payload.get("title") or "")
-    title_translated = str(payload.get("title_translated") or title)
+    payload = _require_mapping(raw_value, "daily_menus[].meals[]")
+    title = _require_non_empty_string(payload.get("title"), "daily_menus[].meals[].title")
+    raw_title_translated = payload.get("title_translated")
+    if raw_title_translated is None:
+        title_translated = title
+    else:
+        title_translated = _require_non_empty_string(
+            raw_title_translated,
+            "daily_menus[].meals[].title_translated",
+        )
 
     return {
         "title": title,
         "title_translated": title_translated,
-        "grams": _normalize_numeric_map(payload.get("grams")),
-        "kcal": _coerce_float(payload.get("kcal")) or 0.0,
-        "macros": _normalize_numeric_map(payload.get("macros")),
-        "micros": _normalize_numeric_map(payload.get("micros")),
-        "price_est": _coerce_float(payload.get("price_est")),
+        "grams": _normalize_numeric_map(payload.get("grams"), "daily_menus[].meals[].grams"),
+        "kcal": _require_float(payload.get("kcal"), "daily_menus[].meals[].kcal"),
+        "macros": _normalize_numeric_map(payload.get("macros"), "daily_menus[].meals[].macros"),
+        "micros": _normalize_numeric_map(payload.get("micros"), "daily_menus[].meals[].micros"),
+        "price_est": (
+            None
+            if payload.get("price_est") is None
+            else _require_float(payload.get("price_est"), "daily_menus[].meals[].price_est")
+        ),
     }
 
 
 def _normalize_day_menu(raw_value: Any) -> dict[str, Any]:
     """Normalize one day menu into the canonical typed payload."""
-    payload = raw_value if isinstance(raw_value, Mapping) else {}
+    payload = _require_mapping(raw_value, "daily_menus[]")
     raw_meals = payload.get("meals")
-    meals = (
-        [_normalize_meal_item(meal) for meal in raw_meals] if isinstance(raw_meals, list) else []
-    )
+    if not isinstance(raw_meals, list):
+        raise ValueError("daily_menus[].meals must be a list")
+    meals = [_normalize_meal_item(meal) for meal in raw_meals]
 
     raw_tips = payload.get("tips")
-    tips = [str(tip) for tip in raw_tips] if isinstance(raw_tips, list) else []
+    if raw_tips is None:
+        tips: list[str] = []
+    elif isinstance(raw_tips, list):
+        tips = [_require_non_empty_string(tip, "daily_menus[].tips[]") for tip in raw_tips]
+    else:
+        raise ValueError("daily_menus[].tips must be a list of strings")
 
     total_cost = _coerce_float(payload.get("total_cost"))
-    if total_cost is None:
+    if payload.get("total_cost") is None:
         total_cost = round(
             sum(meal["price_est"] or 0.0 for meal in meals),
             2,
         )
+    elif total_cost is None:
+        raise ValueError("daily_menus[].total_cost must be a finite number")
 
     return {
         "meals": meals,
-        "kcal": _coerce_float(payload.get("kcal")) or 0.0,
-        "macros": _normalize_numeric_map(payload.get("macros")),
-        "micros": _normalize_numeric_map(payload.get("micros")),
-        "coverage": _normalize_numeric_map(payload.get("coverage")),
+        "kcal": _require_float(payload.get("kcal"), "daily_menus[].kcal"),
+        "macros": _normalize_numeric_map(payload.get("macros"), "daily_menus[].macros"),
+        "micros": _normalize_numeric_map(payload.get("micros"), "daily_menus[].micros"),
+        "coverage": _normalize_numeric_map(payload.get("coverage"), "daily_menus[].coverage"),
         "tips": tips,
         "total_cost": total_cost,
     }
@@ -85,24 +127,27 @@ def _normalize_day_menu(raw_value: Any) -> dict[str, Any]:
 
 def normalize_weekly_plan_payload(raw_value: Any) -> dict[str, Any]:
     """Normalize build_week output before validating with typed DTOs."""
-    payload = raw_value if isinstance(raw_value, Mapping) else {}
+    payload = _require_mapping(raw_value, "weekly_plan")
     raw_daily_menus = payload.get("daily_menus")
-    daily_menus = (
-        [_normalize_day_menu(day) for day in raw_daily_menus]
-        if isinstance(raw_daily_menus, list)
-        else []
-    )
+    if not isinstance(raw_daily_menus, list):
+        raise ValueError("weekly plan payload missing required daily_menus list")
+    daily_menus = [_normalize_day_menu(day) for day in raw_daily_menus]
 
     total_cost = _coerce_float(payload.get("total_cost"))
-    if total_cost is None:
+    if payload.get("total_cost") is None:
         total_cost = round(sum(day["total_cost"] for day in daily_menus), 2)
+    elif total_cost is None:
+        raise ValueError("weekly_plan.total_cost must be a finite number")
 
     return {
         "daily_menus": daily_menus,
-        "weekly_coverage": _normalize_numeric_map(payload.get("weekly_coverage")),
-        "shopping_list": _normalize_numeric_map(payload.get("shopping_list")),
+        "weekly_coverage": _normalize_numeric_map(
+            payload.get("weekly_coverage"),
+            "weekly_coverage",
+        ),
+        "shopping_list": _normalize_numeric_map(payload.get("shopping_list"), "shopping_list"),
         "total_cost": total_cost,
-        "adherence_score": _coerce_float(payload.get("adherence_score")) or 0.0,
+        "adherence_score": _require_float(payload.get("adherence_score"), "adherence_score"),
     }
 
 

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -5,23 +5,49 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915388839 -> cf4f6381
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905404349 -> def635b9
 Disposition: FIXED
 Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_app_endpoints_1383_1401.py:121
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> cf4f6381
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905404366 -> def635b9
 Disposition: FIXED
-Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_app_endpoints_1383_1401.py:121
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> 36f21947
+Evidence: tests/test_app_endpoints_1383_1401.py:118; tests/test_app_endpoints_1383_1401.py:119
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905427942
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429719
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md:1461
+Reason: moving `/terms` and `/privacy` out of `legacy_app.py` belongs to the existing `legacy_app.py` migration epic, not this bounded weekly-plan contract PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905427947 -> 744f16f0
 Disposition: FIXED
-Evidence: tests/test_app_openapi_coverage.py:103; tests/test_weekly_plan_schema_normalization.py:38; frontend/src/api/premium/weekly-plan.ts:5; legacy_app.py:2294
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:61; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:108
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429697 -> 744f16f0
+Disposition: FIXED
+Evidence: app/routers/premium_week.py:275; tests/test_premium_week_router_isolated.py:55
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429714
 Disposition: NOT-A-BUG
 Evidence: frontend/src/api/schema.ts:3227; frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts:16
 Reason: canonical `ProWeekPlanRequest` requires `lang: "ru" | "en" | "es"`, so coercing unsupported values to a supported enum preserves request validity and avoids 422 drift.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151
-Disposition: DEFERRED
-Backlog: docs/roadmap/BACKLOG_LEDGER.md:1355
-Reason: moving `/terms` and `/privacy` out of `legacy_app.py` belongs to the existing long-tail legacy-app migration track, not this bounded weekly-plan contract PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429724 -> def635b9
+Disposition: FIXED
+Evidence: tests/test_app_endpoints_1383_1401.py:118; tests/test_app_endpoints_1383_1401.py:119
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429729 -> def635b9
+Disposition: FIXED
+Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_pro_premium_contract_parity.py:256
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905746565 -> 4dea1108
+Disposition: FIXED
+Evidence: legacy_app.py:745; legacy_app.py:756; legacy_app.py:803
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915767054
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905746565
+Reason: this review entry is a summary shell for the single child actionable comment above; the actionable thread is dispositioned separately and is the canonical proof target.
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -76,6 +76,16 @@ Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905746565
 Reason: this review entry is a summary shell for the single child actionable comment above; the actionable thread is dispositioned separately and is the canonical proof target.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3916090710
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906038434
+Reason: cubic identified this issue in the review summary shell; the exact actionable child thread is dispositioned separately below and is the canonical proof target.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906038434 -> 56ca4c1b
+Disposition: FIXED
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:157; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:130
+Reason: preserve original `daily_menus` indices while skipping malformed entries so valid days retain the correct `day`/`dayName`.
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -106,6 +106,11 @@ Disposition: FIXED
 Evidence: tests/test_pro_router.py:185
 Reason: JSON content-type is asserted before parsing the 500-path PRO router response body.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181781 -> 38a5e257
+Disposition: FIXED
+Evidence: docs/review/PR_1053_FIXED_MAPPING.md:107; docs/review/PR_1053_FIXED_MAPPING.md:108; docs/review/PR_1053_FIXED_MAPPING.md:109
+Reason: merge-readiness checklist remains unchecked until the final merge pass instead of being marked done prematurely.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3916255202
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181768; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181781; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181787; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181793; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181795

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -44,6 +44,18 @@ Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_pro_premium_
 Disposition: FIXED
 Evidence: legacy_app.py:745; legacy_app.py:756; legacy_app.py:803
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885722 -> f373f4f8
+Disposition: FIXED
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:16; frontend/src/features/weekly-plan/model/adapter.ts:179; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:130
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885731 -> f373f4f8
+Disposition: FIXED
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:122; frontend/src/features/weekly-plan/model/adapter.ts:156; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:119
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885748 -> f373f4f8
+Disposition: FIXED
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:147; frontend/src/features/weekly-plan/model/adapter.ts:174; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:72
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915767054
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905746565

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -86,10 +86,35 @@ Disposition: FIXED
 Evidence: frontend/src/features/weekly-plan/model/adapter.ts:157; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:130
 Reason: preserve original `daily_menus` indices while skipping malformed entries so valid days retain the correct `day`/`dayName`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181768 -> 7995b062
+Disposition: FIXED
+Evidence: app/schemas/weekly_plan.py:64; tests/test_weekly_plan_schema_normalization.py:40
+Reason: weekly-plan normalization now fails closed for malformed meal/day/root payloads instead of silently manufacturing DTO defaults.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181787 -> 7995b062
+Disposition: FIXED
+Evidence: frontend/src/features/weekly-plan/model/adapter.ts:156; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:62
+Reason: root payloads are now shape-guarded before dereferencing `daily_menus`, returning a safe incomplete VM for null/primitive input.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181793 -> 7995b062
+Disposition: FIXED
+Evidence: tests/test_premium_week_router_isolated.py:82
+Reason: JSON content-type is asserted before parsing the 500-path premium router response body.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181795 -> 7995b062
+Disposition: FIXED
+Evidence: tests/test_pro_router.py:185
+Reason: JSON content-type is asserted before parsing the 500-path PRO router response body.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3916255202
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181768; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181781; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181787; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181793; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2906181795
+Reason: this CodeRabbit review entry is a summary shell for the actionable child threads dispositioned separately below.
+
 ## Merge Readiness
-- [x] Scope tied to PR objective
-- [x] Docs/runtime changes applied
-- [x] Verification completed
+- [ ] Scope tied to PR objective
+- [ ] Docs/runtime changes applied
+- [ ] Verification completed
 - [ ] Required GitHub checks PASS with no pending required jobs
 - [ ] CodeRabbit PASS / no-actionables
 - [ ] Sourcery PASS / no-actionables

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -5,6 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915388839
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905404349; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905404366
+Reason: this cubic review entry is a summary shell; the actionable child comments are dispositioned separately below with exact thread URLs.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905404349 -> def635b9
 Disposition: FIXED
 Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_app_endpoints_1383_1401.py:121
@@ -55,6 +60,16 @@ Evidence: frontend/src/features/weekly-plan/model/adapter.ts:122; frontend/src/f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885748 -> f373f4f8
 Disposition: FIXED
 Evidence: frontend/src/features/weekly-plan/model/adapter.ts:147; frontend/src/features/weekly-plan/model/adapter.ts:174; frontend/src/features/weekly-plan/__tests__/adapter.test.ts:72
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429697; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429714; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429719; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429724; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905429729
+Reason: this CodeRabbit review entry is a summary shell for the actionable child threads already dispositioned above.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915916533
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885722; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885731; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#discussion_r2905885748
+Reason: this later CodeRabbit review entry is a summary shell for the follow-up actionable child threads already dispositioned above.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915767054
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1053_FIXED_MAPPING.md
+++ b/docs/review/PR_1053_FIXED_MAPPING.md
@@ -1,0 +1,35 @@
+# PR 1053 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915388839 -> cf4f6381
+Disposition: FIXED
+Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_app_endpoints_1383_1401.py:121
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> cf4f6381
+Disposition: FIXED
+Evidence: tests/test_pro_premium_contract_parity.py:254; tests/test_app_endpoints_1383_1401.py:121
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> 36f21947
+Disposition: FIXED
+Evidence: tests/test_app_openapi_coverage.py:103; tests/test_weekly_plan_schema_normalization.py:38; frontend/src/api/premium/weekly-plan.ts:5; legacy_app.py:2294
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151
+Disposition: NOT-A-BUG
+Evidence: frontend/src/api/schema.ts:3227; frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts:16
+Reason: canonical `ProWeekPlanRequest` requires `lang: "ru" | "en" | "es"`, so coercing unsupported values to a supported enum preserves request validity and avoids 422 drift.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md:1355
+Reason: moving `/terms` and `/privacy` out of `legacy_app.py` belongs to the existing long-tail legacy-app migration track, not this bounded weekly-plan contract PR.
+
+## Merge Readiness
+- [x] Scope tied to PR objective
+- [x] Docs/runtime changes applied
+- [x] Verification completed
+- [ ] Required GitHub checks PASS with no pending required jobs
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] No unresolved review threads or actionable bot comments remain
+- [ ] Review wait-window completed

--- a/frontend/src/api/__tests__/weekly-plan-integration.test.ts
+++ b/frontend/src/api/__tests__/weekly-plan-integration.test.ts
@@ -2,19 +2,58 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getWeeklyPlan } from '../premium/weekly-plan';
 import type { WeeklyMenuResponse, WeekPlanRequest } from '../premium/weekly-plan';
 
-// Mock the API client
 vi.mock('../client', () => ({
   api: vi.fn(),
 }));
 
 import { api } from '../client';
 
+function createMockWeeklyPlanResponse(
+  overrides: Partial<WeeklyMenuResponse> = {}
+): WeeklyMenuResponse {
+  return {
+    daily_menus: [
+      {
+        coverage: { protein: 96, calcium: 88 },
+        kcal: 1850,
+        macros: { protein_g: 110, carbs_g: 180, fat_g: 65 },
+        meals: [
+          {
+            title: 'Chicken bowl',
+            title_translated: 'Chicken bowl',
+            grams: { chicken: 180, rice: 150 },
+            kcal: 620,
+            macros: { protein_g: 42, carbs_g: 58, fat_g: 14 },
+            micros: { iron_mg: 3.4 },
+            price_est: 7.25,
+          },
+        ],
+        micros: { iron_mg: 10.5, vitamin_c_mg: 88 },
+        tips: ['Hydrate well'],
+        total_cost: 18.4,
+      },
+    ],
+    weekly_coverage: {
+      protein: 97,
+      iron: 93,
+      vitamin_c: 105,
+      calcium: 89,
+    },
+    shopping_list: {
+      chicken: 1260,
+      rice: 1050,
+    },
+    total_cost: 74.6,
+    adherence_score: 0.87,
+    ...overrides,
+  };
+}
+
 describe('Weekly Plan API Integration', () => {
   const mockApi = vi.mocked(api);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set up environment for CI
     vi.stubEnv('VITE_API_BASE', 'http://test-api.com');
   });
 
@@ -24,7 +63,7 @@ describe('Weekly Plan API Integration', () => {
   });
 
   describe('Successful API calls (200)', () => {
-    it('should generate weekly plan successfully with valid request', async () => {
+    it('should generate weekly plan successfully with valid profile request', async () => {
       const mockRequest: WeekPlanRequest = {
         sex: 'female',
         age: 25,
@@ -32,61 +71,10 @@ describe('Weekly Plan API Integration', () => {
         weight_kg: 60,
         activity: 'moderate',
         goal: 'maintain',
-        life_stage: 'adult',
+        diet_flags: [],
         lang: 'en',
       };
-
-      const mockResponse = {
-        week_summary: {
-          total_calories: 14000,
-          total_protein: 1050,
-          total_carbs: 1750,
-          total_fat: 469,
-        },
-        daily_menus: [
-          {
-            day: 'Monday',
-            meals: [
-              {
-                name: 'Breakfast',
-                calories: 500,
-                protein: 25,
-                carbs: 60,
-                fat: 15,
-              },
-              {
-                name: 'Lunch',
-                calories: 600,
-                protein: 35,
-                carbs: 70,
-                fat: 20,
-              },
-              {
-                name: 'Dinner',
-                calories: 500,
-                protein: 30,
-                carbs: 50,
-                fat: 18,
-              },
-            ],
-          },
-          // ... other days
-        ],
-        weekly_coverage: {
-          protein: 95,
-          carbs: 98,
-          fat: 92,
-          fiber: 85,
-        },
-        shopping_list: {
-          'chicken breast': 500,
-          'brown rice': 1000,
-          'broccoli': 300,
-          'olive oil': 200,
-        },
-        total_cost: 45.50,
-        adherence_score: 87,
-      } as unknown as WeeklyMenuResponse;
+      const mockResponse = createMockWeeklyPlanResponse();
 
       mockApi.mockResolvedValue(mockResponse);
 
@@ -102,49 +90,27 @@ describe('Weekly Plan API Integration', () => {
         undefined,
         true
       );
-
       expect(result).toEqual(mockResponse);
     });
 
-    it('should handle request with all optional fields', async () => {
+    it('should accept canonical request with ready targets payload', async () => {
       const mockRequest: WeekPlanRequest = {
-        sex: 'male',
-        age: 30,
-        height_cm: 180,
-        weight_kg: 80,
-        activity: 'very_active',
-        goal: 'loss',
-        deficit_pct: 20,
-        surplus_pct: null,
-        bodyfat: 15,
+        targets: {
+          kcal: 2100,
+          macros: { protein_g: 140, carbs_g: 220, fat_g: 70 },
+          micro: { iron_mg: 18, calcium_mg: 1000 },
+          water_ml: 2200,
+          activity_week: { moderate_aerobic_min: 150, strength_sessions: 2 },
+        },
         diet_flags: ['HIGH_PROTEIN', 'LOW_CARB'],
-        life_stage: 'adult',
         lang: 'ru',
+        activity: 'active',
+        goal: 'loss',
       };
-
-      const mockResponse = {
-        week_summary: {
-          total_calories: 16800,
-          total_protein: 1400,
-          total_carbs: 1050,
-          total_fat: 560,
-        },
+      const mockResponse = createMockWeeklyPlanResponse({
         daily_menus: [],
-        weekly_coverage: {
-          protein: 98,
-          carbs: 85,
-          fat: 95,
-          fiber: 80,
-        },
-        shopping_list: {
-          'salmon': 600,
-          'quinoa': 800,
-          'spinach': 400,
-          'avocado': 300,
-        },
-        total_cost: 65.75,
-        adherence_score: 92,
-      } as unknown as WeeklyMenuResponse;
+        total_cost: 0,
+      });
 
       mockApi.mockResolvedValue(mockResponse);
 
@@ -152,55 +118,9 @@ describe('Weekly Plan API Integration', () => {
 
       expect(result).toEqual(mockResponse);
     });
-
-    it('should handle different life stages', async () => {
-      const lifeStages = ['child', 'teen', 'adult', 'pregnant', 'lactating', 'elderly'] as const;
-
-      for (const lifeStage of lifeStages) {
-        const mockRequest: WeekPlanRequest = {
-          sex: 'female',
-          age: lifeStage === 'child' ? 8 : lifeStage === 'teen' ? 16 : 25,
-          height_cm: 165,
-          weight_kg: 60,
-          activity: 'moderate',
-          goal: 'maintain',
-          life_stage: lifeStage,
-          lang: 'en',
-        };
-
-        const mockResponse = {
-          week_summary: {
-            total_calories: 14000,
-            total_protein: 1050,
-            total_carbs: 1750,
-            total_fat: 469,
-          },
-          daily_menus: [],
-          weekly_coverage: {
-            protein: 95,
-            carbs: 98,
-            fat: 92,
-            fiber: 85,
-          },
-          shopping_list: {
-            'chicken breast': 500,
-            'brown rice': 1000,
-            'broccoli': 300,
-          },
-          total_cost: 45.50,
-          adherence_score: 87,
-        } as unknown as WeeklyMenuResponse;
-
-        mockApi.mockResolvedValue(mockResponse);
-
-        const result = await getWeeklyPlan(mockRequest);
-
-        expect(result).toEqual(mockResponse);
-      }
-    });
   });
 
-  describe('Error handling (401)', () => {
+  describe('Error handling', () => {
     it('should handle authentication errors', async () => {
       const mockRequest: WeekPlanRequest = {
         sex: 'female',
@@ -209,7 +129,6 @@ describe('Weekly Plan API Integration', () => {
         weight_kg: 60,
         activity: 'moderate',
         goal: 'maintain',
-        life_stage: 'adult',
         lang: 'en',
       };
 
@@ -220,65 +139,22 @@ describe('Weekly Plan API Integration', () => {
       await expect(getWeeklyPlan(mockRequest)).rejects.toThrow('Unauthorized');
     });
 
-    it('should handle missing API key', async () => {
-      const mockRequest: WeekPlanRequest = {
-        sex: 'female',
-        age: 25,
-        height_cm: 165,
-        weight_kg: 60,
-        activity: 'moderate',
-        goal: 'maintain',
-        life_stage: 'adult',
-        lang: 'en',
-      };
-
-      const keyError = new Error('API key required');
-      keyError.name = 'MissingApiKey';
-      mockApi.mockRejectedValue(keyError);
-
-      await expect(getWeeklyPlan(mockRequest)).rejects.toThrow('API key required');
-    });
-  });
-
-  describe('Validation errors (422)', () => {
-    it('should handle invalid request data', async () => {
-      const invalidRequest = {
-        sex: 'female',
-        age: -5, // Invalid age
-        height_cm: 165,
-        weight_kg: 60,
-        activity: 'moderate',
-        goal: 'maintain',
-        life_stage: 'adult',
-        lang: 'en',
-      } as WeekPlanRequest;
-
-      const validationError = new Error('Validation error: age must be positive');
-      validationError.name = 'ValidationError';
-      mockApi.mockRejectedValue(validationError);
-
-      await expect(getWeeklyPlan(invalidRequest)).rejects.toThrow('Validation error: age must be positive');
-    });
-
     it('should handle missing required fields', async () => {
       const invalidRequest = {
-        sex: 'female',
-        // Missing age, height, weight, etc.
         activity: 'moderate',
         goal: 'maintain',
-        life_stage: 'adult',
         lang: 'en',
-      } as any;
+      } as WeekPlanRequest;
 
       const validationError = new Error('Validation error: missing required fields');
       validationError.name = 'ValidationError';
       mockApi.mockRejectedValue(validationError);
 
-      await expect(getWeeklyPlan(invalidRequest)).rejects.toThrow('Validation error: missing required fields');
+      await expect(getWeeklyPlan(invalidRequest)).rejects.toThrow(
+        'Validation error: missing required fields'
+      );
     });
-  });
 
-  describe('Network errors', () => {
     it('should handle network timeout', async () => {
       const mockRequest: WeekPlanRequest = {
         sex: 'female',
@@ -287,7 +163,6 @@ describe('Weekly Plan API Integration', () => {
         weight_kg: 60,
         activity: 'moderate',
         goal: 'maintain',
-        life_stage: 'adult',
         lang: 'en',
       };
 
@@ -296,25 +171,6 @@ describe('Weekly Plan API Integration', () => {
       mockApi.mockRejectedValue(timeoutError);
 
       await expect(getWeeklyPlan(mockRequest)).rejects.toThrow('Request timeout');
-    });
-
-    it('should handle server errors (500)', async () => {
-      const mockRequest: WeekPlanRequest = {
-        sex: 'female',
-        age: 25,
-        height_cm: 165,
-        weight_kg: 60,
-        activity: 'moderate',
-        goal: 'maintain',
-        life_stage: 'adult',
-        lang: 'en',
-      };
-
-      const serverError = new Error('Internal server error');
-      serverError.name = 'ServerError';
-      mockApi.mockRejectedValue(serverError);
-
-      await expect(getWeeklyPlan(mockRequest)).rejects.toThrow('Internal server error');
     });
   });
 
@@ -327,18 +183,9 @@ describe('Weekly Plan API Integration', () => {
         weight_kg: 60,
         activity: 'moderate',
         goal: 'maintain',
-        life_stage: 'adult',
         lang: 'en',
       };
-
-      const mockResponse = {
-        week_summary: {},
-        daily_menus: [],
-        weekly_coverage: {},
-        shopping_list: {},
-        total_cost: 0,
-        adherence_score: 0,
-      } as unknown as WeeklyMenuResponse;
+      const mockResponse = createMockWeeklyPlanResponse({ daily_menus: [] });
 
       mockApi.mockResolvedValue(mockResponse);
 

--- a/frontend/src/api/__tests__/weekly-plan-integration.test.ts
+++ b/frontend/src/api/__tests__/weekly-plan-integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getWeeklyPlan } from '../premium/weekly-plan';
-import type { WeeklyMenuResponse, WeekPlanRequest } from '../premium/weekly-plan';
+import type { WeeklyMealPlanResponse, ProWeekPlanRequest } from '../premium/weekly-plan';
 
 vi.mock('../client', () => ({
   api: vi.fn(),
@@ -9,8 +9,8 @@ vi.mock('../client', () => ({
 import { api } from '../client';
 
 function createMockWeeklyPlanResponse(
-  overrides: Partial<WeeklyMenuResponse> = {}
-): WeeklyMenuResponse {
+  overrides: Partial<WeeklyMealPlanResponse> = {}
+): WeeklyMealPlanResponse {
   return {
     daily_menus: [
       {
@@ -64,7 +64,7 @@ describe('Weekly Plan API Integration', () => {
 
   describe('Successful API calls (200)', () => {
     it('should generate weekly plan successfully with valid profile request', async () => {
-      const mockRequest: WeekPlanRequest = {
+      const mockRequest: ProWeekPlanRequest = {
         sex: 'female',
         age: 25,
         height_cm: 165,
@@ -94,7 +94,7 @@ describe('Weekly Plan API Integration', () => {
     });
 
     it('should accept canonical request with ready targets payload', async () => {
-      const mockRequest: WeekPlanRequest = {
+      const mockRequest: ProWeekPlanRequest = {
         targets: {
           kcal: 2100,
           macros: { protein_g: 140, carbs_g: 220, fat_g: 70 },
@@ -122,7 +122,7 @@ describe('Weekly Plan API Integration', () => {
 
   describe('Error handling', () => {
     it('should handle authentication errors', async () => {
-      const mockRequest: WeekPlanRequest = {
+      const mockRequest: ProWeekPlanRequest = {
         sex: 'female',
         age: 25,
         height_cm: 165,
@@ -144,7 +144,7 @@ describe('Weekly Plan API Integration', () => {
         activity: 'moderate',
         goal: 'maintain',
         lang: 'en',
-      } as WeekPlanRequest;
+      } as ProWeekPlanRequest;
 
       const validationError = new Error('Validation error: missing required fields');
       validationError.name = 'ValidationError';
@@ -156,7 +156,7 @@ describe('Weekly Plan API Integration', () => {
     });
 
     it('should handle network timeout', async () => {
-      const mockRequest: WeekPlanRequest = {
+      const mockRequest: ProWeekPlanRequest = {
         sex: 'female',
         age: 25,
         height_cm: 165,
@@ -176,7 +176,7 @@ describe('Weekly Plan API Integration', () => {
 
   describe('Request options', () => {
     it('should pass through request options correctly', async () => {
-      const mockRequest: WeekPlanRequest = {
+      const mockRequest: ProWeekPlanRequest = {
         sex: 'female',
         age: 25,
         height_cm: 165,

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -70,39 +70,6 @@
         "title": "ActivationStatus",
         "type": "string"
       },
-      "AdherenceEventRequest": {
-        "additionalProperties": false,
-        "description": "Request schema for recording an adherence event.\n\nRU: Схема запроса для записи события adherence.\nEN: Request schema for recording an adherence event.\n\nSecurity Note:\n    subject_id is derived from authenticated API key (not from request payload)\n    to prevent horizontal privilege escalation.",
-        "properties": {
-          "analyzer_key": {
-            "default": "v1:adherence",
-            "maxLength": 64,
-            "minLength": 3,
-            "title": "Analyzer Key",
-            "type": "string"
-          },
-          "event_type": {
-            "enum": [
-              "meal_logged",
-              "slip"
-            ],
-            "title": "Event Type",
-            "type": "string"
-          },
-          "weight": {
-            "default": 1.0,
-            "exclusiveMinimum": 0.0,
-            "maximum": 10.0,
-            "title": "Weight",
-            "type": "number"
-          }
-        },
-        "required": [
-          "event_type"
-        ],
-        "title": "AdherenceEventRequest",
-        "type": "object"
-      },
       "AdherenceResponse": {
         "description": "Response schema for adherence endpoints.\n\nRU: Схема ответа для эндпоинтов adherence.\nEN: Response schema for adherence endpoints.",
         "properties": {
@@ -1158,108 +1125,6 @@
         "title": "BMIRangeSpec",
         "type": "object"
       },
-      "BMIRequest": {
-        "properties": {
-          "age": {
-            "default": 30,
-            "maximum": 120.0,
-            "minimum": 0.0,
-            "title": "Age",
-            "type": "integer"
-          },
-          "athlete": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "boolean"
-              }
-            ],
-            "default": "no",
-            "title": "Athlete"
-          },
-          "gender": {
-            "default": "male",
-            "title": "Gender",
-            "type": "string"
-          },
-          "height_m": {
-            "exclusiveMinimum": 0.0,
-            "title": "Height M",
-            "type": "number"
-          },
-          "include_chart": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": false,
-            "title": "Include Chart"
-          },
-          "lang": {
-            "default": "ru",
-            "enum": [
-              "ru",
-              "en",
-              "es"
-            ],
-            "title": "Lang",
-            "type": "string"
-          },
-          "pregnant": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "boolean"
-              }
-            ],
-            "default": "no",
-            "title": "Pregnant"
-          },
-          "premium": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": false,
-            "title": "Premium"
-          },
-          "waist_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Waist Cm"
-          },
-          "weight_kg": {
-            "exclusiveMinimum": 0.0,
-            "title": "Weight Kg",
-            "type": "number"
-          }
-        },
-        "required": [
-          "weight_kg",
-          "height_m"
-        ],
-        "title": "BMIRequest",
-        "type": "object"
-      },
       "BMIRequestV1": {
         "properties": {
           "age": {
@@ -1428,401 +1293,6 @@
           "marker"
         ],
         "title": "BMIScaleV1Spec",
-        "type": "object"
-      },
-      "BMRRequest": {
-        "description": "Request model for BMR calculation",
-        "properties": {
-          "activity": {
-            "pattern": "^(sedentary|light|moderate|active|very_active)$",
-            "title": "Activity",
-            "type": "string"
-          },
-          "age": {
-            "maximum": 120.0,
-            "minimum": 0.0,
-            "title": "Age",
-            "type": "integer"
-          },
-          "bodyfat": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "maximum": 60.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bodyfat"
-          },
-          "height_cm": {
-            "exclusiveMinimum": 0.0,
-            "title": "Height Cm",
-            "type": "number"
-          },
-          "lang": {
-            "default": "en",
-            "enum": [
-              "ru",
-              "en",
-              "es"
-            ],
-            "title": "Lang",
-            "type": "string"
-          },
-          "sex": {
-            "pattern": "^(male|female)$",
-            "title": "Sex",
-            "type": "string"
-          },
-          "weight_kg": {
-            "exclusiveMinimum": 0.0,
-            "title": "Weight Kg",
-            "type": "number"
-          }
-        },
-        "required": [
-          "weight_kg",
-          "height_cm",
-          "age",
-          "sex",
-          "activity"
-        ],
-        "title": "BMRRequest",
-        "type": "object"
-      },
-      "BMRRequestLegacy": {
-        "description": "Lenient legacy request model to allow testing error paths without 422.\n\nRU: Более мягкая модель для обратной совместимости.\nEN: Lenient model for backward compatibility.",
-        "properties": {
-          "activity": {
-            "title": "Activity",
-            "type": "string"
-          },
-          "age": {
-            "title": "Age",
-            "type": "integer"
-          },
-          "bodyfat": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bodyfat"
-          },
-          "height_cm": {
-            "title": "Height Cm",
-            "type": "number"
-          },
-          "lang": {
-            "default": "en",
-            "enum": [
-              "ru",
-              "en",
-              "es"
-            ],
-            "title": "Lang",
-            "type": "string"
-          },
-          "sex": {
-            "title": "Sex",
-            "type": "string"
-          },
-          "weight_kg": {
-            "title": "Weight Kg",
-            "type": "number"
-          }
-        },
-        "required": [
-          "weight_kg",
-          "height_cm",
-          "age",
-          "sex",
-          "activity"
-        ],
-        "title": "BMRRequestLegacy",
-        "type": "object"
-      },
-      "BMRResponse": {
-        "description": "Response model for BMR calculation",
-        "properties": {
-          "activity_level": {
-            "description": "Localized description of the activity level used in calculations (e.g., 'sedentary', 'light', 'moderate', 'active', 'very_active').",
-            "title": "Activity Level",
-            "type": "string"
-          },
-          "bmr": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "description": "BMR values calculated by different formulas. Keys are formula names (e.g., 'mifflin', 'harris', 'katch'), values are BMR in kcal/day.",
-            "title": "Bmr",
-            "type": "object"
-          },
-          "formulas_used": {
-            "description": "List of BMR formula names that were used in the calculation (e.g., ['mifflin', 'harris', 'katch']).",
-            "items": {
-              "type": "string"
-            },
-            "title": "Formulas Used",
-            "type": "array"
-          },
-          "notes": {
-            "description": "Informational messages about the calculation (e.g., notes about body fat usage, warnings, or fallback explanations).",
-            "items": {
-              "type": "string"
-            },
-            "title": "Notes",
-            "type": "array"
-          },
-          "recommended_intake": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "description": "Recommended daily calorie intake for different goals. Keys: 'maintenance', 'weight_loss' (20% deficit), 'weight_gain' (20% surplus); values are calories in kcal/day.",
-            "title": "Recommended Intake",
-            "type": "object"
-          },
-          "tdee": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "description": "TDEE (Total Daily Energy Expenditure) values for different formulas and activity levels. Keys are formula names, values are TDEE in kcal/day.",
-            "title": "Tdee",
-            "type": "object"
-          }
-        },
-        "required": [
-          "bmr",
-          "tdee",
-          "activity_level",
-          "recommended_intake",
-          "formulas_used",
-          "notes"
-        ],
-        "title": "BMRResponse",
-        "type": "object"
-      },
-      "BodyFatRequest": {
-        "properties": {
-          "age": {
-            "anyOf": [
-              {
-                "maximum": 120.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Age in years, 1..120",
-            "title": "Age"
-          },
-          "bmi": {
-            "anyOf": [
-              {
-                "maximum": 100.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "BMI value, 0..100",
-            "title": "Bmi"
-          },
-          "gender": {
-            "title": "Gender",
-            "type": "string"
-          },
-          "height_m": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Height in meters, must be positive",
-            "title": "Height M"
-          },
-          "hip_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Hip circumference in cm, must be > 0",
-            "title": "Hip Cm"
-          },
-          "language": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "en",
-            "title": "Language"
-          },
-          "neck_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Neck circumference in cm, must be > 0",
-            "title": "Neck Cm"
-          },
-          "waist_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Waist circumference in cm, must be > 0",
-            "title": "Waist Cm"
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Weight in kg, must be positive",
-            "title": "Weight Kg"
-          }
-        },
-        "required": [
-          "gender"
-        ],
-        "title": "BodyFatRequest",
-        "type": "object"
-      },
-      "BusinessAnalysisRequest": {
-        "description": "Request model for business analysis.",
-        "properties": {
-          "code": {
-            "description": "Code to analyze (max 100KB)",
-            "title": "Code",
-            "type": "string"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "test_name": {
-            "default": "business_analysis",
-            "title": "Test Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "code"
-        ],
-        "title": "BusinessAnalysisRequest",
-        "type": "object"
-      },
-      "BusinessAnalysisResponse": {
-        "description": "Response model for business analysis.",
-        "properties": {
-          "business_category": {
-            "title": "Business Category",
-            "type": "string"
-          },
-          "cost_impact": {
-            "title": "Cost Impact",
-            "type": "string"
-          },
-          "customer_impact": {
-            "title": "Customer Impact",
-            "type": "string"
-          },
-          "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error Message"
-          },
-          "error_type": {
-            "title": "Error Type",
-            "type": "string"
-          },
-          "optimization_potential": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Optimization Potential"
-          },
-          "revenue_impact": {
-            "title": "Revenue Impact",
-            "type": "string"
-          },
-          "success": {
-            "title": "Success",
-            "type": "boolean"
-          },
-          "test_name": {
-            "title": "Test Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "test_name",
-          "success",
-          "business_category",
-          "error_type",
-          "error_message",
-          "revenue_impact",
-          "cost_impact",
-          "customer_impact",
-          "optimization_potential"
-        ],
-        "title": "BusinessAnalysisResponse",
         "type": "object"
       },
       "CBTInsightRequest": {
@@ -2042,234 +1512,6 @@
           "region_id"
         ],
         "title": "CatalogInfoDTO",
-        "type": "object"
-      },
-      "CatalogRegion": {
-        "additionalProperties": true,
-        "description": "RU: Регион каталога (legacy/public contract).\nEN: Catalog region (legacy/public contract).\n\nRegion catalog public DTO (used by app/routers/catalog.py).\nKeep backward-compatible with core.catalog.service model_dump().",
-        "properties": {
-          "id": {
-            "examples": [
-              "es"
-            ],
-            "maxLength": 8,
-            "minLength": 2,
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "examples": [
-              "Spain"
-            ],
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "CatalogRegion",
-        "type": "object"
-      },
-      "CatalogSKU": {
-        "additionalProperties": true,
-        "description": "RU: SKU запись (legacy/public contract).\nEN: SKU record (legacy/public contract).\n\nSKU public DTO (used by app/routers/catalog.py).",
-        "properties": {
-          "aisle": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "examples": [
-              "Vegetables"
-            ],
-            "title": "Aisle"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "maxLength": 64,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "examples": [
-              "1234567890123"
-            ],
-            "title": "Barcode"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "maxLength": 100,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "examples": [
-              "Carrefour"
-            ],
-            "title": "Brand"
-          },
-          "id": {
-            "examples": [
-              "CRF-ES-000123"
-            ],
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "examples": [
-              "Carrot 500g"
-            ],
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
-          },
-          "pack_label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "examples": [
-              "500 g bag"
-            ],
-            "title": "Pack Label"
-          },
-          "price_currency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "examples": [
-              "EUR"
-            ],
-            "title": "Price Currency"
-          },
-          "price_value": {
-            "anyOf": [
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Decimal serialized as string in JSON (Pydantic v2).",
-            "examples": [
-              "1.29"
-            ],
-            "title": "Price Value"
-          },
-          "region_id": {
-            "examples": [
-              "es"
-            ],
-            "maxLength": 8,
-            "minLength": 2,
-            "title": "Region Id",
-            "type": "string"
-          },
-          "source_id": {
-            "examples": [
-              "carrefour"
-            ],
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Source Id",
-            "type": "string"
-          },
-          "store_id": {
-            "examples": [
-              "carrefour_es"
-            ],
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Store Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "region_id",
-          "store_id",
-          "source_id"
-        ],
-        "title": "CatalogSKU",
-        "type": "object"
-      },
-      "CatalogStore": {
-        "additionalProperties": true,
-        "description": "RU: Магазин/сеть в регионе (legacy/public contract).\nEN: Store in region (legacy/public contract).\n\nStore public DTO (used by app/routers/catalog.py).",
-        "properties": {
-          "id": {
-            "examples": [
-              "carrefour_es"
-            ],
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "examples": [
-              "Carrefour ES"
-            ],
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
-          },
-          "region_id": {
-            "examples": [
-              "es"
-            ],
-            "maxLength": 8,
-            "minLength": 2,
-            "title": "Region Id",
-            "type": "string"
-          },
-          "source_id": {
-            "examples": [
-              "carrefour"
-            ],
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Source Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "region_id",
-          "name",
-          "source_id"
-        ],
-        "title": "CatalogStore",
         "type": "object"
       },
       "CurrencyDTO": {
@@ -2553,208 +1795,6 @@
           }
         },
         "title": "HTTPValidationError",
-        "type": "object"
-      },
-      "Ingredient": {
-        "properties": {
-          "food_id": {
-            "title": "Food Id",
-            "type": "string"
-          },
-          "grams": {
-            "title": "Grams",
-            "type": "number"
-          }
-        },
-        "required": [
-          "food_id",
-          "grams"
-        ],
-        "title": "Ingredient",
-        "type": "object"
-      },
-      "LegacyWeekPlanRequest": {
-        "additionalProperties": false,
-        "description": "Extended request for week plan with optional pre-calculated targets.\n\nSupports two modes:\n- Mode A: With targets (pre-calculated nutrition goals)\n- Mode B: Calculate targets from user profile (sex, age, etc.)",
-        "properties": {
-          "activity": {
-            "anyOf": [
-              {
-                "enum": [
-                  "sedentary",
-                  "light",
-                  "moderate",
-                  "active",
-                  "very_active"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Activity"
-          },
-          "age": {
-            "anyOf": [
-              {
-                "maximum": 120.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Age"
-          },
-          "bodyfat": {
-            "anyOf": [
-              {
-                "maximum": 60.0,
-                "minimum": 3.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bodyfat"
-          },
-          "deficit_pct": {
-            "anyOf": [
-              {
-                "maximum": 25.0,
-                "minimum": 5.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deficit Pct"
-          },
-          "diet_flags": {
-            "anyOf": [
-              {
-                "items": {
-                  "enum": [
-                    "VEG",
-                    "GF",
-                    "DAIRY_FREE",
-                    "LOW_COST",
-                    "HIGH_PROTEIN",
-                    "LOW_CARB",
-                    "MEDITERRANEAN",
-                    "VEGAN",
-                    "KETO",
-                    "PALEO"
-                  ],
-                  "type": "string"
-                },
-                "type": "array",
-                "uniqueItems": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diet Flags"
-          },
-          "goal": {
-            "default": "maintain",
-            "enum": [
-              "loss",
-              "maintain",
-              "gain"
-            ],
-            "title": "Goal",
-            "type": "string"
-          },
-          "height_cm": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Height Cm"
-          },
-          "lang": {
-            "default": "en",
-            "title": "Lang",
-            "type": "string"
-          },
-          "life_stage": {
-            "default": "adult",
-            "enum": [
-              "child",
-              "teen",
-              "adult",
-              "pregnant",
-              "lactating",
-              "elderly"
-            ],
-            "title": "Life Stage",
-            "type": "string"
-          },
-          "sex": {
-            "anyOf": [
-              {
-                "enum": [
-                  "female",
-                  "male"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sex"
-          },
-          "surplus_pct": {
-            "anyOf": [
-              {
-                "maximum": 20.0,
-                "minimum": 5.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Surplus Pct"
-          },
-          "targets": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Targets"
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weight Kg"
-          }
-        },
-        "title": "LegacyWeekPlanRequest",
         "type": "object"
       },
       "ManualPaymentSource": {
@@ -3215,106 +2255,6 @@
           "overall_score"
         ],
         "title": "NutrientCoverageSummary",
-        "type": "object"
-      },
-      "NutrientGapsRequest": {
-        "description": "RU: Запрос на анализ дефицитов нутриентов.\nEN: Request for nutrient gap analysis.",
-        "properties": {
-          "consumed_nutrients": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Consumed Nutrients",
-            "type": "object"
-          },
-          "user_profile": {
-            "$ref": "#/components/schemas/WHOTargetsRequest"
-          }
-        },
-        "required": [
-          "consumed_nutrients",
-          "user_profile"
-        ],
-        "title": "NutrientGapsRequest",
-        "type": "object"
-      },
-      "NutrientGapsResponse": {
-        "description": "RU: Ответ с анализом дефицитов и рекомендациями.\nEN: Response with gap analysis and recommendations.",
-        "properties": {
-          "adherence_score": {
-            "title": "Adherence Score",
-            "type": "number"
-          },
-          "food_recommendations": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Food Recommendations",
-            "type": "array"
-          },
-          "gaps": {
-            "additionalProperties": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Gaps",
-            "type": "object"
-          }
-        },
-        "required": [
-          "gaps",
-          "food_recommendations",
-          "adherence_score"
-        ],
-        "title": "NutrientGapsResponse",
-        "type": "object"
-      },
-      "NutrientRecommendationsResponse": {
-        "description": "FREE endpoint response: basic nutrient recommendations.\n\nRU: Ответ для бесплатного эндпоинта рекомендаций по питанию.\nEN: Response for the free nutrient recommendations endpoint.",
-        "properties": {
-          "activity": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "description": "Activity targets: moderate_aerobic_min, vigorous_aerobic_min, strength_sessions, steps_daily",
-            "title": "Activity",
-            "type": "object"
-          },
-          "kcal_daily": {
-            "description": "Target daily calories (kcal)",
-            "title": "Kcal Daily",
-            "type": "integer"
-          },
-          "macros": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "description": "Macronutrient targets: protein_g, fat_g, carbs_g, fiber_g",
-            "title": "Macros",
-            "type": "object"
-          },
-          "micros": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "description": "Priority micronutrient targets (WHO/EFSA)",
-            "title": "Micros",
-            "type": "object"
-          },
-          "water_ml_daily": {
-            "description": "Daily water intake target (ml)",
-            "title": "Water Ml Daily",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "kcal_daily",
-          "macros",
-          "water_ml_daily",
-          "micros",
-          "activity"
-        ],
-        "title": "NutrientRecommendationsResponse",
         "type": "object"
       },
       "NutritionSegmentData": {
@@ -4466,172 +3406,6 @@
         "title": "PlateResponse",
         "type": "object"
       },
-      "PremiumWeekPlanRequest": {
-        "properties": {
-          "activity": {
-            "anyOf": [
-              {
-                "enum": [
-                  "sedentary",
-                  "light",
-                  "moderate",
-                  "active",
-                  "very_active"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "moderate",
-            "title": "Activity"
-          },
-          "age": {
-            "anyOf": [
-              {
-                "exclusiveMaximum": 90.0,
-                "exclusiveMinimum": 10.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Age"
-          },
-          "diet_flags": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Diet Flags",
-            "type": "array"
-          },
-          "goal": {
-            "anyOf": [
-              {
-                "enum": [
-                  "loss",
-                  "maintain",
-                  "gain"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "maintain",
-            "title": "Goal"
-          },
-          "height_cm": {
-            "anyOf": [
-              {
-                "exclusiveMaximum": 220.0,
-                "exclusiveMinimum": 100.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Height Cm"
-          },
-          "lang": {
-            "default": "en",
-            "enum": [
-              "ru",
-              "en",
-              "es"
-            ],
-            "title": "Lang",
-            "type": "string"
-          },
-          "sex": {
-            "anyOf": [
-              {
-                "enum": [
-                  "female",
-                  "male"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sex"
-          },
-          "targets": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TargetsIn"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "exclusiveMaximum": 300.0,
-                "exclusiveMinimum": 30.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weight Kg"
-          }
-        },
-        "title": "PremiumWeekPlanRequest",
-        "type": "object"
-      },
-      "PremiumWeekPlanResponse": {
-        "properties": {
-          "adherence_score": {
-            "title": "Adherence Score",
-            "type": "number"
-          },
-          "daily_menus": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Daily Menus",
-            "type": "array"
-          },
-          "shopping_list": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Shopping List",
-            "type": "object"
-          },
-          "total_cost": {
-            "title": "Total Cost",
-            "type": "number"
-          },
-          "weekly_coverage": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Weekly Coverage",
-            "type": "object"
-          }
-        },
-        "required": [
-          "daily_menus",
-          "weekly_coverage",
-          "shopping_list",
-          "total_cost",
-          "adherence_score"
-        ],
-        "title": "PremiumWeekPlanResponse",
-        "type": "object"
-      },
       "ProWeekPlanRequest": {
         "description": "Request model for weekly meal plan generation.\n\nSupports two modes:\n- Mode A: Provide ready targets\n- Mode B: Quick profile (fallback)",
         "properties": {
@@ -4754,50 +3528,6 @@
           }
         },
         "title": "ProWeekPlanRequest",
-        "type": "object"
-      },
-      "ProWeekPlanResponse": {
-        "description": "Response model for weekly meal plan.",
-        "properties": {
-          "adherence_score": {
-            "title": "Adherence Score",
-            "type": "number"
-          },
-          "daily_menus": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Daily Menus",
-            "type": "array"
-          },
-          "shopping_list": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Shopping List",
-            "type": "object"
-          },
-          "total_cost": {
-            "title": "Total Cost",
-            "type": "number"
-          },
-          "weekly_coverage": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Weekly Coverage",
-            "type": "object"
-          }
-        },
-        "required": [
-          "daily_menus",
-          "weekly_coverage",
-          "shopping_list",
-          "total_cost",
-          "adherence_score"
-        ],
-        "title": "ProWeekPlanResponse",
         "type": "object"
       },
       "ProfileInput": {
@@ -5027,186 +3757,6 @@
         "title": "QuantityDTO",
         "type": "object"
       },
-      "RAGChunkInput": {
-        "description": "Input schema for a retrieved chunk in feedback.",
-        "properties": {
-          "chunk_id": {
-            "anyOf": [
-              {
-                "maxLength": 256,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Chunk Id"
-          },
-          "file": {
-            "anyOf": [
-              {
-                "maxLength": 512,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File"
-          },
-          "preview": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Preview"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "maximum": 1.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score"
-          }
-        },
-        "title": "RAGChunkInput",
-        "type": "object"
-      },
-      "RAGFeedbackRequest": {
-        "description": "Request schema for submitting RAG feedback.",
-        "properties": {
-          "agent_id": {
-            "anyOf": [
-              {
-                "maxLength": 64,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agent Id"
-          },
-          "confidence": {
-            "anyOf": [
-              {
-                "maximum": 1.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confidence"
-          },
-          "hops": {
-            "anyOf": [
-              {
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hops"
-          },
-          "llm_response": {
-            "anyOf": [
-              {
-                "maxLength": 50000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Llm Response"
-          },
-          "query": {
-            "maxLength": 10000,
-            "minLength": 1,
-            "title": "Query",
-            "type": "string"
-          },
-          "retrieved_chunks": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/RAGChunkInput"
-                },
-                "maxItems": 50,
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retrieved Chunks"
-          },
-          "user_correction": {
-            "anyOf": [
-              {
-                "maxLength": 50000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Correction"
-          },
-          "user_rating": {
-            "anyOf": [
-              {
-                "maximum": 5.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Rating"
-          }
-        },
-        "required": [
-          "query"
-        ],
-        "title": "RAGFeedbackRequest",
-        "type": "object"
-      },
-      "RAGFeedbackResponse": {
-        "description": "Response schema for feedback submission.",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "message": {
-            "default": "Feedback submitted successfully",
-            "title": "Message",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "RAGFeedbackResponse",
-        "type": "object"
-      },
       "RateLimitErrorResponse": {
         "description": "Error response for 429 rate-limit exceeded.\n\nMatches FastAPI/Starlette HTTPException envelope: {\"detail\": \"...\"}.",
         "properties": {
@@ -5219,184 +3769,6 @@
           "detail"
         ],
         "title": "RateLimitErrorResponse",
-        "type": "object"
-      },
-      "Recipe": {
-        "properties": {
-          "allergens": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Allergens",
-            "type": "array"
-          },
-          "cost_per_serv": {
-            "default": 0.0,
-            "title": "Cost Per Serv",
-            "type": "number"
-          },
-          "cost_total": {
-            "default": 0.0,
-            "title": "Cost Total",
-            "type": "number"
-          },
-          "ingredients": {
-            "items": {
-              "$ref": "#/components/schemas/Ingredient"
-            },
-            "minItems": 1,
-            "title": "Ingredients",
-            "type": "array"
-          },
-          "locale": {
-            "default": "en",
-            "title": "Locale",
-            "type": "string"
-          },
-          "nutrients_per_serv": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Nutrients Per Serv",
-            "type": "object"
-          },
-          "recipe_id": {
-            "title": "Recipe Id",
-            "type": "string"
-          },
-          "servings": {
-            "title": "Servings",
-            "type": "integer"
-          },
-          "source": {
-            "default": "internal",
-            "title": "Source",
-            "type": "string"
-          },
-          "steps": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Steps",
-            "type": "array"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Tags",
-            "type": "array"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "version_date": {
-            "title": "Version Date",
-            "type": "string"
-          },
-          "yield_total_g": {
-            "title": "Yield Total G",
-            "type": "number"
-          }
-        },
-        "required": [
-          "recipe_id",
-          "title",
-          "servings",
-          "yield_total_g",
-          "ingredients",
-          "version_date"
-        ],
-        "title": "Recipe",
-        "type": "object"
-      },
-      "RecipePreviewRequest": {
-        "properties": {
-          "ingredients": {
-            "items": {
-              "$ref": "#/components/schemas/Ingredient"
-            },
-            "minItems": 1,
-            "title": "Ingredients",
-            "type": "array"
-          },
-          "servings": {
-            "default": 1,
-            "title": "Servings",
-            "type": "integer"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          }
-        },
-        "required": [
-          "title",
-          "ingredients"
-        ],
-        "title": "RecipePreviewRequest",
-        "type": "object"
-      },
-      "RecipePreviewResponse": {
-        "properties": {
-          "per_serving": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Per Serving",
-            "type": "object"
-          },
-          "servings": {
-            "title": "Servings",
-            "type": "integer"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "total_g": {
-            "title": "Total G",
-            "type": "number"
-          }
-        },
-        "required": [
-          "title",
-          "servings",
-          "total_g",
-          "per_serving"
-        ],
-        "title": "RecipePreviewResponse",
-        "type": "object"
-      },
-      "RecipeQueryHit": {
-        "properties": {
-          "kcal_per_serv": {
-            "title": "Kcal Per Serv",
-            "type": "number"
-          },
-          "recipe_id": {
-            "title": "Recipe Id",
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Tags",
-            "type": "array"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          }
-        },
-        "required": [
-          "recipe_id",
-          "title",
-          "kcal_per_serv"
-        ],
-        "title": "RecipeQueryHit",
         "type": "object"
       },
       "ReconcileDecision": {
@@ -5686,36 +4058,6 @@
         "title": "ShoplistAnalyticsDTO",
         "type": "object"
       },
-      "ShoplistDailyRequest": {
-        "description": "Request payload for POST /api/v1/vip/shoplist/daily.\n\nSame contract as ShoplistGenerateRequest.",
-        "properties": {
-          "items": {
-            "description": "Shopping list items (can be empty)",
-            "items": {
-              "$ref": "#/components/schemas/ShoplistItemDTO"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "packaging_rules": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/PackageRuleDTO"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional. If missing/None, items without rules go to 'unpacked'.",
-            "title": "Packaging Rules"
-          }
-        },
-        "title": "ShoplistDailyRequest",
-        "type": "object"
-      },
       "ShoplistDayItemDTO": {
         "description": "One day shopping list item (server → iOS).\n\nkey: stable dedup key (server-side normalized slug or food_id-like).\ntitle: localized title for UI.\n\nRU: Одна строка списка покупок на день (сервер → iOS).",
         "properties": {
@@ -5943,98 +4285,6 @@
         "title": "ShoplistGenerateResponse",
         "type": "object"
       },
-      "ShoplistGroup": {
-        "description": "Group of items by aisle.",
-        "properties": {
-          "aisle": {
-            "title": "Aisle",
-            "type": "string"
-          },
-          "items": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Items",
-            "type": "array"
-          }
-        },
-        "required": [
-          "aisle",
-          "items"
-        ],
-        "title": "ShoplistGroup",
-        "type": "object"
-      },
-      "ShoplistItem": {
-        "description": "Single item in the shoplist.",
-        "properties": {
-          "aisle": {
-            "title": "Aisle",
-            "type": "string"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          },
-          "qty": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Qty"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          }
-        },
-        "required": [
-          "aisle"
-        ],
-        "title": "ShoplistItem",
-        "type": "object"
-      },
       "ShoplistItemDTO": {
         "description": "Shopping list item specification (food, quantity, form).",
         "properties": {
@@ -6157,46 +4407,6 @@
         "title": "ShoplistPreviewResponse",
         "type": "object"
       },
-      "ShoplistResponse": {
-        "description": "Response model for shoplist endpoint.",
-        "properties": {
-          "currency": {
-            "title": "Currency",
-            "type": "string"
-          },
-          "groups": {
-            "items": {
-              "$ref": "#/components/schemas/ShoplistGroup"
-            },
-            "title": "Groups",
-            "type": "array"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ShoplistItem"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "store": {
-            "title": "Store",
-            "type": "string"
-          },
-          "total_estimated": {
-            "title": "Total Estimated",
-            "type": "number"
-          }
-        },
-        "required": [
-          "store",
-          "currency",
-          "total_estimated",
-          "groups",
-          "items"
-        ],
-        "title": "ShoplistResponse",
-        "type": "object"
-      },
       "ShoplistSourceDTO": {
         "description": "Optional provenance of an item.\n\nRU: Источник/происхождение позиции (опционально).",
         "properties": {
@@ -6223,69 +4433,6 @@
           }
         },
         "title": "ShoplistSourceDTO",
-        "type": "object"
-      },
-      "ShoplistWeeklyDayRequest": {
-        "description": "Request payload for one day in weekly shoplist.\n\nSame contract as ShoplistGenerateRequest per day.",
-        "properties": {
-          "items": {
-            "description": "Shopping list items for this day (can be empty)",
-            "items": {
-              "$ref": "#/components/schemas/ShoplistItemDTO"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "packaging_rules": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/PackageRuleDTO"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional. If missing/None, items without rules go to 'unpacked'.",
-            "title": "Packaging Rules"
-          }
-        },
-        "title": "ShoplistWeeklyDayRequest",
-        "type": "object"
-      },
-      "ShoplistWeeklyRequest": {
-        "description": "Request payload for POST /api/v1/vip/shoplist/weekly.",
-        "properties": {
-          "days": {
-            "description": "One element per day. Contract: length = as requested by client (no fixed 7-day requirement).",
-            "items": {
-              "$ref": "#/components/schemas/ShoplistWeeklyDayRequest"
-            },
-            "title": "Days",
-            "type": "array"
-          }
-        },
-        "required": [
-          "days"
-        ],
-        "title": "ShoplistWeeklyRequest",
-        "type": "object"
-      },
-      "ShoplistWeeklyResponse": {
-        "description": "Response for POST /api/v1/vip/shoplist/weekly.",
-        "properties": {
-          "days": {
-            "description": "One response per day (length = as requested by client)",
-            "items": {
-              "$ref": "#/components/schemas/ShoplistGenerateResponse"
-            },
-            "title": "Days",
-            "type": "array"
-          }
-        },
-        "title": "ShoplistWeeklyResponse",
         "type": "object"
       },
       "ShoppingListCategory": {
@@ -6498,54 +4645,6 @@
           }
         },
         "title": "ShoppingListRequest",
-        "type": "object"
-      },
-      "SignRequest": {
-        "properties": {
-          "path": {
-            "title": "Path",
-            "type": "string"
-          },
-          "ttl_seconds": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ttl Seconds"
-          }
-        },
-        "required": [
-          "path"
-        ],
-        "title": "SignRequest",
-        "type": "object"
-      },
-      "SignedLinkResponse": {
-        "description": "Response model for signed export links.",
-        "properties": {
-          "exp": {
-            "title": "Exp",
-            "type": "integer"
-          },
-          "ttl": {
-            "title": "Ttl",
-            "type": "integer"
-          },
-          "url": {
-            "title": "Url",
-            "type": "string"
-          }
-        },
-        "required": [
-          "url",
-          "exp",
-          "ttl"
-        ],
-        "title": "SignedLinkResponse",
         "type": "object"
       },
       "SoftPaywallAvailability": {
@@ -6856,41 +4955,6 @@
           "water_ml_daily"
         ],
         "title": "TargetsSummary",
-        "type": "object"
-      },
-      "TestResponse": {
-        "description": "Standard test response model.",
-        "properties": {
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
-          "request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Request Id"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "timestamp": {
-            "title": "Timestamp",
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "message",
-          "timestamp"
-        ],
-        "title": "TestResponse",
         "type": "object"
       },
       "UnpackedLineDTO": {
@@ -7337,8 +5401,126 @@
         "title": "WaistRiskResultSchema",
         "type": "object"
       },
-      "WeeklyMenuResponse": {
-        "description": "RU: Ответ с недельным меню.\nEN: Response with weekly menu.",
+      "WeeklyMealPlanDayMenu": {
+        "description": "Typed representation of one generated day menu.",
+        "properties": {
+          "coverage": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Coverage",
+            "type": "object"
+          },
+          "kcal": {
+            "title": "Kcal",
+            "type": "number"
+          },
+          "macros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Macros",
+            "type": "object"
+          },
+          "meals": {
+            "items": {
+              "$ref": "#/components/schemas/WeeklyMealPlanItem"
+            },
+            "title": "Meals",
+            "type": "array"
+          },
+          "micros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Micros",
+            "type": "object"
+          },
+          "tips": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tips",
+            "type": "array"
+          },
+          "total_cost": {
+            "title": "Total Cost",
+            "type": "number"
+          }
+        },
+        "required": [
+          "meals",
+          "kcal",
+          "macros",
+          "micros",
+          "coverage",
+          "tips",
+          "total_cost"
+        ],
+        "title": "WeeklyMealPlanDayMenu",
+        "type": "object"
+      },
+      "WeeklyMealPlanItem": {
+        "description": "Typed representation of one generated meal entry.",
+        "properties": {
+          "grams": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Grams",
+            "type": "object"
+          },
+          "kcal": {
+            "title": "Kcal",
+            "type": "number"
+          },
+          "macros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Macros",
+            "type": "object"
+          },
+          "micros": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Micros",
+            "type": "object"
+          },
+          "price_est": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Price Est"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "title_translated": {
+            "title": "Title Translated",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "title_translated",
+          "grams",
+          "kcal",
+          "macros",
+          "micros"
+        ],
+        "title": "WeeklyMealPlanItem",
+        "type": "object"
+      },
+      "WeeklyMealPlanResponse": {
+        "description": "Typed canonical response for PRO/premium weekly-plan endpoints.",
         "properties": {
           "adherence_score": {
             "title": "Adherence Score",
@@ -7346,8 +5528,7 @@
           },
           "daily_menus": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/WeeklyMealPlanDayMenu"
             },
             "title": "Daily Menus",
             "type": "array"
@@ -7363,11 +5544,6 @@
             "title": "Total Cost",
             "type": "number"
           },
-          "week_summary": {
-            "additionalProperties": true,
-            "title": "Week Summary",
-            "type": "object"
-          },
           "weekly_coverage": {
             "additionalProperties": {
               "type": "number"
@@ -7377,14 +5553,13 @@
           }
         },
         "required": [
-          "week_summary",
           "daily_menus",
           "weekly_coverage",
           "shopping_list",
           "total_cost",
           "adherence_score"
         ],
-        "title": "WeeklyMenuResponse",
+        "title": "WeeklyMealPlanResponse",
         "type": "object"
       },
       "WeeklyPlanResponse": {
@@ -7830,7 +6005,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProWeekPlanResponse"
+                  "$ref": "#/components/schemas/WeeklyMealPlanResponse"
                 }
               }
             },

--- a/frontend/src/api/premium/index.ts
+++ b/frontend/src/api/premium/index.ts
@@ -3,7 +3,7 @@ export type { BmrRequest, BmrApiResponse } from './bmr';
 export type { CbtInsightRequest, CbtInsightResponse } from './cbt-insight';
 export type { PlateRequest, PlateResponse } from './plate';
 export type { TargetsRequest, TargetsApiResponse } from './targets';
-export type { WeeklyMenuResponse } from './weekly-plan';
+export type { ProWeekPlanRequest, WeeklyMealPlanResponse } from './weekly-plan';
 
 export { getBmr } from './bmr';
 export { getCbtInsight } from './cbt-insight';

--- a/frontend/src/api/premium/weekly-plan.ts
+++ b/frontend/src/api/premium/weekly-plan.ts
@@ -2,8 +2,8 @@ import { createPremiumEndpoint } from './types';
 import type { components } from '../schema';
 
 // Use canonical OpenAPI types from the public PRO contract.
-export type WeekPlanRequest = components['schemas']['ProWeekPlanRequest'];
-export type WeeklyMenuResponse = components['schemas']['WeeklyMealPlanResponse'];
+export type ProWeekPlanRequest = components['schemas']['ProWeekPlanRequest'];
+export type WeeklyMealPlanResponse = components['schemas']['WeeklyMealPlanResponse'];
 
 /**
  * Generate weekly meal plan (PRO tier).
@@ -11,6 +11,6 @@ export type WeeklyMenuResponse = components['schemas']['WeeklyMealPlanResponse']
  * Migrated from deprecated /api/v1/premium/plan/week to canonical /api/v1/pro/meal/weekly.
  * Uses canonical OpenAPI request/response types from /api/v1/pro/meal/weekly.
  */
-export const getWeeklyPlan = createPremiumEndpoint<WeekPlanRequest, WeeklyMenuResponse>(
+export const getWeeklyPlan = createPremiumEndpoint<ProWeekPlanRequest, WeeklyMealPlanResponse>(
   '/api/v1/pro/meal/weekly'  // ✅ Canonical endpoint
 );

--- a/frontend/src/api/premium/weekly-plan.ts
+++ b/frontend/src/api/premium/weekly-plan.ts
@@ -1,15 +1,15 @@
 import { createPremiumEndpoint } from './types';
 import type { components } from '../schema';
 
-// Use OpenAPI types (canonical)
-export type WeekPlanRequest = components['schemas']['WeekPlanRequest'];
-export type WeeklyMenuResponse = components['schemas']['WeeklyMenuResponse'];
+// Use canonical OpenAPI types from the public PRO contract.
+export type WeekPlanRequest = components['schemas']['ProWeekPlanRequest'];
+export type WeeklyMenuResponse = components['schemas']['WeeklyMealPlanResponse'];
 
 /**
  * Generate weekly meal plan (PRO tier).
  *
  * Migrated from deprecated /api/v1/premium/plan/week to canonical /api/v1/pro/meal/weekly.
- * Uses OpenAPI WeekPlanRequest and WeeklyMenuResponse types.
+ * Uses canonical OpenAPI request/response types from /api/v1/pro/meal/weekly.
  */
 export const getWeeklyPlan = createPremiumEndpoint<WeekPlanRequest, WeeklyMenuResponse>(
   '/api/v1/pro/meal/weekly'  // ✅ Canonical endpoint

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1426,34 +1426,6 @@ export interface components {
          */
         ActivationStatus: "pending_verification" | "active" | "rejected";
         /**
-         * AdherenceEventRequest
-         * @description Request schema for recording an adherence event.
-         *
-         *     RU: Схема запроса для записи события adherence.
-         *     EN: Request schema for recording an adherence event.
-         *
-         *     Security Note:
-         *         subject_id is derived from authenticated API key (not from request payload)
-         *         to prevent horizontal privilege escalation.
-         */
-        AdherenceEventRequest: {
-            /**
-             * Analyzer Key
-             * @default v1:adherence
-             */
-            analyzer_key: string;
-            /**
-             * Event Type
-             * @enum {string}
-             */
-            event_type: "meal_logged" | "slip";
-            /**
-             * Weight
-             * @default 1
-             */
-            weight: number;
-        };
-        /**
          * AdherenceResponse
          * @description Response schema for adherence endpoints.
          *
@@ -2017,51 +1989,6 @@ export interface components {
              */
             to: number;
         };
-        /** BMIRequest */
-        BMIRequest: {
-            /**
-             * Age
-             * @default 30
-             */
-            age: number;
-            /**
-             * Athlete
-             * @default no
-             */
-            athlete: string | boolean;
-            /**
-             * Gender
-             * @default male
-             */
-            gender: string;
-            /** Height M */
-            height_m: number;
-            /**
-             * Include Chart
-             * @default false
-             */
-            include_chart: boolean | null;
-            /**
-             * Lang
-             * @default ru
-             * @enum {string}
-             */
-            lang: "ru" | "en" | "es";
-            /**
-             * Pregnant
-             * @default no
-             */
-            pregnant: string | boolean;
-            /**
-             * Premium
-             * @default false
-             */
-            premium: boolean | null;
-            /** Waist Cm */
-            waist_cm?: number | null;
-            /** Weight Kg */
-            weight_kg: number;
-        };
         /** BMIRequestV1 */
         BMIRequestV1: {
             /**
@@ -2171,186 +2098,6 @@ export interface components {
             ranges: components["schemas"]["BMIRangeSpec"][];
         };
         /**
-         * BMRRequest
-         * @description Request model for BMR calculation
-         */
-        BMRRequest: {
-            /** Activity */
-            activity: string;
-            /** Age */
-            age: number;
-            /** Bodyfat */
-            bodyfat?: number | null;
-            /** Height Cm */
-            height_cm: number;
-            /**
-             * Lang
-             * @default en
-             * @enum {string}
-             */
-            lang: "ru" | "en" | "es";
-            /** Sex */
-            sex: string;
-            /** Weight Kg */
-            weight_kg: number;
-        };
-        /**
-         * BMRRequestLegacy
-         * @description Lenient legacy request model to allow testing error paths without 422.
-         *
-         *     RU: Более мягкая модель для обратной совместимости.
-         *     EN: Lenient model for backward compatibility.
-         */
-        BMRRequestLegacy: {
-            /** Activity */
-            activity: string;
-            /** Age */
-            age: number;
-            /** Bodyfat */
-            bodyfat?: number | null;
-            /** Height Cm */
-            height_cm: number;
-            /**
-             * Lang
-             * @default en
-             * @enum {string}
-             */
-            lang: "ru" | "en" | "es";
-            /** Sex */
-            sex: string;
-            /** Weight Kg */
-            weight_kg: number;
-        };
-        /**
-         * BMRResponse
-         * @description Response model for BMR calculation
-         */
-        BMRResponse: {
-            /**
-             * Activity Level
-             * @description Localized description of the activity level used in calculations (e.g., 'sedentary', 'light', 'moderate', 'active', 'very_active').
-             */
-            activity_level: string;
-            /**
-             * Bmr
-             * @description BMR values calculated by different formulas. Keys are formula names (e.g., 'mifflin', 'harris', 'katch'), values are BMR in kcal/day.
-             */
-            bmr: {
-                [key: string]: number;
-            };
-            /**
-             * Formulas Used
-             * @description List of BMR formula names that were used in the calculation (e.g., ['mifflin', 'harris', 'katch']).
-             */
-            formulas_used: string[];
-            /**
-             * Notes
-             * @description Informational messages about the calculation (e.g., notes about body fat usage, warnings, or fallback explanations).
-             */
-            notes: string[];
-            /**
-             * Recommended Intake
-             * @description Recommended daily calorie intake for different goals. Keys: 'maintenance', 'weight_loss' (20% deficit), 'weight_gain' (20% surplus); values are calories in kcal/day.
-             */
-            recommended_intake: {
-                [key: string]: number;
-            };
-            /**
-             * Tdee
-             * @description TDEE (Total Daily Energy Expenditure) values for different formulas and activity levels. Keys are formula names, values are TDEE in kcal/day.
-             */
-            tdee: {
-                [key: string]: number;
-            };
-        };
-        /** BodyFatRequest */
-        BodyFatRequest: {
-            /**
-             * Age
-             * @description Age in years, 1..120
-             */
-            age?: number | null;
-            /**
-             * Bmi
-             * @description BMI value, 0..100
-             */
-            bmi?: number | null;
-            /** Gender */
-            gender: string;
-            /**
-             * Height M
-             * @description Height in meters, must be positive
-             */
-            height_m?: number | null;
-            /**
-             * Hip Cm
-             * @description Hip circumference in cm, must be > 0
-             */
-            hip_cm?: number | null;
-            /**
-             * Language
-             * @default en
-             */
-            language: string | null;
-            /**
-             * Neck Cm
-             * @description Neck circumference in cm, must be > 0
-             */
-            neck_cm?: number | null;
-            /**
-             * Waist Cm
-             * @description Waist circumference in cm, must be > 0
-             */
-            waist_cm?: number | null;
-            /**
-             * Weight Kg
-             * @description Weight in kg, must be positive
-             */
-            weight_kg?: number | null;
-        };
-        /**
-         * BusinessAnalysisRequest
-         * @description Request model for business analysis.
-         */
-        BusinessAnalysisRequest: {
-            /**
-             * Code
-             * @description Code to analyze (max 100KB)
-             */
-            code: string;
-            /** Locale */
-            locale?: string | null;
-            /**
-             * Test Name
-             * @default business_analysis
-             */
-            test_name: string;
-        };
-        /**
-         * BusinessAnalysisResponse
-         * @description Response model for business analysis.
-         */
-        BusinessAnalysisResponse: {
-            /** Business Category */
-            business_category: string;
-            /** Cost Impact */
-            cost_impact: string;
-            /** Customer Impact */
-            customer_impact: string;
-            /** Error Message */
-            error_message: string | null;
-            /** Error Type */
-            error_type: string;
-            /** Optimization Potential */
-            optimization_potential: string | null;
-            /** Revenue Impact */
-            revenue_impact: string;
-            /** Success */
-            success: boolean;
-            /** Test Name */
-            test_name: string;
-        };
-        /**
          * CatalogInfoDTO
          * @description RU: Каталожная информация для enrichment слоя (adapter-only).
          *     EN: Catalog enrichment info (adapter-only).
@@ -2395,126 +2142,6 @@ export interface components {
              * @example walmart_us
              */
             store_id: string;
-        };
-        /**
-         * CatalogRegion
-         * @description RU: Регион каталога (legacy/public contract).
-         *     EN: Catalog region (legacy/public contract).
-         *
-         *     Region catalog public DTO (used by app/routers/catalog.py).
-         *     Keep backward-compatible with core.catalog.service model_dump().
-         */
-        CatalogRegion: {
-            /**
-             * Id
-             * @example es
-             */
-            id: string;
-            /**
-             * Name
-             * @example Spain
-             */
-            name: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
-         * CatalogSKU
-         * @description RU: SKU запись (legacy/public contract).
-         *     EN: SKU record (legacy/public contract).
-         *
-         *     SKU public DTO (used by app/routers/catalog.py).
-         */
-        CatalogSKU: {
-            /**
-             * Aisle
-             * @example Vegetables
-             */
-            aisle?: string | null;
-            /**
-             * Barcode
-             * @example 1234567890123
-             */
-            barcode?: string | null;
-            /**
-             * Brand
-             * @example Carrefour
-             */
-            brand?: string | null;
-            /**
-             * Id
-             * @example CRF-ES-000123
-             */
-            id: string;
-            /**
-             * Name
-             * @example Carrot 500g
-             */
-            name: string;
-            /**
-             * Pack Label
-             * @example 500 g bag
-             */
-            pack_label?: string | null;
-            /**
-             * Price Currency
-             * @example EUR
-             */
-            price_currency?: string | null;
-            /**
-             * Price Value
-             * @description Decimal serialized as string in JSON (Pydantic v2).
-             * @example 1.29
-             */
-            price_value?: string | null;
-            /**
-             * Region Id
-             * @example es
-             */
-            region_id: string;
-            /**
-             * Source Id
-             * @example carrefour
-             */
-            source_id: string;
-            /**
-             * Store Id
-             * @example carrefour_es
-             */
-            store_id: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
-         * CatalogStore
-         * @description RU: Магазин/сеть в регионе (legacy/public contract).
-         *     EN: Store in region (legacy/public contract).
-         *
-         *     Store public DTO (used by app/routers/catalog.py).
-         */
-        CatalogStore: {
-            /**
-             * Id
-             * @example carrefour_es
-             */
-            id: string;
-            /**
-             * Name
-             * @example Carrefour ES
-             */
-            name: string;
-            /**
-             * Region Id
-             * @example es
-             */
-            region_id: string;
-            /**
-             * Source Id
-             * @example carrefour
-             */
-            source_id: string;
-        } & {
-            [key: string]: unknown;
         };
         /**
          * CBTInsightRequest
@@ -2785,62 +2412,6 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
-        };
-        /** Ingredient */
-        Ingredient: {
-            /** Food Id */
-            food_id: string;
-            /** Grams */
-            grams: number;
-        };
-        /**
-         * LegacyWeekPlanRequest
-         * @description Extended request for week plan with optional pre-calculated targets.
-         *
-         *     Supports two modes:
-         *     - Mode A: With targets (pre-calculated nutrition goals)
-         *     - Mode B: Calculate targets from user profile (sex, age, etc.)
-         */
-        LegacyWeekPlanRequest: {
-            /** Activity */
-            activity?: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
-            /** Age */
-            age?: number | null;
-            /** Bodyfat */
-            bodyfat?: number | null;
-            /** Deficit Pct */
-            deficit_pct?: number | null;
-            /** Diet Flags */
-            diet_flags?: ("VEG" | "GF" | "DAIRY_FREE" | "LOW_COST" | "HIGH_PROTEIN" | "LOW_CARB" | "MEDITERRANEAN" | "VEGAN" | "KETO" | "PALEO")[] | null;
-            /**
-             * Goal
-             * @default maintain
-             * @enum {string}
-             */
-            goal: "loss" | "maintain" | "gain";
-            /** Height Cm */
-            height_cm?: number | null;
-            /**
-             * Lang
-             * @default en
-             */
-            lang: string;
-            /**
-             * Life Stage
-             * @default adult
-             * @enum {string}
-             */
-            life_stage: "child" | "teen" | "adult" | "pregnant" | "lactating" | "elderly";
-            /** Sex */
-            sex?: ("female" | "male") | null;
-            /** Surplus Pct */
-            surplus_pct?: number | null;
-            /** Targets */
-            targets?: {
-                [key: string]: unknown;
-            } | null;
-            /** Weight Kg */
-            weight_kg?: number | null;
         };
         /**
          * ManualPaymentSource
@@ -3113,75 +2684,6 @@ export interface components {
              * @description Total nutrients scored
              */
             total_nutrients: number;
-        };
-        /**
-         * NutrientGapsRequest
-         * @description RU: Запрос на анализ дефицитов нутриентов.
-         *     EN: Request for nutrient gap analysis.
-         */
-        NutrientGapsRequest: {
-            /** Consumed Nutrients */
-            consumed_nutrients: {
-                [key: string]: number;
-            };
-            user_profile: components["schemas"]["WHOTargetsRequest"];
-        };
-        /**
-         * NutrientGapsResponse
-         * @description RU: Ответ с анализом дефицитов и рекомендациями.
-         *     EN: Response with gap analysis and recommendations.
-         */
-        NutrientGapsResponse: {
-            /** Adherence Score */
-            adherence_score: number;
-            /** Food Recommendations */
-            food_recommendations: string[];
-            /** Gaps */
-            gaps: {
-                [key: string]: {
-                    [key: string]: unknown;
-                };
-            };
-        };
-        /**
-         * NutrientRecommendationsResponse
-         * @description FREE endpoint response: basic nutrient recommendations.
-         *
-         *     RU: Ответ для бесплатного эндпоинта рекомендаций по питанию.
-         *     EN: Response for the free nutrient recommendations endpoint.
-         */
-        NutrientRecommendationsResponse: {
-            /**
-             * Activity
-             * @description Activity targets: moderate_aerobic_min, vigorous_aerobic_min, strength_sessions, steps_daily
-             */
-            activity: {
-                [key: string]: number;
-            };
-            /**
-             * Kcal Daily
-             * @description Target daily calories (kcal)
-             */
-            kcal_daily: number;
-            /**
-             * Macros
-             * @description Macronutrient targets: protein_g, fat_g, carbs_g, fiber_g
-             */
-            macros: {
-                [key: string]: number;
-            };
-            /**
-             * Micros
-             * @description Priority micronutrient targets (WHO/EFSA)
-             */
-            micros: {
-                [key: string]: number;
-            };
-            /**
-             * Water Ml Daily
-             * @description Daily water intake target (ml)
-             */
-            water_ml_daily: number;
         };
         /**
          * NutritionSegmentData
@@ -3648,55 +3150,6 @@ export interface components {
                 [key: string]: number;
             };
         };
-        /** PremiumWeekPlanRequest */
-        PremiumWeekPlanRequest: {
-            /**
-             * Activity
-             * @default moderate
-             */
-            activity: ("sedentary" | "light" | "moderate" | "active" | "very_active") | null;
-            /** Age */
-            age?: number | null;
-            /** Diet Flags */
-            diet_flags?: string[];
-            /**
-             * Goal
-             * @default maintain
-             */
-            goal: ("loss" | "maintain" | "gain") | null;
-            /** Height Cm */
-            height_cm?: number | null;
-            /**
-             * Lang
-             * @default en
-             * @enum {string}
-             */
-            lang: "ru" | "en" | "es";
-            /** Sex */
-            sex?: ("female" | "male") | null;
-            targets?: components["schemas"]["TargetsIn"] | null;
-            /** Weight Kg */
-            weight_kg?: number | null;
-        };
-        /** PremiumWeekPlanResponse */
-        PremiumWeekPlanResponse: {
-            /** Adherence Score */
-            adherence_score: number;
-            /** Daily Menus */
-            daily_menus: {
-                [key: string]: unknown;
-            }[];
-            /** Shopping List */
-            shopping_list: {
-                [key: string]: number;
-            };
-            /** Total Cost */
-            total_cost: number;
-            /** Weekly Coverage */
-            weekly_coverage: {
-                [key: string]: number;
-            };
-        };
         /**
          * ProfileInput
          * @description Reusable profile input for nutrition endpoints.
@@ -3801,28 +3254,6 @@ export interface components {
             weight_kg?: number | null;
         };
         /**
-         * ProWeekPlanResponse
-         * @description Response model for weekly meal plan.
-         */
-        ProWeekPlanResponse: {
-            /** Adherence Score */
-            adherence_score: number;
-            /** Daily Menus */
-            daily_menus: {
-                [key: string]: unknown;
-            }[];
-            /** Shopping List */
-            shopping_list: {
-                [key: string]: number;
-            };
-            /** Total Cost */
-            total_cost: number;
-            /** Weekly Coverage */
-            weekly_coverage: {
-                [key: string]: number;
-            };
-        };
-        /**
          * QuantityDTO
          * @description Quantity with value and unit (deterministic, no prices).
          */
@@ -3869,55 +3300,6 @@ export interface components {
             value: string;
         };
         /**
-         * RAGChunkInput
-         * @description Input schema for a retrieved chunk in feedback.
-         */
-        RAGChunkInput: {
-            /** Chunk Id */
-            chunk_id?: string | null;
-            /** File */
-            file?: string | null;
-            /** Preview */
-            preview?: string | null;
-            /** Score */
-            score?: number | null;
-        };
-        /**
-         * RAGFeedbackRequest
-         * @description Request schema for submitting RAG feedback.
-         */
-        RAGFeedbackRequest: {
-            /** Agent Id */
-            agent_id?: string | null;
-            /** Confidence */
-            confidence?: number | null;
-            /** Hops */
-            hops?: number | null;
-            /** Llm Response */
-            llm_response?: string | null;
-            /** Query */
-            query: string;
-            /** Retrieved Chunks */
-            retrieved_chunks?: components["schemas"]["RAGChunkInput"][] | null;
-            /** User Correction */
-            user_correction?: string | null;
-            /** User Rating */
-            user_rating?: number | null;
-        };
-        /**
-         * RAGFeedbackResponse
-         * @description Response schema for feedback submission.
-         */
-        RAGFeedbackResponse: {
-            /** Id */
-            id: number;
-            /**
-             * Message
-             * @default Feedback submitted successfully
-             */
-            message: string;
-        };
-        /**
          * RateLimitErrorResponse
          * @description Error response for 429 rate-limit exceeded.
          *
@@ -3926,87 +3308,6 @@ export interface components {
         RateLimitErrorResponse: {
             /** Detail */
             detail: string;
-        };
-        /** Recipe */
-        Recipe: {
-            /** Allergens */
-            allergens?: string[];
-            /**
-             * Cost Per Serv
-             * @default 0
-             */
-            cost_per_serv: number;
-            /**
-             * Cost Total
-             * @default 0
-             */
-            cost_total: number;
-            /** Ingredients */
-            ingredients: components["schemas"]["Ingredient"][];
-            /**
-             * Locale
-             * @default en
-             */
-            locale: string;
-            /** Nutrients Per Serv */
-            nutrients_per_serv?: {
-                [key: string]: number;
-            };
-            /** Recipe Id */
-            recipe_id: string;
-            /** Servings */
-            servings: number;
-            /**
-             * Source
-             * @default internal
-             */
-            source: string;
-            /** Steps */
-            steps?: string[];
-            /** Tags */
-            tags?: string[];
-            /** Title */
-            title: string;
-            /** Version Date */
-            version_date: string;
-            /** Yield Total G */
-            yield_total_g: number;
-        };
-        /** RecipePreviewRequest */
-        RecipePreviewRequest: {
-            /** Ingredients */
-            ingredients: components["schemas"]["Ingredient"][];
-            /**
-             * Servings
-             * @default 1
-             */
-            servings: number;
-            /** Title */
-            title: string;
-        };
-        /** RecipePreviewResponse */
-        RecipePreviewResponse: {
-            /** Per Serving */
-            per_serving: {
-                [key: string]: number;
-            };
-            /** Servings */
-            servings: number;
-            /** Title */
-            title: string;
-            /** Total G */
-            total_g: number;
-        };
-        /** RecipeQueryHit */
-        RecipeQueryHit: {
-            /** Kcal Per Serv */
-            kcal_per_serv: number;
-            /** Recipe Id */
-            recipe_id: string;
-            /** Tags */
-            tags?: string[];
-            /** Title */
-            title: string;
         };
         /**
          * ReconcileDecision
@@ -4189,24 +3490,6 @@ export interface components {
             unpacked_lines: number;
         };
         /**
-         * ShoplistDailyRequest
-         * @description Request payload for POST /api/v1/vip/shoplist/daily.
-         *
-         *     Same contract as ShoplistGenerateRequest.
-         */
-        ShoplistDailyRequest: {
-            /**
-             * Items
-             * @description Shopping list items (can be empty)
-             */
-            items?: components["schemas"]["ShoplistItemDTO"][];
-            /**
-             * Packaging Rules
-             * @description Optional. If missing/None, items without rules go to 'unpacked'.
-             */
-            packaging_rules?: components["schemas"]["PackageRuleDTO"][] | null;
-        };
-        /**
          * ShoplistDayItemDTO
          * @description One day shopping list item (server → iOS).
          *
@@ -4351,36 +3634,6 @@ export interface components {
             unpacked?: components["schemas"]["UnpackedLineDTO"][];
         };
         /**
-         * ShoplistGroup
-         * @description Group of items by aisle.
-         */
-        ShoplistGroup: {
-            /** Aisle */
-            aisle: string;
-            /** Items */
-            items: {
-                [key: string]: unknown;
-            }[];
-        };
-        /**
-         * ShoplistItem
-         * @description Single item in the shoplist.
-         */
-        ShoplistItem: {
-            /** Aisle */
-            aisle: string;
-            /** Id */
-            id?: string | null;
-            /** Name */
-            name?: string | null;
-            /** Note */
-            note?: string | null;
-            /** Qty */
-            qty?: number | null;
-            /** Unit */
-            unit?: string | null;
-        };
-        /**
          * ShoplistItemDTO
          * @description Shopping list item specification (food, quantity, form).
          */
@@ -4452,22 +3705,6 @@ export interface components {
             meta?: components["schemas"]["ShoplistPreviewMeta"];
         };
         /**
-         * ShoplistResponse
-         * @description Response model for shoplist endpoint.
-         */
-        ShoplistResponse: {
-            /** Currency */
-            currency: string;
-            /** Groups */
-            groups: components["schemas"]["ShoplistGroup"][];
-            /** Items */
-            items: components["schemas"]["ShoplistItem"][];
-            /** Store */
-            store: string;
-            /** Total Estimated */
-            total_estimated: number;
-        };
-        /**
          * ShoplistSourceDTO
          * @description Optional provenance of an item.
          *
@@ -4482,46 +3719,6 @@ export interface components {
              * @enum {string}
              */
             type: "plan" | "manual" | "import";
-        };
-        /**
-         * ShoplistWeeklyDayRequest
-         * @description Request payload for one day in weekly shoplist.
-         *
-         *     Same contract as ShoplistGenerateRequest per day.
-         */
-        ShoplistWeeklyDayRequest: {
-            /**
-             * Items
-             * @description Shopping list items for this day (can be empty)
-             */
-            items?: components["schemas"]["ShoplistItemDTO"][];
-            /**
-             * Packaging Rules
-             * @description Optional. If missing/None, items without rules go to 'unpacked'.
-             */
-            packaging_rules?: components["schemas"]["PackageRuleDTO"][] | null;
-        };
-        /**
-         * ShoplistWeeklyRequest
-         * @description Request payload for POST /api/v1/vip/shoplist/weekly.
-         */
-        ShoplistWeeklyRequest: {
-            /**
-             * Days
-             * @description One element per day. Contract: length = as requested by client (no fixed 7-day requirement).
-             */
-            days: components["schemas"]["ShoplistWeeklyDayRequest"][];
-        };
-        /**
-         * ShoplistWeeklyResponse
-         * @description Response for POST /api/v1/vip/shoplist/weekly.
-         */
-        ShoplistWeeklyResponse: {
-            /**
-             * Days
-             * @description One response per day (length = as requested by client)
-             */
-            days?: components["schemas"]["ShoplistGenerateResponse"][];
         };
         /**
          * ShoppingListCategory
@@ -4640,25 +3837,6 @@ export interface components {
          * @enum {string}
          */
         ShopUnit: "g" | "kg" | "ml" | "l" | "pcs";
-        /**
-         * SignedLinkResponse
-         * @description Response model for signed export links.
-         */
-        SignedLinkResponse: {
-            /** Exp */
-            exp: number;
-            /** Ttl */
-            ttl: number;
-            /** Url */
-            url: string;
-        };
-        /** SignRequest */
-        SignRequest: {
-            /** Path */
-            path: string;
-            /** Ttl Seconds */
-            ttl_seconds?: number | null;
-        };
         /**
          * SoftPaywallAvailability
          * @description PRO tier availability status.
@@ -4856,20 +4034,6 @@ export interface components {
             water_ml_daily: number;
         };
         /**
-         * TestResponse
-         * @description Standard test response model.
-         */
-        TestResponse: {
-            /** Message */
-            message: string;
-            /** Request Id */
-            request_id?: string | null;
-            /** Status */
-            status: string;
-            /** Timestamp */
-            timestamp: string;
-        };
-        /**
          * UnpackedLineDTO
          * @description Unpacked shopping list line (no packaging rule available).
          */
@@ -4953,27 +4117,72 @@ export interface components {
             wht_ratio?: number | null;
         };
         /**
-         * WeeklyMenuResponse
-         * @description RU: Ответ с недельным меню.
-         *     EN: Response with weekly menu.
+         * WeeklyMealPlanDayMenu
+         * @description Typed representation of one generated day menu.
          */
-        WeeklyMenuResponse: {
+        WeeklyMealPlanDayMenu: {
+            /** Coverage */
+            coverage: {
+                [key: string]: number;
+            };
+            /** Kcal */
+            kcal: number;
+            /** Macros */
+            macros: {
+                [key: string]: number;
+            };
+            /** Meals */
+            meals: components["schemas"]["WeeklyMealPlanItem"][];
+            /** Micros */
+            micros: {
+                [key: string]: number;
+            };
+            /** Tips */
+            tips: string[];
+            /** Total Cost */
+            total_cost: number;
+        };
+        /**
+         * WeeklyMealPlanItem
+         * @description Typed representation of one generated meal entry.
+         */
+        WeeklyMealPlanItem: {
+            /** Grams */
+            grams: {
+                [key: string]: number;
+            };
+            /** Kcal */
+            kcal: number;
+            /** Macros */
+            macros: {
+                [key: string]: number;
+            };
+            /** Micros */
+            micros: {
+                [key: string]: number;
+            };
+            /** Price Est */
+            price_est?: number | null;
+            /** Title */
+            title: string;
+            /** Title Translated */
+            title_translated: string;
+        };
+        /**
+         * WeeklyMealPlanResponse
+         * @description Typed canonical response for PRO/premium weekly-plan endpoints.
+         */
+        WeeklyMealPlanResponse: {
             /** Adherence Score */
             adherence_score: number;
             /** Daily Menus */
-            daily_menus: {
-                [key: string]: unknown;
-            }[];
+            daily_menus: components["schemas"]["WeeklyMealPlanDayMenu"][];
             /** Shopping List */
             shopping_list: {
                 [key: string]: number;
             };
             /** Total Cost */
             total_cost: number;
-            /** Week Summary */
-            week_summary: {
-                [key: string]: unknown;
-            };
             /** Weekly Coverage */
             weekly_coverage: {
                 [key: string]: number;
@@ -5431,7 +4640,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ProWeekPlanResponse"];
+                    "application/json": components["schemas"]["WeeklyMealPlanResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/components/WhoTargetsPanel/IntegratedWhoTargetsPanel.tsx
+++ b/frontend/src/components/WhoTargetsPanel/IntegratedWhoTargetsPanel.tsx
@@ -1,11 +1,11 @@
 import { useWhoTargetsWithWeeklyPlan } from '../../hooks/useWhoTargetsWithWeeklyPlan';
 import type { TargetsRequest } from '../../api/premium/types';
-import type { WeeklyMenuResponse } from '../../api/premium/weekly-plan';
+import type { WeeklyMealPlanResponse } from '../../api/premium/weekly-plan';
 import { WhoTargetsPanel } from '../WhoTargetsPanel';
 
 interface IntegratedWhoTargetsPanelProps {
   request: TargetsRequest | null;
-  onWeeklyPlanGenerated?: (weeklyPlan: WeeklyMenuResponse) => void;
+  onWeeklyPlanGenerated?: (weeklyPlan: WeeklyMealPlanResponse) => void;
   onError?: (error: Error) => void;
   className?: string;
 }

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { components } from "../../api/schema";
 import { getWeeklyPlan } from "../../api/premium/weekly-plan";
+import type { WeekPlanRequest, WeeklyMenuResponse } from "../../api/premium/weekly-plan";
 import { fetchBlob } from "../../api/client";
 import GlassCard from "../../components/GlassCard";
 import { shareSignedExport, formatShareErrorMessage } from "../../lib/shareFile";
@@ -54,9 +54,8 @@ async function downloadSignedFile(url: string, filename: string): Promise<void> 
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
 }
 
-type WeekPlanRequest = components["schemas"]["WeekPlanRequest"];
-type WeeklyMenuResponse = components["schemas"]["WeeklyMenuResponse"];
-type UnknownRecord = Record<string, unknown>;
+type WeeklyDayMenu = WeeklyMenuResponse["daily_menus"][number];
+type WeeklyMeal = WeeklyDayMenu["meals"][number];
 
 const DEFAULT_REQUEST: WeekPlanRequest = {
   sex: "female",
@@ -69,77 +68,30 @@ const DEFAULT_REQUEST: WeekPlanRequest = {
   lang: "en",
 };
 
-function getDayTitle(day: UnknownRecord, idx: number, t: (key: string, options?: any) => string): string {
-  return typeof day.date === "string"
-    ? day.date
-    : typeof day.day_label === "string"
-    ? day.day_label
-    : t("plan.day_fallback", { number: idx + 1 }); // e.g., "Day {number}"
+function getDayTitle(index: number, t: (key: string, options?: Record<string, unknown>) => string): string {
+  return t("plan.day_fallback", { number: index + 1 });
 }
 
-function getDayEnergy(day: UnknownRecord): number | undefined {
-  return typeof day.energy_kcal === "number"
-    ? day.energy_kcal
-    : typeof day.kcal === "number"
-    ? day.kcal
-    : undefined;
+function getMealName(meal: WeeklyMeal): string {
+  return meal.title_translated || meal.title;
 }
 
-function getMealName(meal: UnknownRecord, mi: number, t: (key: string, options?: any) => string): string {
-  return typeof meal.name === "string"
-    ? meal.name
-    : typeof meal.meal === "string"
-    ? meal.meal
-    : t("plan.meal_fallback", { number: mi + 1 }); // e.g., "Meal {number}"
+function formatMetricLabel(key: string): string {
+  return key.replace(/_/g, " ");
 }
 
-function getMealEnergy(meal: UnknownRecord): number | undefined {
-  return typeof meal.energy_kcal === "number"
-    ? meal.energy_kcal
-    : typeof meal.kcal === "number"
-    ? meal.kcal
-    : undefined;
-}
+function getMealDetails(meal: WeeklyMeal): string[] {
+  const grams = Object.entries(meal.grams).slice(0, 2).map(
+    ([label, value]) => `${formatMetricLabel(label)}: ${Math.round(value)} g`
+  );
 
-function getMealItems(meal: UnknownRecord): UnknownRecord[] {
-  const rawItems = Array.isArray(meal.items)
-    ? (meal.items as UnknownRecord[])
-    : [];
+  if (grams.length > 0) {
+    return grams;
+  }
 
-  const fallbackItem =
-    typeof meal.food_item === "string"
-      ? [
-          {
-            name: meal.food_item,
-            energy_kcal:
-              typeof meal.kcal === "number"
-                ? meal.kcal
-                : typeof meal.energy_kcal === "number"
-                ? meal.energy_kcal
-                : undefined,
-          },
-        ]
-      : [];
-
-  return rawItems.length > 0 ? rawItems : fallbackItem;
-}
-
-function getItemName(item: UnknownRecord, ii: number, t: (key: string, options?: any) => string): string {
-  return typeof item.name === "string"
-    ? item.name
-    : typeof item.title === "string"
-    ? item.title
-    : typeof item.food_item === "string"
-    ? item.food_item
-    : t("plan.item_fallback", { number: ii + 1 }); // e.g., "Item {number}"
-}
-
-function getItemEnergy(item: UnknownRecord): number | undefined {
-  return typeof item.energy_kcal === "number"
-    ? item.energy_kcal
-    : typeof item.kcal === "number"
-    ? item.kcal
-    : undefined;
+  return Object.entries(meal.macros).slice(0, 2).map(
+    ([label, value]) => `${formatMetricLabel(label)}: ${Math.round(value)}`
+  );
 }
 
 export default function WeeklyPlanViewer() {
@@ -184,9 +136,7 @@ export default function WeeklyPlanViewer() {
     );
   }
 
-  const dailyMenus = Array.isArray(data?.daily_menus)
-    ? (data!.daily_menus as UnknownRecord[])
-    : [];
+  const dailyMenus = data?.daily_menus ?? [];
 
   const openSheetsHelp = () => {
     window.open("https://sheets.new", "_blank", "noopener,noreferrer");
@@ -330,13 +280,9 @@ export default function WeeklyPlanViewer() {
         ) : (
           <ul className="space-y-4">
             {dailyMenus.map((menu, idx) => {
-              const day = menu as UnknownRecord;
-              const dayTitle = getDayTitle(day, idx, t);
-              const dayEnergy = getDayEnergy(day);
-
-              const meals = Array.isArray(day.meals)
-                ? (day.meals as UnknownRecord[])
-                : [];
+              const dayTitle = getDayTitle(idx, t);
+              const dayEnergy = menu.kcal;
+              const meals = menu.meals;
 
               return (
                 <li
@@ -351,10 +297,8 @@ export default function WeeklyPlanViewer() {
                   </div>
                   <ul className="space-y-2">
                     {meals.map((meal, mi) => {
-                      const mealObj = meal as UnknownRecord;
-                      const mealName = getMealName(mealObj, mi, t);
-                      const mealEnergy = getMealEnergy(mealObj);
-                      const items = getMealItems(mealObj);
+                      const mealName = getMealName(meal);
+                      const items = getMealDetails(meal);
 
                       return (
                         <li
@@ -363,36 +307,26 @@ export default function WeeklyPlanViewer() {
                         >
                           <div className="flex items-center justify-between">
                             <div className="font-medium">{mealName}</div>
-                            {typeof mealEnergy === "number" && (
-                              <div className="text-sm opacity-70">{Math.round(mealEnergy)} {t('plan.kcal')}</div>
-                            )}
+                            <div className="text-sm opacity-70">{Math.round(meal.kcal)} {t('plan.kcal')}</div>
                           </div>
                           <ul className="mt-2 grid gap-1">
                             {items.length > 0 ? (
-                              items.map((item, ii) => {
-                                const itemObj = item as UnknownRecord;
-                                const itemName = getItemName(itemObj, ii, t);
-                                const itemEnergy = getItemEnergy(itemObj);
-                            return (
-                              <li key={`${itemName}-${ii}`} className="text-sm">
-                                • {itemName}
-                                {typeof itemEnergy === "number" && (
-                                  <span className="opacity-70"> — {Math.round(itemEnergy)} {t('plan.kcal')}</span>
-                                )}
-                              </li>
-                            );
-                          })
-                        ) : (
-                          <li className="text-sm opacity-60">{t('plan.noItems')}</li>
-                        )}
-                      </ul>
-                    </li>
-                  );
-                })}
-              </ul>
-            </li>
-          );
-        })}
+                              items.map((item, ii) => (
+                                <li key={`${mealName}-${ii}`} className="text-sm">
+                                  • {item}
+                                </li>
+                              ))
+                            ) : (
+                              <li className="text-sm opacity-60">{t('plan.noItems')}</li>
+                            )}
+                          </ul>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </li>
+              );
+            })}
           </ul>
         )}
       </GlassCard>

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getWeeklyPlan } from "../../api/premium/weekly-plan";
-import type { WeekPlanRequest, WeeklyMenuResponse } from "../../api/premium/weekly-plan";
+import type { ProWeekPlanRequest, WeeklyMealPlanResponse } from "../../api/premium/weekly-plan";
 import { fetchBlob } from "../../api/client";
 import GlassCard from "../../components/GlassCard";
 import { shareSignedExport, formatShareErrorMessage } from "../../lib/shareFile";
@@ -54,10 +54,10 @@ async function downloadSignedFile(url: string, filename: string): Promise<void> 
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
 }
 
-type WeeklyDayMenu = WeeklyMenuResponse["daily_menus"][number];
+type WeeklyDayMenu = WeeklyMealPlanResponse["daily_menus"][number];
 type WeeklyMeal = WeeklyDayMenu["meals"][number];
 
-const DEFAULT_REQUEST: WeekPlanRequest = {
+const DEFAULT_REQUEST: ProWeekPlanRequest = {
   sex: "female",
   age: 30,
   height_cm: 168,
@@ -98,7 +98,7 @@ export default function WeeklyPlanViewer() {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const [data, setData] = useState<WeeklyMenuResponse | null>(null);
+  const [data, setData] = useState<WeeklyMealPlanResponse | null>(null);
   const [hint, setHint] = useState<string | null>(null);
   const [lastSignedLink, setLastSignedLink] = useState<string | null>(null);
 
@@ -107,9 +107,9 @@ export default function WeeklyPlanViewer() {
       setLoading(true);
       setErr(null);
       try {
-        const locale = getClientLocale() as WeekPlanRequest["lang"];
-        const supportedLangs: WeekPlanRequest["lang"][] = ["en", "ru", "es"];
-        const payload: WeekPlanRequest = {
+        const locale = getClientLocale() as ProWeekPlanRequest["lang"];
+        const supportedLangs: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"];
+        const payload: ProWeekPlanRequest = {
           ...DEFAULT_REQUEST,
           lang: supportedLangs.includes(locale) ? locale : "en",
         };

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -115,4 +115,17 @@ describe('normalizeWeekPlan', () => {
     expect(meal.macros.protein_g).toBe(16);
     expect(meal.micros.iron_mg).toBe(3.2);
   });
+
+  it('should tolerate malformed day menu entries without crashing', () => {
+    const result = normalizeWeekPlan(
+      createRawWeekPlan({
+        daily_menus: [null as unknown as RawWeekPlanResponse['daily_menus'][number]],
+      })
+    );
+
+    expect(result.days).toHaveLength(1);
+    expect(result.days[0].meals).toHaveLength(0);
+    expect(result.days[0].kcal).toBe(0);
+    expect(result.days[0].total_cost).toBe(0);
+  });
 });

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -127,6 +127,40 @@ describe('normalizeWeekPlan', () => {
     expect(result.meta.has_incomplete_data).toBe(true);
   });
 
+  it('should preserve original day index after skipping malformed daily menu entries', () => {
+    const result = normalizeWeekPlan(
+      createRawWeekPlan({
+        daily_menus: [
+          null as unknown as RawWeekPlanResponse['daily_menus'][number],
+          {
+            coverage: { protein: 88 },
+            kcal: 1740,
+            macros: { protein_g: 105, carbs_g: 160, fat_g: 58 },
+            meals: [
+              {
+                title: 'Lunch bowl',
+                title_translated: 'Lunch bowl',
+                grams: { chicken: 140 },
+                kcal: 520,
+                macros: { protein_g: 42, carbs_g: 28, fat_g: 14 },
+                micros: { iron_mg: 2.1 },
+                price_est: 6.25,
+              },
+            ],
+            micros: { iron_mg: 9.5 },
+            tips: ['Stay hydrated'],
+            total_cost: 21,
+          },
+        ],
+      })
+    );
+
+    expect(result.days).toHaveLength(1);
+    expect(result.days[0].day).toBe(2);
+    expect(result.days[0].dayName).toBe('Tuesday');
+    expect(result.meta.has_incomplete_data).toBe(true);
+  });
+
   it('should mark incomplete data when fallbacks or drops happen', () => {
     const result = normalizeWeekPlan(
       createRawWeekPlan({

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -69,6 +69,18 @@ describe('normalizeWeekPlan', () => {
     expect(result.meta.total_days).toBe(0);
   });
 
+  it('should return safe defaults for malformed root payloads', () => {
+    const result = normalizeWeekPlan(null as unknown as RawWeekPlanResponse);
+
+    expect(result.days).toEqual([]);
+    expect(result.weekly_coverage).toEqual({});
+    expect(result.shopping_list).toEqual({});
+    expect(result.metrics.total_cost).toBe(0);
+    expect(result.metrics.adherence_score).toBe(0);
+    expect(result.meta.total_days).toBe(0);
+    expect(result.meta.has_incomplete_data).toBe(true);
+  });
+
   it('should preserve backend coverage values without frontend clamping', () => {
     const result = normalizeWeekPlan(
       createRawWeekPlan({

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -69,7 +69,7 @@ describe('normalizeWeekPlan', () => {
     expect(result.meta.total_days).toBe(0);
   });
 
-  it('should clamp coverage values into supported range', () => {
+  it('should preserve backend coverage values without frontend clamping', () => {
     const result = normalizeWeekPlan(
       createRawWeekPlan({
         weekly_coverage: {
@@ -82,9 +82,9 @@ describe('normalizeWeekPlan', () => {
       })
     );
 
-    expect(result.weekly_coverage.protein).toBe(300);
-    expect(result.weekly_coverage.iron).toBe(0);
-    expect(result.weekly_coverage.magnesium).toBe(300);
+    expect(result.weekly_coverage.protein).toBe(450);
+    expect(result.weekly_coverage.iron).toBe(-10);
+    expect(result.weekly_coverage.magnesium).toBe(330);
   });
 
   it('should ignore invalid numeric map values', () => {
@@ -101,10 +101,10 @@ describe('normalizeWeekPlan', () => {
     expect(result.shopping_list.bad).toBeUndefined();
   });
 
-  it('should clamp adherence score to 0..1', () => {
+  it('should preserve backend adherence score without frontend clamping', () => {
     const result = normalizeWeekPlan(createRawWeekPlan({ adherence_score: 2.5 }));
 
-    expect(result.metrics.adherence_score).toBe(1);
+    expect(result.metrics.adherence_score).toBe(2.5);
   });
 
   it('should keep meal maps typed and intact', () => {
@@ -123,9 +123,39 @@ describe('normalizeWeekPlan', () => {
       })
     );
 
-    expect(result.days).toHaveLength(1);
-    expect(result.days[0].meals).toHaveLength(0);
-    expect(result.days[0].kcal).toBe(0);
-    expect(result.days[0].total_cost).toBe(0);
+    expect(result.days).toHaveLength(0);
+    expect(result.meta.has_incomplete_data).toBe(true);
+  });
+
+  it('should mark incomplete data when fallbacks or drops happen', () => {
+    const result = normalizeWeekPlan(
+      createRawWeekPlan({
+        daily_menus: [
+          {
+            coverage: { protein: 102 },
+            kcal: 1860,
+            macros: { protein_g: 112 },
+            meals: [
+              {
+                title: 'Broken meal',
+                title_translated: 42 as unknown as string,
+                grams: { oats: 80, bad: Number.NaN },
+                kcal: Number.NaN,
+                macros: { protein_g: 16 },
+                micros: { iron_mg: 3.2 },
+                price_est: 'oops' as unknown as number,
+              },
+              null as unknown as RawWeekPlanResponse['daily_menus'][number]['meals'][number],
+            ],
+            micros: { iron_mg: 11.2 },
+            tips: ['Rotate vegetables', 42 as unknown as string],
+            total_cost: 18.5,
+          },
+        ],
+      })
+    );
+
+    expect(result.days[0].meals).toHaveLength(1);
+    expect(result.meta.has_incomplete_data).toBe(true);
   });
 });

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -70,15 +70,23 @@ describe('normalizeWeekPlan', () => {
   });
 
   it('should return safe defaults for malformed root payloads', () => {
-    const result = normalizeWeekPlan(null as unknown as RawWeekPlanResponse);
+    const malformedPayloads = [
+      null,
+      42,
+      'broken-root',
+    ] as unknown as RawWeekPlanResponse[];
 
-    expect(result.days).toEqual([]);
-    expect(result.weekly_coverage).toEqual({});
-    expect(result.shopping_list).toEqual({});
-    expect(result.metrics.total_cost).toBe(0);
-    expect(result.metrics.adherence_score).toBe(0);
-    expect(result.meta.total_days).toBe(0);
-    expect(result.meta.has_incomplete_data).toBe(true);
+    malformedPayloads.forEach((payload) => {
+      const result = normalizeWeekPlan(payload);
+
+      expect(result.days).toEqual([]);
+      expect(result.weekly_coverage).toEqual({});
+      expect(result.shopping_list).toEqual({});
+      expect(result.metrics.total_cost).toBe(0);
+      expect(result.metrics.adherence_score).toBe(0);
+      expect(result.meta.total_days).toBe(0);
+      expect(result.meta.has_incomplete_data).toBe(true);
+    });
   });
 
   it('should preserve backend coverage values without frontend clamping', () => {

--- a/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
+++ b/frontend/src/features/weekly-plan/__tests__/adapter.test.ts
@@ -6,248 +6,113 @@ import { describe, it, expect } from 'vitest';
 import { normalizeWeekPlan } from '../model/adapter';
 import type { RawWeekPlanResponse } from '../model/types';
 
+function createRawWeekPlan(
+  overrides: Partial<RawWeekPlanResponse> = {}
+): RawWeekPlanResponse {
+  return {
+    daily_menus: [
+      {
+        coverage: { protein: 102, iron: 91 },
+        kcal: 1860,
+        macros: { protein_g: 112, carbs_g: 175, fat_g: 63 },
+        meals: [
+          {
+            title: 'Oat bowl',
+            title_translated: 'Oat bowl',
+            grams: { oats: 80, berries: 60 },
+            kcal: 430,
+            macros: { protein_g: 16, carbs_g: 62, fat_g: 11 },
+            micros: { iron_mg: 3.2 },
+            price_est: 3.75,
+          },
+        ],
+        micros: { iron_mg: 11.2, vitamin_c_mg: 84 },
+        tips: ['Rotate vegetables'],
+        total_cost: 18.5,
+      },
+    ],
+    weekly_coverage: {
+      protein: 98.5,
+      iron: 95.1,
+      vitamin_c: 120.2,
+      calcium: 88,
+    },
+    shopping_list: { oats: 560, berries: 420 },
+    total_cost: 150,
+    adherence_score: 0.95,
+    ...overrides,
+  };
+}
+
 describe('normalizeWeekPlan', () => {
   it('should normalize complete valid response', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [
-        {
-          day: 1,
-          meals: [
-            {
-              meal_type: 'breakfast',
-              recipes: [
-                { id: 'r1', name: 'Oatmeal', portions: 1.5 },
-                { id: 'r2', name: 'Berries', portions: 1 },
-              ],
-              totals: { kcal: 450, protein_g: 15, fat_g: 10, carbs_g: 70 },
-            },
-          ],
-          daily_totals: { kcal: 2000, protein_g: 100, fat_g: 70, carbs_g: 250 },
-        },
-      ],
-      weekly_coverage: { protein: 98.5, iron: 95.1, vitamin_c: 120.2, calcium: 88.0 },
-      shopping_list: {},
-      total_cost: 150.0,
-      adherence_score: 0.95,
-    };
-
-    const result = normalizeWeekPlan(raw);
+    const result = normalizeWeekPlan(createRawWeekPlan());
 
     expect(result.days).toHaveLength(1);
     expect(result.days[0].day).toBe(1);
     expect(result.days[0].dayName).toBe('Monday');
     expect(result.days[0].meals).toHaveLength(1);
-    expect(result.days[0].meals[0].meal_type).toBe('breakfast');
-    expect(result.days[0].meals[0].recipes).toHaveLength(2);
+    expect(result.days[0].meals[0].title).toBe('Oat bowl');
+    expect(result.days[0].meals[0].price_est).toBe(3.75);
     expect(result.weekly_coverage.protein).toBe(98.5);
-    expect(result.metrics.total_cost).toBe(150.0);
+    expect(result.shopping_list.oats).toBe(560);
+    expect(result.metrics.total_cost).toBe(150);
     expect(result.metrics.adherence_score).toBe(0.95);
     expect(result.meta.total_days).toBe(1);
     expect(result.meta.has_incomplete_data).toBe(false);
   });
 
-  it('should handle missing daily_menus with empty array', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
-
-    const result = normalizeWeekPlan(raw);
+  it('should keep empty daily_menus as empty array', () => {
+    const result = normalizeWeekPlan(createRawWeekPlan({ daily_menus: [] }));
 
     expect(result.days).toHaveLength(0);
     expect(result.meta.total_days).toBe(0);
   });
 
-  it('should provide defaults for malformed day data', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [null as unknown as Record<string, unknown>],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
-
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.days).toHaveLength(1);
-    expect(result.days[0].day).toBe(1);
-    expect(result.days[0].dayName).toBe('Monday');
-    expect(result.days[0].meals).toEqual([]);
-    expect(result.meta.has_incomplete_data).toBe(true);
-  });
-
-  it('should calculate daily totals from meals if not provided', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [
-        {
-          day: 1,
-          meals: [
-            {
-              meal_type: 'breakfast',
-              recipes: [],
-              totals: { kcal: 500, protein_g: 20, fat_g: 15, carbs_g: 60, fiber_g: 4 },
-            },
-            {
-              meal_type: 'lunch',
-              recipes: [],
-              totals: { kcal: 700, protein_g: 35, fat_g: 25, carbs_g: 80, fiber_g: 9 },
-            },
-          ],
-          // No daily_totals provided
+  it('should clamp coverage values into supported range', () => {
+    const result = normalizeWeekPlan(
+      createRawWeekPlan({
+        weekly_coverage: {
+          protein: 450,
+          iron: -10,
+          vitamin_c: 125,
+          calcium: 85,
+          magnesium: 330,
         },
-      ],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
+      })
+    );
 
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.days[0].daily_totals.kcal).toBe(1200);
-    expect(result.days[0].daily_totals.protein_g).toBe(55);
-    expect(result.days[0].daily_totals.fat_g).toBe(40);
-    expect(result.days[0].daily_totals.carbs_g).toBe(140);
-    expect(result.days[0].daily_totals.fiber_g).toBe(13);
+    expect(result.weekly_coverage.protein).toBe(300);
+    expect(result.weekly_coverage.iron).toBe(0);
+    expect(result.weekly_coverage.magnesium).toBe(300);
   });
 
-  it('should use daily_totals.fiber_g when provided (overrides calculated fallback)', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [
-        {
-          day: 1,
-          meals: [
-            {
-              meal_type: 'breakfast',
-              recipes: [],
-              totals: { kcal: 200, protein_g: 10, fat_g: 5, carbs_g: 30, fiber_g: 4 },
-            },
-            {
-              meal_type: 'lunch',
-              recipes: [],
-              totals: { kcal: 400, protein_g: 25, fat_g: 15, carbs_g: 45, fiber_g: 9 },
-            },
-          ],
-          daily_totals: {
-            kcal: 600,
-            protein_g: 35,
-            fat_g: 20,
-            carbs_g: 75,
-            fiber_g: 99, // Explicit value overrides calculated (4 + 9 = 13)
-          },
+  it('should ignore invalid numeric map values', () => {
+    const result = normalizeWeekPlan(
+      createRawWeekPlan({
+        shopping_list: {
+          apples: 5,
+          bad: Number.NaN,
         },
-      ],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
+      })
+    );
 
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.days[0].daily_totals.fiber_g).toBe(99);
+    expect(result.shopping_list.apples).toBe(5);
+    expect(result.shopping_list.bad).toBeUndefined();
   });
 
-  it('should handle missing meal recipes gracefully', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [
-        {
-          day: 1,
-          meals: [
-            {
-              meal_type: 'breakfast',
-              // No recipes
-              totals: { kcal: 450 },
-            },
-          ],
-          daily_totals: { kcal: 450, protein_g: 0, fat_g: 0, carbs_g: 0 },
-        },
-      ],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
+  it('should clamp adherence score to 0..1', () => {
+    const result = normalizeWeekPlan(createRawWeekPlan({ adherence_score: 2.5 }));
 
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.days[0].meals[0].recipes).toEqual([]);
+    expect(result.metrics.adherence_score).toBe(1);
   });
 
-  it('should assign correct day names based on day number', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [
-        { day: 1, meals: [], daily_totals: { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 } },
-        { day: 2, meals: [], daily_totals: { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 } },
-        { day: 7, meals: [], daily_totals: { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 } },
-      ],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
+  it('should keep meal maps typed and intact', () => {
+    const result = normalizeWeekPlan(createRawWeekPlan());
+    const meal = result.days[0].meals[0];
 
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.days[0].dayName).toBe('Monday');
-    expect(result.days[1].dayName).toBe('Tuesday');
-    expect(result.days[2].dayName).toBe('Sunday');
-  });
-
-  it('should normalize weekly coverage with defaults', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [],
-      weekly_coverage: { protein: 100, iron: 90 }, // Missing vitamin_c, calcium
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
-
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.weekly_coverage.protein).toBe(100);
-    expect(result.weekly_coverage.iron).toBe(90);
-    expect(result.weekly_coverage.vitamin_c).toBe(0);
-    expect(result.weekly_coverage.calcium).toBe(0);
-  });
-
-  it('should preserve extra coverage fields', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [],
-      weekly_coverage: {
-        protein: 100,
-        iron: 90,
-        vitamin_c: 120,
-        calcium: 85,
-        vitamin_d: 110,
-        magnesium: 95,
-      },
-      shopping_list: {},
-      total_cost: 0,
-      adherence_score: 0,
-    };
-
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.weekly_coverage.vitamin_d).toBe(110);
-    expect(result.weekly_coverage.magnesium).toBe(95);
-  });
-
-  it('should handle NaN values by falling back to defaults', () => {
-    const raw: RawWeekPlanResponse = {
-      daily_menus: [],
-      weekly_coverage: {},
-      shopping_list: {},
-      total_cost: NaN,
-      adherence_score: NaN,
-    };
-
-    const result = normalizeWeekPlan(raw);
-
-    expect(result.metrics.total_cost).toBe(0);
-    expect(result.metrics.adherence_score).toBe(0);
+    expect(meal.grams.oats).toBe(80);
+    expect(meal.macros.protein_g).toBe(16);
+    expect(meal.micros.iron_mg).toBe(3.2);
   });
 });

--- a/frontend/src/features/weekly-plan/hooks/useWeeklyPlan.ts
+++ b/frontend/src/features/weekly-plan/hooks/useWeeklyPlan.ts
@@ -7,13 +7,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getWeeklyPlan } from '../../../api/premium/weekly-plan';
-import type { WeekPlanRequest } from '../../../api/premium/weekly-plan';
+import type { ProWeekPlanRequest } from '../../../api/premium/weekly-plan';
 import { normalizeWeekPlan } from '../model/adapter';
 import type { WeekPlanVM } from '../model/types';
 
 export interface UseWeeklyPlanOptions {
   /** User targets for meal plan generation */
-  targets: WeekPlanRequest | null;
+  targets: ProWeekPlanRequest | null;
   /** Enable/disable query */
   enabled?: boolean;
   /** Callback on successful fetch */

--- a/frontend/src/features/weekly-plan/hooks/useWeeklyPlan.ts
+++ b/frontend/src/features/weekly-plan/hooks/useWeeklyPlan.ts
@@ -7,13 +7,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getWeeklyPlan } from '../../../api/premium/weekly-plan';
-import type { TargetsRequest } from '../../../api/premium/types';
+import type { WeekPlanRequest } from '../../../api/premium/weekly-plan';
 import { normalizeWeekPlan } from '../model/adapter';
-import type { WeekPlanVM, RawWeekPlanResponse } from '../model/types';
+import type { WeekPlanVM } from '../model/types';
 
 export interface UseWeeklyPlanOptions {
   /** User targets for meal plan generation */
-  targets: TargetsRequest | null;
+  targets: WeekPlanRequest | null;
   /** Enable/disable query */
   enabled?: boolean;
   /** Callback on successful fetch */
@@ -72,7 +72,7 @@ export function useWeeklyPlan(options: UseWeeklyPlanOptions): UseWeeklyPlanRetur
       }
 
       // Normalize to view model (adapter handles type coercion and validation)
-      const normalized = normalizeWeekPlan(rawResponse as RawWeekPlanResponse);
+      const normalized = normalizeWeekPlan(rawResponse);
 
       setData(normalized);
       onSuccess?.(normalized);

--- a/frontend/src/features/weekly-plan/model/adapter.ts
+++ b/frontend/src/features/weekly-plan/model/adapter.ts
@@ -153,6 +153,23 @@ function normalizeWeeklyCoverage(
 
 export function normalizeWeekPlan(raw: RawWeekPlanResponse): WeekPlanVM {
   const state: NormalizationState = { incomplete: false };
+  if (!isObjectRecord(raw)) {
+    markIncomplete(state);
+    return {
+      days: [],
+      weekly_coverage: {},
+      shopping_list: {},
+      metrics: {
+        total_cost: 0,
+        adherence_score: 0,
+      },
+      meta: {
+        total_days: 0,
+        has_incomplete_data: state.incomplete,
+      },
+    };
+  }
+
   const days = Array.isArray(raw.daily_menus)
     ? raw.daily_menus.flatMap((menu, index) => {
         if (!isObjectRecord(menu)) {

--- a/frontend/src/features/weekly-plan/model/adapter.ts
+++ b/frontend/src/features/weekly-plan/model/adapter.ts
@@ -58,17 +58,29 @@ function normalizeMeal(raw: RawMeal): Meal {
 
 function normalizeDayMenu(raw: RawDayMenu, index: number): DayMenu {
   const day = index + 1;
+  const payload =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? raw
+      : ({
+          meals: [],
+          kcal: 0,
+          macros: {},
+          micros: {},
+          coverage: {},
+          tips: [],
+          total_cost: 0,
+        } as RawDayMenu);
 
   return {
     day,
     dayName: DAY_NAMES[index] ?? `Day ${day}`,
-    meals: Array.isArray(raw.meals) ? raw.meals.map(normalizeMeal) : [],
-    kcal: safeNumber(raw.kcal),
-    macros: normalizeNumericMap(raw.macros),
-    micros: normalizeNumericMap(raw.micros),
-    coverage: normalizeNumericMap(raw.coverage),
-    tips: normalizeTips(raw.tips),
-    total_cost: safeNumber(raw.total_cost),
+    meals: Array.isArray(payload.meals) ? payload.meals.map(normalizeMeal) : [],
+    kcal: safeNumber(payload.kcal),
+    macros: normalizeNumericMap(payload.macros),
+    micros: normalizeNumericMap(payload.micros),
+    coverage: normalizeNumericMap(payload.coverage),
+    tips: normalizeTips(payload.tips),
+    total_cost: safeNumber(payload.total_cost),
   };
 }
 

--- a/frontend/src/features/weekly-plan/model/adapter.ts
+++ b/frontend/src/features/weekly-plan/model/adapter.ts
@@ -154,15 +154,14 @@ function normalizeWeeklyCoverage(
 export function normalizeWeekPlan(raw: RawWeekPlanResponse): WeekPlanVM {
   const state: NormalizationState = { incomplete: false };
   const days = Array.isArray(raw.daily_menus)
-    ? raw.daily_menus
-        .filter((menu): menu is RawDayMenu => {
-          const isValid = isObjectRecord(menu);
-          if (!isValid) {
-            markIncomplete(state);
-          }
-          return isValid;
-        })
-        .map((menu, index) => normalizeDayMenu(menu, index, state))
+    ? raw.daily_menus.flatMap((menu, index) => {
+        if (!isObjectRecord(menu)) {
+          markIncomplete(state);
+          return [];
+        }
+
+        return [normalizeDayMenu(menu, index, state)];
+      })
     : (markIncomplete(state), []);
   const shoppingList = normalizeNumericMap(raw.shopping_list, state);
 

--- a/frontend/src/features/weekly-plan/model/adapter.ts
+++ b/frontend/src/features/weekly-plan/model/adapter.ts
@@ -9,113 +9,174 @@ import type { RawDayMenu, RawMeal, RawWeekPlanResponse, WeekPlanVM, DayMenu, Mea
 const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
 const BLOCKED_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
+interface NormalizationState {
+  incomplete: boolean;
 }
 
-function safeNumber(value: unknown, fallback = 0): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+function markIncomplete(state: NormalizationState): void {
+  state.incomplete = true;
 }
 
-function safeString(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value : fallback;
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function normalizeNumericMap(raw: unknown): Record<string, number> {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+function safeRequiredNumber(value: unknown, fallback: number, state: NormalizationState): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  markIncomplete(state);
+  return fallback;
+}
+
+function safeNullableNumber(value: unknown, state: NormalizationState): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  markIncomplete(state);
+  return null;
+}
+
+function safeString(value: unknown, fallback: string, state: NormalizationState): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  markIncomplete(state);
+  return fallback;
+}
+
+function normalizeNumericMap(raw: unknown, state: NormalizationState): Record<string, number> {
+  if (!isObjectRecord(raw)) {
+    markIncomplete(state);
     return {};
   }
 
   const normalized: Record<string, number> = Object.create(null);
   for (const [key, value] of Object.entries(raw)) {
     if (BLOCKED_OBJECT_KEYS.has(key)) {
+      markIncomplete(state);
       continue;
     }
 
     if (typeof value === 'number' && Number.isFinite(value)) {
       normalized[key] = value;
+    } else {
+      markIncomplete(state);
     }
   }
 
   return normalized;
 }
 
-function normalizeTips(raw: unknown): string[] {
-  return Array.isArray(raw) ? raw.filter((tip): tip is string => typeof tip === 'string') : [];
+function normalizeTips(raw: unknown, state: NormalizationState): string[] {
+  if (!Array.isArray(raw)) {
+    markIncomplete(state);
+    return [];
+  }
+
+  const normalized: string[] = [];
+  raw.forEach((tip) => {
+    if (typeof tip === 'string') {
+      normalized.push(tip);
+    } else {
+      markIncomplete(state);
+    }
+  });
+  return normalized;
 }
 
-function normalizeMeal(raw: RawMeal): Meal {
+function normalizeMeal(raw: unknown, state: NormalizationState): Meal {
+  const payload = isObjectRecord(raw) ? raw : {};
+  if (!isObjectRecord(raw)) {
+    markIncomplete(state);
+  }
+
+  const title = safeString(payload.title, 'Untitled meal', state);
+  const titleTranslated = safeString(payload.title_translated, title, state);
+
   return {
-    title: safeString(raw.title, 'Untitled meal'),
-    title_translated: safeString(raw.title_translated, safeString(raw.title, 'Untitled meal')),
-    kcal: safeNumber(raw.kcal),
-    price_est: raw.price_est == null ? null : safeNumber(raw.price_est, 0),
-    grams: normalizeNumericMap(raw.grams),
-    macros: normalizeNumericMap(raw.macros),
-    micros: normalizeNumericMap(raw.micros),
+    title,
+    title_translated: titleTranslated,
+    kcal: safeRequiredNumber(payload.kcal, 0, state),
+    price_est: safeNullableNumber(payload.price_est, state),
+    grams: normalizeNumericMap(payload.grams, state),
+    macros: normalizeNumericMap(payload.macros, state),
+    micros: normalizeNumericMap(payload.micros, state),
   };
 }
 
-function normalizeDayMenu(raw: RawDayMenu, index: number): DayMenu {
+function normalizeDayMenu(raw: unknown, index: number, state: NormalizationState): DayMenu {
   const day = index + 1;
-  const payload =
-    raw && typeof raw === 'object' && !Array.isArray(raw)
-      ? raw
-      : ({
-          meals: [],
-          kcal: 0,
-          macros: {},
-          micros: {},
-          coverage: {},
-          tips: [],
-          total_cost: 0,
-        } as RawDayMenu);
+  const payload: Partial<RawDayMenu> = isObjectRecord(raw) ? raw : {};
+  if (!isObjectRecord(raw)) {
+    markIncomplete(state);
+  }
+
+  const meals = Array.isArray(payload.meals)
+    ? payload.meals
+        .filter((meal): meal is RawMeal => {
+          const isValid = isObjectRecord(meal);
+          if (!isValid) {
+            markIncomplete(state);
+          }
+          return isValid;
+        })
+        .map((meal) => normalizeMeal(meal, state))
+    : (markIncomplete(state), []);
 
   return {
     day,
     dayName: DAY_NAMES[index] ?? `Day ${day}`,
-    meals: Array.isArray(payload.meals) ? payload.meals.map(normalizeMeal) : [],
-    kcal: safeNumber(payload.kcal),
-    macros: normalizeNumericMap(payload.macros),
-    micros: normalizeNumericMap(payload.micros),
-    coverage: normalizeNumericMap(payload.coverage),
-    tips: normalizeTips(payload.tips),
-    total_cost: safeNumber(payload.total_cost),
+    meals,
+    kcal: safeRequiredNumber(payload.kcal, 0, state),
+    macros: normalizeNumericMap(payload.macros, state),
+    micros: normalizeNumericMap(payload.micros, state),
+    coverage: normalizeNumericMap(payload.coverage, state),
+    tips: normalizeTips(payload.tips, state),
+    total_cost: safeRequiredNumber(payload.total_cost, 0, state),
   };
 }
 
 function normalizeWeeklyCoverage(
-  raw: RawWeekPlanResponse['weekly_coverage']
+  raw: RawWeekPlanResponse['weekly_coverage'],
+  state: NormalizationState
 ): WeekPlanVM['weekly_coverage'] {
-  const normalized = normalizeNumericMap(raw);
-
-  return {
-    protein: clamp(safeNumber(normalized.protein), 0, 300),
-    iron: clamp(safeNumber(normalized.iron), 0, 300),
-    vitamin_c: clamp(safeNumber(normalized.vitamin_c), 0, 300),
-    calcium: clamp(safeNumber(normalized.calcium), 0, 300),
-    ...Object.fromEntries(
-      Object.entries(normalized).map(([key, value]) => [key, clamp(value, 0, 300)])
-    ),
-  };
+  return normalizeNumericMap(raw, state);
 }
 
 export function normalizeWeekPlan(raw: RawWeekPlanResponse): WeekPlanVM {
-  const dailyMenus = Array.isArray(raw.daily_menus) ? raw.daily_menus : [];
-  const days = dailyMenus.map(normalizeDayMenu);
-  const shoppingList = normalizeNumericMap(raw.shopping_list);
+  const state: NormalizationState = { incomplete: false };
+  const days = Array.isArray(raw.daily_menus)
+    ? raw.daily_menus
+        .filter((menu): menu is RawDayMenu => {
+          const isValid = isObjectRecord(menu);
+          if (!isValid) {
+            markIncomplete(state);
+          }
+          return isValid;
+        })
+        .map((menu, index) => normalizeDayMenu(menu, index, state))
+    : (markIncomplete(state), []);
+  const shoppingList = normalizeNumericMap(raw.shopping_list, state);
 
   return {
     days,
-    weekly_coverage: normalizeWeeklyCoverage(raw.weekly_coverage),
+    weekly_coverage: normalizeWeeklyCoverage(raw.weekly_coverage, state),
     shopping_list: shoppingList,
     metrics: {
-      total_cost: safeNumber(raw.total_cost),
-      adherence_score: clamp(safeNumber(raw.adherence_score), 0, 1),
+      total_cost: safeRequiredNumber(raw.total_cost, 0, state),
+      adherence_score: safeRequiredNumber(raw.adherence_score, 0, state),
     },
     meta: {
       total_days: days.length,
-      has_incomplete_data: false,
+      has_incomplete_data: state.incomplete,
     },
   };
 }

--- a/frontend/src/features/weekly-plan/model/adapter.ts
+++ b/frontend/src/features/weekly-plan/model/adapter.ts
@@ -1,204 +1,109 @@
 /**
- * Weekly Plan Adapter
+ * Weekly plan adapter.
  *
- * Normalizes raw API response into safe, type-strict view model.
- * Prevents contract drift by providing sensible defaults for missing/malformed data.
+ * Normalizes canonical API payloads into a stable UI view model.
  */
 
-import type { RawWeekPlanResponse, WeekPlanVM, DayMenu, Meal } from './types';
+import type { RawDayMenu, RawMeal, RawWeekPlanResponse, WeekPlanVM, DayMenu, Meal } from './types';
 
 const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
+const BLOCKED_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
-/**
- * Clamp number to range
- */
-function clamp(n: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, n));
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
-/**
- * Safely extract coverage percentage (0-300%)
- */
-function safeCoverage(value: unknown): number {
-  return clamp(safeNumber(value, 0), 0, 300);
-}
-
-/**
- * Safely extract number from unknown value
- */
 function safeNumber(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-  return fallback;
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
-/**
- * Safely extract string from unknown value
- */
 function safeString(value: unknown, fallback = ''): string {
-  if (typeof value === 'string') {
-    return value;
+  return typeof value === 'string' ? value : fallback;
+}
+
+function normalizeNumericMap(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
   }
-  return fallback;
-}
 
-/**
- * Log contract drift warning in development
- */
-function logContractDrift(context: string, details?: string): void {
-  if (import.meta.env.DEV) {
-    const message = details
-      ? `[WeekPlan Adapter] ${context}: ${details}`
-      : `[WeekPlan Adapter] ${context}`;
-    console.warn(message);
-  }
-}
-
-/**
- * Normalize a single meal from raw data
- */
-function normalizeMeal(raw: Record<string, unknown>): Meal {
-  const recipes = Array.isArray(raw.recipes)
-    ? raw.recipes
-        .filter(
-          (r): r is Record<string, unknown> =>
-            r != null && typeof r === 'object' && !Array.isArray(r)
-        )
-        .map((r) => ({
-          id: safeString(r.id, 'unknown'),
-          name: safeString(r.name, 'Unnamed Recipe'),
-          portions: Math.max(1, Math.trunc(safeNumber(r.portions, 1))),
-        }))
-    : [];
-
-  const totals = raw.totals as Record<string, unknown> | undefined;
-
-  return {
-    meal_type: safeString(raw.meal_type, 'meal'),
-    recipes,
-    totals: {
-      kcal: safeNumber(totals?.kcal),
-      protein_g: safeNumber(totals?.protein_g),
-      fat_g: safeNumber(totals?.fat_g),
-      carbs_g: safeNumber(totals?.carbs_g),
-      fiber_g: safeNumber(totals?.fiber_g),
-    },
-  };
-}
-
-/**
- * Normalize a single day menu from raw data
- */
-function normalizeDayMenu(raw: Record<string, unknown>, index: number): DayMenu {
-  const dayNumber = Math.min(7, Math.max(1, Math.trunc(safeNumber(raw.day, index + 1))));
-  const meals = Array.isArray(raw.meals)
-    ? raw.meals
-        .filter((m): m is Record<string, unknown> => m != null && typeof m === 'object' && !Array.isArray(m))
-        .map(normalizeMeal)
-    : [];
-
-  // Calculate daily totals from meals if not provided
-  const dailyTotals = raw.daily_totals as Record<string, unknown> | undefined;
-  const calculatedTotals = meals.reduce(
-    (acc, meal) => ({
-      kcal: acc.kcal + (meal.totals.kcal || 0),
-      protein_g: acc.protein_g + (meal.totals.protein_g || 0),
-      fat_g: acc.fat_g + (meal.totals.fat_g || 0),
-      carbs_g: acc.carbs_g + (meal.totals.carbs_g || 0),
-      fiber_g: acc.fiber_g + (meal.totals.fiber_g || 0),
-    }),
-    { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0, fiber_g: 0 }
-  );
-
-  return {
-    day: dayNumber,
-    dayName: DAY_NAMES[dayNumber - 1],
-    meals,
-    daily_totals: {
-      kcal: safeNumber(dailyTotals?.kcal, calculatedTotals.kcal),
-      protein_g: safeNumber(dailyTotals?.protein_g, calculatedTotals.protein_g),
-      fat_g: safeNumber(dailyTotals?.fat_g, calculatedTotals.fat_g),
-      carbs_g: safeNumber(dailyTotals?.carbs_g, calculatedTotals.carbs_g),
-      fiber_g: safeNumber(dailyTotals?.fiber_g, calculatedTotals.fiber_g),
-    },
-  };
-}
-
-/**
- * Normalize weekly coverage data
- */
-function normalizeWeeklyCoverage(raw: Record<string, unknown>): WeekPlanVM['weekly_coverage'] {
-  const blockedKeys = new Set(['__proto__', 'constructor', 'prototype']);
-  const extras: Record<string, number> = Object.create(null);
-
+  const normalized: Record<string, number> = Object.create(null);
   for (const [key, value] of Object.entries(raw)) {
-    if (key === 'protein' || key === 'iron' || key === 'vitamin_c' || key === 'calcium') continue;
-    if (blockedKeys.has(key)) continue;
-    extras[key] = safeCoverage(value);
+    if (BLOCKED_OBJECT_KEYS.has(key)) {
+      continue;
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      normalized[key] = value;
+    }
   }
 
+  return normalized;
+}
+
+function normalizeTips(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((tip): tip is string => typeof tip === 'string') : [];
+}
+
+function normalizeMeal(raw: RawMeal): Meal {
   return {
-    protein: safeCoverage(raw.protein),
-    iron: safeCoverage(raw.iron),
-    vitamin_c: safeCoverage(raw.vitamin_c),
-    calcium: safeCoverage(raw.calcium),
-    ...extras,
+    title: safeString(raw.title, 'Untitled meal'),
+    title_translated: safeString(raw.title_translated, safeString(raw.title, 'Untitled meal')),
+    kcal: safeNumber(raw.kcal),
+    price_est: raw.price_est == null ? null : safeNumber(raw.price_est, 0),
+    grams: normalizeNumericMap(raw.grams),
+    macros: normalizeNumericMap(raw.macros),
+    micros: normalizeNumericMap(raw.micros),
   };
 }
 
-/**
- * Normalize raw API response into view model
- *
- * @param raw - Raw API response
- * @returns Normalized view model safe for UI consumption
- */
+function normalizeDayMenu(raw: RawDayMenu, index: number): DayMenu {
+  const day = index + 1;
+
+  return {
+    day,
+    dayName: DAY_NAMES[index] ?? `Day ${day}`,
+    meals: Array.isArray(raw.meals) ? raw.meals.map(normalizeMeal) : [],
+    kcal: safeNumber(raw.kcal),
+    macros: normalizeNumericMap(raw.macros),
+    micros: normalizeNumericMap(raw.micros),
+    coverage: normalizeNumericMap(raw.coverage),
+    tips: normalizeTips(raw.tips),
+    total_cost: safeNumber(raw.total_cost),
+  };
+}
+
+function normalizeWeeklyCoverage(
+  raw: RawWeekPlanResponse['weekly_coverage']
+): WeekPlanVM['weekly_coverage'] {
+  const normalized = normalizeNumericMap(raw);
+
+  return {
+    protein: clamp(safeNumber(normalized.protein), 0, 300),
+    iron: clamp(safeNumber(normalized.iron), 0, 300),
+    vitamin_c: clamp(safeNumber(normalized.vitamin_c), 0, 300),
+    calcium: clamp(safeNumber(normalized.calcium), 0, 300),
+    ...Object.fromEntries(
+      Object.entries(normalized).map(([key, value]) => [key, clamp(value, 0, 300)])
+    ),
+  };
+}
+
 export function normalizeWeekPlan(raw: RawWeekPlanResponse): WeekPlanVM {
-  let hasIncompleteData = false;
-
-  // Normalize days
-  const days = Array.isArray(raw.daily_menus)
-    ? raw.daily_menus.map((menu, index) => {
-        if (!menu || typeof menu !== 'object' || Array.isArray(menu)) {
-          hasIncompleteData = true;
-          logContractDrift('Incomplete data detected', `day ${index + 1}: invalid menu object`);
-          return normalizeDayMenu({}, index);
-        }
-        return normalizeDayMenu(menu, index);
-      })
-    : (() => {
-        if (raw.daily_menus !== undefined) {
-          hasIncompleteData = true;
-          logContractDrift('Invalid daily_menus', 'expected array, using empty');
-        }
-        return [];
-      })();
-
-  // Log contract drift summary
-  if (hasIncompleteData) {
-    logContractDrift('API response contains incomplete or malformed data');
-  }
-
-  // Normalize coverage
-  let weekly_coverage: WeekPlanVM['weekly_coverage'];
-  if (raw.weekly_coverage && typeof raw.weekly_coverage === 'object') {
-    weekly_coverage = normalizeWeeklyCoverage(raw.weekly_coverage);
-  } else {
-    hasIncompleteData = true;
-    logContractDrift('Missing weekly_coverage', 'using default values');
-    weekly_coverage = { protein: 0, iron: 0, vitamin_c: 0, calcium: 0 };
-  }
+  const dailyMenus = Array.isArray(raw.daily_menus) ? raw.daily_menus : [];
+  const days = dailyMenus.map(normalizeDayMenu);
+  const shoppingList = normalizeNumericMap(raw.shopping_list);
 
   return {
     days,
-    weekly_coverage,
+    weekly_coverage: normalizeWeeklyCoverage(raw.weekly_coverage),
+    shopping_list: shoppingList,
     metrics: {
-      total_cost: safeNumber(raw.total_cost, 0),
-      adherence_score: Math.min(1, Math.max(0, safeNumber(raw.adherence_score, 0))),
+      total_cost: safeNumber(raw.total_cost),
+      adherence_score: clamp(safeNumber(raw.adherence_score), 0, 1),
     },
     meta: {
       total_days: days.length,
-      has_incomplete_data: hasIncompleteData,
+      has_incomplete_data: false,
     },
   };
 }

--- a/frontend/src/features/weekly-plan/model/types.ts
+++ b/frontend/src/features/weekly-plan/model/types.ts
@@ -2,9 +2,9 @@
  * Weekly plan view-model types derived from the canonical OpenAPI contract.
  */
 
-import type { WeeklyMenuResponse } from '../../../api/premium/weekly-plan';
+import type { WeeklyMealPlanResponse } from '../../../api/premium/weekly-plan';
 
-export type RawWeekPlanResponse = WeeklyMenuResponse;
+export type RawWeekPlanResponse = WeeklyMealPlanResponse;
 export type RawDayMenu = RawWeekPlanResponse['daily_menus'][number];
 export type RawMeal = RawDayMenu['meals'][number];
 

--- a/frontend/src/features/weekly-plan/model/types.ts
+++ b/frontend/src/features/weekly-plan/model/types.ts
@@ -1,70 +1,59 @@
 /**
- * Weekly Plan Data Models
- *
- * Strict typing for API contract and view models to prevent contract drift.
+ * Weekly plan view-model types derived from the canonical OpenAPI contract.
  */
 
-/** Raw API response from backend (POST /api/v1/pro/meal/weekly) */
-export interface RawWeekPlanResponse {
-  daily_menus: Array<Record<string, unknown>>;
-  weekly_coverage: Record<string, unknown>;
-  shopping_list: Record<string, unknown>;
-  total_cost: number;
-  adherence_score: number;
-}
+import type { WeeklyMenuResponse } from '../../../api/premium/weekly-plan';
 
-/** Normalized meal data */
+export type RawWeekPlanResponse = WeeklyMenuResponse;
+export type RawDayMenu = RawWeekPlanResponse['daily_menus'][number];
+export type RawMeal = RawDayMenu['meals'][number];
+
+/** Normalized meal data for UI consumption. */
 export interface Meal {
-  meal_type: string; // "breakfast" | "lunch" | "dinner" | "snack"
-  recipes: Array<{
-    id: string;
-    name: string;
-    portions: number;
-  }>;
-  totals: {
-    kcal: number;
-    protein_g?: number;
-    fat_g?: number;
-    carbs_g?: number;
-    fiber_g?: number;
-  };
+  title: string;
+  title_translated: string;
+  kcal: number;
+  price_est: number | null;
+  grams: Record<string, number>;
+  macros: Record<string, number>;
+  micros: Record<string, number>;
 }
 
-/** Normalized day data */
+/** Normalized day data for UI consumption. */
 export interface DayMenu {
-  day: number; // 1-7
-  dayName?: string; // "Monday", "Tuesday", etc.
+  day: number;
+  dayName: string;
   meals: Meal[];
-  daily_totals: {
-    kcal: number;
-    protein_g: number;
-    fat_g: number;
-    carbs_g: number;
-    fiber_g: number;
-  };
+  kcal: number;
+  macros: Record<string, number>;
+  micros: Record<string, number>;
+  coverage: Record<string, number>;
+  tips: string[];
+  total_cost: number;
 }
 
-/** View Model for Weekly Plan (normalized, safe for UI consumption) */
+/** View model for weekly plan screen. */
 export interface WeekPlanVM {
   days: DayMenu[];
   weekly_coverage: {
-    protein: number; // percentage
+    protein: number;
     iron: number;
     vitamin_c: number;
     calcium: number;
     [key: string]: number;
   };
+  shopping_list: Record<string, number>;
   metrics: {
     total_cost: number;
-    adherence_score: number; // 0.0 - 1.0
+    adherence_score: number;
   };
   meta: {
     total_days: number;
-    has_incomplete_data: boolean; // true if any normalization fallbacks triggered
+    has_incomplete_data: boolean;
   };
 }
 
-/** Loading/error states for UI */
+/** Loading/error states for UI. */
 export type WeekPlanState =
   | { status: 'idle' }
   | { status: 'loading' }

--- a/frontend/src/features/weekly-plan/model/types.ts
+++ b/frontend/src/features/weekly-plan/model/types.ts
@@ -35,13 +35,7 @@ export interface DayMenu {
 /** View model for weekly plan screen. */
 export interface WeekPlanVM {
   days: DayMenu[];
-  weekly_coverage: {
-    protein: number;
-    iron: number;
-    vitamin_c: number;
-    calcium: number;
-    [key: string]: number;
-  };
+  weekly_coverage: Record<string, number>;
   shopping_list: Record<string, number>;
   metrics: {
     total_cost: number;

--- a/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
+++ b/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTargets, getWeeklyPlan } from '../api/premium';
-import type { TargetsRequest, TargetsApiResponse, WeeklyMenuResponse } from '../api/premium';
-import type { WeekPlanRequest } from '../api/premium/weekly-plan';
+import type { TargetsRequest, TargetsApiResponse } from '../api/premium';
+import type { ProWeekPlanRequest, WeeklyMealPlanResponse } from '../api/premium/weekly-plan';
 
-function toWeekPlanRequest(request: TargetsRequest): WeekPlanRequest {
+function toWeekPlanRequest(request: TargetsRequest): ProWeekPlanRequest {
   return {
     sex: request.sex,
     age: request.age,
@@ -21,7 +21,7 @@ function toWeekPlanRequest(request: TargetsRequest): WeekPlanRequest {
 }
 
 interface UseWhoTargetsWithWeeklyPlanOptions {
-  onSuccess?: (targets: TargetsApiResponse, weeklyPlan: WeeklyMenuResponse) => void;
+  onSuccess?: (targets: TargetsApiResponse, weeklyPlan: WeeklyMealPlanResponse) => void;
   onError?: (error: Error) => void;
 }
 
@@ -32,7 +32,7 @@ interface UseWhoTargetsWithWeeklyPlanReturn {
   targetsError: string | null;
 
   // Weekly plan state
-  weeklyPlanData: WeeklyMenuResponse | null;
+  weeklyPlanData: WeeklyMealPlanResponse | null;
   weeklyPlanLoading: boolean;
   weeklyPlanError: string | null;
 
@@ -55,7 +55,7 @@ export function useWhoTargetsWithWeeklyPlan(
   const [targetsError, setTargetsError] = useState<string | null>(null);
 
   // Weekly plan state
-  const [weeklyPlanData, setWeeklyPlanData] = useState<WeeklyMenuResponse | null>(null);
+  const [weeklyPlanData, setWeeklyPlanData] = useState<WeeklyMealPlanResponse | null>(null);
   const [weeklyPlanLoading, setWeeklyPlanLoading] = useState(false);
   const [weeklyPlanError, setWeeklyPlanError] = useState<string | null>(null);
 

--- a/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
+++ b/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
@@ -2,6 +2,23 @@ import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTargets, getWeeklyPlan } from '../api/premium';
 import type { TargetsRequest, TargetsApiResponse, WeeklyMenuResponse } from '../api/premium';
+import type { WeekPlanRequest } from '../api/premium/weekly-plan';
+
+function toWeekPlanRequest(request: TargetsRequest): WeekPlanRequest {
+  return {
+    sex: request.sex,
+    age: request.age,
+    height_cm: request.height_cm,
+    weight_kg: request.weight_kg,
+    activity: request.activity,
+    goal: request.goal,
+    diet_flags: request.diet_flags ?? [],
+    lang:
+      request.lang === 'ru' || request.lang === 'es' || request.lang === 'en'
+        ? request.lang
+        : 'en',
+  };
+}
 
 interface UseWhoTargetsWithWeeklyPlanOptions {
   onSuccess?: (targets: TargetsApiResponse, weeklyPlan: WeeklyMenuResponse) => void;
@@ -86,7 +103,7 @@ export function useWhoTargetsWithWeeklyPlan(
       }
 
       // Then generate weekly plan
-      const weeklyPlan = await getWeeklyPlan(request);
+      const weeklyPlan = await getWeeklyPlan(toWeekPlanRequest(request));
       setWeeklyPlanData(weeklyPlan);
 
       // Call success callback with both data

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -727,6 +727,59 @@ def _is_openapi_public_path(path: str) -> bool:
     return any(path.startswith(prefix) for prefix in _OPENAPI_ALLOWED_PREFIXES)
 
 
+def _collect_schema_refs(node: Any, refs: set[str]) -> None:
+    """Collect schema component names referenced from an OpenAPI subtree."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            refs.add(ref.rsplit("/", 1)[-1])
+        for value in node.values():
+            _collect_schema_refs(value, refs)
+        return
+
+    if isinstance(node, list):
+        for item in node:
+            _collect_schema_refs(item, refs)
+
+
+def _prune_unreferenced_schema_components(schema: dict[str, Any]) -> None:
+    """Drop schema components not reachable from the filtered public OpenAPI surface."""
+    components = schema.get("components")
+    if not isinstance(components, dict):
+        return
+
+    schemas = components.get("schemas")
+    if not isinstance(schemas, dict):
+        return
+
+    referenced_names: set[str] = set()
+    schema_without_defs = dict(schema)
+    if isinstance(schema_without_defs.get("components"), dict):
+        component_copy = dict(cast(dict[str, Any], schema_without_defs["components"]))
+        component_copy.pop("schemas", None)
+        schema_without_defs["components"] = component_copy
+
+    _collect_schema_refs(schema_without_defs, referenced_names)
+
+    retained_schemas: dict[str, Any] = {}
+    queue = list(referenced_names)
+    while queue:
+        schema_name = queue.pop()
+        if schema_name in retained_schemas:
+            continue
+        schema_node = schemas.get(schema_name)
+        if not isinstance(schema_node, dict):
+            continue
+        retained_schemas[schema_name] = schema_node
+        nested_refs: set[str] = set()
+        _collect_schema_refs(schema_node, nested_refs)
+        for nested_ref in nested_refs:
+            if nested_ref not in retained_schemas:
+                queue.append(nested_ref)
+
+    components["schemas"] = dict(sorted(retained_schemas.items()))
+
+
 def _build_canonical_openapi(target_app: FastAPI) -> dict[str, Any]:
     """Generate OpenAPI and filter legacy/non-canonical namespaces out of schema."""
     from fastapi.openapi.utils import get_openapi
@@ -747,6 +800,7 @@ def _build_canonical_openapi(target_app: FastAPI) -> dict[str, Any]:
         path: value for path, value in all_paths.items() if _is_openapi_public_path(path)
     }
     schema["paths"] = dict(sorted(filtered_paths.items()))
+    _prune_unreferenced_schema_components(schema)
     target_app.openapi_schema = schema
     return schema
 
@@ -1708,6 +1762,50 @@ async def privacy() -> Dict[str, Any]:
     from core.compliance import build_privacy_endpoint_payload
 
     return build_privacy_endpoint_payload()
+
+
+@app.get("/terms", include_in_schema=False)
+async def terms() -> Dict[str, Any]:
+    """Terms of use endpoint for release-safe legal publication.
+
+    RU: Эндпоинт условий использования для канонической legal-публикации.
+    EN: Terms of use endpoint for canonical legal publication.
+    """
+
+    return {
+        "terms_of_use": (
+            "PulsePlate provides wellness-oriented planning, nutrition, and coaching-style features. "
+            "It does not provide medical diagnosis, treatment, emergency response, or licensed clinical services."
+        ),
+        "service_scope": {
+            "category": "wellness / nutrition planning / coaching support",
+            "medical_boundary": (
+                "Content is informational and product-guidance only. Users must not treat the service as "
+                "medical, psychiatric, or emergency advice."
+            ),
+            "age_requirement": "The service is intended for adults unless a specific flow states otherwise.",
+        },
+        "billing_and_subscriptions": {
+            "ios_app_store": "Apple-managed digital subscription flow with server-side verification.",
+            "manual_rails": "Operational fallback rails may include ERIP QR or SWIFT manual reconciliation.",
+            "cancellation": "Users manage subscription cancellation in the original purchase channel.",
+            "entitlement_truth": "Subscription entitlement is determined by backend verification and audit state.",
+        },
+        "acceptable_use": {
+            "forbidden": [
+                "attempting to bypass tier controls or payment verification",
+                "submitting unlawful, abusive, or malicious content",
+                "using the service for medical triage or emergency decisions",
+            ],
+            "security_note": "Abuse-prevention and platform-protection controls may block unsafe or fraudulent use.",
+        },
+        "liability_boundary": (
+            "The service is provided on a best-effort basis for wellness support. "
+            "Users remain responsible for critical health, legal, and financial decisions."
+        ),
+        "contact": "For legal or billing questions, please contact the application administrator.",
+        "effective_date": "2026-03-08",
+    }
 
 
 @app.post("/admin/logs/cleanup", dependencies=[Depends(_get_api_key_dynamic)])

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2281,7 +2281,6 @@ async def _execute_insight_request(
     subject_id: int | None = None,
 ) -> InsightResponse:
     """Shared /insight execution path with philosophical runtime support."""
-
     require_safe_ai_agent_input(req.text)
     prompt_input = _ensure_insight_text_length(req.text)
 

--- a/tests/test_app_openapi_coverage.py
+++ b/tests/test_app_openapi_coverage.py
@@ -100,6 +100,7 @@ class TestAppOpenAPICoverage:
         assert "BMIRequestV1" in schemas
         assert "WeeklyMealPlanResponse" in schemas
         assert "WeeklyMealPlanDayMenu" in schemas
+        assert "WeeklyMealPlanItem" in schemas
         # BMIResponse может называться по-другому
         # assert "BMIResponse" in schemas
 

--- a/tests/test_app_openapi_coverage.py
+++ b/tests/test_app_openapi_coverage.py
@@ -97,8 +97,9 @@ class TestAppOpenAPICoverage:
         # Проверяем основные схемы
         assert "HTTPValidationError" in schemas
         assert "ValidationError" in schemas
-        assert "BMIRequest" in schemas
         assert "BMIRequestV1" in schemas
+        assert "WeeklyMealPlanResponse" in schemas
+        assert "WeeklyMealPlanDayMenu" in schemas
         # BMIResponse может называться по-другому
         # assert "BMIResponse" in schemas
 

--- a/tests/test_app_premium_week_bmi_flow.py
+++ b/tests/test_app_premium_week_bmi_flow.py
@@ -39,6 +39,44 @@ def _make_profile_payload(extra: Dict[str, object] | None = None) -> Dict[str, o
     return payload
 
 
+def _make_week_payload(
+    *,
+    day_kcal: float,
+    weekly_coverage: Dict[str, float],
+    shopping_list: Dict[str, float],
+    total_cost: float,
+    adherence_score: float,
+) -> Dict[str, object]:
+    """Return a canonical weekly-plan payload for build_week test doubles."""
+    return {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "Protein bowl",
+                        "title_translated": "Protein bowl",
+                        "grams": {"serving_g": 420.0},
+                        "kcal": day_kcal,
+                        "macros": {"protein_g": 42.0},
+                        "micros": {"iron_mg": 4.2},
+                        "price_est": 8.5,
+                    }
+                ],
+                "kcal": day_kcal,
+                "macros": {"protein_g": 42.0},
+                "micros": {"iron_mg": 4.2},
+                "coverage": {"protein": 0.9},
+                "tips": ["Stay hydrated"],
+                "total_cost": total_cost,
+            }
+        ],
+        "weekly_coverage": weekly_coverage,
+        "shopping_list": shopping_list,
+        "total_cost": total_cost,
+        "adherence_score": adherence_score,
+    }
+
+
 class TestPremiumWeekPlanEndToEnd:
     """Интеграционные тесты премиального недельного плана."""
 
@@ -71,13 +109,13 @@ class TestPremiumWeekPlanEndToEnd:
 
         def fake_build_week(targets, diet_flags, lang, fooddb, recipedb):
             captured.update({"targets": targets, "diet_flags": diet_flags, "lang": lang})
-            return {
-                "daily_menus": [{"kcal": 2200}],
-                "weekly_coverage": {"protein": 0.9},
-                "shopping_list": {"eggs": 12},
-                "total_cost": 37.5,
-                "adherence_score": 0.8,
-            }
+            return _make_week_payload(
+                day_kcal=2200,
+                weekly_coverage={"protein": 0.9},
+                shopping_list={"eggs": 12},
+                total_cost=37.5,
+                adherence_score=0.8,
+            )
 
         monkeypatch.setattr(premium_week, "build_week", fake_build_week)
         monkeypatch.setattr(premium_week, "FoodDB", lambda *_args, **_kwargs: object())
@@ -106,13 +144,13 @@ class TestPremiumWeekPlanEndToEnd:
                     "lang": lang,
                 }
             )
-            return {
-                "daily_menus": [{"kcal": 2500}],
-                "weekly_coverage": {"fiber": 1.1},
-                "shopping_list": {"avocado": 4},
-                "total_cost": 44.0,
-                "adherence_score": 0.82,
-            }
+            return _make_week_payload(
+                day_kcal=2500,
+                weekly_coverage={"fiber": 1.1},
+                shopping_list={"avocado": 4},
+                total_cost=44.0,
+                adherence_score=0.82,
+            )
 
         monkeypatch.setattr(premium_week, "build_week", fake_build_week)
         monkeypatch.setattr(premium_week, "FoodDB", lambda *_args, **_kwargs: object())

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -87,9 +87,11 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
     # Sanity-check: generator must produce FULL schema (no schema-only markers) and include
     # key endpoints that were previously excluded behind schema-only mode.
     schema = json.loads(openapi_path.read_text(encoding="utf-8"))
+    schema_ts = schema_path.read_text(encoding="utf-8")
     info = schema.get("info") or {}
     assert info.get("x-openapi-mode") != "schema-only"
     paths = schema.get("paths") or {}
+    components = (schema.get("components") or {}).get("schemas") or {}
     assert "/api/v1/pro/meal/weekly" in paths
     assert "/api/v1/pro/nutrition/daily" in paths
     assert "/api/v1/pro/nutrition/meal-log" in paths
@@ -98,6 +100,14 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
     assert "/api/v1/business/analyze" not in paths
     assert "/api/v1/foods" not in paths
     assert "/api/v1/restaurants/search" not in paths
+    assert "PremiumWeekPlanRequest" not in components
+    assert "PremiumWeekPlanResponse" not in components
+    assert "WeeklyMealPlanResponse" in components
+    assert "WeeklyMealPlanDayMenu" in components
+    assert "PremiumWeekPlanRequest" not in schema_ts
+    assert "PremiumWeekPlanResponse" not in schema_ts
+    assert 'daily_menus: components["schemas"]["WeeklyMealPlanDayMenu"][];' in schema_ts
+    assert "daily_menus: unknown[]" not in schema_ts
 
     h1: tuple[str, str] = (_sha256(openapi_path), _sha256(schema_path))
 
@@ -144,3 +154,107 @@ def test_register_pro_routes_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> N
     assert after == before
     assert pro_router is sentinel_pro
     assert premium_week_router is sentinel_week
+
+
+def test_prune_unreferenced_schema_components_ignores_missing_components() -> None:
+    from legacy_app import _prune_unreferenced_schema_components
+
+    schema_without_components = {"openapi": "3.1.0", "paths": {}}
+    schema_without_schemas = {"components": {"securitySchemes": {"ApiKeyAuth": {}}}}
+
+    _prune_unreferenced_schema_components(schema_without_components)
+    _prune_unreferenced_schema_components(schema_without_schemas)
+
+    assert schema_without_components == {"openapi": "3.1.0", "paths": {}}
+    assert schema_without_schemas["components"]["securitySchemes"]["ApiKeyAuth"] == {}
+
+
+def test_prune_unreferenced_schema_components_skips_duplicates_and_missing_refs() -> None:
+    from legacy_app import _prune_unreferenced_schema_components
+
+    schema = {
+        "paths": {
+            "/api/v1/demo": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PublicResponse"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "PublicResponse": {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/SharedItem"},
+                        },
+                        "duplicate": {"$ref": "#/components/schemas/SharedItem"},
+                        "missing": {"$ref": "#/components/schemas/MissingItem"},
+                    },
+                },
+                "SharedItem": {
+                    "type": "object",
+                    "properties": {
+                        "self": {"$ref": "#/components/schemas/SharedItem"},
+                    },
+                },
+                "UnusedSchema": {"type": "object"},
+            },
+            "securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-Key"}},
+        },
+    }
+
+    _prune_unreferenced_schema_components(schema)
+
+    retained = schema["components"]["schemas"]
+    assert set(retained) == {"PublicResponse", "SharedItem"}
+    assert "UnusedSchema" not in retained
+    assert schema["components"]["securitySchemes"]["ApiKeyAuth"]["type"] == "apiKey"
+
+
+def test_prune_unreferenced_schema_components_skips_non_dict_schema_nodes() -> None:
+    from legacy_app import _prune_unreferenced_schema_components
+
+    schema = {
+        "paths": {
+            "/api/v1/demo": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "oneOf": [
+                                            {"$ref": "#/components/schemas/PublicResponse"},
+                                            {"$ref": "#/components/schemas/BrokenNode"},
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "PublicResponse": {"type": "object"},
+                "BrokenNode": "not-a-dict",
+            }
+        },
+    }
+
+    _prune_unreferenced_schema_components(schema)
+
+    retained = schema["components"]["schemas"]
+    assert "PublicResponse" in retained
+    assert "BrokenNode" not in retained

--- a/tests/test_premium_week_endpoint_96.py
+++ b/tests/test_premium_week_endpoint_96.py
@@ -12,6 +12,43 @@ from fastapi.testclient import TestClient
 from app import app
 
 
+def _make_canonical_week_payload() -> dict[str, object]:
+    """Return a weekly-plan payload that matches the public endpoint contract.
+
+    RU: Тестовые заглушки должны использовать каноническую форму weekly-plan,
+    иначе fail-closed нормализация корректно возвращает 500.
+    EN: Test doubles must match the canonical weekly-plan shape so fail-closed
+    normalization only rejects truly malformed payloads.
+    """
+    return {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "Protein bowl",
+                        "title_translated": "Protein bowl",
+                        "grams": {"serving_g": 420.0},
+                        "kcal": 550.0,
+                        "macros": {"protein_g": 42.0},
+                        "micros": {"iron_mg": 4.2},
+                        "price_est": 8.5,
+                    }
+                ],
+                "kcal": 550.0,
+                "macros": {"protein_g": 42.0},
+                "micros": {"iron_mg": 4.2},
+                "coverage": {"protein": 0.8},
+                "tips": ["Stay hydrated"],
+                "total_cost": 8.5,
+            }
+        ],
+        "weekly_coverage": {"protein": 0.8},
+        "shopping_list": {"apple": 5.0},
+        "total_cost": 25.50,
+        "adherence_score": 0.85,
+    }
+
+
 class TestPremiumWeekEndpoint96:
     """Tests for premium week endpoint coverage."""
 
@@ -30,13 +67,7 @@ class TestPremiumWeekEndpoint96:
             mock_recipedb.return_value = Mock()
 
             # Mock build_week response
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "sex": "male",
@@ -78,13 +109,7 @@ class TestPremiumWeekEndpoint96:
             mock_recipedb.return_value = Mock()
 
             # Mock build_week response but let database instantiation happen
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "targets": {
@@ -142,13 +167,7 @@ class TestPremiumWeekEndpoint96:
             }
 
             # Mock build_week response
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "sex": "male",
@@ -228,13 +247,7 @@ class TestPremiumWeekEndpoint96:
             mock_estimate.return_value = None
 
             # Mock build_week to return a predictable result
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "sex": "male",
@@ -285,13 +298,7 @@ class TestPremiumWeekEndpoint96:
                 }
 
                 # Mock build_week response
-                mock_build_week.return_value = {
-                    "daily_menus": [{"breakfast": "test"}],
-                    "weekly_coverage": {"protein": 0.8},
-                    "shopping_list": {"apple": 5.0},
-                    "total_cost": 25.50,
-                    "adherence_score": 0.85,
-                }
+                mock_build_week.return_value = _make_canonical_week_payload()
 
                 payload = {
                     "sex": "male",
@@ -348,13 +355,7 @@ class TestPremiumWeekEndpoint96:
                 }
 
                 # Mock build_week response
-                mock_build_week.return_value = {
-                    "daily_menus": [{"breakfast": "test"}],
-                    "weekly_coverage": {"protein": 0.8},
-                    "shopping_list": {"apple": 5.0},
-                    "total_cost": 25.50,
-                    "adherence_score": 0.85,
-                }
+                mock_build_week.return_value = _make_canonical_week_payload()
 
                 payload = {
                     "sex": "male",

--- a/tests/test_premium_week_endpoint_simple_96.py
+++ b/tests/test_premium_week_endpoint_simple_96.py
@@ -12,6 +12,41 @@ from fastapi.testclient import TestClient
 from app import app
 
 
+def _make_canonical_week_payload() -> dict[str, object]:
+    """Return a weekly-plan payload that matches the public endpoint contract.
+
+    RU: Фейковые build_week ответы должны быть каноническими.
+    EN: Fake build_week responses must use the canonical typed weekly-plan shape.
+    """
+    return {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "Protein bowl",
+                        "title_translated": "Protein bowl",
+                        "grams": {"serving_g": 420.0},
+                        "kcal": 550.0,
+                        "macros": {"protein_g": 42.0},
+                        "micros": {"iron_mg": 4.2},
+                        "price_est": 8.5,
+                    }
+                ],
+                "kcal": 550.0,
+                "macros": {"protein_g": 42.0},
+                "micros": {"iron_mg": 4.2},
+                "coverage": {"protein": 0.8},
+                "tips": ["Stay hydrated"],
+                "total_cost": 8.5,
+            }
+        ],
+        "weekly_coverage": {"protein": 0.8},
+        "shopping_list": {"apple": 5.0},
+        "total_cost": 25.50,
+        "adherence_score": 0.85,
+    }
+
+
 class TestPremiumWeekEndpointSimple96:
     """Simple tests for premium week endpoint coverage."""
 
@@ -30,13 +65,7 @@ class TestPremiumWeekEndpointSimple96:
             mock_recipedb.return_value = Mock()
 
             # Mock build_week response
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "sex": "male",
@@ -88,13 +117,7 @@ class TestPremiumWeekEndpointSimple96:
             }
 
             # Mock build_week response
-            mock_build_week.return_value = {
-                "daily_menus": [{"breakfast": "test"}],
-                "weekly_coverage": {"protein": 0.8},
-                "shopping_list": {"apple": 5.0},
-                "total_cost": 25.50,
-                "adherence_score": 0.85,
-            }
+            mock_build_week.return_value = _make_canonical_week_payload()
 
             payload = {
                 "sex": "male",

--- a/tests/test_premium_week_router.py
+++ b/tests/test_premium_week_router.py
@@ -45,7 +45,26 @@ class TestPremiumWeekRouter:
 
         # Mock the build_week function
         mock_build_week.return_value = {
-            "daily_menus": [{"day": "Monday", "meals": []}],
+            "daily_menus": [
+                {
+                    "meals": [
+                        {
+                            "title": "chicken_rice",
+                            "title_translated": "Chicken rice",
+                            "grams": {"chicken": 140.0},
+                            "kcal": 510.0,
+                            "macros": {"protein_g": 40.0, "fat_g": 12.0, "carbs_g": 55.0},
+                            "micros": {"iron_mg": 4.5},
+                            "price_est": "6.75",
+                        }
+                    ],
+                    "kcal": 510.0,
+                    "macros": {"protein_g": 40.0, "fat_g": 12.0, "carbs_g": 55.0},
+                    "micros": {"iron_mg": 4.5},
+                    "coverage": {"iron_mg": 92.0},
+                    "tips": ["Pair with vegetables"],
+                }
+            ],
             "weekly_coverage": {"protein": 0.95},
             "shopping_list": {"chicken": 1.0},
             "total_cost": 25.50,
@@ -80,6 +99,8 @@ class TestPremiumWeekRouter:
         assert "shopping_list" in data
         assert "total_cost" in data
         assert "adherence_score" in data
+        assert data["daily_menus"][0]["meals"][0]["price_est"] == 6.75
+        assert data["daily_menus"][0]["total_cost"] == 6.75
 
     @patch("app.routers.premium_week.FoodDB")
     @patch("app.routers.premium_week.RecipeDB")
@@ -112,7 +133,26 @@ class TestPremiumWeekRouter:
 
         # Mock the build_week function
         mock_build_week.return_value = {
-            "daily_menus": [{"day": "Monday", "meals": []}],
+            "daily_menus": [
+                {
+                    "meals": [
+                        {
+                            "title": "oatmeal",
+                            "title_translated": "Oatmeal",
+                            "grams": {"oats": 80.0},
+                            "kcal": 300.0,
+                            "macros": {"protein_g": 12.0, "fat_g": 6.0, "carbs_g": 50.0},
+                            "micros": {"fiber_g": 7.0},
+                        }
+                    ],
+                    "kcal": 300.0,
+                    "macros": {"protein_g": 12.0, "fat_g": 6.0, "carbs_g": 50.0},
+                    "micros": {"fiber_g": 7.0},
+                    "coverage": {"fiber_g": 80.0},
+                    "tips": [],
+                    "total_cost": 0.0,
+                }
+            ],
             "weekly_coverage": {"protein": 0.95},
             "shopping_list": {"chicken": 1.0},
             "total_cost": 25.50,
@@ -281,7 +321,27 @@ class TestPremiumWeekRouter:
     def test_week_plan_response_model(self) -> None:
         """Test WeekPlanResponse model."""
         response = PremiumWeekPlanResponse(
-            daily_menus=[{"day": "Monday", "meals": []}],
+            daily_menus=[
+                {
+                    "meals": [
+                        {
+                            "title": "salad",
+                            "title_translated": "Salad",
+                            "grams": {"lettuce": 100.0},
+                            "kcal": 120.0,
+                            "macros": {"protein_g": 2.0, "fat_g": 5.0, "carbs_g": 15.0},
+                            "micros": {"vitamin_c_mg": 18.0},
+                            "price_est": 2.5,
+                        }
+                    ],
+                    "kcal": 120.0,
+                    "macros": {"protein_g": 2.0, "fat_g": 5.0, "carbs_g": 15.0},
+                    "micros": {"vitamin_c_mg": 18.0},
+                    "coverage": {"vitamin_c_mg": 35.0},
+                    "tips": ["Add protein"],
+                    "total_cost": 2.5,
+                }
+            ],
             weekly_coverage={"protein": 0.95, "carbs": 0.90},
             shopping_list={"chicken": 1.0},
             total_cost=25.50,

--- a/tests/test_premium_week_router_isolated.py
+++ b/tests/test_premium_week_router_isolated.py
@@ -45,3 +45,41 @@ def test_premium_week_pipeline_type_mismatch_raises_typeerror(
     finally:
         client.close()
         app.dependency_overrides.clear()
+
+
+def test_premium_week_pipeline_invalid_payload_surfaces_postprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import premium_week as premium_mod
+    from app.middleware.api_tiers import require_pro_tier
+
+    app = FastAPI()
+    app.include_router(premium_mod.router)
+    app.dependency_overrides[require_pro_tier] = lambda: None
+
+    monkeypatch.setattr(premium_mod, "_get_food_db", lambda: object())
+    monkeypatch.setattr(premium_mod, "_get_recipe_db", lambda: object())
+    monkeypatch.setattr(premium_mod, "_is_complete_targets", lambda _d: True)
+
+    def _fake_pipeline(**kwargs: Any) -> dict[str, Any]:
+        postprocess_fn = kwargs["postprocess_fn"]
+        try:
+            postprocess_fn({"weekly_coverage": {}, "shopping_list": {}})
+        except ValueError:
+            return {
+                "status": "error",
+                "code": "weekly_postprocess_failed",
+                "message": "Failed to build weekly plan response",
+            }
+        raise AssertionError("postprocess_fn should fail for malformed weekly payloads")
+
+    monkeypatch.setattr(premium_mod, "run_weekly_pipeline_guarded", _fake_pipeline)
+
+    client = TestClient(app)
+    try:
+        response = client.post("/api/v1/premium/plan/week-flexible", json={})
+        assert response.status_code == 500, response.text
+        assert response.json()["code"] == "weekly_postprocess_failed"
+    finally:
+        client.close()
+        app.dependency_overrides.clear()

--- a/tests/test_premium_week_router_isolated.py
+++ b/tests/test_premium_week_router_isolated.py
@@ -79,6 +79,7 @@ def test_premium_week_pipeline_invalid_payload_surfaces_postprocess_error(
     try:
         response = client.post("/api/v1/premium/plan/week-flexible", json={})
         assert response.status_code == 500, response.text
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json()["code"] == "weekly_postprocess_failed"
     finally:
         client.close()

--- a/tests/test_pro_premium_contract_parity.py
+++ b/tests/test_pro_premium_contract_parity.py
@@ -245,3 +245,23 @@ def test_premium_endpoints_hidden_from_openapi(client: TestClient, endpoint_path
     assert r.headers.get("content-type", "").startswith("application/json")
     spec = r.json()
     assert endpoint_path not in spec["paths"], f"{endpoint_path} must be hidden from OpenAPI"
+
+
+def test_openapi_prunes_premium_week_components_after_path_filtering(client: TestClient) -> None:
+    """Assert hidden premium-week contracts do not leak orphaned schema components."""
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+
+    spec = response.json()
+    components = spec.get("components") or {}
+    schemas = components.get("schemas") or {}
+
+    assert "/api/v1/pro/meal/weekly" in spec.get("paths", {})
+    assert "/api/v1/premium/plan/week-flexible" not in spec.get("paths", {})
+    assert "PremiumWeekPlanRequest" not in schemas
+    assert "PremiumWeekPlanResponse" not in schemas
+
+    weekly_response = schemas.get("WeeklyMealPlanResponse") or {}
+    daily_menus = (weekly_response.get("properties") or {}).get("daily_menus") or {}
+    daily_menu_items = daily_menus.get("items") or {}
+    assert daily_menu_items.get("$ref") == "#/components/schemas/WeeklyMealPlanDayMenu"

--- a/tests/test_pro_premium_contract_parity.py
+++ b/tests/test_pro_premium_contract_parity.py
@@ -251,6 +251,7 @@ def test_openapi_prunes_premium_week_components_after_path_filtering(client: Tes
     """Assert hidden premium-week contracts do not leak orphaned schema components."""
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
+    assert response.headers.get("content-type", "").startswith("application/json")
 
     spec = response.json()
     components = spec.get("components") or {}

--- a/tests/test_pro_router.py
+++ b/tests/test_pro_router.py
@@ -158,6 +158,32 @@ class TestProRouterIsolated:
         with pytest.raises(TypeError, match=r"Expected ProWeekPlanResponse"):
             _ = self.client.post("/api/v1/pro/meal/weekly", json={})
 
+    def test_weekly_meal_plan_invalid_payload_surfaces_postprocess_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed build output must fail closed in the postprocess stage."""
+        monkeypatch.setattr(self.pro_mod, "get_food_db", lambda: object())
+        monkeypatch.setattr(self.pro_mod, "get_recipe_db", lambda: object())
+        monkeypatch.setattr(self.pro_mod, "_is_complete_targets", lambda _d: True)
+
+        def _fake_pipeline(**kwargs: Any) -> dict[str, Any]:
+            postprocess_fn = kwargs["postprocess_fn"]
+            try:
+                postprocess_fn({"weekly_coverage": {}, "shopping_list": {}})
+            except ValueError:
+                return {
+                    "status": "error",
+                    "code": "weekly_postprocess_failed",
+                    "message": "Failed to build weekly plan response",
+                }
+            raise AssertionError("postprocess_fn should fail for malformed weekly payloads")
+
+        monkeypatch.setattr(self.pro_mod, "run_weekly_pipeline_guarded", _fake_pipeline)
+
+        response = self.client.post("/api/v1/pro/meal/weekly", json={})
+        assert response.status_code == 500, response.text
+        assert response.json()["code"] == "weekly_postprocess_failed"
+
     def test_weekly_meal_plan_missing_profile_field_400(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_pro_router.py
+++ b/tests/test_pro_router.py
@@ -63,10 +63,29 @@ class TestProRouterIsolated:
 
         def _fake_build_week(*args: Any, **kwargs: Any) -> Dict[str, Any]:
             return {
-                "daily_menus": [{"day": 1, "meals": []}],
+                "daily_menus": [
+                    {
+                        "meals": [
+                            {
+                                "title": "salmon_bowl",
+                                "title_translated": "Salmon bowl",
+                                "grams": {"salmon": 150.0},
+                                "kcal": 420.0,
+                                "macros": {"protein_g": 35.0, "fat_g": 18.0, "carbs_g": 12.0},
+                                "micros": {"omega3_mg": 900.0},
+                                "price_est": "5.25",
+                            }
+                        ],
+                        "kcal": 420.0,
+                        "macros": {"protein_g": 35.0, "fat_g": 18.0, "carbs_g": 12.0},
+                        "micros": {"omega3_mg": 900.0},
+                        "coverage": {"omega3_mg": 85.0},
+                        "tips": ["Add greens"],
+                    }
+                ],
                 "weekly_coverage": {"protein_g": 1.0},
                 "shopping_list": {"rice_g": 500.0},
-                "total_cost": 0.0,
+                "total_cost": 5.25,
                 "adherence_score": 1.0,
             }
 
@@ -117,6 +136,8 @@ class TestProRouterIsolated:
         assert "shopping_list" in data
         assert "total_cost" in data
         assert "adherence_score" in data
+        assert data["daily_menus"][0]["meals"][0]["price_est"] == 5.25
+        assert data["daily_menus"][0]["total_cost"] == 5.25
 
     def test_weekly_meal_plan_pipeline_type_mismatch_raises_typeerror(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_pro_router.py
+++ b/tests/test_pro_router.py
@@ -182,6 +182,7 @@ class TestProRouterIsolated:
 
         response = self.client.post("/api/v1/pro/meal/weekly", json={})
         assert response.status_code == 500, response.text
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json()["code"] == "weekly_postprocess_failed"
 
     def test_weekly_meal_plan_missing_profile_field_400(

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -4,39 +4,45 @@ from __future__ import annotations
 
 import pytest
 
-from app.schemas.weekly_plan import WeeklyMealPlanResponse, normalize_weekly_plan_payload
+from app.schemas.weekly_plan import (
+    WeeklyMealPlanResponse,
+    normalize_weekly_plan_payload,
+    require_weekly_plan_payload_shape,
+)
+
+
+def _valid_week_payload() -> dict[str, object]:
+    return {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "Breakfast",
+                        "title_translated": "Breakfast",
+                        "grams": {"oats": "50"},
+                        "kcal": "350",
+                        "macros": {"carbs": "30"},
+                        "micros": {"iron": "2.5"},
+                        "price_est": "4.5",
+                    }
+                ],
+                "kcal": "350",
+                "macros": {"carbs": "30"},
+                "micros": {"iron": "2.5"},
+                "coverage": {"protein": "80"},
+                "tips": ["Add fruit"],
+                "total_cost": None,
+            }
+        ],
+        "weekly_coverage": {"protein": "92"},
+        "shopping_list": {"oats": "50"},
+        "total_cost": None,
+        "adherence_score": "0.9",
+    }
 
 
 def test_normalize_weekly_plan_payload_normalizes_valid_numeric_like_values() -> None:
-    payload = normalize_weekly_plan_payload(
-        {
-            "daily_menus": [
-                {
-                    "meals": [
-                        {
-                            "title": "Breakfast",
-                            "title_translated": "Breakfast",
-                            "grams": {"oats": "50"},
-                            "kcal": "350",
-                            "macros": {"carbs": "30"},
-                            "micros": {"iron": "2.5"},
-                            "price_est": "4.5",
-                        }
-                    ],
-                    "kcal": "350",
-                    "macros": {"carbs": "30"},
-                    "micros": {"iron": "2.5"},
-                    "coverage": {"protein": "80"},
-                    "tips": ["Add fruit"],
-                    "total_cost": None,
-                }
-            ],
-            "weekly_coverage": {"protein": "92"},
-            "shopping_list": {"oats": "50"},
-            "total_cost": None,
-            "adherence_score": "0.9",
-        }
-    )
+    payload = normalize_weekly_plan_payload(_valid_week_payload())
 
     meal = payload["daily_menus"][0]["meals"][0]
     assert meal["grams"] == {"oats": 50.0}
@@ -197,3 +203,77 @@ def test_normalize_weekly_plan_payload_rejects_invalid_adherence_score() -> None
                 "adherence_score": "nan",
             }
         )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda payload: payload["daily_menus"][0]["meals"].__setitem__(
+                0,
+                {
+                    "title": 42,
+                    "grams": {"oats": "50"},
+                    "kcal": "350",
+                    "macros": {"carbs": "30"},
+                    "micros": {"iron": "2.5"},
+                },
+            ),
+            r"daily_menus\[\]\.meals\[\]\.title must be a non-empty string",
+        ),
+        (
+            lambda payload: payload["daily_menus"][0]["meals"].__setitem__(
+                0,
+                {
+                    "title": "Breakfast",
+                    "title_translated": 42,
+                    "grams": {"oats": "50"},
+                    "kcal": "350",
+                    "macros": {"carbs": "30"},
+                    "micros": {"iron": "2.5"},
+                },
+            ),
+            r"daily_menus\[\]\.meals\[\]\.title_translated must be a non-empty string",
+        ),
+        (
+            lambda payload: payload["daily_menus"][0]["meals"].__setitem__(
+                0,
+                {
+                    "title": "Breakfast",
+                    "grams": {1: "50"},
+                    "kcal": "350",
+                    "macros": {"carbs": "30"},
+                    "micros": {"iron": "2.5"},
+                },
+            ),
+            r"daily_menus\[\]\.meals\[\]\.grams keys must be strings",
+        ),
+        (
+            lambda payload: payload["daily_menus"][0].__setitem__("meals", {}),
+            r"daily_menus\[\]\.meals must be a list",
+        ),
+        (
+            lambda payload: payload["daily_menus"][0].__setitem__("tips", "hydrate"),
+            r"daily_menus\[\]\.tips must be a list of strings",
+        ),
+        (
+            lambda payload: payload.__setitem__("daily_menus", {}),
+            r"weekly plan payload missing required daily_menus list",
+        ),
+        (
+            lambda payload: payload.__setitem__("total_cost", "bad"),
+            r"weekly_plan.total_cost must be a finite number",
+        ),
+    ],
+)
+def test_normalize_weekly_plan_payload_covers_fail_closed_branches(mutator, message) -> None:
+    payload = _valid_week_payload()
+    mutator(payload)
+
+    with pytest.raises(ValueError, match=message):
+        normalize_weekly_plan_payload(payload)
+
+
+def test_require_weekly_plan_payload_shape_rejects_non_mapping() -> None:
+    with pytest.raises(ValueError, match=r"weekly plan payload must be a mapping"):
+        require_weekly_plan_payload_shape(None)

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.schemas.weekly_plan import normalize_weekly_plan_payload
+from app.schemas.weekly_plan import WeeklyMealPlanResponse, normalize_weekly_plan_payload
 
 
 def test_normalize_weekly_plan_payload_skips_invalid_numeric_entries() -> None:
@@ -35,6 +35,7 @@ def test_normalize_weekly_plan_payload_skips_invalid_numeric_entries() -> None:
     assert meal["price_est"] is None
     assert payload["daily_menus"][0]["total_cost"] == 0.0
     assert payload["total_cost"] == 0.0
+    WeeklyMealPlanResponse.model_validate(payload)
 
 
 def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
@@ -55,3 +56,4 @@ def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
     assert day["kcal"] == 0.0
     assert day["coverage"] == {"protein": 25.0}
     assert payload["adherence_score"] == 0.0
+    WeeklyMealPlanResponse.model_validate(payload)

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -76,6 +76,43 @@ def test_normalize_weekly_plan_payload_rejects_invalid_numeric_entries() -> None
         )
 
 
+def test_normalize_weekly_plan_payload_rejects_non_mapping_root_payload() -> None:
+    with pytest.raises(ValueError, match=r"weekly_plan must be a mapping"):
+        normalize_weekly_plan_payload(["not", "a", "mapping"])
+
+
+def test_normalize_weekly_plan_payload_rejects_non_mapping_day_payload() -> None:
+    with pytest.raises(ValueError, match=r"daily_menus\[\] must be a mapping"):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": ["bad-day-payload"],
+                "adherence_score": "0.9",
+            }
+        )
+
+
+def test_normalize_weekly_plan_payload_rejects_non_mapping_meal_payload() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"daily_menus\[\]\.meals\[\] must be a mapping",
+    ):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": ["bad-meal-payload"],
+                        "kcal": "350",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {},
+                        "total_cost": None,
+                    }
+                ],
+                "adherence_score": "0.9",
+            }
+        )
+
+
 def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
     with pytest.raises(ValueError, match=r"daily_menus\[\]\.kcal must be a finite number"):
         normalize_weekly_plan_payload(
@@ -91,6 +128,25 @@ def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
                     }
                 ],
                 "adherence_score": "nan",
+            }
+        )
+
+
+def test_normalize_weekly_plan_payload_rejects_invalid_total_cost_scalars() -> None:
+    with pytest.raises(ValueError, match=r"daily_menus\[\]\.total_cost must be a finite number"):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": [],
+                        "kcal": "350",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {},
+                        "total_cost": "bad",
+                    }
+                ],
+                "adherence_score": "0.9",
             }
         )
 

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.schemas.weekly_plan import WeeklyMealPlanResponse, normalize_weekly_plan_payload
 
 
-def test_normalize_weekly_plan_payload_skips_invalid_numeric_entries() -> None:
+def test_normalize_weekly_plan_payload_normalizes_valid_numeric_like_values() -> None:
     payload = normalize_weekly_plan_payload(
         {
             "daily_menus": [
@@ -13,47 +15,129 @@ def test_normalize_weekly_plan_payload_skips_invalid_numeric_entries() -> None:
                     "meals": [
                         {
                             "title": "Breakfast",
-                            "grams": {"oats": "50", 7: "10"},
-                            "kcal": "bad",
-                            "macros": {"protein": "nan", "carbs": "30"},
-                            "micros": {"iron": object()},
-                            "price_est": "oops",
+                            "title_translated": "Breakfast",
+                            "grams": {"oats": "50"},
+                            "kcal": "350",
+                            "macros": {"carbs": "30"},
+                            "micros": {"iron": "2.5"},
+                            "price_est": "4.5",
                         }
                     ],
+                    "kcal": "350",
+                    "macros": {"carbs": "30"},
+                    "micros": {"iron": "2.5"},
+                    "coverage": {"protein": "80"},
+                    "tips": ["Add fruit"],
                     "total_cost": None,
                 }
             ],
+            "weekly_coverage": {"protein": "92"},
+            "shopping_list": {"oats": "50"},
             "total_cost": None,
+            "adherence_score": "0.9",
         }
     )
 
     meal = payload["daily_menus"][0]["meals"][0]
     assert meal["grams"] == {"oats": 50.0}
-    assert meal["kcal"] == 0.0
+    assert meal["kcal"] == 350.0
     assert meal["macros"] == {"carbs": 30.0}
-    assert meal["micros"] == {}
-    assert meal["price_est"] is None
-    assert payload["daily_menus"][0]["total_cost"] == 0.0
-    assert payload["total_cost"] == 0.0
+    assert meal["micros"] == {"iron": 2.5}
+    assert meal["price_est"] == 4.5
+    assert payload["daily_menus"][0]["total_cost"] == 4.5
+    assert payload["total_cost"] == 4.5
     WeeklyMealPlanResponse.model_validate(payload)
+
+
+def test_normalize_weekly_plan_payload_rejects_invalid_numeric_entries() -> None:
+    with pytest.raises(
+        ValueError, match=r"daily_menus\[\]\.meals\[\]\.kcal must be a finite number"
+    ):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": [
+                            {
+                                "title": "Breakfast",
+                                "grams": {"oats": "50"},
+                                "kcal": "bad",
+                            }
+                        ],
+                        "kcal": "350",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {},
+                        "total_cost": None,
+                    }
+                ],
+                "adherence_score": "0.9",
+            }
+        )
 
 
 def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
-    payload = normalize_weekly_plan_payload(
-        {
-            "daily_menus": [
-                {
-                    "kcal": "inf",
-                    "coverage": {"fiber": "-inf", "protein": "25"},
-                    "total_cost": "12.5",
-                }
-            ],
-            "adherence_score": "nan",
-        }
-    )
+    with pytest.raises(ValueError, match=r"daily_menus\[\]\.kcal must be a finite number"):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": [],
+                        "kcal": "inf",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {"fiber": "-inf", "protein": "25"},
+                        "total_cost": "12.5",
+                    }
+                ],
+                "adherence_score": "nan",
+            }
+        )
 
-    day = payload["daily_menus"][0]
-    assert day["kcal"] == 0.0
-    assert day["coverage"] == {"protein": 25.0}
-    assert payload["adherence_score"] == 0.0
-    WeeklyMealPlanResponse.model_validate(payload)
+
+def test_normalize_weekly_plan_payload_rejects_missing_meal_title() -> None:
+    with pytest.raises(
+        ValueError, match=r"daily_menus\[\]\.meals\[\]\.title must be a non-empty string"
+    ):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": [
+                            {
+                                "title": "",
+                                "grams": {"oats": "50"},
+                                "kcal": "350",
+                                "macros": {"carbs": "30"},
+                                "micros": {"iron": "2.5"},
+                            }
+                        ],
+                        "kcal": "350",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {},
+                        "total_cost": None,
+                    }
+                ],
+                "adherence_score": "0.9",
+            }
+        )
+
+
+def test_normalize_weekly_plan_payload_rejects_invalid_adherence_score() -> None:
+    with pytest.raises(ValueError, match=r"adherence_score must be a finite number"):
+        normalize_weekly_plan_payload(
+            {
+                "daily_menus": [
+                    {
+                        "meals": [],
+                        "kcal": "350",
+                        "macros": {},
+                        "micros": {},
+                        "coverage": {},
+                        "total_cost": None,
+                    }
+                ],
+                "adherence_score": "nan",
+            }
+        )

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -277,3 +277,13 @@ def test_normalize_weekly_plan_payload_covers_fail_closed_branches(mutator, mess
 def test_require_weekly_plan_payload_shape_rejects_non_mapping() -> None:
     with pytest.raises(ValueError, match=r"weekly plan payload must be a mapping"):
         require_weekly_plan_payload_shape(None)
+
+
+def test_require_weekly_plan_payload_shape_rejects_missing_daily_menus_list() -> None:
+    with pytest.raises(ValueError, match=r"weekly plan payload missing required daily_menus list"):
+        require_weekly_plan_payload_shape({"daily_menus": {}})
+
+
+def test_require_weekly_plan_payload_shape_accepts_canonical_payload() -> None:
+    payload = _valid_week_payload()
+    assert require_weekly_plan_payload_shape(payload) is payload

--- a/tests/test_weekly_plan_schema_normalization.py
+++ b/tests/test_weekly_plan_schema_normalization.py
@@ -1,0 +1,57 @@
+"""Unit tests for weekly-plan DTO normalization helpers."""
+
+from __future__ import annotations
+
+from app.schemas.weekly_plan import normalize_weekly_plan_payload
+
+
+def test_normalize_weekly_plan_payload_skips_invalid_numeric_entries() -> None:
+    payload = normalize_weekly_plan_payload(
+        {
+            "daily_menus": [
+                {
+                    "meals": [
+                        {
+                            "title": "Breakfast",
+                            "grams": {"oats": "50", 7: "10"},
+                            "kcal": "bad",
+                            "macros": {"protein": "nan", "carbs": "30"},
+                            "micros": {"iron": object()},
+                            "price_est": "oops",
+                        }
+                    ],
+                    "total_cost": None,
+                }
+            ],
+            "total_cost": None,
+        }
+    )
+
+    meal = payload["daily_menus"][0]["meals"][0]
+    assert meal["grams"] == {"oats": 50.0}
+    assert meal["kcal"] == 0.0
+    assert meal["macros"] == {"carbs": 30.0}
+    assert meal["micros"] == {}
+    assert meal["price_est"] is None
+    assert payload["daily_menus"][0]["total_cost"] == 0.0
+    assert payload["total_cost"] == 0.0
+
+
+def test_normalize_weekly_plan_payload_rejects_non_finite_numbers() -> None:
+    payload = normalize_weekly_plan_payload(
+        {
+            "daily_menus": [
+                {
+                    "kcal": "inf",
+                    "coverage": {"fiber": "-inf", "protein": "25"},
+                    "total_cost": "12.5",
+                }
+            ],
+            "adherence_score": "nan",
+        }
+    )
+
+    day = payload["daily_menus"][0]
+    assert day["kcal"] == 0.0
+    assert day["coverage"] == {"protein": 25.0}
+    assert payload["adherence_score"] == 0.0


### PR DESCRIPTION
## Summary
- add typed weekly-plan DTO normalization so canonical `/api/v1/pro/meal/weekly` no longer degrades to `unknown` in generated TypeScript
- keep deprecated `/api/v1/premium/plan/week-flexible` hidden from public OpenAPI while pruning orphaned premium schemas
- align frontend weekly-plan consumers with regenerated OpenAPI types and close follow-up review feedback on contract tests and type naming drift

## Validation
- `pre-commit run --all-files`
- `make verify`
- `make openapi-check`
- `pytest -q tests/test_app_openapi_coverage.py tests/test_openapi_determinism.py tests/test_pro_premium_contract_parity.py tests/test_pro_router.py tests/test_premium_week_router.py tests/test_weekly_plan_schema_normalization.py`
- `npm --prefix frontend run test -- --run src/api/__tests__/weekly-plan-integration.test.ts src/features/weekly-plan/__tests__/adapter.test.ts src/components/__tests__/IntegratedWhoTargetsPanel.test.tsx`

## Notes
- public OpenAPI keeps canonical `/api/v1/pro/*` visible and deprecated `/api/v1/premium/*` weekly-plan hidden
- canonical fixed-mapping artifact: `docs/review/PR_1053_FIXED_MAPPING.md`
- merge remains blocked until the newest commits finish remote checks and the review wait-window completes

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915388839 -> cf4f6381`
  - Disposition: `FIXED`
  - Evidence: `tests/test_pro_premium_contract_parity.py:254`, `tests/test_app_endpoints_1383_1401.py:121`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> cf4f6381`
  - Disposition: `FIXED`
  - Evidence: `tests/test_pro_premium_contract_parity.py:254`, `tests/test_app_endpoints_1383_1401.py:121`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151 -> 36f21947`
  - Disposition: `FIXED`
  - Evidence: `tests/test_app_openapi_coverage.py:103`, `tests/test_weekly_plan_schema_normalization.py:38`, `frontend/src/api/premium/weekly-plan.ts:5`, `legacy_app.py:2294`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151`
  - Disposition: `NOT-A-BUG`
  - Evidence: `frontend/src/api/schema.ts:3227`, `frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts:16`
  - Reason: canonical `ProWeekPlanRequest` requires `lang: "ru" | "en" | "es"`, so coercing unsupported values avoids invalid request bodies and 422 drift.
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1053#pullrequestreview-3915417151`
  - Disposition: `DEFERRED`
  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md:1355`
  - Reason: moving `/terms` and `/privacy` out of `legacy_app.py` belongs to the existing long-tail legacy-app migration track, not this bounded weekly-plan contract PR.

## Merge Readiness
- [x] Scope tied to PR objective
- [x] Docs/runtime changes applied
- [x] Verification completed
- [ ] Required GitHub checks PASS with no pending required jobs
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] No unresolved review threads or actionable bot comments remain
- [ ] Review wait-window completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized weekly meal plan format across the app, consolidating schemas for meals, daily totals, nutrition, shopping lists and pricing.
  * Improved normalization so frontends consume a single canonical weekly plan shape.

* **New Features**
  * Responses now include richer meal details (titles, translations, grams, macros, micros, price estimates) and per-day total cost and adherence metrics.

* **Bug Fixes**
  * Stronger payload validation and normalization to surface malformed data earlier and prevent inconsistent displays.

* **Documentation**
  * Added a terms endpoint exposing canonical terms of service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->