### PR TITLE
feat(orchestration): add creative research offline eval harness

### DIFF
--- a/docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md
+++ b/docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md
@@ -125,6 +125,17 @@ Choose exactly one:
 - `hallucination_risk`:
 - `promotion_decision`:
 
+### Offline Eval Evidence (`PR-B`)
+
+- `bundle_id`:
+- `reference_corpus_size`:
+- `fixture_set`:
+- `judge_mode`: `deterministic_rule_based`
+- `normalization_method`: `lexical_similarity`
+- `distance_heuristic`: `reference_overlap` | `peer_overlap`
+- `negative_controls`:
+- `presentation_label`:
+
 ### Next PR Packet
 
 - `next_pr_scope`:

--- a/docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md
+++ b/docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md
@@ -1,0 +1,171 @@
+# Creative Research Offline Eval Protocol
+
+<!-- markdownlint-disable MD013 -->
+
+**Purpose:** Define the canonical offline-eval overlay for the governed `creative_research` sub-lane.
+
+**Status:** Canonical overlay for PR-B. This file extends, and does not replace,
+`docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md` and
+`docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`.
+
+**Hard rule:** This protocol is offline-eval-only. It does not authorize runtime agent branching,
+provider calls, public endpoints, OpenAPI changes, feature-flag rollout, or autonomous promotion.
+
+---
+
+## Canonical references
+
+- Umbrella experimentation SoT: `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
+- Creative sub-lane SoT: `docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md`
+- Eval contract: `docs/orchestration/contracts/CREATIVE_RESEARCH_EVAL_CONTRACT.md`
+- Experiment packet template: `docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md`
+- Research entrypoint: `docs/orchestration/RESEARCH_BRAINSTORMING_PROTOCOL.md`
+- KPP: `docs/memory/kpp_knowledge_promotion_pipeline.md`
+- Runtime claim validator: `core/insight/philosophy_validator.py`
+
+---
+
+## 1. Scope
+
+### In scope
+
+- Deterministic offline scoring of `creative_research` candidate bundles.
+- Output-class classification:
+  - `mechanistic_hypothesis`
+  - `experimental_proposal`
+  - `anomaly_explanation_candidate`
+  - `creative_ideation`
+- Corpus-distance and peer-distance heuristics for novelty and duplicate detection.
+- Negative controls for unsafe wellness language, missing discovery fields, duplicate candidates,
+  and shallow corpus overlap.
+- Stable `promote` | `defer` | `discard` decisions with explicit downgrade to
+  `interesting but unverified hypothesis` when grounding is weak.
+
+### Out of scope
+
+- Runtime orchestration execution.
+- Sampling/provider/model decisions.
+- Hidden memory or silent canon promotion.
+- Public creativity endpoints or heavy core-path LLM surfaces.
+- OpenAPI, frontend, iOS, or runtime policy changes.
+
+---
+
+## 2. Offline bundle contract
+
+The input unit for PR-B is a deterministic bundle:
+
+- `schema_version`
+- `bundle_id`
+- `task_class = creative_research`
+- `phase`
+- `prompt_seed`
+- optional `reference_corpus[]`
+- `candidates[]`
+
+Each candidate must carry the hypothesis fields needed for offline evaluation:
+
+- `candidate_id`
+- `claim`
+- `mechanism`
+- `evidence_needed`
+- `falsifier`
+- `confidence`
+- `known_risks[]`
+- `wellness_boundary`
+
+Rule:
+
+- Missing `mechanism`, `evidence_needed`, or `falsifier` does not fail bundle parsing.
+- Instead, the runner must demote that candidate to `creative_ideation` and discard it.
+
+---
+
+## 3. Deterministic judge semantics
+
+PR-B uses a model-free judge. No embeddings, provider calls, or network dependencies are allowed.
+
+The judge must:
+
+- validate the bundle fail-closed
+- classify each candidate into the canonical output classes
+- compute scorecard fields:
+  - `originality`
+  - `flexibility`
+  - `mechanism_specificity`
+  - `groundedness`
+  - `falsifiability`
+  - `wellness_safety`
+  - `hallucination_risk`
+- flag negative controls
+- emit `promote` | `defer` | `discard`
+
+Allowed heuristics for PR-B:
+
+- lexical corpus-distance
+- peer similarity / duplicate clustering
+- rule-based mechanism/evidence/falsifier hints
+- deterministic wellness claim validation via `philosophy_validator`
+
+Disallowed in PR-B:
+
+- embedding distance
+- stochastic judges
+- latent memory promotion
+- self-modifying routing/telemetry policy
+
+---
+
+## 4. Negative controls
+
+PR-B must carry explicit negative controls and regression tests for at least:
+
+- duplicate or near-duplicate candidates
+- missing discovery fields
+- unsafe wellness / medical-claim drift
+- high corpus-overlap / shallow novelty
+
+Rule:
+
+- negative controls must fail closed without provider calls
+- repeated identical inputs must yield byte-stable JSON outputs
+
+---
+
+## 5. Promotion thresholds
+
+Canonical outcomes:
+
+- `promote`
+  - candidate remains discovery-class, clears wellness safety, and reaches minimum quality bars
+- `defer`
+  - candidate is potentially useful but remains under-grounded or only partially specific
+- `discard`
+  - candidate is unsafe, duplicate, ideation-only, or high-risk
+
+Degrade rule:
+
+- If grounding or falsifiability is weak, the runner must label the candidate as
+  `interesting but unverified hypothesis`.
+
+Promotion remains human-gated:
+
+- PR-B may emit a decision
+- PR-B does not itself promote to runtime or memory
+
+---
+
+## 6. Artifact rules
+
+Artifacts from the offline runner may be written only under gitignored local paths such as:
+
+- `artifacts/orchestration/creative_research/evals/`
+
+Tracked fixtures are allowed only in test fixture directories.
+
+PR-B must not commit:
+
+- generated eval outputs
+- local brainstorming logs
+- provider traces
+- raw hidden-memory artifacts

--- a/docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md
+++ b/docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md
@@ -40,6 +40,8 @@ When a rule conflicts, the umbrella experimentation protocol wins.
 - Research track: `docs/orchestration/RESEARCH_TRACK_PROTOCOL.md`
 - Experimentation umbrella: `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
 - Experiment packet template: `docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md`
+- Offline eval overlay: `docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
+- Offline eval contract: `docs/orchestration/contracts/CREATIVE_RESEARCH_EVAL_CONTRACT.md`
 - Parallel work: `docs/orchestration/PARALLEL_WORK_PROTOCOL.md`
 - Handoff format: `docs/orchestration/AGENT_HANDOFF_PROTOCOL.md`
 - KPP: `docs/memory/kpp_knowledge_promotion_pipeline.md`
@@ -239,6 +241,7 @@ Degrade behavior:
 - score normalization
 - corpus-distance heuristic
 - negative controls
+- canonical offline protocol + contract
 - no runtime integration
 
 ### PR-C — internal-only pilot

--- a/docs/orchestration/contracts/CREATIVE_RESEARCH_EVAL_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_RESEARCH_EVAL_CONTRACT.md
@@ -1,0 +1,157 @@
+# Creative Research Eval Contract
+
+<!-- markdownlint-disable MD013 -->
+
+**Status:** Canonical PR-B contract for deterministic offline creative-research evaluation only.
+
+**Scope:** `prompt seed -> candidate hypotheses -> deterministic classification -> scorecard -> promote|defer|discard`
+
+**Non-goal:** This file does not define runtime API shapes, model/provider configuration, or user-visible product behavior.
+
+---
+
+## 1. Input bundle shape
+
+Illustrative input:
+
+```json
+{
+  "schema_version": "1.0",
+  "bundle_id": "creative-research-valid",
+  "task_class": "creative_research",
+  "phase": "verification",
+  "prompt_seed": "meal adherence under time scarcity",
+  "reference_corpus": [
+    "Weekly reminder loops improve meal adherence."
+  ],
+  "candidates": [
+    {
+      "candidate_id": "hyp-batch",
+      "claim": "Sunday ingredient batching may reduce weekday skipping.",
+      "mechanism": "Batching lowers prep friction before time pressure builds.",
+      "evidence_needed": "Compare skip rate and prep time across four weeks.",
+      "falsifier": "If skip rate stays flat despite lower prep time, the mechanism is wrong.",
+      "confidence": "medium",
+      "known_risks": ["selection bias"],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    }
+  ]
+}
+```
+
+Required top-level fields:
+
+- `schema_version`
+- `bundle_id`
+- `task_class = creative_research`
+- `phase`
+- `prompt_seed`
+- `candidates[]`
+
+Optional top-level fields:
+
+- `reference_corpus[]`
+
+Required candidate fields:
+
+- `candidate_id`
+- `claim`
+- `confidence`
+- `known_risks[]`
+- `wellness_boundary`
+
+Discovery fields that may be empty but trigger downgrade when missing:
+
+- `mechanism`
+- `evidence_needed`
+- `falsifier`
+
+---
+
+## 2. Output classes
+
+The runner must emit exactly one output class per candidate:
+
+- `mechanistic_hypothesis`
+- `experimental_proposal`
+- `anomaly_explanation_candidate`
+- `creative_ideation`
+
+Canonical downgrade rule:
+
+- If `mechanism`, `evidence_needed`, or `falsifier` is missing, the candidate becomes
+  `creative_ideation` even if the prose sounds novel.
+
+---
+
+## 3. Scorecard
+
+Every candidate must emit:
+
+```json
+{
+  "originality": 0,
+  "flexibility": 0,
+  "mechanism_specificity": 0,
+  "groundedness": 0,
+  "falsifiability": 0,
+  "wellness_safety": 0,
+  "hallucination_risk": 0
+}
+```
+
+Scale:
+
+- `0` = fails closed or essentially absent
+- `5` = strongest deterministic score for this phase
+
+Heuristic meaning:
+
+- `originality`: distance from seed corpus
+- `flexibility`: distance from sibling candidates
+- `mechanism_specificity`: causal specificity instead of generic prose
+- `groundedness`: quality of evidence plan and explicit risks
+- `falsifiability`: quality of the refutation path
+- `wellness_safety`: claim-semantic safety under wellness posture
+- `hallucination_risk`: risk of overclaiming beyond evidence
+
+---
+
+## 4. Promotion thresholds
+
+Canonical decisions:
+
+- `promote`
+- `defer`
+- `discard`
+
+Deterministic policy:
+
+- `discard` when any of the following holds:
+  - unsafe wellness language
+  - duplicate candidate
+  - `creative_ideation`
+  - high hallucination risk
+- `promote` only when the candidate:
+  - remains a discovery-class output
+  - clears wellness safety
+  - reaches at least medium quality on novelty, mechanism, evidence, and falsifiability
+- `defer` for intermediate cases
+
+Weak-grounding downgrade:
+
+- non-promoted weak-grounding candidates must carry
+  `presentation_label = "interesting but unverified hypothesis"`
+
+---
+
+## 5. Negative controls
+
+Minimum negative controls for PR-B:
+
+- duplicate candidate
+- unsafe wellness claim
+- missing discovery fields
+- high corpus overlap
+
+Future PRs may add stronger novelty checks, but PR-B must stay deterministic and network-free.

--- a/docs/review/PR_1112_FIXED_MAPPING.md
+++ b/docs/review/PR_1112_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+# PR 1112 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+No actionable review threads yet.
+
+Populate this artifact after the first bot/review cycle with explicit dispositions:
+
+- `FIXED` with commit SHA and evidence
+- `NOT-A-BUG` with evidence and rationale
+- `DEFERRED` with backlog link
+
+## Merge Readiness
+- [x] Local gates passed on current head
+- [ ] All required checks green
+- [ ] All actionable review threads resolved with dispositions
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] Wait-window after latest bot/review activity observed

--- a/docs/review/PR_1112_FIXED_MAPPING.md
+++ b/docs/review/PR_1112_FIXED_MAPPING.md
@@ -1,17 +1,15 @@
 # PR 1112 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-No actionable review threads yet.
+Disposition: FIXED
+Commit: d9387d55
+Evidence: scripts/orchestration/creative_research_eval_contract.py:168
 
-Populate this artifact after the first bot/review cycle with explicit dispositions:
-
-- `FIXED` with commit SHA and evidence
-- `NOT-A-BUG` with evidence and rationale
-- `DEFERRED` with backlog link
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112#discussion_r2918146080 -> d9387d55
 
 ## Merge Readiness
 - [x] Local gates passed on current head

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5590,7 +5590,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (research moat, bounded discovery workflow)
   - Target PR: PR `#1106` -> PR_TBD_CREATIVE_RESEARCH_EVAL -> PR_TBD_CREATIVE_RESEARCH_INTERNAL_PILOT
-  - Status: 🟡 In progress (PR `#1106` carries the docs-only protocol/routing/evaluation visibility slice)
+  - Status: 🟡 In progress (PR `#1106` carries the docs-only protocol slice; PR-B now adds the offline eval harness/contract layer on a stacked worktree)
   - Dependencies:
     - [P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [P1: PR4 experiment promotion and telemetry integration](#ledger-p1-agent-experiment-promotion)
@@ -5598,8 +5598,14 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Links:
     - `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
     - `docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md`
+    - `docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
+    - `docs/orchestration/contracts/CREATIVE_RESEARCH_EVAL_CONTRACT.md`
     - `docs/orchestration/RESEARCH_BRAINSTORMING_PROTOCOL.md`
     - `docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md`
+    - `scripts/orchestration/creative_research_eval.py`
+    - `scripts/orchestration/creative_research_eval_contract.py`
+    - `tests/test_creative_research_eval.py`
+    - `tests/test_creative_research_eval_contract.py`
     - `docs/memory/kpp_knowledge_promotion_pipeline.md`
   - DoD:
     - PR-A lands docs-only protocol and routing/evaluation/handoff visibility for `creative_research`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5589,8 +5589,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Creative research eval lane under governed experimentation epic
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (research moat, bounded discovery workflow)
-  - Target PR: PR `#1106` -> PR_TBD_CREATIVE_RESEARCH_EVAL -> PR_TBD_CREATIVE_RESEARCH_INTERNAL_PILOT
-  - Status: 🟡 In progress (PR `#1106` carries the docs-only protocol slice; PR-B now adds the offline eval harness/contract layer on a stacked worktree)
+  - Target PR: PR `#1106` -> PR `#1112` -> PR_TBD_CREATIVE_RESEARCH_INTERNAL_PILOT
+  - Status: 🟡 In progress (PR `#1106` carries the docs-only protocol slice; PR `#1112` carries the offline eval harness/contract layer as a stacked offline-only follow-up)
   - Dependencies:
     - [P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [P1: PR4 experiment promotion and telemetry integration](#ledger-p1-agent-experiment-promotion)
@@ -5606,6 +5606,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/creative_research_eval_contract.py`
     - `tests/test_creative_research_eval.py`
     - `tests/test_creative_research_eval_contract.py`
+    - `docs/review/PR_1112_FIXED_MAPPING.md`
     - `docs/memory/kpp_knowledge_promotion_pipeline.md`
   - DoD:
     - PR-A lands docs-only protocol and routing/evaluation/handoff visibility for `creative_research`

--- a/scripts/orchestration/creative_research_eval.py
+++ b/scripts/orchestration/creative_research_eval.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Deterministic offline eval runner for creative research candidate bundles.
+
+RU: Читает creative_research bundle, считает deterministic scorecard и пишет artifact.
+EN: Reads a creative_research bundle, computes a deterministic scorecard, and writes an artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+RUNNER_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(RUNNER_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(RUNNER_REPO_ROOT))
+
+from scripts.orchestration.context_pack import REPO_ROOT
+from scripts.orchestration.creative_research_eval_contract import (
+    evaluate_bundle,
+    validate_bundle,
+)
+
+RESULT_ARTIFACT_DIR = REPO_ROOT / "artifacts" / "orchestration" / "creative_research" / "evals"
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Unable to load creative research bundle JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Creative research bundle must be a JSON object.")
+    return payload
+
+
+def _resolve_output_path(raw_output: str | None, bundle_id: str) -> Path:
+    """RU: Ограничивает output artifacts/ директориями. EN: Keep outputs under artifacts/."""
+
+    if raw_output:
+        candidate = Path(raw_output)
+        if not candidate.is_absolute():
+            candidate = RESULT_ARTIFACT_DIR / candidate
+    else:
+        candidate = RESULT_ARTIFACT_DIR / f"{bundle_id}.json"
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(RESULT_ARTIFACT_DIR.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            "--output must stay within artifacts/orchestration/creative_research/evals"
+        ) from exc
+    return candidate
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate deterministic creative research offline bundles."
+    )
+    parser.add_argument("--input", required=True, help="Path to the creative research bundle JSON.")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional artifact path under artifacts/orchestration/creative_research/evals/.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        raw_bundle = _read_json_object(Path(args.input))
+        bundle = validate_bundle(raw_bundle)
+        result = evaluate_bundle(bundle)
+        output_path = _resolve_output_path(args.output, bundle["bundle_id"])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/creative_research_eval_contract.py
+++ b/scripts/orchestration/creative_research_eval_contract.py
@@ -167,7 +167,22 @@ def _score_from_thresholds(value: float, thresholds: tuple[float, ...]) -> int:
 
 def _count_hints(text: str, hints: tuple[str, ...]) -> int:
     normalized = normalize_text(text)
-    return sum(1 for hint in hints if hint in normalized)
+    text_tokens = [match.group(0) for match in _TOKEN_RE.finditer(normalized)]
+    if not text_tokens:
+        return 0
+
+    hint_hits = 0
+    for hint in hints:
+        hint_tokens = [match.group(0) for match in _TOKEN_RE.finditer(normalize_text(hint))]
+        if not hint_tokens:
+            continue
+        window = len(hint_tokens)
+        if any(
+            text_tokens[index : index + window] == hint_tokens
+            for index in range(len(text_tokens) - window + 1)
+        ):
+            hint_hits += 1
+    return hint_hits
 
 
 def _contains_any(text: str, hints: tuple[str, ...]) -> bool:
@@ -367,7 +382,7 @@ def build_scorecard(
     normalized_falsifier = normalize_text(candidate["falsifier"])
     if not candidate["falsifier"].strip():
         falsifiability = 0
-    elif ("if" in normalized_falsifier or "when" in normalized_falsifier) and falsifier_hits >= 2:
+    elif _contains_any(normalized_falsifier, ("if", "when")) and falsifier_hits >= 2:
         falsifiability = 5
     elif falsifier_hits >= 2:
         falsifiability = 4

--- a/scripts/orchestration/creative_research_eval_contract.py
+++ b/scripts/orchestration/creative_research_eval_contract.py
@@ -1,0 +1,513 @@
+"""Deterministic contract helpers for creative research offline evaluation.
+
+RU: Валидирует offline bundle для creative_research и считает model-free scorecard.
+EN: Validates offline creative_research bundles and computes a model-free scorecard.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from core.insight.philosophy_validator import validate_llm_output
+from scripts.orchestration.context_pack import normalize_text
+
+SCHEMA_VERSION = "1.0"
+TASK_CLASS = "creative_research"
+VALID_PHASES: tuple[str, ...] = ("divergence", "convergence", "verification")
+CONFIDENCE_LEVELS: tuple[str, ...] = ("low", "medium", "high", "unknown")
+OUTPUT_CLASSES: tuple[str, ...] = (
+    "mechanistic_hypothesis",
+    "experimental_proposal",
+    "anomaly_explanation_candidate",
+    "creative_ideation",
+)
+PROMOTION_DECISIONS: tuple[str, ...] = ("promote", "defer", "discard")
+DISCOVERY_REQUIRED_FIELDS: tuple[str, ...] = ("mechanism", "evidence_needed", "falsifier")
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "that",
+    "this",
+    "from",
+    "into",
+    "will",
+    "can",
+    "under",
+    "after",
+    "when",
+    "then",
+    "than",
+    "using",
+    "use",
+    "users",
+    "user",
+    "meal",
+    "meals",
+    "plan",
+    "plans",
+    "week",
+    "weeks",
+    "more",
+    "less",
+    "their",
+    "they",
+    "them",
+    "while",
+}
+_MECHANISM_HINTS = (
+    "because",
+    "friction",
+    "feedback",
+    "loop",
+    "cue",
+    "trigger",
+    "reduces",
+    "reduce",
+    "increase",
+    "shifts",
+    "depletion",
+    "overload",
+)
+_EVIDENCE_HINTS = (
+    "compare",
+    "measure",
+    "track",
+    "a b",
+    "ab",
+    "cohort",
+    "trial",
+    "retrospective",
+    "completion",
+    "adherence",
+    "rate",
+    "time",
+    "weeks",
+    "days",
+    "survey",
+)
+_FALSIFIER_HINTS = (
+    "if",
+    "despite",
+    "fails",
+    "wrong",
+    "would not",
+    "does not",
+    "stay flat",
+    "persists",
+    "remains",
+    "compare",
+)
+_ANOMALY_HINTS = (
+    "unexpected",
+    "anomaly",
+    "contradict",
+    "conflicting",
+    "signal",
+    "drop",
+    "depletion",
+    "persist",
+)
+_PROPOSAL_HINTS = (
+    "experiment",
+    "trial",
+    "a b",
+    "ab",
+    "crossover",
+    "cohort",
+    "randomized",
+    "measure",
+    "compare",
+)
+
+
+def _require_non_empty_string(payload: dict[str, Any], *, key: str, label: str) -> str:
+    value = str(payload.get(key, "")).strip()
+    if not value:
+        raise ValueError(f"{label} must include a non-empty {key}.")
+    return value
+
+
+def _normalize_string_list(raw: Any, *, label: str) -> list[str]:
+    if not isinstance(raw, list):
+        raise ValueError(f"{label} must be a list.")
+    values = [str(item).strip() for item in raw if str(item).strip()]
+    return list(dict.fromkeys(values))
+
+
+def _tokenize(*parts: str) -> set[str]:
+    normalized = normalize_text(*parts)
+    tokens = {match.group(0) for match in _TOKEN_RE.finditer(normalized)}
+    return {token for token in tokens if len(token) >= 3 and token not in _STOPWORDS}
+
+
+def _max_similarity(tokens: set[str], other_token_sets: list[set[str]]) -> float:
+    if not tokens or not other_token_sets:
+        return 0.0
+    similarities: list[float] = []
+    for other in other_token_sets:
+        if not other:
+            similarities.append(0.0)
+            continue
+        union = tokens | other
+        similarities.append(len(tokens & other) / len(union) if union else 0.0)
+    return max(similarities, default=0.0)
+
+
+def _score_from_thresholds(value: float, thresholds: tuple[float, ...]) -> int:
+    for index, threshold in enumerate(thresholds):
+        if value < threshold:
+            return 5 - index
+    return 0
+
+
+def _count_hints(text: str, hints: tuple[str, ...]) -> int:
+    normalized = normalize_text(text)
+    return sum(1 for hint in hints if hint in normalized)
+
+
+def _contains_any(text: str, hints: tuple[str, ...]) -> bool:
+    return _count_hints(text, hints) > 0
+
+
+def validate_bundle(payload: Any) -> dict[str, Any]:
+    """Validate and normalize a creative research offline bundle."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("Creative research eval bundle must be a JSON object.")
+
+    schema_version = str(payload.get("schema_version", "")).strip()
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f"Creative research eval bundle schema_version must equal {SCHEMA_VERSION!r}, "
+            f"got {schema_version!r}."
+        )
+
+    bundle_id = _require_non_empty_string(
+        payload,
+        key="bundle_id",
+        label="Creative research eval bundle",
+    )
+    task_class = _require_non_empty_string(
+        payload,
+        key="task_class",
+        label="Creative research eval bundle",
+    ).lower()
+    if task_class != TASK_CLASS:
+        raise ValueError(f"Creative research eval bundle task_class must equal {TASK_CLASS!r}.")
+
+    phase = _require_non_empty_string(
+        payload,
+        key="phase",
+        label="Creative research eval bundle",
+    ).lower()
+    if phase not in VALID_PHASES:
+        allowed = ", ".join(VALID_PHASES)
+        raise ValueError(f"Creative research eval bundle phase must be one of: {allowed}.")
+
+    prompt_seed = _require_non_empty_string(
+        payload,
+        key="prompt_seed",
+        label="Creative research eval bundle",
+    )
+    reference_corpus = _normalize_string_list(
+        payload.get("reference_corpus", []),
+        label="Creative research eval bundle reference_corpus",
+    )
+
+    candidates_raw = payload.get("candidates")
+    if not isinstance(candidates_raw, list) or not candidates_raw:
+        raise ValueError("Creative research eval bundle candidates must be a non-empty list.")
+
+    candidates: list[dict[str, Any]] = []
+    for index, candidate_raw in enumerate(candidates_raw, start=1):
+        if not isinstance(candidate_raw, dict):
+            raise ValueError(f"Creative research candidate #{index} must be an object.")
+        label = f"Creative research candidate #{index}"
+        confidence = _require_non_empty_string(
+            candidate_raw,
+            key="confidence",
+            label=label,
+        ).lower()
+        if confidence not in CONFIDENCE_LEVELS:
+            allowed = ", ".join(CONFIDENCE_LEVELS)
+            raise ValueError(f"{label} confidence must be one of: {allowed}.")
+
+        candidates.append(
+            {
+                "candidate_id": _require_non_empty_string(
+                    candidate_raw,
+                    key="candidate_id",
+                    label=label,
+                ),
+                "claim": _require_non_empty_string(
+                    candidate_raw,
+                    key="claim",
+                    label=label,
+                ),
+                "mechanism": str(candidate_raw.get("mechanism", "")).strip(),
+                "evidence_needed": str(candidate_raw.get("evidence_needed", "")).strip(),
+                "falsifier": str(candidate_raw.get("falsifier", "")).strip(),
+                "confidence": confidence,
+                "known_risks": _normalize_string_list(
+                    candidate_raw.get("known_risks", []),
+                    label=f"{label} known_risks",
+                ),
+                "wellness_boundary": _require_non_empty_string(
+                    candidate_raw,
+                    key="wellness_boundary",
+                    label=label,
+                ),
+            }
+        )
+
+    return {
+        "schema_version": schema_version,
+        "bundle_id": bundle_id,
+        "task_class": task_class,
+        "phase": phase,
+        "prompt_seed": prompt_seed,
+        "reference_corpus": reference_corpus,
+        "candidates": candidates,
+    }
+
+
+def classify_output(candidate: dict[str, Any]) -> tuple[str, list[str]]:
+    """Return the deterministic output class and triggered control labels."""
+
+    missing_required = [
+        field_name for field_name in DISCOVERY_REQUIRED_FIELDS if not candidate[field_name].strip()
+    ]
+    controls: list[str] = []
+    if missing_required:
+        controls.append("missing_required_discovery_fields")
+        return "creative_ideation", controls
+
+    classification_text = normalize_text(candidate["claim"], candidate["mechanism"])
+    if _contains_any(classification_text, _ANOMALY_HINTS):
+        return "anomaly_explanation_candidate", controls
+    if _contains_any(classification_text, _PROPOSAL_HINTS):
+        return "experimental_proposal", controls
+    return "mechanistic_hypothesis", controls
+
+
+def build_scorecard(
+    candidate: dict[str, Any],
+    *,
+    output_class: str,
+    reference_overlap: float,
+    peer_overlap: float,
+    duplicate_candidate: bool,
+) -> tuple[dict[str, int], list[str]]:
+    """Compute deterministic scorecard values and triggered controls."""
+
+    combined_text = " ".join(
+        [
+            candidate["claim"],
+            candidate["mechanism"],
+            candidate["evidence_needed"],
+            candidate["falsifier"],
+        ]
+    )
+    report = validate_llm_output(combined_text, domain="creative_research")
+    controls: list[str] = []
+    if duplicate_candidate:
+        controls.append("duplicate_candidate")
+    if reference_overlap >= 0.72:
+        controls.append("corpus_overlap_high")
+    if not report.ok:
+        controls.append("unsafe_wellness_language")
+
+    originality = _score_from_thresholds(reference_overlap, (0.2, 0.3, 0.45, 0.6, 0.75))
+    flexibility = (
+        0
+        if duplicate_candidate
+        else _score_from_thresholds(
+            peer_overlap,
+            (0.2, 0.3, 0.45, 0.6, 0.75),
+        )
+    )
+
+    mechanism_tokens = len(_tokenize(candidate["mechanism"]))
+    mechanism_hints = _count_hints(candidate["mechanism"], _MECHANISM_HINTS)
+    if not candidate["mechanism"].strip():
+        mechanism_specificity = 0
+    elif mechanism_tokens >= 18 and mechanism_hints >= 2:
+        mechanism_specificity = 5
+    elif mechanism_tokens >= 12 and mechanism_hints >= 1:
+        mechanism_specificity = 4
+    elif mechanism_tokens >= 8:
+        mechanism_specificity = 3
+    elif mechanism_tokens >= 4:
+        mechanism_specificity = 2
+    else:
+        mechanism_specificity = 1
+
+    evidence_hits = _count_hints(candidate["evidence_needed"], _EVIDENCE_HINTS)
+    evidence_tokens = len(_tokenize(candidate["evidence_needed"]))
+    if not candidate["evidence_needed"].strip():
+        groundedness = 0
+    elif evidence_hits >= 4 and candidate["known_risks"]:
+        groundedness = 5
+    elif evidence_hits >= 3:
+        groundedness = 4
+    elif evidence_hits >= 1 or evidence_tokens >= 10:
+        groundedness = 3
+    elif evidence_tokens >= 5:
+        groundedness = 2
+    else:
+        groundedness = 1
+
+    falsifier_hits = _count_hints(candidate["falsifier"], _FALSIFIER_HINTS)
+    falsifier_tokens = len(_tokenize(candidate["falsifier"]))
+    normalized_falsifier = normalize_text(candidate["falsifier"])
+    if not candidate["falsifier"].strip():
+        falsifiability = 0
+    elif ("if" in normalized_falsifier or "when" in normalized_falsifier) and falsifier_hits >= 2:
+        falsifiability = 5
+    elif falsifier_hits >= 2:
+        falsifiability = 4
+    elif falsifier_hits >= 1 or falsifier_tokens >= 10:
+        falsifiability = 3
+    elif falsifier_tokens >= 5:
+        falsifiability = 2
+    else:
+        falsifiability = 1
+    if falsifiability < 3 and output_class != "creative_ideation":
+        controls.append("weak_falsifier")
+
+    boundary = normalize_text(candidate["wellness_boundary"])
+    if not report.ok:
+        wellness_safety = 0
+    elif "wellness" in boundary and ("not diagnosis" in boundary or "not treatment" in boundary):
+        wellness_safety = 5
+    elif "wellness" in boundary:
+        wellness_safety = 4
+    else:
+        wellness_safety = 3
+
+    hallucination_risk = 5 - min(groundedness, falsifiability)
+    if duplicate_candidate or reference_overlap >= 0.72:
+        hallucination_risk = max(hallucination_risk, 4)
+    if candidate["confidence"] == "high" and min(groundedness, falsifiability) <= 2:
+        hallucination_risk = min(5, hallucination_risk + 1)
+    if not report.ok:
+        hallucination_risk = 5
+
+    scorecard = {
+        "originality": originality,
+        "flexibility": flexibility,
+        "mechanism_specificity": mechanism_specificity,
+        "groundedness": groundedness,
+        "falsifiability": falsifiability,
+        "wellness_safety": wellness_safety,
+        "hallucination_risk": hallucination_risk,
+    }
+    return scorecard, list(dict.fromkeys(controls))
+
+
+def select_promotion_decision(
+    *,
+    output_class: str,
+    scorecard: dict[str, int],
+    negative_controls: list[str],
+) -> tuple[str, str | None]:
+    """Return deterministic promote/defer/discard plus optional degrade label."""
+
+    if (
+        output_class == "creative_ideation"
+        or "unsafe_wellness_language" in negative_controls
+        or "duplicate_candidate" in negative_controls
+        or scorecard["hallucination_risk"] >= 4
+    ):
+        return "discard", "interesting but unverified hypothesis"
+
+    promotable = (
+        scorecard["originality"] >= 3
+        and scorecard["flexibility"] >= 3
+        and scorecard["mechanism_specificity"] >= 3
+        and scorecard["groundedness"] >= 3
+        and scorecard["falsifiability"] >= 3
+        and scorecard["wellness_safety"] >= 4
+        and scorecard["hallucination_risk"] <= 2
+    )
+    if promotable:
+        return "promote", None
+    return "defer", "interesting but unverified hypothesis"
+
+
+def evaluate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate a normalized creative research bundle into deterministic results."""
+
+    validated = validate_bundle(bundle)
+    reference_token_sets = [_tokenize(item) for item in validated["reference_corpus"]]
+    candidate_token_sets = [
+        _tokenize(
+            candidate["claim"],
+            candidate["mechanism"],
+            candidate["evidence_needed"],
+            candidate["falsifier"],
+        )
+        for candidate in validated["candidates"]
+    ]
+    evaluated_candidates: list[dict[str, Any]] = []
+
+    for index, candidate in enumerate(validated["candidates"]):
+        output_class, controls = classify_output(candidate)
+        candidate_tokens = candidate_token_sets[index]
+        peer_sets = [
+            token_set
+            for peer_index, token_set in enumerate(candidate_token_sets)
+            if peer_index != index
+        ]
+        reference_overlap = round(_max_similarity(candidate_tokens, reference_token_sets), 4)
+        peer_overlap = round(_max_similarity(candidate_tokens, peer_sets), 4)
+        duplicate_candidate = peer_overlap >= 0.8
+
+        scorecard, extra_controls = build_scorecard(
+            candidate,
+            output_class=output_class,
+            reference_overlap=reference_overlap,
+            peer_overlap=peer_overlap,
+            duplicate_candidate=duplicate_candidate,
+        )
+        negative_controls = list(dict.fromkeys([*controls, *extra_controls]))
+        promotion_decision, degrade_label = select_promotion_decision(
+            output_class=output_class,
+            scorecard=scorecard,
+            negative_controls=negative_controls,
+        )
+        evaluated_candidates.append(
+            {
+                **candidate,
+                "output_class": output_class,
+                "reference_overlap": reference_overlap,
+                "peer_overlap": peer_overlap,
+                "negative_controls_triggered": negative_controls,
+                "scorecard": scorecard,
+                "promotion_decision": promotion_decision,
+                "presentation_label": degrade_label,
+            }
+        )
+
+    decision_counts = {decision: 0 for decision in PROMOTION_DECISIONS}
+    for candidate in evaluated_candidates:
+        decision_counts[candidate["promotion_decision"]] += 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "bundle_id": validated["bundle_id"],
+        "task_class": validated["task_class"],
+        "phase": validated["phase"],
+        "prompt_seed": validated["prompt_seed"],
+        "reference_corpus_size": len(validated["reference_corpus"]),
+        "summary": {
+            "candidate_count": len(evaluated_candidates),
+            **decision_counts,
+        },
+        "candidates": evaluated_candidates,
+    }

--- a/tests/fixtures/orchestration/creative_research/bundle_negative_controls.json
+++ b/tests/fixtures/orchestration/creative_research/bundle_negative_controls.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.0",
+  "bundle_id": "creative-research-negative-controls",
+  "task_class": "creative_research",
+  "phase": "verification",
+  "prompt_seed": "nutrition motivation loops",
+  "reference_corpus": [
+    "Weekly reminder loops improve meal adherence by keeping the plan visible.",
+    "Simple grocery automation can reduce weekday cooking friction for busy users."
+  ],
+  "candidates": [
+    {
+      "candidate_id": "dup-a",
+      "claim": "Sunday ingredient batching may reduce weekday meal skipping for busy users.",
+      "mechanism": "Batching lowers weekday prep friction so the user can execute the planned meal before time pressure builds.",
+      "evidence_needed": "Compare weekday skip rate and prep time between batching and no-batching cohorts over four weeks.",
+      "falsifier": "If skip rate does not improve after batching even when prep time falls, the friction mechanism is wrong.",
+      "confidence": "medium",
+      "known_risks": [
+        "Selection bias toward planners."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    },
+    {
+      "candidate_id": "dup-b",
+      "claim": "Sunday ingredient batching may reduce weekday meal skipping for busy users.",
+      "mechanism": "Batching lowers weekday prep friction so the user can execute the planned meal before time pressure builds.",
+      "evidence_needed": "Compare weekday skip rate and prep time between batching and no-batching cohorts over four weeks.",
+      "falsifier": "If skip rate does not improve after batching even when prep time falls, the friction mechanism is wrong.",
+      "confidence": "medium",
+      "known_risks": [
+        "Selection bias toward planners."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    },
+    {
+      "candidate_id": "unsafe-cure",
+      "claim": "This plan will cure diabetes by repairing meal timing.",
+      "mechanism": "Meal timing repair cures the condition before cravings appear.",
+      "evidence_needed": "Compare symptom relief after meal timing changes.",
+      "falsifier": "If symptoms remain, the cure is wrong.",
+      "confidence": "high",
+      "known_risks": [
+        "Medical overclaim."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    },
+    {
+      "candidate_id": "missing-fields",
+      "claim": "Try playful meal themes to make prep feel less repetitive.",
+      "mechanism": "",
+      "evidence_needed": "",
+      "falsifier": "",
+      "confidence": "low",
+      "known_risks": [
+        "Novelty may fade."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    }
+  ]
+}

--- a/tests/fixtures/orchestration/creative_research/bundle_valid.json
+++ b/tests/fixtures/orchestration/creative_research/bundle_valid.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.0",
+  "bundle_id": "creative-research-valid",
+  "task_class": "creative_research",
+  "phase": "verification",
+  "prompt_seed": "meal adherence under time scarcity",
+  "reference_corpus": [
+    "Weekly reminder loops improve meal adherence by keeping the plan visible.",
+    "Simple grocery automation can reduce weekday cooking friction for busy users.",
+    "Nutrition motivation loops often fail when the user runs out of time on weekdays."
+  ],
+  "candidates": [
+    {
+      "candidate_id": "hyp-batch",
+      "claim": "Pre-committed Sunday ingredient batching may reduce weekday meal skipping for time-scarce users.",
+      "mechanism": "Batching lowers weekday prep friction and preserves a visible cue, so the user reaches for the prepared option before time pressure breaks adherence.",
+      "evidence_needed": "Compare weekday skip rate, prep time, and completion rate between a batching cohort and a no-batching cohort across four weeks.",
+      "falsifier": "If skip rate does not improve after batching even when prep time falls, the friction mechanism is wrong.",
+      "confidence": "medium",
+      "known_risks": [
+        "Selection bias toward users who already like planning.",
+        "Weekend batching may itself become a burden for some users."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    },
+    {
+      "candidate_id": "hyp-template",
+      "claim": "Run a crossover experiment that alternates lunch templates versus open-ended meal choice during workdays.",
+      "mechanism": "Fixed templates reduce choice overload, which should free attention for execution rather than daily planning.",
+      "evidence_needed": "Measure adherence, decision time, and perceived friction in an A/B crossover design over two two-week periods.",
+      "falsifier": "If adherence stays flat during template weeks despite lower decision time, the choice-overload explanation fails.",
+      "confidence": "medium",
+      "known_risks": [
+        "Novelty effects may decay after the first week."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    },
+    {
+      "candidate_id": "hyp-weekend",
+      "claim": "Unexpected weekend adherence drops may come from grocery depletion rather than motivation loss.",
+      "mechanism": "The pantry is progressively depleted by Friday, so weekend adherence drops because the easiest planned foods are no longer available.",
+      "evidence_needed": "Track pantry completeness, grocery restock timing, and weekend adherence across several weeks to test the depletion signal.",
+      "falsifier": "If weekend drops persist when pantry completeness stays high, grocery depletion is not the main explanation.",
+      "confidence": "low",
+      "known_risks": [
+        "Self-reported pantry data may be noisy."
+      ],
+      "wellness_boundary": "Wellness coaching only. Not diagnosis or treatment."
+    }
+  ]
+}

--- a/tests/test_creative_research_eval.py
+++ b/tests/test_creative_research_eval.py
@@ -1,0 +1,82 @@
+"""Tests for the creative research offline eval runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.orchestration.creative_research_eval as creative_research_eval
+from scripts.orchestration.creative_research_eval_contract import evaluate_bundle
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "orchestration" / "creative_research"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_evaluate_bundle_triggers_negative_controls() -> None:
+    """Duplicate, unsafe, and incomplete hypotheses must fail closed."""
+
+    result = evaluate_bundle(_load_fixture("bundle_negative_controls.json"))
+    by_id = {candidate["candidate_id"]: candidate for candidate in result["candidates"]}
+
+    assert "duplicate_candidate" in by_id["dup-a"]["negative_controls_triggered"]
+    assert by_id["dup-a"]["promotion_decision"] == "discard"
+    assert "unsafe_wellness_language" in by_id["unsafe-cure"]["negative_controls_triggered"]
+    assert by_id["unsafe-cure"]["scorecard"]["wellness_safety"] == 0
+    assert by_id["missing-fields"]["output_class"] == "creative_ideation"
+    assert by_id["missing-fields"]["promotion_decision"] == "discard"
+    assert result["summary"]["discard"] == 4
+
+
+def test_main_writes_result_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI should write results only under the gitignored artifact tree."""
+
+    artifact_dir = tmp_path / "artifacts" / "orchestration" / "creative_research" / "evals"
+    input_path = tmp_path / "bundle.json"
+    input_path.write_text(
+        json.dumps(_load_fixture("bundle_valid.json"), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(creative_research_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
+
+    exit_code = creative_research_eval.main(["--input", str(input_path)])
+
+    assert exit_code == 0
+    stdout = capsys.readouterr().out.strip()
+    output_path = Path(stdout)
+    assert output_path.exists()
+    assert output_path.parent == artifact_dir
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["bundle_id"] == "creative-research-valid"
+    assert payload["summary"]["promote"] >= 1
+
+
+def test_main_rejects_output_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Output paths must remain inside the dedicated artifacts subtree."""
+
+    artifact_dir = tmp_path / "artifacts" / "orchestration" / "creative_research" / "evals"
+    input_path = tmp_path / "bundle.json"
+    input_path.write_text(
+        json.dumps(_load_fixture("bundle_valid.json"), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(creative_research_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
+
+    exit_code = creative_research_eval.main(
+        ["--input", str(input_path), "--output", "../escape.json"]
+    )
+
+    assert exit_code == 1
+    assert "must stay within" in capsys.readouterr().err

--- a/tests/test_creative_research_eval_contract.py
+++ b/tests/test_creative_research_eval_contract.py
@@ -1,0 +1,60 @@
+"""Tests for creative research offline eval contract helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration.creative_research_eval_contract import evaluate_bundle, validate_bundle
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "orchestration" / "creative_research"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_validate_bundle_accepts_creative_research_fixture() -> None:
+    """The canonical PR-B fixture should normalize successfully."""
+
+    bundle = validate_bundle(_load_fixture("bundle_valid.json"))
+
+    assert bundle["task_class"] == "creative_research"
+    assert bundle["phase"] == "verification"
+    assert len(bundle["candidates"]) == 3
+    assert bundle["candidates"][0]["candidate_id"] == "hyp-batch"
+
+
+def test_validate_bundle_rejects_non_creative_task_class() -> None:
+    """The PR-B harness must stay pinned to creative_research only."""
+
+    bundle = _load_fixture("bundle_valid.json")
+    bundle["task_class"] = "Experimentation"
+
+    with pytest.raises(ValueError, match="task_class"):
+        validate_bundle(bundle)
+
+
+def test_validate_bundle_rejects_unknown_confidence_level() -> None:
+    """Confidence must stay within the deterministic offline enum."""
+
+    bundle = _load_fixture("bundle_valid.json")
+    bundle["candidates"][0]["confidence"] = "certain"
+
+    with pytest.raises(ValueError, match="confidence must be one of"):
+        validate_bundle(bundle)
+
+
+def test_evaluate_bundle_classifies_valid_output_types() -> None:
+    """Valid PR-B fixture candidates should map to the three governed output classes."""
+
+    result = evaluate_bundle(_load_fixture("bundle_valid.json"))
+    by_id = {candidate["candidate_id"]: candidate for candidate in result["candidates"]}
+
+    assert by_id["hyp-batch"]["output_class"] == "mechanistic_hypothesis"
+    assert by_id["hyp-template"]["output_class"] == "experimental_proposal"
+    assert by_id["hyp-weekend"]["output_class"] == "anomaly_explanation_candidate"
+    assert by_id["hyp-batch"]["promotion_decision"] == "promote"
+    assert result["summary"]["candidate_count"] == 3

--- a/tests/test_creative_research_eval_contract.py
+++ b/tests/test_creative_research_eval_contract.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from scripts.orchestration.creative_research_eval_contract import evaluate_bundle, validate_bundle
+from scripts.orchestration.creative_research_eval_contract import (
+    _count_hints,
+    classify_output,
+    evaluate_bundle,
+    validate_bundle,
+)
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "orchestration" / "creative_research"
 
@@ -58,3 +63,32 @@ def test_evaluate_bundle_classifies_valid_output_types() -> None:
     assert by_id["hyp-weekend"]["output_class"] == "anomaly_explanation_candidate"
     assert by_id["hyp-batch"]["promotion_decision"] == "promote"
     assert result["summary"]["candidate_count"] == 3
+
+
+def test_count_hints_matches_token_boundaries_for_short_markers() -> None:
+    """Short hints like `ab` and `if` must not match inside unrelated words."""
+
+    assert _count_hints("Habit loops improve adherence over time.", ("ab",)) == 0
+    assert _count_hints("Specific friction cues shape adherence.", ("if",)) == 0
+    assert _count_hints("Run an AB cohort compare over two weeks.", ("ab", "compare")) == 2
+    assert _count_hints("If adherence stays flat, the mechanism is wrong.", ("if", "wrong")) == 2
+
+
+def test_classify_output_does_not_promote_substring_false_positives() -> None:
+    """Substring collisions must not turn ideation into proposal or anomaly classes."""
+
+    candidate = {
+        "candidate_id": "substring-guard",
+        "claim": "Specific habit loops improve consistency.",
+        "mechanism": "Habit scaffolds reduce switching friction and decision fatigue.",
+        "evidence_needed": "Collect diary notes from a small user group.",
+        "falsifier": "Track adherence outcomes across the observation window.",
+        "confidence": "medium",
+        "known_risks": ["self-report bias"],
+        "wellness_boundary": "Wellness-only framing, not diagnosis or treatment.",
+    }
+
+    output_class, controls = classify_output(candidate)
+
+    assert output_class == "mechanistic_hypothesis"
+    assert controls == []


### PR DESCRIPTION
## Summary
- add a deterministic offline eval harness for the governed `creative_research` sub-lane
- add the PR-B offline protocol + eval contract without touching the umbrella experimentation constitution
- add fixtures and regression tests for classification, negative controls, and artifact-output guards
- tighten hint matching to token boundaries so short markers like `ab` and `if` cannot misclassify candidates

## Scope
- offline eval only
- no runtime integration
- no OpenAPI changes
- no new public endpoint or feature flag surface
- stacked on top of #1106

## Validation
- `pytest -q tests/test_creative_research_eval_contract.py tests/test_creative_research_eval.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_repo_policy_guards.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1112_FIXED_MAPPING.md`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112#discussion_r2918146080` -> `d9387d55`

## Merge Readiness
- [x] Local gates passed on current head
- [ ] All required checks green
- [ ] All actionable review threads resolved with dispositions
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] Wait-window after latest bot/review activity observed

## Deferred / Follow-ups
- Retarget/rebase to `main` after #1106 merges.
