### PR TITLE
fix(authz): enforce DB-backed tier checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -576,7 +576,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 419
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-11T11:20:52Z"
+  "generated_at": "2026-03-11T11:38:44Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -576,7 +576,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 397
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T12:21:11Z"
+  "generated_at": "2026-03-11T11:20:52Z"
 }

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -27,14 +27,19 @@ import hashlib
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request, Security, status
-from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
+from app.schemas.payments import (
+    SubscriptionStatus as PersistedSubscriptionStatus,
+    SubscriptionTier as PersistedSubscriptionTier,
+)
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
+from app.services import subscriptions as subscriptions_store
 
 from app.utils.feature_flags import is_vip_module_enabled
 from settings import (
@@ -125,21 +130,71 @@ def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
     return None
 
 
+def _parse_persisted_subscription_tier(raw_tier: str) -> SubscriptionTier | None:
+    """Convert persisted billing tier string into authz tier enum."""
+
+    normalized = raw_tier.strip().lower()
+    try:
+        persisted_tier = PersistedSubscriptionTier(normalized)
+    except ValueError:
+        return None
+
+    return {
+        PersistedSubscriptionTier.free: SubscriptionTier.FREE,
+        PersistedSubscriptionTier.pro: SubscriptionTier.PRO,
+        PersistedSubscriptionTier.vip: SubscriptionTier.VIP,
+    }[persisted_tier]
+
+
+def _parse_persisted_subscription_status(
+    raw_status: str,
+) -> PersistedSubscriptionStatus | None:
+    """Convert persisted billing status string into canonical status enum."""
+
+    normalized = raw_status.strip().lower()
+    try:
+        return PersistedSubscriptionStatus(normalized)
+    except ValueError:
+        return None
+
+
+def _normalize_utc_datetime(value: datetime | None) -> datetime | None:
+    """Normalize naive/aware datetimes to UTC for deterministic expiry checks."""
+
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _tier_rank(tier: SubscriptionTier) -> int:
+    """Return deterministic rank for effective paid-tier resolution."""
+
+    return {
+        SubscriptionTier.FREE: 0,
+        SubscriptionTier.PRO: 1,
+        SubscriptionTier.VIP: 2,
+    }[tier]
+
+
 def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
-    """Try to resolve API key tier from DB with explicit outcome.
+    """Try to resolve API key tier from persisted subscriptions with explicit outcome.
 
-    RU: Пытается определить tier из БД и возвращает статус lookup.
-    EN: Attempts to resolve tier from DB and returns structured status.
+    RU: Пытается определить entitlement из persisted subscriptions и возвращает статус lookup.
+    EN: Attempts to resolve entitlement from persisted subscriptions and returns structured status.
     """
-    query = text("SELECT tier FROM api_keys WHERE api_key = :api_key LIMIT 1")
-
     try:
         from core.db import get_session_factory
 
+        user_id = derive_subject_id_from_api_key(api_key)
         session_factory = get_session_factory()
         session = session_factory()
         try:
-            raw_tier = session.execute(query, {"api_key": api_key}).scalar_one_or_none()
+            subscriptions = subscriptions_store.list_subscriptions_for_user(
+                session=session,
+                user_id=user_id,
+            )
         finally:
             session.close()
     except Exception:
@@ -150,17 +205,45 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         )
         return DBLookupResult(status=DBLookupStatus.ERROR)
 
-    if raw_tier is None:
+    if not subscriptions:
         return DBLookupResult(status=DBLookupStatus.MISS)
 
-    parsed_tier = _parse_tier_value(str(raw_tier))
-    if parsed_tier is None:
+    now = datetime.now(timezone.utc)
+    saw_valid_state = False
+    saw_invalid_state = False
+    effective_tier = SubscriptionTier.FREE
+
+    for subscription in subscriptions:
+        parsed_tier = _parse_persisted_subscription_tier(subscription.tier)
+        parsed_status = _parse_persisted_subscription_status(subscription.status)
+        if parsed_tier is None or parsed_status is None:
+            saw_invalid_state = True
+            continue
+
+        saw_valid_state = True
+        if parsed_status is not PersistedSubscriptionStatus.active:
+            continue
+
+        expires_at = _normalize_utc_datetime(subscription.expires_at)
+        if expires_at is not None and expires_at <= now:
+            continue
+
+        if _tier_rank(parsed_tier) > _tier_rank(effective_tier):
+            effective_tier = parsed_tier
+
+    if saw_valid_state:
+        return DBLookupResult(status=DBLookupStatus.HIT, tier=effective_tier)
+
+    if saw_invalid_state:
         logger.warning(
-            "Subscription DB lookup returned unknown tier value; denying env fallback",
+            "Subscription DB lookup returned invalid persisted entitlement state; denying access",
             extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.INVALID_TIER.value},
         )
         return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
-    return DBLookupResult(status=DBLookupStatus.HIT, tier=parsed_tier)
+
+    # RU: Защитный хвост для типизатора; неожиданный непустой, но нейтральный набор трактуем как MISS.
+    # EN: Defensive tail for the type checker; treat any unexpected neutral non-empty set as MISS.
+    return DBLookupResult(status=DBLookupStatus.MISS)
 
 
 def _resolve_tier_from_env(
@@ -213,8 +296,7 @@ def _resolve_authorized_api_key_tier(
             if _tier_allows_access(db_lookup.tier, required_tier):
                 return db_lookup.tier
             return None
-        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
-            return None
+        return None
 
     resolved_env_tier = _resolve_tier_from_env(
         api_key,
@@ -507,8 +589,7 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         db_lookup = _lookup_tier_from_db(api_key)
         if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
             return db_lookup.tier
-        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
-            return SubscriptionTier.FREE
+        return SubscriptionTier.FREE
 
     env_tier = _resolve_tier_from_env(
         api_key,

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -39,7 +39,6 @@ from app.schemas.payments import (
     SubscriptionTier as PersistedSubscriptionTier,
 )
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
-from app.services import subscriptions as subscriptions_store
 
 from app.utils.feature_flags import is_vip_module_enabled
 from settings import (
@@ -185,6 +184,7 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
     EN: Attempts to resolve entitlement from persisted subscriptions and returns structured status.
     """
     try:
+        from app.services import subscriptions as subscriptions_store
         from core.db import get_session_factory
 
         user_id = derive_subject_id_from_api_key(api_key)
@@ -231,15 +231,15 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         if _tier_rank(parsed_tier) > _tier_rank(effective_tier):
             effective_tier = parsed_tier
 
-    if saw_valid_state:
-        return DBLookupResult(status=DBLookupStatus.HIT, tier=effective_tier)
-
     if saw_invalid_state:
         logger.warning(
             "Subscription DB lookup returned invalid persisted entitlement state; denying access",
             extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.INVALID_TIER.value},
         )
         return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
+
+    if saw_valid_state:
+        return DBLookupResult(status=DBLookupStatus.HIT, tier=effective_tier)
 
     # RU: Защитный хвост для типизатора; неожиданный непустой, но нейтральный набор трактуем как MISS.
     # EN: Defensive tail for the type checker; treat any unexpected neutral non-empty set as MISS.

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -23,6 +23,7 @@ from fastapi import (  # pyright: ignore[reportMissingImports]
 )
 from fastapi.security import APIKeyHeader  # pyright: ignore[reportMissingImports]
 
+import app.middleware.api_tiers as api_tiers_mod
 from app.schemas.fitchef import FitChefWeeklyPlanInput, FitChefWeeklyPlanTaskEnvelope
 from app.schemas.vip import ErrorResponse, WeeklyPlanRequest, WeeklyPlanResponse
 from app.services import fitchef_runtime
@@ -640,9 +641,17 @@ def _require_api_key_dev_legacy(request: Request) -> str:
 
     if api_key:
         try:
-            return _require_api_key(api_key)
+            resolved_api_key = _require_api_key(api_key)
+            if api_tiers_mod._is_subscription_db_enabled():
+                api_tiers_mod.require_vip_tier(x_api_key=resolved_api_key, request=request)
+            return resolved_api_key
         except HTTPException as exc:
             if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Forbidden: VIP access required",
+                ) from exc
+            if exc.status_code == status.HTTP_403_FORBIDDEN:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Forbidden: VIP access required",

--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -30,6 +30,30 @@ def get_subscription_for_user_source(
     return subscription
 
 
+def list_subscriptions_for_user(
+    *,
+    session: Session,
+    user_id: int,
+) -> list[Subscription]:
+    """Return all persisted subscription rows for the given user.
+
+    RU: Возвращает все persisted subscriptions пользователя.
+    EN: Returns all persisted subscriptions for a user.
+    """
+
+    statement = (
+        select(Subscription)
+        .where(Subscription.user_id == user_id)
+        .order_by(
+            desc(Subscription.updated_at),
+            desc(Subscription.created_at),
+            desc(Subscription.id),
+        )
+    )
+    subscriptions = list(session.execute(statement).scalars().all())
+    return subscriptions
+
+
 def get_audit_by_user_key(
     *,
     session: Session,

--- a/docs/review/PR_1109_FIXED_MAPPING.md
+++ b/docs/review/PR_1109_FIXED_MAPPING.md
@@ -8,7 +8,6 @@
 Disposition: FIXED
 Commit: 9f879dbf
 Evidence: `app/middleware/api_tiers.py:187`, `app/middleware/api_tiers.py:234`, `tests/test_api_tiers.py:343`, `tests/test_api_tiers_db_lookup.py:173`
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917776854 -> 9f879dbf
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794871 -> 9f879dbf
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794878 -> 9f879dbf

--- a/docs/review/PR_1109_FIXED_MAPPING.md
+++ b/docs/review/PR_1109_FIXED_MAPPING.md
@@ -5,4 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 9f879dbf
+Evidence: `app/middleware/api_tiers.py:187`, `app/middleware/api_tiers.py:234`, `tests/test_api_tiers.py:343`, `tests/test_api_tiers_db_lookup.py:173`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917776854 -> 9f879dbf
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794871 -> 9f879dbf
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794878 -> 9f879dbf

--- a/docs/review/PR_1109_FIXED_MAPPING.md
+++ b/docs/review/PR_1109_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1109 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1109_FIXED_MAPPING.md
+++ b/docs/review/PR_1109_FIXED_MAPPING.md
@@ -8,6 +8,7 @@
 Disposition: FIXED
 Commit: 9f879dbf
 Evidence: `app/middleware/api_tiers.py:187`, `app/middleware/api_tiers.py:234`, `tests/test_api_tiers.py:343`, `tests/test_api_tiers_db_lookup.py:173`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#pullrequestreview-3928975998 -> 9f879dbf
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917776854 -> 9f879dbf
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794871 -> 9f879dbf
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794878 -> 9f879dbf

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 import app.middleware.api_tiers as api_tiers_mod
+from app.services import subscriptions as subscriptions_store
 from app.middleware.api_tiers import (
     AuthSource,
     DBLookupResult,
@@ -275,7 +276,7 @@ class TestDBLookupHelpers:
         session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
         monkeypatch.setattr(
-            api_tiers_mod.subscriptions_store,
+            subscriptions_store,
             "list_subscriptions_for_user",
             lambda **_kwargs: [],
         )
@@ -293,7 +294,7 @@ class TestDBLookupHelpers:
         session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
         monkeypatch.setattr(
-            api_tiers_mod.subscriptions_store,
+            subscriptions_store,
             "list_subscriptions_for_user",
             lambda **_kwargs: [_subscription_row(tier="not_a_tier", status="active")],
         )
@@ -309,7 +310,7 @@ class TestDBLookupHelpers:
         session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
         monkeypatch.setattr(
-            api_tiers_mod.subscriptions_store,
+            subscriptions_store,
             "list_subscriptions_for_user",
             lambda **_kwargs: [_subscription_row(tier="vip", status="active")],
         )
@@ -327,7 +328,7 @@ class TestDBLookupHelpers:
         session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
         monkeypatch.setattr(
-            api_tiers_mod.subscriptions_store,
+            subscriptions_store,
             "list_subscriptions_for_user",
             lambda **_kwargs: [
                 _subscription_row(tier="vip", status="expired"),
@@ -337,6 +338,27 @@ class TestDBLookupHelpers:
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.HIT
         assert result.tier == SubscriptionTier.FREE
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_fails_closed_when_rows_mix_valid_and_invalid_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Any malformed persisted row must force INVALID_TIER even if another row parses."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [
+                _subscription_row(tier="vip", status="active"),
+                _subscription_row(tier="not_a_tier", status="active"),
+            ],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.INVALID_TIER
+        assert result.tier is None
         assert session.closed is True
 
     def test_lookup_tier_from_db_defensive_tail_returns_miss(
@@ -355,7 +377,7 @@ class TestDBLookupHelpers:
         session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
         monkeypatch.setattr(
-            api_tiers_mod.subscriptions_store,
+            subscriptions_store,
             "list_subscriptions_for_user",
             lambda **_kwargs: _TruthyEmptySubscriptions(),
         )

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -4,6 +4,9 @@ RU: Тесты для промежуточного ПО проверки уро�
 EN: Tests for API tier validation middleware.
 """
 
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -157,8 +160,10 @@ class TestValidateAPIKeyTier:
         )
         assert _validate_api_key_tier("env_key", SubscriptionTier.VIP) is False
 
-    def test_production_db_miss_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test DB MISS allows env fallback (migration path)."""
+    def test_production_db_miss_does_not_fallback_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB MISS is fail-closed for canonical paid-route authz."""
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.setenv("DEBUG", "false")
         monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
@@ -168,7 +173,7 @@ class TestValidateAPIKeyTier:
             "_lookup_tier_from_db",
             lambda _: DBLookupResult(status=DBLookupStatus.MISS),
         )
-        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is False
         assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.VIP) is False
 
     def test_environment_overrides_app_env_for_runtime_detection(
@@ -184,24 +189,23 @@ class TestValidateAPIKeyTier:
         assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is False
 
 
-class _FakeResult:
-    def __init__(self, value: object) -> None:
-        self._value = value
-
-    def scalar_one_or_none(self) -> object:
-        return self._value
-
-
 class _FakeSession:
-    def __init__(self, value: object) -> None:
-        self._value = value
+    def __init__(self) -> None:
         self.closed = False
-
-    def execute(self, _query: object, _params: dict[str, str]) -> _FakeResult:
-        return _FakeResult(self._value)
 
     def close(self) -> None:
         self.closed = True
+
+
+def _subscription_row(
+    *,
+    tier: str,
+    status: str,
+    expires_at: object = None,
+) -> SimpleNamespace:
+    """Build minimal persisted subscription row for api_tiers unit tests."""
+
+    return SimpleNamespace(tier=tier, status=status, expires_at=expires_at)
 
 
 def _request_with_cookie(token: str) -> Request:
@@ -224,6 +228,13 @@ def _request_with_cookie(token: str) -> Request:
 
 class TestDBLookupHelpers:
     """Test low-level DB tier lookup helpers."""
+
+    def test_normalize_utc_datetime_converts_aware_values(self) -> None:
+        """Aware datetimes must normalize to UTC instead of preserving source offset."""
+
+        aware_value = datetime(2026, 3, 11, 15, 30, tzinfo=timezone(timedelta(hours=3)))
+        normalized = api_tiers_mod._normalize_utc_datetime(aware_value)
+        assert normalized == datetime(2026, 3, 11, 12, 30, tzinfo=timezone.utc)
 
     def test_tier_allows_access_helper(self) -> None:
         """Test tier inclusion matrix helper."""
@@ -261,8 +272,13 @@ class TestDBLookupHelpers:
         """Test _lookup_tier_from_db returns DBLookupResult with status MISS when no record is found."""
         import core.db as core_db
 
-        session = _FakeSession(None)
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.MISS
         assert result.tier is None
@@ -274,22 +290,78 @@ class TestDBLookupHelpers:
         """Test _lookup_tier_from_db returns DBLookupResult with status INVALID_TIER for unknown tier values."""
         import core.db as core_db
 
-        session = _FakeSession("not_a_tier")
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="not_a_tier", status="active")],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.INVALID_TIER
         assert result.tier is None
         assert session.closed is True
 
     def test_lookup_tier_from_db_returns_parsed_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test DB lookup returns parsed tier for valid DB value."""
+        """Test DB lookup returns parsed tier for valid active subscription state."""
         import core.db as core_db
 
-        session = _FakeSession("VIP")
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="vip", status="active")],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.HIT
         assert result.tier == SubscriptionTier.VIP
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_returns_free_for_non_active_states(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Persisted non-active subscription rows must deny paid access authoritatively."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [
+                _subscription_row(tier="vip", status="expired"),
+                _subscription_row(tier="pro", status="cancelled"),
+            ],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.HIT
+        assert result.tier == SubscriptionTier.FREE
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_defensive_tail_returns_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A truthy-but-empty iterable should hit the defensive MISS tail without crashing."""
+        import core.db as core_db
+
+        class _TruthyEmptySubscriptions:
+            def __bool__(self) -> bool:
+                return True
+
+            def __iter__(self):
+                return iter(())
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: _TruthyEmptySubscriptions(),
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.MISS
+        assert result.tier is None
         assert session.closed is True
 
 
@@ -549,10 +621,10 @@ class TestGetSubscriptionTier:
         )
         assert get_subscription_tier("db_key") == SubscriptionTier.VIP
 
-    def test_production_db_enabled_falls_back_to_env_on_db_miss(
+    def test_production_db_enabled_returns_free_on_db_miss(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test get_subscription_tier falls back to env only when DB lookup misses."""
+        """Test get_subscription_tier is fail-closed on DB MISS in DB-backed mode."""
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.setenv("DEBUG", "false")
         monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
@@ -562,7 +634,7 @@ class TestGetSubscriptionTier:
             "_lookup_tier_from_db",
             lambda _: DBLookupResult(status=DBLookupStatus.MISS),
         )
-        assert get_subscription_tier("env_key") == SubscriptionTier.VIP
+        assert get_subscription_tier("env_key") == SubscriptionTier.FREE
         assert get_subscription_tier("unknown_key") == SubscriptionTier.FREE
 
     def test_production_db_error_returns_free_without_env_fallback(

--- a/tests/test_api_tiers_db_lookup.py
+++ b/tests/test_api_tiers_db_lookup.py
@@ -170,6 +170,30 @@ def test_lookup_tier_from_db_returns_invalid_tier_for_malformed_status() -> None
     assert result.tier is None
 
 
+def test_lookup_tier_from_db_fails_closed_for_mixed_valid_and_malformed_rows() -> None:
+    """Mixed persisted rows must deny paid access when any row is malformed."""
+
+    future = datetime.now(timezone.utc) + timedelta(days=14)
+    _persist_subscription(
+        api_key="mixed-malformed-key",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="vip",
+        status="active",
+        expires_at=future,
+    )
+    _persist_subscription(
+        api_key="mixed-malformed-key",  # pragma: allowlist secret
+        source="swift_manual",
+        tier="enterprise",
+        status="active",
+        expires_at=future,
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("mixed-malformed-key")
+    assert result.status == DBLookupStatus.INVALID_TIER
+    assert result.tier is None
+
+
 def test_get_subscription_tier_is_fail_closed_on_db_miss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_api_tiers_db_lookup.py
+++ b/tests/test_api_tiers_db_lookup.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+import app.middleware.api_tiers as api_tiers_mod
+from app.middleware.api_tiers import (
+    DBLookupStatus,
+    SubscriptionTier,
+    TEST_KEY_PRO,
+    TEST_KEY_VIP,
+    derive_subject_id_from_api_key,
+    get_subscription_tier,
+)
+from app.models import Subscription
+from app.services import payments_activation
+from core import db as core_db
+
+
+@pytest.fixture(autouse=True)
+def _reset_subscription_state(configure_sqlite_database: object) -> None:
+    """Reset persisted billing state between tests."""
+
+    payments_activation.reset_state()
+
+
+def _persist_subscription(
+    *,
+    api_key: str,
+    source: str,
+    tier: str,
+    status: str,
+    expires_at: datetime | None = None,
+) -> None:
+    """Insert a persisted subscription row for DB-backed authz tests."""
+
+    session_factory = core_db.get_session_factory()
+    session = session_factory()
+    now = datetime.now(timezone.utc)
+    try:
+        session.add(
+            Subscription(
+                id=str(uuid4()),
+                user_id=derive_subject_id_from_api_key(api_key),
+                source=source,
+                tier=tier,
+                status=status,
+                platform="ios",
+                source_reference=f"{source}:{api_key}",
+                product_id=f"com.pulseplate.{tier}.monthly",
+                expires_at=expires_at,
+                activated_at=now if status == "active" else None,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_lookup_tier_from_db_returns_highest_active_entitlement() -> None:
+    """VIP must win when multiple active persisted subscriptions exist."""
+
+    future = datetime.now(timezone.utc) + timedelta(days=14)
+    _persist_subscription(
+        api_key=TEST_KEY_VIP,
+        source="ios_app_store",
+        tier="pro",
+        status="active",
+        expires_at=future,
+    )
+    _persist_subscription(
+        api_key=TEST_KEY_VIP,
+        source="swift_manual",
+        tier="vip",
+        status="active",
+        expires_at=future,
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db(TEST_KEY_VIP)
+    assert result.status == DBLookupStatus.HIT
+    assert result.tier == SubscriptionTier.VIP
+
+
+def test_lookup_tier_from_db_returns_free_for_non_active_entitlements() -> None:
+    """Persisted non-active rows must authoritatively deny paid access."""
+
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    _persist_subscription(
+        api_key=TEST_KEY_PRO,
+        source="ios_app_store",
+        tier="pro",
+        status="expired",
+        expires_at=past,
+    )
+    _persist_subscription(
+        api_key=TEST_KEY_PRO,
+        source="erip_qr",
+        tier="vip",
+        status="pending_manual_review",
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db(TEST_KEY_PRO)
+    assert result.status == DBLookupStatus.HIT
+    assert result.tier == SubscriptionTier.FREE
+
+
+def test_lookup_tier_from_db_parses_free_tier_and_normalizes_aware_expiry() -> None:
+    """Aware datetimes must normalize to UTC and a persisted free tier must stay free."""
+
+    future = datetime.now(timezone.utc).astimezone(timezone(timedelta(hours=3))) + timedelta(days=2)
+    _persist_subscription(
+        api_key="free-tier-user",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="free",
+        status="active",
+        expires_at=future,
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("free-tier-user")
+    assert result.status == DBLookupStatus.HIT
+    assert result.tier == SubscriptionTier.FREE
+
+
+def test_lookup_tier_from_db_ignores_active_rows_that_are_already_expired() -> None:
+    """An active row with past expiry must not unlock paid access."""
+
+    past = datetime.now(timezone.utc).astimezone(timezone(timedelta(hours=-5))) - timedelta(days=2)
+    _persist_subscription(
+        api_key="expired-active-user",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="vip",
+        status="active",
+        expires_at=past,
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("expired-active-user")
+    assert result.status == DBLookupStatus.HIT
+    assert result.tier == SubscriptionTier.FREE
+
+
+def test_lookup_tier_from_db_returns_invalid_tier_for_malformed_rows() -> None:
+    """Malformed persisted tier/state rows must fail closed."""
+
+    _persist_subscription(
+        api_key="malformed-subscription-key",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="enterprise",
+        status="active",
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("malformed-subscription-key")
+    assert result.status == DBLookupStatus.INVALID_TIER
+    assert result.tier is None
+
+
+def test_lookup_tier_from_db_returns_invalid_tier_for_malformed_status() -> None:
+    """Malformed persisted status rows must fail closed."""
+
+    _persist_subscription(
+        api_key="malformed-status-key",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="pro",
+        status="waiting_for_review",
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("malformed-status-key")
+    assert result.status == DBLookupStatus.INVALID_TIER
+    assert result.tier is None
+
+
+def test_get_subscription_tier_is_fail_closed_on_db_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB-backed tier resolution must not fall back to env/test keys on MISS."""
+
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.setenv("PRO_API_KEYS", TEST_KEY_PRO)  # pragma: allowlist secret
+    monkeypatch.setenv("VIP_API_KEYS", TEST_KEY_VIP)  # pragma: allowlist secret
+
+    assert get_subscription_tier(TEST_KEY_PRO) == SubscriptionTier.FREE
+    assert get_subscription_tier(TEST_KEY_VIP) == SubscriptionTier.FREE

--- a/tests/test_paid_route_guards.py
+++ b/tests/test_paid_route_guards.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.middleware.api_tiers import TEST_KEY_PRO, TEST_KEY_VIP, derive_subject_id_from_api_key
+from app.models import Subscription
+from app.schemas.payments import SubscriptionStatus
+from app.services import payments_activation
+from core import db as core_db
+
+
+@pytest.fixture(autouse=True)
+def _db_backed_paid_authz(
+    monkeypatch: pytest.MonkeyPatch,
+    configure_sqlite_database: object,
+) -> None:
+    """Force canonical paid routes onto persisted backend entitlement truth."""
+
+    payments_activation.reset_state()
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("PRO_API_KEYS", TEST_KEY_PRO)  # pragma: allowlist secret
+    monkeypatch.setenv("VIP_API_KEYS", TEST_KEY_VIP)  # pragma: allowlist secret
+
+
+def _json(response: Any) -> dict[str, Any]:
+    assert response.headers.get("content-type", "").startswith("application/json"), response.text
+    payload: dict[str, Any] = response.json()
+    return payload
+
+
+def _ios_payload(*, tier: str, status: str, transaction_id: str) -> dict[str, Any]:
+    expires_at = (
+        (datetime.now(timezone.utc) + timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    )
+    if status == "expired":
+        expires_at = (
+            (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+        )
+    return {
+        "source": "ios_app_store",
+        "payload": {
+            "verification_result": {
+                "transaction_id": transaction_id,
+                "original_transaction_id": f"orig-{transaction_id}",
+                "product_id": f"com.pulseplate.{tier}.monthly",
+                "subscription_tier": tier,
+                "status": status,
+                "expires_at": expires_at,
+                "platform": "ios",
+            },
+            "receipt_data": f"receipt-{transaction_id}",
+        },
+    }
+
+
+def _manual_payload(*, source: str, source_reference: str) -> dict[str, Any]:
+    return {
+        "source": source,
+        "payload": {
+            "source_reference": source_reference,
+            "submitted_amount": "9.99",
+            "submitted_currency": "BYN",
+        },
+    }
+
+
+def _load_subscription(*, api_key: str, source: str) -> Subscription:
+    session_factory = core_db.get_session_factory()
+    session = session_factory()
+    try:
+        statement = select(Subscription).where(
+            Subscription.user_id == derive_subject_id_from_api_key(api_key),
+            Subscription.source == source,
+        )
+        subscription = session.execute(statement).scalar_one()
+        session.expunge(subscription)
+        return subscription
+    finally:
+        session.close()
+
+
+def _set_subscription_status(*, api_key: str, source: str, status: str) -> None:
+    session_factory = core_db.get_session_factory()
+    session = session_factory()
+    try:
+        statement = select(Subscription).where(
+            Subscription.user_id == derive_subject_id_from_api_key(api_key),
+            Subscription.source == source,
+        )
+        subscription = session.execute(statement).scalar_one()
+        subscription.status = status
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_pro_header_without_persisted_entitlement_is_denied(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Client-declared PRO key must not unlock canonical PRO routes without backend truth."""
+
+    response = client.get("/api/v1/pro/session", headers=pro_headers)
+    assert response.status_code == 403, response.text
+
+
+def test_vip_header_without_persisted_entitlement_is_denied(
+    client: TestClient,
+    vip_headers: dict[str, str],
+) -> None:
+    """Client-declared VIP key must not unlock canonical VIP routes without backend truth."""
+
+    response = client.get("/api/v1/vip/health", headers=vip_headers)
+    assert response.status_code == 403, response.text
+
+
+def test_activation_unlocks_pro_route_but_not_vip(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Active PRO entitlement must unlock canonical PRO and still deny canonical VIP."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(tier="pro", status="active", transaction_id="txn-pro-active"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    pro_response = client.get("/api/v1/pro/session", headers=pro_headers)
+    assert pro_response.status_code == 200, pro_response.text
+    assert _json(pro_response)["tier"] == "PRO"
+
+    vip_response = client.get("/api/v1/vip/health", headers=pro_headers)
+    assert vip_response.status_code == 403, vip_response.text
+
+
+def test_activation_unlocks_vip_and_pro_routes(
+    client: TestClient,
+    vip_headers: dict[str, str],
+) -> None:
+    """Active VIP entitlement must unlock canonical VIP and inherited PRO surfaces."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(tier="vip", status="active", transaction_id="txn-vip-active"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    pro_response = client.get("/api/v1/pro/session", headers=vip_headers)
+    assert pro_response.status_code == 200, pro_response.text
+    assert _json(pro_response)["tier"] == "VIP"
+
+    vip_response = client.get("/api/v1/vip/health", headers=vip_headers)
+    assert vip_response.status_code == 200, vip_response.text
+    assert _json(vip_response)["status"] == "success"
+
+
+def test_expired_entitlement_does_not_unlock_paid_routes(
+    client: TestClient,
+    vip_headers: dict[str, str],
+) -> None:
+    """Expired persisted entitlements must deny both canonical paid surfaces."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(tier="vip", status="expired", transaction_id="txn-expired"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    assert client.get("/api/v1/pro/session", headers=vip_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=vip_headers).status_code == 403
+
+
+def test_pending_manual_review_does_not_unlock_paid_routes(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Manual-rail pending review must not unlock canonical paid routes."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_manual_payload(source="erip_qr", source_reference="erip-order-001"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    payload = _json(activate)
+    assert payload["status"] == "pending_manual_review"
+
+    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=pro_headers).status_code == 403
+
+
+def test_cancelled_entitlement_does_not_unlock_paid_routes(
+    client: TestClient,
+    vip_headers: dict[str, str],
+) -> None:
+    """Cancelled persisted subscriptions must deny canonical PRO and VIP routes."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(tier="vip", status="active", transaction_id="txn-cancelled"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    subscription = _load_subscription(api_key=TEST_KEY_VIP, source="ios_app_store")
+    assert subscription.status == SubscriptionStatus.active.value
+    _set_subscription_status(
+        api_key=TEST_KEY_VIP,
+        source="ios_app_store",
+        status=SubscriptionStatus.cancelled.value,
+    )
+
+    assert client.get("/api/v1/pro/session", headers=vip_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=vip_headers).status_code == 403
+
+
+def test_billing_entry_route_stays_outside_paid_entitlement_gate(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Activation route must remain callable before any paid entitlement exists."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(tier="pro", status="active", transaction_id="txn-carveout"),
+    )
+    assert activate.status_code == 200, activate.text
+    assert _json(activate)["status"] == "active"
+
+
+def test_deprecated_pro_alias_does_not_bypass_missing_entitlement(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Deprecated PRO alias must not bypass canonical paid authz outcome."""
+
+    response = client.post("/api/v1/premium/plan/week-flexible", headers=pro_headers, json={})
+    assert response.status_code == 403, response.text
+
+
+def test_deprecated_vip_alias_does_not_bypass_pro_only_entitlement(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """VIP alias must still deny a user who only has active PRO entitlement."""
+
+    activate = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(tier="pro", status="active", transaction_id="txn-alias-pro"),
+    )
+    assert activate.status_code == 200, activate.text
+
+    response = client.post("/api/v1/vip/weekly-plan", headers=pro_headers, json={})
+    assert response.status_code == 403, response.text


### PR DESCRIPTION
## Summary
- switch paid-route authorization to DB-backed subscription entitlement lookup
- resolve tier truth from persisted subscription rows instead of env fallback when `SUBSCRIPTION_DB_ENABLED=true`
- make DB-enabled paid auth fail closed on `MISS`, malformed entitlement state, and lookup errors
- select the highest active entitlement across persisted rows while collapsing expired/cancelled/non-active states to `FREE`
- enforce DB-backed VIP checks on the legacy VIP entry path so deprecated aliases cannot bypass canonical authz
- add deterministic DB lookup and paid-route guard coverage for free/pro/vip, expired, cancelled, pending-manual-review, and mixed malformed persisted states
- refresh `.secrets.baseline` for shifted test line numbers and annotated false positives in test fixtures

## Validation
- `pre-commit run --all-files`
- `pytest -q tests/test_api_tiers.py tests/test_api_tiers_db_lookup.py tests/test_paid_route_guards.py`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#pullrequestreview-3928975998 -> 9f879dbf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917776854 -> 9f879dbf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794871 -> 9f879dbf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1109#discussion_r2917794878 -> 9f879dbf

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed
