### PR TITLE
refactor(vip): thin premium weekly alias

### DIFF
--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -600,6 +600,35 @@ async def _execute_weekly_menu_plan_payload(
     return request_obj, echo_payload, result.menu
 
 
+async def execute_legacy_premium_week_alias_payload(
+    payload: Mapping[str, Any],
+    *,
+    menu_builder: Optional[Callable[..., Any]] = None,
+) -> Dict[str, Any]:
+    """Run the canonical VIP weekly-plan path for the legacy premium alias.
+
+    RU: Выполнить canonical VIP weekly-plan path для legacy premium alias.
+    EN: Execute the canonical VIP weekly-plan path for the legacy premium alias.
+    """
+    has_targets_only_payload = payload.get("targets") is not None and not any(
+        payload.get(key) is not None for key in ("sex", "age", "height_cm", "weight_kg", "activity")
+    )
+    if has_targets_only_payload:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Targets-based weekly plans are not supported on this endpoint. "
+                "Provide full profile data or use /api/v1/premium/plan/week-flexible."
+            ),
+        )
+
+    _, _, menu_payload = await _execute_weekly_menu_plan_payload(
+        dict(payload),
+        menu_builder=menu_builder,
+    )
+    return menu_payload
+
+
 def _require_api_key_dev_legacy(request: Request) -> str:
     """Dev-friendly variant: allow anonymous in dev/test/local by default for legacy path.
 

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -615,7 +615,7 @@ async def execute_legacy_premium_week_alias_payload(
     )
     if has_targets_only_payload:
         raise HTTPException(
-            status_code=422,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
                 "Targets-based weekly plans are not supported on this endpoint. "
                 "Provide full profile data or use /api/v1/premium/plan/week-flexible."
@@ -763,7 +763,7 @@ async def weekly_menu_plan_alias(
             ]
         ):
             raise HTTPException(
-                status_code=422,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Missing required fields: sex, age, height_cm, weight_kg, activity, goal",
             )
 

--- a/docs/review/PR_1069_FIXED_MAPPING.md
+++ b/docs/review/PR_1069_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1069 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks are PASS
+- [x] Fixed in Commit Mapping artifact updated
+- [ ] No unresolved review threads remain
+- [ ] No actionable bot comments remain
+- [ ] Final wait-cycle completed after latest review/bot activity

--- a/docs/review/PR_1069_FIXED_MAPPING.md
+++ b/docs/review/PR_1069_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 62f7314a
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1069#discussion_r2910249960 -> 62f7314a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1069#discussion_r2910249977 -> 62f7314a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1069#pullrequestreview-3920759025 -> 62f7314a
 
 ## Merge Readiness
 - [ ] All required checks are PASS

--- a/docs/review/PR_1069_FIXED_MAPPING.md
+++ b/docs/review/PR_1069_FIXED_MAPPING.md
@@ -9,7 +9,7 @@
 
 ## Merge Readiness
 - [ ] All required checks are PASS
-- [x] Fixed in Commit Mapping artifact updated
+- [ ] Fixed in Commit Mapping artifact updated
 - [ ] No unresolved review threads remain
 - [ ] No actionable bot comments remain
 - [ ] Final wait-cycle completed after latest review/bot activity

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3321,6 +3321,28 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
     )
 
 
+def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
+    """Resolve the canonical weekly-menu builder for the legacy premium alias.
+
+    RU: Разрешить canonical weekly-menu builder для legacy premium alias.
+    EN: Resolve the canonical weekly-menu builder for the legacy premium alias.
+    """
+    import sys as _sys
+
+    package_module = _sys.modules.get("app")
+    package_has_override = package_module is not None and "make_weekly_menu" in getattr(
+        package_module,
+        "__dict__",
+        {},
+    )
+    if package_has_override:
+        package_builder = getattr(package_module, "make_weekly_menu")
+        return package_builder if callable(package_builder) else None
+
+    local_builder = globals().get("make_weekly_menu")
+    return local_builder if callable(local_builder) else None
+
+
 class WeeklyPlanFlexibleRequest(BaseModel):
     # Either 'targets' or a lightweight user profile
     targets: Optional[Dict[str, Any]] = None
@@ -4623,53 +4645,17 @@ async def api_weekly_menu(
         if _vip_env is None and not VIP_MODULE_ENABLED:
             raise HTTPException(status_code=503, detail="VIP module is disabled")
 
-        # Mode A: targets-only payloads are not yet supported for this endpoint.
-        # For such requests, return a clear validation error instead of leaking 500s.
-        if req.targets is not None and not any(
-            [req.sex, req.age, req.height_cm, req.weight_kg, req.activity]
-        ):
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    "Targets-based weekly plans are not supported on this endpoint. "
-                    "Provide full profile data or use /api/v1/premium/plan/week-flexible."
-                ),
-            )
-
-        # Resolve make_weekly_menu with preference for package-level patching in tests
-        import sys as _sys
-
-        pkg_mod = _sys.modules.get("app")
-        pkg_has_override = pkg_mod is not None and "make_weekly_menu" in getattr(
-            pkg_mod, "__dict__", {}
-        )
-        _make_weekly_menu = (
-            getattr(pkg_mod, "make_weekly_menu")
-            if pkg_has_override
-            else globals().get("make_weekly_menu")
-        )
-        if not callable(_make_weekly_menu):
+        menu_builder = _resolve_legacy_weekly_menu_builder()
+        if menu_builder is None:
             raise HTTPException(
                 status_code=503, detail="Weekly menu generation feature not available"
             )
 
-        from app.routers.vip import _execute_weekly_menu_plan_payload
+        from app.routers.vip import execute_legacy_premium_week_alias_payload
 
-        if (
-            req.sex is None
-            or req.age is None
-            or req.height_cm is None
-            or req.weight_kg is None
-            or req.activity is None
-        ):
-            raise HTTPException(
-                status_code=422,
-                detail="Required fields missing: sex, age, height_cm, weight_kg, and activity are all required.",
-            )
-
-        _, _, menu_payload = await _execute_weekly_menu_plan_payload(
+        menu_payload = await execute_legacy_premium_week_alias_payload(
             req.model_dump(exclude_none=True),
-            menu_builder=_make_weekly_menu,
+            menu_builder=menu_builder,
         )
         return _build_legacy_weekly_menu_response(menu_payload)
 


### PR DESCRIPTION
## Summary
- turn `/api/v1/premium/plan/week` into a thinner compatibility shim over the canonical VIP weekly-plan execution seam
- keep legacy runtime behavior intact for feature-flag gating, targets-only guidance, and package-level builder override precedence
- avoid widening this PR into broader `/premium/*` cleanup or frontend/iOS weekly-plan work

## What Changed
- added `execute_legacy_premium_week_alias_payload(...)` in `app/routers/vip.py` as the canonical weekly-plan execution helper for the legacy premium alias
- added `_resolve_legacy_weekly_menu_builder()` in `legacy_app.py` so package-level `app.make_weekly_menu` overrides still win over the legacy fallback
- removed direct weekly-plan business logic duplication from `legacy_app.py` and delegated the legacy route through the canonical VIP execution seam while preserving legacy HTTP error behavior
- added canonical review artifact `docs/review/PR_1069_FIXED_MAPPING.md`

## Validation
- `bash -lc '. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/activate && pytest -q tests/test_legacy_weekly_plan_alias_api.py tests/test_targets_in_parity.py -k "legacy_week_endpoint or legacy_targets_in or legacy_weekly_alias"'`
- `bash -lc '. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/activate && pytest -q tests/test_premium_week_app_coverage.py -k "api_weekly_menu"'`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1069_FIXED_MAPPING.md`
- No actionable review comments

## Merge Readiness
- [ ] All required checks are PASS
- [x] Fixed in Commit Mapping artifact updated
- [ ] No unresolved review threads remain
- [ ] No actionable bot comments remain
- [ ] Final wait-cycle completed after latest review/bot activity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly meal plan API now accepts fuller user profiles (personal metrics, dietary flags, life stage, language).

* **Bug Fixes**
  * Legacy premium weekly-plan requests now reject targets-only submissions with clear 422 responses and return 503 when the legacy menu feature is unavailable.

* **Documentation**
  * Added PR review tracking document summarizing fixes and merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->