### PR TITLE
feat(fitchef): bind weekly-plan task through fitchef runtime

### DIFF
--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Literal,
     Mapping,
     Optional,
     Type,
@@ -24,7 +23,9 @@ from fastapi import (  # pyright: ignore[reportMissingImports]
 )
 from fastapi.security import APIKeyHeader  # pyright: ignore[reportMissingImports]
 
+from app.schemas.fitchef import FitChefWeeklyPlanInput, FitChefWeeklyPlanTaskEnvelope
 from app.schemas.vip import ErrorResponse, WeeklyPlanRequest, WeeklyPlanResponse
+from app.services import fitchef_runtime
 from core.utils import resolve_attr
 from app.dependencies import get_recipe_synthesizer as get_recipe_synth_dep
 from core.recipe_synth import RecipeSynthesizer
@@ -46,7 +47,7 @@ EN: Router for VIP functions - micronutrient goals, auto-repair menu, shopping l
 """
 
 # Test key constant for development mode only
-TEST_KEY = "test_key"  # nosec B105  # Development mode only
+TEST_KEY = "test_key"  # nosec B105: development-only test fixture constant (remove-by: 2026-06-30, ref: PR-1056)
 
 # VIP feature flag: enable/disable VIP module via env or default True
 VIP_MODULE_ENABLED = is_vip_module_enabled()
@@ -405,61 +406,8 @@ def _extract_api_key(request: Request) -> Optional[str]:
 
 def _create_user_profile_from_dict(profile_data: Dict[str, Any]) -> "UserProfile":
     """Create UserProfile from dictionary data with validation."""
-    from core.targets import UserProfile
-
-    # Use default values for missing fields instead of validation
-    # Convert diet_flags to set if it's a list
-    diet_flags = profile_data.get("diet_flags", [])
-    if isinstance(diet_flags, list):
-        diet_flags = set(diet_flags)
-
-    # Convert medical_conditions to set if it's a list
-    medical_conditions = profile_data.get("medical_conditions", [])
-    if isinstance(medical_conditions, list):
-        medical_conditions = set(medical_conditions)
-
-    # Use explicit conversions with safe fallbacks so typing is precise
-    age_raw = profile_data.get("age")
-    try:
-        age_val: int = 30 if age_raw is None else int(age_raw)
-    except (TypeError, ValueError):
-        age_val = 30
-
-    height_raw = profile_data.get("height_cm")
-    try:
-        height_val: float = 175.0 if height_raw is None else float(height_raw)
-    except (TypeError, ValueError):
-        height_val = 175.0
-
-    weight_raw = profile_data.get("weight_kg")
-    try:
-        weight_val: float = 70.0 if weight_raw is None else float(weight_raw)
-    except (TypeError, ValueError):
-        weight_val = 70.0
-
-    # Use explicit None checks so that missing/None values fall back to defaults
-    return UserProfile(
-        sex=cast(Literal["male", "female"], profile_data.get("sex") or "male"),
-        age=age_val,
-        height_cm=height_val,
-        weight_kg=weight_val,
-        activity=cast(
-            Literal["sedentary", "light", "moderate", "active", "very_active"],
-            profile_data.get("activity") or "moderate",
-        ),
-        goal=cast(Literal["loss", "maintain", "gain"], profile_data.get("goal") or "maintain"),
-        deficit_pct=profile_data.get("deficit_pct"),
-        surplus_pct=profile_data.get("surplus_pct"),
-        bodyfat=profile_data.get("bodyfat"),
-        region=profile_data.get("region") or "BY",
-        timezone=profile_data.get("timezone") or "UTC",
-        diet_flags=diet_flags,
-        life_stage=cast(
-            Literal["child", "teen", "adult", "pregnant", "lactating", "elderly"],
-            profile_data.get("life_stage") or "adult",
-        ),
-        medical_conditions=medical_conditions,
-    )
+    profile = fitchef_runtime._build_weekly_user_profile(profile_data)
+    return cast("UserProfile", profile)
 
 
 def _adapter_make_weekly_menu(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
@@ -568,7 +516,7 @@ def vip_health() -> Dict[str, Any]:
 
 
 @router.post("/menu/weekly/plan", dependencies=[Depends(require_vip_tier)])
-def weekly_menu_plan(
+async def weekly_menu_plan(
     payload: Dict[str, Any] = Body(...),
 ) -> Dict[str, Any]:
     """
@@ -605,28 +553,20 @@ def weekly_menu_plan(
             continue
         original_data[key] = value
 
-    if make_weekly_menu is None:
-        return {
-            "status": "success",
-            "echo": original_data,
-            "menu": {"mode": "echo"},
-            "message": "Weekly menu plan generated (echo mode)",
-        }
-
     try:
-        # Convert WeeklyPlanRequest to dict for the core function
-        request_dict = request_obj.model_dump()
-        plan_candidate = _safe_call_with_adapter("make_weekly_menu", **request_dict)
-
-        # Check if _safe_call_with_adapter returned an error
-        if isinstance(plan_candidate, dict) and plan_candidate.get("status") == "error":
-            return plan_candidate
-
-        plan = plan_candidate
+        task = FitChefWeeklyPlanTaskEnvelope(
+            mode="auto-safe",
+            input=FitChefWeeklyPlanInput(request_data=request_obj.model_dump()),
+        )
+        result = await fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=make_weekly_menu,
+        )
+        echo_payload = original_data if make_weekly_menu is None else request_obj.model_dump()
         return {
             "status": "success",
-            "echo": request_obj.model_dump(),
-            "menu": plan if plan is not None else {"mode": "echo"},
+            "echo": echo_payload,
+            "menu": result.menu,
             "message": "Weekly menu plan generated (echo mode)",
         }
     except Exception:

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -406,7 +406,7 @@ def _extract_api_key(request: Request) -> Optional[str]:
 
 def _create_user_profile_from_dict(profile_data: Dict[str, Any]) -> "UserProfile":
     """Create UserProfile from dictionary data with validation."""
-    profile = fitchef_runtime._build_weekly_user_profile(profile_data)
+    profile = fitchef_runtime.build_weekly_user_profile(profile_data)
     return cast("UserProfile", profile)
 
 

--- a/app/schemas/fitchef.py
+++ b/app/schemas/fitchef.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -37,6 +37,19 @@ class FitChefCoachInsightTaskEnvelope(FitChefTaskEnvelope):
     input: FitChefCoachInsightInput
 
 
+class FitChefWeeklyPlanInput(BaseModel):
+    """Internal weekly-plan input. / Входные данные weekly-plan задачи."""
+
+    request_data: dict[str, Any] = Field(default_factory=dict)
+
+
+class FitChefWeeklyPlanTaskEnvelope(FitChefTaskEnvelope):
+    """Weekly-plan task envelope. / Envelope для задачи weekly-plan."""
+
+    task_type: Literal["weekly_plan"] = "weekly_plan"
+    input: FitChefWeeklyPlanInput
+
+
 class FitChefSourceItem(BaseModel):
     """Internal source item. / Внутренний элемент источника."""
 
@@ -60,3 +73,9 @@ class FitChefCoachInsightResult(BaseModel):
     automated_analysis: bool
     transparency_notice_id: str
     wellness_boundary: str
+
+
+class FitChefWeeklyPlanResult(BaseModel):
+    """Internal weekly-plan result. / Внутренний результат weekly-plan."""
+
+    menu: dict[str, Any]

--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -6,9 +6,11 @@ import asyncio
 import hashlib
 import logging
 import os
+from typing import Any, Callable, Literal, cast
 
 from fastapi import HTTPException, status
 from fastapi.concurrency import run_in_threadpool
+from fastapi.encoders import jsonable_encoder
 
 from app.middleware.api_tiers import derive_subject_id_from_api_key
 from app.schemas.fitchef import (
@@ -16,6 +18,8 @@ from app.schemas.fitchef import (
     FitChefCoachInsightTaskEnvelope,
     FitChefQuotaState,
     FitChefSourceItem,
+    FitChefWeeklyPlanResult,
+    FitChefWeeklyPlanTaskEnvelope,
 )
 from app.security.agent_control_plane import (
     AUDIT_SIGNING_KEY_ENV,
@@ -36,6 +40,7 @@ CBT_POLICY_ALLOWLIST = {
     ("rag.retrieve", "corpus://cbt-agent"),
     ("llm.generate", "provider://default"),
 }
+WeeklyPlanBuilder = Callable[..., Any]
 
 
 def _build_cbt_prompt(query: str, rag_context: str) -> str:
@@ -78,6 +83,78 @@ def _sha256_hex(value: str) -> str:
     """Return audit-safe sha256 digest. / Вернуть audit-safe sha256 digest."""
 
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _build_weekly_user_profile(profile_data: dict[str, Any]) -> Any:
+    """Create UserProfile with legacy-safe defaults. / Собрать UserProfile с совместимыми fallback."""
+
+    from core.targets import UserProfile
+
+    diet_flags = profile_data.get("diet_flags", [])
+    if isinstance(diet_flags, list):
+        diet_flags = set(diet_flags)
+
+    medical_conditions = profile_data.get("medical_conditions", [])
+    if isinstance(medical_conditions, list):
+        medical_conditions = set(medical_conditions)
+
+    age_raw = profile_data.get("age")
+    try:
+        age_val: int = 30 if age_raw is None else int(age_raw)
+    except (TypeError, ValueError):
+        age_val = 30
+
+    height_raw = profile_data.get("height_cm")
+    try:
+        height_val: float = 175.0 if height_raw is None else float(height_raw)
+    except (TypeError, ValueError):
+        height_val = 175.0
+
+    weight_raw = profile_data.get("weight_kg")
+    try:
+        weight_val: float = 70.0 if weight_raw is None else float(weight_raw)
+    except (TypeError, ValueError):
+        weight_val = 70.0
+
+    profile = UserProfile(
+        sex=cast(Literal["male", "female"], profile_data.get("sex") or "male"),
+        age=age_val,
+        height_cm=height_val,
+        weight_kg=weight_val,
+        activity=cast(
+            Literal["sedentary", "light", "moderate", "active", "very_active"],
+            profile_data.get("activity") or "moderate",
+        ),
+        goal=cast(Literal["loss", "maintain", "gain"], profile_data.get("goal") or "maintain"),
+        deficit_pct=profile_data.get("deficit_pct"),
+        surplus_pct=profile_data.get("surplus_pct"),
+        bodyfat=profile_data.get("bodyfat"),
+        region=profile_data.get("region") or "BY",
+        timezone=profile_data.get("timezone") or "UTC",
+        diet_flags=diet_flags,
+        life_stage=cast(
+            Literal["child", "teen", "adult", "pregnant", "lactating", "elderly"],
+            profile_data.get("life_stage") or "adult",
+        ),
+        medical_conditions=medical_conditions,
+    )
+    return profile
+
+
+def _run_weekly_menu_builder(
+    profile_data: dict[str, Any],
+    menu_builder: WeeklyPlanBuilder,
+) -> dict[str, Any]:
+    """Run weekly menu builder and serialize result. / Выполнить weekly builder и сериализовать результат."""
+
+    profile = _build_weekly_user_profile(profile_data)
+    menu = menu_builder(profile)
+    if menu is None:
+        return {"mode": "echo"}
+    encoded_menu = jsonable_encoder(menu)
+    if isinstance(encoded_menu, dict):
+        return encoded_menu
+    return {"mode": "echo"}
 
 
 def _persist_privileged_action_audit(
@@ -287,4 +364,24 @@ async def run_coach_insight_task(
         transparency_notice_id=str(notice_surface_id),
         wellness_boundary=str(notice_boundary),
     )
+    return result
+
+
+async def run_weekly_plan_task(
+    task: FitChefWeeklyPlanTaskEnvelope,
+    *,
+    menu_builder: WeeklyPlanBuilder | None,
+) -> FitChefWeeklyPlanResult:
+    """Run weekly-plan orchestration. / Выполнить оркестрацию weekly-plan."""
+
+    if menu_builder is None:
+        result = FitChefWeeklyPlanResult(menu={"mode": "echo"})
+        return result
+
+    menu_payload = await run_in_threadpool(
+        _run_weekly_menu_builder,
+        task.input.request_data,
+        menu_builder,
+    )
+    result = FitChefWeeklyPlanResult(menu=menu_payload)
     return result

--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -116,8 +116,13 @@ def _build_weekly_user_profile(profile_data: dict[str, Any]) -> Any:
     except (TypeError, ValueError):
         weight_val = 70.0
 
+    sex_raw = profile_data.get("sex")
+    sex_value: Literal["male", "female"] = "male"
+    if sex_raw in {"male", "female"}:
+        sex_value = cast(Literal["male", "female"], sex_raw)
+
     profile = UserProfile(
-        sex=cast(Literal["male", "female"], profile_data.get("sex") or "male"),
+        sex=sex_value,
         age=age_val,
         height_cm=height_val,
         weight_kg=weight_val,
@@ -141,13 +146,20 @@ def _build_weekly_user_profile(profile_data: dict[str, Any]) -> Any:
     return profile
 
 
+def build_weekly_user_profile(profile_data: dict[str, Any]) -> Any:
+    """Public profile helper for weekly runtime. / Публичный helper профиля для weekly runtime."""
+
+    profile = _build_weekly_user_profile(profile_data)
+    return profile
+
+
 def _run_weekly_menu_builder(
     profile_data: dict[str, Any],
     menu_builder: WeeklyPlanBuilder,
 ) -> dict[str, Any]:
     """Run weekly menu builder and serialize result. / Выполнить weekly builder и сериализовать результат."""
 
-    profile = _build_weekly_user_profile(profile_data)
+    profile = build_weekly_user_profile(profile_data)
     menu = menu_builder(profile)
     if menu is None:
         return {"mode": "echo"}

--- a/docs/review/PR_1057_FIXED_MAPPING.md
+++ b/docs/review/PR_1057_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No review threads resolved yet; mapping will be updated after the first actionable review cycle.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1057_FIXED_MAPPING.md
+++ b/docs/review/PR_1057_FIXED_MAPPING.md
@@ -5,7 +5,37 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916383991 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: app/services/fitchef_runtime.py:149
+Evidence: app/routers/vip.py:409
+Evidence: tests/helpers/fitchef_runtime_helpers.py:9
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:115
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916392098 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: app/services/fitchef_runtime.py:119
+Evidence: app/services/fitchef_runtime.py:125
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:77
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:177
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916429319 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: tests/test_vip_api.py:79
+Evidence: tests/test_vip_guard_order_403_vs_422.py:98
+Evidence: tests/helpers/fitchef_runtime_helpers.py:9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906346185 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: tests/test_vip_api.py:79
+Evidence: tests/test_vip_api.py:81
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906346192 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: tests/test_vip_guard_order_403_vs_422.py:98
+Evidence: tests/test_vip_guard_order_403_vs_422.py:112
+Evidence: tests/helpers/fitchef_runtime_helpers.py:16
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1057_FIXED_MAPPING.md
+++ b/docs/review/PR_1057_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1057 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No review threads resolved yet; mapping will be updated after the first actionable review cycle.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1057_FIXED_MAPPING.md
+++ b/docs/review/PR_1057_FIXED_MAPPING.md
@@ -12,6 +12,21 @@ Evidence: app/services/fitchef_runtime.py:149
 Evidence: app/routers/vip.py:409
 Evidence: tests/helpers/fitchef_runtime_helpers.py:9
 Evidence: tests/test_fitchef_runtime_weekly_plan.py:115
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302959 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: app/services/fitchef_runtime.py:149
+Evidence: app/routers/vip.py:409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302968 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:115
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:147
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302970 -> 003d5d8b
+Disposition: FIXED
+Commit: 003d5d8b
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:177
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:195
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916392098 -> 003d5d8b
 Disposition: FIXED
 Commit: 003d5d8b

--- a/docs/review/PR_1057_FIXED_MAPPING.md
+++ b/docs/review/PR_1057_FIXED_MAPPING.md
@@ -51,6 +51,11 @@ Commit: 003d5d8b
 Evidence: tests/test_vip_guard_order_403_vs_422.py:98
 Evidence: tests/test_vip_guard_order_403_vs_422.py:112
 Evidence: tests/helpers/fitchef_runtime_helpers.py:16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916576683 -> e8211fc9
+Disposition: FIXED
+Commit: e8211fc9
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:190
+Evidence: tests/test_fitchef_runtime_weekly_plan.py:198
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/tests/helpers/fitchef_runtime_helpers.py
+++ b/tests/helpers/fitchef_runtime_helpers.py
@@ -1,0 +1,23 @@
+"""FitChef runtime test helpers. / Вспомогательные helpers для тестов FitChef runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def make_mock_run_weekly_plan_task(
+    *,
+    menu: dict[str, Any] | None = None,
+    capture: dict[str, Any] | None = None,
+) -> Callable[..., Any]:
+    """Build async weekly runtime mock. / Собрать async mock для weekly runtime."""
+
+    async def _mock_run_weekly_plan_task(task, *, menu_builder):
+        if capture is not None:
+            capture["task_type"] = task.task_type
+            capture["menu_builder"] = menu_builder
+        payload = {"days": []} if menu is None else menu
+        return type("WeeklyPlanResult", (), {"menu": payload})()
+
+    return _mock_run_weekly_plan_task

--- a/tests/test_fitchef_runtime_weekly_plan.py
+++ b/tests/test_fitchef_runtime_weekly_plan.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from app.schemas.fitchef import FitChefWeeklyPlanInput, FitChefWeeklyPlanTaskEnvelope
 from app.services import fitchef_runtime
 
@@ -185,14 +187,12 @@ def test_run_weekly_plan_task_propagates_builder_exceptions() -> None:
     def failing_menu_builder(profile):
         raise RuntimeError("weekly builder exploded")
 
-    try:
+    with pytest.raises(RuntimeError, match="weekly builder exploded") as exc_info:
         asyncio.run(
             fitchef_runtime.run_weekly_plan_task(
                 task,
                 menu_builder=failing_menu_builder,
             )
         )
-    except RuntimeError as exc:
-        assert str(exc) == "weekly builder exploded"
-    else:
-        raise AssertionError("Expected RuntimeError from menu_builder to propagate")
+
+    assert str(exc_info.value) == "weekly builder exploded"

--- a/tests/test_fitchef_runtime_weekly_plan.py
+++ b/tests/test_fitchef_runtime_weekly_plan.py
@@ -1,0 +1,136 @@
+"""FitChef weekly-plan runtime tests. / Тесты weekly-plan runtime FitChef."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from app.schemas.fitchef import FitChefWeeklyPlanInput, FitChefWeeklyPlanTaskEnvelope
+from app.services import fitchef_runtime
+
+
+def test_run_weekly_plan_task_returns_echo_when_builder_missing() -> None:
+    """Missing builder falls back to echo mode. / Отсутствующий builder даёт echo mode."""
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(request_data={"calories": 2000}),
+    )
+
+    result = asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=None,
+        )
+    )
+
+    assert result.menu == {"mode": "echo"}
+
+
+def test_run_weekly_plan_task_serializes_menu_and_builds_profile_defaults() -> None:
+    """Weekly runtime serializes output and preserves profile defaults. / Runtime сериализует меню и хранит fallback."""
+
+    captured: dict[str, object] = {}
+
+    def fake_menu_builder(profile):
+        captured["profile"] = profile
+        return SimpleNamespace(
+            week_start="2026-03-09",
+            daily_menus=[],
+            weekly_coverage={"protein": 1.0},
+            shopping_list=[],
+            total_cost=42.0,
+            adherence_score=0.85,
+        )
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(
+            request_data={
+                "sex": "female",
+                "age": 29,
+                "height_cm": 168.0,
+                "weight_kg": 58.0,
+                "activity": "active",
+                "goal": "maintain",
+                "diet_flags": ["VEG"],
+                "medical_conditions": ["iron_deficiency"],
+            }
+        ),
+    )
+
+    result = asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=fake_menu_builder,
+        )
+    )
+
+    profile = captured["profile"]
+    assert getattr(profile, "sex") == "female"
+    assert getattr(profile, "diet_flags") == {"VEG"}
+    assert getattr(profile, "medical_conditions") == {"iron_deficiency"}
+    assert result.menu["week_start"] == "2026-03-09"
+    assert result.menu["weekly_coverage"] == {"protein": 1.0}
+
+
+def test_run_weekly_plan_task_uses_safe_numeric_fallbacks() -> None:
+    """Invalid numeric input falls back safely. / Неверные numeric поля переходят на safe fallback."""
+
+    captured: dict[str, object] = {}
+
+    def fake_menu_builder(profile):
+        captured["profile"] = profile
+        return {"days": []}
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(
+            request_data={
+                "sex": "male",
+                "age": "bad-age",
+                "height_cm": "bad-height",
+                "weight_kg": "bad-weight",
+                "activity": "moderate",
+                "goal": "maintain",
+            }
+        ),
+    )
+
+    result = asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=fake_menu_builder,
+        )
+    )
+
+    profile = captured["profile"]
+    assert getattr(profile, "age") == 30
+    assert getattr(profile, "height_cm") == 175.0
+    assert getattr(profile, "weight_kg") == 70.0
+    assert result.menu == {"days": []}
+
+
+def test_run_weekly_plan_task_falls_back_when_builder_returns_none_or_non_dict() -> None:
+    """Weekly runtime falls back to echo mode. / Weekly runtime откатывается в echo mode."""
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(request_data={"calories": 1800}),
+    )
+
+    none_result = asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=lambda profile: None,
+        )
+    )
+    list_result = asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=lambda profile: ["not", "a", "dict"],
+        )
+    )
+
+    assert none_result.menu == {"mode": "echo"}
+    assert list_result.menu == {"mode": "echo"}

--- a/tests/test_fitchef_runtime_weekly_plan.py
+++ b/tests/test_fitchef_runtime_weekly_plan.py
@@ -108,7 +108,45 @@ def test_run_weekly_plan_task_uses_safe_numeric_fallbacks() -> None:
     assert getattr(profile, "age") == 30
     assert getattr(profile, "height_cm") == 175.0
     assert getattr(profile, "weight_kg") == 70.0
+    assert getattr(profile, "sex") == "male"
     assert result.menu == {"days": []}
+
+
+def test_run_weekly_plan_task_preserves_set_inputs() -> None:
+    """Set inputs stay intact. / Set-входы сохраняются без лишней нормализации."""
+
+    captured: dict[str, object] = {}
+
+    def fake_menu_builder(profile):
+        captured["profile"] = profile
+        return {"days": []}
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(
+            request_data={
+                "sex": "female",
+                "age": 30,
+                "height_cm": 170.0,
+                "weight_kg": 60.0,
+                "activity": "light",
+                "goal": "maintain",
+                "diet_flags": {"VEG"},
+                "medical_conditions": {"iron_deficiency"},
+            }
+        ),
+    )
+
+    asyncio.run(
+        fitchef_runtime.run_weekly_plan_task(
+            task,
+            menu_builder=fake_menu_builder,
+        )
+    )
+
+    profile = captured["profile"]
+    assert getattr(profile, "diet_flags") == {"VEG"}
+    assert getattr(profile, "medical_conditions") == {"iron_deficiency"}
 
 
 def test_run_weekly_plan_task_falls_back_when_builder_returns_none_or_non_dict() -> None:
@@ -134,3 +172,27 @@ def test_run_weekly_plan_task_falls_back_when_builder_returns_none_or_non_dict()
 
     assert none_result.menu == {"mode": "echo"}
     assert list_result.menu == {"mode": "echo"}
+
+
+def test_run_weekly_plan_task_propagates_builder_exceptions() -> None:
+    """Builder exceptions propagate. / Исключения builder проходят наружу как есть."""
+
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(request_data={"calories": 1800}),
+    )
+
+    def failing_menu_builder(profile):
+        raise RuntimeError("weekly builder exploded")
+
+    try:
+        asyncio.run(
+            fitchef_runtime.run_weekly_plan_task(
+                task,
+                menu_builder=failing_menu_builder,
+            )
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "weekly builder exploded"
+    else:
+        raise AssertionError("Expected RuntimeError from menu_builder to propagate")

--- a/tests/test_vip_api.py
+++ b/tests/test_vip_api.py
@@ -70,8 +70,13 @@ def test_deprecated_weekly_plan_handles_dict_plan(
     assert data["data"]["daily_menus"] == []
 
 
-def test_vip_weekly_plan_echo(client: TestClient, vip_headers: dict[str, str]) -> None:
+def test_vip_weekly_plan_echo(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    vip_headers: dict[str, str],
+) -> None:
     """Test VIP weekly plan endpoint returns echo structure"""
+    monkeypatch.setattr("app.routers.vip.make_weekly_menu", None)
     payload = {
         "sex": "male",
         "age": 30,

--- a/tests/test_vip_api.py
+++ b/tests/test_vip_api.py
@@ -76,7 +76,9 @@ def test_vip_weekly_plan_echo(
     vip_headers: dict[str, str],
 ) -> None:
     """Test VIP weekly plan endpoint returns echo structure"""
-    monkeypatch.setattr("app.routers.vip.make_weekly_menu", None)
+    import app.routers.vip as vip
+
+    monkeypatch.setattr(vip, "make_weekly_menu", None)
     payload = {
         "sex": "male",
         "age": 30,

--- a/tests/test_vip_guard_consistency.py
+++ b/tests/test_vip_guard_consistency.py
@@ -176,17 +176,16 @@ def test_vip_guard_post_allows_vip_and_returns_2xx(
     """
     # Mock internal calls for endpoints that require them
     if path == "/api/v1/vip/menu/weekly/plan":
-        # Conditional mock: only return success for expected function name
-        def mock_safe_call(func_name: str, **kwargs: Any) -> dict[str, Any]:
-            if func_name == "make_weekly_menu":
-                return {"status": "success", "menu": {"days": []}}
-            return {
-                "status": "error",
-                "code": "unexpected_call",
-                "message": "unexpected adapter call",
-            }
 
-        monkeypatch.setattr("app.routers.vip._safe_call_with_adapter", mock_safe_call)
+        async def mock_run_weekly_plan_task(task, *, menu_builder):
+            assert task.task_type == "weekly_plan"
+            assert menu_builder is not None
+            return type("WeeklyPlanResult", (), {"menu": {"days": []}})()
+
+        monkeypatch.setattr(
+            "app.services.fitchef_runtime.run_weekly_plan_task",
+            mock_run_weekly_plan_task,
+        )
     elif path == "/api/v1/vip/shoplist/weekly":
         # Mock all three functions in the chain
         monkeypatch.setattr("app.routers.vip.aggregate_ingredients", lambda req: [])

--- a/tests/test_vip_guard_consistency.py
+++ b/tests/test_vip_guard_consistency.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.middleware.api_tiers import TEST_KEY_PRO, TEST_KEY_VIP
+from tests.helpers.fitchef_runtime_helpers import make_mock_run_weekly_plan_task
 
 
 @pytest.fixture
@@ -176,15 +177,9 @@ def test_vip_guard_post_allows_vip_and_returns_2xx(
     """
     # Mock internal calls for endpoints that require them
     if path == "/api/v1/vip/menu/weekly/plan":
-
-        async def mock_run_weekly_plan_task(task, *, menu_builder):
-            assert task.task_type == "weekly_plan"
-            assert menu_builder is not None
-            return type("WeeklyPlanResult", (), {"menu": {"days": []}})()
-
         monkeypatch.setattr(
             "app.services.fitchef_runtime.run_weekly_plan_task",
-            mock_run_weekly_plan_task,
+            make_mock_run_weekly_plan_task(),
         )
     elif path == "/api/v1/vip/shoplist/weekly":
         # Mock all three functions in the chain

--- a/tests/test_vip_guard_order_403_vs_422.py
+++ b/tests/test_vip_guard_order_403_vs_422.py
@@ -94,10 +94,14 @@ def test_vip_guard_200_with_valid_tier_and_payload(
         "goal": "maintain",
     }
 
-    # Mock internal call
+    async def mock_run_weekly_plan_task(task, *, menu_builder):
+        assert task.task_type == "weekly_plan"
+        assert menu_builder is not None
+        return type("WeeklyPlanResult", (), {"menu": {"days": []}})()
+
     monkeypatch.setattr(
-        "app.routers.vip._safe_call_with_adapter",
-        lambda func_name, **kwargs: {"status": "success", "menu": {"days": []}},
+        "app.services.fitchef_runtime.run_weekly_plan_task",
+        mock_run_weekly_plan_task,
     )
 
     # With valid VIP key

--- a/tests/test_vip_guard_order_403_vs_422.py
+++ b/tests/test_vip_guard_order_403_vs_422.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.middleware.api_tiers import TEST_KEY_PRO, TEST_KEY_VIP
+from tests.helpers.fitchef_runtime_helpers import make_mock_run_weekly_plan_task
 
 
 def test_vip_guard_403_before_422_no_key(client: TestClient) -> None:
@@ -94,14 +95,11 @@ def test_vip_guard_200_with_valid_tier_and_payload(
         "goal": "maintain",
     }
 
-    async def mock_run_weekly_plan_task(task, *, menu_builder):
-        assert task.task_type == "weekly_plan"
-        assert menu_builder is not None
-        return type("WeeklyPlanResult", (), {"menu": {"days": []}})()
+    captured: dict[str, object] = {}
 
     monkeypatch.setattr(
         "app.services.fitchef_runtime.run_weekly_plan_task",
-        mock_run_weekly_plan_task,
+        make_mock_run_weekly_plan_task(capture=captured),
     )
 
     # With valid VIP key
@@ -111,3 +109,5 @@ def test_vip_guard_200_with_valid_tier_and_payload(
         headers={"X-API-Key": TEST_KEY_VIP},
     )
     assert response.status_code == 200, "With valid VIP key and payload, should return 200"
+    assert captured["task_type"] == "weekly_plan"
+    assert captured["menu_builder"] is not None


### PR DESCRIPTION
## Summary
- extend internal `FitChef` Phase 1 runtime contracts with `weekly_plan`
- move canonical VIP weekly-plan orchestration behind `app/services/fitchef_runtime.py`
- keep the public `/api/v1/vip/menu/weekly/plan` contract unchanged while delegating through the wrapper

## Scope
- internal weekly-plan schemas in `app/schemas/fitchef.py`
- internal weekly-plan runtime in `app/services/fitchef_runtime.py`
- thin route delegation in `app/routers/vip.py`
- regression and delegation coverage in weekly-plan tests

## Non-goals
- no new public endpoint
- no shopping-followup binding in this PR
- no exports, realtime progress, or broader multi-tool autonomy
- no changes to deprecated alias semantics beyond keeping compatibility intact

## Backlog Anchor
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-weekly-plan-binding`
- Phase 2 remains deferred under `docs/orchestration/FITCHEF_SANDBOX_PHASE2_CONTRACT.md`

## Validation
```bash
source .venv/bin/activate && pytest -q tests/test_fitchef_runtime_weekly_plan.py
source .venv/bin/activate && pytest -q tests/test_vip_guard_order_403_vs_422.py::test_vip_guard_200_with_valid_tier_and_payload tests/test_vip_api.py::test_vip_weekly_plan_echo
source .venv/bin/activate && pre-commit run --all-files
source .venv/bin/activate && make verify
```

## Security Notes
- preserves current VIP tier gating and 403-before-422 behavior on the canonical route
- keeps the public weekly-plan namespace unchanged and adds no new external API surface
- Phase 1 remains bounded backend orchestration only

## Marketing & GTM
- internal backend orchestration only; no new user-facing capability claims
- FitChef Phase 2 features remain planned-only and out of scope here

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1057_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916383991 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: app/services/fitchef_runtime.py:149
Evidence: app/routers/vip.py:409
Evidence: tests/helpers/fitchef_runtime_helpers.py:9
Evidence: tests/test_fitchef_runtime_weekly_plan.py:115
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302959 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: app/services/fitchef_runtime.py:149
Evidence: app/routers/vip.py:409
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302968 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: tests/test_fitchef_runtime_weekly_plan.py:115
Evidence: tests/test_fitchef_runtime_weekly_plan.py:147
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906302970 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: tests/test_fitchef_runtime_weekly_plan.py:177
Evidence: tests/test_fitchef_runtime_weekly_plan.py:195
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916392098 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: app/services/fitchef_runtime.py:119
Evidence: app/services/fitchef_runtime.py:125
Evidence: tests/test_fitchef_runtime_weekly_plan.py:77
Evidence: tests/test_fitchef_runtime_weekly_plan.py:177
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916429319 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: tests/test_vip_api.py:79
Evidence: tests/test_vip_guard_order_403_vs_422.py:98
Evidence: tests/helpers/fitchef_runtime_helpers.py:9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906346185 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: tests/test_vip_api.py:79
Evidence: tests/test_vip_api.py:81
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#discussion_r2906346192 -> 003d5d8b
Disposition: FIXED
Commit: 003d5d8b
Evidence: tests/test_vip_guard_order_403_vs_422.py:98
Evidence: tests/test_vip_guard_order_403_vs_422.py:112
Evidence: tests/helpers/fitchef_runtime_helpers.py:16

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1057#pullrequestreview-3916576683 -> e8211fc9
Disposition: FIXED
Commit: e8211fc9
Evidence: tests/test_fitchef_runtime_weekly_plan.py:190
Evidence: tests/test_fitchef_runtime_weekly_plan.py:198

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly plan workflow for personalized menu generation, with new request/result models.

* **Refactor**
  * Weekly menu endpoint migrated to async and now runs via a centralized runtime orchestration, with safer default/echo fallbacks.

* **Tests**
  * Expanded tests and helpers covering runtime behavior, serialization, numeric fallbacks, error propagation, and echo mode.

* **Documentation**
  * Added review notes documenting the fix mapping and readiness status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
