### PR TITLE
fix(metrics): restore late bootstrap route on main

### DIFF
--- a/app/bootstrap/metrics.py
+++ b/app/bootstrap/metrics.py
@@ -94,8 +94,8 @@ def register_metrics(app: FastAPI) -> None:
         return
 
     # Starlette forbids adding middleware after the stack is built (first request).
-    # In that case, we must skip registration to avoid runtime errors in tests/teardown.
-    can_mutate = getattr(app, "middleware_stack", None) is None
+    # In that case, we must skip middleware registration to avoid runtime errors.
+    can_mutate_middleware = getattr(app, "middleware_stack", None) is None
 
     # Starlette does not expose a public middleware-registry API, so register_metrics()
     # still checks user_middleware/middleware_stack and keeps an app.state fallback
@@ -107,16 +107,17 @@ def register_metrics(app: FastAPI) -> None:
         is metrics_middleware
         for mw in getattr(app, "user_middleware", None) or []
     )
-    if not has_middleware and can_mutate:
+    if not has_middleware and can_mutate_middleware:
         app.middleware("http")(metrics_middleware)
         has_middleware = True
 
-    # Register /metrics endpoint (idempotent).
+    # Route registration remains safe after the stack is built, which is important
+    # for legacy import-order paths that bootstrap observability late.
     has_metrics_route = any(
         getattr(r, "path", None) == "/metrics" and "GET" in (getattr(r, "methods", None) or set())
         for r in getattr(app, "routes", None) or []
     )
-    if not has_metrics_route and can_mutate:
+    if not has_metrics_route:
         app.add_api_route("/metrics", metrics_endpoint, methods=["GET"], include_in_schema=False)
         has_metrics_route = True
 

--- a/docs/review/PR_1101_FIXED_MAPPING.md
+++ b/docs/review/PR_1101_FIXED_MAPPING.md
@@ -1,0 +1,12 @@
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1101_FIXED_MAPPING.md
+++ b/docs/review/PR_1101_FIXED_MAPPING.md
@@ -3,7 +3,26 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927561503 -> 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
+Disposition: FIXED
+Commit: 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
+Evidence: tests/test_metrics.py:261
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520874 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Disposition: FIXED
+Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Evidence: tests/test_metrics.py:286
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520896 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Disposition: FIXED
+Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Evidence: tests/test_metrics.py:21
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927579898 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916538182 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Disposition: FIXED
+Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:216
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1101_FIXED_MAPPING.md
+++ b/docs/review/PR_1101_FIXED_MAPPING.md
@@ -3,35 +3,35 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#issuecomment-4037158758 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#issuecomment-4037158758 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Disposition: FIXED
-Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
-Evidence: tests/test_metrics.py:286
+Commit: e31bbc9fc16b1d47c6179197396f6ced27d07a6c
+Evidence: tests/test_metrics.py:285
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927561503 -> 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927561503 -> a864adf4e1d6d02383ca2f5c0f02441776c5bfef
 Disposition: FIXED
-Commit: 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
+Commit: a864adf4e1d6d02383ca2f5c0f02441776c5bfef
 Evidence: tests/test_metrics.py:261
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520874 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520874 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Disposition: FIXED
-Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
-Evidence: tests/test_metrics.py:286
+Commit: e31bbc9fc16b1d47c6179197396f6ced27d07a6c
+Evidence: tests/test_metrics.py:285
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520896 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520896 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Disposition: FIXED
-Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Commit: e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Evidence: tests/test_metrics.py:21
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927579898 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916538182 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927579898 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916538182 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Disposition: FIXED
-Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Commit: e31bbc9fc16b1d47c6179197396f6ced27d07a6c
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:216
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927619630 -> 0fbf9cdc4c32007ae6ca1bb9d813afd9915ea1c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927619630 -> de6c2b3755dd1f230ad0fe14d5ffb198b60f6cab
 Disposition: FIXED
-Commit: 0fbf9cdc4c32007ae6ca1bb9d813afd9915ea1c7
+Commit: de6c2b3755dd1f230ad0fe14d5ffb198b60f6cab
 Evidence: tests/test_metrics.py:263
 
 ## Merge Readiness

--- a/docs/review/PR_1101_FIXED_MAPPING.md
+++ b/docs/review/PR_1101_FIXED_MAPPING.md
@@ -3,6 +3,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#issuecomment-4037158758 -> 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Disposition: FIXED
+Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
+Evidence: tests/test_metrics.py:286
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927561503 -> 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
 Disposition: FIXED
 Commit: 83131dd8f2caf2c7c4d8c657d032c6a1c1d7e444
@@ -23,6 +28,11 @@ Evidence: tests/test_metrics.py:21
 Disposition: FIXED
 Commit: 4ff6f934aa121ce05aa1677b0d99d3f4f8a3a307
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:216
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927619630 -> 0fbf9cdc4c32007ae6ca1bb9d813afd9915ea1c7
+Disposition: FIXED
+Commit: 0fbf9cdc4c32007ae6ca1bb9d813afd9915ea1c7
+Evidence: tests/test_metrics.py:263
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -209,6 +209,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Signed provenance/SBOM verification is enforced before deploy
     - Follow-up docs and CI checks explicitly cover the restored path
 
+<a id="ledger-p1-canonical-bootstrap-late-rehydration"></a>
+- [ ] P1: Canonical app bootstrap late-rehydration hardening
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (runtime reliability follow-up after `/metrics` hotfix)
+  - Target PR: PR-TBD-CANONICAL-BOOTSTRAP-LATE-REHYDRATION
+  - Area: backend / bootstrap / observability
+  - Finding Type: import-order follow-up
+  - Reason: The `/metrics` hotfix restores late route registration on already-built apps, but it intentionally does not attempt full middleware rehydration after `middleware_stack` exists. A follow-up is needed to define and harden the canonical behavior for late bootstrap/import-order paths without reintroducing unsafe post-start middleware mutation.
+  - Links:
+    - `app/main.py`
+    - `app/bootstrap/metrics.py`
+    - `tests/test_metrics.py`
+    - `tests/test_no_direct_testclient.py`
+  - DoD:
+    - Canonical late-bootstrap contract is documented for route vs middleware behavior
+    - Tests cover legacy/app-first import order for additive observability surfaces
+    - Direct TestClient bypass debt is reduced or explicitly re-audited against the canonical bootstrap contract
+
 <a id="ledger-p1-billing-activation-openapi-refinements"></a>
 - [ ] P1: Billing activation OpenAPI refinements after PR #1095
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -213,11 +213,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Canonical app bootstrap late-rehydration hardening
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (runtime reliability follow-up after `/metrics` hotfix)
-  - Target PR: PR-TBD-CANONICAL-BOOTSTRAP-LATE-REHYDRATION
+  - Target PR: PR #1101 (`fix(metrics): restore late bootstrap route on main`) -> PR-TBD-CANONICAL-BOOTSTRAP-LATE-REHYDRATION
   - Area: backend / bootstrap / observability
   - Finding Type: import-order follow-up
   - Reason: The `/metrics` hotfix restores late route registration on already-built apps, but it intentionally does not attempt full middleware rehydration after `middleware_stack` exists. A follow-up is needed to define and harden the canonical behavior for late bootstrap/import-order paths without reintroducing unsafe post-start middleware mutation.
   - Links:
+    - `docs/review/PR_1101_FIXED_MAPPING.md`
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101`
     - `app/main.py`
     - `app/bootstrap/metrics.py`
     - `tests/test_metrics.py`

--- a/tests/test_app_main_import.py
+++ b/tests/test_app_main_import.py
@@ -1,3 +1,9 @@
+import importlib
+import subprocess
+import sys
+import textwrap
+
+
 def test_app_main_import_smoke() -> None:
     """Smoke: importing canonical app entrypoint should succeed."""
     import app.main  # noqa: F401
@@ -9,3 +15,35 @@ def test_app_main_exposes_tracing_bootstrap() -> None:
     import app.bootstrap
 
     assert hasattr(app.bootstrap, "register_tracing")
+
+
+def test_app_main_late_import_restores_metrics_route() -> None:
+    """Late canonical bootstrap must restore /metrics after app-first stack build."""
+
+    scenario = textwrap.dedent("""
+        import importlib
+
+        from fastapi.testclient import TestClient
+
+        app_package = importlib.import_module("app")
+
+        with TestClient(app_package.app) as client:
+            health_response = client.get("/health")
+            assert health_response.status_code == 200
+            assert client.app.middleware_stack is not None
+
+        main_module = importlib.import_module("app.main")
+
+        with TestClient(main_module.app) as client:
+            metrics_response = client.get("/metrics")
+            assert metrics_response.status_code == 200
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", scenario],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -260,13 +260,13 @@ def test_register_metrics_adds_route_after_stack_is_built() -> None:
 
     middleware_stack = getattr(app_instance, "middleware_stack", None)
     assert middleware_stack is not None
-    before_user_middleware = len(getattr(app_instance, "user_middleware", []) or [])
+    before_user_middleware = len(getattr(app_instance, "user_middleware", []))
 
     register_metrics(app_instance)
 
     assert getattr(app_instance, "middleware_stack", None) is middleware_stack
     assert len(_get_metrics_get_routes(app_instance)) == 1
-    assert len(getattr(app_instance, "user_middleware", []) or []) == before_user_middleware
+    assert len(getattr(app_instance, "user_middleware", [])) == before_user_middleware
 
     with TestClient(app_instance) as client:
         metrics_response = client.get("/metrics")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,6 +18,17 @@ from app.bootstrap.metrics import register_metrics
 # Use conftest.py client fixture (don't define local one to avoid bypassing test setup)
 
 
+def _get_metrics_get_routes(app_instance: FastAPI) -> list[object]:
+    """Collect registered GET routes for the canonical /metrics endpoint."""
+
+    return [
+        route
+        for route in app_instance.routes
+        if getattr(route, "path", None) == "/metrics"
+        and "GET" in (getattr(route, "methods", None) or set())
+    ]
+
+
 def _metric_value(text: str, *, method: str, route: str, status: str) -> float:
     """Extract metric value for specific labelset from Prometheus text format.
 
@@ -252,13 +263,7 @@ def test_register_metrics_adds_route_after_stack_is_built() -> None:
 
     register_metrics(app_instance)
 
-    metrics_routes = [
-        route
-        for route in app_instance.routes
-        if getattr(route, "path", None) == "/metrics"
-        and "GET" in (getattr(route, "methods", None) or set())
-    ]
-    assert len(metrics_routes) == 1
+    assert len(_get_metrics_get_routes(app_instance)) == 1
     assert len(getattr(app_instance, "user_middleware", []) or []) == before_user_middleware
 
     with TestClient(app_instance) as client:
@@ -275,13 +280,26 @@ def test_register_metrics_is_idempotent_for_route_registration() -> None:
     register_metrics(app_instance)
     register_metrics(app_instance)
 
-    metrics_routes = [
-        route
-        for route in app_instance.routes
-        if getattr(route, "path", None) == "/metrics"
-        and "GET" in (getattr(route, "methods", None) or set())
-    ]
-    assert len(metrics_routes) == 1
+    assert len(_get_metrics_get_routes(app_instance)) == 1
+
+
+def test_register_metrics_is_idempotent_after_stack_is_built() -> None:
+    """Repeated late bootstrap must not duplicate the /metrics route."""
+
+    app_instance = FastAPI()
+    register_metrics(app_instance)
+
+    with TestClient(app_instance) as client:
+        metrics_response = client.get("/metrics")
+        assert metrics_response.status_code == 200
+
+        register_metrics(app_instance)
+        register_metrics(app_instance)
+
+        assert len(_get_metrics_get_routes(app_instance)) == 1
+
+        metrics_response = client.get("/metrics")
+        assert metrics_response.status_code == 200
 
 
 def test_metrics_hidden_from_openapi(client: TestClient) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -258,11 +258,13 @@ def test_register_metrics_adds_route_after_stack_is_built() -> None:
         response = client.get("/")
         assert response.status_code == 200
 
-    assert getattr(app_instance, "middleware_stack", None) is not None
+    middleware_stack = getattr(app_instance, "middleware_stack", None)
+    assert middleware_stack is not None
     before_user_middleware = len(getattr(app_instance, "user_middleware", []) or [])
 
     register_metrics(app_instance)
 
+    assert getattr(app_instance, "middleware_stack", None) is middleware_stack
     assert len(_get_metrics_get_routes(app_instance)) == 1
     assert len(getattr(app_instance, "user_middleware", []) or []) == before_user_middleware
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import re
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import app
+from app.bootstrap.metrics import register_metrics
 
 # Use conftest.py client fixture (don't define local one to avoid bypassing test setup)
 
@@ -230,6 +232,56 @@ def test_metrics_json_fallback_when_exporter_raises(
     # RuntimeError during generate_latest() should return "Metrics export failed"
     assert data["error"] == "Metrics export failed"
     assert "detail" in data
+
+
+def test_register_metrics_adds_route_after_stack_is_built() -> None:
+    """Late bootstrap must still restore /metrics without mutating middleware."""
+
+    app_instance = FastAPI()
+
+    @app_instance.get("/")
+    def root() -> dict[str, str]:
+        return {"status": "ok"}
+
+    with TestClient(app_instance) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+
+    assert getattr(app_instance, "middleware_stack", None) is not None
+    before_user_middleware = len(getattr(app_instance, "user_middleware", []) or [])
+
+    register_metrics(app_instance)
+
+    metrics_routes = [
+        route
+        for route in app_instance.routes
+        if getattr(route, "path", None) == "/metrics"
+        and "GET" in (getattr(route, "methods", None) or set())
+    ]
+    assert len(metrics_routes) == 1
+    assert len(getattr(app_instance, "user_middleware", []) or []) == before_user_middleware
+
+    with TestClient(app_instance) as client:
+        metrics_response = client.get("/metrics")
+
+    assert metrics_response.status_code == 200
+
+
+def test_register_metrics_is_idempotent_for_route_registration() -> None:
+    """Repeated bootstrap calls must not duplicate the /metrics route."""
+
+    app_instance = FastAPI()
+
+    register_metrics(app_instance)
+    register_metrics(app_instance)
+
+    metrics_routes = [
+        route
+        for route in app_instance.routes
+        if getattr(route, "path", None) == "/metrics"
+        and "GET" in (getattr(route, "methods", None) or set())
+    ]
+    assert len(metrics_routes) == 1
 
 
 def test_metrics_hidden_from_openapi(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

Restores the canonical `/metrics` route when observability bootstrap runs after the FastAPI middleware stack is already built.

This hotfix is intentionally narrow:
- keeps metrics bootstrap in `app/main.py`
- preserves the current `/metrics` response contract and OpenAPI visibility rules
- does not move runtime behavior into `legacy_app.py`
- adds regression coverage for late bootstrap and idempotent route registration

## Changes

### Backend
- allow `register_metrics()` to add `/metrics` idempotently even after `middleware_stack` exists
- keep middleware registration fail-closed once the stack is already built

### Tests
- add regression coverage for late `/metrics` route registration after stack build
- add idempotence coverage for repeated registration before and after stack build
- assert late bootstrap preserves `middleware_stack` identity and does not mutate middleware
- reduce `/metrics` route-matching duplication with a local test helper

### Backlog
- record follow-up for broader canonical late-bootstrap / middleware rehydration hardening

## Validation

- `pytest -q tests/test_metrics.py`
- `pytest -q tests/test_no_direct_testclient.py tests/test_app_main_import.py`
- `pytest -q tests/test_app_key_coverage_clean.py tests/test_final_97_coverage.py`
- `pre-commit run --all-files`
- `make verify`

## Deferred / Follow-ups

- [Canonical late-bootstrap hardening ledger item](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/fix/main-metrics-bootstrap/docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-canonical-bootstrap-late-rehydration)
- [PR 1101 fixed mapping artifact](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/fix/main-metrics-bootstrap/docs/review/PR_1101_FIXED_MAPPING.md)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#issuecomment-4037158758 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927561503 -> a864adf4e1d6d02383ca2f5c0f02441776c5bfef
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520874 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916520896 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927579898 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#discussion_r2916538182 -> e31bbc9fc16b1d47c6179197396f6ced27d07a6c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1101#pullrequestreview-3927619630 -> de6c2b3755dd1f230ad0fe14d5ffb198b60f6cab

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed

