### PR TITLE
feat(fitchef): bind shopping-followup task through fitchef runtime

### DIFF
--- a/app/routers/shopping_list_pro.py
+++ b/app/routers/shopping_list_pro.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.core.shopping_list.generator import generate_shopping_list_from_plan
+from app.services import fitchef_runtime
 from app.middleware.api_tiers import require_pro_tier
+from app.schemas.fitchef import (
+    FitChefShoppingFollowupInput,
+    FitChefShoppingFollowupTaskEnvelope,
+)
 from app.schemas.shopping_list import ShoppingListDTO, ShoppingListRequest
 
 router = APIRouter(prefix="/api/v1/pro/meal", tags=["pro", "shopping-list"])
@@ -70,21 +75,19 @@ async def generate_shopping_list(request: ShoppingListRequest) -> ShoppingListDT
             detail="weekly_plan_id support not yet implemented",
         )
 
-    # Use inline plan_data (guaranteed non-None by Pydantic validator)
-    # Type narrowing: if we reach here, plan_data must be non-None
-    if request.plan_data is None:
-        # Should never happen due to XOR validation in model
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal error: plan_data is None",
-        )
-
-    # Generate shopping list using core logic
-    return generate_shopping_list_from_plan(
-        plan_data=request.plan_data,
-        preferences=request.preferences,
-        source="inline_plan",
+    task = FitChefShoppingFollowupTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefShoppingFollowupInput(
+            weekly_plan_id=request.weekly_plan_id,
+            plan_data=request.plan_data,
+            preferences=request.preferences,
+        ),
     )
+    result = await fitchef_runtime.run_shopping_followup_task(
+        task,
+        shopping_list_builder=generate_shopping_list_from_plan,
+    )
+    return result.shopping_list
 
 
 __all__ = ["router"]

--- a/app/schemas/fitchef.py
+++ b/app/schemas/fitchef.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from app.schemas.shopping_list import ShoppingListDTO, ShoppingListPreferences
+
 FitChefAgentId = Literal["fitchef-agent"]
 FitChefExecutionMode = Literal["auto-safe", "review-required", "blocked"]
 FitChefTaskType = Literal["coach_insight", "weekly_plan", "shopping_followup"]
@@ -79,3 +81,24 @@ class FitChefWeeklyPlanResult(BaseModel):
     """Internal weekly-plan result. / Внутренний результат weekly-plan."""
 
     menu: dict[str, Any]
+
+
+class FitChefShoppingFollowupInput(BaseModel):
+    """Internal shopping-followup input. / Входные данные shopping-followup задачи."""
+
+    weekly_plan_id: str | None = None
+    plan_data: dict[str, Any] | None = None
+    preferences: ShoppingListPreferences = Field(default_factory=ShoppingListPreferences)
+
+
+class FitChefShoppingFollowupTaskEnvelope(FitChefTaskEnvelope):
+    """Shopping-followup task envelope. / Envelope для shopping-followup."""
+
+    task_type: Literal["shopping_followup"] = "shopping_followup"
+    input: FitChefShoppingFollowupInput
+
+
+class FitChefShoppingFollowupResult(BaseModel):
+    """Internal shopping-followup result. / Внутренний результат shopping-followup."""
+
+    shopping_list: ShoppingListDTO

--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -17,10 +17,13 @@ from app.schemas.fitchef import (
     FitChefCoachInsightResult,
     FitChefCoachInsightTaskEnvelope,
     FitChefQuotaState,
+    FitChefShoppingFollowupResult,
+    FitChefShoppingFollowupTaskEnvelope,
     FitChefSourceItem,
     FitChefWeeklyPlanResult,
     FitChefWeeklyPlanTaskEnvelope,
 )
+from app.schemas.shopping_list import ShoppingListDTO
 from app.security.agent_control_plane import (
     AUDIT_SIGNING_KEY_ENV,
     persist_audit_envelope,
@@ -41,6 +44,7 @@ CBT_POLICY_ALLOWLIST = {
     ("llm.generate", "provider://default"),
 }
 WeeklyPlanBuilder = Callable[..., Any]
+ShoppingFollowupBuilder = Callable[..., ShoppingListDTO]
 
 
 def _build_cbt_prompt(query: str, rag_context: str) -> str:
@@ -396,4 +400,40 @@ async def run_weekly_plan_task(
         menu_builder,
     )
     result = FitChefWeeklyPlanResult(menu=menu_payload)
+    return result
+
+
+def _run_shopping_followup_builder(
+    task: FitChefShoppingFollowupTaskEnvelope,
+    shopping_list_builder: ShoppingFollowupBuilder,
+) -> ShoppingListDTO:
+    """Run shopping-followup builder. / Выполнить builder shopping-followup."""
+
+    if task.input.plan_data is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal error: plan_data is None",
+        )
+
+    shopping_list = shopping_list_builder(
+        plan_data=task.input.plan_data,
+        preferences=task.input.preferences,
+        source="inline_plan",
+    )
+    return shopping_list
+
+
+async def run_shopping_followup_task(
+    task: FitChefShoppingFollowupTaskEnvelope,
+    *,
+    shopping_list_builder: ShoppingFollowupBuilder,
+) -> FitChefShoppingFollowupResult:
+    """Run shopping-followup orchestration. / Выполнить оркестрацию shopping-followup."""
+
+    shopping_list = await run_in_threadpool(
+        _run_shopping_followup_builder,
+        task,
+        shopping_list_builder,
+    )
+    result = FitChefShoppingFollowupResult(shopping_list=shopping_list)
     return result

--- a/docs/review/PR_1058_FIXED_MAPPING.md
+++ b/docs/review/PR_1058_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1058 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass initialized at PR creation
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments at PR creation.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1058_FIXED_MAPPING.md
+++ b/docs/review/PR_1058_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1058 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass initialized at PR creation
+- [x] Fixed in commit mapping initialized
+
+## Fixed in Commit Mapping
+- No actionable review comments at PR creation.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/tests/helpers/fitchef_runtime_helpers.py
+++ b/tests/helpers/fitchef_runtime_helpers.py
@@ -21,3 +21,35 @@ def make_mock_run_weekly_plan_task(
         return type("WeeklyPlanResult", (), {"menu": payload})()
 
     return _mock_run_weekly_plan_task
+
+
+def make_mock_run_shopping_followup_task(
+    *,
+    shopping_list: dict[str, Any] | None = None,
+    capture: dict[str, Any] | None = None,
+) -> Callable[..., Any]:
+    """Build async shopping runtime mock. / Собрать async mock для shopping runtime."""
+
+    async def _mock_run_shopping_followup_task(task, *, shopping_list_builder):
+        if capture is not None:
+            capture["task_type"] = task.task_type
+            capture["shopping_list_builder"] = shopping_list_builder
+            capture["plan_data"] = task.input.plan_data
+            capture["preferences"] = task.input.preferences
+        payload = (
+            {
+                "categories": [],
+                "total_items": 0,
+                "generated_at": "2025-01-01T00:00:00Z",
+                "meta": {
+                    "source": "inline_plan",
+                    "unit_system": "metric",
+                    "warnings": [],
+                },
+            }
+            if shopping_list is None
+            else shopping_list
+        )
+        return type("ShoppingFollowupResult", (), {"shopping_list": payload})()
+
+    return _mock_run_shopping_followup_task

--- a/tests/test_fitchef_runtime_shopping_followup.py
+++ b/tests/test_fitchef_runtime_shopping_followup.py
@@ -1,0 +1,113 @@
+"""FitChef shopping-followup runtime tests. / Тесты shopping-followup runtime FitChef."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.fitchef import (
+    FitChefShoppingFollowupInput,
+    FitChefShoppingFollowupTaskEnvelope,
+)
+from app.schemas.shopping_list import ShoppingListDTO, ShoppingListPreferences
+from app.services import fitchef_runtime
+
+
+def _make_shopping_list_dto() -> ShoppingListDTO:
+    """Build deterministic shopping DTO. / Собрать детерминированный shopping DTO."""
+
+    dto: ShoppingListDTO
+    dto = ShoppingListDTO.model_validate(
+        {
+            "categories": [],
+            "total_items": 0,
+            "generated_at": "2025-01-01T00:00:00Z",
+            "meta": {
+                "source": "inline_plan",
+                "unit_system": "metric",
+                "warnings": [],
+            },
+        }
+    )
+    return dto
+
+
+def test_run_shopping_followup_task_delegates_builder() -> None:
+    """Shopping runtime delegates builder. / Shopping runtime делегирует builder."""
+
+    captured: dict[str, object] = {}
+    task = FitChefShoppingFollowupTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefShoppingFollowupInput(
+            plan_data={"daily_menus": []},
+            preferences=ShoppingListPreferences(),
+        ),
+    )
+
+    def fake_builder(*, plan_data, preferences, source):
+        captured["plan_data"] = plan_data
+        captured["preferences"] = preferences
+        captured["source"] = source
+        return _make_shopping_list_dto()
+
+    result = asyncio.run(
+        fitchef_runtime.run_shopping_followup_task(
+            task,
+            shopping_list_builder=fake_builder,
+        )
+    )
+
+    assert captured["plan_data"] == {"daily_menus": []}
+    assert captured["source"] == "inline_plan"
+    assert isinstance(captured["preferences"], ShoppingListPreferences)
+    assert result.shopping_list.meta.source == "inline_plan"
+
+
+def test_run_shopping_followup_task_rejects_missing_plan_data() -> None:
+    """Missing plan_data fails closed. / Отсутствующий plan_data закрывается fail-closed."""
+
+    task = FitChefShoppingFollowupTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefShoppingFollowupInput(
+            plan_data=None,
+            preferences=ShoppingListPreferences(),
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            fitchef_runtime.run_shopping_followup_task(
+                task,
+                shopping_list_builder=lambda **_kwargs: _make_shopping_list_dto(),
+            )
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Internal error: plan_data is None"
+
+
+def test_run_shopping_followup_task_propagates_builder_exceptions() -> None:
+    """Builder exceptions propagate. / Исключения builder проходят наружу как есть."""
+
+    task = FitChefShoppingFollowupTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefShoppingFollowupInput(
+            plan_data={"daily_menus": []},
+            preferences=ShoppingListPreferences(),
+        ),
+    )
+
+    def failing_builder(**_kwargs):
+        raise RuntimeError("shopping builder exploded")
+
+    with pytest.raises(RuntimeError, match="shopping builder exploded") as exc_info:
+        asyncio.run(
+            fitchef_runtime.run_shopping_followup_task(
+                task,
+                shopping_list_builder=failing_builder,
+            )
+        )
+
+    assert str(exc_info.value) == "shopping builder exploded"

--- a/tests/test_shopping_list_pro_router.py
+++ b/tests/test_shopping_list_pro_router.py
@@ -7,6 +7,8 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from tests.helpers.fitchef_runtime_helpers import make_mock_run_shopping_followup_task
+
 
 class TestShoppingListProRouterIsolated:
     """Isolated tests for the PRO shopping list router.
@@ -91,14 +93,15 @@ class TestShoppingListProRouterIsolated:
             },
         }
 
-        def _fake_generate(*, plan_data: Any, preferences: Any, source: str) -> Dict[str, Any]:
-            assert source == "inline_plan"
-            assert plan_data == {"days": []}
-            # preferences is a ShoppingListPreferences instance; avoid over-asserting
-            assert preferences.unit_system == "metric"
-            return expected
-
-        monkeypatch.setattr(self.mod, "generate_shopping_list_from_plan", _fake_generate)
+        captured: Dict[str, Any] = {}
+        monkeypatch.setattr(
+            self.mod.fitchef_runtime,
+            "run_shopping_followup_task",
+            make_mock_run_shopping_followup_task(
+                shopping_list=expected,
+                capture=captured,
+            ),
+        )
 
         payload: Dict[str, Any] = {
             "plan_data": {"days": []},
@@ -116,6 +119,10 @@ class TestShoppingListProRouterIsolated:
         assert body["total_items"] == 1
         assert body["meta"]["source"] == "inline_plan"
         assert body["meta"]["unit_system"] == "metric"
+        assert captured["task_type"] == "shopping_followup"
+        assert captured["plan_data"] == {"days": []}
+        assert captured["preferences"].unit_system == "metric"
+        assert captured["shopping_list_builder"] is self.mod.generate_shopping_list_from_plan
 
     def test_generate_shopping_list_422_group_by_recipe_not_supported(
         self, monkeypatch: pytest.MonkeyPatch
@@ -265,3 +272,36 @@ async def test_generate_shopping_list_plan_data_none_guard() -> None:
 
     assert exc_info.value.status_code == 500
     assert "plan_data is None" in exc_info.value.detail
+
+
+def test_generate_shopping_list_runtime_exception_no_leak(
+    app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+    pro_headers: dict[str, str],
+) -> None:
+    """Unexpected runtime errors stay sanitized. / Ошибки runtime остаются без утечки деталей."""
+
+    import app.routers.shopping_list_pro as shopping_mod
+
+    async def _explode(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("traceback /private/tmp/internal.py secret-token")
+
+    monkeypatch.setattr(shopping_mod.fitchef_runtime, "run_shopping_followup_task", _explode)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/api/v1/pro/meal/shopping-list",
+            json={"plan_data": {"daily_menus": []}},
+            headers=pro_headers,
+        )
+
+    assert response.status_code == 500
+    content_type = response.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        detail = str(response.json().get("detail", ""))
+    else:
+        detail = response.text
+    lowered = detail.lower()
+    assert "traceback" not in lowered
+    assert "internal.py" not in lowered
+    assert "secret-token" not in lowered


### PR DESCRIPTION
## Summary
- bind the canonical PRO shopping-followup route through `app/services/fitchef_runtime.py`
- keep `app/routers/shopping_list_pro.py` as the public surface without namespace changes
- preserve current request/response contract, XOR validation, unsupported-preferences behavior, and `weekly_plan_id` 501 semantics

## Validation
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Local `pre-commit run --all-files` passed
- [x] Local `make verify` passed
- [x] Required PR artifact/body sections initialized
- [x] No unresolved review threads at PR creation
- [x] Zero-actionable baseline recorded; follow-up review comments will be mapped in `docs/review/PR_1058_FIXED_MAPPING.md`

## Deferred / Follow-ups
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shopping follow-up workflow using runtime orchestration to generate shopping lists.

* **Bug Fixes**
  * Improved error handling to avoid leaking internal traces or sensitive info in error responses.
  * Ensured unsupported weekly-plan paths remain properly reported.

* **Tests**
  * Added extensive tests and test helpers for the shopping follow-up flow; updated existing tests to use the runtime-based approach.

* **Documentation**
  * Added a short PR review summary document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->