### PR TITLE
docs: add OpenAI docs freshness pilot

### DIFF
--- a/docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md
+++ b/docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md
@@ -16,6 +16,14 @@ winner for live MCP integration in Codex/Cursor.
 not the first-choice pilot for this repo's OpenAI-first use case as of
 `10 March 2026`.
 
+Pilot owner and lifecycle:
+
+- Owner: `@katsiaryna_kavaleuskaya`
+- Timeline: one review cycle after PR `#1100`, then explicit keep/adjust/stop
+  decision
+- Ledger item:
+  `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-openai-docs-freshness-pilot`
+
 Why:
 
 - PulsePlate already has deterministic repo context bootstrap and skill routing:
@@ -29,6 +37,18 @@ Why:
 - Official OpenAI guidance for new work points to the **Responses API**, which
   is the exact failure mode this pilot is trying to prevent:
   <https://platform.openai.com/docs/guides/responses-vs-chat-completions>.
+
+Exit criteria:
+
+- Success metric: on repeated OpenAI integration prompts, the chosen lane
+  produces Responses API-oriented, source-linked answers without invented
+  parameters.
+- Graduation criteria: the runbook stays accurate for one review cycle, at
+  least one durable insight is promoted through KPP, and the optional lane does
+  not require CI/runtime changes.
+- Rollback triggers: stale or unsafe auth guidance, repeated OpenAI lookup
+  misses versus official docs, or pressure to treat external caches/annotations
+  as repo canon.
 
 ---
 
@@ -52,7 +72,7 @@ Why:
 
 ---
 
-## 3. Pilot Inputs And Live Command Evidence
+## 3. Pilot Inputs And Spot-Check Evidence
 
 ### 3.1 Official OpenAI baseline
 
@@ -63,62 +83,41 @@ Why:
 
 ### 3.2 Context Hub CLI spot-check
 
-Command:
+Command: `npx -y @aisuite/chub --help`
 
-```bash
-npx -y @aisuite/chub --help
-```
-
-Observed output:
+Raw stdout:
 
 ```text
 Usage: chub [options] [command]
+
 Context Hub - search and retrieve LLM-optimized docs and skills
-Commands:
-  update
-  cache
-  search
-  get
-  build
-  feedback
-  annotate
 ```
 
-Command:
+Exit code: `0`
 
-```bash
-npx -y @aisuite/chub search openai --json
-```
+Command: `npx -y @aisuite/chub search openai --json`
 
-Observed output excerpt:
+Raw stdout:
 
-```json
+```text
 {
   "results": [
     {
-      "id": "openai/chat",
-      "name": "chat",
-      "description": "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
-    }
-  ]
-}
 ```
 
-Command:
+Exit code: `0`
 
-```bash
-npx -y @aisuite/chub search responses openai --json
-```
+Command: `npx -y @aisuite/chub search responses openai --json`
 
-Observed output:
+Raw stdout:
 
-```json
+```text
 {
   "results": [],
   "total": 0,
-  "query": "responses"
-}
 ```
+
+Exit code: `0`
 
 Interpretation:
 
@@ -128,21 +127,17 @@ Interpretation:
 
 ### 3.3 Context7 packaging spot-check
 
-Command:
+Command: `npx -y @upstash/context7-mcp --help`
 
-```bash
-npx -y @upstash/context7-mcp --help
-```
-
-Observed output:
+Raw stdout:
 
 ```text
 Usage: context7-mcp [options]
+
 Options:
-  --transport <stdio|http>
-  --port <number>
-  --api-key <key>
 ```
+
+Exit code: `0`
 
 Interpretation:
 
@@ -212,6 +207,8 @@ first local adoption target for this repo's OpenAI-first pilot.
    - `Context Hub` as the CLI/OSS comparator
 3. Reuse one OpenAI-first prompt pack for future spot-checks.
 4. Promote only durable findings through KPP.
+5. Track pilot graduation or rollback in
+   `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-openai-docs-freshness-pilot`.
 
 ---
 

--- a/docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md
+++ b/docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md
@@ -1,0 +1,223 @@
+# OpenAI-First External Docs Freshness Pilot — Decision
+
+**Date:** 10 March 2026 (`America/New_York`)
+**Status:** Decision (docs + command-evidence pilot)
+**Scope:** Dev-agent docs freshness only; no runtime product changes
+
+---
+
+## 1. Executive Summary
+
+**Decision:** keep the repo-native context lane as canonical, keep `openai-docs`
+as the default OpenAI source, and choose **Context7** as the optional pilot
+winner for live MCP integration in Codex/Cursor.
+
+**Context Hub** remains in the comparison set as the OSS comparator, but it is
+not the first-choice pilot for this repo's OpenAI-first use case as of
+`10 March 2026`.
+
+Why:
+
+- PulsePlate already has deterministic repo context bootstrap and skill routing:
+  `scripts/orchestration/context_pack.py:14`,
+  `scripts/orchestration/task_bootstrap.py:45`,
+  `docs/dev/CODEX_SKILLS.md:32`.
+- Canonical project learning must stay in git through KPP, not in hidden local
+  agent notes: `docs/memory/kpp_knowledge_promotion_pipeline.md:11`,
+  `docs/memory/kpp_knowledge_promotion_pipeline.md:32`,
+  `docs/memory/kpp_knowledge_promotion_pipeline.md:43`.
+- Official OpenAI guidance for new work points to the **Responses API**, which
+  is the exact failure mode this pilot is trying to prevent:
+  <https://platform.openai.com/docs/guides/responses-vs-chat-completions>.
+
+---
+
+## 2. Repo Fit Constraints
+
+### 2.1 What is already canonical here
+
+- Repo context pack is deterministic and source-controlled:
+  `scripts/orchestration/context_pack.py:14`
+- Coordinator bootstrap already carries context + recommended skills:
+  `scripts/orchestration/task_bootstrap.py:69`
+- `openai-docs` is already explicitly approved for matching tasks:
+  `docs/dev/CODEX_SKILLS.md:64`
+
+### 2.2 What external tools must not become
+
+- External doc caches, MCP outputs, and local annotations must not become
+  canonical policy by accident.
+- Durable learning must be promoted through KPP into exactly one repo artifact:
+  `docs/memory/kpp_knowledge_promotion_pipeline.md:32`
+
+---
+
+## 3. Pilot Inputs And Live Command Evidence
+
+### 3.1 Official OpenAI baseline
+
+- Source checked on `10 March 2026`: OpenAI docs page
+  <https://platform.openai.com/docs/guides/responses-vs-chat-completions>
+- Pilot criterion: a winning tool must help the agent prefer **Responses API**
+  over legacy Chat Completions patterns.
+
+### 3.2 Context Hub CLI spot-check
+
+Command:
+
+```bash
+npx -y @aisuite/chub --help
+```
+
+Observed output:
+
+```text
+Usage: chub [options] [command]
+Context Hub - search and retrieve LLM-optimized docs and skills
+Commands:
+  update
+  cache
+  search
+  get
+  build
+  feedback
+  annotate
+```
+
+Command:
+
+```bash
+npx -y @aisuite/chub search openai --json
+```
+
+Observed output excerpt:
+
+```json
+{
+  "results": [
+    {
+      "id": "openai/chat",
+      "name": "chat",
+      "description": "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
+    }
+  ]
+}
+```
+
+Command:
+
+```bash
+npx -y @aisuite/chub search responses openai --json
+```
+
+Observed output:
+
+```json
+{
+  "results": [],
+  "total": 0,
+  "query": "responses"
+}
+```
+
+Interpretation:
+
+- `Context Hub` is real, usable, and OSS-friendly for CLI lookup.
+- In this terminal spot-check, it did **not** surface a dedicated OpenAI
+  `responses` hit, which weakens it for an OpenAI-first freshness pilot.
+
+### 3.3 Context7 packaging spot-check
+
+Command:
+
+```bash
+npx -y @upstash/context7-mcp --help
+```
+
+Observed output:
+
+```text
+Usage: context7-mcp [options]
+Options:
+  --transport <stdio|http>
+  --port <number>
+  --api-key <key>
+```
+
+Interpretation:
+
+- `Context7` is packaged as a direct MCP server, which matches the primary
+  integration surface for Codex/Cursor.
+- Its published setup instructions include explicit Codex/Cursor MCP config
+  examples, which reduces integration ambiguity for dev agents.
+
+---
+
+## 4. Comparison And Decision
+
+| Lane | Strength in this repo | Weakness in this repo | Decision |
+| --- | --- | --- | --- |
+| Repo-native + official OpenAI docs | Deterministic, governed, already approved | No live third-party docs retrieval layer by itself | Keep as baseline |
+| Context7 | Direct MCP fit for Codex/Cursor; version-specific docs positioning | External service lane; not canonical memory | **Pilot winner** |
+| Context Hub | OSS, CLI-first, skill-copy workflow, local annotations | OpenAI-first lookup signal was weaker in the live spot-check; annotations are non-canonical | Keep as comparator |
+
+**Decision note:** this is a repo-fit decision, not a universal product verdict.
+`Context Hub` may still be useful for OSS/local workflows, but it is not the
+first local adoption target for this repo's OpenAI-first pilot.
+
+---
+
+## 5. Implementation Boundaries
+
+### IN
+
+- Docs-only runbook for local setup and verification
+- Optional local MCP/config examples
+- Explicit governance rule for KPP promotion
+
+### OUT
+
+- CI integration
+- Runtime app code
+- OpenAPI generation path
+- Production endpoints
+- Hidden local notes promoted as policy
+
+---
+
+## 6. Security Notes
+
+- Treat external docs tools as untrusted input surfaces.
+- Do not auto-promote MCP output or local annotations into repo canon.
+- Prefer project-scoped examples where the client supports them.
+- Never commit API keys or local tool tokens.
+
+---
+
+## 7. Marketing & GTM
+
+- This rollout is internal-only.
+- Success metric is faster, more correct agent output for OpenAI integration
+  tasks, not user-facing feature velocity.
+- If the pilot stays useful for one review cycle, package it as a short team
+  enablement pattern with a narrow "use / do not use" note.
+
+---
+
+## 8. Chosen Next Step
+
+1. Keep repo-native context + `openai-docs` as the canonical baseline.
+2. Add a local-only runbook with:
+   - `Context7` as the first MCP lane
+   - `Context Hub` as the CLI/OSS comparator
+3. Reuse one OpenAI-first prompt pack for future spot-checks.
+4. Promote only durable findings through KPP.
+
+---
+
+## References
+
+- OpenAI docs: <https://platform.openai.com/docs/guides/responses-vs-chat-completions>
+- Context Hub repo: <https://github.com/andrewyng/context-hub>
+- Context Hub npm: <https://www.npmjs.com/package/@aisuite/chub>
+- Context7 repo: <https://github.com/upstash/context7>

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -64,8 +64,22 @@ Recommended now for PulsePlate:
   structured memory and handoff pages
 - `openai-docs`, `playwright`, `linear` when the task explicitly matches
 
-For canonical design-tooling precedence, see
-`docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`.
+OpenAI-specific baseline:
+
+- `openai-docs` remains the canonical external-docs lane for OpenAI tasks
+- optional runtime pilot for live docs retrieval is documented in
+  `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md`
+- external MCP/CLI outputs remain advisory and must promote durable findings
+  through KPP before they become repo memory
+
+Design-tooling precedence for this repo:
+
+1. `Figma`
+2. `Notion`
+3. `Airweave`
+4. `Penpot`
+
+See `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`.
 
 Not approved as default:
 

--- a/docs/review/PR_1100_FIXED_MAPPING.md
+++ b/docs/review/PR_1100_FIXED_MAPPING.md
@@ -5,7 +5,25 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926922812 -> b5b94237
+Disposition: FIXED
+Commit: `b5b94237`
+Evidence: `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:69`; `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:165`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926938762 -> b5b94237
+Disposition: FIXED
+Commit: `b5b94237`
+Evidence: `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:19`; `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:86`; `docs/roadmap/BACKLOG_LEDGER.md:1018`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904808 -> b5b94237
+Disposition: FIXED
+Commit: `b5b94237`
+Evidence: `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:19`; `docs/roadmap/BACKLOG_LEDGER.md:1018`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904810 -> b5b94237
+Disposition: FIXED
+Commit: `b5b94237`
+Evidence: `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:69`; `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:130`
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1100_FIXED_MAPPING.md
+++ b/docs/review/PR_1100_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1100 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1100_FIXED_MAPPING.md
+++ b/docs/review/PR_1100_FIXED_MAPPING.md
@@ -36,7 +36,7 @@ Commit: 308dc14c
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md:1022`
 
 ## Merge Readiness
-- [ ] Required checks PASS with no pending required jobs
-- [ ] No unresolved review threads
-- [ ] No actionable bot comments
-- [ ] Final post-bot wait cycle completed
+- [x] Required checks PASS with no pending required jobs
+- [x] No unresolved review threads
+- [x] No actionable bot comments
+- [x] Final post-bot wait cycle completed

--- a/docs/review/PR_1100_FIXED_MAPPING.md
+++ b/docs/review/PR_1100_FIXED_MAPPING.md
@@ -7,22 +7,22 @@
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926922812 -> b5b94237
 Disposition: FIXED
-Commit: `b5b94237`
+Commit: b5b94237
 Evidence: `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:69`; `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:165`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926938762 -> b5b94237
 Disposition: FIXED
-Commit: `b5b94237`
+Commit: b5b94237
 Evidence: `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:19`; `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:86`; `docs/roadmap/BACKLOG_LEDGER.md:1018`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904808 -> b5b94237
 Disposition: FIXED
-Commit: `b5b94237`
+Commit: b5b94237
 Evidence: `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md:19`; `docs/roadmap/BACKLOG_LEDGER.md:1018`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904810 -> b5b94237
 Disposition: FIXED
-Commit: `b5b94237`
+Commit: b5b94237
 Evidence: `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:69`; `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:130`
 
 ## Merge Readiness

--- a/docs/review/PR_1100_FIXED_MAPPING.md
+++ b/docs/review/PR_1100_FIXED_MAPPING.md
@@ -25,6 +25,16 @@ Disposition: FIXED
 Commit: b5b94237
 Evidence: `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:69`; `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md:130`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3927434096 -> 308dc14c
+Disposition: FIXED
+Commit: 308dc14c
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:1022`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2916384480 -> 308dc14c
+Disposition: FIXED
+Commit: 308dc14c
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:1022`
+
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1015,6 +1015,35 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P2
 
+<a id="ledger-p2-openai-docs-freshness-pilot"></a>
+- [ ] P2: Govern the OpenAI external docs freshness pilot lifecycle
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR #1100
+  - Area: docs / orchestration / dev-agent tooling
+  - Finding Type: pilot lifecycle governance
+  - Reason: PR #1100 introduces an optional external-docs lane for OpenAI-first
+    dev-agent work. The pilot must have explicit graduation and rollback gates
+    so it does not drift into hidden repo policy or CI/runtime scope.
+  - Links:
+    - `docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md`
+    - `docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md`
+    - `docs/dev/CODEX_SKILLS.md`
+    - `docs/memory/kpp_knowledge_promotion_pipeline.md`
+    - `docs/review/PR_1100_FIXED_MAPPING.md`
+  - Blockers:
+    - Need one full review cycle of real OpenAI-first usage evidence
+    - Need confirmation that external-docs guidance stays accurate without CI
+      coupling
+  - DoD:
+    - A follow-up decision records keep, adjust, or stop for the pilot after one
+      review cycle
+    - At least one durable workflow insight is either promoted through KPP or
+      explicitly marked as non-canonical
+    - The runbook stays aligned with the chosen auth model for Context7 and the
+      preferred invocation model for Context Hub
+    - No CI/runtime/production integration is introduced under this ledger item
+
 <a id="ledger-p2-dsar-transaction-neutral-helper"></a>
 - [ ] P2: Make internal DSAR delete helper transaction-neutral
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1019,7 +1019,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Govern the OpenAI external docs freshness pilot lifecycle
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1100
+  - Target PR: PR #1100 -> PR-TBD-OPENAI-DOCS-FRESHNESS-PILOT-FOLLOWUP
   - Area: docs / orchestration / dev-agent tooling
   - Finding Type: pilot lifecycle governance
   - Reason: PR #1100 introduces an optional external-docs lane for OpenAI-first

--- a/docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md
+++ b/docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md
@@ -66,14 +66,23 @@ Do **not** treat `chub annotate` notes as canonical project memory.
 
 ## Codex Setup (Context7)
 
-Add this to your Codex MCP config:
+Preferred secure default:
+
+```bash
+export CONTEXT7_API_KEY="<set-in-your-shell>"
+```
+
+Then add this to your Codex MCP config:
 
 ```toml
 [mcp_servers.context7]
-args = ["-y", "@upstash/context7-mcp", "--api-key", "ctx7-demo-value"]
+args = ["-y", "@upstash/context7-mcp"]
 command = "npx"
 startup_timeout_ms = 20_000
 ```
+
+If your Codex client supports a hosted MCP flow, prefer a remote config so no
+CLI flag carries the secret.
 
 Remote alternative:
 
@@ -86,6 +95,7 @@ http_headers = { "<context7-auth-header>" = "ctx7-demo-value" }
 Notes:
 
 - do not commit API keys
+- prefer shell environment variables or hosted-header auth over CLI flags
 - replace `<context7-auth-header>` with the provider's documented auth header
 - restart Codex after config changes
 - if `npx` startup times out, raise `startup_timeout_ms` before changing lanes
@@ -93,6 +103,13 @@ Notes:
 ## Cursor Setup (Context7)
 
 Prefer a **project-scoped** config when testing inside this repo.
+
+If you run the local `npx` server, export the key in your shell before starting
+Cursor:
+
+```bash
+export CONTEXT7_API_KEY="<set-in-your-shell>"
+```
 
 Example `.cursor/mcp.json` shape:
 
@@ -104,13 +121,25 @@ Example `.cursor/mcp.json` shape:
     },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp", "--api-key", "ctx7-demo-value"]
+      "args": ["-y", "@upstash/context7-mcp"]
     }
   }
 }
 ```
 
-Remote alternative:
+Hosted alternative:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp/oauth"
+    }
+  }
+}
+```
+
+Header-based fallback:
 
 ```json
 {
@@ -132,6 +161,10 @@ Install:
 ```bash
 npm install -g @aisuite/chub
 ```
+
+Preferred invocation in this runbook: use the global `chub` binary after
+install. Use `npx -y @aisuite/chub ...` only for one-off checks on machines
+where you do not want a global install.
 
 CLI checks:
 
@@ -212,7 +245,7 @@ and do not use legacy Chat Completions.
 
 ```bash
 npx -y @upstash/context7-mcp --help
-npx -y @aisuite/chub --help
-npx -y @aisuite/chub search openai --json
-npx -y @aisuite/chub search responses openai --json
+chub --help
+chub search openai --json
+chub search responses openai --json
 ```

--- a/docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md
+++ b/docs/runbooks/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md
@@ -1,0 +1,218 @@
+# OpenAI External Docs Freshness Pilot (Codex / Cursor)
+
+<!-- markdownlint-disable MD013 -->
+
+This runbook standardizes a **local-only** OpenAI docs freshness workflow for
+PulsePlate dev agents.
+
+The goal is narrow:
+
+1. keep repo-native context canonical,
+2. use official OpenAI docs as the truth source for OpenAI behavior,
+3. add an optional external docs lane for live agent sessions.
+
+## Scope
+
+### IN
+
+- Local dev-agent setup for OpenAI docs freshness
+- Codex/Cursor examples
+- One shared prompt pack for spot-checking tool quality
+- Governance rules for external doc tools
+
+### OUT
+
+- CI integration
+- Runtime app behavior changes
+- Product-facing RAG
+- Automatic promotion of external notes into repo canon
+
+## Canonical Baseline
+
+Before any MCP or CLI docs helper:
+
+- repo context stays canonical through `context_pack` and task bootstrap
+- OpenAI tasks should prefer official OpenAI docs
+- durable findings must be promoted through KPP
+
+Canonical references:
+
+- `scripts/orchestration/context_pack.py`
+- `scripts/orchestration/task_bootstrap.py`
+- `docs/memory/kpp_knowledge_promotion_pipeline.md`
+- `docs/dev/CODEX_SKILLS.md`
+
+## Recommendation
+
+### Primary optional pilot: Context7
+
+Use `Context7` first when you want live MCP-backed docs in Codex/Cursor.
+
+Why this lane won the pilot:
+
+- it is packaged directly as an MCP server
+- its published setup covers Codex and Cursor explicitly
+- it fits the repo's dev-agent runtime shape better than a CLI-only lookup flow
+
+### Secondary comparator: Context Hub
+
+Use `Context Hub` as the OSS comparator when you want:
+
+- CLI lookup from terminal
+- skill-file copy into agent tooling
+- local annotations for personal notes
+
+Do **not** treat `chub annotate` notes as canonical project memory.
+
+## Codex Setup (Context7)
+
+Add this to your Codex MCP config:
+
+```toml
+[mcp_servers.context7]
+args = ["-y", "@upstash/context7-mcp", "--api-key", "ctx7-demo-value"]
+command = "npx"
+startup_timeout_ms = 20_000
+```
+
+Remote alternative:
+
+```toml
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+http_headers = { "<context7-auth-header>" = "ctx7-demo-value" }
+```
+
+Notes:
+
+- do not commit API keys
+- replace `<context7-auth-header>` with the provider's documented auth header
+- restart Codex after config changes
+- if `npx` startup times out, raise `startup_timeout_ms` before changing lanes
+
+## Cursor Setup (Context7)
+
+Prefer a **project-scoped** config when testing inside this repo.
+
+Example `.cursor/mcp.json` shape:
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp", "--api-key", "ctx7-demo-value"]
+    }
+  }
+}
+```
+
+Remote alternative:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "<context7-auth-header>": "ctx7-demo-value"
+      }
+    }
+  }
+}
+```
+
+## Context Hub Comparator Setup
+
+Install:
+
+```bash
+npm install -g @aisuite/chub
+```
+
+CLI checks:
+
+```bash
+chub --help
+chub search openai --json
+chub search responses openai --json
+```
+
+Cursor skill copy flow:
+
+```bash
+mkdir -p .cursor/rules
+cp $(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md .cursor/rules/get-api-docs.md
+```
+
+Terminal-first usage:
+
+```bash
+chub get openai/chat
+```
+
+Use this lane as advisory tooling only. If it finds a useful workaround, move
+the durable conclusion into git through KPP.
+
+## OpenAI-First Prompt Pack
+
+Use the same prompt when comparing lanes:
+
+```text
+Implement a minimal Python example that calls the current OpenAI Responses API
+for text generation. Cite the official OpenAI documentation link you used and
+do not fall back to legacy Chat Completions unless the docs explicitly require
+it.
+```
+
+Optional JavaScript variant:
+
+```text
+Implement a minimal JavaScript example that calls the current OpenAI Responses
+API for text generation. Cite the official OpenAI documentation link you used
+and do not use legacy Chat Completions.
+```
+
+## Verification Checklist
+
+- The answer uses **Responses API**.
+- The answer includes an official OpenAI docs link.
+- The answer does not invent parameters.
+- Any reusable insight is promoted into a repo artifact through KPP.
+- No CI/runtime files are modified just to enable local docs tooling.
+
+## Governance Rules
+
+- External docs tools are advisory, not canonical.
+- Local caches, MCP outputs, and `chub annotate` notes do not override repo SoT.
+- If a rule, workaround, or stable instruction is worth keeping, promote it
+  into exactly one repo artifact.
+- Keep external docs tooling out of CI and production app paths.
+
+## Security Notes
+
+- Never commit `CONTEXT7_API_KEY` or any other token.
+- Prefer project-scoped MCP config where supported.
+- Treat external retrieved docs like any other untrusted input: verify against
+  official sources before promotion into repo memory.
+
+## Troubleshooting
+
+- **Context7 server missing:** restart the client after adding MCP config.
+- **Context7 startup timeout:** increase `startup_timeout_ms` first.
+- **Context Hub returns generic OpenAI hits only:** fall back to official
+  OpenAI docs for the task and record the limitation in the pilot notes.
+- **Agent answer is unsourced:** reject the answer and rerun with the prompt
+  pack requirement to cite official docs.
+
+## Evidence Commands
+
+```bash
+npx -y @upstash/context7-mcp --help
+npx -y @aisuite/chub --help
+npx -y @aisuite/chub search openai --json
+npx -y @aisuite/chub search responses openai --json
+```

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -37,6 +37,9 @@ operational tasks.
 
 - [`FIGMA_MCP_CODEX.md`](FIGMA_MCP_CODEX.md) — Figma MCP setup and
   code-to-canvas flow for Codex / GPT-5.4 Pro
+- [`OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md`](OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT.md) —
+  local-only OpenAI docs freshness pilot for Codex / Cursor using official
+  OpenAI docs, Context7, and Context Hub
 - [`FIGMA_MCP_RUNTIME_MATRIX.md`](FIGMA_MCP_RUNTIME_MATRIX.md) — runtime
   capability matrix (`generate_figma_design` availability by client)
 - [`FIGMA_MCP_LIVE_ACTIVATION.md`](FIGMA_MCP_LIVE_ACTIVATION.md) —


### PR DESCRIPTION
## Summary
- add a decision artifact for the OpenAI-first external-docs freshness pilot
- add a local-only runbook for Context7 and Context Hub usage
- document the OpenAI docs baseline in runbook indexing and Codex skills guidance
- add the canonical review mapping artifact for this PR
- tighten pilot lifecycle governance, auth defaults, deferred follow-up traceability, and final merge-readiness recording after bot review

## Validation
- `python scripts/ci/check_docs_phase1_gates.py --files docs/audit/OPENAI_EXTERNAL_DOCS_FRESHNESS_PILOT_DECISION_2026-03-10.md`
- `python scripts/ci/check_pr_body_phase2_gates.py --pr-number 1100`
- `pre-commit run --all-files`
- `make verify`

## Security Notes
- external docs lanes remain advisory only
- no CI/runtime/production integration added
- local Context7 examples now prefer shell env / hosted auth instead of CLI secrets
- Context Hub invocation is standardized in the runbook

## Marketing & GTM
- internal-only dev-agent enablement
- success metric is OpenAI integration correctness and speed

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926922812 -> b5b94237
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3926938762 -> b5b94237
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904808 -> b5b94237
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2915904810 -> b5b94237
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#pullrequestreview-3927434096 -> 308dc14c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1100#discussion_r2916384480 -> 308dc14c

## Merge Readiness
- [x] Required checks PASS with no pending required jobs
- [x] No unresolved review threads
- [x] No actionable bot comments
- [x] Final post-bot wait cycle completed
