### PR TITLE
fix(frontend): gate weekly plan initial load

### DIFF
--- a/docs/review/PR_1075_FIXED_MAPPING.md
+++ b/docs/review/PR_1075_FIXED_MAPPING.md
@@ -7,7 +7,11 @@ This artifact remains scoped to PR `#1075` only.
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 3617401f
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1075#discussion_r2911251623 -> 3617401f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1075#pullrequestreview-3921854659 -> 3617401f
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1075_FIXED_MAPPING.md
+++ b/docs/review/PR_1075_FIXED_MAPPING.md
@@ -1,0 +1,18 @@
+# PR 1075 — Fixed in Commit Mapping
+
+This artifact remains scoped to PR `#1075` only.
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Pending initial review.
+
+No actionable review threads recorded yet.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1075_FIXED_MAPPING.md
+++ b/docs/review/PR_1075_FIXED_MAPPING.md
@@ -3,13 +3,11 @@
 This artifact remains scoped to PR `#1075` only.
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-Pending initial review.
-
-No actionable review threads recorded yet.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/frontend/src/features/plan/WeeklyPlanViewer.tsx
+++ b/frontend/src/features/plan/WeeklyPlanViewer.tsx
@@ -137,8 +137,9 @@ export default function WeeklyPlanViewer() {
   const { data, loading, error: err } = useWeeklyPlan({
     targets: request,
   });
+  const isInitialLoad = data === null && err === null;
 
-  if (loading) {
+  if (loading || isInitialLoad) {
     return <div className="max-w-3xl mx-auto p-6">{t('plan.loadingWeek')}</div>;
   }
 

--- a/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
+++ b/frontend/src/features/plan/__tests__/WeeklyPlanViewer.test.tsx
@@ -107,6 +107,21 @@ describe('WeeklyPlanViewer', () => {
     expect(screen.getByText('plan.loadingWeek')).toBeInTheDocument();
   });
 
+  it('treats the initial empty hook state as loading instead of empty summary', () => {
+    mockUseWeeklyPlan.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      clearData: vi.fn(),
+    });
+
+    render(<WeeklyPlanViewer />);
+
+    expect(screen.getByText('plan.loadingWeek')).toBeInTheDocument();
+    expect(screen.queryByText('plan.emptySummary')).not.toBeInTheDocument();
+  });
+
   it('renders the hook error state', () => {
     mockUseWeeklyPlan.mockReturnValue({
       data: null,


### PR DESCRIPTION
## Summary
- fix post-merge weekly-plan viewer regression from PR #1070
- treat the initial empty hook state as loading instead of rendering the empty summary before the first fetch starts
- add a targeted viewer regression test for `{ data: null, loading: false, error: null }`

## Carryover
- This is a focused post-merge hotfix for PR #1070 after main-sanity review found a first-render weekly-plan UI regression.

## Testing
- `cd frontend && npm test -- --run src/features/plan/__tests__/WeeklyPlanViewer.test.tsx`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1075#discussion_r2911251623 -> 3617401f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1075#pullrequestreview-3921854659 -> 3617401f

## Merge Readiness
- [x] All local hard gates passed (`pre-commit run --all-files` and `make verify`)
- [x] Fixed in Commit Mapping artifact initialized for this PR
- [ ] All required checks are PASS
- [ ] No unresolved review threads remain
- [ ] No actionable bot comments remain
- [ ] Final wait-cycle completed after latest review/bot activity
