### PR TITLE
fix(app): align package bootstrap facade

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,20 @@ _LOCAL_EXPORTS: dict[str, tuple[str, str]] = {
 
 
 @lru_cache(maxsize=1)
+def _ensure_canonical_bootstrap() -> None:
+    """Run canonical additive bootstrap without changing facade identity.
+
+    RU: Импорт `app.main` нужен только для запуска additive bootstrap поверх
+    `legacy_app.app`; наружу пакет всё равно должен отдавать именно
+    `legacy_app.app`, чтобы сохранялся инвариант identity в тестах и reload path.
+    EN: Import `app.main` only to execute additive bootstrap on top of
+    `legacy_app.app`; the package must still expose `legacy_app.app` itself to
+    preserve identity under tests and reload scenarios.
+    """
+    importlib.import_module("app.main")
+
+
+@lru_cache(maxsize=1)
 def _legacy() -> Any:
     """Import legacy_app lazily and cache it.
 
@@ -70,6 +84,9 @@ def __getattr__(name: str) -> Any:
     PEP 562 forwarder: pure delegation, no side effects.
     Observability bootstrap (register_metrics) is applied ONLY in app/main.py.
     """
+    if name == "app":
+        _ensure_canonical_bootstrap()
+        return getattr(_legacy(), "app")
     if name in _LOCAL_EXPORTS:
         mod_name, attr = _LOCAL_EXPORTS[name]
         mod = importlib.import_module(mod_name)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,7 +41,6 @@ _LOCAL_EXPORTS: dict[str, tuple[str, str]] = {
 }
 
 
-@lru_cache(maxsize=1)
 def _ensure_canonical_bootstrap() -> None:
     """Run canonical additive bootstrap without changing facade identity.
 
@@ -52,7 +51,19 @@ def _ensure_canonical_bootstrap() -> None:
     `legacy_app.app`; the package must still expose `legacy_app.app` itself to
     preserve identity under tests and reload scenarios.
     """
-    importlib.import_module("app.main")
+    legacy_app_instance = getattr(_legacy(), "app")
+    main_module = sys.modules.get("app.main")
+
+    if main_module is None:
+        main_module = importlib.import_module("app.main")
+
+    main_app_instance = getattr(main_module, "app", None)
+    if main_app_instance is legacy_app_instance:
+        return
+
+    ensure_bootstrap = getattr(main_module, "ensure_canonical_app_bootstrap", None)
+    if callable(ensure_bootstrap):
+        ensure_bootstrap(legacy_app_instance)
 
 
 @lru_cache(maxsize=1)

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,47 @@ from app.routers.legal import router as legal_router
 
 app: FastAPI = _legacy_app
 
+_WS_ROUTE_PATHS: tuple[str, str] = ("/api/v1/pro/ws", "/ws")
+_FEEDBACK_ROUTE_PATH: str = "/api/v1/feedback/rag"
+_TERMS_ROUTE_PATH: str = "/terms"
+_CBT_INSIGHT_ROUTE_PATH: str = "/api/v1/pro/cbt/insight"
+
+
+def _has_route(
+    target_app: FastAPI,
+    path: str,
+    method: str | None = None,
+) -> bool:
+    """Check whether a route is already registered on the target app.
+
+    RU: Помогает делать additive bootstrap идемпотентным для reload paths.
+    EN: Keeps additive bootstrap idempotent for reload-path rehydration.
+    """
+    method_name = method.upper() if method else None
+    for route in target_app.routes:
+        if getattr(route, "path", None) != path:
+            continue
+        methods = getattr(route, "methods", None) or set()
+        if method_name is None or method_name in methods:
+            return True
+    return False
+
+
+def _assert_no_duplicate_ws_route(target_app: FastAPI | None = None) -> None:
+    """Fail fast when WS paths are already occupied before canonical registration.
+
+    RU: Отдельный guard сохраняет старый fail-fast контракт для tests/runtime.
+    EN: Separate guard preserves the legacy fail-fast contract for tests/runtime.
+    """
+    current_app = target_app or app
+    existing_paths = {getattr(route, "path", None) for route in current_app.routes}
+    for path in _WS_ROUTE_PATHS:
+        if path in existing_paths:
+            raise RuntimeError(
+                f"Duplicate {path} route detected. "
+                "Check legacy_app.py or other router registration points."
+            )
+
 
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
     """Hide legacy users CRUD from the public OpenAPI contract.
@@ -53,37 +94,42 @@ def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
     target_app.openapi_schema = None
 
 
-_internalize_users_openapi_surface(app)
-_install_openapi_builder(app)
-register_metrics(app)
-register_pro_contract_routes(app)
+def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
+    """Apply canonical additive bootstrap to the provided FastAPI instance.
+
+    RU: Используется и при первичном импорте `app.main`, и когда `app.app`
+    должен перевести facade на новый `legacy_app.app` без потери additive routes.
+    EN: Used both on initial `app.main` import and when `app.app` must rehydrate
+    a replaced `legacy_app.app` without losing additive routes.
+    """
+    global app
+
+    app = target_app
+    _internalize_users_openapi_surface(app)
+    _install_openapi_builder(app)
+    register_metrics(app)
+    register_pro_contract_routes(app)
+
+    ws_paths_present = {path for path in _WS_ROUTE_PATHS if _has_route(app, path)}
+    if not ws_paths_present:
+        app.include_router(realtime_ws.router)
+    elif ws_paths_present != set(_WS_ROUTE_PATHS):
+        _assert_no_duplicate_ws_route(app)
+
+    if not _has_route(app, _FEEDBACK_ROUTE_PATH, "POST"):
+        app.include_router(feedback_router)
+
+    if not _has_route(app, _TERMS_ROUTE_PATH, "GET"):
+        app.include_router(legal_router)
+
+    register_billing_routes(app)
+
+    if not _has_route(app, _CBT_INSIGHT_ROUTE_PATH, "POST"):
+        app.include_router(cbt_insight_router)
+
+    return app
 
 
-def _assert_no_duplicate_ws_route() -> None:
-    """Fail fast if WS routes are already registered elsewhere."""
-    existing_paths = {getattr(route, "path", None) for route in app.routes}
-    ws_paths = ("/api/v1/pro/ws", "/ws")  # tuple for deterministic order
-    for path in ws_paths:
-        if path in existing_paths:
-            raise RuntimeError(
-                f"Duplicate {path} route detected. "
-                "Check legacy_app.py or other router registration points."
-            )
-
-
-_assert_no_duplicate_ws_route()
-app.include_router(realtime_ws.router)
-
-# Register feedback router (new endpoint, not legacy — belongs here per policy)
-app.include_router(feedback_router)
-
-# Register legal publication router outside legacy compatibility layer.
-app.include_router(legal_router)
-
-# Register billing router (canonical additive runtime payment surface).
-register_billing_routes(app)
-
-# Register CBT insight router (PRO tier, feature-flagged via FEATURE_CBT_AGENT)
-app.include_router(cbt_insight_router)
+ensure_canonical_app_bootstrap(app)
 
 __all__ = ["app"]

--- a/docs/review/PR_1087_FIXED_MAPPING.md
+++ b/docs/review/PR_1087_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925160422 -> 722fd965
+Disposition: FIXED
+Commit: `722fd965`
+Evidence: `tests/test_app_openapi_coverage.py:146`; `tests/test_app_basic_combined.py:50`
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1087_FIXED_MAPPING.md
+++ b/docs/review/PR_1087_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1087 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass initialized
-- [x] Fixed in commit mapping artifact created
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- Initial state: no review threads or actionable bot comments mapped yet.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1087_FIXED_MAPPING.md
+++ b/docs/review/PR_1087_FIXED_MAPPING.md
@@ -17,6 +17,12 @@ Disposition: FIXED
 Commit: `4c0b9c73`
 Evidence: `app/__init__.py:54`; `app/main.py:54`; `app/main.py:97`; `tests/test_app_basic_combined.py:31`; `tests/test_app_basic_combined.py:60`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925377952 -> 94dfa281
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914429902 -> 94dfa281
+Disposition: FIXED
+Commit: `94dfa281`
+Evidence: `tests/test_app_basic_combined.py:57`; `tests/test_app_basic_combined.py:69`; `tests/test_app_basic_combined.py:74`
+
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads

--- a/docs/review/PR_1087_FIXED_MAPPING.md
+++ b/docs/review/PR_1087_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1087 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass initialized
+- [x] Fixed in commit mapping artifact created
+
+## Fixed in Commit Mapping
+- Initial state: no review threads or actionable bot comments mapped yet.
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1087_FIXED_MAPPING.md
+++ b/docs/review/PR_1087_FIXED_MAPPING.md
@@ -10,6 +10,13 @@ Disposition: FIXED
 Commit: `722fd965`
 Evidence: `tests/test_app_openapi_coverage.py:146`; `tests/test_app_basic_combined.py:50`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925174721 -> 4c0b9c73
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914230561 -> 4c0b9c73
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914230563 -> 4c0b9c73
+Disposition: FIXED
+Commit: `4c0b9c73`
+Evidence: `app/__init__.py:54`; `app/main.py:54`; `app/main.py:97`; `tests/test_app_basic_combined.py:31`; `tests/test_app_basic_combined.py:60`
+
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -49,7 +49,6 @@ class TestAppImport:
 
         assert additive_paths.issubset(package_paths)
         assert additive_paths.issubset(main_paths)
-        assert additive_paths.issubset(package_paths & main_paths)
 
     def test_app_package_keeps_legacy_app_identity(self) -> None:
         """The package shim must preserve the underlying legacy FastAPI object."""

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -2,11 +2,11 @@
 Combined basic app tests: import, VIP integration, and package spec.
 """
 
+import importlib
 import sys
 from fastapi import FastAPI
 
 import app
-import legacy_app
 import pytest
 
 
@@ -54,7 +54,9 @@ class TestAppImport:
         """The package shim must preserve the underlying legacy FastAPI object."""
         from app.main import app as main_app
 
-        assert app.app is legacy_app.app
+        legacy_module = importlib.import_module("legacy_app")
+
+        assert app.app is legacy_module.app
         assert app.app is main_app
 
     def test_app_package_rehydrates_bootstrap_after_legacy_app_swap(
@@ -64,10 +66,12 @@ class TestAppImport:
         """Facade access must reapply additive bootstrap when legacy_app.app changes."""
         import app.main as main_module
 
+        legacy_module = importlib.import_module("legacy_app")
+
         original_main_app = main_module.app
         replacement_app = FastAPI()
         monkeypatch.setattr(main_module, "app", original_main_app)
-        monkeypatch.setattr(legacy_app, "app", replacement_app)
+        monkeypatch.setattr(legacy_module, "app", replacement_app)
 
         package_app = app.app
         route_paths = {

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -30,8 +30,6 @@ class TestAppImport:
 
     def test_app_package_exposes_canonical_bootstrapped_routes(self) -> None:
         """`import app` must expose additive routes registered in app.main."""
-        from app.main import app as main_app
-
         additive_paths = {
             "/api/v1/billing/apple/verify-receipt",
             "/api/v1/feedback/rag",
@@ -42,6 +40,8 @@ class TestAppImport:
             getattr(route, "path", None) or getattr(route, "path_format", "")
             for route in app.app.routes
         }
+        from app.main import app as main_app
+
         main_paths = {
             getattr(route, "path", None) or getattr(route, "path_format", "")
             for route in main_app.routes
@@ -56,6 +56,31 @@ class TestAppImport:
 
         assert app.app is legacy_app.app
         assert app.app is main_app
+
+    def test_app_package_rehydrates_bootstrap_after_legacy_app_swap(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Facade access must reapply additive bootstrap when legacy_app.app changes."""
+        import app.main as main_module
+
+        original_main_app = main_module.app
+        replacement_app = FastAPI()
+        monkeypatch.setattr(main_module, "app", original_main_app)
+        monkeypatch.setattr(legacy_app, "app", replacement_app)
+
+        package_app = app.app
+        route_paths = {
+            getattr(route, "path", None) or getattr(route, "path_format", "")
+            for route in package_app.routes
+        }
+
+        assert package_app is replacement_app
+        assert main_module.app is replacement_app
+        assert "/api/v1/billing/apple/verify-receipt" in route_paths
+        assert "/api/v1/feedback/rag" in route_paths
+        assert "/api/v1/pro/cbt/insight" in route_paths
+        assert "/ws" in route_paths
 
 
 class TestAppVIPIntegration:

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -6,6 +6,7 @@ import sys
 from fastapi import FastAPI
 
 import app
+import legacy_app
 import pytest
 
 
@@ -26,6 +27,36 @@ class TestAppImport:
         assert hasattr(app.app, "routes")
         assert app.app.routes is not None
         assert len(app.app.routes) > 0
+
+    def test_app_package_exposes_canonical_bootstrapped_routes(self) -> None:
+        """`import app` must expose additive routes registered in app.main."""
+        from app.main import app as main_app
+
+        additive_paths = {
+            "/api/v1/billing/apple/verify-receipt",
+            "/api/v1/feedback/rag",
+            "/api/v1/pro/cbt/insight",
+            "/ws",
+        }
+        package_paths = {
+            getattr(route, "path", None) or getattr(route, "path_format", "")
+            for route in app.app.routes
+        }
+        main_paths = {
+            getattr(route, "path", None) or getattr(route, "path_format", "")
+            for route in main_app.routes
+        }
+
+        assert additive_paths.issubset(package_paths)
+        assert additive_paths.issubset(main_paths)
+        assert additive_paths.issubset(package_paths & main_paths)
+
+    def test_app_package_keeps_legacy_app_identity(self) -> None:
+        """The package shim must preserve the underlying legacy FastAPI object."""
+        from app.main import app as main_app
+
+        assert app.app is legacy_app.app
+        assert app.app is main_app
 
 
 class TestAppVIPIntegration:

--- a/tests/test_app_openapi_coverage.py
+++ b/tests/test_app_openapi_coverage.py
@@ -143,7 +143,7 @@ class TestAppOpenAPICoverage:
         assert "post" in paths["/api/v1/vip/menu/weekly/plan"]
         assert "post" in paths["/api/v1/vip/weekly-plan"]
 
-    def test_app_openapi_exposes_additive_runtime_surface(self, client):
+    def test_app_openapi_exposes_additive_runtime_surface(self, client) -> None:
         """Runtime `/openapi.json` must include additive routes registered in app.main."""
         response = client.get("/openapi.json")
         assert response.status_code == 200

--- a/tests/test_app_openapi_coverage.py
+++ b/tests/test_app_openapi_coverage.py
@@ -143,6 +143,16 @@ class TestAppOpenAPICoverage:
         assert "post" in paths["/api/v1/vip/menu/weekly/plan"]
         assert "post" in paths["/api/v1/vip/weekly-plan"]
 
+    def test_app_openapi_exposes_additive_runtime_surface(self, client):
+        """Runtime `/openapi.json` must include additive routes registered in app.main."""
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        _assert_json_content_type(response)
+
+        paths = response.json()["paths"]
+        assert "/api/v1/billing/apple/verify-receipt" in paths
+        assert "/api/v1/pro/cbt/insight" in paths
+
     def test_app_openapi_parameters_coverage(self, client):
         """Тест покрытия app.py OpenAPI parameters"""
         # Тестируем OpenAPI parameters


### PR DESCRIPTION
## Summary
- align `app.__getattr__("app")` with the canonical bootstrap path by importing `app.main` lazily before exposing the facade app
- preserve the identity invariant `app.app is legacy_app.app` while restoring additive runtime registrations under `import app`
- rehydrate canonical bootstrap when `legacy_app.app` changes and add regression coverage for package/runtime/openapi parity across entrypoints

## Testing
- python3 scripts/orchestration/check_preflight.py
- pytest -q tests/test_env_guards.py tests/test_app_openapi_coverage.py tests/test_app_basic_combined.py
- pytest -q tests/test_billing_openapi_contract.py tests/test_feedback_api.py tests/test_cbt_insight_api.py tests/test_realtime_ws_security.py
- pytest -q tests/test_main_ws_registration_guard.py tests/test_websocket_security_api.py
- pre-commit run --all-files
- make verify

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925160422 -> 722fd965
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925174721 -> 4c0b9c73
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914230561 -> 4c0b9c73
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914230563 -> 4c0b9c73
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#pullrequestreview-3925377952 -> 94dfa281
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1087#discussion_r2914429902 -> 94dfa281

## Merge Readiness
- [x] Scope is narrow and runtime-only
- [x] No worker.js / FitChef / sandbox / design changes
- [x] Hard gates passed locally (`pre-commit run --all-files`, `make verify`)
- [ ] Required checks green
- [ ] Review threads resolved with canonical mapping artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime-added routes are now exposed in the app and reflected in the OpenAPI surface; package-level app identity is preserved and rehydrates after replacement.

* **Tests**
  * Added tests to verify additive routes surface at runtime and in OpenAPI, ensure package preserves app identity, and confirm bootstrapped routes rehydrate after swaps.

* **Documentation**
  * Added a PR review note documenting fixed-commit mapping and merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
