### PR TITLE
fix(security): fail fast on production api key toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,11 @@ PRO_LLM_INSIGHT_REQUESTS_PER_MONTH=20
 # Provide your API key in real deployments via environment variables.
 # Leaving this empty keeps the app in lenient dev mode.
 API_KEY=
+# Keep true only for local/test workflows. Production/staging must override to false.
 ALLOW_DEV_API_KEY=true
+# Optional local/dev override for anonymous VIP/API-tier testing.
+# Production/staging must keep this false; startup now fails closed otherwise.
+# ALLOW_ANONYMOUS_API_KEYS=false
 
 # === Food Search Feature Flags ===
 # Keep both flags disabled by default in production rollout.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -585,7 +585,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 306
+        "line_number": 325
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1438,29 +1438,6 @@
         "line_number": 269
       }
     ],
-    "tests/test_vip_anonymous_api_key_safety.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_anonymous_api_key_safety.py",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 87
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_anonymous_api_key_safety.py",
-        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
-        "is_verified": false,
-        "line_number": 232
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_anonymous_api_key_safety.py",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 327
-      }
-    ],
     "tests/test_vip_coverage_97_final.py": [
       {
         "type": "Secret Keyword",
@@ -1474,16 +1451,9 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/test_vip_coverage_additional.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 40
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_coverage_additional.py",
         "hashed_secret": "18de8e8747c829741cc7fd44c0f801a10a1d2b5b",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 92
       }
     ],
     "tests/test_vip_coverage_clean.py": [
@@ -1556,22 +1526,6 @@
         "line_number": 341
       }
     ],
-    "tests/test_vip_production_simple.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_production_simple.py",
-        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
-        "is_verified": false,
-        "line_number": 25
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_vip_production_simple.py",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 38
-      }
-    ],
     "tests/test_web_interface_spanish.py": [
       {
         "type": "Secret Keyword",
@@ -1598,5 +1552,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T13:50:42Z"
+  "generated_at": "2026-03-09T14:55:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -212,14 +212,14 @@
         "filename": "conftest.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 273
+        "line_number": 275
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 276
       }
     ],
     "core/integrated_bayesian_analyzer.py": [
@@ -612,14 +612,14 @@
         "filename": "tests/test_app_branching_and_errors.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 19
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_branching_and_errors.py",
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 20
       }
     ],
     "tests/test_app_coverage_missing_lines.py": [
@@ -1444,21 +1444,21 @@
         "filename": "tests/test_vip_anonymous_api_key_safety.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 87
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_vip_anonymous_api_key_safety.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 232
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_vip_anonymous_api_key_safety.py",
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_verified": false,
-        "line_number": 352
+        "line_number": 327
       }
     ],
     "tests/test_vip_coverage_97_final.py": [
@@ -1476,14 +1476,14 @@
         "filename": "tests/test_vip_coverage_additional.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 40
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_vip_coverage_additional.py",
         "hashed_secret": "18de8e8747c829741cc7fd44c0f801a10a1d2b5b",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 95
       }
     ],
     "tests/test_vip_coverage_clean.py": [
@@ -1598,5 +1598,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T21:42:27Z"
+  "generated_at": "2026-03-09T13:50:42Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -552,15 +552,6 @@
         "line_number": 67
       }
     ],
-    "tests/edges/test_vip_auth_edges.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/edges/test_vip_auth_edges.py",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
     "tests/test_aliases_coverage_96.py": [
       {
         "type": "Secret Keyword",
@@ -1552,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T14:55:38Z"
+  "generated_at": "2026-03-09T18:58:50Z"
 }

--- a/app/bootstrap/startup_guards.py
+++ b/app/bootstrap/startup_guards.py
@@ -1,0 +1,23 @@
+"""Startup guard orchestration for canonical app bootstrap.
+
+RU: Собирает fail-closed startup guards в одном bootstrap seam.
+EN: Centralizes fail-closed startup guards in one bootstrap seam.
+"""
+
+from __future__ import annotations
+
+from app.security.llm_monthly_quota import require_vip_llm_monthly_limit
+from app.security.server_salt import require_server_salt
+from settings import validate_api_key_toggle_guard
+
+
+def run_startup_guards() -> None:
+    """Execute startup-time hard guards before the app serves traffic.
+
+    RU: Выполняет обязательные startup guards до начала обработки запросов.
+    EN: Runs required startup guards before request handling begins.
+    """
+
+    require_server_salt()
+    require_vip_llm_monthly_limit()
+    validate_api_key_toggle_guard()

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -204,7 +204,8 @@ def _resolve_authorized_api_key_tier(
     """Resolve authorized tier in a single pass, else None."""
 
     is_production, app_env = _is_production_environment()
-    allow_developer_fallbacks = is_explicit_developer_env()
+    in_developer_env = is_explicit_developer_env()
+    allow_developer_api_keys = in_developer_env and is_truthy_env_var("ALLOW_DEV_API_KEY", "true")
 
     if _is_subscription_db_enabled():
         db_lookup = _lookup_tier_from_db(api_key)
@@ -217,7 +218,7 @@ def _resolve_authorized_api_key_tier(
 
     resolved_env_tier = _resolve_tier_from_env(
         api_key,
-        allow_test_keys=allow_developer_fallbacks,
+        allow_test_keys=allow_developer_api_keys,
     )
     if resolved_env_tier is not None:
         if _tier_allows_access(resolved_env_tier, required_tier):
@@ -225,7 +226,7 @@ def _resolve_authorized_api_key_tier(
         return None
 
     # In non-production mode with anonymous access enabled, allow any key.
-    if allow_developer_fallbacks and not is_production:
+    if in_developer_env and not is_production:
         allow_anonymous = is_truthy_env_var("ALLOW_ANONYMOUS_API_KEYS", "false")
         if allow_anonymous:
             logger.warning(

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -499,6 +499,9 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         In development mode, test keys return their respective tiers.
     """
     is_production, _ = _is_production_environment()
+    allow_developer_api_keys = is_explicit_developer_env() and is_truthy_env_var(
+        "ALLOW_DEV_API_KEY", "true"
+    )
 
     if _is_subscription_db_enabled():
         db_lookup = _lookup_tier_from_db(api_key)
@@ -507,7 +510,10 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
             return SubscriptionTier.FREE
 
-    env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
+    env_tier = _resolve_tier_from_env(
+        api_key,
+        allow_test_keys=allow_developer_api_keys and not is_production,
+    )
     return env_tier if env_tier is not None else SubscriptionTier.FREE
 
 

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -37,7 +37,12 @@ from app.routers.api_key import api_key_header
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
 
 from app.utils.feature_flags import is_vip_module_enabled
-from settings import get_runtime_env_name, is_production_like_env, is_truthy_env_var
+from settings import (
+    get_runtime_env_name,
+    is_explicit_developer_env,
+    is_production_like_env,
+    is_truthy_env_var,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +204,7 @@ def _resolve_authorized_api_key_tier(
     """Resolve authorized tier in a single pass, else None."""
 
     is_production, app_env = _is_production_environment()
+    allow_developer_fallbacks = is_explicit_developer_env()
 
     if _is_subscription_db_enabled():
         db_lookup = _lookup_tier_from_db(api_key)
@@ -209,14 +215,17 @@ def _resolve_authorized_api_key_tier(
         if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
             return None
 
-    resolved_env_tier = _resolve_tier_from_env(api_key, allow_test_keys=not is_production)
+    resolved_env_tier = _resolve_tier_from_env(
+        api_key,
+        allow_test_keys=allow_developer_fallbacks,
+    )
     if resolved_env_tier is not None:
         if _tier_allows_access(resolved_env_tier, required_tier):
             return resolved_env_tier
         return None
 
     # In non-production mode with anonymous access enabled, allow any key.
-    if not is_production:
+    if allow_developer_fallbacks and not is_production:
         allow_anonymous = is_truthy_env_var("ALLOW_ANONYMOUS_API_KEYS", "false")
         if allow_anonymous:
             logger.warning(

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -37,6 +37,7 @@ from app.routers.api_key import api_key_header
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
 
 from app.utils.feature_flags import is_vip_module_enabled
+from settings import get_runtime_env_name, is_production_like_env, is_truthy_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -93,13 +94,8 @@ TEST_KEY_VIP = "test_vip_key"  # nosec B105: deterministic non-production test k
 
 # Environment configuration
 VIP_MODULE_ENABLED = is_vip_module_enabled()
-ALLOW_ANONYMOUS_API_KEYS = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in (
-    "true",
-    "1",
-    "yes",
-    "on",
-)
-# Note: SUBSCRIPTION_DB_ENABLED is checked dynamically in code to support testing
+# Note: SUBSCRIPTION_DB_ENABLED and ALLOW_ANONYMOUS_API_KEYS are checked dynamically in code
+# to support testing and avoid import-time config freeze.
 
 
 def _is_subscription_db_enabled() -> bool:
@@ -191,11 +187,8 @@ def _is_production_environment() -> tuple[bool, str]:
     Returns:
         tuple[bool, str]: (is_production, app_env)
     """
-    app_env = os.getenv("APP_ENV", "local").lower()
-    debug_mode = os.getenv("DEBUG", "true").lower() in ("true", "1", "yes", "on")
-    # Production if env is production/staging AND debug is off
-    is_production = (app_env in ("production", "prod", "staging")) and (not debug_mode)
-    return is_production, app_env
+    app_env = get_runtime_env_name()
+    return is_production_like_env(), app_env
 
 
 def _resolve_authorized_api_key_tier(
@@ -224,12 +217,7 @@ def _resolve_authorized_api_key_tier(
 
     # In non-production mode with anonymous access enabled, allow any key.
     if not is_production:
-        allow_anonymous = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in (
-            "true",
-            "1",
-            "yes",
-            "on",
-        )
+        allow_anonymous = is_truthy_env_var("ALLOW_ANONYMOUS_API_KEYS", "false")
         if allow_anonymous:
             logger.warning(
                 "Anonymous API key accepted in %s mode for tier %s",

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -141,7 +141,7 @@ _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 def _is_production() -> bool:
     """Single source of truth for tests & runtime (do NOT cache settings here)."""
-    return is_production_like_env()
+    return bool(is_production_like_env())
 
 
 def _is_production_environment() -> tuple[bool, str]:
@@ -168,7 +168,7 @@ def _should_allow_anonymous_access(is_production: bool) -> bool:
     flag = is_truthy_env_var("ALLOW_ANONYMOUS_API_KEYS", "false")
     if is_production:
         return False
-    return flag
+    return bool(flag)
 
 
 def _is_dev_mode(app_env: str) -> bool:
@@ -181,7 +181,7 @@ def _is_dev_mode(app_env: str) -> bool:
         bool: True if in development mode
     """
     allow_dev = is_truthy_env_var("ALLOW_DEV_API_KEY", "true")
-    return is_explicit_developer_env() and allow_dev
+    return bool(is_explicit_developer_env() and allow_dev)
 
 
 def _validate_with_app_get_api_key(raw_key: Optional[str]) -> str:

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -33,7 +33,12 @@ from app.utils.feature_flags import is_vip_module_enabled
 from app.routers.vip_shoplist import router as vip_shoplist_router
 from app.contracts.vip_contract import vip_error, vip_success
 from app.middleware.api_tiers import require_vip_tier
-from settings import get_runtime_env_name, is_production_like_env, is_truthy_env_var
+from settings import (
+    get_runtime_env_name,
+    is_explicit_developer_env,
+    is_production_like_env,
+    is_truthy_env_var,
+)
 
 if TYPE_CHECKING:
     from core.targets import UserProfile
@@ -175,9 +180,8 @@ def _is_dev_mode(app_env: str) -> bool:
     Returns:
         bool: True if in development mode
     """
-    # ALLOW_DEV_API_KEY only has effect outside production/staging
-    allow_dev = is_truthy_env_var("ALLOW_DEV_API_KEY", "false")
-    return (app_env in ("test", "testing", "dev", "development", "local")) or allow_dev
+    allow_dev = is_truthy_env_var("ALLOW_DEV_API_KEY", "true")
+    return is_explicit_developer_env() and allow_dev
 
 
 def _validate_with_app_get_api_key(raw_key: Optional[str]) -> str:
@@ -272,7 +276,7 @@ def _require_api_key(raw_key: Optional[str] = Depends(_api_key_header)) -> str:
             )
             return "anonymous"
         # Dev/test fallback for unit scenarios (not used by strict route wrappers)
-        if not is_production and not _explicit_false:
+        if is_dev_mode and not _explicit_false:
             _log_api_key_event(
                 "VIP endpoint accessed without API key in development mode.", is_production, app_env
             )
@@ -664,7 +668,12 @@ def _require_api_key_dev_legacy(request: Request) -> str:
                         detail="Forbidden: VIP access required",
                     ) from e
                 raise
-        return str(api_key)
+        if _is_dev_mode(app_env):
+            return str(api_key)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden: VIP access required",
+        )
 
     # No API key provided
     if is_strict_env or debug_false:
@@ -681,7 +690,7 @@ def _require_api_key_dev_legacy(request: Request) -> str:
         "no",
         "off",
     }
-    if not is_production and not _explicit_false:
+    if _is_dev_mode(app_env) and not _explicit_false:
         _log_api_key_event(
             "VIP endpoint accessed without API key in legacy dev mode.",
             is_production,

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -652,31 +652,19 @@ def _require_api_key_dev_legacy(request: Request) -> str:
     api_key = _extract_api_key(request)
     is_production, app_env = _is_production_environment()
 
-    # Treat staging like production for VIP
-    is_strict_env = _is_production() or os.getenv("APP_ENV", "").lower() == "staging"
-    debug_false = os.getenv("DEBUG", "").lower() == "false"
-
     if api_key:
-        # In production validate strictly; in dev/test accept any provided key
-        if is_production:
-            try:
-                return _require_api_key(api_key)
-            except HTTPException as e:
-                if e.status_code == status.HTTP_401_UNAUTHORIZED:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="Forbidden: VIP access required",
-                    ) from e
-                raise
-        if _is_dev_mode(app_env):
-            return str(api_key)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Forbidden: VIP access required",
-        )
+        try:
+            return _require_api_key(api_key)
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Forbidden: VIP access required",
+                ) from exc
+            raise
 
     # No API key provided
-    if is_strict_env or debug_false:
+    if is_production:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Forbidden: VIP access required",
@@ -697,7 +685,10 @@ def _require_api_key_dev_legacy(request: Request) -> str:
             app_env,
         )
         return TEST_KEY
-    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Forbidden: VIP access required",
+    )
 
 
 @router.post(

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -33,6 +33,7 @@ from app.utils.feature_flags import is_vip_module_enabled
 from app.routers.vip_shoplist import router as vip_shoplist_router
 from app.contracts.vip_contract import vip_error, vip_success
 from app.middleware.api_tiers import require_vip_tier
+from settings import get_runtime_env_name, is_production_like_env, is_truthy_env_var
 
 if TYPE_CHECKING:
     from core.targets import UserProfile
@@ -46,7 +47,7 @@ EN: Router for VIP functions - micronutrient goals, auto-repair menu, shopping l
 """
 
 # Test key constant for development mode only
-TEST_KEY = "test_key"  # nosec B105  # Development mode only
+TEST_KEY = "test_key"  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)
 
 # VIP feature flag: enable/disable VIP module via env or default True
 VIP_MODULE_ENABLED = is_vip_module_enabled()
@@ -135,7 +136,7 @@ _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 def _is_production() -> bool:
     """Single source of truth for tests & runtime (do NOT cache settings here)."""
-    return os.getenv("APP_ENV", "").lower() == "production"
+    return is_production_like_env()
 
 
 def _is_production_environment() -> tuple[bool, str]:
@@ -144,10 +145,8 @@ def _is_production_environment() -> tuple[bool, str]:
     Returns:
         tuple[bool, str]: (is_production, app_env)
     """
-    app_env = os.getenv("APP_ENV", "local").lower()
-    # Production detection: only APP_ENV, not DEBUG (for test compatibility)
-    is_production = app_env == "production"
-    return is_production, app_env
+    app_env = get_runtime_env_name()
+    return is_production_like_env(), app_env
 
 
 def _should_allow_anonymous_access(is_production: bool) -> bool:
@@ -161,10 +160,9 @@ def _should_allow_anonymous_access(is_production: bool) -> bool:
     """
     # Default is strict.
     # In production-like environments, allow only if explicitly enabled.
-    flag = os.getenv("ALLOW_ANONYMOUS_API_KEYS", "false").lower() in ("true", "1", "yes", "on")
+    flag = is_truthy_env_var("ALLOW_ANONYMOUS_API_KEYS", "false")
     if is_production:
-        # Default deny in production unless explicitly allowed
-        return flag
+        return False
     return flag
 
 
@@ -178,8 +176,8 @@ def _is_dev_mode(app_env: str) -> bool:
         bool: True if in development mode
     """
     # ALLOW_DEV_API_KEY only has effect outside production/staging
-    allow_dev = os.getenv("ALLOW_DEV_API_KEY", "false").lower() == "true"
-    return app_env in ("test", "testing", "dev", "development", "local") or allow_dev
+    allow_dev = is_truthy_env_var("ALLOW_DEV_API_KEY", "false")
+    return (app_env in ("test", "testing", "dev", "development", "local")) or allow_dev
 
 
 def _validate_with_app_get_api_key(raw_key: Optional[str]) -> str:

--- a/conftest.py
+++ b/conftest.py
@@ -249,6 +249,8 @@ def production_environment():  # sourcery skip: dict-assign-update-to-union
             "APP_ENV": "production",
             "ALLOW_DEV_API_KEY": "false",
             "API_KEY": "production-secret-key",
+            "PRO_API_KEYS": "test_pro_key",  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)  # pragma: allowlist secret
+            "VIP_API_KEYS": "test_vip_key",  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)  # pragma: allowlist secret
             "FEATURE_PREMIUM_NUTRITION": "true",
             "VIP_MODULE_ENABLED": "true",
         }

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -22,13 +22,15 @@ The VIP router now implements production-safe API key authentication with config
 
 - **`ALLOW_ANONYMOUS_API_KEYS`**: Controls whether anonymous API key access is permitted
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
-  - Default: `false` in production, `true` in development
+  - Default: `false` in production/staging, `true` in development
   - When `false`, requests without API keys are rejected with 401 Unauthorized
+  - **Hard rule:** must stay `false` in `production` / `staging`; startup now fails closed otherwise
 
 - **`ALLOW_DEV_API_KEY`**: Legacy development mode flag
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
   - Default: `true`
   - Used for backward compatibility with existing development workflows
+  - **Hard rule:** must stay `false` in `production` / `staging`; startup now fails closed otherwise
 
 ### API Key Configuration
 
@@ -41,9 +43,9 @@ The VIP router now implements production-safe API key authentication with config
 | Environment | DEBUG | ALLOW_ANONYMOUS_API_KEYS | Behavior |
 |-------------|-------|---------------------------|----------|
 | `production` | `false` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
-| `production` | `false` | `true` | **Allow anonymous access** - Log warning |
+| `production` | `false` | `true` | **Startup error** - unsafe anonymous toggle rejected |
 | `staging` | `false` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
-| `staging` | `false` | `true` | **Allow anonymous access** - Log warning |
+| `staging` | `false` | `true` | **Startup error** - unsafe anonymous toggle rejected |
 | `development` | `true` | `true` (default) | **Allow anonymous access** - Log info |
 | `development` | `true` | `false` | **Reject anonymous access** - 401 Unauthorized |
 | `local` | `true` | `true` (default) | **Allow anonymous access** - Log info |
@@ -60,7 +62,7 @@ The VIP router now implements production-safe API key authentication with config
 
 ### Security Features
 
-1. **Fail-fast authentication**: Production environments immediately reject requests without valid API keys
+1. **Fail-fast configuration**: Production/staging startup raises an explicit error if `ALLOW_ANONYMOUS_API_KEYS=true` or `ALLOW_DEV_API_KEY=true`
 2. **Clear error messages**: Different error messages for production vs development contexts
 3. **Comprehensive logging**: All authentication events are logged with appropriate severity levels
 4. **Environment-aware defaults**: Safe defaults that prevent accidental exposure in production
@@ -105,6 +107,7 @@ export APP_ENV=staging
 export DEBUG=false
 export API_KEY=your-staging-api-key
 export ALLOW_ANONYMOUS_API_KEYS=false
+export ALLOW_DEV_API_KEY=false
 ```
 
 ### Development Configuration (Restricted)

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -150,7 +150,7 @@ If you were previously relying on anonymous access in production:
 3. **Restart and verify startup remains clean**:
 
    ```bash
-   python -c "from settings import validate_api_key_toggle_guard; validate_api_key_toggle_guard()"
+   python -c "from app.bootstrap.startup_guards import run_startup_guards; run_startup_guards()"
    ```
 
 4. **Do not use `ALLOW_ANONYMOUS_API_KEYS=true` or `ALLOW_DEV_API_KEY=true` as a production workaround.**
@@ -162,7 +162,7 @@ To test the new authentication behavior:
 
 ```bash
 # Test production mode rejection
-export APP_ENV=production
+export ENVIRONMENT=production
 export DEBUG=false
 # No API_KEY set
 curl -X POST http://localhost:8000/api/v1/vip/weekly-plan \

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -131,10 +131,17 @@ If you were previously relying on anonymous access in production:
    export API_KEY=your-production-api-key
    ```
 
-2. **Or explicitly allow anonymous access** (not recommended for production):
+2. **Keep fail-closed toggles disabled**:
 
    ```bash
-   export ALLOW_ANONYMOUS_API_KEYS=true
+   export ALLOW_ANONYMOUS_API_KEYS=false
+   export ALLOW_DEV_API_KEY=false
+   ```
+
+3. **Restart and verify startup remains clean**:
+
+   ```bash
+   python -c "from settings import validate_api_key_toggle_guard; validate_api_key_toggle_guard()"
    ```
 
 ### Testing
@@ -162,7 +169,7 @@ curl -X POST http://localhost:8000/api/v1/vip/weekly-plan \
 
 ## Security Considerations
 
-1. **Never use `ALLOW_ANONYMOUS_API_KEYS=true` in production** unless absolutely necessary
+1. **Never enable `ALLOW_ANONYMOUS_API_KEYS=true` or `ALLOW_DEV_API_KEY=true` in production/staging**
 2. **Use strong API keys** in production environments
 3. **Monitor authentication logs** for suspicious activity
 4. **Rotate API keys regularly** in production
@@ -177,8 +184,9 @@ curl -X POST http://localhost:8000/api/v1/vip/weekly-plan \
    - Verify `APP_ENV` and `DEBUG` settings
 
 2. **Anonymous access allowed in production**
-   - Check if `ALLOW_ANONYMOUS_API_KEYS=true` is explicitly set
-   - Verify `APP_ENV` and `DEBUG` settings
+   - Treat this as a misconfiguration, not a supported workaround
+   - Remove `ALLOW_ANONYMOUS_API_KEYS=true` and `ALLOW_DEV_API_KEY=true`
+   - Configure a real `API_KEY` and keep production/staging fail-closed
 
 3. **Inconsistent behavior**
    - Ensure environment variables are set correctly

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -209,9 +209,11 @@ curl -X POST http://localhost:8000/api/v1/vip/weekly-plan \
 
 ```bash
 # Check current configuration
+echo "ENVIRONMENT: $ENVIRONMENT"
 echo "APP_ENV: $APP_ENV"
 echo "DEBUG: $DEBUG"
 echo "ALLOW_ANONYMOUS_API_KEYS: $ALLOW_ANONYMOUS_API_KEYS"
+echo "ALLOW_DEV_API_KEY: $ALLOW_DEV_API_KEY"
 echo "API_KEY: ${API_KEY:+SET}"
 
 # Test authentication endpoint

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -8,15 +8,20 @@ The VIP router now implements production-safe API key authentication with config
 
 ### Environment Detection
 
-- **`APP_ENV`**: Primary environment identifier
+- **`ENVIRONMENT`**: Primary runtime environment identifier
   - Values: `production`, `staging`, `development`, `local`, `test`
   - Default: `local`
   - Used to determine if the application is running in production mode
 
+- **`APP_ENV`**: Legacy fallback environment identifier
+  - Values: `production`, `staging`, `development`, `local`, `test`
+  - Used only when `ENVIRONMENT` is unset
+  - **Rule:** `ENVIRONMENT` overrides `APP_ENV`
+
 - **`DEBUG`**: Debug mode flag
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
   - Default: `true`
-  - When `false`, the application is treated as production-like regardless of `APP_ENV`
+  - When `false`, the application is treated as production-like regardless of `ENVIRONMENT` / `APP_ENV`
 
 ### Anonymous Access Control
 
@@ -29,7 +34,7 @@ The VIP router now implements production-safe API key authentication with config
 - **`ALLOW_DEV_API_KEY`**: Legacy development mode flag
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
   - Default: `true`
-  - Used for backward compatibility with existing development workflows
+  - Used only for explicit local/dev/test workflows
   - **Hard rule:** must stay `false` in `production` / `staging`; startup now fails closed otherwise
 
 ### API Key Configuration
@@ -57,7 +62,7 @@ The VIP router now implements production-safe API key authentication with config
 
 ### Default Behavior
 
-- **Production environments** (`APP_ENV=production` or `DEBUG=false`) **reject anonymous access by default**
+- **Production environments** (`ENVIRONMENT=production`, legacy `APP_ENV=production`, or `DEBUG=false`) **reject anonymous access by default**
 - **Development environments** allow anonymous access by default but can be restricted
 
 ### Security Features
@@ -86,16 +91,17 @@ Log messages include:
 ### Production Configuration (Recommended)
 
 ```bash
-export APP_ENV=production
+export ENVIRONMENT=production
 export DEBUG=false
 export API_KEY=your-secret-api-key
 # ALLOW_ANONYMOUS_API_KEYS defaults to false
+export ALLOW_DEV_API_KEY=false
 ```
 
 ### Development Configuration
 
 ```bash
-export APP_ENV=development
+export ENVIRONMENT=development
 export DEBUG=true
 # ALLOW_ANONYMOUS_API_KEYS defaults to true
 ```
@@ -103,7 +109,7 @@ export DEBUG=true
 ### Staging Configuration (Strict)
 
 ```bash
-export APP_ENV=staging
+export ENVIRONMENT=staging
 export DEBUG=false
 export API_KEY=your-staging-api-key
 export ALLOW_ANONYMOUS_API_KEYS=false
@@ -113,10 +119,11 @@ export ALLOW_DEV_API_KEY=false
 ### Development Configuration (Restricted)
 
 ```bash
-export APP_ENV=development
+export ENVIRONMENT=development
 export DEBUG=true
 export ALLOW_ANONYMOUS_API_KEYS=false
 export API_KEY=your-dev-api-key
+export ALLOW_DEV_API_KEY=true
 ```
 
 ## Migration Guide

--- a/docs/deploy/VIP_API_KEYS.md
+++ b/docs/deploy/VIP_API_KEYS.md
@@ -21,13 +21,13 @@ The VIP router now implements production-safe API key authentication with config
 - **`DEBUG`**: Debug mode flag
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
   - Default: `true`
-  - When `false`, the application is treated as production-like regardless of `ENVIRONMENT` / `APP_ENV`
+  - Helps opt unknown environments into production-like mode when the runtime env is not explicitly `development`, `local`, or `test`
 
 ### Anonymous Access Control
 
 - **`ALLOW_ANONYMOUS_API_KEYS`**: Controls whether anonymous API key access is permitted
   - Values: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
-  - Default: `false` in production/staging, `true` in development
+  - Default: `false`
   - When `false`, requests without API keys are rejected with 401 Unauthorized
   - **Hard rule:** must stay `false` in `production` / `staging`; startup now fails closed otherwise
 
@@ -51,19 +51,20 @@ The VIP router now implements production-safe API key authentication with config
 | `production` | `false` | `true` | **Startup error** - unsafe anonymous toggle rejected |
 | `staging` | `false` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
 | `staging` | `false` | `true` | **Startup error** - unsafe anonymous toggle rejected |
-| `development` | `true` | `true` (default) | **Allow anonymous access** - Log info |
-| `development` | `true` | `false` | **Reject anonymous access** - 401 Unauthorized |
-| `local` | `true` | `true` (default) | **Allow anonymous access** - Log info |
-| `local` | `true` | `false` | **Reject anonymous access** - 401 Unauthorized |
-| `test` | `true` | `true` (default) | **Allow anonymous access** - Log info |
-| `test` | `true` | `false` | **Reject anonymous access** - 401 Unauthorized |
+| `development` | `true` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
+| `development` | `true` | `true` | **Allow anonymous access** - Log info |
+| `local` | `true` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
+| `local` | `true` | `true` | **Allow anonymous access** - Log info |
+| `test` | `true` | `false` (default) | **Reject anonymous access** - 401 Unauthorized |
+| `test` | `true` | `true` | **Allow anonymous access** - Log info |
 
 ## Production Safety
 
 ### Default Behavior
 
-- **Production environments** (`ENVIRONMENT=production`, legacy `APP_ENV=production`, or `DEBUG=false`) **reject anonymous access by default**
-- **Development environments** allow anonymous access by default but can be restricted
+- **Production-like environments** reject anonymous access by default when `ENVIRONMENT` / `APP_ENV` are not explicitly `development`, `local`, or `test`
+- **`DEBUG=false` alone is not enough** to override an explicit developer-like runtime label
+- **Development environments** reject anonymous access by default and only allow it when `ALLOW_ANONYMOUS_API_KEYS=true`
 
 ### Security Features
 
@@ -103,7 +104,8 @@ export ALLOW_DEV_API_KEY=false
 ```bash
 export ENVIRONMENT=development
 export DEBUG=true
-# ALLOW_ANONYMOUS_API_KEYS defaults to true
+export ALLOW_ANONYMOUS_API_KEYS=true
+export ALLOW_DEV_API_KEY=true
 ```
 
 ### Staging Configuration (Strict)
@@ -151,6 +153,9 @@ If you were previously relying on anonymous access in production:
    python -c "from settings import validate_api_key_toggle_guard; validate_api_key_toggle_guard()"
    ```
 
+4. **Do not use `ALLOW_ANONYMOUS_API_KEYS=true` or `ALLOW_DEV_API_KEY=true` as a production workaround.**
+   Configure a real `API_KEY` instead.
+
 ### Testing
 
 To test the new authentication behavior:
@@ -187,8 +192,9 @@ curl -X POST http://localhost:8000/api/v1/vip/weekly-plan \
 ### Common Issues
 
 1. **401 Unauthorized in development**
-   - Check if `ALLOW_ANONYMOUS_API_KEYS=false` is set
-   - Verify `APP_ENV` and `DEBUG` settings
+   - Check if `ALLOW_ANONYMOUS_API_KEYS=true` is set for the anonymous flow you expect
+   - Verify `ALLOW_DEV_API_KEY=true` for deterministic dev/test keys
+   - Verify `APP_ENV` / `ENVIRONMENT` and `DEBUG` settings
 
 2. **Anonymous access allowed in production**
    - Treat this as a misconfiguration, not a supported workaround

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -103,6 +103,12 @@ Commit: 0f1b4f47
 Evidence: The latest CodeRabbit review summary is now dispositioned as four concrete fixes in `0f1b4f47` (`app/middleware/api_tiers.py`, `docs/deploy/VIP_API_KEYS.md`, `docs/roadmap/BACKLOG_LEDGER.md`, `tests/edges/test_vip_auth_edges.py`, and `tests/test_vip_anonymous_api_key_safety.py`) plus one `NOT-A-BUG` clarification for the deprecated `/weekly-plan` alias path in `tests/test_vip_production_simple.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916595868 -> 0f1b4f47
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917624345
+Disposition: FIXED
+Commit: ef54e8ad
+Evidence: `docs/deploy/VIP_API_KEYS.md:212` and `docs/deploy/VIP_API_KEYS.md:216` now print both `ENVIRONMENT` and `ALLOW_DEV_API_KEY`; the remaining duplicate adapter-path comment is already classified as `NOT-A-BUG` under `discussion_r2906496216` because the deprecated `/api/v1/vip/weekly-plan` alias calls `app.routers.vip.make_weekly_menu` directly.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917624345 -> ef54e8ad
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -109,6 +109,24 @@ Commit: ef54e8ad
 Evidence: `docs/deploy/VIP_API_KEYS.md:212` and `docs/deploy/VIP_API_KEYS.md:216` now print both `ENVIRONMENT` and `ALLOW_DEV_API_KEY`; the remaining duplicate adapter-path comment is already classified as `NOT-A-BUG` under `discussion_r2906496216` because the deprecated `/api/v1/vip/weekly-plan` alias calls `app.routers.vip.make_weekly_menu` directly.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917624345 -> ef54e8ad
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449922
+Disposition: FIXED
+Commit: 5c0ff3f1
+Evidence: `docs/deploy/VIP_API_KEYS.md:165` now uses `ENVIRONMENT=production` in the runnable production-mode test recipe, which keeps the example deterministic under the documented rule that `ENVIRONMENT` overrides `APP_ENV`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449922 -> 5c0ff3f1
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449929
+Disposition: FIXED
+Commit: 5c0ff3f1
+Evidence: `docs/deploy/VIP_API_KEYS.md:153` now uses the centralized startup guard entrypoint `run_startup_guards()` from `app.bootstrap.startup_guards`, matching the runtime bootstrap seam introduced by this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449929 -> 5c0ff3f1
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917666615
+Disposition: FIXED
+Commit: 5c0ff3f1
+Evidence: The latest CodeRabbit review summary is fully dispositioned by the two docs fixes above: `docs/deploy/VIP_API_KEYS.md:153` now points operators at `run_startup_guards()`, and `docs/deploy/VIP_API_KEYS.md:165` uses canonical `ENVIRONMENT=production` in the runnable production-mode recipe.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917666615 -> 5c0ff3f1
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#issuecomment-4024056533
+Disposition: NOT-A-BUG
+Evidence: GitHub required check `diff-coverage` passed on current head; local `make verify` reported `Coverage: 100%` for changed lines in `settings.py`, `legacy_app.py`, and `app/middleware/api_tiers.py`.
+Reason: Codecov patch comment is informational-only and disagrees with the canonical merge gate for this repo (`make diff-cov` / `diff-coverage` check), which already passed on the current head.
 
 ## Merge Readiness
 - [x] Scope tied to PR objective

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1054 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Scope tied to PR objective
+- [x] Docs/runtime changes applied
+- [x] Verification completed
+- [ ] Required GitHub checks PASS with no pending required jobs
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] No unresolved review threads or actionable bot comments remain
+- [ ] Review wait-window completed

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -28,6 +28,12 @@ Commit: 656e0239
 Evidence: `app/bootstrap/startup_guards.py:14` centralizes startup hard guards; `legacy_app.py:516` delegates to the bootstrap seam; `tests/test_app_lifespan_additional.py:90` and `tests/test_app_lifespan_additional.py:112` verify fail-closed startup behavior through the shared bootstrap seam.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783689 -> 656e0239
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3915807041
+Disposition: FIXED
+Commit: 656e0239
+Evidence: `app/middleware/api_tiers.py:207` restricts developer fallbacks to `is_explicit_developer_env()`; `legacy_app.py:792` limits lenient API-key mode to explicit dev/test-like environments; `tests/test_vip_anonymous_api_key_safety.py:380` and `tests/test_vip_coverage_additional.py:130` cover preview/unknown-env fail-closed behavior; `tests/test_vip_anonymous_api_key_safety.py:17` and `tests/test_vip_coverage_additional.py:18` now use autouse `monkeypatch` fixtures instead of direct `os.environ` mutation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3915807041 -> 656e0239
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -34,6 +34,40 @@ Commit: 656e0239
 Evidence: `app/middleware/api_tiers.py:207` restricts developer fallbacks to `is_explicit_developer_env()`; `legacy_app.py:792` limits lenient API-key mode to explicit dev/test-like environments; `tests/test_vip_anonymous_api_key_safety.py:380` and `tests/test_vip_coverage_additional.py:130` cover preview/unknown-env fail-closed behavior; `tests/test_vip_anonymous_api_key_safety.py:17` and `tests/test_vip_coverage_additional.py:18` now use autouse `monkeypatch` fixtures instead of direct `os.environ` mutation.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3915807041 -> 656e0239
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906058549
+Disposition: FIXED
+Commit: d7482420
+Evidence: cubic found that `pytest.importorskip()` could silently skip the startup-guard seam. `tests/test_app_lifespan_additional.py:6` now imports `app.bootstrap.startup_guards` directly, and `tests/test_app_lifespan_additional.py:100` / `tests/test_app_lifespan_additional.py:121` inject the seam without skip-based masking.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906058549 -> d7482420
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916112663
+Disposition: FIXED
+Commit: d7482420
+Evidence: cubic identified the same missing fail-fast import seam in `tests/test_app_lifespan_additional.py`. The test file now uses a direct module import at `tests/test_app_lifespan_additional.py:6` and reuses `startup_guards.run_startup_guards` at `tests/test_app_lifespan_additional.py:100` / `tests/test_app_lifespan_additional.py:121`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916112663 -> d7482420
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102580
+Disposition: FIXED
+Commit: d7482420
+Evidence: `tests/test_app_lifespan_additional.py:6` now imports `startup_guards` directly, and the two security regression tests wire `run_startup_guards` via `lifespan_globals` without `pytest.importorskip()`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102580 -> d7482420
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102591
+Disposition: FIXED
+Commit: d7482420
+Evidence: `tests/test_vip_anonymous_api_key_safety.py:18` now pins `ALLOW_DEV_API_KEY=false` after clearing the rest of the auth env, so production-like tests no longer inherit implicit dev-key behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102591 -> d7482420
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102575
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization`
+Evidence: The remaining concern is legacy module-level env gating outside the narrow runtime hardening diff for `PR-TBD-API-KEY-TOGGLE-GUARD`. It is tracked as a dedicated follow-up item so the current PR can stay focused on fail-fast toggle enforcement without mixing a wider `legacy_app.py` env-surface refactor.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916162189
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization`
+Evidence: The review summary includes three findings fixed in `d7482420` (`app/middleware/api_tiers.py`, `app/routers/vip.py`, `docs/deploy/VIP_API_KEYS.md`, and the targeted tests) plus one valid `legacy_app.py` env-surface follow-up, which is explicitly tracked in the new backlog item to avoid widening this near-ready security PR.
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -10,6 +10,24 @@ Disposition: NOT-A-BUG
 Evidence: GitHub required check `diff-coverage` passed on current head; local `make verify` reported `Coverage: 100%` for changed lines in `settings.py`, `legacy_app.py`, and `app/middleware/api_tiers.py`.
 Reason: Codecov patch comment is informational-only and disagrees with the canonical merge gate for this repo (`make diff-cov` / `diff-coverage` check), which already passed on the current head.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905754667
+Disposition: FIXED
+Commit: 656e0239
+Evidence: `settings.py:20` now prefers `ENVIRONMENT` over `APP_ENV`; `settings.py:42` keeps production-like detection fail-closed on the canonical runtime label; `tests/test_api_tiers.py:174` proves `ENVIRONMENT=production` overrides `APP_ENV=local`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905754667 -> 656e0239
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783682
+Disposition: FIXED
+Commit: 656e0239
+Evidence: `docs/deploy/VIP_API_KEYS.md:124` rewrites the migration path to require a real `API_KEY`; `docs/deploy/VIP_API_KEYS.md:186` rewrites troubleshooting to treat anonymous/dev toggles in production as a misconfiguration instead of a workaround.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783682 -> 656e0239
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783689
+Disposition: FIXED
+Commit: 656e0239
+Evidence: `app/bootstrap/startup_guards.py:14` centralizes startup hard guards; `legacy_app.py:516` delegates to the bootstrap seam; `tests/test_app_lifespan_additional.py:90` and `tests/test_app_lifespan_additional.py:112` verify fail-closed startup behavior through the shared bootstrap seam.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783689 -> 656e0239
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/review/PR_1054_FIXED_MAPPING.md
+++ b/docs/review/PR_1054_FIXED_MAPPING.md
@@ -68,6 +68,41 @@ Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization`
 Evidence: The review summary includes three findings fixed in `d7482420` (`app/middleware/api_tiers.py`, `app/routers/vip.py`, `docs/deploy/VIP_API_KEYS.md`, and the targeted tests) plus one valid `legacy_app.py` env-surface follow-up, which is explicitly tracked in the new backlog item to avoid widening this near-ready security PR.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496197
+Disposition: FIXED
+Commit: 0f1b4f47
+Evidence: `docs/deploy/VIP_API_KEYS.md:20` no longer claims `DEBUG=false` alone makes an explicit developer runtime production-like; `docs/deploy/VIP_API_KEYS.md:27` and `docs/deploy/VIP_API_KEYS.md:45` now document `ALLOW_ANONYMOUS_API_KEYS` defaulting to `false`, and the matrix/troubleshooting sections were aligned with the runtime helpers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496197 -> 0f1b4f47
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496203
+Disposition: FIXED
+Commit: 0f1b4f47
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:343` now marks `ledger-p1-legacy-runtime-env-canonicalization` as the residual follow-up from PR `#1054` and links both the parent ledger item and the PR URL, making the carryover explicit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496203 -> 0f1b4f47
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496207
+Disposition: FIXED
+Commit: 0f1b4f47
+Evidence: `tests/edges/test_vip_auth_edges.py:7` now uses an autouse `monkeypatch` fixture to reset auth env, and the edge tests use `monkeypatch.setenv()` / `delenv()` instead of process-global `os.environ` writes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496207 -> 0f1b4f47
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496213
+Disposition: FIXED
+Commit: 0f1b4f47
+Evidence: `tests/test_vip_anonymous_api_key_safety.py:134`, `tests/test_vip_anonymous_api_key_safety.py:157`, `tests/test_vip_anonymous_api_key_safety.py:180`, and `tests/test_vip_anonymous_api_key_safety.py:294` explicitly enable `ALLOW_DEV_API_KEY=true` for dev/local/test anonymous flows and now assert `200` instead of `!= 401`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496213 -> 0f1b4f47
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496216
+Disposition: NOT-A-BUG
+Evidence: `app/routers/vip.py:759` shows the deprecated `/api/v1/vip/weekly-plan` alias calls the module-level `make_weekly_menu` symbol directly, not `_safe_call_with_adapter()`. `tests/test_vip_production_simple.py:78` therefore correctly monkeypatches `app.routers.vip.make_weekly_menu` to exercise the alias error path and assert the `"Weekly plan generation failed"` response.
+Reason: The review comment describes the `/menu/weekly/plan` adapter path, but this test targets the deprecated `/weekly-plan` alias, which uses a different callable path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916595868
+Disposition: FIXED
+Commit: 0f1b4f47
+Evidence: The latest CodeRabbit review summary is now dispositioned as four concrete fixes in `0f1b4f47` (`app/middleware/api_tiers.py`, `docs/deploy/VIP_API_KEYS.md`, `docs/roadmap/BACKLOG_LEDGER.md`, `tests/edges/test_vip_auth_edges.py`, and `tests/test_vip_anonymous_api_key_safety.py`) plus one `NOT-A-BUG` clarification for the deprecated `/weekly-plan` alias path in `tests/test_vip_production_simple.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916595868 -> 0f1b4f47
+
 ## Merge Readiness
 - [x] Scope tied to PR objective
 - [x] Docs/runtime changes applied

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -332,6 +332,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Deploy docs show the safe production values
 
 
+<a id="ledger-p1-legacy-runtime-env-canonicalization"></a>
+- [ ] P1: Canonicalize legacy runtime env gating
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-LEGACY-RUNTIME-ENV-CANONICALIZATION
+  - Area: backend / security / legacy compatibility
+  - Finding Type: configuration drift
+  - Reason: `legacy_app.py` still contains module-level `APP_ENV`-only gates for local `.env` loading, dev-only docs, test-router registration, and `/debug_env`. This drifts from the canonical `ENVIRONMENT`-first runtime helpers introduced by the API key toggle guard and can re-enable development-only surfaces when only `ENVIRONMENT` is set in production-like deployments.
+  - Links:
+    - `legacy_app.py`
+    - `settings.py`
+    - `docs/deploy/VIP_API_KEYS.md`
+    - `docs/review/PR_1054_FIXED_MAPPING.md`
+  - DoD:
+    - Module-level env gating in `legacy_app.py` uses canonical runtime helpers instead of raw `APP_ENV`
+    - Local `.env` loading, test-router registration, and `/debug_env` gating follow the same environment semantics as startup guards
+    - Tests cover `ENVIRONMENT` overriding `APP_ENV` for the remaining legacy surfaces
+
+
 <a id="ledger-p1-openapi-decoupling-split"></a>
 - [ ] P1: Split backend OpenAPI generation from frontend type generation
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -337,10 +337,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-TBD-LEGACY-RUNTIME-ENV-CANONICALIZATION
+  - Follow-up from PR `#1054` (parent: `ledger-p1-api-key-toggle-guard`)
   - Area: backend / security / legacy compatibility
   - Finding Type: configuration drift
   - Reason: `legacy_app.py` still contains module-level `APP_ENV`-only gates for local `.env` loading, dev-only docs, test-router registration, and `/debug_env`. This drifts from the canonical `ENVIRONMENT`-first runtime helpers introduced by the API key toggle guard and can re-enable development-only surfaces when only `ENVIRONMENT` is set in production-like deployments.
   - Links:
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054`
+    - `#ledger-p1-api-key-toggle-guard`
     - `legacy_app.py`
     - `settings.py`
     - `docs/deploy/VIP_API_KEYS.md`

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session
 from starlette import status as fastapi_status
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
+from settings import get_runtime_env_name, is_production_like_env, validate_api_key_toggle_guard
 
 from app.dependencies import validate_template_dir
 from app.routers.api_key import api_key_header
@@ -509,14 +510,15 @@ def reset_targets_cache() -> None:
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Startup
     # Detect environment first (before any DB operations)
-    env_name = (os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or "").strip().lower()
-    is_production = env_name not in {"", "local", "dev", "development", "staging", "test", "ci"}
+    env_name = get_runtime_env_name()
+    is_production = is_production_like_env()
     truthy = {"1", "true", "yes", "on"}
 
     # PR-647 (P0 security): Monthly quota fingerprinting requires a secret salt.
     # Fail-fast on startup to avoid running with predictable/empty fingerprints.
     require_server_salt()
     require_vip_llm_monthly_limit()
+    validate_api_key_toggle_guard()
 
     try:
         init_db()
@@ -789,10 +791,9 @@ def get_api_key(api_key: str = Depends(api_key_header)) -> str:
         - If API_KEY_REQUIRED=true → reject requests (enforce configuration)
         - else (default in tests/dev): accept non-trivial tokens when in dev/test mode
     """
-    app_env = (os.getenv("APP_ENV", "") or "").strip().lower()
     api_key_value = api_key or ""
     dev_mode = _is_truthy(os.getenv("ALLOW_DEV_API_KEY"))
-    if app_env in {"", "local", "dev", "development", "test"}:
+    if not is_production_like_env():
         dev_mode = True
         # Warn once when lenient mode is enabled - provides no real security
         global _lenient_mode_warning_logged

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -43,8 +43,9 @@ from sqlalchemy.orm import Session
 from starlette import status as fastapi_status
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
-from settings import get_runtime_env_name, is_production_like_env, validate_api_key_toggle_guard
+from settings import get_runtime_env_name, is_explicit_developer_env, is_production_like_env
 
+from app.bootstrap.startup_guards import run_startup_guards
 from app.dependencies import validate_template_dir
 from app.routers.api_key import api_key_header
 from app.routers.bmi import router as bmi_router
@@ -122,8 +123,6 @@ from app.utils.feature_flags import _is_truthy
 from app.middleware.api_tiers import derive_subject_id_from_api_key, require_vip_tier
 from app.security.llm_monthly_quota import (
     attempt_consume_vip_llm_monthly_quota,
-    require_server_salt,
-    require_vip_llm_monthly_limit,
 )
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
@@ -514,11 +513,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     is_production = is_production_like_env()
     truthy = {"1", "true", "yes", "on"}
 
-    # PR-647 (P0 security): Monthly quota fingerprinting requires a secret salt.
-    # Fail-fast on startup to avoid running with predictable/empty fingerprints.
-    require_server_salt()
-    require_vip_llm_monthly_limit()
-    validate_api_key_toggle_guard()
+    # RU: Делегируем startup hard guards в bootstrap seam, чтобы legacy layer оставался thin.
+    # EN: Delegate startup hard guards to bootstrap seam to keep legacy layer thin.
+    run_startup_guards()
 
     try:
         init_db()
@@ -792,9 +789,8 @@ def get_api_key(api_key: str = Depends(api_key_header)) -> str:
         - else (default in tests/dev): accept non-trivial tokens when in dev/test mode
     """
     api_key_value = api_key or ""
-    dev_mode = _is_truthy(os.getenv("ALLOW_DEV_API_KEY"))
-    if not is_production_like_env():
-        dev_mode = True
+    dev_mode = is_explicit_developer_env() and _is_truthy(os.getenv("ALLOW_DEV_API_KEY", "true"))
+    if dev_mode:
         # Warn once when lenient mode is enabled - provides no real security
         global _lenient_mode_warning_logged
         if not _lenient_mode_warning_logged:

--- a/settings.py
+++ b/settings.py
@@ -13,17 +13,20 @@ _EXPORT_SIGNING_PLACEHOLDERS = frozenset(
 )
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 _PRODUCTION_LIKE_ENVS = frozenset({"production", "prod", "staging"})
-_NON_PRODUCTION_ENVS = frozenset({"", "local", "dev", "development", "test", "testing", "ci"})
+_DEVELOPER_LIKE_ENVS = frozenset({"local", "dev", "development", "test", "testing", "ci"})
+_NON_PRODUCTION_ENVS = frozenset({""}) | _DEVELOPER_LIKE_ENVS
 
 
 def get_runtime_env_name() -> str:
     """Return canonical runtime environment label.
 
-    RU: Канонизирует имя окружения из APP_ENV/ENVIRONMENT.
-    EN: Canonicalizes runtime environment from APP_ENV/ENVIRONMENT.
+    RU: Канонизирует имя окружения, отдавая приоритет ENVIRONMENT над APP_ENV.
+    EN: Canonicalizes runtime environment, preferring ENVIRONMENT over APP_ENV.
     """
 
-    return (os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "local").strip().lower()
+    if environment := (os.getenv("ENVIRONMENT") or "").strip().lower():
+        return environment
+    return (os.getenv("APP_ENV") or "local").strip().lower()
 
 
 def is_truthy_env_var(name: str, default: str = "") -> bool:
@@ -43,12 +46,22 @@ def is_production_like_env() -> bool:
     EN: Canonically detects production-like mode from APP_ENV/ENVIRONMENT and DEBUG.
     """
 
-    runtime_env = (os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "").strip().lower()
+    runtime_env = get_runtime_env_name()
     if runtime_env in _PRODUCTION_LIKE_ENVS:
         return True
     if runtime_env in (_NON_PRODUCTION_ENVS - {""}):
         return False
     return not is_truthy_env_var("DEBUG", "true")
+
+
+def is_explicit_developer_env() -> bool:
+    """Return whether runtime env is explicitly local/dev/test-like.
+
+    RU: Разрешает dev-only fallback только для явных local/dev/test окружений.
+    EN: Limits dev-only fallback to explicit local/dev/test environments.
+    """
+
+    return get_runtime_env_name() in _DEVELOPER_LIKE_ENVS
 
 
 def validate_api_key_toggle_guard() -> None:

--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,9 @@ _EXPORT_SIGNING_PLACEHOLDERS = frozenset(
         "replace_me_with_export_secret",
     }
 )
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_PRODUCTION_LIKE_ENVS = frozenset({"production", "prod", "staging"})
+_NON_PRODUCTION_ENVS = frozenset({"", "local", "dev", "development", "test", "testing", "ci"})
 
 
 def get_runtime_env_name() -> str:
@@ -21,6 +24,50 @@ def get_runtime_env_name() -> str:
     """
 
     return (os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "local").strip().lower()
+
+
+def is_truthy_env_var(name: str, default: str = "") -> bool:
+    """Return whether an environment variable is set to a truthy value.
+
+    RU: Проверяет truthy-значение env-переменной единым способом.
+    EN: Evaluates truthy env vars via one canonical helper.
+    """
+
+    return (os.getenv(name, default) or "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def is_production_like_env() -> bool:
+    """Return whether runtime config should be treated as production-like.
+
+    RU: Канонически определяет production-like режим через APP_ENV/ENVIRONMENT и DEBUG.
+    EN: Canonically detects production-like mode from APP_ENV/ENVIRONMENT and DEBUG.
+    """
+
+    runtime_env = (os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "").strip().lower()
+    if runtime_env in _PRODUCTION_LIKE_ENVS:
+        return True
+    if runtime_env in (_NON_PRODUCTION_ENVS - {""}):
+        return False
+    return not is_truthy_env_var("DEBUG", "true")
+
+
+def validate_api_key_toggle_guard() -> None:
+    """Reject unsafe API-key escape hatches in production-like environments.
+
+    RU: Запрещает dev/anonymous API-key escape hatches в production-like окружениях.
+    EN: Fails closed when dev/anonymous API-key toggles are enabled in production-like envs.
+    """
+
+    if not is_production_like_env():
+        return
+    invalid_flags = [
+        name
+        for name in ("ALLOW_ANONYMOUS_API_KEYS", "ALLOW_DEV_API_KEY")
+        if is_truthy_env_var(name, "false")
+    ]
+    if invalid_flags:
+        joined = ", ".join(invalid_flags)
+        raise RuntimeError(f"{joined} must be false in production/staging environments.")
 
 
 def is_private_exports_enabled() -> bool:

--- a/tests/edges/test_vip_auth_edges.py
+++ b/tests/edges/test_vip_auth_edges.py
@@ -22,7 +22,7 @@ def test_require_api_key_allow_anonymous_nonprod():
     os.environ["APP_ENV"] = "development"
     os.environ["DEBUG"] = "true"
     os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
-    _clear(["API_KEY"])  # ensure no env API_KEY
+    _clear(["API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])  # ensure no env drift
 
     assert _require_api_key(None) == "anonymous"
 
@@ -33,7 +33,7 @@ def test_require_api_key_dev_fallback_returns_test_key():
     # Non-production, no explicit allow/deny → fallback to dev test key
     os.environ["APP_ENV"] = "local"
     os.environ["DEBUG"] = "true"
-    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY"])  # default behavior
+    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])
 
     assert _require_api_key(None) == "test_key"
 
@@ -75,7 +75,7 @@ def test_require_api_key_dev_legacy_nonprod_and_prod_allow():
     # Dev/local: returns TEST_KEY (not anonymous) when no explicit flag
     os.environ["APP_ENV"] = "dev"
     os.environ["DEBUG"] = "true"
-    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY"])  # default
+    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])
     mock_request = MagicMock(spec=Request)
     mock_request.headers.get.return_value = None
     assert _require_api_key_dev_legacy(mock_request) == TEST_KEY
@@ -84,6 +84,7 @@ def test_require_api_key_dev_legacy_nonprod_and_prod_allow():
     os.environ["APP_ENV"] = "production"
     os.environ["DEBUG"] = "false"
     os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
+    _clear(["ENVIRONMENT", "ALLOW_DEV_API_KEY"])
     mock_request = MagicMock(spec=Request)
     mock_request.headers.get.return_value = None
 

--- a/tests/edges/test_vip_auth_edges.py
+++ b/tests/edges/test_vip_auth_edges.py
@@ -1,39 +1,47 @@
 # -*- coding: utf-8 -*-
-"""
-VIP auth and adapter edge tests to raise coverage for app/routers/vip.py.
-"""
-
-import os
+"""VIP auth and adapter edge tests to raise coverage for app/routers/vip.py."""
 
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 
-def _clear(keys):
-    for k in keys:
-        os.environ.pop(k, None)
+@pytest.fixture(autouse=True)
+def auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset auth env deterministically for each test.
+
+    RU: Изолируем env через monkeypatch, без прямой мутации os.environ.
+    EN: Isolate env through monkeypatch without direct os.environ mutation.
+    """
+
+    for key in (
+        "APP_ENV",
+        "ENVIRONMENT",
+        "DEBUG",
+        "ALLOW_ANONYMOUS_API_KEYS",
+        "ALLOW_DEV_API_KEY",
+        "API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
-def test_require_api_key_allow_anonymous_nonprod():
+def test_require_api_key_allow_anonymous_nonprod(monkeypatch: pytest.MonkeyPatch):
     from app.routers.vip import _require_api_key
 
     # Non-production, explicit allow
-    os.environ["APP_ENV"] = "development"
-    os.environ["DEBUG"] = "true"
-    os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
-    _clear(["API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])  # ensure no env drift
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
 
     assert _require_api_key(None) == "anonymous"
 
 
-def test_require_api_key_dev_fallback_returns_test_key():
+def test_require_api_key_dev_fallback_returns_test_key(monkeypatch: pytest.MonkeyPatch):
     from app.routers.vip import _require_api_key
 
     # Non-production, no explicit allow/deny → fallback to dev test key
-    os.environ["APP_ENV"] = "local"
-    os.environ["DEBUG"] = "true"
-    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("DEBUG", "true")
 
     assert _require_api_key(None) == "test_key"
 
@@ -67,24 +75,24 @@ def test_require_vip_tier_with_vip_key_returns_2xx(
     assert response.status_code == 200
 
 
-def test_require_api_key_dev_legacy_nonprod_and_prod_allow():
+def test_require_api_key_dev_legacy_nonprod_and_prod_allow(
+    monkeypatch: pytest.MonkeyPatch,
+):
     from app.routers.vip import _require_api_key_dev_legacy, TEST_KEY
     from fastapi import Request
     from unittest.mock import MagicMock
 
     # Dev/local: returns TEST_KEY (not anonymous) when no explicit flag
-    os.environ["APP_ENV"] = "dev"
-    os.environ["DEBUG"] = "true"
-    _clear(["ALLOW_ANONYMOUS_API_KEYS", "API_KEY", "ENVIRONMENT", "ALLOW_DEV_API_KEY"])
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.setenv("DEBUG", "true")
     mock_request = MagicMock(spec=Request)
     mock_request.headers.get.return_value = None
     assert _require_api_key_dev_legacy(mock_request) == TEST_KEY
 
     # Production with explicit anonymous allow - should raise 403 (no anonymous in prod)
-    os.environ["APP_ENV"] = "production"
-    os.environ["DEBUG"] = "false"
-    os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
-    _clear(["ENVIRONMENT", "ALLOW_DEV_API_KEY"])
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
     mock_request = MagicMock(spec=Request)
     mock_request.headers.get.return_value = None
 

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -26,6 +26,13 @@ from app.middleware.api_tiers import (
     require_vip_tier,
 )
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
+from settings import get_runtime_env_name, is_production_like_env
+
+
+@pytest.fixture(autouse=True)
+def clear_environment_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid cross-test bleed from ENVIRONMENT precedence checks."""
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
 
 
 class TestSubscriptionTier:
@@ -163,6 +170,18 @@ class TestValidateAPIKeyTier:
         )
         assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is True
         assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.VIP) is False
+
+    def test_environment_overrides_app_env_for_runtime_detection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ENVIRONMENT must win over APP_ENV to keep production-like guards fail-closed."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
+
+        assert get_runtime_env_name() == "production"
+        assert is_production_like_env() is True
+        assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is False
 
 
 class _FakeResult:

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -11,10 +11,19 @@ from fastapi.testclient import TestClient
 # Автофикстура для форсирования production env и API_KEY
 @pytest.fixture(autouse=True)
 def _force_prod_env():
-    old = {k: os.environ.get(k) for k in ("APP_ENV", "ALLOW_DEV_API_KEY", "API_KEY")}
+    old = {
+        k: os.environ.get(k)
+        for k in ("APP_ENV", "ALLOW_DEV_API_KEY", "API_KEY", "PRO_API_KEYS", "VIP_API_KEYS")
+    }
     os.environ["APP_ENV"] = "production"
     os.environ["ALLOW_DEV_API_KEY"] = "false"
     os.environ["API_KEY"] = "secret-key"
+    os.environ["PRO_API_KEYS"] = (
+        "test_pro_key"  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)  # pragma: allowlist secret
+    )
+    os.environ["VIP_API_KEYS"] = (
+        "test_vip_key"  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)  # pragma: allowlist secret
+    )
     try:
         yield
     finally:

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import app
+from app.bootstrap import startup_guards as bootstrap_guards
 
 
 @pytest.mark.asyncio
@@ -96,7 +97,6 @@ async def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
     """
 
     lifespan_globals = app.lifespan.__wrapped__.__globals__
-    bootstrap_guards = pytest.importorskip("app.bootstrap.startup_guards")
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.delenv("APP_ENV", raising=False)
@@ -118,7 +118,6 @@ async def test_lifespan_rejects_dev_api_toggle_in_env_staging(
     """
 
     lifespan_globals = app.lifespan.__wrapped__.__globals__
-    bootstrap_guards = pytest.importorskip("app.bootstrap.startup_guards")
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "staging")
     monkeypatch.delenv("APP_ENV", raising=False)

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -84,3 +84,47 @@ async def test_lifespan_init_db_raises_calls_fallback(monkeypatch: pytest.Monkey
         with pytest.raises(OSError, match="DB unreachable"):
             async with app.lifespan(app.app):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RU: Startup должен падать на anonymous toggle в prod-like ENVIRONMENT.
+
+    EN: Startup must fail closed when anonymous API-key toggle is enabled in prod-like ENVIRONMENT.
+    """
+
+    lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "require_server_salt", lambda: "salt" * 8)
+    monkeypatch.setitem(lifespan_globals, "require_vip_llm_monthly_limit", lambda: 30)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
+    monkeypatch.setenv("DEBUG", "false")
+
+    with pytest.raises(RuntimeError, match="ALLOW_ANONYMOUS_API_KEYS"):
+        async with app.lifespan(app.app):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_rejects_dev_api_toggle_in_env_staging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RU: Startup должен падать на dev API toggle в staging.
+
+    EN: Startup must fail closed when ALLOW_DEV_API_KEY is enabled in staging.
+    """
+
+    lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "require_server_salt", lambda: "salt" * 8)
+    monkeypatch.setitem(lifespan_globals, "require_vip_llm_monthly_limit", lambda: 30)
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
+    monkeypatch.setenv("DEBUG", "false")
+
+    with pytest.raises(RuntimeError, match="ALLOW_DEV_API_KEY"):
+        async with app.lifespan(app.app):
+            pass

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -96,8 +96,8 @@ async def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
     """
 
     lifespan_globals = app.lifespan.__wrapped__.__globals__
-    monkeypatch.setitem(lifespan_globals, "require_server_salt", lambda: "salt" * 8)
-    monkeypatch.setitem(lifespan_globals, "require_vip_llm_monthly_limit", lambda: 30)
+    bootstrap_guards = pytest.importorskip("app.bootstrap.startup_guards")
+    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
@@ -118,8 +118,8 @@ async def test_lifespan_rejects_dev_api_toggle_in_env_staging(
     """
 
     lifespan_globals = app.lifespan.__wrapped__.__globals__
-    monkeypatch.setitem(lifespan_globals, "require_server_salt", lambda: "salt" * 8)
-    monkeypatch.setitem(lifespan_globals, "require_vip_llm_monthly_limit", lambda: 30)
+    bootstrap_guards = pytest.importorskip("app.bootstrap.startup_guards")
+    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "staging")
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")

--- a/tests/test_app_production_coverage.py
+++ b/tests/test_app_production_coverage.py
@@ -109,10 +109,14 @@ class TestAppProductionCoverage:
         )
         assert response.status_code in [422, 401]
 
-    def test_app_production_metrics_coverage(self, client: TestClient, production_environment):
+    def test_app_production_metrics_coverage(self, production_environment):
         """Тест покрытия app.py production metrics"""
-        # Проверяем, что metrics работает в production режиме
-        response = client.get("/metrics")
+        # /metrics route registration is covered by canonical metrics tests.
+        # RU: Здесь проверяем exporter helper напрямую, чтобы не зависеть от singleton route state.
+        # EN: Exercise the exporter helper directly to avoid singleton route-registration drift.
+        from app.bootstrap.metrics import metrics_endpoint
+
+        response = metrics_endpoint()
         assert response.status_code == 200
 
     def test_app_production_health_check_coverage(self, client: TestClient, production_environment):

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -144,6 +144,7 @@ class TestVIPAnonymousAPIKeySafety:
         """Test that development mode allows anonymous access by default."""
         monkeypatch.setenv("APP_ENV", "development")
         monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
 
         import app
 
@@ -161,13 +162,13 @@ class TestVIPAnonymousAPIKeySafety:
                 "goal": "maintain",
             },
         )
-        # Should not be 401 (anonymous access allowed in development)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_local_mode_allows_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that local mode allows anonymous access by default."""
         monkeypatch.setenv("APP_ENV", "local")
         monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
 
         import app
 
@@ -185,13 +186,13 @@ class TestVIPAnonymousAPIKeySafety:
                 "goal": "maintain",
             },
         )
-        # Should not be 401 (anonymous access allowed in local development)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_test_mode_allows_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that test mode allows anonymous access by default."""
         monkeypatch.setenv("APP_ENV", "test")
         monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
 
         import app
 
@@ -209,8 +210,7 @@ class TestVIPAnonymousAPIKeySafety:
                 "goal": "maintain",
             },
         )
-        # Should not be 401 (anonymous access allowed in test mode)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_explicit_anonymous_disabled_in_development(
         self, monkeypatch: pytest.MonkeyPatch
@@ -283,6 +283,7 @@ class TestVIPAnonymousAPIKeySafety:
         """Test that development mode logs info when anonymous access is used."""
         monkeypatch.setenv("APP_ENV", "development")
         monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
 
         import app
 
@@ -300,8 +301,7 @@ class TestVIPAnonymousAPIKeySafety:
                 "goal": "maintain",
             },
         )
-        # Should not be 401 (anonymous access allowed in development)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_production_with_valid_api_key_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that production mode works correctly with valid API key."""
@@ -326,8 +326,7 @@ class TestVIPAnonymousAPIKeySafety:
             },
             headers={"X-API-Key": "secret-key"},
         )
-        # Should not be 401 (valid API key)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_production_with_invalid_api_key_rejects(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that production mode rejects invalid API key."""
@@ -374,8 +373,7 @@ class TestVIPAnonymousAPIKeySafety:
                 "goal": "maintain",
             },
         )
-        # Should not be 401 (default is local development mode)
-        assert response.status_code != 401
+        assert response.status_code in (401, 403)
 
     def test_unknown_environment_rejects_anonymous_access(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -6,6 +6,7 @@ Tests the new production-safe behavior that prevents anonymous access by default
 import os
 from typing import cast
 
+import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
@@ -78,8 +79,8 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "vip" in detail_lower or "invalid" in detail_lower
 
-    def test_production_mode_with_explicit_anonymous_allowed(self):
-        """Test that production mode allows anonymous access when explicitly configured."""
+    def test_production_mode_with_explicit_anonymous_allowed_fails_fast(self):
+        """Test that production mode fails fast when anonymous access is enabled."""
         # Set production environment but allow anonymous access
         os.environ["APP_ENV"] = "production"
         os.environ["DEBUG"] = "false"
@@ -88,22 +89,9 @@ class TestVIPAnonymousAPIKeySafety:
 
         import app
 
-        client = TestClient(cast(ASGIApp, app.app))
-
-        # Test request without API key to VIP endpoint
-        response = client.post(
-            "/api/v1/vip/weekly-plan",
-            json={
-                "sex": "female",
-                "age": 30,
-                "height_cm": 165.0,
-                "weight_kg": 60.0,
-                "activity": "moderate",
-                "goal": "maintain",
-            },
-        )
-        # Should not be 401 (anonymous access allowed)
-        assert response.status_code != 401
+        with pytest.raises(RuntimeError, match="ALLOW_ANONYMOUS_API_KEYS"):
+            with TestClient(cast(ASGIApp, app.app)):
+                pass
 
     def test_staging_mode_rejects_anonymous_access(self):
         """Test that staging mode rejects anonymous access by default."""
@@ -291,8 +279,8 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "api key" in detail_lower or "vip access" in detail_lower
 
-    def test_anonymous_allowed_logs_warning(self):
-        """Test that anonymous access when allowed logs a warning."""
+    def test_anonymous_allowed_logs_warning_fails_fast(self):
+        """Test that production no longer tolerates anonymous access warnings."""
         # Set production environment but allow anonymous access
         os.environ["APP_ENV"] = "production"
         os.environ["DEBUG"] = "false"
@@ -301,22 +289,9 @@ class TestVIPAnonymousAPIKeySafety:
 
         import app
 
-        client = TestClient(cast(ASGIApp, app.app))
-
-        # Test request without API key to VIP endpoint
-        response = client.post(
-            "/api/v1/vip/weekly-plan",
-            json={
-                "sex": "female",
-                "age": 30,
-                "height_cm": 165.0,
-                "weight_kg": 60.0,
-                "activity": "moderate",
-                "goal": "maintain",
-            },
-        )
-        # Should not be 401 (anonymous access allowed)
-        assert response.status_code != 401
+        with pytest.raises(RuntimeError, match="ALLOW_ANONYMOUS_API_KEYS"):
+            with TestClient(cast(ASGIApp, app.app)):
+                pass
 
     def test_development_mode_logs_info(self):
         """Test that development mode logs info when anonymous access is used."""

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -20,11 +20,11 @@ def vip_anonymous_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "API_KEY",
         "APP_ENV",
         "ENVIRONMENT",
-        "ALLOW_DEV_API_KEY",
         "ALLOW_ANONYMOUS_API_KEYS",
         "DEBUG",
     ):
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
 
 
 class TestVIPAnonymousAPIKeySafety:

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -1,9 +1,5 @@
-"""
-Tests for VIP router anonymous API key safety in production environments.
-Tests the new production-safe behavior that prevents anonymous access by default.
-"""
+"""Tests for VIP router anonymous API key safety in production environments."""
 
-import os
 from typing import cast
 
 import pytest
@@ -11,35 +7,35 @@ from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
 
+@pytest.fixture(autouse=True)
+def vip_anonymous_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset auth-related env for each test via canonical monkeypatch fixtures.
+
+    RU: Используем monkeypatch вместо прямой мутации os.environ.
+    EN: Use monkeypatch instead of direct os.environ mutation.
+    """
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    for name in (
+        "API_KEY",
+        "APP_ENV",
+        "ENVIRONMENT",
+        "ALLOW_DEV_API_KEY",
+        "ALLOW_ANONYMOUS_API_KEYS",
+        "DEBUG",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 class TestVIPAnonymousAPIKeySafety:
     """Test VIP router anonymous API key safety functionality."""
 
-    def setup_method(self):
-        """Setup for each test method."""
-        # Enable VIP module for app initialization
-        os.environ["VIP_MODULE_ENABLED"] = "true"
-
-    def teardown_method(self):
-        """Cleanup after each test method."""
-        # Clear environment variables
-        env_vars_to_clear = [
-            "API_KEY",
-            "APP_ENV",
-            "ALLOW_DEV_API_KEY",
-            "ALLOW_ANONYMOUS_API_KEYS",
-            "DEBUG",
-            "VIP_MODULE_ENABLED",
-        ]
-        for var in env_vars_to_clear:
-            if var in os.environ:
-                del os.environ[var]
-
-    def test_production_mode_rejects_anonymous_access(self):
+    def test_production_mode_rejects_anonymous_access(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that production mode rejects anonymous access by default."""
-        # Set production environment
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
 
         import app
 
@@ -77,15 +73,15 @@ class TestVIPAnonymousAPIKeySafety:
         # Invalid key should be 403 (insufficient permissions), not 401 (missing auth)
         assert response.status_code == 403
         detail_lower = response.json()["detail"].lower()
-        assert "vip" in detail_lower or "invalid" in detail_lower
+        assert "vip" in detail_lower or "invalid" in detail_lower or "required" in detail_lower
 
-    def test_production_mode_with_explicit_anonymous_allowed_fails_fast(self):
+    def test_production_mode_with_explicit_anonymous_allowed_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that production mode fails fast when anonymous access is enabled."""
-        # Set production environment but allow anonymous access
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
 
         import app
 
@@ -93,12 +89,10 @@ class TestVIPAnonymousAPIKeySafety:
             with TestClient(cast(ASGIApp, app.app)):
                 pass
 
-    def test_staging_mode_rejects_anonymous_access(self):
+    def test_staging_mode_rejects_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that staging mode rejects anonymous access by default."""
-        # Set staging environment
-        os.environ["APP_ENV"] = "staging"
-        os.environ["DEBUG"] = "false"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "staging")
+        monkeypatch.setenv("DEBUG", "false")
 
         import app
 
@@ -120,11 +114,9 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "api key" in detail_lower or "vip access" in detail_lower
 
-    def test_debug_false_rejects_anonymous_access(self):
+    def test_debug_false_rejects_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that DEBUG=false rejects anonymous access even without explicit production env."""
-        # Set debug to false (production-like behavior)
-        os.environ["DEBUG"] = "false"
-        # Don't set APP_ENV or API_KEY
+        monkeypatch.setenv("DEBUG", "false")
 
         import app
 
@@ -146,12 +138,12 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "api key" in detail_lower or "vip access" in detail_lower
 
-    def test_development_mode_allows_anonymous_access(self):
+    def test_development_mode_allows_anonymous_access(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that development mode allows anonymous access by default."""
-        # Set development environment
-        os.environ["APP_ENV"] = "development"
-        os.environ["DEBUG"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.setenv("DEBUG", "true")
 
         import app
 
@@ -172,12 +164,10 @@ class TestVIPAnonymousAPIKeySafety:
         # Should not be 401 (anonymous access allowed in development)
         assert response.status_code != 401
 
-    def test_local_mode_allows_anonymous_access(self):
+    def test_local_mode_allows_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that local mode allows anonymous access by default."""
-        # Set local environment (default)
-        os.environ["APP_ENV"] = "local"
-        os.environ["DEBUG"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "local")
+        monkeypatch.setenv("DEBUG", "true")
 
         import app
 
@@ -198,12 +188,10 @@ class TestVIPAnonymousAPIKeySafety:
         # Should not be 401 (anonymous access allowed in local development)
         assert response.status_code != 401
 
-    def test_test_mode_allows_anonymous_access(self):
+    def test_test_mode_allows_anonymous_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that test mode allows anonymous access by default."""
-        # Set test environment
-        os.environ["APP_ENV"] = "test"
-        os.environ["DEBUG"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "test")
+        monkeypatch.setenv("DEBUG", "true")
 
         import app
 
@@ -224,13 +212,13 @@ class TestVIPAnonymousAPIKeySafety:
         # Should not be 401 (anonymous access allowed in test mode)
         assert response.status_code != 401
 
-    def test_explicit_anonymous_disabled_in_development(self):
+    def test_explicit_anonymous_disabled_in_development(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that explicit ALLOW_ANONYMOUS_API_KEYS=false disables anonymous access even in development."""
-        # Set development environment but explicitly disable anonymous access
-        os.environ["APP_ENV"] = "development"
-        os.environ["DEBUG"] = "true"
-        os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "false"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
 
         import app
 
@@ -252,12 +240,10 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "api key" in detail_lower or "vip access" in detail_lower
 
-    def test_production_mode_logs_error(self):
+    def test_production_mode_logs_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that production mode logs error when anonymous access is attempted."""
-        # Set production environment
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
 
         import app
 
@@ -279,13 +265,13 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "api key" in detail_lower or "vip access" in detail_lower
 
-    def test_anonymous_allowed_logs_warning_fails_fast(self):
+    def test_anonymous_allowed_logs_warning_fails_fast(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that production no longer tolerates anonymous access warnings."""
-        # Set production environment but allow anonymous access
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        os.environ["ALLOW_ANONYMOUS_API_KEYS"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
 
         import app
 
@@ -293,12 +279,10 @@ class TestVIPAnonymousAPIKeySafety:
             with TestClient(cast(ASGIApp, app.app)):
                 pass
 
-    def test_development_mode_logs_info(self):
+    def test_development_mode_logs_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that development mode logs info when anonymous access is used."""
-        # Set development environment
-        os.environ["APP_ENV"] = "development"
-        os.environ["DEBUG"] = "true"
-        # Don't set API_KEY to test anonymous fallback behavior
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.setenv("DEBUG", "true")
 
         import app
 
@@ -319,12 +303,11 @@ class TestVIPAnonymousAPIKeySafety:
         # Should not be 401 (anonymous access allowed in development)
         assert response.status_code != 401
 
-    def test_production_with_valid_api_key_works(self):
+    def test_production_with_valid_api_key_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that production mode works correctly with valid API key."""
-        # Set production environment
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -346,12 +329,11 @@ class TestVIPAnonymousAPIKeySafety:
         # Should not be 401 (valid API key)
         assert response.status_code != 401
 
-    def test_production_with_invalid_api_key_rejects(self):
+    def test_production_with_invalid_api_key_rejects(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that production mode rejects invalid API key."""
-        # Set production environment
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -374,13 +356,8 @@ class TestVIPAnonymousAPIKeySafety:
         detail_lower = response.json()["detail"].lower()
         assert "vip" in detail_lower or "invalid" in detail_lower
 
-    def test_environment_variable_defaults(self):
+    def test_environment_variable_defaults(self) -> None:
         """Test that environment variables have correct defaults."""
-        # Clear all relevant environment variables
-        for var in ["APP_ENV", "DEBUG", "ALLOW_ANONYMOUS_API_KEYS", "ALLOW_DEV_API_KEY"]:
-            if var in os.environ:
-                del os.environ[var]
-
         import app
 
         client = TestClient(cast(ASGIApp, app.app))
@@ -399,3 +376,28 @@ class TestVIPAnonymousAPIKeySafety:
         )
         # Should not be 401 (default is local development mode)
         assert response.status_code != 401
+
+    def test_unknown_environment_rejects_anonymous_access(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unknown env labels must not inherit dev-only anonymous fallbacks."""
+        monkeypatch.setenv("APP_ENV", "preview")
+        monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
+
+        import app
+
+        client = TestClient(cast(ASGIApp, app.app))
+
+        response = client.post(
+            "/api/v1/vip/weekly-plan",
+            json={
+                "sex": "female",
+                "age": 30,
+                "height_cm": 165.0,
+                "weight_kg": 60.0,
+                "activity": "moderate",
+                "goal": "maintain",
+            },
+        )
+        assert response.status_code in (401, 403)

--- a/tests/test_vip_coverage_97_clean.py
+++ b/tests/test_vip_coverage_97_clean.py
@@ -42,7 +42,10 @@ class TestVIPCoverage97Clean:
         )
 
         # Test _is_production_environment
-        with patch.dict(os.environ, {"APP_ENV": "production"}):
+        with patch.dict(
+            os.environ,
+            {"APP_ENV": "production", "ENVIRONMENT": "", "DEBUG": "false"},
+        ):
             is_production, app_env = _is_production_environment()
             assert is_production is True
             assert app_env == "production"

--- a/tests/test_vip_coverage_additional.py
+++ b/tests/test_vip_coverage_additional.py
@@ -17,7 +17,10 @@ from app.middleware import api_tiers
 
 @pytest.fixture(autouse=True)
 def vip_auth_env(monkeypatch):
-    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("API_KEY", "test-key")
     monkeypatch.setenv("API_KEY_REQUIRED", "true")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
     monkeypatch.setenv(
@@ -32,12 +35,6 @@ def vip_auth_env(monkeypatch):
 
 class TestVIPCoverageAdditional:
     """Additional test class to achieve 97% coverage for VIP router."""
-
-    def setup_method(self):
-        """Set up test fixtures."""
-        # Ensure we're testing in production mode
-        os.environ["APP_ENV"] = "production"
-        os.environ["API_KEY"] = "test-key"
 
     def test_vip_require_api_key_app_get_api_key_coverage_lines_92_104(self):
         """Test VIP _require_api_key with app_get_api_key coverage for lines 92-104."""
@@ -129,6 +126,23 @@ class TestVIPCoverageAdditional:
         assert response.status_code == 403
         data = response.json()
         assert "vip access" in data["detail"].lower()
+
+    def test_api_tier_resolution_rejects_preview_env_fallbacks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preview-like envs must not inherit developer-only API tier fallbacks."""
+        monkeypatch.setenv("APP_ENV", "preview")
+        monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "true")
+        monkeypatch.delenv("PRO_API_KEYS", raising=False)
+        monkeypatch.delenv("VIP_API_KEYS", raising=False)
+
+        resolved = api_tiers._resolve_authorized_api_key_tier(
+            api_tiers.TEST_KEY_VIP,
+            required_tier=api_tiers.SubscriptionTier.VIP,
+        )
+
+        assert resolved is None
 
     def test_vip_weekly_menu_plan_success_coverage_lines_172_178(self, vip_headers):
         """Test VIP weekly menu plan success coverage for lines 172-178."""

--- a/tests/test_vip_coverage_additional.py
+++ b/tests/test_vip_coverage_additional.py
@@ -19,6 +19,15 @@ from app.middleware import api_tiers
 def vip_auth_env(monkeypatch):
     monkeypatch.setenv("API_KEY", "test_key")
     monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv(
+        "PRO_API_KEYS",
+        "test_pro_key",  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)
+    )
+    monkeypatch.setenv(
+        "VIP_API_KEYS",
+        "test_vip_key",  # nosec B105: deterministic non-production test key (remove-by: 2026-09-30, ref: PR-1052)
+    )
 
 
 class TestVIPCoverageAdditional:

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -1,41 +1,31 @@
-"""
-Tests for VIP router in production mode to cover API key validation,
-error handling, and real business logic paths.
-Targets lines that are skipped in echo mode (~49 lines, ~1% coverage).
-"""
+"""Tests for VIP router in production mode."""
 
-import os
 from typing import cast
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
+
+
+@pytest.fixture(autouse=True)
+def vip_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep production-mode VIP tests isolated from ENVIRONMENT drift."""
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
 
 
 class TestVIPProductionMode:
     """Test VIP router production mode functionality."""
 
-    def setup_method(self):
-        """Setup for each test method."""
-        # Enable VIP module for app initialization
-        os.environ["VIP_MODULE_ENABLED"] = "true"
-        # Set production environment to test real API key validation paths
-        os.environ["APP_ENV"] = "production"
-        os.environ["DEBUG"] = "false"
-        os.environ["ALLOW_DEV_API_KEY"] = "false"
-
-    def teardown_method(self):
-        """Cleanup after each test method."""
-        # Clear environment variables
-        env_vars_to_clear = ["API_KEY", "APP_ENV", "ALLOW_DEV_API_KEY"]
-        for var in env_vars_to_clear:
-            if var in os.environ:
-                del os.environ[var]
-
-    def test_vip_api_key_validation_missing_key(self):
+    def test_vip_api_key_validation_missing_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test API key validation when API_KEY is set but key is missing (line 95)."""
-        # Set API_KEY environment variable to enable validation
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -47,10 +37,9 @@ class TestVIPProductionMode:
         detail_lower = response.json()["detail"].lower()
         assert "vip access" in detail_lower or "invalid api key" in detail_lower
 
-    def test_vip_api_key_validation_wrong_key(self):
+    def test_vip_api_key_validation_wrong_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test API key validation with incorrect key (line 95)."""
-        # Set API_KEY environment variable
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -61,12 +50,12 @@ class TestVIPProductionMode:
             "/api/v1/vip/weekly-plan", json={"test": "data"}, headers={"X-API-Key": "wrong-key"}
         )
         assert response.status_code == 403
-        assert "Invalid API" in response.json()["detail"]
+        detail_lower = response.json()["detail"].lower()
+        assert "invalid api" in detail_lower or "vip access" in detail_lower
 
-    def test_vip_api_key_validation_correct_key(self):
+    def test_vip_api_key_validation_correct_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test API key validation with correct key passes authentication."""
-        # Set API_KEY environment variable
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -82,10 +71,11 @@ class TestVIPProductionMode:
         assert response.status_code != 401
 
     @patch("app.routers.vip.make_weekly_menu")
-    def test_weekly_menu_generation_error_handling(self, mock_make_weekly_menu):
+    def test_weekly_menu_generation_error_handling(
+        self, mock_make_weekly_menu, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test weekly menu generation error handling (line 155)."""
-        # Set API_KEY to enable production mode
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         # Mock make_weekly_menu to raise exception synchronously
         def raise_exc(*args, **kwargs):
@@ -104,13 +94,12 @@ class TestVIPProductionMode:
             headers={"X-API-Key": "secret-key"},
         )
 
-        # Should handle error gracefully - but gets validation error first
-        assert response.status_code == 422  # Validation error for invalid request
+        # Current guard order may reject before payload validation in production mode.
+        assert response.status_code in (403, 422)
 
-    def test_vip_recipes_endpoint_auth_check(self):
+    def test_vip_recipes_endpoint_auth_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP recipes endpoint requires authentication."""
-        # Set API_KEY to enable production mode
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -122,10 +111,9 @@ class TestVIPProductionMode:
         detail = response.json()["detail"].lower()
         assert any(sub in detail for sub in ("vip", "access"))
 
-    def test_vip_regions_endpoint_auth_check(self):
+    def test_vip_regions_endpoint_auth_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP regions endpoint requires authentication."""
-        # Set API_KEY to enable production mode
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -137,7 +125,7 @@ class TestVIPProductionMode:
         detail = response.json()["detail"].lower()
         assert any(sub in detail for sub in ("vip", "access"))
 
-    def test_vip_production_mode_coverage_lines(self):
+    def test_vip_production_mode_coverage_lines(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test specific production mode lines for coverage.
 
         This test targets the specific uncovered lines in VIP router:
@@ -146,8 +134,7 @@ class TestVIPProductionMode:
         - Line 320: Recipe search error handling
         - Line 663: Regional search error handling
         """
-        # Set API_KEY to enable production mode
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         import app
 
@@ -170,10 +157,9 @@ class TestVIPProductionMode:
         # Should not be 401 (auth should pass)
         assert response.status_code != 401
 
-    def test_vip_app_get_api_key_http_exception_403(self):
+    def test_vip_app_get_api_key_http_exception_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test app.get_api_key raising HTTPException with 403 (line 88-92)."""
-        # Set API_KEY to enable production mode
-        os.environ["API_KEY"] = "secret-key"
+        monkeypatch.setenv("API_KEY", "secret-key")
 
         from fastapi import HTTPException
 

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -7,6 +7,15 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
+VALID_WEEKLY_PLAN_REQUEST = {
+    "sex": "male",
+    "age": 30,
+    "height_cm": 175,
+    "weight_kg": 70,
+    "activity": "moderate",
+    "goal": "maintain",
+}
+
 
 @pytest.fixture(autouse=True)
 def vip_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,38 +73,35 @@ class TestVIPProductionMode:
         # Test request with correct API key
         response = client.post(
             "/api/v1/vip/weekly-plan",
-            json={"calories": 2000, "preferences": []},
+            json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "secret-key"},
         )
         # Should not be 401 (auth should pass)
         assert response.status_code != 401
 
-    @patch("app.routers.vip.make_weekly_menu")
-    def test_weekly_menu_generation_error_handling(
-        self, mock_make_weekly_menu, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_weekly_menu_generation_error_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test weekly menu generation error handling (line 155)."""
         monkeypatch.setenv("API_KEY", "secret-key")
 
-        # Mock make_weekly_menu to raise exception synchronously
+        import app
+        import app.routers.vip as vip_router
+
         def raise_exc(*args, **kwargs):
             # sourcery skip: raise-specific-error
             raise Exception("Menu generation failed")
 
-        mock_make_weekly_menu.side_effect = raise_exc
-
-        import app
+        monkeypatch.setattr(vip_router, "make_weekly_menu", raise_exc)
 
         client = TestClient(cast(ASGIApp, app.app))
 
         response = client.post(
             "/api/v1/vip/weekly-plan",
-            json={"calories": 2000, "preferences": []},
+            json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "secret-key"},
         )
 
-        # Current guard order may reject before payload validation in production mode.
-        assert response.status_code in (403, 422)
+        assert response.status_code == 200
+        assert "Weekly plan generation failed" in response.json()["message"]
 
     def test_vip_recipes_endpoint_auth_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test VIP recipes endpoint requires authentication."""
@@ -143,7 +149,7 @@ class TestVIPProductionMode:
         # Test 1: Invalid API key (lines 88-95)
         response = client.post(
             "/api/v1/vip/weekly-plan",
-            json={"calories": 2000, "preferences": []},
+            json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "wrong-key"},
         )
         assert response.status_code == 403
@@ -151,7 +157,7 @@ class TestVIPProductionMode:
         # Test 2: Valid API key allows access
         response = client.post(
             "/api/v1/vip/weekly-plan",
-            json={"calories": 2000, "preferences": []},
+            json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "secret-key"},
         )
         # Should not be 401 (auth should pass)

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -82,14 +82,27 @@ class TestVIPProductionMode:
         """Test weekly menu generation error handling (line 155)."""
         monkeypatch.setenv("API_KEY", "secret-key")
 
+        from fastapi.routing import APIRoute
+
         import app
-        import app.routers.vip as vip_router
 
         def raise_exc(*args, **kwargs):
             # sourcery skip: raise-specific-error
             raise Exception("Menu generation failed")
 
-        monkeypatch.setattr(vip_router, "make_weekly_menu", raise_exc)
+        deprecated_route = next(
+            (
+                route
+                for route in app.app.routes
+                if isinstance(route, APIRoute)
+                and route.path == "/api/v1/vip/weekly-plan"
+                and "POST" in (route.methods or set())
+            ),
+            None,
+        )
+        assert deprecated_route is not None, "POST /api/v1/vip/weekly-plan route not found"
+        # Patch the registered route globals for deterministic behavior under reload/shim imports.
+        monkeypatch.setitem(deprecated_route.endpoint.__globals__, "make_weekly_menu", raise_exc)
 
         client = TestClient(cast(ASGIApp, app.app))
 

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -76,8 +76,7 @@ class TestVIPProductionMode:
             json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "secret-key"},
         )
-        # Should not be 401 (auth should pass)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_weekly_menu_generation_error_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test weekly menu generation error handling (line 155)."""
@@ -160,8 +159,7 @@ class TestVIPProductionMode:
             json=VALID_WEEKLY_PLAN_REQUEST,
             headers={"X-API-Key": "secret-key"},
         )
-        # Should not be 401 (auth should pass)
-        assert response.status_code != 401
+        assert response.status_code == 200
 
     def test_vip_app_get_api_key_http_exception_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test app.get_api_key raising HTTPException with 403 (line 88-92)."""


### PR DESCRIPTION
## Summary
- fail fast at startup when `ALLOW_ANONYMOUS_API_KEYS` or `ALLOW_DEV_API_KEY` are enabled in production-like environments
- unify canonical VIP/API-tier env handling so deterministic dev keys and legacy weekly-plan auth no longer drift from the production/staging contract
- align deployment docs and security tests with the hardened `ENVIRONMENT`-first behavior

## Testing
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type security`
- `pytest -q tests/test_vip_production_simple.py tests/test_app_lifespan_additional.py tests/test_vip_anonymous_api_key_safety.py tests/test_vip_coverage_additional.py tests/test_app_production_coverage.py`
- `make verify`
- `pre-commit run --all-files`

## Carryover
- `legacy_app.py` still has module-level `APP_ENV`-only gating outside this narrow runtime hardening diff. Follow-up is tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization` as the residual carryover from PR `#1054` under parent `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-api-key-toggle-guard`.

# PR 1054 - Fixed in Commit Mapping

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#issuecomment-4024056533
Disposition: NOT-A-BUG
Evidence: GitHub required check `diff-coverage` passed on current head; local `make verify` reported `Coverage: 100%` for changed lines in `settings.py`, `legacy_app.py`, and `app/middleware/api_tiers.py`.
Reason: Codecov patch comment is informational-only and disagrees with the canonical merge gate for this repo (`make diff-cov` / `diff-coverage` check), which already passed on the current head.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905754667
Disposition: FIXED
Commit: 656e0239
Evidence: `settings.py:20` now prefers `ENVIRONMENT` over `APP_ENV`; `settings.py:42` keeps production-like detection fail-closed on the canonical runtime label; `tests/test_api_tiers.py:174` proves `ENVIRONMENT=production` overrides `APP_ENV=local`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905754667 -> 656e0239

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783682
Disposition: FIXED
Commit: 656e0239
Evidence: `docs/deploy/VIP_API_KEYS.md:124` rewrites the migration path to require a real `API_KEY`; `docs/deploy/VIP_API_KEYS.md:186` rewrites troubleshooting to treat anonymous/dev toggles in production as a misconfiguration instead of a workaround.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783682 -> 656e0239

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783689
Disposition: FIXED
Commit: 656e0239
Evidence: `app/bootstrap/startup_guards.py:14` centralizes startup hard guards; `legacy_app.py:516` delegates to the bootstrap seam; `tests/test_app_lifespan_additional.py:90` and `tests/test_app_lifespan_additional.py:112` verify fail-closed startup behavior through the shared bootstrap seam.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2905783689 -> 656e0239

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3915807041
Disposition: FIXED
Commit: 656e0239
Evidence: `app/middleware/api_tiers.py:207` restricts developer fallbacks to `is_explicit_developer_env()`; `legacy_app.py:792` limits lenient API-key mode to explicit dev/test-like environments; `tests/test_vip_anonymous_api_key_safety.py:380` and `tests/test_vip_coverage_additional.py:130` cover preview/unknown-env fail-closed behavior; `tests/test_vip_anonymous_api_key_safety.py:17` and `tests/test_vip_coverage_additional.py:18` now use autouse `monkeypatch` fixtures instead of direct `os.environ` mutation.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3915807041 -> 656e0239

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906058549
Disposition: FIXED
Commit: d7482420
Evidence: cubic found that `pytest.importorskip()` could silently skip the startup-guard seam. `tests/test_app_lifespan_additional.py:6` now imports `app.bootstrap.startup_guards` directly, and `tests/test_app_lifespan_additional.py:100` / `tests/test_app_lifespan_additional.py:121` inject the seam without skip-based masking.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906058549 -> d7482420

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916112663
Disposition: FIXED
Commit: d7482420
Evidence: cubic identified the same missing fail-fast import seam in `tests/test_app_lifespan_additional.py`. The test file now uses a direct module import at `tests/test_app_lifespan_additional.py:6` and reuses `startup_guards.run_startup_guards` at `tests/test_app_lifespan_additional.py:100` / `tests/test_app_lifespan_additional.py:121`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916112663 -> d7482420

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102580
Disposition: FIXED
Commit: d7482420
Evidence: `tests/test_app_lifespan_additional.py:6` now imports `startup_guards` directly, and the two security regression tests wire `run_startup_guards` via `lifespan_globals` without `pytest.importorskip()`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102580 -> d7482420

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102591
Disposition: FIXED
Commit: d7482420
Evidence: `tests/test_vip_anonymous_api_key_safety.py:18` now pins `ALLOW_DEV_API_KEY=false` after clearing the rest of the auth env, so production-like tests no longer inherit implicit dev-key behavior.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102591 -> d7482420

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906102575
Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization`
Evidence: The remaining concern is legacy module-level env gating outside the narrow runtime hardening diff for `PR-TBD-API-KEY-TOGGLE-GUARD`. It is tracked as a dedicated follow-up item so the current PR can stay focused on fail-fast toggle enforcement without mixing a wider `legacy_app.py` env-surface refactor.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916162189
Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-legacy-runtime-env-canonicalization`
Evidence: The review summary includes three findings fixed in `d7482420` (`app/middleware/api_tiers.py`, `app/routers/vip.py`, `docs/deploy/VIP_API_KEYS.md`, and the targeted tests) plus one valid `legacy_app.py` env-surface follow-up, which is explicitly tracked in the new backlog item to avoid widening this near-ready security PR.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496197
Disposition: FIXED
Commit: 0f1b4f47
Evidence: `docs/deploy/VIP_API_KEYS.md:20` no longer claims `DEBUG=false` alone makes an explicit developer runtime production-like; `docs/deploy/VIP_API_KEYS.md:27` and `docs/deploy/VIP_API_KEYS.md:45` now document `ALLOW_ANONYMOUS_API_KEYS` defaulting to `false`, and the matrix/troubleshooting sections were aligned with the runtime helpers.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496197 -> 0f1b4f47

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496203
Disposition: FIXED
Commit: 0f1b4f47
Evidence: `docs/roadmap/BACKLOG_LEDGER.md:343` now marks `ledger-p1-legacy-runtime-env-canonicalization` as the residual follow-up from PR `#1054` and links both the parent ledger item and the PR URL, making the carryover explicit.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496203 -> 0f1b4f47

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496207
Disposition: FIXED
Commit: 0f1b4f47
Evidence: `tests/edges/test_vip_auth_edges.py:7` now uses an autouse `monkeypatch` fixture to reset auth env, and the edge tests use `monkeypatch.setenv()` / `delenv()` instead of process-global `os.environ` writes.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496207 -> 0f1b4f47

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496213
Disposition: FIXED
Commit: 0f1b4f47
Evidence: `tests/test_vip_anonymous_api_key_safety.py:134`, `tests/test_vip_anonymous_api_key_safety.py:157`, `tests/test_vip_anonymous_api_key_safety.py:180`, and `tests/test_vip_anonymous_api_key_safety.py:294` explicitly enable `ALLOW_DEV_API_KEY=true` for dev/local/test anonymous flows and now assert `200` instead of `!= 401`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496213 -> 0f1b4f47

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2906496216
Disposition: NOT-A-BUG
Evidence: `app/routers/vip.py:759` shows the deprecated `/api/v1/vip/weekly-plan` alias calls the module-level `make_weekly_menu` symbol directly, not `_safe_call_with_adapter()`. `tests/test_vip_production_simple.py:78` therefore correctly monkeypatches `app.routers.vip.make_weekly_menu` to exercise the alias error path and assert the `"Weekly plan generation failed"` response.
Reason: The review comment describes the `/menu/weekly/plan` adapter path, but this test targets the deprecated `/weekly-plan` alias, which uses a different callable path.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916595868
Disposition: FIXED
Commit: 0f1b4f47
Evidence: The latest CodeRabbit review summary is now dispositioned as four concrete fixes in `0f1b4f47` (`app/middleware/api_tiers.py`, `docs/deploy/VIP_API_KEYS.md`, `docs/roadmap/BACKLOG_LEDGER.md`, `tests/edges/test_vip_auth_edges.py`, and `tests/test_vip_anonymous_api_key_safety.py`) plus one `NOT-A-BUG` clarification for the deprecated `/weekly-plan` alias path in `tests/test_vip_production_simple.py`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3916595868 -> 0f1b4f47

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917624345
Disposition: FIXED
Commit: ef54e8ad
Evidence: `docs/deploy/VIP_API_KEYS.md:212` and `docs/deploy/VIP_API_KEYS.md:216` now print both `ENVIRONMENT` and `ALLOW_DEV_API_KEY`; the remaining duplicate adapter-path comment is already classified as `NOT-A-BUG` under `discussion_r2906496216` because the deprecated `/api/v1/vip/weekly-plan` alias calls `app.routers.vip.make_weekly_menu` directly.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917624345 -> ef54e8ad

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449922
Disposition: FIXED
Commit: 5c0ff3f1
Evidence: `docs/deploy/VIP_API_KEYS.md:165` now uses `ENVIRONMENT=production` in the runnable production-mode test recipe, which keeps the example deterministic under the documented rule that `ENVIRONMENT` overrides `APP_ENV`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449922 -> 5c0ff3f1

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449929
Disposition: FIXED
Commit: 5c0ff3f1
Evidence: `docs/deploy/VIP_API_KEYS.md:153` now uses the centralized startup guard entrypoint `run_startup_guards()` from `app.bootstrap.startup_guards`, matching the runtime bootstrap seam introduced by this PR.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#discussion_r2907449929 -> 5c0ff3f1

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917666615
Disposition: FIXED
Commit: 5c0ff3f1
Evidence: The latest CodeRabbit review summary is fully dispositioned by the two docs fixes above: `docs/deploy/VIP_API_KEYS.md:153` now points operators at `run_startup_guards()`, and `docs/deploy/VIP_API_KEYS.md:165` uses canonical `ENVIRONMENT=production` in the runnable production-mode recipe.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1054#pullrequestreview-3917666615 -> 5c0ff3f1
## Merge Readiness
- [x] Scope tied to PR objective
- [x] Docs/runtime changes applied
- [x] Verification completed
- [ ] Required GitHub checks PASS with no pending required jobs
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] No unresolved review threads or actionable bot comments remain
- [ ] Review wait-window completed
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment-based startup validation now enforces safe configuration for API key toggles before application starts.

* **Bug Fixes**
  * Anonymous access and developer API keys are now restricted to explicit development environments.
  * Fixed environment detection to prioritize ENVIRONMENT variable over legacy APP_ENV.

* **Documentation**
  * Updated deployment guides with new environment variables, configuration examples, and security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
