### PR TITLE
fix(security): resolve dependabot alert #48 (hono)

### DIFF
--- a/docs/review/PR_1103_FIXED_MAPPING.md
+++ b/docs/review/PR_1103_FIXED_MAPPING.md
@@ -5,4 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#issuecomment-4037252424 -> 5f2df819
+  Disposition: FIXED
+  Evidence: tests/test_root_npm_dependency_guards.py:18
+  Reason: Added the missing helper docstring so CodeRabbit docstring coverage no longer reports a warning.

--- a/docs/review/PR_1103_FIXED_MAPPING.md
+++ b/docs/review/PR_1103_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1103 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1103_FIXED_MAPPING.md
+++ b/docs/review/PR_1103_FIXED_MAPPING.md
@@ -9,3 +9,15 @@
   Disposition: FIXED
   Evidence: tests/test_root_npm_dependency_guards.py:18
   Reason: Added the missing helper docstring so CodeRabbit docstring coverage no longer reports a warning.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#discussion_r2916659557 -> 99016831
+  Disposition: FIXED
+  Evidence: docs/security/GHSA-v8w9-8mx6-g223-hono.md:49
+  Reason: Capitalized "Dependabot" to satisfy the Sourcery typo nit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#pullrequestreview-3927729975 -> 99016831
+  Disposition: FIXED
+  Evidence: tests/test_root_npm_dependency_guards.py:48
+  Reason: Removed the hard-coded `^4.` semver-major assertion so the guard only verifies that the transitive MCP SDK edge exists.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#pullrequestreview-3927714599
+  Disposition: NOT-A-BUG
+  Evidence: tests/test_root_npm_dependency_guards.py:36
+  Reason: The registry host/path assertions are intentionally strict because this remediation specifically guards the public npm resolution surface; a future private-registry migration should update this security guard explicitly in the same PR.

--- a/docs/security/GHSA-v8w9-8mx6-g223-hono.md
+++ b/docs/security/GHSA-v8w9-8mx6-g223-hono.md
@@ -1,0 +1,52 @@
+# GHSA-v8w9-8mx6-g223 — hono (transitive via @modelcontextprotocol/sdk) — Dependabot alert #48 remediation
+
+## Summary
+
+- **GHSA**: GHSA-v8w9-8mx6-g223
+- **CVE**: none assigned as of March 11, 2026
+- **Package**: `hono`
+- **Alert type**: GitHub Dependabot alert `#48`
+- **Scope**: transitive runtime dependency in the root npm graph
+
+Dependabot reported a prototype-pollution hardening issue in `hono` when
+`parseBody({ dot: true })` allows `__proto__` path segments. The first patched
+version is `4.12.7`.
+
+## Root Cause
+
+The root npm graph brings in `hono` transitively:
+
+- `package.json:24` — root direct dependency on `@goplus/agentguard`
+- `package-lock.json:681` — `@modelcontextprotocol/sdk` depends on `hono`
+- `package-lock.json:1851` — resolved vulnerable `hono` node was `4.12.5`
+
+## Remediation Implemented
+
+- Refreshed the root lockfile to resolve `hono` `4.12.7` from the npm registry.
+- Kept the remediation lockfile-only because the existing semver range already
+  admits the patched transitive release.
+- Added a deterministic root lockfile guard so `hono < 4.12.7` does not return
+  silently in future updates.
+
+## Evidence Anchors
+
+- `package-lock.json:1851` — resolved `hono` entry updated to `4.12.7`
+- `tests/test_root_npm_dependency_guards.py:1` — deterministic regression guard
+- `docs/security/GHSA-v8w9-8mx6-g223-hono.md:1` — canonical remediation record
+
+## Validation
+
+```bash
+npm update hono --package-lock-only
+npm ci
+pytest -q tests/test_root_npm_dependency_guards.py
+pre-commit run --all-files
+make verify
+```
+
+## Notes
+
+- This remediation supersedes the raw dependabot PR `#1098` with a human-owned
+  canonical PR so the repo-specific Phase 2 and merge-readiness contracts can be
+  satisfied.
+- No runtime API, schema, or application code changes were required.

--- a/docs/security/GHSA-v8w9-8mx6-g223-hono.md
+++ b/docs/security/GHSA-v8w9-8mx6-g223-hono.md
@@ -46,7 +46,7 @@ make verify
 
 ## Notes
 
-- This remediation supersedes the raw dependabot PR `#1098` with a human-owned
+- This remediation supersedes the raw Dependabot PR `#1098` with a human-owned
   canonical PR so the repo-specific Phase 2 and merge-readiness contracts can be
   satisfied.
 - No runtime API, schema, or application code changes were required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1849,9 +1849,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tests/test_root_npm_dependency_guards.py
+++ b/tests/test_root_npm_dependency_guards.py
@@ -1,0 +1,49 @@
+"""Deterministic root npm dependency security guards.
+
+RU: Проверяем, что root package-lock.json держит hono на безопасной версии.
+EN: Ensure the root package-lock.json keeps hono at a safe npm release.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_LOCK_JSON = REPO_ROOT / "package-lock.json"
+MIN_HONO_VERSION = Version("4.12.7")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_root_lock_resolves_hono_to_safe_npm_release() -> None:
+    """RU/EN: Root lockfile must resolve hono from npm registry at secure floor version."""
+    package_lock = _load_json(ROOT_LOCK_JSON)
+    hono_pkg = package_lock.get("packages", {}).get("node_modules/hono", {})
+    lock_version = hono_pkg.get("version")
+    resolved = hono_pkg.get("resolved", "")
+
+    assert isinstance(lock_version, str), "package-lock.json: hono version missing"
+    assert Version(lock_version) >= MIN_HONO_VERSION
+    assert isinstance(resolved, str) and resolved, "package-lock.json: hono resolved missing"
+
+    parsed = urlparse(resolved)
+    assert parsed.scheme == "https", "hono lock resolution must use https"
+    assert parsed.netloc == "registry.npmjs.org", "hono must resolve from npm registry"
+    assert parsed.path.startswith("/hono/"), "hono lock resolution path mismatch"
+
+
+def test_root_lock_tracks_hono_as_mcp_sdk_transitive_dependency() -> None:
+    """RU/EN: Dependency path should still show hono under @modelcontextprotocol/sdk."""
+    package_lock = _load_json(ROOT_LOCK_JSON)
+    mcp_sdk_pkg = package_lock.get("packages", {}).get("node_modules/@modelcontextprotocol/sdk", {})
+    dependencies = mcp_sdk_pkg.get("dependencies", {})
+
+    hono_range = dependencies.get("hono")
+    assert isinstance(hono_range, str), "package-lock.json: MCP SDK hono dependency missing"
+    assert hono_range.startswith("^4."), "package-lock.json: unexpected hono semver range"

--- a/tests/test_root_npm_dependency_guards.py
+++ b/tests/test_root_npm_dependency_guards.py
@@ -47,4 +47,4 @@ def test_root_lock_tracks_hono_as_mcp_sdk_transitive_dependency() -> None:
 
     hono_range = dependencies.get("hono")
     assert isinstance(hono_range, str), "package-lock.json: MCP SDK hono dependency missing"
-    assert hono_range.startswith("^4."), "package-lock.json: unexpected hono semver range"
+    assert hono_range.strip(), "package-lock.json: MCP SDK hono dependency range missing"

--- a/tests/test_root_npm_dependency_guards.py
+++ b/tests/test_root_npm_dependency_guards.py
@@ -18,6 +18,7 @@ MIN_HONO_VERSION = Version("4.12.7")
 
 
 def _load_json(path: Path) -> dict:
+    """RU/EN: Read a UTF-8 JSON file and return the decoded object."""
     return json.loads(path.read_text(encoding="utf-8"))
 
 


### PR DESCRIPTION
## Summary

Supersedes #1098.

Fixes GitHub security alert #48 (`GHSA-v8w9-8mx6-g223`) by replacing the auto-generated Dependabot path with a repo-canonical security PR that updates transitive runtime `hono` from `4.12.5` to `4.12.7` on the root npm lock surface. Carries over the already-validated lockfile bump from #1098 and adds deterministic regression coverage for this dependency path.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [x] Linked issues/PRs: Supersedes #1098; fixes security alert #48

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [x] Manual verification steps

Manual verification:
- `npm update hono --package-lock-only`
- `npm ci`
- `pytest -q tests/test_root_npm_dependency_guards.py`
- `pytest -q tests/test_repo_policy_guards.py`
- `pre-commit run --all-files`
- `make verify`

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#issuecomment-4037252424 -> 5f2df819
  Disposition: FIXED
  Evidence: tests/test_root_npm_dependency_guards.py:18
  Reason: Added the missing helper docstring so CodeRabbit docstring coverage no longer reports a warning.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#discussion_r2916659557 -> 99016831
  Disposition: FIXED
  Evidence: docs/security/GHSA-v8w9-8mx6-g223-hono.md:49
  Reason: Capitalized "Dependabot" to satisfy the Sourcery typo nit.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#pullrequestreview-3927729975 -> 99016831
  Disposition: FIXED
  Evidence: tests/test_root_npm_dependency_guards.py:48
  Reason: Removed the hard-coded `^4.` semver-major assertion so the guard only verifies that the transitive MCP SDK edge exists.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1103#pullrequestreview-3927714599
  Disposition: NOT-A-BUG
  Evidence: tests/test_root_npm_dependency_guards.py:36
  Reason: The registry host/path assertions are intentionally strict because this remediation specifically guards the public npm resolution surface; a future private-registry migration should update this security guard explicitly in the same PR.

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): None
- [x] GitHub issue(s): None

## Notes

### For Simple Changes

- [x] No database/schema/migration changes
- [x] No public API contract changes (endpoints, request/response, events)
- [x] Covered by existing tests plus focused dependency guards
- [ ] < 50 LOC changed (excluding tests/docs)
- [x] No performance impact

Rollback / Feature flag (brief):

- How to revert: revert commits `8fa2da82`, `99016831`, `ec0fe645`, `5f2df819`, and `86096472`
- Feature flag/toggle (if any): none
- Owner for emergency contact: @Katsiarynakavaleuskaya

## Summary by Sourcery

Устранение рекомендаций по безопасности путём обновления транзитивной зависимости hono до исправленной версии и добавления детерминированных защитных проверок вокруг её разрешения в корневом lock-файле npm.

Исправления ошибок:
- Устранить оповещение безопасности GitHub Dependabot #48, гарантируя, что hono обновлён до неуязвимой версии в корневом графе зависимостей npm.

Документация:
- Добавить каноничную запись о выполненном устранении уязвимости, документирующую рекомендацию GHSA, путь зависимости, реализованное исправление и шаги валидации для уязвимости в hono.

Тесты:
- Добавить защитные тесты для корневых зависимостей npm, которые обеспечивают, что версия hono остаётся на уровне безопасной или выше и корректно разрешается как транзитивная зависимость @modelcontextprotocol/sdk.

Рутинные задачи:
- Зафиксировать метаданные сопоставления «исправлено-в-коммите» для этого PR для повышения прозрачности при ревью.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Address a security advisory by updating the transitive hono dependency to a patched version and adding deterministic guards around its resolution in the root npm lockfile.

Bug Fixes:
- Resolve GitHub Dependabot security alert #48 by ensuring hono is updated to a non-vulnerable version in the root npm dependency graph.

Documentation:
- Add a canonical security remediation record documenting the GHSA advisory, dependency path, implemented fix, and validation steps for the hono vulnerability.

Tests:
- Introduce root npm dependency guard tests that enforce hono remains at or above the secure version and is resolved correctly as a transitive dependency of @modelcontextprotocol/sdk.

Chores:
- Record the fixed-in-commit mapping metadata for this PR for review traceability.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security remediation notes for a hono dependency vulnerability (GHSA-v8w9-8mx6-g223), including root-cause, remediation steps, validation, and mitigation guidance.
  * Added PR review documentation summarizing review outcomes and mappings.

* **Tests**
  * Added validation tests to ensure hono is resolved to a safe release in the root lock and tracked as a transitive dependency to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
