### PR TITLE
refactor(fitchef): deduplicate runtime orchestration path

### DIFF
--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any, Callable, Literal, cast
 
 from fastapi import HTTPException, status
@@ -16,6 +17,7 @@ from app.middleware.api_tiers import derive_subject_id_from_api_key
 from app.schemas.fitchef import (
     FitChefCoachInsightResult,
     FitChefCoachInsightTaskEnvelope,
+    FitChefExecutionMode,
     FitChefMascotInsightResult,
     FitChefMascotInsightTaskEnvelope,
     FitChefQuotaState,
@@ -41,6 +43,7 @@ from app.security.server_salt import require_server_salt
 from core.compliance import get_transparency_registry, sanitize_chunk_preview
 from core.data_sanitizer import sanitize_rag_markdown
 from core.insight.fitchef_companion import (
+    FitChefCoachingDraft,
     build_mascot_prompt,
     build_slip_support_prompt,
     build_weekly_reflection_prompt,
@@ -227,6 +230,205 @@ def _persist_privileged_action_audit(
         secret=signing_secret,
     )
     persist_audit_envelope(envelope, metadata=audit_metadata)
+
+
+@dataclass(frozen=True)
+class _FitChefVipTextTaskConfig:
+    """Shared config for VIP FitChef text flows."""
+
+    retrieval_text: str
+    api_key: str
+    endpoint: str
+    method: str
+    mode: FitChefExecutionMode
+    prompt_builder: Callable[[str], str]
+    draft_builder: Callable[[str], FitChefCoachingDraft]
+    unavailable_detail: str
+    log_label: str
+
+
+@dataclass(frozen=True)
+class _FitChefVipTextTaskOutput:
+    """Shared result for VIP FitChef text flows."""
+
+    prepared: FitChefCoachingDraft
+    sources: list[FitChefSourceItem]
+    confidence: float
+    warnings: list[str]
+    quota_state: FitChefQuotaState
+    transparency_notice_id: str
+    wellness_boundary: str
+
+
+async def _run_fitchef_vip_text_task(
+    config: _FitChefVipTextTaskConfig,
+) -> _FitChefVipTextTaskOutput:
+    """Run the shared VIP FitChef text orchestration flow."""
+
+    rag_context_str = ""
+    sources: list[FitChefSourceItem] = []
+    confidence = 0.0
+    warnings: list[str] = []
+    quota_state: FitChefQuotaState = "not_consumed"
+    redaction_applied = False
+    sanitization_applied = False
+
+    try:
+        await run_in_threadpool(
+            _persist_privileged_action_audit,
+            action="rag.retrieve",
+            target="corpus://fitchef-agent",
+            mode=config.mode,
+            endpoint=config.endpoint,
+            metadata={
+                "method": config.method,
+                "query_hash": _sha256_hex(config.retrieval_text),
+                "query_length": len(config.retrieval_text),
+            },
+        )
+    except (PermissionError, RuntimeError) as exc:
+        logger.error("%s RAG gate failed", config.log_label, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="rag_retrieval_unavailable",
+        ) from exc
+
+    try:
+        from core.rag.vector_rag import retrieve_context_structured
+
+        rag_ctx = await run_in_threadpool(
+            retrieve_context_structured,
+            config.retrieval_text,
+            max_chunks=5,
+            agent_id="fitchef-agent",
+            user_tier="VIP",
+            subject_id=derive_subject_id_from_api_key(config.api_key),
+        )
+
+        if rag_ctx.chunks:
+            context_parts: list[str] = []
+            for chunk in rag_ctx.chunks:
+                sanitized_chunk = sanitize_rag_markdown(chunk.content)
+                if sanitized_chunk != chunk.content:
+                    sanitization_applied = True
+                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
+                if sanitized_content != sanitized_chunk:
+                    redaction_applied = True
+                if not sanitized_content.strip():
+                    continue
+                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
+                sources.append(
+                    FitChefSourceItem(
+                        chunk_id=chunk.chunk_id,
+                        file=chunk.file,
+                        preview=sanitize_chunk_preview(sanitized_content) or "",
+                        score=chunk.score,
+                    )
+                )
+            if context_parts:
+                rag_context_str = "\n\n".join(context_parts)
+                confidence = rag_ctx.confidence
+    except Exception:
+        logger.warning("%s RAG retrieval failed", config.log_label, exc_info=True)
+        warnings.append("rag_retrieval_failed")
+
+    if sanitization_applied:
+        warnings.append("source_content_sanitized")
+    if redaction_applied:
+        warnings.append("source_content_redacted")
+
+    transparency_notice = get_transparency_registry().get("ai_generated_insight")
+    if transparency_notice is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="transparency_registry_unavailable",
+        )
+    notice_surface_id = transparency_notice.get("surface_id")
+    notice_boundary = transparency_notice.get("boundary")
+    if notice_surface_id is None or notice_boundary is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="transparency_registry_incomplete",
+        )
+
+    prompt = config.prompt_builder(rag_context_str)
+
+    try:
+        await run_in_threadpool(
+            _persist_privileged_action_audit,
+            action="llm.generate",
+            target="provider://default",
+            mode=config.mode,
+            endpoint=config.endpoint,
+            metadata={
+                "method": config.method,
+                "prompt_hash": _sha256_hex(prompt),
+                "prompt_length": len(prompt),
+                "source_count": len(sources),
+            },
+        )
+    except (PermissionError, RuntimeError) as exc:
+        logger.error("%s LLM gate failed", config.log_label, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="llm_generation_unavailable",
+        ) from exc
+
+    try:
+        from llm import get_provider
+
+        provider = get_provider()
+
+        allowed = await run_in_threadpool(
+            attempt_consume_llm_monthly_quota,
+            config.api_key,
+            tier="VIP",
+        )
+        if not allowed:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="quota_exceeded",
+            )
+        raw_message = await asyncio.wait_for(
+            run_in_threadpool(provider.generate, prompt),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
+        if not isinstance(raw_message, str) or not raw_message.strip():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="LLM provider returned empty response",
+            )
+        prepared = config.draft_builder(raw_message)
+        quota_state = "consumed"
+    except ImportError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LLM provider not available",
+        ) from None
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="LLM provider call timed out",
+        ) from None
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("%s generation failed", config.log_label, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=config.unavailable_detail,
+        ) from exc
+
+    result = _FitChefVipTextTaskOutput(
+        prepared=prepared,
+        sources=sources,
+        confidence=min(max(confidence, 0.0), 1.0),
+        warnings=[*warnings, *prepared.warnings],
+        quota_state=quota_state,
+        transparency_notice_id=str(notice_surface_id),
+        wellness_boundary=str(notice_boundary),
+    )
+    return result
 
 
 async def run_coach_insight_task(
@@ -440,174 +642,30 @@ async def run_mascot_insight_task(
     """Run FitChef mascot insight orchestration. / Выполнить mascot-insight оркестрацию."""
 
     safe_query = task.input.safe_query
-    api_key = task.input.api_key
-    endpoint = task.input.endpoint
-    method = task.input.method
-
-    rag_context_str = ""
-    sources: list[FitChefSourceItem] = []
-    confidence = 0.0
-    warnings: list[str] = []
-    quota_state: FitChefQuotaState = "not_consumed"
-    redaction_applied = False
-    sanitization_applied = False
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="rag.retrieve",
-            target="corpus://fitchef-agent",
+    shared_result = await _run_fitchef_vip_text_task(
+        _FitChefVipTextTaskConfig(
+            retrieval_text=safe_query,
+            api_key=task.input.api_key,
+            endpoint=task.input.endpoint,
+            method=task.input.method,
             mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "query_hash": _sha256_hex(safe_query),
-                "query_length": len(safe_query),
-            },
+            prompt_builder=lambda rag_context: build_mascot_prompt(safe_query, rag_context),
+            draft_builder=lambda raw_message: prepare_mascot_draft(raw_message, query=safe_query),
+            unavailable_detail="fitchef_mascot_unavailable",
+            log_label="FitChef mascot",
         )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef mascot RAG gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="rag_retrieval_unavailable",
-        ) from exc
-
-    try:
-        from core.rag.vector_rag import retrieve_context_structured
-
-        rag_ctx = await run_in_threadpool(
-            retrieve_context_structured,
-            safe_query,
-            max_chunks=5,
-            agent_id="fitchef-agent",
-            user_tier="VIP",
-            subject_id=derive_subject_id_from_api_key(api_key),
-        )
-
-        if rag_ctx.chunks:
-            context_parts: list[str] = []
-            for chunk in rag_ctx.chunks:
-                sanitized_chunk = sanitize_rag_markdown(chunk.content)
-                if sanitized_chunk != chunk.content:
-                    sanitization_applied = True
-                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
-                if sanitized_content != sanitized_chunk:
-                    redaction_applied = True
-                if not sanitized_content.strip():
-                    continue
-                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
-                sources.append(
-                    FitChefSourceItem(
-                        chunk_id=chunk.chunk_id,
-                        file=chunk.file,
-                        preview=sanitize_chunk_preview(sanitized_content) or "",
-                        score=chunk.score,
-                    )
-                )
-            if context_parts:
-                rag_context_str = "\n\n".join(context_parts)
-                confidence = rag_ctx.confidence
-    except Exception:
-        logger.warning("FitChef mascot RAG retrieval failed", exc_info=True)
-        warnings.append("rag_retrieval_failed")
-
-    if sanitization_applied:
-        warnings.append("source_content_sanitized")
-    if redaction_applied:
-        warnings.append("source_content_redacted")
-
-    transparency_notice = get_transparency_registry().get("ai_generated_insight")
-    if transparency_notice is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    notice_surface_id = transparency_notice.get("surface_id")
-    notice_boundary = transparency_notice.get("boundary")
-    if notice_surface_id is None or notice_boundary is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_incomplete",
-        )
-
-    prompt = build_mascot_prompt(safe_query, rag_context_str)
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="llm.generate",
-            target="provider://default",
-            mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "prompt_hash": _sha256_hex(prompt),
-                "prompt_length": len(prompt),
-                "source_count": len(sources),
-            },
-        )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef mascot LLM gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="llm_generation_unavailable",
-        ) from exc
-
-    try:
-        from llm import get_provider
-
-        provider = get_provider()
-
-        allowed = await run_in_threadpool(
-            attempt_consume_llm_monthly_quota,
-            api_key,
-            tier="VIP",
-        )
-        if not allowed:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="quota_exceeded",
-            )
-        raw_message = await asyncio.wait_for(
-            run_in_threadpool(provider.generate, prompt),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-        if not isinstance(raw_message, str) or not raw_message.strip():
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="LLM provider returned empty response",
-            )
-        prepared = prepare_mascot_draft(raw_message, query=safe_query)
-        quota_state = "consumed"
-    except ImportError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM provider not available",
-        ) from None
-    except asyncio.TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail="LLM provider call timed out",
-        ) from None
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.error("FitChef mascot generation failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="fitchef_mascot_unavailable",
-        ) from exc
+    )
 
     result: FitChefMascotInsightResult = FitChefMascotInsightResult(
-        message=prepared.message,
-        sources=sources,
-        confidence=min(max(confidence, 0.0), 1.0),
-        warnings=[*warnings, *prepared.warnings],
-        action_items=prepared.action_items,
+        message=shared_result.prepared.message,
+        sources=shared_result.sources,
+        confidence=shared_result.confidence,
+        warnings=shared_result.warnings,
+        action_items=shared_result.prepared.action_items,
         mode=task.mode,
-        quota_state=quota_state,
-        transparency_notice_id=str(notice_surface_id),
-        wellness_boundary=str(notice_boundary),
+        quota_state=shared_result.quota_state,
+        transparency_notice_id=shared_result.transparency_notice_id,
+        wellness_boundary=shared_result.wellness_boundary,
     )
     return result
 
@@ -619,179 +677,39 @@ async def run_weekly_reflection_task(
 
     safe_summary = task.input.safe_summary
     safe_goal = task.input.safe_goal
-    api_key = task.input.api_key
-    endpoint = task.input.endpoint
-    method = task.input.method
-
     retrieval_text = _build_fitchef_reflection_query(safe_summary, safe_goal)
-    rag_context_str = ""
-    sources: list[FitChefSourceItem] = []
-    confidence = 0.0
-    warnings: list[str] = []
-    quota_state: FitChefQuotaState = "not_consumed"
-    redaction_applied = False
-    sanitization_applied = False
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="rag.retrieve",
-            target="corpus://fitchef-agent",
+    shared_result = await _run_fitchef_vip_text_task(
+        _FitChefVipTextTaskConfig(
+            retrieval_text=retrieval_text,
+            api_key=task.input.api_key,
+            endpoint=task.input.endpoint,
+            method=task.input.method,
             mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "query_hash": _sha256_hex(retrieval_text),
-                "query_length": len(retrieval_text),
-            },
+            prompt_builder=lambda rag_context: build_weekly_reflection_prompt(
+                safe_summary,
+                safe_goal,
+                rag_context,
+            ),
+            draft_builder=lambda raw_message: prepare_weekly_reflection_draft(
+                raw_message,
+                summary=safe_summary,
+                goal=safe_goal,
+            ),
+            unavailable_detail="fitchef_weekly_reflection_unavailable",
+            log_label="FitChef weekly reflection",
         )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef weekly reflection RAG gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="rag_retrieval_unavailable",
-        ) from exc
-
-    try:
-        from core.rag.vector_rag import retrieve_context_structured
-
-        rag_ctx = await run_in_threadpool(
-            retrieve_context_structured,
-            retrieval_text,
-            max_chunks=5,
-            agent_id="fitchef-agent",
-            user_tier="VIP",
-            subject_id=derive_subject_id_from_api_key(api_key),
-        )
-
-        if rag_ctx.chunks:
-            context_parts: list[str] = []
-            for chunk in rag_ctx.chunks:
-                sanitized_chunk = sanitize_rag_markdown(chunk.content)
-                if sanitized_chunk != chunk.content:
-                    sanitization_applied = True
-                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
-                if sanitized_content != sanitized_chunk:
-                    redaction_applied = True
-                if not sanitized_content.strip():
-                    continue
-                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
-                sources.append(
-                    FitChefSourceItem(
-                        chunk_id=chunk.chunk_id,
-                        file=chunk.file,
-                        preview=sanitize_chunk_preview(sanitized_content) or "",
-                        score=chunk.score,
-                    )
-                )
-            if context_parts:
-                rag_context_str = "\n\n".join(context_parts)
-                confidence = rag_ctx.confidence
-    except Exception:
-        logger.warning("FitChef weekly reflection RAG retrieval failed", exc_info=True)
-        warnings.append("rag_retrieval_failed")
-
-    if sanitization_applied:
-        warnings.append("source_content_sanitized")
-    if redaction_applied:
-        warnings.append("source_content_redacted")
-
-    transparency_notice = get_transparency_registry().get("ai_generated_insight")
-    if transparency_notice is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    notice_surface_id = transparency_notice.get("surface_id")
-    notice_boundary = transparency_notice.get("boundary")
-    if notice_surface_id is None or notice_boundary is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_incomplete",
-        )
-
-    prompt = build_weekly_reflection_prompt(safe_summary, safe_goal, rag_context_str)
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="llm.generate",
-            target="provider://default",
-            mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "prompt_hash": _sha256_hex(prompt),
-                "prompt_length": len(prompt),
-                "source_count": len(sources),
-            },
-        )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef weekly reflection LLM gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="llm_generation_unavailable",
-        ) from exc
-
-    try:
-        from llm import get_provider
-
-        provider = get_provider()
-
-        allowed = await run_in_threadpool(
-            attempt_consume_llm_monthly_quota,
-            api_key,
-            tier="VIP",
-        )
-        if not allowed:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="quota_exceeded",
-            )
-        raw_message = await asyncio.wait_for(
-            run_in_threadpool(provider.generate, prompt),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-        if not isinstance(raw_message, str) or not raw_message.strip():
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="LLM provider returned empty response",
-            )
-        prepared = prepare_weekly_reflection_draft(
-            raw_message,
-            summary=safe_summary,
-            goal=safe_goal,
-        )
-        quota_state = "consumed"
-    except ImportError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM provider not available",
-        ) from None
-    except asyncio.TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail="LLM provider call timed out",
-        ) from None
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.error("FitChef weekly reflection generation failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="fitchef_weekly_reflection_unavailable",
-        ) from exc
+    )
 
     result: FitChefWeeklyReflectionResult = FitChefWeeklyReflectionResult(
-        message=prepared.message,
-        sources=sources,
-        confidence=min(max(confidence, 0.0), 1.0),
-        warnings=[*warnings, *prepared.warnings],
-        action_items=prepared.action_items,
+        message=shared_result.prepared.message,
+        sources=shared_result.sources,
+        confidence=shared_result.confidence,
+        warnings=shared_result.warnings,
+        action_items=shared_result.prepared.action_items,
         mode=task.mode,
-        quota_state=quota_state,
-        transparency_notice_id=str(notice_surface_id),
-        wellness_boundary=str(notice_boundary),
+        quota_state=shared_result.quota_state,
+        transparency_notice_id=shared_result.transparency_notice_id,
+        wellness_boundary=shared_result.wellness_boundary,
     )
     return result
 
@@ -803,179 +721,39 @@ async def run_slip_support_task(
 
     safe_event_text = task.input.safe_event_text
     safe_goal = task.input.safe_goal
-    api_key = task.input.api_key
-    endpoint = task.input.endpoint
-    method = task.input.method
-
     retrieval_text = _build_fitchef_slip_support_query(safe_event_text, safe_goal)
-    rag_context_str = ""
-    sources: list[FitChefSourceItem] = []
-    confidence = 0.0
-    warnings: list[str] = []
-    quota_state: FitChefQuotaState = "not_consumed"
-    redaction_applied = False
-    sanitization_applied = False
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="rag.retrieve",
-            target="corpus://fitchef-agent",
+    shared_result = await _run_fitchef_vip_text_task(
+        _FitChefVipTextTaskConfig(
+            retrieval_text=retrieval_text,
+            api_key=task.input.api_key,
+            endpoint=task.input.endpoint,
+            method=task.input.method,
             mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "query_hash": _sha256_hex(retrieval_text),
-                "query_length": len(retrieval_text),
-            },
+            prompt_builder=lambda rag_context: build_slip_support_prompt(
+                safe_event_text,
+                safe_goal,
+                rag_context,
+            ),
+            draft_builder=lambda raw_message: prepare_slip_support_draft(
+                raw_message,
+                event_text=safe_event_text,
+                goal=safe_goal,
+            ),
+            unavailable_detail="fitchef_slip_support_unavailable",
+            log_label="FitChef slip-support",
         )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef slip-support RAG gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="rag_retrieval_unavailable",
-        ) from exc
-
-    try:
-        from core.rag.vector_rag import retrieve_context_structured
-
-        rag_ctx = await run_in_threadpool(
-            retrieve_context_structured,
-            retrieval_text,
-            max_chunks=5,
-            agent_id="fitchef-agent",
-            user_tier="VIP",
-            subject_id=derive_subject_id_from_api_key(api_key),
-        )
-
-        if rag_ctx.chunks:
-            context_parts: list[str] = []
-            for chunk in rag_ctx.chunks:
-                sanitized_chunk = sanitize_rag_markdown(chunk.content)
-                if sanitized_chunk != chunk.content:
-                    sanitization_applied = True
-                sanitized_content = redact_pii_from_text(sanitized_chunk) or ""
-                if sanitized_content != sanitized_chunk:
-                    redaction_applied = True
-                if not sanitized_content.strip():
-                    continue
-                context_parts.append(f"[{chunk.file}]\n{sanitized_content}")
-                sources.append(
-                    FitChefSourceItem(
-                        chunk_id=chunk.chunk_id,
-                        file=chunk.file,
-                        preview=sanitize_chunk_preview(sanitized_content) or "",
-                        score=chunk.score,
-                    )
-                )
-            if context_parts:
-                rag_context_str = "\n\n".join(context_parts)
-                confidence = rag_ctx.confidence
-    except Exception:
-        logger.warning("FitChef slip-support RAG retrieval failed", exc_info=True)
-        warnings.append("rag_retrieval_failed")
-
-    if sanitization_applied:
-        warnings.append("source_content_sanitized")
-    if redaction_applied:
-        warnings.append("source_content_redacted")
-
-    transparency_notice = get_transparency_registry().get("ai_generated_insight")
-    if transparency_notice is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    notice_surface_id = transparency_notice.get("surface_id")
-    notice_boundary = transparency_notice.get("boundary")
-    if notice_surface_id is None or notice_boundary is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_incomplete",
-        )
-
-    prompt = build_slip_support_prompt(safe_event_text, safe_goal, rag_context_str)
-
-    try:
-        await run_in_threadpool(
-            _persist_privileged_action_audit,
-            action="llm.generate",
-            target="provider://default",
-            mode=task.mode,
-            endpoint=endpoint,
-            metadata={
-                "method": method,
-                "prompt_hash": _sha256_hex(prompt),
-                "prompt_length": len(prompt),
-                "source_count": len(sources),
-            },
-        )
-    except (PermissionError, RuntimeError) as exc:
-        logger.error("FitChef slip-support LLM gate failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="llm_generation_unavailable",
-        ) from exc
-
-    try:
-        from llm import get_provider
-
-        provider = get_provider()
-
-        allowed = await run_in_threadpool(
-            attempt_consume_llm_monthly_quota,
-            api_key,
-            tier="VIP",
-        )
-        if not allowed:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="quota_exceeded",
-            )
-        raw_message = await asyncio.wait_for(
-            run_in_threadpool(provider.generate, prompt),
-            timeout=LLM_TIMEOUT_SECONDS,
-        )
-        if not isinstance(raw_message, str) or not raw_message.strip():
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="LLM provider returned empty response",
-            )
-        prepared = prepare_slip_support_draft(
-            raw_message,
-            event_text=safe_event_text,
-            goal=safe_goal,
-        )
-        quota_state = "consumed"
-    except ImportError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM provider not available",
-        ) from None
-    except asyncio.TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail="LLM provider call timed out",
-        ) from None
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.error("FitChef slip-support generation failed", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="fitchef_slip_support_unavailable",
-        ) from exc
+    )
 
     result: FitChefSlipSupportResult = FitChefSlipSupportResult(
-        message=prepared.message,
-        sources=sources,
-        confidence=min(max(confidence, 0.0), 1.0),
-        warnings=[*warnings, *prepared.warnings],
-        action_items=prepared.action_items,
+        message=shared_result.prepared.message,
+        sources=shared_result.sources,
+        confidence=shared_result.confidence,
+        warnings=shared_result.warnings,
+        action_items=shared_result.prepared.action_items,
         mode=task.mode,
-        quota_state=quota_state,
-        transparency_notice_id=str(notice_surface_id),
-        wellness_boundary=str(notice_boundary),
+        quota_state=shared_result.quota_state,
+        transparency_notice_id=shared_result.transparency_notice_id,
+        wellness_boundary=shared_result.wellness_boundary,
     )
     return result
 

--- a/docs/review/PR_1083_FIXED_MAPPING.md
+++ b/docs/review/PR_1083_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1083 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass initialized
+- [x] Fixed in commit mapping initialized
+
+## Fixed in Commit Mapping
+- Initial implementation commit -> `a01ec5df`
+Disposition: FIXED
+Commit: a01ec5df
+Evidence: app/services/fitchef_runtime.py:232
+Evidence: tests/test_fitchef_insight_api.py:2062
+Reason: Extracted a shared private helper for the VIP FitChef text-task flow and added regression coverage for shared audit ordering plus task-specific draft dispatch.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1083_FIXED_MAPPING.md
+++ b/docs/review/PR_1083_FIXED_MAPPING.md
@@ -1,16 +1,11 @@
 # PR 1083 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass initialized
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- Initial implementation commit -> `a01ec5df`
-Disposition: FIXED
-Commit: a01ec5df
-Evidence: app/services/fitchef_runtime.py:232
-Evidence: tests/test_fitchef_insight_api.py:2062
-Reason: Extracted a shared private helper for the VIP FitChef text-task flow and added regression coverage for shared audit ordering plus task-specific draft dispatch.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1903,7 +1903,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: FitChef runtime orchestration dedup
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR-TBD-FITCHEF-RUNTIME-DEDUP
+  - Target PR: PR #1083 (`refactor(fitchef): deduplicate runtime orchestration path`)
   - Status: Open
   - Area: AI runtime / orchestration / tech debt
   - Finding Type: tech-debt

--- a/tests/test_fitchef_insight_api.py
+++ b/tests/test_fitchef_insight_api.py
@@ -2059,6 +2059,233 @@ class TestFitChefSlipSupportRuntimeCoverage:
         assert exc_info.value.detail == "fitchef_slip_support_unavailable"
 
 
+@pytest.mark.parametrize(
+    ("runner_name", "task_factory", "provider_text"),
+    [
+        (
+            "run_mascot_insight_task",
+            lambda: FitChefMascotInsightTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefMascotInsightInput(
+                    safe_query="Need help with breakfast consistency",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef",
+                    method="POST",
+                ),
+            ),
+            "- Choose one balanced breakfast.\n- Add protein to the first meal.",
+        ),
+        (
+            "run_weekly_reflection_task",
+            lambda: FitChefWeeklyReflectionTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefWeeklyReflectionInput(
+                    safe_summary="Meals felt uneven and evenings were rushed",
+                    safe_goal="more steady dinners",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef/weekly-reflection",
+                    method="POST",
+                ),
+            ),
+            "- Keep one dinner template.\n- Plan one calmer evening reset.",
+        ),
+        (
+            "run_slip_support_task",
+            lambda: FitChefSlipSupportTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefSlipSupportInput(
+                    safe_event_text="I kept snacking after dinner",
+                    safe_goal="more steady dinners",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef/slip-support",
+                    method="POST",
+                ),
+            ),
+            "- Pause before the next snack.\n- Restart with one balanced next meal.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fitchef_text_tasks_preserve_shared_audit_sequence(
+    runner_name: str,
+    task_factory,
+    provider_text: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All FitChef text tasks should keep the same audit sequence after dedup."""
+
+    from app.services import fitchef_runtime
+
+    audit_calls: list[tuple[str, str]] = []
+
+    def _track_audit(**kwargs: object) -> None:
+        audit_calls.append((str(kwargs["action"]), str(kwargs["target"])))
+
+    mock_provider = MagicMock()
+    mock_provider.generate.return_value = provider_text
+
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.get_transparency_registry",
+        lambda: {
+            "ai_generated_insight": {
+                "surface_id": "ai_generated_insight",
+                "boundary": "Wellness coaching only.",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime._persist_privileged_action_audit",
+        _track_audit,
+    )
+    monkeypatch.setattr(
+        "core.rag.vector_rag.retrieve_context_structured",
+        lambda *args, **kwargs: _make_rag_context(),
+    )
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr("llm.get_provider", lambda: mock_provider)
+
+    runner = getattr(fitchef_runtime, runner_name)
+    await runner(task_factory())
+
+    assert audit_calls[:2] == [
+        ("rag.retrieve", "corpus://fitchef-agent"),
+        ("llm.generate", "provider://default"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("runner_name", "task_factory", "expected_message", "expected_calls"),
+    [
+        (
+            "run_mascot_insight_task",
+            lambda: FitChefMascotInsightTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefMascotInsightInput(
+                    safe_query="Need breakfast support",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef",
+                    method="POST",
+                ),
+            ),
+            "mascot-draft",
+            {"mascot": 1, "weekly": 0, "slip": 0},
+        ),
+        (
+            "run_weekly_reflection_task",
+            lambda: FitChefWeeklyReflectionTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefWeeklyReflectionInput(
+                    safe_summary="Meals felt uneven",
+                    safe_goal="more steady dinners",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef/weekly-reflection",
+                    method="POST",
+                ),
+            ),
+            "weekly-draft",
+            {"mascot": 0, "weekly": 1, "slip": 0},
+        ),
+        (
+            "run_slip_support_task",
+            lambda: FitChefSlipSupportTaskEnvelope(
+                mode="auto-safe",
+                input=FitChefSlipSupportInput(
+                    safe_event_text="I kept snacking after dinner",
+                    safe_goal="more steady dinners",
+                    api_key=TEST_KEY_VIP,
+                    endpoint="/api/v1/insight/fitchef/slip-support",
+                    method="POST",
+                ),
+            ),
+            "slip-draft",
+            {"mascot": 0, "weekly": 0, "slip": 1},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fitchef_text_tasks_use_task_specific_draft_builder(
+    runner_name: str,
+    task_factory,
+    expected_message: str,
+    expected_calls: dict[str, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dedup must keep each task wired to its own draft preparer."""
+
+    from app.services import fitchef_runtime
+    from core.insight.fitchef_companion import FitChefCoachingDraft
+
+    draft_calls = {"mascot": 0, "weekly": 0, "slip": 0}
+
+    def _mascot_draft(*args: object, **kwargs: object) -> FitChefCoachingDraft:
+        draft_calls["mascot"] += 1
+        return FitChefCoachingDraft(
+            message="mascot-draft",
+            action_items=["mascot action"],
+            warnings=["mascot warning"],
+        )
+
+    def _weekly_draft(*args: object, **kwargs: object) -> FitChefCoachingDraft:
+        draft_calls["weekly"] += 1
+        return FitChefCoachingDraft(
+            message="weekly-draft",
+            action_items=["weekly action"],
+            warnings=["weekly warning"],
+        )
+
+    def _slip_draft(*args: object, **kwargs: object) -> FitChefCoachingDraft:
+        draft_calls["slip"] += 1
+        return FitChefCoachingDraft(
+            message="slip-draft",
+            action_items=["slip action"],
+            warnings=["slip warning"],
+        )
+
+    mock_provider = MagicMock()
+    mock_provider.generate.return_value = "raw provider text"
+
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.get_transparency_registry",
+        lambda: {
+            "ai_generated_insight": {
+                "surface_id": "ai_generated_insight",
+                "boundary": "Wellness coaching only.",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime._persist_privileged_action_audit",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "core.rag.vector_rag.retrieve_context_structured",
+        lambda *args, **kwargs: _make_rag_context(),
+    )
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr("llm.get_provider", lambda: mock_provider)
+    monkeypatch.setattr("app.services.fitchef_runtime.prepare_mascot_draft", _mascot_draft)
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.prepare_weekly_reflection_draft",
+        _weekly_draft,
+    )
+    monkeypatch.setattr(
+        "app.services.fitchef_runtime.prepare_slip_support_draft",
+        _slip_draft,
+    )
+
+    runner = getattr(fitchef_runtime, runner_name)
+    result = await runner(task_factory())
+
+    assert result.message == expected_message
+    assert draft_calls == expected_calls
+
+
 def test_prepare_mascot_draft_preserves_bulleted_action_items() -> None:
     """Bullet/newline structure should survive action-item extraction."""
 


### PR DESCRIPTION
## Summary
- deduplicate the shared VIP FitChef text orchestration flow in `app/services/fitchef_runtime.py`
- preserve public route contracts for mascot, weekly reflection, and slip-support
- add regression coverage for shared audit ordering and task-specific draft dispatch
- implementation commit: `a01ec5df`
- governance traceability commit: `5be38b41`
- artifact-format alignment commit: `2aefb7b0`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pytest -q tests/test_fitchef_insight_api.py -k 'shared_audit_sequence or task_specific_draft_builder'`
- `pytest -q tests/test_fitchef_insight_api.py -k 'weekly_reflection or slip_support or mascot'`
- `pytest -q tests/vip/test_vip_diff_coverage.py`
- `make lint`
- `make typecheck`
- `make openapi-check`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Public route namespace unchanged: `/api/v1/insight/fitchef*`
- [x] Public schemas unchanged
- [x] VIP-only / rate-limit / quota / audit ordering preserved
- [x] OpenAPI contract unchanged
- [x] Backlog anchor linked: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-fitchef-runtime-orchestration-dedup`
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal architecture for FitChef coaching and planning tasks to use a unified configuration and execution pattern, improving consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for FitChef text-based tasks (mascot insights, weekly reflections, slip support) to ensure reliability and proper audit sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->