### PR TITLE
docs(ledger): close user knowledge rls item

### DIFF
--- a/docs/review/PR_1104_FIXED_MAPPING.md
+++ b/docs/review/PR_1104_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1104 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -872,11 +872,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - CI remains deterministic
 
 
-- [ ] P1: `user_knowledge` DB-level RLS / policy hardening
+- [x] P1: `user_knowledge` DB-level RLS / policy hardening
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (security / defense-in-depth)
   - Target PR: PR #1089 (`feat/p1-user-knowledge-rls`)
-  - Status: 🟡 In progress (active PR `#1089`)
+  - Status: ✅ Merged evidence (PR #1089, 2026-03-11)
   - Reason (EN): Application-layer tenant scoping prevents cross-tenant leaks in runtime retrieval, but Postgres still needed explicit DB-level RLS/policy enforcement plus a canonical session-context bridge to make the policy enforceable in runtime paths.
   - Links:
     - `docs/contracts/RAG_CONTRACT.md` (§7, §8)


### PR DESCRIPTION
## Summary
- close stale backlog state for `#ledger-p1-user-knowledge-rls`
- align the canonical backlog ledger with merged runtime PR #1089
- keep scope docs-only

## Validation
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md`
- `pre-commit run --all-files`
- `make verify`

## Carryover
- no runtime changes; this PR only promotes merged evidence into the canonical backlog ledger

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Local validation completed
- [x] PR body updated to mirror canonical artifact
- [x] Deferred/follow-up items captured in `docs/roadmap/BACKLOG_LEDGER.md` when applicable
