### PR TITLE
fix(app): restore bootstrap patchability on main

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,12 +58,24 @@ def _ensure_canonical_bootstrap() -> None:
         main_module = importlib.import_module("app.main")
 
     main_app_instance = getattr(main_module, "app", None)
+    ensure_bootstrap = getattr(main_module, "ensure_canonical_app_bootstrap", None)
     if main_app_instance is legacy_app_instance:
+        # RU: Даже при совпадающем объекте дополнительно удерживаем ссылку
+        # `app.main.app` синхронизированной для reload / monkeypatch churn.
+        # EN: Keep `app.main.app` synchronized even when identity already matches
+        # to stabilize reload / monkeypatch churn across Python versions.
+        setattr(main_module, "app", legacy_app_instance)
         return
 
-    ensure_bootstrap = getattr(main_module, "ensure_canonical_app_bootstrap", None)
     if callable(ensure_bootstrap):
         ensure_bootstrap(legacy_app_instance)
+        return
+
+    # RU: Фолбэк только для safety-path; нормальный runtime идёт через
+    # `ensure_canonical_app_bootstrap` в app.main.
+    # EN: Safety fallback only; normal runtime should go through
+    # `ensure_canonical_app_bootstrap` in app.main.
+    setattr(main_module, "app", legacy_app_instance)
 
 
 @lru_cache(maxsize=1)

--- a/docs/review/PR_1096_FIXED_MAPPING.md
+++ b/docs/review/PR_1096_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1096 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1096_FIXED_MAPPING.md
+++ b/docs/review/PR_1096_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#pullrequestreview-3926005775 -> 7b531003
+Disposition: FIXED
+Commit: `7b531003`
+Evidence: `legacy_app.py:3326`; `legacy_app.py:3340`; `legacy_app.py:3361`
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1096_FIXED_MAPPING.md
+++ b/docs/review/PR_1096_FIXED_MAPPING.md
@@ -9,6 +9,14 @@
 Disposition: FIXED
 Commit: `7b531003`
 Evidence: `legacy_app.py:3326`; `legacy_app.py:3340`; `legacy_app.py:3361`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#discussion_r2915036542 -> edde2170
+Disposition: FIXED
+Commit: `edde2170`
+Evidence: `legacy_app.py:3318`; `tests/test_premium_week_app_coverage.py:116`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#discussion_r2915036547 -> edde2170
+Disposition: FIXED
+Commit: `edde2170`
+Evidence: `legacy_app.py:3330`; `tests/test_premium_week_app_coverage.py:127`
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3334,7 +3334,22 @@ def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
         return package_builder if callable(package_builder) else None
 
     local_builder = globals().get("make_weekly_menu")
-    return local_builder if callable(local_builder) else None
+    if callable(local_builder):
+        return cast(Callable[..., Any], local_builder)
+
+    # RU: Если legacy_app.make_weekly_menu временно пропатчен в None, но пакет
+    # `app` по-прежнему экспортирует canonical builder через lazy facade,
+    # используем package export как стабильный fallback.
+    # EN: If legacy_app.make_weekly_menu is temporarily patched to None while the
+    # `app` package still exports the canonical builder through the lazy facade,
+    # use the package export as the stable fallback.
+    if package_module is not None:
+        package_builder = getattr(package_module, "make_weekly_menu", None)
+        if callable(package_builder):
+            return cast(Callable[..., Any], package_builder)
+        return None
+
+    return None
 
 
 class WeeklyPlanFlexibleRequest(BaseModel):

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3323,19 +3323,31 @@ def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
     """
     import sys as _sys
 
-    package_module = _sys.modules.get("app")
-    package_has_override = package_module is not None and "make_weekly_menu" in getattr(
-        package_module,
-        "__dict__",
-        {},
-    )
-    if package_has_override:
-        package_builder = getattr(package_module, "make_weekly_menu")
-        return package_builder if callable(package_builder) else None
+    def _callable_or_none(value: Any) -> Optional[Callable[..., Any]]:
+        """Return a typed callable or None for explicit override semantics.
 
+        RU: Явно сохраняем семантику override: невызываемое значение означает
+        отключение, а не молчаливый fallback.
+        EN: Preserve explicit override semantics: a non-callable value means
+        disable/override, not a silent fallback.
+        """
+
+        return cast(Callable[..., Any], value) if callable(value) else None
+
+    package_module = _sys.modules.get("app")
+    package_namespace = getattr(package_module, "__dict__", {}) if package_module else {}
+
+    # RU: Приоритет №1 — явный override в `app.__dict__`.
+    # EN: Priority #1 — explicit override in `app.__dict__`.
+    if "make_weekly_menu" in package_namespace:
+        return _callable_or_none(package_namespace.get("make_weekly_menu"))
+
+    # RU: Приоритет №2 — legacy_app global, если он всё ещё вызываемый.
+    # EN: Priority #2 — legacy_app global, if it is still callable.
     local_builder = globals().get("make_weekly_menu")
-    if callable(local_builder):
-        return cast(Callable[..., Any], local_builder)
+    resolved_local_builder = _callable_or_none(local_builder)
+    if resolved_local_builder is not None:
+        return resolved_local_builder
 
     # RU: Если legacy_app.make_weekly_menu временно пропатчен в None, но пакет
     # `app` по-прежнему экспортирует canonical builder через lazy facade,
@@ -3343,13 +3355,12 @@ def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
     # EN: If legacy_app.make_weekly_menu is temporarily patched to None while the
     # `app` package still exports the canonical builder through the lazy facade,
     # use the package export as the stable fallback.
-    if package_module is not None:
-        package_builder = getattr(package_module, "make_weekly_menu", None)
-        if callable(package_builder):
-            return cast(Callable[..., Any], package_builder)
+    if package_module is None:
         return None
 
-    return None
+    # RU: Приоритет №3 — lazy package export через `app.__getattr__`.
+    # EN: Priority #3 — lazy package export via `app.__getattr__`.
+    return _callable_or_none(getattr(package_module, "make_weekly_menu", None))
 
 
 class WeeklyPlanFlexibleRequest(BaseModel):

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3315,13 +3315,41 @@ def _build_legacy_weekly_menu_response(menu_payload: Dict[str, Any]) -> WeeklyMe
     )
 
 
+def _get_app_package_module() -> Optional[Any]:
+    """Return the loaded `app` package module if present.
+
+    RU: Выделено в helper, чтобы тесты не мутировали `sys.modules`.
+    EN: Extracted into a helper so tests can avoid mutating `sys.modules`.
+    """
+
+    import sys as _sys
+
+    return _sys.modules.get("app")
+
+
+def _resolve_package_weekly_menu_export(package_module: Any) -> Optional[Callable[..., Any]]:
+    """Resolve lazy `app.make_weekly_menu` export without surfacing ImportError.
+
+    RU: PEP-562 facade может поднять ImportError при lazy export; для legacy alias
+    это трактуется как «feature unavailable», а не как 500.
+    EN: The PEP-562 facade may raise ImportError during lazy export; for the
+    legacy alias this should mean "feature unavailable", not a 500.
+    """
+
+    try:
+        package_builder = getattr(package_module, "make_weekly_menu", None)
+    except ImportError:
+        return None
+
+    return cast(Callable[..., Any], package_builder) if callable(package_builder) else None
+
+
 def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
     """Resolve the canonical weekly-menu builder for the legacy premium alias.
 
     RU: Разрешить canonical weekly-menu builder для legacy premium alias.
     EN: Resolve the canonical weekly-menu builder for the legacy premium alias.
     """
-    import sys as _sys
 
     def _callable_or_none(value: Any) -> Optional[Callable[..., Any]]:
         """Return a typed callable or None for explicit override semantics.
@@ -3334,7 +3362,7 @@ def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
 
         return cast(Callable[..., Any], value) if callable(value) else None
 
-    package_module = _sys.modules.get("app")
+    package_module = _get_app_package_module()
     package_namespace = getattr(package_module, "__dict__", {}) if package_module else {}
 
     # RU: Приоритет №1 — явный override в `app.__dict__`.
@@ -3360,7 +3388,7 @@ def _resolve_legacy_weekly_menu_builder() -> Optional[Callable[..., Any]]:
 
     # RU: Приоритет №3 — lazy package export через `app.__getattr__`.
     # EN: Priority #3 — lazy package export via `app.__getattr__`.
-    return _callable_or_none(getattr(package_module, "make_weekly_menu", None))
+    return _resolve_package_weekly_menu_export(package_module)
 
 
 class WeeklyPlanFlexibleRequest(BaseModel):

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -6,6 +6,7 @@ RU: Простые тесты для покрытия эндпоинта premium
 EN: Simple tests for premium week endpoint coverage in main.py
 """
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,6 +68,62 @@ class TestPremiumWeekAppCoverage:
         data = response.json()
         assert "detail" in data
         assert "not available" in data["detail"].lower()
+
+    def test_resolver_falls_back_to_package_export_when_legacy_builder_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolver uses app package export when legacy builder is patched to None.
+
+        RU: Если legacy_app.make_weekly_menu временно None, резолвер должен
+        использовать canonical export из пакета `app`, если package override не задан.
+        EN: If legacy_app.make_weekly_menu is temporarily None, the resolver must
+        use the canonical `app` package export when no explicit package override exists.
+        """
+        import app as app_package
+
+        monkeypatch.delitem(app_package.__dict__, "make_weekly_menu", raising=False)
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
+
+        builder = legacy_app._resolve_legacy_weekly_menu_builder()
+
+        assert callable(builder)
+
+    def test_resolver_returns_none_when_package_export_is_not_callable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolver returns None when neither legacy nor package export is callable.
+
+        RU: Явно покрываем отрицательный fallback путь без business-logic изменений.
+        EN: Explicitly cover the negative fallback path without changing business logic.
+        """
+        import app as app_package
+
+        original_getattr = getattr(app_package, "__getattr__")
+
+        monkeypatch.delitem(app_package.__dict__, "make_weekly_menu", raising=False)
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
+
+        def _package_getattr(name: str):
+            if name == "make_weekly_menu":
+                return None
+            return original_getattr(name)
+
+        monkeypatch.setattr(app_package, "__getattr__", _package_getattr)
+
+        builder = legacy_app._resolve_legacy_weekly_menu_builder()
+
+        assert builder is None
+
+    def test_resolver_returns_none_when_package_module_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolver returns None when the `app` package is absent from sys.modules."""
+        monkeypatch.delitem(sys.modules, "app", raising=False)
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
+
+        builder = legacy_app._resolve_legacy_weekly_menu_builder()
+
+        assert builder is None
 
     def test_api_weekly_menu_success(self) -> None:
         """Test successful weekly menu generation."""

--- a/tests/test_premium_week_app_coverage.py
+++ b/tests/test_premium_week_app_coverage.py
@@ -6,7 +6,6 @@ RU: Простые тесты для покрытия эндпоинта premium
 EN: Simple tests for premium week endpoint coverage in main.py
 """
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -114,11 +113,29 @@ class TestPremiumWeekAppCoverage:
 
         assert builder is None
 
-    def test_resolver_returns_none_when_package_module_is_missing(
+    def test_resolver_returns_none_when_package_module_lookup_is_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Resolver returns None when the `app` package is absent from sys.modules."""
-        monkeypatch.delitem(sys.modules, "app", raising=False)
+        """Resolver returns None when the package lookup helper yields no module."""
+        monkeypatch.setattr(legacy_app, "_get_app_package_module", lambda: None)
+        monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
+
+        builder = legacy_app._resolve_legacy_weekly_menu_builder()
+
+        assert builder is None
+
+    def test_resolver_returns_none_when_package_export_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolver treats package-export ImportError as feature unavailable."""
+
+        class _ImportErrorPackage:
+            def __getattr__(self, name: str):
+                if name == "make_weekly_menu":
+                    raise ImportError("menu engine unavailable")
+                raise AttributeError(name)
+
+        monkeypatch.setattr(legacy_app, "_get_app_package_module", lambda: _ImportErrorPackage())
         monkeypatch.setattr(legacy_app, "make_weekly_menu", None)
 
         builder = legacy_app._resolve_legacy_weekly_menu_builder()


### PR DESCRIPTION
## Summary
- restore the canonical `app` package facade to rehydrate `app.main.app` after legacy app swaps
- preserve package-level patchability for scheduler wrappers and weekly-menu resolution
- add regression coverage for bootstrap sync and weekly-menu resolver fallback precedence

## Problem
`main` turned red after `#1088` because the `app` package facade no longer preserved the expected bootstrap/patchability contract under test/runtime churn.

GitHub Actions failures on `main` were:
- `tests/test_app_extended_coverage.py::test_weekly_menu_unavailable`
- `tests/test_app_error_paths_97.py::test_start_background_updates_no_running_loop`
- `tests/test_app_error_paths_97.py::test_stop_background_updates_no_running_loop`
- `tests/test_app_basic_combined.py::test_app_package_rehydrates_bootstrap_after_legacy_app_swap`

## Changes
- special-case `app.app` resolution through `app.main` bootstrap alignment in `app/__init__.py`
- keep `app.main.app` synchronized with `legacy_app.app` during reload/monkeypatch churn
- make legacy weekly-menu builder resolution respect explicit package overrides while falling back to the canonical package export when `legacy_app.make_weekly_menu` is temporarily `None`
- add direct resolver regression tests for callable fallback and explicit `None` paths
- introduce helper-based package lookup and ImportError-safe package export resolution to preserve test policy and legacy 503 behavior

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `CI=true .venv/bin/pytest -q tests/test_app_error_paths_97.py tests/test_app_basic_combined.py tests/test_app_extended_coverage.py tests/test_app_openapi_coverage.py tests/test_feedback_api.py tests/test_cbt_insight_api.py tests/test_realtime_ws_security.py tests/test_premium_week_app_coverage.py --maxfail=10`
- `pre-commit run --all-files`
- `make verify`

## Scope
- runtime hotfix only
- no FitChef/sandbox/design changes
- no worker.js changes
- no backlog/docs closure in this PR

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#pullrequestreview-3926005775 -> 7b531003
Disposition: FIXED
Commit: `7b531003`
Evidence: `legacy_app.py:3326`; `legacy_app.py:3340`; `legacy_app.py:3361`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#discussion_r2915036542 -> edde2170
Disposition: FIXED
Commit: `edde2170`
Evidence: `legacy_app.py:3318`; `tests/test_premium_week_app_coverage.py:116`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1096#discussion_r2915036547 -> edde2170
Disposition: FIXED
Commit: `edde2170`
Evidence: `legacy_app.py:3330`; `tests/test_premium_week_app_coverage.py:127`

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed
