### PR TITLE
feat(fitchef): add backend orchestration wrapper for coach insight

### DIFF
--- a/app/routers/cbt_insight.py
+++ b/app/routers/cbt_insight.py
@@ -9,49 +9,30 @@ Feature-gated via FEATURE_CBT_AGENT environment variable.
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import logging
 import os
 from typing import Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
-from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
-from app.middleware.api_tiers import derive_subject_id_from_api_key, require_pro_tier
+from app.middleware.api_tiers import require_pro_tier
 from app.routers.api_key import api_key_header
-from app.security.agent_control_plane import (
-    AUDIT_SIGNING_KEY_ENV,
-    normalize_execution_mode,
-    persist_audit_envelope,
-    require_execution_mode,
-    require_policy_allow,
-    sign_audit_envelope,
-)
+from app.schemas.fitchef import FitChefCoachInsightInput, FitChefCoachInsightTaskEnvelope
+from app.security.agent_control_plane import normalize_execution_mode, require_execution_mode
 from app.security.agent_input_guard import require_safe_ai_agent_input
-from app.security.llm_monthly_quota import attempt_consume_llm_monthly_quota
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,
     RATE_LIMIT_INSIGHT,
     limit_if_available,
 )
-from app.security.server_salt import require_server_salt
-from core.data_sanitizer import sanitize_rag_markdown
-from core.compliance import get_transparency_registry, sanitize_chunk_preview
-from core.pii_redaction import redact_pii_from_text
+from app.services import fitchef_runtime
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/pro/cbt", tags=["CBT", "pro"])
 
-# LLM provider call timeout (seconds) - prevents unbounded requests
-LLM_TIMEOUT_SECONDS: float = 60.0
 CBT_EXECUTION_MODE_ENV = "CBT_AGENT_EXECUTION_MODE"
-CBT_POLICY_ALLOWLIST = {
-    ("rag.retrieve", "corpus://cbt-agent"),
-    ("llm.generate", "provider://default"),
-}
 CBTExecutionMode = Literal["auto-safe", "review-required", "blocked"]
 CBTQuotaState = Literal["not_consumed", "consumed"]
 
@@ -133,85 +114,6 @@ class CBTInsightResponse(BaseModel):
     )
 
 
-# ---------------------------------------------------------------------------
-# CBT prompt builder
-# ---------------------------------------------------------------------------
-
-
-def _build_cbt_prompt(query: str, rag_context: str) -> str:
-    """Build CBT-informed prompt for LLM with RAG context.
-
-    The system prompt establishes the CBT coaching role and boundaries.
-    """
-    system_prompt = """You are a supportive wellness coach using evidence-based CBT (Cognitive Behavioral Therapy) principles. Your role is to:
-
-1. Help users identify and challenge unhelpful thought patterns
-2. Suggest practical CBT techniques (thought records, cognitive restructuring)
-3. Encourage self-compassion and gradual progress
-4. Focus on nutrition and wellness goals
-
-IMPORTANT BOUNDARIES:
-- You are NOT a therapist and cannot provide therapy or diagnose conditions
-- Avoid medical advice; suggest consulting professionals for health concerns
-- If someone expresses crisis/self-harm thoughts, encourage them to seek professional help
-- Use non-judgmental, supportive language
-
-Respond with practical, actionable suggestions based on CBT principles."""
-
-    if rag_context:
-        return f"""{system_prompt}
-
-RELEVANT CBT KNOWLEDGE:
-{rag_context}
-
-USER QUESTION:
-{query}
-
-Provide a helpful, CBT-informed response:"""
-    return f"""{system_prompt}
-
-USER QUESTION:
-{query}
-
-Provide a helpful, CBT-informed response:"""
-
-
-def _sha256_hex(value: str) -> str:
-    """Return deterministic sha256 hex digest for audit-safe metadata."""
-
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
-def _persist_privileged_action_audit(
-    *,
-    action: str,
-    target: str,
-    mode: str,
-    endpoint: str,
-    metadata: dict[str, object],
-) -> None:
-    """Run policy gate and persist a signed audit envelope before privileged work."""
-
-    decision = require_policy_allow(action, target, allowlist=CBT_POLICY_ALLOWLIST)
-    audit_metadata = {
-        "endpoint": endpoint,
-        "mode": mode,
-        **metadata,
-    }
-    signing_secret = (os.getenv(AUDIT_SIGNING_KEY_ENV) or "").strip() or require_server_salt()
-    envelope = sign_audit_envelope(
-        decision,
-        metadata=audit_metadata,
-        secret=signing_secret,
-    )
-    persist_audit_envelope(envelope, metadata=audit_metadata)
-
-
-# ---------------------------------------------------------------------------
-# Endpoint
-# ---------------------------------------------------------------------------
-
-
 @router.post(
     "/insight",
     response_model=CBTInsightResponse,
@@ -265,175 +167,35 @@ async def cbt_insight(
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
 
     safe_query = require_safe_ai_agent_input(request.query)
-
-    # Retrieve RAG context with CBT corpus filtering
-    rag_context_str = ""
-    sources: list[CBTSourceItem] = []
-    confidence = 0.0
-    rag_used = False
-    quota_state: CBTQuotaState = "not_consumed"
-    warnings: list[str] = []
-    redaction_applied = False
-    sanitization_applied = False
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="rag.retrieve",
-            target="corpus://cbt-agent",
-            mode=execution_mode,
-            endpoint=str(raw_request.url.path),
-            metadata={
-                "method": raw_request.method,
-                "query_hash": _sha256_hex(safe_query),
-                "query_length": len(safe_query),
-            },
-        )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("RAG privileged-action gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="rag_retrieval_unavailable",
-        ) from exc
-
-    try:
-        from core.rag.vector_rag import retrieve_context_structured
-
-        rag_ctx = await run_in_threadpool(
-            retrieve_context_structured,
-            safe_query,
-            max_chunks=5,
-            agent_id="cbt-agent",
-            user_tier="PRO",
-            subject_id=derive_subject_id_from_api_key(_api_key),
-        )
-
-        if rag_ctx.chunks:
-            # Build context string from chunks
-            context_parts = []
-            for chunk in rag_ctx.chunks:
-                sanitized_chunk = sanitize_rag_markdown(chunk.content)
-                if sanitized_chunk != chunk.content:
-                    sanitization_applied = True
-                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
-                if sanitized_content != sanitized_chunk:
-                    redaction_applied = True
-                if not sanitized_content.strip():
-                    continue
-                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
-                sources.append(
-                    CBTSourceItem(
-                        chunk_id=chunk.chunk_id,
-                        file=chunk.file,
-                        preview=sanitize_chunk_preview(sanitized_content) or "",
-                        score=chunk.score,
-                    )
-                )
-            if context_parts:
-                rag_used = True
-                confidence = rag_ctx.confidence
-                rag_context_str = "\n\n".join(context_parts)
-
-    except Exception:
-        logger.warning("RAG retrieval failed for CBT insight", exc_info=True)
-        warnings.append("rag_retrieval_failed")
-        # Continue without RAG context
-
-    if sanitization_applied:
-        warnings.append("source_content_sanitized")
-
-    if redaction_applied:
-        warnings.append("source_content_redacted")
-
-    # Build prompt with RAG context
-    transparency_notice = get_transparency_registry().get("ai_generated_insight")
-    if transparency_notice is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    prompt = _build_cbt_prompt(safe_query, rag_context_str)
-
-    # Generate insight via LLM
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="llm.generate",
-            target="provider://default",
-            mode=execution_mode,
-            endpoint=str(raw_request.url.path),
-            metadata={
-                "method": raw_request.method,
-                "prompt_hash": _sha256_hex(prompt),
-                "prompt_length": len(prompt),
-                "rag_used": rag_used,
-                "source_count": len(sources),
-            },
-        )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("LLM privileged-action gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="llm_generation_unavailable",
-        ) from exc
-    try:
-        allowed = await run_in_threadpool(
-            attempt_consume_llm_monthly_quota,
-            _api_key,
-            tier="PRO",
-        )
-        if not allowed:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="quota_exceeded"
-            )
-        quota_state = "consumed"
-
-        from llm import get_provider
-
-        provider = get_provider()
-        insight_text = await asyncio.wait_for(
-            run_in_threadpool(provider.generate, prompt),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-
-        if not insight_text:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="LLM provider returned empty response",
-            )
-
-    except ImportError:
-        logger.error("LLM provider not available")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM provider not available",
-        )
-    except asyncio.TimeoutError:
-        logger.error("LLM provider call timed out after %s seconds", LLM_TIMEOUT_SECONDS)
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail="LLM provider call timed out",
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("LLM generation failed: %s", e, exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Failed to generate CBT insight",
-        )
-
-    bounded_confidence = min(max(confidence, 0.0), 1.0)
-    return CBTInsightResponse(
-        insight=insight_text,
-        rag_used=rag_used,
-        sources=sources,
-        confidence=bounded_confidence,
-        uncertainty=round(max(0.0, 1.0 - bounded_confidence), 4),
-        warnings=warnings,
+    task = FitChefCoachInsightTaskEnvelope(
         mode=execution_mode,
-        quota_state=quota_state,
-        automated_analysis=True,
-        transparency_notice_id=str(transparency_notice["surface_id"]),
-        wellness_boundary=str(transparency_notice["boundary"]),
+        input=FitChefCoachInsightInput(
+            safe_query=safe_query,
+            api_key=_api_key,
+            endpoint=str(raw_request.url.path),
+            method=raw_request.method,
+        ),
     )
+    result = await fitchef_runtime.run_coach_insight_task(task)
+    response = CBTInsightResponse(
+        insight=result.insight,
+        rag_used=result.rag_used,
+        sources=[
+            CBTSourceItem(
+                chunk_id=item.chunk_id,
+                file=item.file,
+                preview=item.preview,
+                score=item.score,
+            )
+            for item in result.sources
+        ],
+        confidence=result.confidence,
+        uncertainty=result.uncertainty,
+        warnings=result.warnings,
+        mode=result.mode,
+        quota_state=result.quota_state,
+        automated_analysis=result.automated_analysis,
+        transparency_notice_id=result.transparency_notice_id,
+        wellness_boundary=result.wellness_boundary,
+    )
+    return response

--- a/app/schemas/fitchef.py
+++ b/app/schemas/fitchef.py
@@ -1,0 +1,62 @@
+"""Internal FitChef runtime contracts. / Внутренние контракты runtime FitChef."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+FitChefAgentId = Literal["fitchef-agent"]
+FitChefExecutionMode = Literal["auto-safe", "review-required", "blocked"]
+FitChefTaskType = Literal["coach_insight", "weekly_plan", "shopping_followup"]
+FitChefQuotaState = Literal["not_consumed", "consumed"]
+
+
+class FitChefCoachInsightInput(BaseModel):
+    """Internal coach-insight task input. / Входные данные coach-insight задачи."""
+
+    safe_query: str = Field(..., min_length=1)
+    api_key: str = Field(..., min_length=1)
+    endpoint: str = Field(..., min_length=1)
+    method: str = Field(..., min_length=1)
+
+
+class FitChefTaskEnvelope(BaseModel):
+    """Shared internal FitChef task envelope. / Общий внутренний envelope задачи FitChef."""
+
+    agent_id: FitChefAgentId = "fitchef-agent"
+    mode: FitChefExecutionMode
+    task_type: FitChefTaskType
+    tool_budget: int = Field(default=1, ge=1, le=3)
+
+
+class FitChefCoachInsightTaskEnvelope(FitChefTaskEnvelope):
+    """Coach-insight task envelope. / Envelope для задачи coach-insight."""
+
+    task_type: Literal["coach_insight"] = "coach_insight"
+    input: FitChefCoachInsightInput
+
+
+class FitChefSourceItem(BaseModel):
+    """Internal source item. / Внутренний элемент источника."""
+
+    chunk_id: str
+    file: str
+    preview: str
+    score: float
+
+
+class FitChefCoachInsightResult(BaseModel):
+    """Internal coach-insight result. / Внутренний результат coach-insight."""
+
+    insight: str
+    rag_used: bool
+    sources: list[FitChefSourceItem]
+    confidence: float
+    uncertainty: float = Field(..., ge=0.0, le=1.0)
+    warnings: list[str]
+    mode: FitChefExecutionMode
+    quota_state: FitChefQuotaState
+    automated_analysis: bool
+    transparency_notice_id: str
+    wellness_boundary: str

--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -195,6 +195,14 @@ async def run_coach_insight_task(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="transparency_registry_unavailable",
         )
+    notice_surface_id = transparency_notice.get("surface_id")
+    notice_boundary = transparency_notice.get("boundary")
+    if notice_surface_id is None or notice_boundary is None:
+        logger.error("Transparency registry entry is incomplete for ai_generated_insight")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="transparency_registry_incomplete",
+        )
     prompt = _build_cbt_prompt(safe_query, rag_context_str)
 
     try:
@@ -276,7 +284,7 @@ async def run_coach_insight_task(
         mode=task.mode,
         quota_state=quota_state,
         automated_analysis=True,
-        transparency_notice_id=str(transparency_notice["surface_id"]),
-        wellness_boundary=str(transparency_notice["boundary"]),
+        transparency_notice_id=str(notice_surface_id),
+        wellness_boundary=str(notice_boundary),
     )
     return result

--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -1,0 +1,282 @@
+"""FitChef runtime orchestration. / Оркестрация runtime FitChef."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+
+from fastapi import HTTPException, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.middleware.api_tiers import derive_subject_id_from_api_key
+from app.schemas.fitchef import (
+    FitChefCoachInsightResult,
+    FitChefCoachInsightTaskEnvelope,
+    FitChefQuotaState,
+    FitChefSourceItem,
+)
+from app.security.agent_control_plane import (
+    AUDIT_SIGNING_KEY_ENV,
+    persist_audit_envelope,
+    require_policy_allow,
+    sign_audit_envelope,
+)
+from app.security.llm_monthly_quota import attempt_consume_llm_monthly_quota
+from app.security.server_salt import require_server_salt
+from core.compliance import get_transparency_registry, sanitize_chunk_preview
+from core.data_sanitizer import sanitize_rag_markdown
+from core.pii_redaction import redact_pii_from_text
+
+logger = logging.getLogger(__name__)
+
+LLM_TIMEOUT_SECONDS: float = 60.0
+CBT_POLICY_ALLOWLIST = {
+    ("rag.retrieve", "corpus://cbt-agent"),
+    ("llm.generate", "provider://default"),
+}
+
+
+def _build_cbt_prompt(query: str, rag_context: str) -> str:
+    """Build CBT prompt. / Собрать CBT prompt."""
+
+    system_prompt = """You are a supportive wellness coach using evidence-based CBT (Cognitive Behavioral Therapy) principles. Your role is to:
+
+1. Help users identify and challenge unhelpful thought patterns
+2. Suggest practical CBT techniques (thought records, cognitive restructuring)
+3. Encourage self-compassion and gradual progress
+4. Focus on nutrition and wellness goals
+
+IMPORTANT BOUNDARIES:
+- You are NOT a therapist and cannot provide therapy or diagnose conditions
+- Avoid medical advice; suggest consulting professionals for health concerns
+- If someone expresses crisis/self-harm thoughts, encourage them to seek professional help
+- Use non-judgmental, supportive language
+
+Respond with practical, actionable suggestions based on CBT principles."""
+
+    if rag_context:
+        return f"""{system_prompt}
+
+RELEVANT CBT KNOWLEDGE:
+{rag_context}
+
+USER QUESTION:
+{query}
+
+Provide a helpful, CBT-informed response:"""
+    return f"""{system_prompt}
+
+USER QUESTION:
+{query}
+
+Provide a helpful, CBT-informed response:"""
+
+
+def _sha256_hex(value: str) -> str:
+    """Return audit-safe sha256 digest. / Вернуть audit-safe sha256 digest."""
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _persist_privileged_action_audit(
+    *,
+    action: str,
+    target: str,
+    mode: str,
+    endpoint: str,
+    metadata: dict[str, object],
+) -> None:
+    """Persist privileged audit envelope. / Сохранить audit envelope привилегированного действия."""
+
+    decision = require_policy_allow(action, target, allowlist=CBT_POLICY_ALLOWLIST)
+    audit_metadata = {
+        "endpoint": endpoint,
+        "mode": mode,
+        **metadata,
+    }
+    signing_secret = (os.getenv(AUDIT_SIGNING_KEY_ENV) or "").strip() or require_server_salt()
+    envelope = sign_audit_envelope(
+        decision,
+        metadata=audit_metadata,
+        secret=signing_secret,
+    )
+    persist_audit_envelope(envelope, metadata=audit_metadata)
+
+
+async def run_coach_insight_task(
+    task: FitChefCoachInsightTaskEnvelope,
+) -> FitChefCoachInsightResult:
+    """Run coach-insight orchestration. / Выполнить оркестрацию coach-insight."""
+
+    safe_query = task.input.safe_query
+    api_key = task.input.api_key
+    endpoint = task.input.endpoint
+    method = task.input.method
+
+    rag_context_str = ""
+    sources: list[FitChefSourceItem] = []
+    confidence = 0.0
+    rag_used = False
+    quota_state: FitChefQuotaState = "not_consumed"
+    warnings: list[str] = []
+    redaction_applied = False
+    sanitization_applied = False
+
+    try:
+        await run_in_threadpool(
+            _persist_privileged_action_audit,
+            action="rag.retrieve",
+            target="corpus://cbt-agent",
+            mode=task.mode,
+            endpoint=endpoint,
+            metadata={
+                "method": method,
+                "query_hash": _sha256_hex(safe_query),
+                "query_length": len(safe_query),
+            },
+        )
+    except (PermissionError, RuntimeError) as exc:
+        logger.error("RAG privileged-action gate failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="rag_retrieval_unavailable",
+        ) from exc
+
+    try:
+        from core.rag.vector_rag import retrieve_context_structured
+
+        rag_ctx = await run_in_threadpool(
+            retrieve_context_structured,
+            safe_query,
+            max_chunks=5,
+            agent_id="cbt-agent",
+            user_tier="PRO",
+            subject_id=derive_subject_id_from_api_key(api_key),
+        )
+
+        if rag_ctx.chunks:
+            context_parts = []
+            for chunk in rag_ctx.chunks:
+                sanitized_chunk = sanitize_rag_markdown(chunk.content)
+                if sanitized_chunk != chunk.content:
+                    sanitization_applied = True
+                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
+                if sanitized_content != sanitized_chunk:
+                    redaction_applied = True
+                if not sanitized_content.strip():
+                    continue
+                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
+                sources.append(
+                    FitChefSourceItem(
+                        chunk_id=chunk.chunk_id,
+                        file=chunk.file,
+                        preview=sanitize_chunk_preview(sanitized_content) or "",
+                        score=chunk.score,
+                    )
+                )
+            if context_parts:
+                rag_used = True
+                confidence = rag_ctx.confidence
+                rag_context_str = "\n\n".join(context_parts)
+    except Exception:
+        logger.warning("RAG retrieval failed for CBT insight", exc_info=True)
+        warnings.append("rag_retrieval_failed")
+
+    if sanitization_applied:
+        warnings.append("source_content_sanitized")
+    if redaction_applied:
+        warnings.append("source_content_redacted")
+
+    transparency_notice = get_transparency_registry().get("ai_generated_insight")
+    if transparency_notice is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="transparency_registry_unavailable",
+        )
+    prompt = _build_cbt_prompt(safe_query, rag_context_str)
+
+    try:
+        await run_in_threadpool(
+            _persist_privileged_action_audit,
+            action="llm.generate",
+            target="provider://default",
+            mode=task.mode,
+            endpoint=endpoint,
+            metadata={
+                "method": method,
+                "prompt_hash": _sha256_hex(prompt),
+                "prompt_length": len(prompt),
+                "rag_used": rag_used,
+                "source_count": len(sources),
+            },
+        )
+    except (PermissionError, RuntimeError) as exc:
+        logger.error("LLM privileged-action gate failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="llm_generation_unavailable",
+        ) from exc
+
+    try:
+        allowed = await run_in_threadpool(
+            attempt_consume_llm_monthly_quota,
+            api_key,
+            tier="PRO",
+        )
+        if not allowed:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="quota_exceeded",
+            )
+        quota_state = "consumed"
+
+        from llm import get_provider
+
+        provider = get_provider()
+        insight_text = await asyncio.wait_for(
+            run_in_threadpool(provider.generate, prompt),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
+        if not insight_text:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="LLM provider returned empty response",
+            )
+    except ImportError:
+        logger.error("LLM provider not available")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LLM provider not available",
+        )
+    except asyncio.TimeoutError:
+        logger.error("LLM provider call timed out after %s seconds", LLM_TIMEOUT_SECONDS)
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="LLM provider call timed out",
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("LLM generation failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Failed to generate CBT insight",
+        ) from exc
+
+    bounded_confidence = min(max(confidence, 0.0), 1.0)
+    result = FitChefCoachInsightResult(
+        insight=insight_text,
+        rag_used=rag_used,
+        sources=sources,
+        confidence=bounded_confidence,
+        uncertainty=round(max(0.0, 1.0 - bounded_confidence), 4),
+        warnings=warnings,
+        mode=task.mode,
+        quota_state=quota_state,
+        automated_analysis=True,
+        transparency_notice_id=str(transparency_notice["surface_id"]),
+        wellness_boundary=str(transparency_notice["boundary"]),
+    )
+    return result

--- a/docs/review/PR_1055_FIXED_MAPPING.md
+++ b/docs/review/PR_1055_FIXED_MAPPING.md
@@ -5,7 +5,13 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1055#pullrequestreview-3915833522 -> ffaded3d
+Disposition: FIXED
+Commit: ffaded3d
+Evidence: app/services/fitchef_runtime.py:198
+Evidence: app/services/fitchef_runtime.py:200
+Evidence: tests/test_cbt_insight_api.py:964
+Evidence: tests/test_cbt_insight_api.py:1000
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1055_FIXED_MAPPING.md
+++ b/docs/review/PR_1055_FIXED_MAPPING.md
@@ -5,6 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1055_FIXED_MAPPING.md
+++ b/docs/review/PR_1055_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1055 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+No resolved review threads yet. Add each actionable thread here with `FIXED`, `NOT-A-BUG`, or `DEFERRED` disposition evidence before resolving it on GitHub.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1055_FIXED_MAPPING.md
+++ b/docs/review/PR_1055_FIXED_MAPPING.md
@@ -5,7 +5,6 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-No resolved review threads yet. Add each actionable thread here with `FIXED`, `NOT-A-BUG`, or `DEFERRED` disposition evidence before resolving it on GitHub.
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -961,6 +961,42 @@ class TestCBTInsightLLMIntegration:
         assert _json_body(response) == {"detail": "transparency_registry_unavailable"}
         assert quota_calls == []
 
+    def test_incomplete_transparency_registry_returns_503_without_consuming_quota(self) -> None:
+        """Incomplete transparency metadata must fail closed before quota use."""
+        quota_calls: list[str] = []
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+        self.monkeypatch.setattr(
+            "app.services.fitchef_runtime.get_transparency_registry",
+            lambda: {"ai_generated_insight": {"surface_id": "ai_generated_insight"}},
+        )
+        self.monkeypatch.setattr(
+            "llm.get_provider",
+            lambda: pytest.fail("llm.get_provider called in registry-failure test"),
+        )
+
+        def _track_quota(*args: object, **kwargs: object) -> bool:
+            quota_calls.append("called")
+            return True
+
+        self.monkeypatch.setattr(
+            "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
+            _track_quota,
+        )
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Need advice"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 503
+        assert _json_body(response) == {"detail": "transparency_registry_incomplete"}
+        assert quota_calls == []
+
     def test_llm_timeout_returns_504(self) -> None:
         """When LLM call times out, endpoint returns 504."""
         import asyncio
@@ -980,12 +1016,9 @@ class TestCBTInsightLLMIntegration:
         )
 
         mock_provider = MagicMock()
-        # Simulate slow LLM that takes longer than timeout
-        import time
 
         def slow_generate(*args: object, **kwargs: object) -> str:
-            time.sleep(0.1)  # 100ms - longer than 1ms timeout
-            return "Response"
+            raise asyncio.TimeoutError
 
         mock_provider.generate.side_effect = slow_generate
         self.monkeypatch.setattr(

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -17,10 +17,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
-from app.middleware.api_tiers import TEST_KEY_PRO
-from app.security.llm_monthly_quota import llm_key_fingerprint, month_start_date_utc
-
 from app.middleware.api_tiers import TEST_KEY_PRO, derive_subject_id_from_api_key
+from app.schemas.fitchef import FitChefCoachInsightResult, FitChefSourceItem
+from app.security.llm_monthly_quota import llm_key_fingerprint, month_start_date_utc
 
 if TYPE_CHECKING:
     from core.rag.contracts import RAGContext
@@ -361,7 +360,7 @@ class TestCBTInsightValidation:
             lambda *args, **kwargs: pytest.fail("RAG must not run for blocked input"),
         )
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight.attempt_consume_llm_monthly_quota",
+            "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
             lambda *args, **kwargs: pytest.fail("quota must not run for blocked input"),
         )
         self.monkeypatch.setattr(
@@ -554,7 +553,7 @@ class TestCBTInsightRAGIntegration:
         """Permission/runtime failures in privileged RAG gate must fail closed."""
 
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight._persist_privileged_action_audit",
+            "app.services.fitchef_runtime._persist_privileged_action_audit",
             lambda **kwargs: (_ for _ in ()).throw(PermissionError("denied")),
         )
 
@@ -902,7 +901,7 @@ class TestCBTInsightLLMIntegration:
                 raise RuntimeError("audit down")
 
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight._persist_privileged_action_audit",
+            "app.services.fitchef_runtime._persist_privileged_action_audit",
             _fail_llm_audit,
         )
 
@@ -911,7 +910,7 @@ class TestCBTInsightLLMIntegration:
             return True
 
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight.attempt_consume_llm_monthly_quota",
+            "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
             _track_quota,
         )
 
@@ -935,7 +934,7 @@ class TestCBTInsightLLMIntegration:
             lambda *args, **kwargs: _make_rag_context(),
         )
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight.get_transparency_registry",
+            "app.services.fitchef_runtime.get_transparency_registry",
             lambda: {},
         )
         self.monkeypatch.setattr(
@@ -948,7 +947,7 @@ class TestCBTInsightLLMIntegration:
             return True
 
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight.attempt_consume_llm_monthly_quota",
+            "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
             _track_quota,
         )
 
@@ -976,7 +975,7 @@ class TestCBTInsightLLMIntegration:
 
         # Set a very short timeout for testing
         self.monkeypatch.setattr(
-            "app.routers.cbt_insight.LLM_TIMEOUT_SECONDS",
+            "app.services.fitchef_runtime.LLM_TIMEOUT_SECONDS",
             0.001,  # 1ms timeout
         )
 
@@ -1000,3 +999,61 @@ class TestCBTInsightLLMIntegration:
         assert response.status_code == 504
         data = _json_body(response)
         assert "timed out" in data["detail"].lower()
+
+
+class TestCBTInsightRouteDelegation:
+    """Tests for thin route delegation into FitChef runtime."""
+
+    def test_route_delegates_to_fitchef_runtime(
+        self,
+        client: TestClient,
+        pro_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The route should build the internal envelope and delegate once."""
+
+        monkeypatch.setenv("FEATURE_CBT_AGENT", "true")
+        captured: dict[str, object] = {}
+
+        async def _fake_run(task: object) -> FitChefCoachInsightResult:
+            captured["task"] = task
+            return FitChefCoachInsightResult(
+                insight="Delegated response",
+                rag_used=False,
+                sources=[
+                    FitChefSourceItem(
+                        chunk_id="chunk-1",
+                        file="docs/cbt/test.md",
+                        preview="Preview",
+                        score=0.9,
+                    )
+                ],
+                confidence=0.25,
+                uncertainty=0.75,
+                warnings=["delegated"],
+                mode="auto-safe",
+                quota_state="consumed",
+                automated_analysis=True,
+                transparency_notice_id="ai_generated_insight",
+                wellness_boundary="Wellness coaching only.",
+            )
+
+        monkeypatch.setattr(
+            "app.routers.cbt_insight.fitchef_runtime.run_coach_insight_task",
+            _fake_run,
+        )
+
+        response = client.post(
+            "/api/v1/pro/cbt/insight",
+            json={"query": "Need support"},
+            headers=pro_headers,
+        )
+
+        assert response.status_code == 200
+        data = _json_body(response)
+        assert data["insight"] == "Delegated response"
+        task = captured["task"]
+        assert getattr(task, "agent_id") == "fitchef-agent"
+        assert getattr(task, "task_type") == "coach_insight"
+        assert getattr(task, "tool_budget") == 1
+        assert getattr(task, "input").safe_query == "Need support"


### PR DESCRIPTION
## Summary
- add internal `FitChef` Phase 1 runtime contracts for bounded backend orchestration
- move CBT insight orchestration from the route layer into `app/services/fitchef_runtime.py`
- keep the public `/api/v1/pro/cbt/insight` contract unchanged while delegating through the wrapper

## Scope
- internal schemas in `app/schemas/fitchef.py`
- internal coach-insight wrapper in `app/services/fitchef_runtime.py`
- thin route delegation in `app/routers/cbt_insight.py`
- regression and delegation coverage in `tests/test_cbt_insight_api.py`

## Non-goals
- no new public endpoint
- no weekly-plan binding in this PR
- no shopping-followup binding in this PR
- no exports, realtime progress, or broader multi-tool autonomy

## Backlog Anchor
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-phase1-wrapper`
- Phase 2 remains deferred under `docs/orchestration/FITCHEF_SANDBOX_PHASE2_CONTRACT.md`

## Validation
```bash
python -m py_compile app/routers/cbt_insight.py app/services/fitchef_runtime.py app/schemas/fitchef.py tests/test_cbt_insight_api.py
. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/activate && pytest -q tests/test_cbt_insight_api.py
pre-commit run --all-files
make verify
```

## Security Notes
- preserves existing execution-mode fail-closed gating on the public route
- preserves the current privileged audit, quota, RAG, and provider timeout ordering behind the wrapper
- introduces no new public API surface

## Marketing & GTM
- internal backend orchestration only; no new user-facing capability claims
- FitChef Phase 2 features remain planned-only and out of scope here

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1055_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1055#pullrequestreview-3915833522 -> ffaded3d
Disposition: FIXED
Commit: ffaded3d
Evidence: app/services/fitchef_runtime.py:198
Evidence: app/services/fitchef_runtime.py:200
Evidence: tests/test_cbt_insight_api.py:964
Evidence: tests/test_cbt_insight_api.py:1000

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed
