### PR TITLE
feat(authz): enforce backend entitlements on canonical PRO/VIP routes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -576,7 +576,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 442
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T12:21:11Z"
+  "generated_at": "2026-03-11T11:13:27Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -576,7 +576,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 419
+        "line_number": 424
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-11T11:38:44Z"
+  "generated_at": "2026-03-11T12:48:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -576,7 +576,7 @@
         "filename": "tests/test_api_tiers.py",
         "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
         "is_verified": false,
-        "line_number": 424
+        "line_number": 452
       }
     ],
     "tests/test_app_97_coverage_simple.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-11T12:48:38Z"
+  "generated_at": "2026-03-11T13:27:51Z"
 }

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -39,7 +39,6 @@ from app.schemas.payments import (
     SubscriptionTier as PersistedSubscriptionTier,
 )
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
-from app.services import subscriptions as subscriptions_store
 
 from app.utils.feature_flags import is_vip_module_enabled
 from settings import (
@@ -165,8 +164,10 @@ def _parse_persisted_subscription_status(
 def _normalize_utc_datetime(value: object) -> datetime | None:
     """Normalize naive/aware datetimes to UTC for deterministic expiry checks."""
 
-    if not isinstance(value, datetime):
+    if value is None:
         return None
+    if not isinstance(value, datetime):
+        raise TypeError(f"expires_at must be datetime | None, got {type(value)!r}")
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
@@ -190,6 +191,7 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
     """
     try:
         from core.db import get_session_factory
+        from app.services import subscriptions as subscriptions_store
 
         user_id = derive_subject_id_from_api_key(api_key)
         session_factory = get_session_factory()
@@ -228,7 +230,12 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         if parsed_status is not PersistedSubscriptionStatus.active:
             continue
 
-        expires_at = _normalize_utc_datetime(getattr(subscription, "expires_at", None))
+        raw_expires_at = getattr(subscription, "expires_at", None)
+        try:
+            expires_at = _normalize_utc_datetime(raw_expires_at)
+        except TypeError:
+            saw_invalid_state = True
+            continue
         if expires_at is not None and expires_at <= now:
             continue
 

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -130,9 +130,11 @@ def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
     return None
 
 
-def _parse_persisted_subscription_tier(raw_tier: str) -> SubscriptionTier | None:
+def _parse_persisted_subscription_tier(raw_tier: object) -> SubscriptionTier | None:
     """Convert persisted billing tier string into authz tier enum."""
 
+    if not isinstance(raw_tier, str):
+        return None
     normalized = raw_tier.strip().lower()
     try:
         persisted_tier = PersistedSubscriptionTier(normalized)
@@ -147,10 +149,12 @@ def _parse_persisted_subscription_tier(raw_tier: str) -> SubscriptionTier | None
 
 
 def _parse_persisted_subscription_status(
-    raw_status: str,
+    raw_status: object,
 ) -> PersistedSubscriptionStatus | None:
     """Convert persisted billing status string into canonical status enum."""
 
+    if not isinstance(raw_status, str):
+        return None
     normalized = raw_status.strip().lower()
     try:
         return PersistedSubscriptionStatus(normalized)
@@ -158,10 +162,10 @@ def _parse_persisted_subscription_status(
         return None
 
 
-def _normalize_utc_datetime(value: datetime | None) -> datetime | None:
+def _normalize_utc_datetime(value: object) -> datetime | None:
     """Normalize naive/aware datetimes to UTC for deterministic expiry checks."""
 
-    if value is None:
+    if not isinstance(value, datetime):
         return None
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
@@ -185,7 +189,6 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
     EN: Attempts to resolve entitlement from persisted subscriptions and returns structured status.
     """
     try:
-        from app.services import subscriptions as subscriptions_store
         from core.db import get_session_factory
 
         user_id = derive_subject_id_from_api_key(api_key)
@@ -215,8 +218,8 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
     effective_tier = SubscriptionTier.FREE
 
     for subscription in subscriptions:
-        parsed_tier = _parse_persisted_subscription_tier(subscription.tier)
-        parsed_status = _parse_persisted_subscription_status(subscription.status)
+        parsed_tier = _parse_persisted_subscription_tier(getattr(subscription, "tier", None))
+        parsed_status = _parse_persisted_subscription_status(getattr(subscription, "status", None))
         if parsed_tier is None or parsed_status is None:
             saw_invalid_state = True
             continue
@@ -225,7 +228,7 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         if parsed_status is not PersistedSubscriptionStatus.active:
             continue
 
-        expires_at = _normalize_utc_datetime(subscription.expires_at)
+        expires_at = _normalize_utc_datetime(getattr(subscription, "expires_at", None))
         if expires_at is not None and expires_at <= now:
             continue
 

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -27,14 +27,19 @@ import hashlib
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
 from fastapi import Depends, HTTPException, Request, Security, status
-from sqlalchemy import text
 
 from app.routers.api_key import api_key_header
+from app.schemas.payments import (
+    SubscriptionStatus as PersistedSubscriptionStatus,
+    SubscriptionTier as PersistedSubscriptionTier,
+)
 from app.security.web_session import WEB_SESSION_COOKIE_NAME, verify_web_session
+from app.services import subscriptions as subscriptions_store
 
 from app.utils.feature_flags import is_vip_module_enabled
 from settings import (
@@ -125,21 +130,69 @@ def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
     return None
 
 
+def _parse_persisted_subscription_tier(raw_tier: object) -> SubscriptionTier | None:
+    """Convert persisted subscription tier values into authz tiers."""
+
+    if not isinstance(raw_tier, str):
+        return None
+    normalized = raw_tier.strip().lower()
+    mapping = {
+        PersistedSubscriptionTier.free.value: SubscriptionTier.FREE,
+        PersistedSubscriptionTier.pro.value: SubscriptionTier.PRO,
+        PersistedSubscriptionTier.vip.value: SubscriptionTier.VIP,
+    }
+    return mapping.get(normalized)
+
+
+def _parse_persisted_subscription_status(raw_status: object) -> PersistedSubscriptionStatus | None:
+    """Convert persisted subscription status values into enum members."""
+
+    if not isinstance(raw_status, str):
+        return None
+    normalized = raw_status.strip().lower()
+    try:
+        return PersistedSubscriptionStatus(normalized)
+    except ValueError:
+        return None
+
+
+def _normalize_utc_datetime(raw_value: object) -> datetime | None:
+    """Normalize persisted datetimes to timezone-aware UTC values."""
+
+    if not isinstance(raw_value, datetime):
+        return None
+    if raw_value.tzinfo is None:
+        return raw_value.replace(tzinfo=timezone.utc)
+    return raw_value.astimezone(timezone.utc)
+
+
+def _tier_rank(tier: SubscriptionTier) -> int:
+    """Return comparable rank for highest-entitlement selection."""
+
+    return {
+        SubscriptionTier.FREE: 0,
+        SubscriptionTier.PRO: 1,
+        SubscriptionTier.VIP: 2,
+    }[tier]
+
+
 def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
     """Try to resolve API key tier from DB with explicit outcome.
 
     RU: Пытается определить tier из БД и возвращает статус lookup.
     EN: Attempts to resolve tier from DB and returns structured status.
     """
-    query = text("SELECT tier FROM api_keys WHERE api_key = :api_key LIMIT 1")
-
     try:
         from core.db import get_session_factory
 
+        user_id = derive_subject_id_from_api_key(api_key)
         session_factory = get_session_factory()
         session = session_factory()
         try:
-            raw_tier = session.execute(query, {"api_key": api_key}).scalar_one_or_none()
+            subscriptions = subscriptions_store.list_subscriptions_for_user(
+                session=session,
+                user_id=user_id,
+            )
         finally:
             session.close()
     except Exception:
@@ -150,17 +203,41 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
         )
         return DBLookupResult(status=DBLookupStatus.ERROR)
 
-    if raw_tier is None:
+    if not subscriptions:
         return DBLookupResult(status=DBLookupStatus.MISS)
 
-    parsed_tier = _parse_tier_value(str(raw_tier))
-    if parsed_tier is None:
-        logger.warning(
-            "Subscription DB lookup returned unknown tier value; denying env fallback",
-            extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.INVALID_TIER.value},
-        )
-        return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
-    return DBLookupResult(status=DBLookupStatus.HIT, tier=parsed_tier)
+    active_tiers: list[SubscriptionTier] = []
+    saw_known_non_active_state = False
+    now = datetime.now(timezone.utc)
+
+    for subscription in subscriptions:
+        parsed_tier = _parse_persisted_subscription_tier(getattr(subscription, "tier", None))
+        parsed_status = _parse_persisted_subscription_status(getattr(subscription, "status", None))
+        if parsed_tier is None or parsed_status is None:
+            continue
+
+        if parsed_status is PersistedSubscriptionStatus.active:
+            expires_at = _normalize_utc_datetime(getattr(subscription, "expires_at", None))
+            if expires_at is not None and expires_at <= now:
+                saw_known_non_active_state = True
+                continue
+            active_tiers.append(parsed_tier)
+            continue
+
+        saw_known_non_active_state = True
+
+    if active_tiers:
+        highest_tier = max(active_tiers, key=_tier_rank)
+        return DBLookupResult(status=DBLookupStatus.HIT, tier=highest_tier)
+
+    if saw_known_non_active_state:
+        return DBLookupResult(status=DBLookupStatus.HIT, tier=SubscriptionTier.FREE)
+
+    logger.warning(
+        "Subscription DB lookup returned malformed persisted entitlement state",
+        extra={"component": "api_tiers", "db_lookup_status": DBLookupStatus.INVALID_TIER.value},
+    )
+    return DBLookupResult(status=DBLookupStatus.INVALID_TIER)
 
 
 def _resolve_tier_from_env(
@@ -213,8 +290,7 @@ def _resolve_authorized_api_key_tier(
             if _tier_allows_access(db_lookup.tier, required_tier):
                 return db_lookup.tier
             return None
-        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
-            return None
+        return None
 
     resolved_env_tier = _resolve_tier_from_env(
         api_key,
@@ -507,8 +583,7 @@ def get_subscription_tier(api_key: str) -> SubscriptionTier:
         db_lookup = _lookup_tier_from_db(api_key)
         if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
             return db_lookup.tier
-        if db_lookup.status in (DBLookupStatus.ERROR, DBLookupStatus.INVALID_TIER):
-            return SubscriptionTier.FREE
+        return SubscriptionTier.FREE
 
     env_tier = _resolve_tier_from_env(
         api_key,

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -642,8 +642,7 @@ def _require_api_key_dev_legacy(request: Request) -> str:
     if api_key:
         try:
             resolved_api_key = _require_api_key(api_key)
-            if api_tiers_mod._is_subscription_db_enabled():
-                api_tiers_mod.require_vip_tier(x_api_key=resolved_api_key, request=request)
+            api_tiers_mod.require_vip_tier(x_api_key=resolved_api_key, request=request)
             return resolved_api_key
         except HTTPException as exc:
             if exc.status_code == status.HTTP_401_UNAUTHORIZED:

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -23,6 +23,7 @@ from fastapi import (  # pyright: ignore[reportMissingImports]
 )
 from fastapi.security import APIKeyHeader  # pyright: ignore[reportMissingImports]
 
+import app.middleware.api_tiers as api_tiers_mod
 from app.schemas.fitchef import FitChefWeeklyPlanInput, FitChefWeeklyPlanTaskEnvelope
 from app.schemas.vip import ErrorResponse, WeeklyPlanRequest, WeeklyPlanResponse
 from app.services import fitchef_runtime
@@ -640,9 +641,17 @@ def _require_api_key_dev_legacy(request: Request) -> str:
 
     if api_key:
         try:
-            return _require_api_key(api_key)
+            resolved_api_key = _require_api_key(api_key)
+            if api_tiers_mod._is_subscription_db_enabled():
+                api_tiers_mod.require_vip_tier(x_api_key=resolved_api_key, request=request)
+            return resolved_api_key
         except HTTPException as exc:
             if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Forbidden: VIP access required",
+                ) from exc
+            if exc.status_code == status.HTTP_403_FORBIDDEN:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Forbidden: VIP access required",

--- a/app/routers/vip.py
+++ b/app/routers/vip.py
@@ -639,11 +639,24 @@ def _require_api_key_dev_legacy(request: Request) -> str:
     api_key = _extract_api_key(request)
     is_production, app_env = _is_production_environment()
 
+    def _require_vip_access(candidate_key: str) -> None:
+        try:
+            api_tiers_mod.require_vip_tier(x_api_key=candidate_key, request=request)
+        except HTTPException as exc:
+            if exc.status_code in {
+                status.HTTP_401_UNAUTHORIZED,
+                status.HTTP_403_FORBIDDEN,
+            }:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Forbidden: VIP access required",
+                ) from exc
+            raise
+
     if api_key:
         try:
             resolved_api_key = _require_api_key(api_key)
-            if api_tiers_mod._is_subscription_db_enabled():
-                api_tiers_mod.require_vip_tier(x_api_key=resolved_api_key, request=request)
+            _require_vip_access(resolved_api_key)
             return resolved_api_key
         except HTTPException as exc:
             if exc.status_code == status.HTTP_401_UNAUTHORIZED:
@@ -674,6 +687,7 @@ def _require_api_key_dev_legacy(request: Request) -> str:
         "off",
     }
     if _is_dev_mode(app_env) and not _explicit_false:
+        _require_vip_access(api_tiers_mod.TEST_KEY_VIP)
         _log_api_key_event(
             "VIP endpoint accessed without API key in legacy dev mode.",
             is_production,

--- a/app/services/subscriptions.py
+++ b/app/services/subscriptions.py
@@ -30,6 +30,26 @@ def get_subscription_for_user_source(
     return subscription
 
 
+def list_subscriptions_for_user(
+    *,
+    session: Session,
+    user_id: int,
+) -> list[Subscription]:
+    """Return subscription rows for a user ordered by freshest persisted state."""
+
+    statement = (
+        select(Subscription)
+        .where(Subscription.user_id == user_id)
+        .order_by(
+            desc(Subscription.updated_at),
+            desc(Subscription.created_at),
+            desc(Subscription.id),
+        )
+    )
+    subscriptions = session.execute(statement).scalars().all()
+    return list(subscriptions)
+
+
 def get_audit_by_user_key(
     *,
     session: Session,

--- a/docs/review/PR_1110_FIXED_MAPPING.md
+++ b/docs/review/PR_1110_FIXED_MAPPING.md
@@ -6,61 +6,88 @@
 
 ### Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917955375 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: app/routers/vip.py:645
-  Reason: Legacy VIP alias now always enforces `require_vip_tier()`, removing the env-backed bypass.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: app/routers/vip.py:645
+Reason: Legacy VIP alias now always enforces `require_vip_tier()`, removing the env-backed bypass.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929151574 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: app/routers/vip.py:645
-  Reason: Review summary covered the same VIP alias bypass and is fixed by the unconditional VIP-tier check.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: app/routers/vip.py:645
+Reason: Review summary covered the same VIP alias bypass and is fixed by the unconditional VIP-tier check.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968517 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: app/routers/vip.py:645
-  Reason: cubic identified the same legacy VIP alias bypass; the guard now runs regardless of DB mode.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: app/routers/vip.py:645
+Reason: cubic identified the same legacy VIP alias bypass; the guard now runs regardless of DB mode.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968531 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: tests/test_subscription_activation_api.py:86
-  Reason: Authz expiry inputs now use `_relative_iso(...)` instead of hard-coded future timestamps.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: tests/test_subscription_activation_api.py:86
+Reason: Authz expiry inputs now use `_relative_iso(...)` instead of hard-coded future timestamps.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929165943 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: app/routers/vip.py:645; tests/test_subscription_activation_api.py:86
-  Reason: cubic review summary covered both the VIP alias bypass and hard-coded authz expiry dates; both were fixed in this commit.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: app/routers/vip.py:645; tests/test_subscription_activation_api.py:86
+Reason: cubic review summary covered both the VIP alias bypass and hard-coded authz expiry dates; both were fixed in this commit.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917973544 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
-  Reason: Merge-readiness checklist items were changed back to unchecked state pending final merge cycle.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
+Reason: Merge-readiness checklist items were changed back to unchecked state pending final merge cycle.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929171608 -> eac2ebf6
-  Disposition: FIXED
-  Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
-  Reason: Review summary covered the same merge-readiness checkbox issue and is fixed in the artifact.
+Disposition: FIXED
+Commit: eac2ebf6
+Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
+Reason: Review summary covered the same merge-readiness checkbox issue and is fixed in the artifact.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929270340 -> 439d41b8
-  Disposition: FIXED
-  Evidence: app/routers/vip.py:642
-  Reason: Legacy VIP alias now applies `require_vip_tier()` to explicit keys and dev/test fallback keys, removing the anonymous bypass outside the original diff.
+Disposition: FIXED
+Commit: 439d41b8
+Evidence: app/routers/vip.py:642
+Reason: Legacy VIP alias now applies `require_vip_tier()` to explicit keys and dev/test fallback keys, removing the anonymous bypass outside the original diff.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122334 -> 439d41b8
-  Disposition: FIXED
-  Evidence: tests/test_vip_anonymous_api_key_safety.py:311
-  Reason: The anonymous-safety fixture no longer enables `VIP_API_KEYS` globally; the VIP env path is now opted into only by the test that exercises it.
+Disposition: FIXED
+Commit: 439d41b8
+Evidence: tests/test_vip_anonymous_api_key_safety.py:311
+Reason: The anonymous-safety fixture no longer enables `VIP_API_KEYS` globally; the VIP env path is now opted into only by the test that exercises it.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122340 -> 439d41b8
-  Disposition: FIXED
-  Evidence: tests/test_vip_production_simple.py:68
-  Reason: Production VIP tests now set `VIP_API_KEYS` only in the cases that intentionally cover that auth path, keeping the source under test explicit.
+Disposition: FIXED
+Commit: 439d41b8
+Evidence: tests/test_vip_production_simple.py:68
+Reason: Production VIP tests now set `VIP_API_KEYS` only in the cases that intentionally cover that auth path, keeping the source under test explicit.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929330945 -> 439d41b8
-  Disposition: FIXED
-  Evidence: tests/test_vip_anonymous_api_key_safety.py:311; tests/test_vip_production_simple.py:68
-  Reason: Review summary covered the same two test-fixture ambiguity fixes and is resolved by the scoped `VIP_API_KEYS` setup.
+Disposition: FIXED
+Commit: 439d41b8
+Evidence: tests/test_vip_anonymous_api_key_safety.py:311; tests/test_vip_production_simple.py:68
+Reason: Review summary covered the same two test-fixture ambiguity fixes and is resolved by the scoped `VIP_API_KEYS` setup.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222586 -> 9a46c760
-  Disposition: FIXED
-  Evidence: app/middleware/api_tiers.py:194
-  Reason: `subscriptions` is now imported inside `_lookup_tier_from_db()` so module import of `api_tiers.py` no longer pulls subscription models into OpenAPI-time import paths.
+Disposition: FIXED
+Commit: 9a46c760
+Evidence: app/middleware/api_tiers.py:194
+Reason: `subscriptions` is now imported inside `_lookup_tier_from_db()` so module import of `api_tiers.py` no longer pulls subscription models into OpenAPI-time import paths.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222595 -> 9a46c760
-  Disposition: FIXED
-  Evidence: app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
-  Reason: Invalid non-datetime `expires_at` values now fail closed through `INVALID_TIER`, with a targeted regression test covering the malformed persisted state.
+Disposition: FIXED
+Commit: 9a46c760
+Evidence: app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
+Reason: Invalid non-datetime `expires_at` values now fail closed through `INVALID_TIER`, with a targeted regression test covering the malformed persisted state.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929437556 -> 9a46c760
-  Disposition: FIXED
-  Evidence: app/middleware/api_tiers.py:194; app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
-  Reason: Review summary covered both api_tiers fixes: localizing the subscriptions import and denying malformed persisted expiry values.
+Disposition: FIXED
+Commit: 9a46c760
+Evidence: app/middleware/api_tiers.py:194; app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
+Reason: Review summary covered both api_tiers fixes: localizing the subscriptions import and denying malformed persisted expiry values.
 
 ## Merge Readiness
 - [ ] python3 scripts/orchestration/check_preflight.py

--- a/docs/review/PR_1110_FIXED_MAPPING.md
+++ b/docs/review/PR_1110_FIXED_MAPPING.md
@@ -1,17 +1,17 @@
 # PR 1110 - Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-- No actionable review comments yet
+- No actionable review comments
 
 ## Merge Readiness
-- [x] python3 scripts/orchestration/check_preflight.py
-- [x] python3 scripts/orchestration/check_agent_consistency.py
-- [x] python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type "authz backend entitlements"
-- [x] pre-commit run --all-files
-- [x] make verify
+- [ ] python3 scripts/orchestration/check_preflight.py
+- [ ] python3 scripts/orchestration/check_agent_consistency.py
+- [ ] python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type "authz backend entitlements"
+- [ ] pre-commit run --all-files
+- [ ] make verify
 - [ ] diff-cover >= 97% in PR CI
 - [ ] required checks PASS

--- a/docs/review/PR_1110_FIXED_MAPPING.md
+++ b/docs/review/PR_1110_FIXED_MAPPING.md
@@ -5,7 +5,34 @@
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917955375 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: app/routers/vip.py:645
+  Reason: Legacy VIP alias now always enforces `require_vip_tier()`, removing the env-backed bypass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929151574 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: app/routers/vip.py:645
+  Reason: Review summary covered the same VIP alias bypass and is fixed by the unconditional VIP-tier check.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968517 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: app/routers/vip.py:645
+  Reason: cubic identified the same legacy VIP alias bypass; the guard now runs regardless of DB mode.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968531 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: tests/test_subscription_activation_api.py:86
+  Reason: Authz expiry inputs now use `_relative_iso(...)` instead of hard-coded future timestamps.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929165943 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: app/routers/vip.py:645; tests/test_subscription_activation_api.py:86
+  Reason: cubic review summary covered both the VIP alias bypass and hard-coded authz expiry dates; both were fixed in this commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917973544 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
+  Reason: Merge-readiness checklist items were changed back to unchecked state pending final merge cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929171608 -> eac2ebf6
+  Disposition: FIXED
+  Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
+  Reason: Review summary covered the same merge-readiness checkbox issue and is fixed in the artifact.
 
 ## Merge Readiness
 - [ ] python3 scripts/orchestration/check_preflight.py

--- a/docs/review/PR_1110_FIXED_MAPPING.md
+++ b/docs/review/PR_1110_FIXED_MAPPING.md
@@ -33,6 +33,34 @@
   Disposition: FIXED
   Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
   Reason: Review summary covered the same merge-readiness checkbox issue and is fixed in the artifact.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929270340 -> 439d41b8
+  Disposition: FIXED
+  Evidence: app/routers/vip.py:642
+  Reason: Legacy VIP alias now applies `require_vip_tier()` to explicit keys and dev/test fallback keys, removing the anonymous bypass outside the original diff.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122334 -> 439d41b8
+  Disposition: FIXED
+  Evidence: tests/test_vip_anonymous_api_key_safety.py:311
+  Reason: The anonymous-safety fixture no longer enables `VIP_API_KEYS` globally; the VIP env path is now opted into only by the test that exercises it.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122340 -> 439d41b8
+  Disposition: FIXED
+  Evidence: tests/test_vip_production_simple.py:68
+  Reason: Production VIP tests now set `VIP_API_KEYS` only in the cases that intentionally cover that auth path, keeping the source under test explicit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929330945 -> 439d41b8
+  Disposition: FIXED
+  Evidence: tests/test_vip_anonymous_api_key_safety.py:311; tests/test_vip_production_simple.py:68
+  Reason: Review summary covered the same two test-fixture ambiguity fixes and is resolved by the scoped `VIP_API_KEYS` setup.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222586 -> 9a46c760
+  Disposition: FIXED
+  Evidence: app/middleware/api_tiers.py:194
+  Reason: `subscriptions` is now imported inside `_lookup_tier_from_db()` so module import of `api_tiers.py` no longer pulls subscription models into OpenAPI-time import paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222595 -> 9a46c760
+  Disposition: FIXED
+  Evidence: app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
+  Reason: Invalid non-datetime `expires_at` values now fail closed through `INVALID_TIER`, with a targeted regression test covering the malformed persisted state.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929437556 -> 9a46c760
+  Disposition: FIXED
+  Evidence: app/middleware/api_tiers.py:194; app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
+  Reason: Review summary covered both api_tiers fixes: localizing the subscriptions import and denying malformed persisted expiry values.
 
 ## Merge Readiness
 - [ ] python3 scripts/orchestration/check_preflight.py

--- a/docs/review/PR_1110_FIXED_MAPPING.md
+++ b/docs/review/PR_1110_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1110 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+- No actionable review comments yet
+
+## Merge Readiness
+- [x] python3 scripts/orchestration/check_preflight.py
+- [x] python3 scripts/orchestration/check_agent_consistency.py
+- [x] python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type "authz backend entitlements"
+- [x] pre-commit run --all-files
+- [x] make verify
+- [ ] diff-cover >= 97% in PR CI
+- [ ] required checks PASS

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -237,6 +237,12 @@ class TestDBLookupHelpers:
         normalized = api_tiers_mod._normalize_utc_datetime(aware_value)
         assert normalized == datetime(2026, 3, 11, 12, 30, tzinfo=timezone.utc)
 
+    def test_normalize_utc_datetime_rejects_non_datetime_values(self) -> None:
+        """Malformed persisted expiry values must be treated as invalid state."""
+
+        with pytest.raises(TypeError, match="expires_at must be datetime"):
+            api_tiers_mod._normalize_utc_datetime("2026-01-01")
+
     def test_tier_allows_access_helper(self) -> None:
         """Test tier inclusion matrix helper."""
         assert api_tiers_mod._tier_allows_access(SubscriptionTier.VIP, SubscriptionTier.PRO) is True
@@ -304,6 +310,28 @@ class TestDBLookupHelpers:
             lambda **_kwargs: [_subscription_row(tier="not_a_tier", status="active")],
         )
         result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.INVALID_TIER
+        assert result.tier is None
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_rejects_invalid_expires_at_type(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed persisted expiry values must fail closed instead of unlocking access."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [
+                _subscription_row(tier="vip", status="active", expires_at="2026-01-01")
+            ],
+        )
+
+        result = api_tiers_mod._lookup_tier_from_db("key")
+
         assert result.status == DBLookupStatus.INVALID_TIER
         assert result.tier is None
         assert session.closed is True

--- a/tests/test_api_tiers.py
+++ b/tests/test_api_tiers.py
@@ -4,6 +4,9 @@ RU: Тесты для промежуточного ПО проверки уро�
 EN: Tests for API tier validation middleware.
 """
 
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -157,8 +160,10 @@ class TestValidateAPIKeyTier:
         )
         assert _validate_api_key_tier("env_key", SubscriptionTier.VIP) is False
 
-    def test_production_db_miss_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test DB MISS allows env fallback (migration path)."""
+    def test_production_db_miss_denies_access_without_env_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test DB MISS is fail-closed for canonical paid-route authorization."""
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.setenv("DEBUG", "false")
         monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
@@ -168,7 +173,7 @@ class TestValidateAPIKeyTier:
             "_lookup_tier_from_db",
             lambda _: DBLookupResult(status=DBLookupStatus.MISS),
         )
-        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is True
+        assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.PRO) is False
         assert _validate_api_key_tier("miss_then_env_key", SubscriptionTier.VIP) is False
 
     def test_environment_overrides_app_env_for_runtime_detection(
@@ -184,24 +189,27 @@ class TestValidateAPIKeyTier:
         assert _validate_api_key_tier(TEST_KEY_VIP, SubscriptionTier.VIP) is False
 
 
-class _FakeResult:
-    def __init__(self, value: object) -> None:
-        self._value = value
-
-    def scalar_one_or_none(self) -> object:
-        return self._value
-
-
 class _FakeSession:
-    def __init__(self, value: object) -> None:
-        self._value = value
+    def __init__(self) -> None:
         self.closed = False
-
-    def execute(self, _query: object, _params: dict[str, str]) -> _FakeResult:
-        return _FakeResult(self._value)
 
     def close(self) -> None:
         self.closed = True
+
+
+def _subscription_row(
+    *,
+    tier: object,
+    status: object,
+    expires_at: object = None,
+) -> SimpleNamespace:
+    """Build lightweight persisted-subscription test row."""
+
+    return SimpleNamespace(
+        tier=tier,
+        status=status,
+        expires_at=expires_at,
+    )
 
 
 def _request_with_cookie(token: str) -> Request:
@@ -241,6 +249,11 @@ class TestDBLookupHelpers:
         assert api_tiers_mod._parse_tier_value("PRO") == SubscriptionTier.PRO
         assert api_tiers_mod._parse_tier_value("unknown") is None
 
+    def test_parse_persisted_helpers_return_none_for_non_string_values(self) -> None:
+        """Test persisted tier/status parsers fail closed on non-string DB values."""
+        assert api_tiers_mod._parse_persisted_subscription_tier(None) is None
+        assert api_tiers_mod._parse_persisted_subscription_status(123) is None
+
     def test_lookup_tier_from_db_handles_db_exception(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -261,8 +274,13 @@ class TestDBLookupHelpers:
         """Test _lookup_tier_from_db returns DBLookupResult with status MISS when no record is found."""
         import core.db as core_db
 
-        session = _FakeSession(None)
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.MISS
         assert result.tier is None
@@ -274,8 +292,13 @@ class TestDBLookupHelpers:
         """Test _lookup_tier_from_db returns DBLookupResult with status INVALID_TIER for unknown tier values."""
         import core.db as core_db
 
-        session = _FakeSession("not_a_tier")
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="not_a_tier", status="active")],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.INVALID_TIER
         assert result.tier is None
@@ -285,11 +308,105 @@ class TestDBLookupHelpers:
         """Test DB lookup returns parsed tier for valid DB value."""
         import core.db as core_db
 
-        session = _FakeSession("VIP")
+        session = _FakeSession()
         monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="vip", status="active")],
+        )
         result = api_tiers_mod._lookup_tier_from_db("key")
         assert result.status == DBLookupStatus.HIT
         assert result.tier == SubscriptionTier.VIP
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_returns_highest_active_entitlement_from_persisted_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test persisted rows resolve highest active entitlement across sources."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [
+                _subscription_row(
+                    tier="pro",
+                    status="active",
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+                ),
+                _subscription_row(
+                    tier="vip",
+                    status="active",
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=60),
+                ),
+            ],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.HIT
+        assert result.tier == SubscriptionTier.VIP
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_returns_free_for_non_active_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test known non-active persisted states resolve to FREE rather than MISS."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="pro", status="cancelled")],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.HIT
+        assert result.tier == SubscriptionTier.FREE
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_ignores_active_rows_with_past_expiry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test active rows with expired timestamps do not unlock paid routes."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [
+                _subscription_row(
+                    tier="vip",
+                    status="active",
+                    expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+                )
+            ],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.HIT
+        assert result.tier == SubscriptionTier.FREE
+        assert session.closed is True
+
+    def test_lookup_tier_from_db_handles_unknown_status_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test malformed persisted status remains fail-closed."""
+        import core.db as core_db
+
+        session = _FakeSession()
+        monkeypatch.setattr(core_db, "get_session_factory", lambda: lambda: session)
+        monkeypatch.setattr(
+            api_tiers_mod.subscriptions_store,
+            "list_subscriptions_for_user",
+            lambda **_kwargs: [_subscription_row(tier="pro", status="paused")],
+        )
+        result = api_tiers_mod._lookup_tier_from_db("key")
+        assert result.status == DBLookupStatus.INVALID_TIER
+        assert result.tier is None
         assert session.closed is True
 
 
@@ -549,10 +666,10 @@ class TestGetSubscriptionTier:
         )
         assert get_subscription_tier("db_key") == SubscriptionTier.VIP
 
-    def test_production_db_enabled_falls_back_to_env_on_db_miss(
+    def test_production_db_enabled_returns_free_on_db_miss(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test get_subscription_tier falls back to env only when DB lookup misses."""
+        """Test get_subscription_tier is fail-closed when persisted entitlement is missing."""
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.setenv("DEBUG", "false")
         monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
@@ -562,7 +679,7 @@ class TestGetSubscriptionTier:
             "_lookup_tier_from_db",
             lambda _: DBLookupResult(status=DBLookupStatus.MISS),
         )
-        assert get_subscription_tier("env_key") == SubscriptionTier.VIP
+        assert get_subscription_tier("env_key") == SubscriptionTier.FREE
         assert get_subscription_tier("unknown_key") == SubscriptionTier.FREE
 
     def test_production_db_error_returns_free_without_env_fallback(

--- a/tests/test_subscription_activation_api.py
+++ b/tests/test_subscription_activation_api.py
@@ -83,6 +83,12 @@ def _ios_payload(
     return payload
 
 
+def _relative_iso(*, days: int) -> str:
+    """Return a deterministic ISO timestamp relative to now for entitlement tests."""
+
+    return (datetime.now(timezone.utc) + timedelta(days=days)).replace(microsecond=0).isoformat()
+
+
 def _manual_payload(
     *,
     source: str,
@@ -344,7 +350,7 @@ def test_active_pro_allows_pro_but_not_vip(
             transaction_id="txn-pro-route-1",
             tier="pro",
             status="active",
-            expires_at="2026-04-01T00:00:00Z",
+            expires_at=_relative_iso(days=30),
         ),
     )
     assert activation.status_code == 200, activation.text
@@ -369,7 +375,7 @@ def test_active_vip_allows_vip_and_pro(
             transaction_id="txn-vip-route-1",
             tier="vip",
             status="active",
-            expires_at="2026-05-01T00:00:00Z",
+            expires_at=_relative_iso(days=45),
         ),
     )
     assert activation.status_code == 200, activation.text
@@ -394,7 +400,7 @@ def test_expired_entitlement_denied_everywhere(
             transaction_id="txn-expired-route-1",
             tier="vip",
             status="expired",
-            expires_at="2026-03-01T00:00:00Z",
+            expires_at=_relative_iso(days=-10),
         ),
     )
     assert activation.status_code == 200, activation.text
@@ -415,7 +421,7 @@ def test_cancelled_entitlement_denied_everywhere(
             transaction_id="txn-cancelled-route-1",
             tier="vip",
             status="active",
-            expires_at="2026-06-01T00:00:00Z",
+            expires_at=_relative_iso(days=60),
         ),
     )
     assert activation.status_code == 200, activation.text
@@ -466,7 +472,7 @@ def test_pre_entitlement_billing_route_stays_accessible(
             transaction_id="txn-pre-entitlement-1",
             tier="pro",
             status="active",
-            expires_at="2026-04-15T00:00:00Z",
+            expires_at=_relative_iso(days=35),
         ),
     )
     assert response.status_code == 200, response.text
@@ -511,7 +517,7 @@ def test_active_row_with_past_expiry_denies_paid_routes(
             transaction_id="txn-expiry-check-1",
             tier="pro",
             status="active",
-            expires_at="2026-06-01T00:00:00Z",
+            expires_at=_relative_iso(days=60),
         ),
     )
     assert activation.status_code == 200, activation.text

--- a/tests/test_subscription_activation_api.py
+++ b/tests/test_subscription_activation_api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import subprocess
 import sys
 from typing import Any
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 import pytest
@@ -33,6 +33,19 @@ def _reset_payments_state() -> None:
     from app.services import payments_activation
 
     payments_activation.reset_state()
+
+
+@pytest.fixture
+def _db_backed_paid_authz(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force production-like DB-backed authz for canonical paid-route checks."""
+
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("PRO_API_KEYS", "test_pro_key")  # pragma: allowlist secret
+    monkeypatch.setenv("VIP_API_KEYS", "test_vip_key")  # pragma: allowlist secret
 
 
 def _json(response: Any) -> dict[str, Any]:
@@ -123,6 +136,64 @@ def _load_audit(activation_id: str) -> SubscriptionActivationAudit:
         return audit
     finally:
         session.close()
+
+
+def _set_subscription_status_for_user_source(
+    *,
+    user_id: int,
+    source: str,
+    status: str,
+    expires_at: datetime | None = None,
+) -> None:
+    session_factory = core_db.get_session_factory()
+    session = session_factory()
+    try:
+        statement = select(Subscription).where(
+            Subscription.user_id == user_id,
+            Subscription.source == source,
+        )
+        subscription = session.execute(statement).scalar_one()
+        subscription.status = status
+        subscription.expires_at = expires_at
+        session.commit()
+    finally:
+        session.close()
+
+
+def _premium_week_payload() -> dict[str, Any]:
+    return {
+        "targets": {
+            "kcal": 2000,
+            "macros": {
+                "protein_g": 110.0,
+                "fat_g": 70.0,
+                "carbs_g": 220.0,
+                "fiber_g": 30.0,
+            },
+            "micro": {"vitamin_c_mg": 90.0, "iron_mg": 14.0},
+            "water_ml": 0,
+            "activity_week": {
+                "moderate_aerobic_min": 150,
+                "vigorous_aerobic_min": 75,
+                "strength_sessions": 2,
+                "steps_daily": 8000,
+            },
+        },
+        "diet_flags": [],
+        "lang": "en",
+    }
+
+
+def _vip_weekly_plan_payload() -> dict[str, Any]:
+    return {
+        "weight": 70.0,
+        "height": 170.0,
+        "age": 30,
+        "gender": "female",
+        "activity_level": "moderate",
+        "dietary_preferences": ["vegetarian"],
+        "target_calories": 1800,
+    }
 
 
 def test_activate_subscription_requires_transport_auth(client: TestClient) -> None:
@@ -241,6 +312,219 @@ def test_ios_expired_evidence_is_persisted_as_expired(
     payload = _json(response)
     assert payload["status"] == "expired"
     assert payload["activated_at"] is None
+
+
+def test_free_user_denied_on_canonical_pro_route(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    response = client.get("/api/v1/pro/session", headers=pro_headers)
+    assert response.status_code == 403, response.text
+
+
+def test_free_user_denied_on_canonical_vip_route(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    response = client.get("/api/v1/vip/health", headers=vip_headers)
+    assert response.status_code == 403, response.text
+
+
+def test_active_pro_allows_pro_but_not_vip(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(
+            transaction_id="txn-pro-route-1",
+            tier="pro",
+            status="active",
+            expires_at="2026-04-01T00:00:00Z",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+
+    pro_response = client.get("/api/v1/pro/session", headers=pro_headers)
+    assert pro_response.status_code == 200, pro_response.text
+    assert _json(pro_response)["tier"] == "PRO"
+
+    vip_response = client.get("/api/v1/vip/health", headers=pro_headers)
+    assert vip_response.status_code == 403, vip_response.text
+
+
+def test_active_vip_allows_vip_and_pro(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(
+            transaction_id="txn-vip-route-1",
+            tier="vip",
+            status="active",
+            expires_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+
+    pro_response = client.get("/api/v1/pro/session", headers=vip_headers)
+    assert pro_response.status_code == 200, pro_response.text
+    assert _json(pro_response)["tier"] == "VIP"
+
+    vip_response = client.get("/api/v1/vip/health", headers=vip_headers)
+    assert vip_response.status_code == 200, vip_response.text
+
+
+def test_expired_entitlement_denied_everywhere(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(
+            transaction_id="txn-expired-route-1",
+            tier="vip",
+            status="expired",
+            expires_at="2026-03-01T00:00:00Z",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+
+    assert client.get("/api/v1/pro/session", headers=vip_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=vip_headers).status_code == 403
+
+
+def test_cancelled_entitlement_denied_everywhere(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=vip_headers,
+        json=_ios_payload(
+            transaction_id="txn-cancelled-route-1",
+            tier="vip",
+            status="active",
+            expires_at="2026-06-01T00:00:00Z",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+    user_id = _json(activation)["user_id"]
+
+    _set_subscription_status_for_user_source(
+        user_id=user_id,
+        source="ios_app_store",
+        status="cancelled",
+    )
+
+    assert client.get("/api/v1/pro/session", headers=vip_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=vip_headers).status_code == 403
+
+
+def test_pending_manual_review_does_not_unlock_paid_routes(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_manual_payload(
+            source="swift_manual",
+            source_reference="swift-manual-route-1",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+    user_id = _json(activation)["user_id"]
+
+    subscription = _load_subscription_for_user_source(user_id, "swift_manual")
+    assert subscription.status == "pending_manual_review"
+
+    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=pro_headers).status_code == 403
+
+
+def test_pre_entitlement_billing_route_stays_accessible(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    response = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(
+            transaction_id="txn-pre-entitlement-1",
+            tier="pro",
+            status="active",
+            expires_at="2026-04-15T00:00:00Z",
+        ),
+    )
+    assert response.status_code == 200, response.text
+    assert _json(response)["status"] == "active"
+
+
+def test_deprecated_premium_alias_does_not_bypass_canonical_pro_authz(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    response = client.post(
+        "/api/v1/premium/plan/week-flexible",
+        headers=pro_headers,
+        json=_premium_week_payload(),
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_deprecated_vip_alias_does_not_bypass_backend_entitlement_truth(
+    client: TestClient,
+    vip_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    response = client.post(
+        "/api/v1/vip/weekly-plan",
+        headers=vip_headers,
+        json=_vip_weekly_plan_payload(),
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_active_row_with_past_expiry_denies_paid_routes(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    _db_backed_paid_authz: None,
+) -> None:
+    activation = client.post(
+        "/api/v1/pro/payments/activate",
+        headers=pro_headers,
+        json=_ios_payload(
+            transaction_id="txn-expiry-check-1",
+            tier="pro",
+            status="active",
+            expires_at="2026-06-01T00:00:00Z",
+        ),
+    )
+    assert activation.status_code == 200, activation.text
+    user_id = _json(activation)["user_id"]
+
+    _set_subscription_status_for_user_source(
+        user_id=user_id,
+        source="ios_app_store",
+        status="active",
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+
+    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
 
 
 def test_activate_subscription_unsupported_source_returns_422(

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -16,6 +16,7 @@ def vip_anonymous_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
     for name in (
         "API_KEY",
         "APP_ENV",

--- a/tests/test_vip_anonymous_api_key_safety.py
+++ b/tests/test_vip_anonymous_api_key_safety.py
@@ -16,7 +16,6 @@ def vip_anonymous_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
-    monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
     for name in (
         "API_KEY",
         "APP_ENV",
@@ -309,6 +308,7 @@ class TestVIPAnonymousAPIKeySafety:
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.setenv("DEBUG", "false")
         monkeypatch.setenv("API_KEY", "secret-key")
+        monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
 
         import app
 

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -22,7 +22,6 @@ def vip_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep production-mode VIP tests isolated from ENVIRONMENT drift."""
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
-    monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
     monkeypatch.setenv("APP_ENV", "production")
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
@@ -66,6 +65,7 @@ class TestVIPProductionMode:
     def test_vip_api_key_validation_correct_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test API key validation with correct key passes authentication."""
         monkeypatch.setenv("API_KEY", "secret-key")
+        monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
 
         import app
 
@@ -82,6 +82,7 @@ class TestVIPProductionMode:
     def test_weekly_menu_generation_error_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test weekly menu generation error handling (line 155)."""
         monkeypatch.setenv("API_KEY", "secret-key")
+        monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
 
         from fastapi.routing import APIRoute
 
@@ -154,6 +155,7 @@ class TestVIPProductionMode:
         - Line 663: Regional search error handling
         """
         monkeypatch.setenv("API_KEY", "secret-key")
+        monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
 
         import app
 

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -22,6 +22,7 @@ def vip_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep production-mode VIP tests isolated from ENVIRONMENT drift."""
 
     monkeypatch.setenv("VIP_MODULE_ENABLED", "true")
+    monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
     monkeypatch.setenv("APP_ENV", "production")
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")


### PR DESCRIPTION
## Summary

Enforce backend subscription entitlements on canonical PRO/VIP routes.

This PR closes the third runtime segment:
activation -> entitlement -> protected routing.

## Why

Purchase and activation are insufficient if backend routing still does not trust
server-side subscription state as the only truth.

Canonical paid routes must be protected by backend entitlement checks.

## Scope

- wire persisted backend entitlement lookup into PRO/VIP guard decisions
- fail closed for canonical paid routes when DB state is missing or invalid
- deny free/expired/cancelled/pending-manual-review users consistently
- preserve pre-entitlement billing entry routes
- prevent deprecated VIP alias from bypassing canonical authz outcome

## Expected Files

- app/middleware/api_tiers.py
- app/services/subscriptions.py
- app/routers/vip.py
- tests/test_api_tiers.py
- tests/test_subscription_activation_api.py

## Non-goals

- no iOS StoreKit UI work
- no OpenAPI namespace cleanup
- no client-side generated model refresh
- no Apple verify or activation persistence redesign

## Risks

- accidental route under-protection
- accidental route over-protection
- legacy alias paths bypassing canonical guards
- expiry semantics inconsistent across routes

## Test Plan

- free user denied on canonical PRO routes
- free user denied on canonical VIP routes
- active PRO allowed on PRO and denied on VIP
- active VIP allowed on PRO and VIP
- expired/cancelled/manual-review denied everywhere
- deprecated aliases do not bypass canonical authz outcome

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917955375 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: app/routers/vip.py:645
Reason: Legacy VIP alias now always enforces `require_vip_tier()`, removing the env-backed bypass.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929151574 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: app/routers/vip.py:645
Reason: Review summary covered the same VIP alias bypass and is fixed by the unconditional VIP-tier check.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968517 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: app/routers/vip.py:645
Reason: cubic identified the same legacy VIP alias bypass; the guard now runs regardless of DB mode.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917968531 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: tests/test_subscription_activation_api.py:86
Reason: Authz expiry inputs now use `_relative_iso(...)` instead of hard-coded future timestamps.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929165943 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: app/routers/vip.py:645; tests/test_subscription_activation_api.py:86
Reason: cubic review summary covered both the VIP alias bypass and hard-coded authz expiry dates; both were fixed in this commit.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2917973544 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
Reason: Merge-readiness checklist items were changed back to unchecked state pending final merge cycle.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929171608 -> eac2ebf6
Disposition: FIXED
Commit: eac2ebf6
Evidence: docs/review/PR_1110_FIXED_MAPPING.md:37
Reason: Review summary covered the same merge-readiness checkbox issue and is fixed in the artifact.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929270340 -> 439d41b8
Disposition: FIXED
Commit: 439d41b8
Evidence: app/routers/vip.py:642
Reason: Legacy VIP alias now applies `require_vip_tier()` to explicit keys and dev/test fallback keys, removing the anonymous bypass outside the original diff.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122334 -> 439d41b8
Disposition: FIXED
Commit: 439d41b8
Evidence: tests/test_vip_anonymous_api_key_safety.py:311
Reason: The anonymous-safety fixture no longer enables `VIP_API_KEYS` globally; the VIP env path is now opted into only by the test that exercises it.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918122340 -> 439d41b8
Disposition: FIXED
Commit: 439d41b8
Evidence: tests/test_vip_production_simple.py:68
Reason: Production VIP tests now set `VIP_API_KEYS` only in the cases that intentionally cover that auth path, keeping the source under test explicit.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929330945 -> 439d41b8
Disposition: FIXED
Commit: 439d41b8
Evidence: tests/test_vip_anonymous_api_key_safety.py:311; tests/test_vip_production_simple.py:68
Reason: Review summary covered the same two test-fixture ambiguity fixes and is resolved by the scoped `VIP_API_KEYS` setup.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222586 -> 9a46c760
Disposition: FIXED
Commit: 9a46c760
Evidence: app/middleware/api_tiers.py:194
Reason: `subscriptions` is now imported inside `_lookup_tier_from_db()` so module import of `api_tiers.py` no longer pulls subscription models into OpenAPI-time import paths.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#discussion_r2918222595 -> 9a46c760
Disposition: FIXED
Commit: 9a46c760
Evidence: app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
Reason: Invalid non-datetime `expires_at` values now fail closed through `INVALID_TIER`, with a targeted regression test covering the malformed persisted state.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1110#pullrequestreview-3929437556 -> 9a46c760
Disposition: FIXED
Commit: 9a46c760
Evidence: app/middleware/api_tiers.py:194; app/middleware/api_tiers.py:233; tests/test_api_tiers.py:317
Reason: Review summary covered both api_tiers fixes: localizing the subscriptions import and denying malformed persisted expiry values.

## Merge Readiness
- [ ] python3 scripts/orchestration/check_preflight.py
- [ ] python3 scripts/orchestration/check_agent_consistency.py
- [ ] python3 scripts/orchestration/route_with_telemetry.py --domain backend --task-type "authz backend entitlements"
- [ ] pre-commit run --all-files
- [ ] make verify
- [ ] diff-cover >= 97% in PR CI
- [ ] required checks PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced input validation for subscription data with improved error handling.
  * Strengthened VIP access verification with consistent error responses across API routes.

* **Bug Fixes**
  * Improved robustness of subscription data parsing to handle edge cases gracefully.

* **Tests**
  * Expanded test coverage for subscription access control and entitlement states.
  * Added fixtures and helpers for authorization testing.

* **Documentation**
  * Added PR review documentation file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
