### PR TITLE
refactor(frontend): normalize weekly plan consumers

### DIFF
--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -29,6 +29,11 @@ Commit: 924ce77d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921127026 -> 924ce77d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910573251 -> 924ce77d
 
+Disposition: FIXED
+Commit: 0f9669bc
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921575188 -> 0f9669bc
+
 ## Merge Readiness
 - [ ] All required checks are PASS
 - [ ] Fixed in Commit Mapping artifact updated

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -18,6 +18,11 @@ Commit: de6908df
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3920884181 -> de6908df
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910360398 -> de6908df
 
+Disposition: FIXED
+Commit: 3f812740
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921037276 -> 3f812740
+
 ## Merge Readiness
 - [ ] All required checks are PASS
 - [ ] Fixed in Commit Mapping artifact updated

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1070 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks are PASS
+- [x] Fixed in Commit Mapping artifact updated
+- [ ] No unresolved review threads remain
+- [ ] No actionable bot comments remain
+- [ ] Final wait-cycle completed after latest review/bot activity

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -23,6 +23,11 @@ Commit: 3f812740
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921037276 -> 3f812740
 
+Disposition: FIXED
+Commit: 924ce77d
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921127026 -> 924ce77d
+
 ## Merge Readiness
 - [ ] All required checks are PASS
 - [ ] Fixed in Commit Mapping artifact updated

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -12,6 +12,12 @@ Commit: 47c9b325
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3920757103 -> 47c9b325
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910248564 -> 47c9b325
 
+Disposition: FIXED
+Commit: de6908df
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3920884181 -> de6908df
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910360398 -> de6908df
+
 ## Merge Readiness
 - [ ] All required checks are PASS
 - [ ] Fixed in Commit Mapping artifact updated

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -9,7 +9,7 @@
 
 ## Merge Readiness
 - [ ] All required checks are PASS
-- [x] Fixed in Commit Mapping artifact updated
+- [ ] Fixed in Commit Mapping artifact updated
 - [ ] No unresolved review threads remain
 - [ ] No actionable bot comments remain
 - [ ] Final wait-cycle completed after latest review/bot activity

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 47c9b325
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3920752800 -> 47c9b325
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3920757103 -> 47c9b325
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910248564 -> 47c9b325
 
 ## Merge Readiness
 - [ ] All required checks are PASS

--- a/docs/review/PR_1070_FIXED_MAPPING.md
+++ b/docs/review/PR_1070_FIXED_MAPPING.md
@@ -27,6 +27,7 @@ Disposition: FIXED
 Commit: 924ce77d
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#pullrequestreview-3921127026 -> 924ce77d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1070#discussion_r2910573251 -> 924ce77d
 
 ## Merge Readiness
 - [ ] All required checks are PASS

--- a/frontend/src/components/WhoTargetsPanel/IntegratedWhoTargetsPanel.tsx
+++ b/frontend/src/components/WhoTargetsPanel/IntegratedWhoTargetsPanel.tsx
@@ -1,11 +1,11 @@
 import { useWhoTargetsWithWeeklyPlan } from '../../hooks/useWhoTargetsWithWeeklyPlan';
 import type { TargetsRequest } from '../../api/premium/types';
-import type { WeeklyMealPlanResponse } from '../../api/premium/weekly-plan';
+import type { WeekPlanVM } from '../../features/weekly-plan/model/types';
 import { WhoTargetsPanel } from '../WhoTargetsPanel';
 
 interface IntegratedWhoTargetsPanelProps {
   request: TargetsRequest | null;
-  onWeeklyPlanGenerated?: (weeklyPlan: WeeklyMealPlanResponse) => void;
+  onWeeklyPlanGenerated?: (weeklyPlan: WeekPlanVM) => void;
   onError?: (error: Error) => void;
   className?: string;
 }

--- a/frontend/src/components/__tests__/IntegratedWhoTargetsPanel.test.tsx
+++ b/frontend/src/components/__tests__/IntegratedWhoTargetsPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntegratedWhoTargetsPanel } from '../WhoTargetsPanel/IntegratedWhoTargetsPanel';
 import type { TargetsRequest } from '../../api/premium/types';
+import type { WeekPlanVM } from '../../features/weekly-plan/model/types';
 
 // Mock the hook
 vi.mock('../../hooks/useWhoTargetsWithWeeklyPlan', () => ({
@@ -53,14 +54,8 @@ describe('IntegratedWhoTargetsPanel', () => {
     warnings: [],
   };
 
-  const mockWeeklyPlanData = {
-    week_summary: {
-      total_calories: 14000,
-      total_protein: 1050,
-      total_carbs: 1750,
-      total_fat: 469,
-    },
-    daily_menus: [],
+  const mockWeeklyPlanData: WeekPlanVM = {
+    days: [],
     weekly_coverage: {
       protein: 95,
       carbs: 98,
@@ -72,9 +67,15 @@ describe('IntegratedWhoTargetsPanel', () => {
       'brown rice': 1000,
       'broccoli': 300,
     },
-    total_cost: 45.50,
-    adherence_score: 87,
-  } as any;
+    metrics: {
+      total_cost: 45.5,
+      adherence_score: 87,
+    },
+    meta: {
+      total_days: 0,
+      has_incomplete_data: false,
+    },
+  };
 
   const mockHook = vi.mocked(useWhoTargetsWithWeeklyPlan);
 
@@ -305,18 +306,22 @@ describe('IntegratedWhoTargetsPanel', () => {
     it('should call onWeeklyPlanGenerated when weekly plan is generated', () => {
       const mockOnWeeklyPlanGenerated = vi.fn();
       const mockOnError = vi.fn();
+      let capturedOnSuccess: ((targets: typeof mockTargetsData, weeklyPlan: WeekPlanVM) => void) | undefined;
 
-      mockHook.mockReturnValue({
-        targetsData: mockTargetsData,
-        targetsLoading: false,
-        targetsError: null,
-        weeklyPlanData: mockWeeklyPlanData,
-        weeklyPlanLoading: false,
-        weeklyPlanError: null,
-        fetchTargets: vi.fn(),
-        saveAndGetWeeklyPlan: vi.fn(),
-        retry: vi.fn(),
-        clearData: vi.fn(),
+      mockHook.mockImplementation((options = {}) => {
+        capturedOnSuccess = options.onSuccess as typeof capturedOnSuccess;
+        return {
+          targetsData: mockTargetsData,
+          targetsLoading: false,
+          targetsError: null,
+          weeklyPlanData: mockWeeklyPlanData,
+          weeklyPlanLoading: false,
+          weeklyPlanError: null,
+          fetchTargets: vi.fn(),
+          saveAndGetWeeklyPlan: vi.fn(),
+          retry: vi.fn(),
+          clearData: vi.fn(),
+        };
       });
 
       render(
@@ -327,9 +332,39 @@ describe('IntegratedWhoTargetsPanel', () => {
         />
       );
 
-      // The callback would be called by the hook when weekly plan is generated
-      // This is tested indirectly through the hook's behavior
       expect(screen.getByTestId('who-targets-panel')).toHaveClass('who-targets-panel--loaded');
+      expect(capturedOnSuccess).toBeTypeOf('function');
+      capturedOnSuccess?.(mockTargetsData, mockWeeklyPlanData);
+      expect(mockOnWeeklyPlanGenerated).toHaveBeenCalledWith(mockWeeklyPlanData);
+      expect(mockOnError).not.toHaveBeenCalled();
+    });
+
+    it('should pass onError through the hook options', () => {
+      const mockOnError = vi.fn();
+      let capturedOnError: ((error: Error) => void) | undefined;
+
+      mockHook.mockImplementation((options = {}) => {
+        capturedOnError = options.onError as typeof capturedOnError;
+        return {
+          targetsData: mockTargetsData,
+          targetsLoading: false,
+          targetsError: null,
+          weeklyPlanData: null,
+          weeklyPlanLoading: false,
+          weeklyPlanError: null,
+          fetchTargets: vi.fn(),
+          saveAndGetWeeklyPlan: vi.fn(),
+          retry: vi.fn(),
+          clearData: vi.fn(),
+        };
+      });
+
+      render(<IntegratedWhoTargetsPanel request={mockRequest} onError={mockOnError} />);
+
+      const error = new Error('weekly-plan-failed');
+      expect(capturedOnError).toBeTypeOf('function');
+      capturedOnError?.(error);
+      expect(mockOnError).toHaveBeenCalledWith(error);
     });
   });
 

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -291,14 +291,15 @@ export default function WeeklyPlanViewer() {
           <div className="opacity-80">{t('plan.emptySummary')}</div>
         ) : (
           <ul className="space-y-4">
-            {dailyMenus.map((menu, idx) => {
-              const dayTitle = getDayTitle(idx, displayLocale, t, menu.dayName);
+            {dailyMenus.map((menu) => {
+              const dayIndex = Math.max(menu.day - 1, 0);
+              const dayTitle = getDayTitle(dayIndex, displayLocale, t, menu.dayName);
               const dayEnergy = menu.kcal;
               const meals = menu.meals;
 
               return (
                 <li
-                  key={`${dayTitle}-${idx}`}
+                  key={`${dayTitle}-${menu.day}`}
                   className="border border-white/15 rounded-2xl bg-white/10 p-4 space-y-2 backdrop-blur-sm"
                 >
                   <div className="flex items-center justify-between">

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ProWeekPlanRequest } from "../../api/premium/weekly-plan";
 import { fetchBlob } from "../../api/client";
@@ -15,6 +15,14 @@ const SUPPORTED_REQUEST_LANGS: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"]
 
 function isSupportedRequestLang(locale: string): locale is ProWeekPlanRequest["lang"] {
   return SUPPORTED_REQUEST_LANGS.some((supportedLocale) => supportedLocale === locale);
+}
+
+function getInitialRequest(): ProWeekPlanRequest {
+  const clientLocale = getClientLocale();
+  return {
+    ...DEFAULT_REQUEST,
+    lang: isSupportedRequestLang(clientLocale) ? clientLocale : "en",
+  };
 }
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -124,19 +132,10 @@ export default function WeeklyPlanViewer() {
   const { t } = useTranslation();
   const [hint, setHint] = useState<string | null>(null);
   const [lastSignedLink, setLastSignedLink] = useState<string | null>(null);
-  const [request, setRequest] = useState<ProWeekPlanRequest | null>(null);
-
-  useEffect(() => {
-    const clientLocale = getClientLocale();
-    setRequest({
-      ...DEFAULT_REQUEST,
-      lang: isSupportedRequestLang(clientLocale) ? clientLocale : "en",
-    });
-  }, []);
+  const [request] = useState<ProWeekPlanRequest>(getInitialRequest);
 
   const { data, loading, error: err } = useWeeklyPlan({
     targets: request,
-    enabled: request !== null,
   });
 
   if (loading) {
@@ -152,7 +151,7 @@ export default function WeeklyPlanViewer() {
   }
 
   const dailyMenus = data?.days ?? [];
-  const displayLocale = request?.lang ?? "en";
+  const displayLocale = request.lang;
 
   const openSheetsHelp = () => {
     window.open("https://sheets.new", "_blank", "noopener,noreferrer");

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getWeeklyPlan } from "../../api/premium/weekly-plan";
-import type { ProWeekPlanRequest, WeeklyMealPlanResponse } from "../../api/premium/weekly-plan";
+import type { ProWeekPlanRequest } from "../../api/premium/weekly-plan";
 import { fetchBlob } from "../../api/client";
 import GlassCard from "../../components/GlassCard";
 import { shareSignedExport, formatShareErrorMessage } from "../../lib/shareFile";
 import { requestSignedLink } from "../../lib/sharedLinks";
 import { getClientLocale } from "../../lib/i18n";
+import { useWeeklyPlan } from "../weekly-plan/hooks/useWeeklyPlan";
+import type { Meal } from "../weekly-plan/model/types";
 
 const DEFAULT_TTL_SECONDS = 900;
 
@@ -54,9 +55,6 @@ async function downloadSignedFile(url: string, filename: string): Promise<void> 
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
 }
 
-type WeeklyDayMenu = WeeklyMealPlanResponse["daily_menus"][number];
-type WeeklyMeal = WeeklyDayMenu["meals"][number];
-
 const DEFAULT_REQUEST: ProWeekPlanRequest = {
   sex: "female",
   age: 30,
@@ -72,7 +70,7 @@ function getDayTitle(index: number, t: (key: string, options?: Record<string, un
   return t("plan.day_fallback", { number: index + 1 });
 }
 
-function getMealName(meal: WeeklyMeal): string {
+function getMealName(meal: Meal): string {
   return meal.title_translated || meal.title;
 }
 
@@ -80,7 +78,7 @@ function formatMetricLabel(key: string): string {
   return key.replace(/_/g, " ");
 }
 
-function getMealDetails(meal: WeeklyMeal): string[] {
+function getMealDetails(meal: Meal): string[] {
   const grams = Object.entries(meal.grams).slice(0, 2).map(
     ([label, value]) => `${formatMetricLabel(label)}: ${Math.round(value)} g`
   );
@@ -96,33 +94,23 @@ function getMealDetails(meal: WeeklyMeal): string[] {
 
 export default function WeeklyPlanViewer() {
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const [data, setData] = useState<WeeklyMealPlanResponse | null>(null);
   const [hint, setHint] = useState<string | null>(null);
   const [lastSignedLink, setLastSignedLink] = useState<string | null>(null);
+  const [request, setRequest] = useState<ProWeekPlanRequest | null>(null);
 
   useEffect(() => {
-    (async () => {
-      setLoading(true);
-      setErr(null);
-      try {
-        const locale = getClientLocale() as ProWeekPlanRequest["lang"];
-        const supportedLangs: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"];
-        const payload: ProWeekPlanRequest = {
-          ...DEFAULT_REQUEST,
-          lang: supportedLangs.includes(locale) ? locale : "en",
-        };
-
-        const week = await getWeeklyPlan(payload);
-        setData(week);
-      } catch (e: any) {
-        setErr(e?.message || "Fetch error");
-      } finally {
-        setLoading(false);
-      }
-    })();
+    const locale = getClientLocale() as ProWeekPlanRequest["lang"];
+    const supportedLangs: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"];
+    setRequest({
+      ...DEFAULT_REQUEST,
+      lang: supportedLangs.includes(locale) ? locale : "en",
+    });
   }, []);
+
+  const { data, loading, error: err } = useWeeklyPlan({
+    targets: request,
+    enabled: request !== null,
+  });
 
   if (loading) {
     return <div className="max-w-3xl mx-auto p-6">{t('plan.loadingWeek')}</div>;
@@ -136,7 +124,7 @@ export default function WeeklyPlanViewer() {
     );
   }
 
-  const dailyMenus = data?.daily_menus ?? [];
+  const dailyMenus = data?.days ?? [];
 
   const openSheetsHelp = () => {
     window.open("https://sheets.new", "_blank", "noopener,noreferrer");
@@ -280,7 +268,7 @@ export default function WeeklyPlanViewer() {
         ) : (
           <ul className="space-y-4">
             {dailyMenus.map((menu, idx) => {
-              const dayTitle = getDayTitle(idx, t);
+              const dayTitle = menu.dayName || getDayTitle(idx, t);
               const dayEnergy = menu.kcal;
               const meals = menu.meals;
 

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -10,6 +10,7 @@ import { useWeeklyPlan } from "../weekly-plan/hooks/useWeeklyPlan";
 import type { Meal } from "../weekly-plan/model/types";
 
 const DEFAULT_TTL_SECONDS = 900;
+const MONDAY_REFERENCE_UTC = Date.UTC(2024, 0, 1);
 
 async function copyToClipboard(text: string): Promise<boolean> {
   try {
@@ -66,8 +67,30 @@ const DEFAULT_REQUEST: ProWeekPlanRequest = {
   lang: "en",
 };
 
-function getDayTitle(index: number, t: (key: string, options?: Record<string, unknown>) => string): string {
-  return t("plan.day_fallback", { number: index + 1 });
+function getLocalizedWeekday(index: number, locale: string): string | null {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      timeZone: "UTC",
+    });
+    return formatter.format(new Date(MONDAY_REFERENCE_UTC + index * 24 * 60 * 60 * 1000));
+  } catch {
+    return null;
+  }
+}
+
+function getDayTitle(
+  index: number,
+  locale: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
+  normalizedDayName?: string
+): string {
+  const fallbackTitle = normalizedDayName || t("plan.day_fallback", { number: index + 1 });
+  if (locale === "en") {
+    return fallbackTitle;
+  }
+
+  return getLocalizedWeekday(index, locale) || fallbackTitle;
 }
 
 function getMealName(meal: Meal): string {
@@ -125,6 +148,7 @@ export default function WeeklyPlanViewer() {
   }
 
   const dailyMenus = data?.days ?? [];
+  const displayLocale = request?.lang ?? "en";
 
   const openSheetsHelp = () => {
     window.open("https://sheets.new", "_blank", "noopener,noreferrer");
@@ -268,7 +292,7 @@ export default function WeeklyPlanViewer() {
         ) : (
           <ul className="space-y-4">
             {dailyMenus.map((menu, idx) => {
-              const dayTitle = menu.dayName || getDayTitle(idx, t);
+              const dayTitle = getDayTitle(idx, displayLocale, t, menu.dayName);
               const dayEnergy = menu.kcal;
               const meals = menu.meals;
 

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -11,6 +11,11 @@ import type { Meal } from "../weekly-plan/model/types";
 
 const DEFAULT_TTL_SECONDS = 900;
 const MONDAY_REFERENCE_UTC = Date.UTC(2024, 0, 1);
+const SUPPORTED_REQUEST_LANGS: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"];
+
+function isSupportedRequestLang(locale: string): locale is ProWeekPlanRequest["lang"] {
+  return SUPPORTED_REQUEST_LANGS.some((supportedLocale) => supportedLocale === locale);
+}
 
 async function copyToClipboard(text: string): Promise<boolean> {
   try {
@@ -122,11 +127,10 @@ export default function WeeklyPlanViewer() {
   const [request, setRequest] = useState<ProWeekPlanRequest | null>(null);
 
   useEffect(() => {
-    const locale = getClientLocale() as ProWeekPlanRequest["lang"];
-    const supportedLangs: ProWeekPlanRequest["lang"][] = ["en", "ru", "es"];
+    const clientLocale = getClientLocale();
     setRequest({
       ...DEFAULT_REQUEST,
-      lang: supportedLangs.includes(locale) ? locale : "en",
+      lang: isSupportedRequestLang(clientLocale) ? clientLocale : "en",
     });
   }, []);
 

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -302,7 +302,7 @@ export default function WeeklyPlanViewer() {
 
               return (
                 <li
-                  key={`${dayTitle}-${menu.day}`}
+                  key={`day-${menu.day}`}
                   className="border border-white/15 rounded-2xl bg-white/10 p-4 space-y-2 backdrop-blur-sm"
                 >
                   <div className="flex items-center justify-between">

--- a/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
+++ b/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
@@ -121,6 +121,29 @@ describe('WeeklyPlanViewer', () => {
     expect(screen.getByText('plan.loadError: backend unavailable')).toBeInTheDocument();
   });
 
+  it('builds the locale-adjusted request on the first render', () => {
+    mockGetClientLocale.mockReturnValue('ru');
+
+    render(<WeeklyPlanViewer />);
+
+    expect(mockUseWeeklyPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: expect.objectContaining({
+          ...{
+            sex: 'female',
+            age: 30,
+            height_cm: 168,
+            weight_kg: 62,
+            activity: 'moderate',
+            goal: 'maintain',
+            diet_flags: [],
+          },
+          lang: 'ru',
+        }),
+      })
+    );
+  });
+
   it('renders normalized week-plan view-model data', () => {
     mockUseWeeklyPlan.mockReturnValue({
       data: WEEK_PLAN_VM,

--- a/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
+++ b/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
@@ -65,6 +65,21 @@ const WEEK_PLAN_VM: WeekPlanVM = {
   },
 };
 
+const SPARSE_WEEK_PLAN_VM: WeekPlanVM = {
+  ...WEEK_PLAN_VM,
+  days: [
+    {
+      ...WEEK_PLAN_VM.days[0],
+      day: 3,
+      dayName: 'Wednesday',
+    },
+  ],
+  meta: {
+    total_days: 1,
+    has_incomplete_data: true,
+  },
+};
+
 describe('WeeklyPlanViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -146,6 +161,38 @@ describe('WeeklyPlanViewer', () => {
       expect(screen.getByText('понедельник')).toBeInTheDocument();
     });
     expect(screen.queryByText('Monday')).not.toBeInTheDocument();
+
+    dateTimeFormatSpy.mockRestore();
+  });
+
+  it('uses the normalized day number for sparse localized plans', async () => {
+    mockGetClientLocale.mockReturnValue('ru');
+    const dateTimeFormatSpy = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+      () =>
+        ({
+          format: (date: Date) => {
+            const weekday = date.getUTCDay();
+            if (weekday === 3) {
+              return 'среда';
+            }
+            return 'понедельник';
+          },
+        }) as Intl.DateTimeFormat
+    );
+    mockUseWeeklyPlan.mockReturnValue({
+      data: SPARSE_WEEK_PLAN_VM,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByText('среда')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('понедельник')).not.toBeInTheDocument();
 
     dateTimeFormatSpy.mockRestore();
   });

--- a/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
+++ b/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import WeeklyPlanViewer from '../WeeklyPlanViewer';
@@ -24,8 +24,10 @@ vi.mock('../../weekly-plan/hooks/useWeeklyPlan', () => ({
 }));
 
 import { useWeeklyPlan } from '../../weekly-plan/hooks/useWeeklyPlan';
+import { getClientLocale } from '../../../lib/i18n';
 
 const mockUseWeeklyPlan = vi.mocked(useWeeklyPlan);
+const mockGetClientLocale = vi.mocked(getClientLocale);
 
 const WEEK_PLAN_VM: WeekPlanVM = {
   days: [
@@ -66,6 +68,7 @@ const WEEK_PLAN_VM: WeekPlanVM = {
 describe('WeeklyPlanViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetClientLocale.mockReturnValue('en');
     mockUseWeeklyPlan.mockReturnValue({
       data: null,
       loading: false,
@@ -89,6 +92,20 @@ describe('WeeklyPlanViewer', () => {
     expect(screen.getByText('plan.loadingWeek')).toBeInTheDocument();
   });
 
+  it('renders the hook error state', () => {
+    mockUseWeeklyPlan.mockReturnValue({
+      data: null,
+      loading: false,
+      error: 'backend unavailable',
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    expect(screen.getByText('plan.loadError: backend unavailable')).toBeInTheDocument();
+  });
+
   it('renders normalized week-plan view-model data', () => {
     mockUseWeeklyPlan.mockReturnValue({
       data: WEEK_PLAN_VM,
@@ -105,5 +122,31 @@ describe('WeeklyPlanViewer', () => {
     expect(screen.getByText(/620 plan.kcal/)).toBeInTheDocument();
     expect(screen.getByText(/chicken: 180 g/i)).toBeInTheDocument();
     expect(screen.getByText(/rice: 150 g/i)).toBeInTheDocument();
+  });
+
+  it('preserves localized day labels for non-English users', async () => {
+    mockGetClientLocale.mockReturnValue('ru');
+    const dateTimeFormatSpy = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+      () =>
+        ({
+          format: () => 'понедельник',
+        }) as Intl.DateTimeFormat
+    );
+    mockUseWeeklyPlan.mockReturnValue({
+      data: WEEK_PLAN_VM,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByText('понедельник')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Monday')).not.toBeInTheDocument();
+
+    dateTimeFormatSpy.mockRestore();
   });
 });

--- a/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
+++ b/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import WeeklyPlanViewer from '../WeeklyPlanViewer';
+import type { WeekPlanVM } from '../../weekly-plan/model/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'plan.day_fallback' && options?.number) {
+        return `Day ${options.number}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../../lib/i18n', () => ({
+  getClientLocale: vi.fn(() => 'en'),
+}));
+
+vi.mock('../../weekly-plan/hooks/useWeeklyPlan', () => ({
+  useWeeklyPlan: vi.fn(),
+}));
+
+import { useWeeklyPlan } from '../../weekly-plan/hooks/useWeeklyPlan';
+
+const mockUseWeeklyPlan = vi.mocked(useWeeklyPlan);
+
+const WEEK_PLAN_VM: WeekPlanVM = {
+  days: [
+    {
+      day: 1,
+      dayName: 'Monday',
+      kcal: 1800,
+      total_cost: 18.4,
+      coverage: { protein: 0.91 },
+      macros: { protein_g: 120 },
+      micros: { iron_mg: 12 },
+      tips: ['Hydrate'],
+      meals: [
+        {
+          title: 'Chicken bowl',
+          title_translated: 'Chicken bowl',
+          kcal: 620,
+          price_est: 7.2,
+          grams: { chicken: 180, rice: 150 },
+          macros: { protein_g: 42, carbs_g: 58 },
+          micros: { iron_mg: 3.4 },
+        },
+      ],
+    },
+  ],
+  weekly_coverage: { protein: 0.95 },
+  shopping_list: { chicken: 1200 },
+  metrics: {
+    total_cost: 72.4,
+    adherence_score: 0.88,
+  },
+  meta: {
+    total_days: 1,
+    has_incomplete_data: false,
+  },
+};
+
+describe('WeeklyPlanViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWeeklyPlan.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+  });
+
+  it('renders loading state from the normalized weekly-plan hook', () => {
+    mockUseWeeklyPlan.mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    expect(screen.getByText('plan.loadingWeek')).toBeInTheDocument();
+  });
+
+  it('renders normalized week-plan view-model data', () => {
+    mockUseWeeklyPlan.mockReturnValue({
+      data: WEEK_PLAN_VM,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    expect(screen.getByText('Monday')).toBeInTheDocument();
+    expect(screen.getByText('Chicken bowl')).toBeInTheDocument();
+    expect(screen.getByText(/620 plan.kcal/)).toBeInTheDocument();
+    expect(screen.getByText(/chicken: 180 g/i)).toBeInTheDocument();
+    expect(screen.getByText(/rice: 150 g/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useWhoTargetsWithWeeklyPlan.test.ts
+++ b/frontend/src/hooks/__tests__/useWhoTargetsWithWeeklyPlan.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWhoTargetsWithWeeklyPlan } from '../useWhoTargetsWithWeeklyPlan';
+import type { TargetsApiResponse, TargetsRequest } from '../../api/premium/types';
+import type { WeeklyMealPlanResponse } from '../../api/premium/weekly-plan';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key,
+  }),
+}));
+
+vi.mock('../../api/premium', () => ({
+  getTargets: vi.fn(),
+  getWeeklyPlan: vi.fn(),
+}));
+
+import { getTargets, getWeeklyPlan } from '../../api/premium';
+
+const mockGetTargets = vi.mocked(getTargets);
+const mockGetWeeklyPlan = vi.mocked(getWeeklyPlan);
+
+const REQUEST: TargetsRequest = {
+  sex: 'female',
+  age: 29,
+  height_cm: 165,
+  weight_kg: 61,
+  activity: 'moderate',
+  goal: 'maintain',
+  lang: 'en',
+  life_stage: 'adult',
+};
+
+const TARGETS_RESPONSE: TargetsApiResponse = {
+  kcal_daily: 2000,
+  macros: {
+    protein_g: 120,
+    carbs_g: 210,
+    fat_g: 70,
+    fiber_g: 28,
+  },
+  water_ml: 2100,
+  priority_micros: {
+    iron: 18,
+    calcium: 1000,
+  },
+  activity_weekly: {
+    moderate_aerobic_min: 150,
+    strength_sessions: 2,
+    steps_daily: 8000,
+  },
+  calculation_date: '2026-03-10T10:00:00Z',
+  warnings: [],
+};
+
+const WEEKLY_PLAN_RESPONSE: WeeklyMealPlanResponse = {
+  daily_menus: [
+    {
+      kcal: 1800,
+      total_cost: 18.5,
+      coverage: { protein: 0.92, fiber: 0.8 },
+      macros: { protein_g: 110, carbs_g: 180, fat_g: 60 },
+      micros: { iron_mg: 12 },
+      tips: ['Hydrate'],
+      meals: [
+        {
+          title: 'Chicken bowl',
+          title_translated: 'Chicken bowl',
+          kcal: 620,
+          price_est: 7.25,
+          grams: { chicken: 180, rice: 150 },
+          macros: { protein_g: 42, carbs_g: 58, fat_g: 14 },
+          micros: { iron_mg: 3.4 },
+        },
+      ],
+    },
+  ],
+  weekly_coverage: { protein: 0.95, fiber: 0.81 },
+  shopping_list: { chicken: 1200, rice: 900 },
+  total_cost: 72.4,
+  adherence_score: 0.88,
+};
+
+describe('useWhoTargetsWithWeeklyPlan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes weekly plan state before exposing it', async () => {
+    mockGetTargets.mockResolvedValue(TARGETS_RESPONSE);
+    mockGetWeeklyPlan.mockResolvedValue(WEEKLY_PLAN_RESPONSE);
+
+    const { result } = renderHook(() => useWhoTargetsWithWeeklyPlan());
+
+    await act(async () => {
+      await result.current.saveAndGetWeeklyPlan(REQUEST);
+    });
+
+    await waitFor(() => {
+      expect(result.current.targetsData).toEqual(TARGETS_RESPONSE);
+      expect(result.current.weeklyPlanData).not.toBeNull();
+    });
+
+    expect(result.current.weeklyPlanData).toEqual({
+      days: [
+        {
+          day: 1,
+          dayName: 'Monday',
+          kcal: 1800,
+          total_cost: 18.5,
+          coverage: { protein: 0.92, fiber: 0.8 },
+          macros: { protein_g: 110, carbs_g: 180, fat_g: 60 },
+          micros: { iron_mg: 12 },
+          tips: ['Hydrate'],
+          meals: [
+            {
+              title: 'Chicken bowl',
+              title_translated: 'Chicken bowl',
+              kcal: 620,
+              price_est: 7.25,
+              grams: { chicken: 180, rice: 150 },
+              macros: { protein_g: 42, carbs_g: 58, fat_g: 14 },
+              micros: { iron_mg: 3.4 },
+            },
+          ],
+        },
+      ],
+      weekly_coverage: { protein: 0.95, fiber: 0.81 },
+      shopping_list: { chicken: 1200, rice: 900 },
+      metrics: {
+        total_cost: 72.4,
+        adherence_score: 0.88,
+      },
+      meta: {
+        total_days: 1,
+        has_incomplete_data: false,
+      },
+    });
+  });
+
+  it('passes the normalized VM into onSuccess', async () => {
+    mockGetTargets.mockResolvedValue(TARGETS_RESPONSE);
+    mockGetWeeklyPlan.mockResolvedValue(WEEKLY_PLAN_RESPONSE);
+
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() =>
+      useWhoTargetsWithWeeklyPlan({
+        onSuccess,
+      })
+    );
+
+    await act(async () => {
+      await result.current.saveAndGetWeeklyPlan(REQUEST);
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      TARGETS_RESPONSE,
+      expect.objectContaining({
+        days: expect.any(Array),
+        weekly_coverage: WEEKLY_PLAN_RESPONSE.weekly_coverage,
+        shopping_list: WEEKLY_PLAN_RESPONSE.shopping_list,
+        metrics: {
+          total_cost: WEEKLY_PLAN_RESPONSE.total_cost,
+          adherence_score: WEEKLY_PLAN_RESPONSE.adherence_score,
+        },
+      })
+    );
+  });
+});

--- a/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
+++ b/frontend/src/hooks/useWhoTargetsWithWeeklyPlan.ts
@@ -2,7 +2,9 @@ import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTargets, getWeeklyPlan } from '../api/premium';
 import type { TargetsRequest, TargetsApiResponse } from '../api/premium';
-import type { ProWeekPlanRequest, WeeklyMealPlanResponse } from '../api/premium/weekly-plan';
+import type { ProWeekPlanRequest } from '../api/premium/weekly-plan';
+import { normalizeWeekPlan } from '../features/weekly-plan/model/adapter';
+import type { WeekPlanVM } from '../features/weekly-plan/model/types';
 
 function toWeekPlanRequest(request: TargetsRequest): ProWeekPlanRequest {
   return {
@@ -21,7 +23,7 @@ function toWeekPlanRequest(request: TargetsRequest): ProWeekPlanRequest {
 }
 
 interface UseWhoTargetsWithWeeklyPlanOptions {
-  onSuccess?: (targets: TargetsApiResponse, weeklyPlan: WeeklyMealPlanResponse) => void;
+  onSuccess?: (targets: TargetsApiResponse, weeklyPlan: WeekPlanVM) => void;
   onError?: (error: Error) => void;
 }
 
@@ -32,7 +34,7 @@ interface UseWhoTargetsWithWeeklyPlanReturn {
   targetsError: string | null;
 
   // Weekly plan state
-  weeklyPlanData: WeeklyMealPlanResponse | null;
+  weeklyPlanData: WeekPlanVM | null;
   weeklyPlanLoading: boolean;
   weeklyPlanError: string | null;
 
@@ -55,7 +57,7 @@ export function useWhoTargetsWithWeeklyPlan(
   const [targetsError, setTargetsError] = useState<string | null>(null);
 
   // Weekly plan state
-  const [weeklyPlanData, setWeeklyPlanData] = useState<WeeklyMealPlanResponse | null>(null);
+  const [weeklyPlanData, setWeeklyPlanData] = useState<WeekPlanVM | null>(null);
   const [weeklyPlanLoading, setWeeklyPlanLoading] = useState(false);
   const [weeklyPlanError, setWeeklyPlanError] = useState<string | null>(null);
 
@@ -104,10 +106,11 @@ export function useWhoTargetsWithWeeklyPlan(
 
       // Then generate weekly plan
       const weeklyPlan = await getWeeklyPlan(toWeekPlanRequest(request));
-      setWeeklyPlanData(weeklyPlan);
+      const normalizedWeeklyPlan = normalizeWeekPlan(weeklyPlan);
+      setWeeklyPlanData(normalizedWeeklyPlan);
 
       // Call success callback with both data
-      onSuccess?.(targets, weeklyPlan);
+      onSuccess?.(targets, normalizedWeeklyPlan);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : t('whoTargets.error.weeklyPlanFailed', 'Failed to generate weekly plan');
       setWeeklyPlanError(errorMessage);


### PR DESCRIPTION
## Summary
- move weekly-plan web consumers onto the normalized `WeekPlanVM` layer instead of passing raw `WeeklyMealPlanResponse` through UI state
- keep transport on the canonical `POST /api/v1/pro/meal/weekly` route
- limit this PR to weekly-plan web parity without widening into shopping-list, iOS, FitChef, or sandbox work

## What Changed
- updated `useWhoTargetsWithWeeklyPlan` to normalize the raw API payload before storing weekly-plan state and before firing `onSuccess`
- updated `IntegratedWhoTargetsPanel` to expose normalized weekly-plan data to callers
- updated `WeeklyPlanViewer` to consume `useWeeklyPlan` and render the normalized view model instead of fetching and rendering the raw response directly
- added frontend tests for the normalized hook/viewer path and updated integrated panel tests accordingly
- added canonical review artifact `docs/review/PR_1070_FIXED_MAPPING.md`

## Validation
- `npm test -- --run src/api/__tests__/weekly-plan-integration.test.ts src/components/__tests__/IntegratedWhoTargetsPanel.test.tsx src/hooks/__tests__/useWhoTargetsWithWeeklyPlan.test.ts src/features/weekly-plan/__tests__/adapter.test.ts src/features/plan/__tests__/WeeklyPlanViewer.test.tsx`
- `npm run build`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1070_FIXED_MAPPING.md`
- No actionable review comments

## Merge Readiness
- [ ] All required checks are PASS
- [x] Fixed in Commit Mapping artifact updated
- [ ] No unresolved review threads remain
- [ ] No actionable bot comments remain
- [ ] Final wait-cycle completed after latest review/bot activity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Weekly plan fetching and rendering now use a unified, normalized WeekPlan view-model; components consume hook-provided data and locale-aware day titles.
  * Success/error callbacks now receive and propagate the normalized weekly plan payload for more reliable downstream behavior.

* **Tests**
  * Expanded coverage for weekly plan viewer, generation flows, hook behaviors, localization, and error propagation (including sparse and localized fixtures).

* **Documentation**
  * Added review notes documenting PR review status and commit mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->