### PR TITLE
fix(rag): harden orchestration confidence fallback

### DIFF
--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, SupportsFloat, cast
 
 if TYPE_CHECKING:
     from core.rag.contracts import RAGChunk
@@ -69,11 +69,18 @@ def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
     )
 
 
-def _normalize_confidence_value(value: Any) -> float | None:
+def _normalize_confidence_value(value: object) -> float | None:
     """Return a finite rounded confidence value or ``None`` for malformed input."""
 
+    if isinstance(value, (str, bytes, bytearray, int, float)):
+        candidate: SupportsFloat | str | bytes | bytearray = value
+    elif hasattr(value, "__float__"):
+        candidate = cast(SupportsFloat, value)
+    else:
+        return None
+
     try:
-        numeric = float(value)
+        numeric = float(candidate)
     except (TypeError, ValueError):
         return None
     if not math.isfinite(numeric):
@@ -96,7 +103,7 @@ def _mean_chunk_score(chunks: list["RAGChunk"]) -> float | None:
 
 def _resolve_confidence(
     *,
-    rag_confidence: Any,
+    rag_confidence: object,
     chunks_to_use: list["RAGChunk"],
     philo_enabled: bool,
 ) -> float | None:

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -107,7 +107,7 @@ def _resolve_confidence(
     chunks_to_use: list["RAGChunk"],
     philo_enabled: bool,
 ) -> float | None:
-    """Prefer explicit confidence, then fall back to valid chunk-score mean."""
+    """Resolve confidence from chunks for philo mode, else prefer normalized RAG confidence."""
 
     if philo_enabled:
         return _mean_chunk_score(chunks_to_use)

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from core.rag.contracts import RAGChunk
@@ -66,6 +67,48 @@ def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
         chunks_retrieved=0,
         chunks_filtered=0,
     )
+
+
+def _normalize_confidence_value(value: Any) -> float | None:
+    """Return a finite rounded confidence value or ``None`` for malformed input."""
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return round(numeric, 4)
+
+
+def _mean_chunk_score(chunks: list["RAGChunk"]) -> float | None:
+    """Return the mean of valid chunk scores, ignoring malformed values."""
+
+    normalized_scores = [
+        normalized
+        for chunk in chunks
+        if (normalized := _normalize_confidence_value(chunk.score)) is not None
+    ]
+    if not normalized_scores:
+        return None
+    return round(sum(normalized_scores) / len(normalized_scores), 4)
+
+
+def _resolve_confidence(
+    *,
+    rag_confidence: Any,
+    chunks_to_use: list["RAGChunk"],
+    philo_enabled: bool,
+) -> float | None:
+    """Prefer explicit confidence, then fall back to valid chunk-score mean."""
+
+    if philo_enabled:
+        return _mean_chunk_score(chunks_to_use)
+
+    normalized_confidence = _normalize_confidence_value(rag_confidence)
+    if normalized_confidence is not None:
+        return normalized_confidence
+    return _mean_chunk_score(chunks_to_use)
 
 
 async def retrieve_and_validate_rag(
@@ -201,14 +244,11 @@ async def _run_orchestration(
             chunks_filtered=chunks_filtered,
         )
 
-    # Calculate confidence
-    if philo_enabled:
-        confidence: Optional[float] = round(
-            sum(c.score for c in chunks_to_use) / len(chunks_to_use),
-            4,
-        )
-    else:
-        confidence = round(rag_ctx.confidence, 4)
+    confidence = _resolve_confidence(
+        rag_confidence=rag_ctx.confidence,
+        chunks_to_use=chunks_to_use,
+        philo_enabled=philo_enabled,
+    )
 
     # Build formatted prompt with RAG context
     from core.insight.safety import redact_rag_context_for_insight

--- a/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
+++ b/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
@@ -1,0 +1,35 @@
+# Experiment Audit Artifact: exp-84ecc3c1e995
+
+- Decision question: Harden RAG orchestration confidence handling so malformed retriever metadata degrades gracefully instead of dropping the full result
+- Promotion target: `audit_artifact`
+- Disposition: `promoted`
+- Result status: `accepted`
+- Failure class: `none`
+
+## Mutable Surface
+
+- `core/rag/orchestration.py`
+
+## Immutable Oracles
+
+- `pytest -q tests/test_rag_orchestration.py` (must pass)
+- `pytest -q tests/test_insight_rag_response_fields.py` (must pass)
+- `pytest -q tests/test_rag_vector_feature_flag_guard.py` (must pass)
+
+## Evidence
+
+- Implementation anchor: `core/rag/orchestration.py:72`
+- Confidence fallback helper path: `core/rag/orchestration.py:97`
+- Regression coverage for malformed retriever confidence: `tests/test_rag_orchestration.py:143`
+- Regression coverage for malformed filtered chunk scores: `tests/test_rag_orchestration.py:406`
+- Regression coverage for all-invalid-score degrade path: `tests/test_rag_orchestration.py:446`
+- `pytest -q tests/test_rag_orchestration.py` -> rc=0, timed_out=false, truncated=false
+- `pytest -q tests/test_insight_rag_response_fields.py` -> rc=0, timed_out=false, truncated=false
+- `pytest -q tests/test_rag_vector_feature_flag_guard.py` -> rc=0, timed_out=false, truncated=false
+
+## Deferred Follow-up Block
+
+- Owner: `@katsiaryna_kavaleuskaya`
+- Priority: `P1`
+- Target PR: `PR_TBD_EXP_84ECC3C1E995`
+- Reason: `failure_class=none`

--- a/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
+++ b/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
@@ -23,13 +23,12 @@
 - Regression coverage for malformed retriever confidence: `tests/test_rag_orchestration.py:164`
 - Regression coverage for malformed filtered chunk scores: `tests/test_rag_orchestration.py:429`
 - Regression coverage for all-invalid-score degrade path: `tests/test_rag_orchestration.py:469`
-- `pytest -q tests/test_rag_orchestration.py` -> rc=0, timed_out=false, truncated=false
-- `pytest -q tests/test_insight_rag_response_fields.py` -> rc=0, timed_out=false, truncated=false
-- `pytest -q tests/test_rag_vector_feature_flag_guard.py` -> rc=0, timed_out=false, truncated=false
-
-## Deferred Follow-up Block
-
-- Owner: `@katsiaryna_kavaleuskaya`
-- Priority: `P1`
-- Target PR: `PR_TBD_EXP_84ECC3C1E995`
-- Reason: `failure_class=none`
+- `pytest -q tests/test_rag_orchestration.py`
+  - stdout: `........................                                                 [100%]`
+  - rc=0, timed_out=false, truncated=false
+- `pytest -q tests/test_insight_rag_response_fields.py`
+  - stdout: `..........                                                               [100%]`
+  - rc=0, timed_out=false, truncated=false
+- `pytest -q tests/test_rag_vector_feature_flag_guard.py`
+  - stdout: `................                                                         [100%]`
+  - rc=0, timed_out=false, truncated=false

--- a/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
+++ b/docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md
@@ -20,9 +20,9 @@
 
 - Implementation anchor: `core/rag/orchestration.py:72`
 - Confidence fallback helper path: `core/rag/orchestration.py:97`
-- Regression coverage for malformed retriever confidence: `tests/test_rag_orchestration.py:143`
-- Regression coverage for malformed filtered chunk scores: `tests/test_rag_orchestration.py:406`
-- Regression coverage for all-invalid-score degrade path: `tests/test_rag_orchestration.py:446`
+- Regression coverage for malformed retriever confidence: `tests/test_rag_orchestration.py:164`
+- Regression coverage for malformed filtered chunk scores: `tests/test_rag_orchestration.py:429`
+- Regression coverage for all-invalid-score degrade path: `tests/test_rag_orchestration.py:469`
 - `pytest -q tests/test_rag_orchestration.py` -> rc=0, timed_out=false, truncated=false
 - `pytest -q tests/test_insight_rag_response_fields.py` -> rc=0, timed_out=false, truncated=false
 - `pytest -q tests/test_rag_vector_feature_flag_guard.py` -> rc=0, timed_out=false, truncated=false

--- a/docs/review/PR_1107_FIXED_MAPPING.md
+++ b/docs/review/PR_1107_FIXED_MAPPING.md
@@ -7,7 +7,28 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `0bfdf740` replaces the PR6 kickoff placeholder with the active PR reference in [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5339) and [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5449), so the orchestration epic and PR6 leaf item both point to PR `#1107`.
+Evidence: `0bfdf740` replaces the PR6 kickoff placeholder with the active PR reference in `docs/roadmap/BACKLOG_LEDGER.md:5339` and `docs/roadmap/BACKLOG_LEDGER.md:5449`, so the orchestration epic and PR6 leaf item both point to PR `#1107`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2916975818 -> 0bfdf740
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928066462 -> 0bfdf740
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-pr5-ledger-closeout-docs-only`
+Reason: PR5 ledger closeout normalization must happen in a docs-only follow-up PR per `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`, not by widening the already active applied PR6 runtime/reliability scope.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917433760
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579386
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `cb4f5aba` removes `Any` from `core/rag/orchestration.py:72`, replaces it with a concrete `object` + `SupportsFloat` narrowing path, and adds anchorable deferred-item IDs plus the PR5 docs-only follow-up ledger item in `docs/roadmap/BACKLOG_LEDGER.md:5469`, `docs/roadmap/BACKLOG_LEDGER.md:5485`, `docs/roadmap/BACKLOG_LEDGER.md:5502`, and `docs/roadmap/BACKLOG_LEDGER.md:5514` so the PR body can link to backlog follow-ups directly.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917433766 -> cb4f5aba
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434435 -> cb4f5aba
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `TBD_MAPPING_SHA` replaces machine-local absolute evidence links with portable repository-relative path anchors in `docs/review/PR_1107_FIXED_MAPPING.md:10`, satisfying the portability requirement for GitHub review evidence.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434439 -> TBD_MAPPING_SHA
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579976 -> TBD_MAPPING_SHA

--- a/docs/review/PR_1107_FIXED_MAPPING.md
+++ b/docs/review/PR_1107_FIXED_MAPPING.md
@@ -1,0 +1,12 @@
+# PR 1107 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `0bfdf740` replaces the PR6 kickoff placeholder with the active PR reference in [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5339) and [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5449), so the orchestration epic and PR6 leaf item both point to PR `#1107`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2916975818 -> 0bfdf740

--- a/docs/review/PR_1107_FIXED_MAPPING.md
+++ b/docs/review/PR_1107_FIXED_MAPPING.md
@@ -10,3 +10,4 @@ Commit: see mapping entries below
 Evidence: `0bfdf740` replaces the PR6 kickoff placeholder with the active PR reference in [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5339) and [BACKLOG_LEDGER.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/roadmap/BACKLOG_LEDGER.md#L5449), so the orchestration epic and PR6 leaf item both point to PR `#1107`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2916975818 -> 0bfdf740
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928066462 -> 0bfdf740

--- a/docs/review/PR_1107_FIXED_MAPPING.md
+++ b/docs/review/PR_1107_FIXED_MAPPING.md
@@ -32,3 +32,10 @@ Evidence: `6cca2117` replaces machine-local absolute evidence links with portabl
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434439 -> 6cca2117
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579976 -> 6cca2117
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `40e7602a` reopens the PR5 ledger item pending its docs-only normalization in `docs/roadmap/BACKLOG_LEDGER.md:5421`, removes the unresolved `PR_TBD` audit placeholder while adding raw stdout evidence in `docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md:26`, and simplifies the redundant `cast(float, float("nan"))` to `float("nan")` in `tests/test_rag_orchestration.py:473`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917683730 -> 40e7602a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928850055 -> 40e7602a

--- a/docs/review/PR_1107_FIXED_MAPPING.md
+++ b/docs/review/PR_1107_FIXED_MAPPING.md
@@ -28,7 +28,7 @@ Evidence: `cb4f5aba` removes `Any` from `core/rag/orchestration.py:72`, replaces
 
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `TBD_MAPPING_SHA` replaces machine-local absolute evidence links with portable repository-relative path anchors in `docs/review/PR_1107_FIXED_MAPPING.md:10`, satisfying the portability requirement for GitHub review evidence.
+Evidence: `6cca2117` replaces machine-local absolute evidence links with portable repository-relative path anchors in `docs/review/PR_1107_FIXED_MAPPING.md:10`, satisfying the portability requirement for GitHub review evidence.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434439 -> TBD_MAPPING_SHA
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579976 -> TBD_MAPPING_SHA
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434439 -> 6cca2117
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579976 -> 6cca2117

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5336,8 +5336,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (process scalability + bounded AI optimization)
-  - Target PR: PR #1073 -> PR #1081 -> PR #1088 -> PR #1096 -> PR #1092 -> PR #1102 -> PR6 kickoff
-  - Status: 🟡 In progress (PR1 governance merged in `#1073`; PR2 bootstrap tooling merged in `#1081`; PR3 runner MVP merged in `#1088`; same-day main bootstrap remediation merged in `#1096`; PR4 promotion/telemetry merged in `#1092`; PR5 CV experimentation lane merged in `#1102`; PR6 kickoff prepared on `feat/agent-experiment-reliability-pr6`)
+  - Target PR: PR #1073 -> PR #1081 -> PR #1088 -> PR #1096 -> PR #1092 -> PR #1102 -> PR #1107
+  - Status: 🟡 In progress (PR1 governance merged in `#1073`; PR2 bootstrap tooling merged in `#1081`; PR3 runner MVP merged in `#1088`; same-day main bootstrap remediation merged in `#1096`; PR4 promotion/telemetry merged in `#1092`; PR5 CV experimentation lane merged in `#1102`; PR6 reliability optimization is active in PR `#1107` on `feat/agent-experiment-reliability-pr6`)
   - Reason (EN): PulsePlate now has coordinator-first workflow, KPP promotion, reflection, research track, telemetry rollups, and deterministic benchmark artifacts, but it still lacks one canonical protocol for `autoresearch`-style experiment loops. We need a governed experimentation lane so future optimization cycles can be bounded, auditable, and KPP-only instead of becoming ad-hoc autonomous mutation. (RU: Нужен единый канон для агентных циклов экспериментов, чтобы оптимизация не превращалась в неконтролируемую автомутацию репозитория.)
   - Links:
     - `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
@@ -5446,8 +5446,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: PR6 first applied LLM/RAG reliability optimization via governed lane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (first practical output of the experimentation lane)
-  - Target PR: PR_TBD_AGENT_EXPERIMENT_FIRST_RELIABILITY_PR
-  - Status: 🟡 Kickoff prepared on 2026-03-11 (`feat/agent-experiment-reliability-pr6`; post-merge handoff after PR `#1102`)
+  - Target PR: PR #1107
+  - Status: 🟡 In progress on 2026-03-11 (PR `#1107`; branch `feat/agent-experiment-reliability-pr6`; post-merge handoff after PR `#1102`)
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [P1: PR3 experiment runner MVP for bounded candidate loops](#ledger-p1-agent-experiment-runner)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5466,6 +5466,51 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Result is promoted through a normal human-reviewed PR
     - No storage-cost or CV scope is mixed into this first applied optimization
 
+- [ ] P2: Eliminate PR body and mapping artifact phase2 drift
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR_TBD_PHASE2_BODY_ARTIFACT_SYNC
+  - Area: orchestration / CI governance
+  - Reason: PR5 closeout exposed a hidden governance fragility: `check_pr_body_phase2_gates.py` requires both the canonical mapping artifact and the PR body mirror to carry checked discussion/mapping markers plus at least one mapping entry, which creates avoidable double-maintenance drift during late review cycles.
+  - Links:
+    - `scripts/ci/check_pr_body_phase2_gates.py`
+    - `docs/review/PR_1102_FIXED_MAPPING.md`
+    - `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
+  - DoD:
+    - Phase2 body mirror is generated or validated from a single canonical source
+    - Late review-cycle updates no longer require manual duplication of mapping lines
+    - CI guidance explicitly distinguishes canonical SoT vs human-readable mirror
+
+- [ ] P2: Restore deterministic clean-clone dependency parity for local verify
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR_TBD_CLEAN_CLONE_DEPENDENCY_PARITY
+  - Area: tooling / developer-experience
+  - Reason: Final PR5 local `make verify` failed in the clean clone because `.venv` was missing locked `opentelemetry-*` packages required by `tests/test_genai_tracing.py`, even though `requirements.txt` already declared them. This is an environment parity gap, not a code regression, but it weakens merge confidence.
+  - Links:
+    - `Makefile`
+    - `requirements.txt`
+    - `tests/test_genai_tracing.py`
+    - `tests/test_genai_tracing_config.py`
+  - DoD:
+    - Fresh clean clones can run `make verify` after one documented bootstrap path with no missing locked dependencies
+    - Local setup docs mention the canonical venv refresh command when lockfile drift is suspected
+    - At least one deterministic check guards against silently incomplete clean-clone environments
+
+- [ ] P2: Filter superseded GitHub check noise in merge triage
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR_TBD_GH_CHECKS_CURRENT_HEAD_FILTER
+  - Area: orchestration / GitHub governance
+  - Reason: PR5 merge triage repeatedly showed stale failed `test-pr` and `coverage-pr` lines from superseded runs in `gh pr checks`, even after the current head became `CLEAN`. This creates false negatives and slows final merge decisions.
+  - Links:
+    - `scripts/ci/check_pr_merge_readiness.py`
+    - `RUNBOOK_AGENT.md`
+  - DoD:
+    - Repo guidance or helper tooling can distinguish current-head required checks from superseded historical failures
+    - Merge triage output clearly labels stale runs as non-blocking when canonical readiness already passed
+    - Final merge checklist references the filtered current-head view
+
 - [ ] P2: First-class CV routing domain in orchestration graph
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5336,8 +5336,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (process scalability + bounded AI optimization)
-  - Target PR: PR #1073 -> PR #1081 -> PR #1088 -> PR #1096 -> PR #1092 -> PR #1102
-  - Status: 🟡 In progress (PR1 governance merged in `#1073`; PR2 bootstrap tooling merged in `#1081`; PR3 runner MVP merged in `#1088`; same-day main bootstrap remediation merged in `#1096`; PR4 promotion/telemetry merged in `#1092`; PR5 CV experimentation lane is executing in `#1102`; PR6 remains open)
+  - Target PR: PR #1073 -> PR #1081 -> PR #1088 -> PR #1096 -> PR #1092 -> PR #1102 -> PR6 kickoff
+  - Status: 🟡 In progress (PR1 governance merged in `#1073`; PR2 bootstrap tooling merged in `#1081`; PR3 runner MVP merged in `#1088`; same-day main bootstrap remediation merged in `#1096`; PR4 promotion/telemetry merged in `#1092`; PR5 CV experimentation lane merged in `#1102`; PR6 kickoff prepared on `feat/agent-experiment-reliability-pr6`)
   - Reason (EN): PulsePlate now has coordinator-first workflow, KPP promotion, reflection, research track, telemetry rollups, and deterministic benchmark artifacts, but it still lacks one canonical protocol for `autoresearch`-style experiment loops. We need a governed experimentation lane so future optimization cycles can be bounded, auditable, and KPP-only instead of becoming ad-hoc autonomous mutation. (RU: Нужен единый канон для агентных циклов экспериментов, чтобы оптимизация не превращалась в неконтролируемую автомутацию репозитория.)
   - Links:
     - `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
@@ -5418,11 +5418,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No hidden-memory path bypasses KPP promotion
 
 <a id="ledger-p1-agent-experiment-cv-lane"></a>
-- [ ] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
+- [x] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
-  - Status: 🟡 In progress (`feat/agent-experiment-cv-lane-pr5`; PR #1102; CV overlay + packet schema extension + orchestration drift audit)
+  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`; CV overlay + packet schema extension + orchestration drift audit delivered)
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)
@@ -5447,7 +5447,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (first practical output of the experimentation lane)
   - Target PR: PR_TBD_AGENT_EXPERIMENT_FIRST_RELIABILITY_PR
-  - Status: 📋 Planned
+  - Status: 🟡 Kickoff prepared on 2026-03-11 (`feat/agent-experiment-reliability-pr6`; post-merge handoff after PR `#1102`)
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [P1: PR3 experiment runner MVP for bounded candidate loops](#ledger-p1-agent-experiment-runner)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5466,6 +5466,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Result is promoted through a normal human-reviewed PR
     - No storage-cost or CV scope is mixed into this first applied optimization
 
+<a id="ledger-p2-phase2-body-artifact-sync"></a>
 - [ ] P2: Eliminate PR body and mapping artifact phase2 drift
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
@@ -5481,6 +5482,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Late review-cycle updates no longer require manual duplication of mapping lines
     - CI guidance explicitly distinguishes canonical SoT vs human-readable mirror
 
+<a id="ledger-p2-clean-clone-dependency-parity"></a>
 - [ ] P2: Restore deterministic clean-clone dependency parity for local verify
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
@@ -5497,6 +5499,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Local setup docs mention the canonical venv refresh command when lockfile drift is suspected
     - At least one deterministic check guards against silently incomplete clean-clone environments
 
+<a id="ledger-p2-gh-checks-current-head-filter"></a>
 - [ ] P2: Filter superseded GitHub check noise in merge triage
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
@@ -5510,6 +5513,22 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Repo guidance or helper tooling can distinguish current-head required checks from superseded historical failures
     - Merge triage output clearly labels stale runs as non-blocking when canonical readiness already passed
     - Final merge checklist references the filtered current-head view
+
+<a id="ledger-p2-pr5-ledger-closeout-docs-only"></a>
+- [ ] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
+  - Area: orchestration / ledger governance
+  - Reason: `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md` requires a docs-only follow-up PR when a merged PR closes a ledger item. PR5 closeout was captured during the mixed-scope PR6 kickoff sequence, so it needs a narrow docs-only normalization PR instead of widening PR6 further.
+  - Links:
+    - `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md`
+    - `docs/review/PR_1102_FIXED_MAPPING.md`
+  - DoD:
+    - A docs-only follow-up PR updates the PR5 ledger closeout in canonical form
+    - The follow-up PR references PR `#1102` and this deferred remediation item
+    - No runtime or tooling files are mixed into that normalization PR
 
 - [ ] P2: First-class CV routing domain in orchestration graph
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5418,11 +5418,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No hidden-memory path bypasses KPP promotion
 
 <a id="ledger-p1-agent-experiment-cv-lane"></a>
-- [x] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
+- [ ] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
-  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`; CV overlay + packet schema extension + orchestration drift audit delivered)
+  - Status: 🟡 Delivered in PR `#1102` on 2026-03-11 (`55783414`; CV overlay + packet schema extension + orchestration drift audit shipped), but canonical ledger closeout remains pending the docs-only normalization follow-up tracked in [P2: Normalize PR5 ledger closeout via docs-only follow-up PR](#ledger-p2-pr5-ledger-closeout-docs-only)
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -24,6 +24,7 @@ from core.rag.orchestration import (
     RAGOrchestrationResult,
     _build_prompt_with_context,
     _empty_result,
+    _normalize_confidence_value,
     retrieve_and_validate_rag,
 )
 from core.rag.philosophy_pipeline import PipelineResult, StageResult
@@ -83,6 +84,26 @@ class TestBuildPromptWithContext:
         assert "some context" in result
         assert "Question: question?" in result
         assert "Answer:" in result
+
+
+class _FloatLike:
+    """Helper object exposing ``__float__`` for branch coverage."""
+
+    def __float__(self) -> float:
+        return 0.875
+
+
+class TestNormalizeConfidenceValue:
+    """Tests for confidence normalization helper."""
+
+    def test_supports_float_protocol_value_is_normalized(self) -> None:
+        assert _normalize_confidence_value(_FloatLike()) == 0.875
+
+    def test_unsupported_object_returns_none(self) -> None:
+        assert _normalize_confidence_value(object()) is None
+
+    def test_non_finite_value_returns_none(self) -> None:
+        assert _normalize_confidence_value(float("inf")) is None
 
 
 class TestRetrieveAndValidateRag:

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -470,7 +470,7 @@ class TestRetrieveAndValidateRag:
         """Malformed filtered scores should degrade confidence, not the full RAG result."""
         chunks = [
             _make_chunk("c1", score=cast(float, "bad-score")),
-            _make_chunk("c2", score=cast(float, float("nan"))),
+            _make_chunk("c2", score=float("nan")),
         ]
         rag_ctx = _make_rag_context(chunks=chunks, confidence=0.1)
         pipeline_result = PipelineResult(

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -13,6 +13,7 @@ Tests cover:
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -137,6 +138,35 @@ class TestRetrieveAndValidateRag:
         assert result.confidence == 0.8  # Original confidence used
         assert result.chunks_filtered == 0
         assert "Context:" in result.formatted_prompt
+
+    @pytest.mark.asyncio
+    async def test_validation_disabled_falls_back_to_chunk_mean_when_confidence_invalid(
+        self,
+    ) -> None:
+        """Malformed retriever confidence should not drop an otherwise usable RAG result."""
+        chunks = [_make_chunk("c1", score=0.9), _make_chunk("c2", score=0.7)]
+        rag_ctx = _make_rag_context(chunks=chunks, confidence=cast(float, "not-a-number"))
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1\nChunk2",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1\nChunk2",
+            ),
+        ):
+            result = await retrieve_and_validate_rag("test prompt", philo_validation_enabled=False)
+
+        assert result.rag_actually_used is True
+        assert result.confidence == 0.8
 
     @pytest.mark.asyncio
     async def test_recursive_enabled_uses_recursive_retriever(self) -> None:
@@ -373,6 +403,87 @@ class TestRetrieveAndValidateRag:
 
         # Mean of 0.9 and 0.8 = 0.85
         assert result.confidence == 0.85
+
+    @pytest.mark.asyncio
+    async def test_validation_enabled_ignores_malformed_chunk_scores(self) -> None:
+        """Validation path should derive confidence from valid filtered scores only."""
+        chunks = [
+            _make_chunk("c1", score=cast(float, "0.9")),
+            _make_chunk("c2", score=cast(float, "bad-score")),
+        ]
+        rag_ctx = _make_rag_context(chunks=chunks, confidence=0.1)
+        pipeline_result = PipelineResult(
+            filtered_chunks=chunks,
+            stage_results=[],
+            warnings=[],
+            total_latency_ms=1.0,
+        )
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
+            ),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1\nChunk2",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1\nChunk2",
+            ),
+        ):
+            result = await retrieve_and_validate_rag("test prompt", philo_validation_enabled=True)
+
+        assert result.rag_actually_used is True
+        assert result.confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_validation_enabled_returns_none_confidence_when_all_scores_invalid(self) -> None:
+        """Malformed filtered scores should degrade confidence, not the full RAG result."""
+        chunks = [
+            _make_chunk("c1", score=cast(float, "bad-score")),
+            _make_chunk("c2", score=cast(float, float("nan"))),
+        ]
+        rag_ctx = _make_rag_context(chunks=chunks, confidence=0.1)
+        pipeline_result = PipelineResult(
+            filtered_chunks=chunks,
+            stage_results=[],
+            warnings=["score_parse_warning"],
+            total_latency_ms=1.0,
+        )
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.philosophy_pipeline.run_pipeline",
+                return_value=pipeline_result,
+            ),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1\nChunk2",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1\nChunk2",
+            ),
+        ):
+            result = await retrieve_and_validate_rag("test prompt", philo_validation_enabled=True)
+
+        assert result.rag_actually_used is True
+        assert result.confidence is None
+        assert result.warnings == ["score_parse_warning"]
 
     @pytest.mark.asyncio
     async def test_warnings_propagated_from_pipeline(self) -> None:

--- a/tests/test_telemetry_rollup.py
+++ b/tests/test_telemetry_rollup.py
@@ -164,14 +164,22 @@ def test_aggregate_single_signal() -> None:
 
 
 def test_build_rollup_empty_dir(tmp_path: Path) -> None:
-    out = build_rollup(tmp_path)
+    out = build_rollup(
+        tmp_path,
+        experiment_results_dir=tmp_path / "results",
+        experiment_promotions_dir=tmp_path / "promotions",
+    )
     assert out["signals_count"] == 0
     assert "runs_dir" in out
 
 
 def test_build_rollup_with_json(tmp_path: Path) -> None:
     run_dir = tmp_path / "runs"
+    results_dir = tmp_path / "results"
+    promotions_dir = tmp_path / "promotions"
     run_dir.mkdir()
+    results_dir.mkdir()
+    promotions_dir.mkdir()
     (run_dir / "abc123__agent-coordinator__docs.json").write_text(
         json.dumps(
             {
@@ -196,7 +204,11 @@ def test_build_rollup_with_json(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
-    out = build_rollup(run_dir)
+    out = build_rollup(
+        run_dir,
+        experiment_results_dir=results_dir,
+        experiment_promotions_dir=promotions_dir,
+    )
     assert out["signals_count"] == 1
     assert "agent-coordinator" in out["agents"]
     assert out["experiment_signals_count"] == 0
@@ -204,9 +216,24 @@ def test_build_rollup_with_json(tmp_path: Path) -> None:
 
 def test_main_writes_output(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
+    results_dir = tmp_path / "results"
+    promotions_dir = tmp_path / "promotions"
     runs_dir.mkdir()
+    results_dir.mkdir()
+    promotions_dir.mkdir()
     out_path = tmp_path / "rollup.json"
-    exit_code = main(["--runs-dir", str(runs_dir), "--output", str(out_path)])
+    exit_code = main(
+        [
+            "--runs-dir",
+            str(runs_dir),
+            "--experiment-results-dir",
+            str(results_dir),
+            "--experiment-promotions-dir",
+            str(promotions_dir),
+            "--output",
+            str(out_path),
+        ]
+    )
     assert exit_code == 0
     assert out_path.exists()
     data = json.loads(out_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

Harden the first applied governed-lane reliability change for RAG orchestration.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [x] Linked issues/PRs: `#1102` (PR5 handoff), `#1107` (active PR6)

Applied changes in this PR:
- make `core.rag.orchestration` degrade gracefully when retriever confidence or filtered chunk scores are malformed instead of dropping the full RAG result
- add focused regression coverage for malformed retriever confidence and malformed chunk-score paths
- add experiment audit evidence for governed-lane run `exp-84ecc3c1e995`
- isolate telemetry rollup tests from local experiment artifacts so `make verify` stays deterministic after governed-lane execution
- align `BACKLOG_LEDGER.md` PR6 references with the live PR number `#1107`
- address the latest bot wave by removing `Any` from `core/rag/orchestration.py`, adding backlog anchors for deferred follow-ups, and normalizing portable review evidence

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [x] Performance-sensitive

Notes:
- runtime scope is limited to `core/rag/orchestration.py`
- no public API contract changes
- no database or migration changes
- telemetry isolation fix is test-only and prevents local artifact leakage into repo gates

## Test Plan

- [x] Unit tests updated/added
- [x] Integration/slow tests (if applicable)
- [x] Manual verification steps

Commands run locally:
- `python3 -m scripts.orchestration.check_preflight`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md`
- `. .venv/bin/activate && pytest -q tests/test_rag_orchestration.py tests/test_insight_rag_response_fields.py tests/test_rag_vector_feature_flag_guard.py`
- `. .venv/bin/activate && pytest -q tests/test_telemetry_rollup.py`
- `. .venv/bin/activate && pytest -q tests/test_rag_orchestration.py tests/test_telemetry_rollup.py`
- `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null core/rag/orchestration.py`
- `pre-commit run --all-files`
- `make verify`

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [x] Diff coverage ≥ 97% on changed lines

Local result:
- `make verify` passed
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=97` passed with `Coverage: 100%` on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2916975818 -> 0bfdf740
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928066462 -> 0bfdf740
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917433760
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579386
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917433766 -> cb4f5aba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434435 -> cb4f5aba
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917434439 -> 6cca2117
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928579976 -> 6cca2117
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#discussion_r2917683730 -> 40e7602a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1107#pullrequestreview-3928850055 -> 40e7602a

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): [P2: Eliminate PR body and mapping artifact phase2 drift](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-phase2-body-artifact-sync)
- [x] Ledger item(s): [P2: Restore deterministic clean-clone dependency parity for local verify](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-clean-clone-dependency-parity)
- [x] Ledger item(s): [P2: Filter superseded GitHub check noise in merge triage](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gh-checks-current-head-filter)
- [x] Ledger item(s): [P2: Normalize PR5 ledger closeout via docs-only follow-up PR](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-pr5-ledger-closeout-docs-only)
- [x] GitHub issue(s): None

## Notes

### For Simple Changes

- [ ] No database/schema/migration changes
- [x] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Why this is not a simple change:
- runtime reliability logic changed in `core/rag/orchestration.py`
- regression tests and experiment audit evidence were added
- a latent telemetry test determinism issue was fixed after governed-lane artifacts exposed it
- latest bot-wave follow-ups added governance-only docs work to preserve merge-readiness canon

Rollback / Feature flag (brief):

- How to revert: revert commits `2745ce52`, `9d7ef40d`, `0bfdf740`, `ecf1f538`, `57d96eee`, `cb4f5aba`, and the latest mapping-only follow-up commit if the PR is merged without squash; for squash merge, revert the resulting merge SHA
- Feature flag/toggle (if any): none; behavior degrades safely to `confidence=None` rather than failing the full RAG result
- Owner for emergency contact: @katsiaryna_kavaleuskaya

### For Complex/High-Risk Changes

#### Deployment Strategy

- [x] Deployment order for multi-service changes (if services depend on each other)
- [x] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

Deployment notes:
- single-service backend deploy only
- no feature flag changes required
- safe rollback is git revert; no data migration rollback needed

#### Database & Data Changes

- [x] Database migrations required (Alembic version, backwards compatibility)
- [x] Data migration/backfill steps (scripts, rollback procedures)
- [x] Data cleanup steps (if removing deprecated data)
- [x] Backwards compatibility guarantees (old clients still work)

Details:
- no DB migrations required
- no data migration or cleanup required
- response shape remains backward compatible; only confidence resilience improves

#### Monitoring & Observability

- [x] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [x] Dashboards to create/update (Grafana, DataDog, etc.)
- [x] Logging changes (new log levels, structured logs, correlation IDs)
- [x] Health check endpoints affected

Details:
- none required for this bounded reliability fix
- experiment evidence is captured via `docs/audit/EXPERIMENT_EXP_84ECC3C1E995.md`

#### Post-Deploy Verification

- [x] Manual verification checklist (specific endpoints, user flows)
- [x] Smoke tests to run (automated or manual)
- [x] Performance benchmarks to verify (latency, throughput)
- [x] Rollback triggers (what conditions require immediate rollback)

Checklist:
- rerun `make verify`
- rerun focused RAG regression tests if any follow-up bot fix touches `core/rag/orchestration.py`
- rollback if orchestration starts returning empty RAG results on malformed confidence metadata

#### Additional Context

- [x] Breaking changes (API contracts, response formats)
- [x] Dependencies updated (requirements.txt, package versions)
- [x] Configuration changes (env vars, secrets, feature toggles)
- [x] Documentation updates needed (README, API docs, runbooks)

Details:
- no breaking changes
- no dependency/config changes
- docs updated only for audit evidence, ledger governance, and canonical review mapping

<!-- markdownlint-enable MD013 MD033 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence scoring with stronger validation, fallback behavior, and malformed-score filtering.

* **New Features**
  * Extended orchestration options for validation, recursive retrieval, and subject routing.
  * Telemetry rollup now accepts explicit experiment results/promotions directories via new CLI flags.

* **Tests**
  * Added comprehensive tests covering confidence normalization, validation scenarios, recursive paths, and warning propagation.

* **Documentation**
  * Expanded backlog ledger and added audit/review artifacts for experiment tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
