### PR TITLE
refactor(weekly-plan): thin legacy VIP weekly alias

### DIFF
--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -533,6 +533,38 @@ async def weekly_menu_plan(
         We intentionally accept raw dict here so auth (403) wins over Pydantic 422.
         Then we validate via WeeklyPlanRequest inside the handler.
     """
+    try:
+        _, echo_payload, menu_payload = await _execute_weekly_menu_plan_payload(payload)
+        return {
+            "status": "success",
+            "echo": echo_payload,
+            "menu": menu_payload,
+            "message": "Weekly menu plan generated (echo mode)",
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        logging.exception("Exception in weekly_menu_plan")
+        # Do not include exception details in responses (CodeQL: info exposure).
+        msg = "Weekly menu generation failed"
+        return {
+            "status": "error",
+            "echo": payload,
+            "menu": {"mode": "echo"},
+            "message": msg,
+        }
+
+
+async def _execute_weekly_menu_plan_payload(
+    payload: Dict[str, Any],
+    *,
+    menu_builder: Optional[Callable[..., Any]] = None,
+) -> tuple[WeeklyPlanRequest, Dict[str, Any], Dict[str, Any]]:
+    """Run canonical weekly-plan execution without HTTP-route wrapping.
+
+    RU: Выполнить canonical weekly-plan path без HTTP-обёртки.
+    EN: Execute the canonical weekly-plan path without the HTTP route envelope.
+    """
     # IMPORTANT: Validate after auth to ensure 403 wins over 422
     # JSONDecodeError is caught earlier in request.json() → 422
     # ValueError here means schema validation failed → 422
@@ -553,32 +585,17 @@ async def weekly_menu_plan(
             continue
         original_data[key] = value
 
-    try:
-        task = FitChefWeeklyPlanTaskEnvelope(
-            mode="auto-safe",
-            input=FitChefWeeklyPlanInput(request_data=request_obj.model_dump()),
-        )
-        result = await fitchef_runtime.run_weekly_plan_task(
-            task,
-            menu_builder=make_weekly_menu,
-        )
-        echo_payload = original_data if make_weekly_menu is None else request_obj.model_dump()
-        return {
-            "status": "success",
-            "echo": echo_payload,
-            "menu": result.menu,
-            "message": "Weekly menu plan generated (echo mode)",
-        }
-    except Exception:
-        logging.exception("Exception in weekly_menu_plan")
-        # Do not include exception details in responses (CodeQL: info exposure).
-        msg = "Weekly menu generation failed"
-        return {
-            "status": "error",
-            "echo": request_obj.model_dump(),
-            "menu": {"mode": "echo"},
-            "message": msg,
-        }
+    resolved_menu_builder = make_weekly_menu if menu_builder is None else menu_builder
+    task = FitChefWeeklyPlanTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefWeeklyPlanInput(request_data=request_obj.model_dump()),
+    )
+    result = await fitchef_runtime.run_weekly_plan_task(
+        task,
+        menu_builder=resolved_menu_builder,
+    )
+    echo_payload = original_data if resolved_menu_builder is None else request_obj.model_dump()
+    return request_obj, echo_payload, result.menu
 
 
 def _require_api_key_dev_legacy(request: Request) -> str:

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -1,8 +1,61 @@
-# PR 1061 - Fixed in Commit Mapping
+# PR 1061 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917772269
+Disposition: NOT-A-BUG
+Evidence: Review body is a Sourcery rate-limit notice with no code finding to address.
+Reason: This review contains no actionable implementation feedback.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917787941 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:225
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907556833 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:225
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917799557 -> 3fbc03db
+Disposition: FIXED
+Commit: 3fbc03db
+Evidence: legacy_app.py:3258
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907567013 -> 3fbc03db
+Disposition: FIXED
+Commit: 3fbc03db
+Evidence: legacy_app.py:3258
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575145
+Disposition: NOT-A-BUG
+Evidence: app/routers/vip.py:588; app/routers/vip.py:597
+Reason: The helper intentionally keys `echo_payload` off the resolved builder so the default route preserves the pre-refactor contract: when module-level `make_weekly_menu` is available, the canonical VIP path echoes `request_obj.model_dump()` instead of the sparse fallback payload.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575159 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: legacy_app.py:3239
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575169 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: legacy_app.py:3265
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575176 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: legacy_app.py:3295
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575193 -> b59964d0
+Disposition: FIXED
+Commit: b59964d0
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:102
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917808319
+Disposition: NOT-A-BUG
+Evidence: legacy_app.py:4590; legacy_app.py:4594; legacy_app.py:4653; app/routers/vip.py:518; app/routers/vip.py:588
+Reason: This review summary aggregates four inline findings fixed above plus two deliberate compatibility decisions: the hidden legacy alias remains runtime-callable under existing `_get_api_key_dynamic` semantics, and the canonical VIP helper keeps the pre-refactor `echo` behavior. The public VIP surface remains gated at `/api/v1/vip/menu/weekly/plan`.

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -13,12 +13,12 @@ Reason: This review contains no actionable implementation feedback.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917787941 -> b59964d0
 Disposition: FIXED
 Commit: b59964d0
-Evidence: tests/test_legacy_weekly_plan_alias_api.py:227
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:251
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907556833 -> b59964d0
 Disposition: FIXED
 Commit: b59964d0
-Evidence: tests/test_legacy_weekly_plan_alias_api.py:227
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:251
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917799557 -> 3fbc03db
 Disposition: FIXED
@@ -69,3 +69,23 @@ Evidence: legacy_app.py:3246; legacy_app.py:3257; tests/test_legacy_weekly_plan_
 Disposition: FIXED
 Commit: dc959872
 Evidence: legacy_app.py:3246; legacy_app.py:4635; tests/test_legacy_weekly_plan_alias_api.py:167
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802282 -> 76824910
+Disposition: FIXED
+Commit: 76824910
+Evidence: docs/review/PR_1061_FIXED_MAPPING.md:16; docs/review/PR_1061_FIXED_MAPPING.md:21
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802293 -> 76824910
+Disposition: FIXED
+Commit: 76824910
+Evidence: legacy_app.py:3223; legacy_app.py:3271; legacy_app.py:3285; tests/test_legacy_weekly_plan_alias_api.py:334
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802299 -> 76824910
+Disposition: FIXED
+Commit: 76824910
+Evidence: legacy_app.py:3302; tests/test_legacy_weekly_plan_alias_api.py:254
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918067947 -> 76824910
+Disposition: FIXED
+Commit: 76824910
+Evidence: docs/review/PR_1061_FIXED_MAPPING.md:16; legacy_app.py:3223; legacy_app.py:3302; tests/test_legacy_weekly_plan_alias_api.py:334

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -104,3 +104,13 @@ Evidence: legacy_app.py:3229; legacy_app.py:3262; legacy_app.py:3272; tests/test
 Disposition: NOT-A-BUG
 Evidence: docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:34; scripts/ci/check_pr_body_phase2_gates.py:111; legacy_app.py:3229; tests/test_legacy_weekly_plan_alias_api.py:363
 Reason: This summary aggregates the two inline findings captured immediately above: the checklist comment is not a bug under the current artifact contract, and the non-finite day-value recovery issue was fixed in `3f42a408`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907948108 -> 79c253a3
+Disposition: FIXED
+Commit: 79c253a3
+Evidence: legacy_app.py:3215; legacy_app.py:3232; legacy_app.py:3246; tests/test_legacy_weekly_plan_alias_api.py:431
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918232238 -> 79c253a3
+Disposition: FIXED
+Commit: 79c253a3
+Evidence: legacy_app.py:3215; tests/test_legacy_weekly_plan_alias_api.py:125; tests/test_legacy_weekly_plan_alias_api.py:431; tests/test_app_openapi_coverage.py:55

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1061 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -59,3 +59,13 @@ Evidence: tests/test_legacy_weekly_plan_alias_api.py:102
 Disposition: NOT-A-BUG
 Evidence: legacy_app.py:4590; legacy_app.py:4594; legacy_app.py:4653; app/routers/vip.py:518; app/routers/vip.py:588
 Reason: This review summary aggregates four inline findings fixed above plus two deliberate compatibility decisions: the hidden legacy alias remains runtime-callable under existing `_get_api_key_dynamic` semantics, and the canonical VIP helper keeps the pre-refactor `echo` behavior. The public VIP surface remains gated at `/api/v1/vip/menu/weekly/plan`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907715232 -> dc959872
+Disposition: FIXED
+Commit: dc959872
+Evidence: legacy_app.py:3246; legacy_app.py:3257; tests/test_legacy_weekly_plan_alias_api.py:270
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917967588 -> dc959872
+Disposition: FIXED
+Commit: dc959872
+Evidence: legacy_app.py:3246; legacy_app.py:4635; tests/test_legacy_weekly_plan_alias_api.py:167

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -89,3 +89,18 @@ Evidence: legacy_app.py:3302; tests/test_legacy_weekly_plan_alias_api.py:254
 Disposition: FIXED
 Commit: 76824910
 Evidence: docs/review/PR_1061_FIXED_MAPPING.md:16; legacy_app.py:3223; legacy_app.py:3302; tests/test_legacy_weekly_plan_alias_api.py:334
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907863018
+Disposition: NOT-A-BUG
+Evidence: docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:34; scripts/ci/check_pr_body_phase2_gates.py:111; scripts/orchestration/review_mapping_artifact.py:101
+Reason: The canonical Phase 2 artifact contract requires these two checkbox lines to remain checked in `docs/review/PR_<N>_FIXED_MAPPING.md`; unchecking them would fail the artifact validator instead of reflecting current governance state.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907863024 -> 3f42a408
+Disposition: FIXED
+Commit: 3f42a408
+Evidence: legacy_app.py:3229; legacy_app.py:3262; legacy_app.py:3272; tests/test_legacy_weekly_plan_alias_api.py:363
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918134801
+Disposition: NOT-A-BUG
+Evidence: docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:34; scripts/ci/check_pr_body_phase2_gates.py:111; legacy_app.py:3229; tests/test_legacy_weekly_plan_alias_api.py:363
+Reason: This summary aggregates the two inline findings captured immediately above: the checklist comment is not a bug under the current artifact contract, and the non-finite day-value recovery issue was fixed in `3f42a408`.

--- a/docs/review/PR_1061_FIXED_MAPPING.md
+++ b/docs/review/PR_1061_FIXED_MAPPING.md
@@ -13,12 +13,12 @@ Reason: This review contains no actionable implementation feedback.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917787941 -> b59964d0
 Disposition: FIXED
 Commit: b59964d0
-Evidence: tests/test_legacy_weekly_plan_alias_api.py:225
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:227
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907556833 -> b59964d0
 Disposition: FIXED
 Commit: b59964d0
-Evidence: tests/test_legacy_weekly_plan_alias_api.py:225
+Evidence: tests/test_legacy_weekly_plan_alias_api.py:227
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917799557 -> 3fbc03db
 Disposition: FIXED

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3211,6 +3211,89 @@ class WeeklyMenuResponse(BaseModel):
     adherence_score: float
 
 
+def _coerce_weekly_menu_float(value: Any, default: float = 0.0) -> float:
+    """Normalize weekly-menu numeric values for legacy compatibility.
+
+    RU: Нормализовать numeric поля недельного меню для legacy-совместимости.
+    EN: Normalize weekly-menu numeric values for legacy compatibility.
+    """
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
+def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMenuResponse:
+    """Translate canonical VIP weekly payload into legacy weekly-menu response.
+
+    RU: Перевести canonical VIP weekly payload в legacy weekly-menu response.
+    EN: Translate the canonical VIP weekly payload into the legacy weekly-menu response.
+    """
+    raw_daily_menus = menu_payload.get("daily_menus")
+    daily_menus_payload: List[Dict[str, Any]] = []
+    if isinstance(raw_daily_menus, list):
+        for raw_menu in raw_daily_menus:
+            if not isinstance(raw_menu, dict):
+                continue
+            raw_meals = raw_menu.get("meals")
+            meals = list(raw_meals) if isinstance(raw_meals, list) else []
+            total_kcal = raw_menu.get("total_kcal")
+            if not isinstance(total_kcal, (int, float)):
+                total_kcal = sum(
+                    meal.get("kcal", 0)
+                    for meal in meals
+                    if isinstance(meal, dict) and isinstance(meal.get("kcal"), (int, float))
+                )
+            daily_menus_payload.append(
+                {
+                    "date": str(raw_menu.get("date", "")),
+                    "meals": meals,
+                    "total_kcal": _coerce_weekly_menu_float(total_kcal, 0.0),
+                    "daily_cost": _coerce_weekly_menu_float(raw_menu.get("daily_cost"), 0.0),
+                }
+            )
+
+    raw_weekly_coverage = menu_payload.get("weekly_coverage")
+    weekly_coverage = (
+        {
+            key: float(value)
+            for key, value in raw_weekly_coverage.items()
+            if isinstance(key, str) and isinstance(value, (int, float))
+        }
+        if isinstance(raw_weekly_coverage, dict)
+        else {}
+    )
+
+    raw_shopping_list = menu_payload.get("shopping_list")
+    shopping_list = (
+        {
+            key: float(value)
+            for key, value in raw_shopping_list.items()
+            if isinstance(key, str) and isinstance(value, (int, float))
+        }
+        if isinstance(raw_shopping_list, dict)
+        else {}
+    )
+
+    total_cost = _coerce_weekly_menu_float(menu_payload.get("total_cost"), 0.0)
+    adherence_score = _coerce_weekly_menu_float(menu_payload.get("adherence_score"), 0.0)
+    week_start = menu_payload.get("week_start", "")
+
+    return WeeklyMenuResponse(
+        week_summary={
+            "week_start": str(week_start),
+            "total_days": len(daily_menus_payload),
+            "avg_daily_cost": round(total_cost / 7, 2) if total_cost else 0.0,
+        },
+        daily_menus=daily_menus_payload,
+        weekly_coverage=weekly_coverage,
+        shopping_list=shopping_list,
+        total_cost=total_cost,
+        adherence_score=adherence_score,
+    )
+
+
 class WeeklyPlanFlexibleRequest(BaseModel):
     # Either 'targets' or a lightweight user profile
     targets: Optional[Dict[str, Any]] = None
@@ -4492,6 +4575,7 @@ async def api_who_targets(payload: Dict[str, Any] = Body(...)) -> WHOTargetsResp
     "/api/v1/premium/plan/week",
     dependencies=[Depends(_get_api_key_dynamic)],
     response_model=WeeklyMenuResponse,
+    include_in_schema=False,
     deprecated=True,
 )
 async def api_weekly_menu(req: LegacyWeekPlanRequest) -> WeeklyMenuResponse:
@@ -4534,8 +4618,7 @@ async def api_weekly_menu(req: LegacyWeekPlanRequest) -> WeeklyMenuResponse:
                 status_code=503, detail="Weekly menu generation feature not available"
             )
 
-        # Convert to UserProfile - validate required fields first
-        from core.targets import UserProfile
+        from app.routers.vip import _execute_weekly_menu_plan_payload
 
         if (
             req.sex is None
@@ -4549,69 +4632,11 @@ async def api_weekly_menu(req: LegacyWeekPlanRequest) -> WeeklyMenuResponse:
                 detail="Required fields missing: sex, age, height_cm, weight_kg, and activity are all required.",
             )
 
-        profile = UserProfile(
-            sex=req.sex,
-            age=req.age,
-            height_cm=req.height_cm,
-            weight_kg=req.weight_kg,
-            activity=req.activity,
-            goal=req.goal,
-            deficit_pct=req.deficit_pct,
-            surplus_pct=req.surplus_pct,
-            bodyfat=req.bodyfat,
-            diet_flags=set(req.diet_flags or []),
-            life_stage=req.life_stage,
+        _, _, menu_payload = await _execute_weekly_menu_plan_payload(
+            req.model_dump(exclude_none=True),
+            menu_builder=_make_weekly_menu,
         )
-
-        # Generate weekly menu via core.menu_engine
-        week_menu = _make_weekly_menu(profile)
-
-        weekly_coverage = getattr(week_menu, "weekly_coverage", {}) or {}
-        if not isinstance(weekly_coverage, dict):
-            weekly_coverage = {}
-
-        shopping_list = getattr(week_menu, "shopping_list", {}) or {}
-        if not isinstance(shopping_list, dict):
-            shopping_list = {}
-
-        total_cost_raw = getattr(week_menu, "total_cost", 0.0)
-        total_cost = float(total_cost_raw) if isinstance(total_cost_raw, (int, float)) else 0.0
-
-        adherence_raw = getattr(week_menu, "adherence_score", 0.0)
-        adherence_score = float(adherence_raw) if isinstance(adherence_raw, (int, float)) else 0.0
-
-        daily_menus = getattr(week_menu, "daily_menus", []) or []
-        daily_menus_payload = []
-        for menu in daily_menus:
-            meals = getattr(menu, "meals", []) or []
-            if not isinstance(meals, (list, tuple)):
-                meals = []
-            date_value = getattr(menu, "date", "")
-            if not isinstance(date_value, str):
-                date_value = str(date_value)
-            daily_cost_raw = getattr(menu, "estimated_cost", 0.0)
-            daily_cost = float(daily_cost_raw) if isinstance(daily_cost_raw, (int, float)) else 0.0
-            daily_menus_payload.append(
-                {
-                    "date": date_value,
-                    "meals": meals,
-                    "total_kcal": sum(meal.get("kcal", 0) for meal in meals) if meals else 0,
-                    "daily_cost": daily_cost,
-                }
-            )
-
-        return WeeklyMenuResponse(
-            week_summary={
-                "week_start": getattr(week_menu, "week_start", ""),
-                "total_days": len(daily_menus_payload),
-                "avg_daily_cost": round(total_cost / 7, 2) if total_cost else 0.0,
-            },
-            daily_menus=daily_menus_payload,
-            weekly_coverage=weekly_coverage,
-            shopping_list=shopping_list,
-            total_cost=total_cost,
-            adherence_score=adherence_score,
-        )
+        return _build_legacy_weekly_menu_response(menu_payload)
 
     except HTTPException:
         # Pass through expected HTTP errors

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3236,8 +3236,13 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
         for raw_menu in raw_daily_menus:
             if not isinstance(raw_menu, dict):
                 continue
+            raw_date = raw_menu.get("date")
             raw_meals = raw_menu.get("meals")
-            meals = list(raw_meals) if isinstance(raw_meals, list) else []
+            if not isinstance(raw_date, str) or not raw_date.strip():
+                continue
+            if not isinstance(raw_meals, list):
+                continue
+            meals = list(raw_meals)
             total_kcal = raw_menu.get("total_kcal")
             if not isinstance(total_kcal, (int, float)):
                 total_kcal = sum(
@@ -3247,7 +3252,7 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
                 )
             daily_menus_payload.append(
                 {
-                    "date": str(raw_menu.get("date", "")),
+                    "date": raw_date,
                     "meals": meals,
                     "total_kcal": _coerce_weekly_menu_float(total_kcal, 0.0),
                     "daily_cost": _coerce_weekly_menu_float(raw_menu.get("daily_cost"), 0.0),
@@ -3259,7 +3264,9 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
         {
             key: float(value)
             for key, value in raw_weekly_coverage.items()
-            if isinstance(key, str) and isinstance(value, (int, float))
+            if isinstance(key, str)
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
         }
         if isinstance(raw_weekly_coverage, dict)
         else {}
@@ -3270,7 +3277,9 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
         {
             key: float(value)
             for key, value in raw_shopping_list.items()
-            if isinstance(key, str) and isinstance(value, (int, float))
+            if isinstance(key, str)
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
         }
         if isinstance(raw_shopping_list, dict)
         else {}
@@ -3284,7 +3293,11 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
         week_summary={
             "week_start": str(week_start),
             "total_days": len(daily_menus_payload),
-            "avg_daily_cost": round(total_cost / 7, 2) if total_cost else 0.0,
+            "avg_daily_cost": (
+                round(total_cost / len(daily_menus_payload), 2)
+                if total_cost and daily_menus_payload
+                else 0.0
+            ),
         },
         daily_menus=daily_menus_payload,
         weekly_coverage=weekly_coverage,
@@ -4578,7 +4591,9 @@ async def api_who_targets(payload: Dict[str, Any] = Body(...)) -> WHOTargetsResp
     include_in_schema=False,
     deprecated=True,
 )
-async def api_weekly_menu(req: LegacyWeekPlanRequest) -> WeeklyMenuResponse:
+async def api_weekly_menu(
+    req: LegacyWeekPlanRequest,
+) -> WeeklyMenuResponse:
     """
     RU: Генерирует недельный план питания (через core.menu_engine.make_weekly_menu).
     EN: Generate a weekly meal plan using core.menu_engine.make_weekly_menu.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3226,6 +3226,19 @@ def _coerce_weekly_menu_float(value: Any, default: float = 0.0) -> float:
     return default
 
 
+def _is_valid_weekly_menu_number(value: Any) -> bool:
+    """Check whether a weekly-menu numeric value is JSON-safe.
+
+    RU: Проверить, что numeric значение weekly menu корректно и конечно.
+    EN: Check that a weekly-menu numeric value is valid and finite.
+    """
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
 def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMenuResponse:
     """Translate canonical VIP weekly payload into legacy weekly-menu response.
 
@@ -3246,18 +3259,16 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
                 continue
             meals = list(raw_meals)
             raw_total_kcal = raw_menu.get("total_kcal")
-            if isinstance(raw_total_kcal, bool) or not isinstance(raw_total_kcal, (int, float)):
+            if not _is_valid_weekly_menu_number(raw_total_kcal):
                 total_kcal = sum(
                     meal.get("kcal", 0)
                     for meal in meals
-                    if isinstance(meal, dict)
-                    and isinstance(meal.get("kcal"), (int, float))
-                    and not isinstance(meal.get("kcal"), bool)
+                    if isinstance(meal, dict) and _is_valid_weekly_menu_number(meal.get("kcal"))
                 )
             else:
                 total_kcal = raw_total_kcal
             raw_daily_cost = raw_menu.get("daily_cost")
-            if isinstance(raw_daily_cost, bool) or not isinstance(raw_daily_cost, (int, float)):
+            if not _is_valid_weekly_menu_number(raw_daily_cost):
                 raw_daily_cost = raw_menu.get("estimated_cost")
             daily_menus_payload.append(
                 {

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3255,7 +3255,10 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
                     "date": raw_date,
                     "meals": meals,
                     "total_kcal": _coerce_weekly_menu_float(total_kcal, 0.0),
-                    "daily_cost": _coerce_weekly_menu_float(raw_menu.get("daily_cost"), 0.0),
+                    "daily_cost": _coerce_weekly_menu_float(
+                        raw_menu.get("daily_cost", raw_menu.get("estimated_cost")),
+                        0.0,
+                    ),
                 }
             )
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3221,7 +3221,10 @@ def _coerce_weekly_menu_float(value: Any, default: float = 0.0) -> float:
     if isinstance(value, bool):
         return default
     if isinstance(value, (int, float)):
-        coerced = float(value)
+        try:
+            coerced = float(value)
+        except OverflowError:
+            return default
         return coerced if math.isfinite(coerced) else default
     return default
 
@@ -3232,11 +3235,28 @@ def _is_valid_weekly_menu_number(value: Any) -> bool:
     RU: Проверить, что numeric значение weekly menu корректно и конечно.
     EN: Check that a weekly-menu numeric value is valid and finite.
     """
-    return (
-        isinstance(value, (int, float))
-        and not isinstance(value, bool)
-        and math.isfinite(float(value))
-    )
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except OverflowError:
+        return False
+
+
+def _normalize_weekly_menu_number_map(raw_values: Any) -> Dict[str, float]:
+    """Keep only finite numeric values in weekly-menu maps.
+
+    RU: Оставить только конечные numeric значения в weekly-menu словарях.
+    EN: Keep only finite numeric values in weekly-menu dictionaries.
+    """
+    if not isinstance(raw_values, dict):
+        return {}
+
+    return {
+        key: _coerce_weekly_menu_float(value, 0.0)
+        for key, value in raw_values.items()
+        if isinstance(key, str) and _is_valid_weekly_menu_number(value)
+    }
 
 
 def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMenuResponse:
@@ -3279,33 +3299,8 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
                 }
             )
 
-    raw_weekly_coverage = menu_payload.get("weekly_coverage")
-    weekly_coverage = (
-        {
-            key: float(value)
-            for key, value in raw_weekly_coverage.items()
-            if isinstance(key, str)
-            and isinstance(value, (int, float))
-            and not isinstance(value, bool)
-            and math.isfinite(float(value))
-        }
-        if isinstance(raw_weekly_coverage, dict)
-        else {}
-    )
-
-    raw_shopping_list = menu_payload.get("shopping_list")
-    shopping_list = (
-        {
-            key: float(value)
-            for key, value in raw_shopping_list.items()
-            if isinstance(key, str)
-            and isinstance(value, (int, float))
-            and not isinstance(value, bool)
-            and math.isfinite(float(value))
-        }
-        if isinstance(raw_shopping_list, dict)
-        else {}
-    )
+    weekly_coverage = _normalize_weekly_menu_number_map(menu_payload.get("weekly_coverage"))
+    shopping_list = _normalize_weekly_menu_number_map(menu_payload.get("shopping_list"))
 
     total_cost = _coerce_weekly_menu_float(menu_payload.get("total_cost"), 0.0)
     adherence_score = _coerce_weekly_menu_float(menu_payload.get("adherence_score"), 0.0)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3243,22 +3243,26 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
             if not isinstance(raw_meals, list):
                 continue
             meals = list(raw_meals)
-            total_kcal = raw_menu.get("total_kcal")
-            if not isinstance(total_kcal, (int, float)):
+            raw_total_kcal = raw_menu.get("total_kcal")
+            if isinstance(raw_total_kcal, bool) or not isinstance(raw_total_kcal, (int, float)):
                 total_kcal = sum(
                     meal.get("kcal", 0)
                     for meal in meals
-                    if isinstance(meal, dict) and isinstance(meal.get("kcal"), (int, float))
+                    if isinstance(meal, dict)
+                    and isinstance(meal.get("kcal"), (int, float))
+                    and not isinstance(meal.get("kcal"), bool)
                 )
+            else:
+                total_kcal = raw_total_kcal
+            raw_daily_cost = raw_menu.get("daily_cost")
+            if isinstance(raw_daily_cost, bool) or not isinstance(raw_daily_cost, (int, float)):
+                raw_daily_cost = raw_menu.get("estimated_cost")
             daily_menus_payload.append(
                 {
                     "date": raw_date,
                     "meals": meals,
                     "total_kcal": _coerce_weekly_menu_float(total_kcal, 0.0),
-                    "daily_cost": _coerce_weekly_menu_float(
-                        raw_menu.get("daily_cost", raw_menu.get("estimated_cost")),
-                        0.0,
-                    ),
+                    "daily_cost": _coerce_weekly_menu_float(raw_daily_cost, 0.0),
                 }
             )
 
@@ -4629,9 +4633,15 @@ async def api_weekly_menu(
         import sys as _sys
 
         pkg_mod = _sys.modules.get("app")
-        pkg_override = getattr(pkg_mod, "make_weekly_menu", None) if pkg_mod else None
-        _make_weekly_menu = pkg_override or globals().get("make_weekly_menu")
-        if _make_weekly_menu is None:
+        pkg_has_override = pkg_mod is not None and "make_weekly_menu" in getattr(
+            pkg_mod, "__dict__", {}
+        )
+        _make_weekly_menu = (
+            getattr(pkg_mod, "make_weekly_menu")
+            if pkg_has_override
+            else globals().get("make_weekly_menu")
+        )
+        if not callable(_make_weekly_menu):
             raise HTTPException(
                 status_code=503, detail="Weekly menu generation feature not available"
             )

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import math
 import os
 import secrets
 import sys
@@ -3220,7 +3221,8 @@ def _coerce_weekly_menu_float(value: Any, default: float = 0.0) -> float:
     if isinstance(value, bool):
         return default
     if isinstance(value, (int, float)):
-        return float(value)
+        coerced = float(value)
+        return coerced if math.isfinite(coerced) else default
     return default
 
 
@@ -3274,6 +3276,7 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
             if isinstance(key, str)
             and isinstance(value, (int, float))
             and not isinstance(value, bool)
+            and math.isfinite(float(value))
         }
         if isinstance(raw_weekly_coverage, dict)
         else {}
@@ -3287,6 +3290,7 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
             if isinstance(key, str)
             and isinstance(value, (int, float))
             and not isinstance(value, bool)
+            and math.isfinite(float(value))
         }
         if isinstance(raw_shopping_list, dict)
         else {}
@@ -3295,16 +3299,16 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
     total_cost = _coerce_weekly_menu_float(menu_payload.get("total_cost"), 0.0)
     adherence_score = _coerce_weekly_menu_float(menu_payload.get("adherence_score"), 0.0)
     week_start = menu_payload.get("week_start", "")
+    total_days = len(daily_menus_payload)
+    returned_day_cost_total = sum(
+        _coerce_weekly_menu_float(day.get("daily_cost"), 0.0) for day in daily_menus_payload
+    )
 
     return WeeklyMenuResponse(
         week_summary={
             "week_start": str(week_start),
-            "total_days": len(daily_menus_payload),
-            "avg_daily_cost": (
-                round(total_cost / len(daily_menus_payload), 2)
-                if total_cost and daily_menus_payload
-                else 0.0
-            ),
+            "total_days": total_days,
+            "avg_daily_cost": round(returned_day_cost_total / total_days, 2) if total_days else 0.0,
         },
         daily_menus=daily_menus_payload,
         weekly_coverage=weekly_coverage,

--- a/tests/test_app_openapi_coverage.py
+++ b/tests/test_app_openapi_coverage.py
@@ -66,6 +66,7 @@ class TestAppOpenAPICoverage:
         assert "/api/v1/bmi" in paths
         assert "/api/v1/pro/nutrition/daily" in paths
         assert "/api/v1/vip/weekly-plan" in paths
+        assert "/api/v1/premium/plan/week" not in paths
         # /docs и /openapi.json не являются путями в схеме
         # assert "/docs" in paths
         # assert "/openapi.json" in paths

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -99,6 +99,8 @@ def test_legacy_weekly_alias_matches_canonical_vip_menu(
 
     assert legacy_response.status_code == 200, legacy_response.text
     assert canonical_response.status_code == 200, canonical_response.text
+    assert legacy_response.headers.get("Content-Type", "").startswith("application/json")
+    assert canonical_response.headers.get("Content-Type", "").startswith("application/json")
 
     legacy_data = legacy_response.json()
     canonical_menu = canonical_response.json()["menu"]
@@ -110,6 +112,9 @@ def test_legacy_weekly_alias_matches_canonical_vip_menu(
     assert legacy_data["adherence_score"] == canonical_menu["adherence_score"]
     assert legacy_data["week_summary"]["week_start"] == canonical_menu["week_start"]
     assert legacy_data["week_summary"]["total_days"] == len(canonical_menu["daily_menus"])
+    assert legacy_data["week_summary"]["avg_daily_cost"] == round(
+        canonical_menu["total_cost"] / len(canonical_menu["daily_menus"]), 2
+    )
 
 
 def test_legacy_weekly_alias_rejects_targets_only_payload_with_guidance(
@@ -136,6 +141,7 @@ def test_legacy_weekly_alias_rejects_targets_only_payload_with_guidance(
     )
 
     assert response.status_code == 422, response.text
+    assert response.headers.get("Content-Type", "").startswith("application/json")
     detail = response.json()["detail"]
     assert "Targets-based weekly plans are not supported on this endpoint." in detail
     assert "/api/v1/premium/plan/week-flexible" in detail
@@ -154,6 +160,7 @@ def test_legacy_weekly_alias_returns_503_when_vip_module_disabled(
     response = client.post("/api/v1/premium/plan/week", json=_valid_payload(), headers=vip_headers)
 
     assert response.status_code == 503, response.text
+    assert response.headers.get("Content-Type", "").startswith("application/json")
     assert response.json()["detail"] == "VIP module is disabled"
 
 
@@ -165,6 +172,18 @@ def test_build_legacy_weekly_menu_response_ignores_non_dict_days() -> None:
             "week_start": "2026-03-09",
             "daily_menus": [
                 "bad-day-entry",
+                {
+                    "date": "",
+                    "meals": [],
+                    "total_kcal": 0,
+                    "daily_cost": 0,
+                },
+                {
+                    "date": "2026-03-09",
+                    "meals": "bad-meals",
+                    "total_kcal": 0,
+                    "daily_cost": 0,
+                },
                 {
                     "date": "2026-03-10",
                     "meals": [],
@@ -197,7 +216,7 @@ def test_build_legacy_weekly_menu_response_rejects_bool_numeric_values() -> None
         }
     )
 
-    assert response.weekly_coverage == {"protein": 1.0, "fiber": 0.84}
-    assert response.shopping_list == {"oats": 1.0, "rice": 250.0}
+    assert response.weekly_coverage == {"fiber": 0.84}
+    assert response.shopping_list == {"rice": 250.0}
     assert response.total_cost == 0.0
     assert response.adherence_score == 0.0

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -202,6 +202,30 @@ def test_build_legacy_weekly_menu_response_ignores_non_dict_days() -> None:
     assert response.daily_menus[0]["date"] == "2026-03-10"
 
 
+def test_build_legacy_weekly_menu_response_accepts_estimated_cost_fallback() -> None:
+    """Canonical day menus may expose estimated_cost instead of daily_cost."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [],
+                    "total_kcal": 0,
+                    "estimated_cost": 12.75,
+                }
+            ],
+            "weekly_coverage": {},
+            "shopping_list": {},
+            "total_cost": 12.75,
+            "adherence_score": 0.1,
+        }
+    )
+
+    assert response.daily_menus[0]["daily_cost"] == 12.75
+
+
 def test_build_legacy_weekly_menu_response_rejects_bool_numeric_values() -> None:
     """Boolean-like numeric fields must fall back to defaults in the legacy adapter."""
 

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -358,3 +358,32 @@ def test_build_legacy_weekly_menu_response_rejects_non_finite_numeric_values() -
     assert response.shopping_list == {"rice": 250.0}
     assert response.total_cost == 0.0
     assert response.adherence_score == 0.0
+
+
+def test_build_legacy_weekly_menu_response_recovers_from_non_finite_day_values() -> None:
+    """Non-finite day numerics must still recover valid meal sum and estimated cost."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [
+                        {"title": "Breakfast", "kcal": math.nan},
+                        {"title": "Lunch", "kcal": 420},
+                    ],
+                    "total_kcal": math.nan,
+                    "daily_cost": math.inf,
+                    "estimated_cost": 14.5,
+                }
+            ],
+            "weekly_coverage": {},
+            "shopping_list": {},
+            "total_cost": 14.5,
+            "adherence_score": 0.25,
+        }
+    )
+
+    assert response.daily_menus[0]["total_kcal"] == 420.0
+    assert response.daily_menus[0]["daily_cost"] == 14.5

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -164,6 +164,27 @@ def test_legacy_weekly_alias_returns_503_when_vip_module_disabled(
     assert response.json()["detail"] == "VIP module is disabled"
 
 
+def test_legacy_weekly_alias_honors_explicit_none_package_override(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit package-level disablement must beat the legacy module fallback."""
+
+    import app as app_module
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
+    monkeypatch.setattr(legacy_app, "make_weekly_menu", _fake_weekly_menu_builder, raising=False)
+    monkeypatch.setattr(app_module, "make_weekly_menu", None, raising=False)
+
+    response = client.post("/api/v1/premium/plan/week", json=_valid_payload(), headers=vip_headers)
+
+    assert response.status_code == 503, response.text
+    assert response.headers.get("Content-Type", "").startswith("application/json")
+    assert response.json()["detail"] == "Weekly menu generation feature not available"
+
+
 def test_build_legacy_weekly_menu_response_ignores_non_dict_days() -> None:
     """Legacy adapter must skip malformed daily menu entries without crashing."""
 
@@ -244,3 +265,32 @@ def test_build_legacy_weekly_menu_response_rejects_bool_numeric_values() -> None
     assert response.shopping_list == {"rice": 250.0}
     assert response.total_cost == 0.0
     assert response.adherence_score == 0.0
+
+
+def test_build_legacy_weekly_menu_response_recovers_from_bool_day_values() -> None:
+    """Bool day numerics must fall back instead of zeroing valid day data."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [
+                        {"title": "Breakfast", "kcal": True},
+                        {"title": "Lunch", "kcal": 420},
+                    ],
+                    "total_kcal": True,
+                    "daily_cost": True,
+                    "estimated_cost": 14.5,
+                }
+            ],
+            "weekly_coverage": {},
+            "shopping_list": {},
+            "total_cost": 14.5,
+            "adherence_score": 0.25,
+        }
+    )
+
+    assert response.daily_menus[0]["total_kcal"] == 420.0
+    assert response.daily_menus[0]["daily_cost"] == 14.5

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import pytest
@@ -112,8 +113,11 @@ def test_legacy_weekly_alias_matches_canonical_vip_menu(
     assert legacy_data["adherence_score"] == canonical_menu["adherence_score"]
     assert legacy_data["week_summary"]["week_start"] == canonical_menu["week_start"]
     assert legacy_data["week_summary"]["total_days"] == len(canonical_menu["daily_menus"])
+    returned_day_cost_total = sum(
+        float(day.get("daily_cost", 0.0)) for day in canonical_menu["daily_menus"]
+    )
     assert legacy_data["week_summary"]["avg_daily_cost"] == round(
-        canonical_menu["total_cost"] / len(canonical_menu["daily_menus"]), 2
+        returned_day_cost_total / len(canonical_menu["daily_menus"]), 2
     )
 
 
@@ -247,6 +251,37 @@ def test_build_legacy_weekly_menu_response_accepts_estimated_cost_fallback() -> 
     assert response.daily_menus[0]["daily_cost"] == 12.75
 
 
+def test_build_legacy_weekly_menu_response_uses_returned_days_for_avg_cost() -> None:
+    """Week summary average must derive from returned day payloads, not top-level total_cost."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [],
+                    "total_kcal": 0,
+                    "daily_cost": 10.0,
+                },
+                {
+                    "date": "2026-03-11",
+                    "meals": [],
+                    "total_kcal": 0,
+                    "daily_cost": 20.0,
+                },
+            ],
+            "weekly_coverage": {},
+            "shopping_list": {},
+            "total_cost": 999.0,
+            "adherence_score": 0.1,
+        }
+    )
+
+    assert response.week_summary["total_days"] == 2
+    assert response.week_summary["avg_daily_cost"] == 15.0
+
+
 def test_build_legacy_weekly_menu_response_rejects_bool_numeric_values() -> None:
     """Boolean-like numeric fields must fall back to defaults in the legacy adapter."""
 
@@ -294,3 +329,32 @@ def test_build_legacy_weekly_menu_response_recovers_from_bool_day_values() -> No
 
     assert response.daily_menus[0]["total_kcal"] == 420.0
     assert response.daily_menus[0]["daily_cost"] == 14.5
+
+
+def test_build_legacy_weekly_menu_response_rejects_non_finite_numeric_values() -> None:
+    """NaN and Infinity must collapse to safe legacy defaults instead of leaking to JSON."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [],
+                    "total_kcal": math.nan,
+                    "daily_cost": math.inf,
+                }
+            ],
+            "weekly_coverage": {"protein": math.inf, "fiber": 0.84},
+            "shopping_list": {"oats": math.nan, "rice": 250.0},
+            "total_cost": math.inf,
+            "adherence_score": math.nan,
+        }
+    )
+
+    assert response.daily_menus[0]["total_kcal"] == 0.0
+    assert response.daily_menus[0]["daily_cost"] == 0.0
+    assert response.weekly_coverage == {"fiber": 0.84}
+    assert response.shopping_list == {"rice": 250.0}
+    assert response.total_cost == 0.0
+    assert response.adherence_score == 0.0

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -119,6 +120,44 @@ def test_legacy_weekly_alias_matches_canonical_vip_menu(
     assert legacy_data["week_summary"]["avg_daily_cost"] == round(
         returned_day_cost_total / len(canonical_menu["daily_menus"]), 2
     )
+
+
+def test_legacy_weekly_alias_delegates_to_canonical_vip_execution(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy alias must delegate through the canonical VIP execution seam."""
+
+    import app as app_module
+    import app.routers.vip as vip_router
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_run_weekly_plan_task(
+        task: Any,
+        *,
+        menu_builder: Any = None,
+    ) -> Any:
+        captured["payload"] = task.input.request_data
+        captured["menu_builder"] = menu_builder
+        return SimpleNamespace(menu=_fake_weekly_menu_builder(object()))
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
+    monkeypatch.setattr(app_module, "make_weekly_menu", _fake_weekly_menu_builder, raising=False)
+    monkeypatch.setattr(
+        vip_router.fitchef_runtime,
+        "run_weekly_plan_task",
+        _fake_run_weekly_plan_task,
+    )
+
+    response = client.post("/api/v1/premium/plan/week", json=_valid_payload(), headers=vip_headers)
+
+    assert response.status_code == 200, response.text
+    assert captured["menu_builder"] is _fake_weekly_menu_builder
+    assert captured["payload"]["sex"] == "female"
+    assert response.json()["daily_menus"] == _fake_weekly_menu_builder(object())["daily_menus"]
 
 
 def test_legacy_weekly_alias_rejects_targets_only_payload_with_guidance(
@@ -387,3 +426,37 @@ def test_build_legacy_weekly_menu_response_recovers_from_non_finite_day_values()
 
     assert response.daily_menus[0]["total_kcal"] == 420.0
     assert response.daily_menus[0]["daily_cost"] == 14.5
+
+
+def test_build_legacy_weekly_menu_response_rejects_overflow_numeric_values() -> None:
+    """Huge integer numerics must be dropped instead of raising overflow errors."""
+
+    huge_number = 10**1000
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                {
+                    "date": "2026-03-10",
+                    "meals": [
+                        {"title": "Lunch", "kcal": huge_number},
+                        {"title": "Dinner", "kcal": 420},
+                    ],
+                    "total_kcal": huge_number,
+                    "daily_cost": huge_number,
+                    "estimated_cost": 14.5,
+                }
+            ],
+            "weekly_coverage": {"protein": huge_number, "fiber": 0.84},
+            "shopping_list": {"oats": huge_number, "rice": 250.0},
+            "total_cost": huge_number,
+            "adherence_score": huge_number,
+        }
+    )
+
+    assert response.daily_menus[0]["total_kcal"] == 420.0
+    assert response.daily_menus[0]["daily_cost"] == 14.5
+    assert response.weekly_coverage == {"fiber": 0.84}
+    assert response.shopping_list == {"rice": 250.0}
+    assert response.total_cost == 0.0
+    assert response.adherence_score == 0.0

--- a/tests/test_legacy_weekly_plan_alias_api.py
+++ b/tests/test_legacy_weekly_plan_alias_api.py
@@ -1,0 +1,203 @@
+"""Tests for the legacy premium weekly-plan alias shim."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+import legacy_app
+
+
+def _fake_weekly_menu_builder(profile: object) -> dict[str, Any]:
+    """Return a deterministic weekly menu payload for alias/canonical parity tests.
+
+    RU: Вернуть детерминированный weekly menu payload для parity тестов.
+    EN: Return a deterministic weekly menu payload for alias/canonical parity tests.
+    """
+    return {
+        "week_start": "2026-03-09",
+        "daily_menus": [
+            {
+                "date": "2026-03-09",
+                "meals": [
+                    {"title": "Breakfast", "kcal": 320},
+                    {"title": "Lunch", "kcal": 610},
+                ],
+                "total_kcal": 930,
+                "daily_cost": 11.5,
+            },
+            {
+                "date": "2026-03-10",
+                "meals": [{"title": "Dinner", "kcal": 540}],
+                "total_kcal": 540,
+                "daily_cost": 9.25,
+            },
+        ],
+        "weekly_coverage": {"protein": 0.91, "fiber": 0.84},
+        "shopping_list": {"oats": 400.0, "chicken": 900.0},
+        "total_cost": 72.8,
+        "adherence_score": 0.67,
+    }
+
+
+def _valid_payload() -> dict[str, Any]:
+    return {
+        "sex": "female",
+        "age": 30,
+        "height_cm": 168.0,
+        "weight_kg": 62.0,
+        "activity": "moderate",
+        "goal": "maintain",
+        "diet_flags": [],
+        "lang": "en",
+    }
+
+
+def test_legacy_weekly_alias_matches_canonical_vip_menu(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy premium alias must be a thin adapter over canonical VIP weekly menu logic."""
+
+    import app as app_module
+    import app.routers.vip as vip_router
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
+    monkeypatch.setattr(app_module, "make_weekly_menu", _fake_weekly_menu_builder, raising=False)
+    monkeypatch.setattr(legacy_app, "make_weekly_menu", _fake_weekly_menu_builder, raising=False)
+    monkeypatch.setattr(vip_router, "make_weekly_menu", _fake_weekly_menu_builder, raising=False)
+
+    vip_route = next(
+        (
+            route
+            for route in client.app.routes
+            if isinstance(route, APIRoute)
+            and route.path == "/api/v1/vip/menu/weekly/plan"
+            and "POST" in (route.methods or set())
+        ),
+        None,
+    )
+    assert vip_route is not None, "POST /api/v1/vip/menu/weekly/plan route not found"
+    monkeypatch.setitem(
+        vip_route.endpoint.__globals__,
+        "make_weekly_menu",
+        _fake_weekly_menu_builder,
+    )
+
+    payload = _valid_payload()
+    legacy_response = client.post("/api/v1/premium/plan/week", json=payload, headers=vip_headers)
+    canonical_response = client.post(
+        "/api/v1/vip/menu/weekly/plan",
+        json=payload,
+        headers=vip_headers,
+    )
+
+    assert legacy_response.status_code == 200, legacy_response.text
+    assert canonical_response.status_code == 200, canonical_response.text
+
+    legacy_data = legacy_response.json()
+    canonical_menu = canonical_response.json()["menu"]
+
+    assert legacy_data["daily_menus"] == canonical_menu["daily_menus"]
+    assert legacy_data["weekly_coverage"] == canonical_menu["weekly_coverage"]
+    assert legacy_data["shopping_list"] == canonical_menu["shopping_list"]
+    assert legacy_data["total_cost"] == canonical_menu["total_cost"]
+    assert legacy_data["adherence_score"] == canonical_menu["adherence_score"]
+    assert legacy_data["week_summary"]["week_start"] == canonical_menu["week_start"]
+    assert legacy_data["week_summary"]["total_days"] == len(canonical_menu["daily_menus"])
+
+
+def test_legacy_weekly_alias_rejects_targets_only_payload_with_guidance(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Targets-only legacy payload must keep the legacy guidance contract."""
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
+
+    response = client.post(
+        "/api/v1/premium/plan/week",
+        json={
+            "targets": {
+                "kcal": 2000,
+                "macros": {"protein_g": 120},
+                "micro": {"iron_mg": 18},
+                "water_ml": 2200,
+            }
+        },
+        headers=vip_headers,
+    )
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert "Targets-based weekly plans are not supported on this endpoint." in detail
+    assert "/api/v1/premium/plan/week-flexible" in detail
+
+
+def test_legacy_weekly_alias_returns_503_when_vip_module_disabled(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """VIP feature flag must short-circuit before canonical weekly-plan delegation."""
+
+    monkeypatch.setenv("VIP_MODULE_ENABLED", "false")
+    monkeypatch.setenv("API_KEY", vip_headers["X-API-Key"])
+
+    response = client.post("/api/v1/premium/plan/week", json=_valid_payload(), headers=vip_headers)
+
+    assert response.status_code == 503, response.text
+    assert response.json()["detail"] == "VIP module is disabled"
+
+
+def test_build_legacy_weekly_menu_response_ignores_non_dict_days() -> None:
+    """Legacy adapter must skip malformed daily menu entries without crashing."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [
+                "bad-day-entry",
+                {
+                    "date": "2026-03-10",
+                    "meals": [],
+                    "total_kcal": 0,
+                    "daily_cost": 0,
+                },
+            ],
+            "weekly_coverage": {},
+            "shopping_list": {},
+            "total_cost": 7.0,
+            "adherence_score": 0.1,
+        }
+    )
+
+    assert len(response.daily_menus) == 1
+    assert response.daily_menus[0]["date"] == "2026-03-10"
+
+
+def test_build_legacy_weekly_menu_response_rejects_bool_numeric_values() -> None:
+    """Boolean-like numeric fields must fall back to defaults in the legacy adapter."""
+
+    response = legacy_app._build_legacy_weekly_menu_response(
+        {
+            "week_start": "2026-03-09",
+            "daily_menus": [],
+            "weekly_coverage": {"protein": True, "fiber": 0.84},
+            "shopping_list": {"oats": True, "rice": 250.0},
+            "total_cost": True,
+            "adherence_score": False,
+        }
+    )
+
+    assert response.weekly_coverage == {"protein": 1.0, "fiber": 0.84}
+    assert response.shopping_list == {"oats": 1.0, "rice": 250.0}
+    assert response.total_cost == 0.0
+    assert response.adherence_score == 0.0


### PR DESCRIPTION
## Summary
- refactor `POST /api/v1/premium/plan/week` into a thin compatibility shim over the canonical VIP weekly-plan execution path
- keep the legacy runtime response contract intact while removing direct weekly-plan business logic from `legacy_app.py`
- keep the route hidden from public OpenAPI and add focused parity/precedence coverage for the shim

## Scope
- `legacy_app.py`
- `app/routers/vip.py`
- `tests/test_legacy_weekly_plan_alias_api.py`
- `docs/review/PR_1061_FIXED_MAPPING.md`

## What Changed
- extracted a shared internal weekly-plan execution helper in `app/routers/vip.py` so the canonical VIP route and the legacy premium alias use the same execution seam
- updated `legacy_app.py:/api/v1/premium/plan/week` to:
  - keep legacy feature-flag / validation / auth semantics
  - delegate execution through the canonical VIP weekly-plan seam
  - translate canonical `menu` payload back into `WeeklyMenuResponse`
  - preserve canonical `estimated_cost` when adapting day payloads
  - skip malformed day entries, reject bool-like numerics in day/menu recovery, and compute `avg_daily_cost` from returned days
  - honor explicit package-level `app.make_weekly_menu = None` disablement instead of falling through to the legacy module global
  - reject `NaN`/`Infinity` in legacy numeric coercion so malformed weekly payloads degrade to stable JSON-safe defaults
  - mark the route `include_in_schema=False`
- added focused tests for:
  - legacy alias vs canonical VIP menu parity
  - targets-only legacy guidance behavior
  - feature-flag precedence
  - JSON content-type assertions before `.json()` decoding
  - malformed day filtering, bool rejection, `estimated_cost` fallback, explicit disablement, bool-safe day recovery, non-finite numeric rejection, and avg-cost parity in the legacy adapter

## Why
Step 1 and Step 3 of the weekly-plan wave are already present on `main`. The remaining repo-grounded gap is Step 2: make the broken legacy VIP alias thin, explicit, and non-public without widening the weekly-plan wave.

## Validation
- `pytest -q tests/test_legacy_weekly_plan_alias_api.py tests/test_pro_premium_contract_parity.py tests/test_openapi_determinism.py tests/test_app_openapi_coverage.py`
- `python3 -m pytest -q tests/test_legacy_app_diff_coverage.py -k week_plan_missing_required_fields_raises_422`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907556833` -> `b59964d0`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907567013` -> `3fbc03db`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575159` -> `b59964d0`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575169` -> `b59964d0`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575176` -> `b59964d0`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575193` -> `b59964d0`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907575145` -> `NOT-A-BUG`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917808319` -> `NOT-A-BUG`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907715232` -> `dc959872`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3917967588` -> `dc959872`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802282` -> `76824910`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802293` -> `76824910`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907802299` -> `76824910`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918067947` -> `76824910`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907863018` -> `NOT-A-BUG`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907863024` -> `3f42a408`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918134801` -> `NOT-A-BUG`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#discussion_r2907948108` -> `79c253a3`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1061#pullrequestreview-3918232238` -> `79c253a3`

## Merge Readiness
- [x] Local hard gate: `pre-commit run --all-files`
- [x] Local hard gate: `make verify`
- [ ] Required checks are green
- [ ] Review threads are resolved
- [ ] CodeRabbit / Sourcery / Cubic are PASS or non-actionable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded user profile fields for weekly plans (demographics, metrics, goals, diet flags, life stage, language).

* **Improvements**
  * Weekly menu generation unified through a canonical execution path for consistent results and simplified error responses.
  * Legacy weekly-menu responses now use a dedicated translator with sanitization and legacy-friendly mappings.

* **Tests**
  * Added comprehensive tests covering parity, error handling, feature-flag behavior, and malformed inputs.

* **Documentation**
  * Added a review summary document detailing mapping and compatibility findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
