### PR TITLE
feat(rag): add verification-first reliability v2

### DIFF
--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -648,7 +648,7 @@ class PhilosophicalRuntime:
     ) -> list[str]:
         """Build deterministic public reason codes for the executed runtime path."""
         reason_codes = list(decision.reason_codes)
-        if rag_used and recursive_rag_executed:
+        if recursive_rag_executed:
             self._append_reason_code(reason_codes, "rag_recursive_path")
         if self._is_verification_first_path(decision=decision, rag_used=rag_used):
             if rewrite_count > 0:

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -394,6 +394,7 @@ class PhilosophicalRuntime:
         final_provider_name = provider.name
         confidence: float | None = None
         rag_used = False
+        recursive_rag_executed = False
         hops = 0
         latency_ms = 0
         prompt_input = decision.simplified_query or text
@@ -410,6 +411,7 @@ class PhilosophicalRuntime:
             prompt_input = rag_result.formatted_prompt
             confidence = rag_result.confidence
             rag_used = rag_result.rag_actually_used
+            recursive_rag_executed = bool(getattr(rag_result, "recursive_executed", False))
             hops = rag_result.hops
             latency_ms = rag_result.latency_ms
             if rag_result.chunks:
@@ -474,7 +476,7 @@ class PhilosophicalRuntime:
         runtime_reason_codes = self._build_runtime_reason_codes(
             decision=decision,
             rag_used=rag_used,
-            recursive_rag_enabled=recursive_rag_enabled,
+            recursive_rag_executed=recursive_rag_executed,
             rewrite_count=rewrite_count,
             fallback_reason=fallback_reason,
         )
@@ -640,13 +642,13 @@ class PhilosophicalRuntime:
         *,
         decision: RouteDecision,
         rag_used: bool,
-        recursive_rag_enabled: bool,
+        recursive_rag_executed: bool,
         rewrite_count: int,
         fallback_reason: str,
     ) -> list[str]:
         """Build deterministic public reason codes for the executed runtime path."""
         reason_codes = list(decision.reason_codes)
-        if rag_used and recursive_rag_enabled:
+        if rag_used and recursive_rag_executed:
             self._append_reason_code(reason_codes, "rag_recursive_path")
         if self._is_verification_first_path(decision=decision, rag_used=rag_used):
             if rewrite_count > 0:

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -471,13 +471,13 @@ class PhilosophicalRuntime:
                     falsification_report = None
                     contradiction_count = 0
                     fallback_reason = "phase12_validation"
-            runtime_reason_codes = self._build_runtime_reason_codes(
-                decision=decision,
-                rag_used=rag_used,
-                recursive_rag_enabled=recursive_rag_enabled,
-                rewrite_count=rewrite_count,
-                fallback_reason=fallback_reason,
-            )
+        runtime_reason_codes = self._build_runtime_reason_codes(
+            decision=decision,
+            rag_used=rag_used,
+            recursive_rag_enabled=recursive_rag_enabled,
+            rewrite_count=rewrite_count,
+            fallback_reason=fallback_reason,
+        )
 
         tokens_saved_estimate = _estimate_tokens_saved(
             prompt_text=prompt_text,
@@ -605,11 +605,6 @@ class PhilosophicalRuntime:
             )
             if pragmatic.practically_useful and contradiction_count == 0:
                 return False
-        if decision.route_type in {RouteType.RAG_FACTUAL, RouteType.DEEP_REASONING}:
-            return bool(
-                verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
-                or falsification_report.falsifiability_rate < _VERIFICATION_FIRST_THRESHOLD
-            )
         return False
 
     def _should_use_conservative_fallback(
@@ -627,7 +622,10 @@ class PhilosophicalRuntime:
         if falsification_report.falsifiability_rate < _BASELINE_VALIDATION_THRESHOLD:
             return True
         if self._is_verification_first_path(decision=decision, rag_used=rag_used):
-            return verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
+            return bool(
+                verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
+                or falsification_report.falsifiability_rate < _VERIFICATION_FIRST_THRESHOLD
+            )
         return verification_report.verification_rate < _BASELINE_VALIDATION_THRESHOLD
 
     def _is_verification_first_path(self, *, decision: RouteDecision, rag_used: bool) -> bool:

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -38,6 +38,8 @@ from core.rag.formatting import RAGSourceDict, build_rag_source_dicts
 
 _APPROX_CHARS_PER_TOKEN = 4
 _DEFAULT_BASELINE_DEPTH = 3
+_VERIFICATION_FIRST_THRESHOLD = 0.7
+_BASELINE_VALIDATION_THRESHOLD = 0.5
 _DEFINITION_TEMPLATES = {
     "en": {
         "bmi": "BMI stands for body mass index. It estimates body size by comparing weight to height.",
@@ -426,6 +428,7 @@ class PhilosophicalRuntime:
         verification_report: VerificationReport | None = None
         falsification_report: FalsificationReport | None = None
         contradiction_count = 0
+        runtime_reason_codes = list(decision.reason_codes)
 
         if philosophy_phase12_enabled:
             citations = [item["file"] for item in rag_source_dicts]
@@ -440,6 +443,7 @@ class PhilosophicalRuntime:
                 answer=answer,
                 query=text,
                 pragmatic_enabled=philosophy_pragmatic_enabled,
+                rag_used=rag_used,
             ):
                 rewrite_count = 1
                 rewrite_prompt = self._build_rewrite_prompt(
@@ -454,10 +458,12 @@ class PhilosophicalRuntime:
                 verification_report = self._verification.validate(answer, citations=citations)
                 falsification_report = self._falsification.validate(answer)
                 contradiction_count = self._contradictions.count(answer)
-                if (
-                    contradiction_count > 0
-                    or verification_report.verification_rate < 0.5
-                    or falsification_report.falsifiability_rate < 0.5
+                if self._should_use_conservative_fallback(
+                    decision=decision,
+                    verification_report=verification_report,
+                    falsification_report=falsification_report,
+                    contradiction_count=contradiction_count,
+                    rag_used=rag_used,
                 ):
                     answer = self._build_conservative_fallback(decision, lang=lang)
                     final_provider_name = "philosophical_runtime"
@@ -465,6 +471,13 @@ class PhilosophicalRuntime:
                     falsification_report = None
                     contradiction_count = 0
                     fallback_reason = "phase12_validation"
+            runtime_reason_codes = self._build_runtime_reason_codes(
+                decision=decision,
+                rag_used=rag_used,
+                recursive_rag_enabled=recursive_rag_enabled,
+                rewrite_count=rewrite_count,
+                fallback_reason=fallback_reason,
+            )
 
         tokens_saved_estimate = _estimate_tokens_saved(
             prompt_text=prompt_text,
@@ -501,7 +514,7 @@ class PhilosophicalRuntime:
                         else falsification_report.falsifiability_rate
                     ),
                     contradiction_count=contradiction_count,
-                    reason_codes=list(decision.reason_codes),
+                    reason_codes=runtime_reason_codes,
                     optimization_applied=decision.optimization_applied,
                 )
                 if public_metadata_enabled
@@ -570,14 +583,20 @@ class PhilosophicalRuntime:
         answer: str,
         query: str,
         pragmatic_enabled: bool,
+        rag_used: bool,
     ) -> bool:
         """Decide if one rewrite attempt is justified."""
         if contradiction_count > 0:
             return True
-        if verification_report.verification_rate < 0.5:
+        if verification_report.verification_rate < _BASELINE_VALIDATION_THRESHOLD:
             return True
-        if falsification_report.falsifiability_rate < 0.5:
+        if falsification_report.falsifiability_rate < _BASELINE_VALIDATION_THRESHOLD:
             return True
+        if self._is_verification_first_path(decision=decision, rag_used=rag_used):
+            return bool(
+                verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
+                or falsification_report.falsifiability_rate < _VERIFICATION_FIRST_THRESHOLD
+            )
         if pragmatic_enabled:
             pragmatic = self._pragmatic.assess(
                 answer,
@@ -588,10 +607,61 @@ class PhilosophicalRuntime:
                 return False
         if decision.route_type in {RouteType.RAG_FACTUAL, RouteType.DEEP_REASONING}:
             return bool(
-                verification_report.verification_rate < 0.7
-                or falsification_report.falsifiability_rate < 0.7
+                verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
+                or falsification_report.falsifiability_rate < _VERIFICATION_FIRST_THRESHOLD
             )
         return False
+
+    def _should_use_conservative_fallback(
+        self,
+        *,
+        decision: RouteDecision,
+        verification_report: VerificationReport,
+        falsification_report: FalsificationReport,
+        contradiction_count: int,
+        rag_used: bool,
+    ) -> bool:
+        """Return True when the repaired answer still fails the acceptance gate."""
+        if contradiction_count > 0:
+            return True
+        if falsification_report.falsifiability_rate < _BASELINE_VALIDATION_THRESHOLD:
+            return True
+        if self._is_verification_first_path(decision=decision, rag_used=rag_used):
+            return verification_report.verification_rate < _VERIFICATION_FIRST_THRESHOLD
+        return verification_report.verification_rate < _BASELINE_VALIDATION_THRESHOLD
+
+    def _is_verification_first_path(self, *, decision: RouteDecision, rag_used: bool) -> bool:
+        """Apply stricter verification only to RAG-backed factual/deep paths."""
+        return rag_used and decision.route_type in {
+            RouteType.RAG_FACTUAL,
+            RouteType.DEEP_REASONING,
+        }
+
+    def _build_runtime_reason_codes(
+        self,
+        *,
+        decision: RouteDecision,
+        rag_used: bool,
+        recursive_rag_enabled: bool,
+        rewrite_count: int,
+        fallback_reason: str,
+    ) -> list[str]:
+        """Build deterministic public reason codes for the executed runtime path."""
+        reason_codes = list(decision.reason_codes)
+        if rag_used and recursive_rag_enabled:
+            self._append_reason_code(reason_codes, "rag_recursive_path")
+        if self._is_verification_first_path(decision=decision, rag_used=rag_used):
+            if rewrite_count > 0:
+                self._append_reason_code(reason_codes, "verification_first_rewrite")
+            if fallback_reason == "phase12_validation":
+                self._append_reason_code(reason_codes, "verification_first_fallback")
+        return reason_codes
+
+    @staticmethod
+    def _append_reason_code(reason_codes: list[str], reason_code: str) -> None:
+        """Append a reason code once while preserving stable order."""
+        if reason_code not in reason_codes:
+            reason_codes.append(reason_code)
 
     def _build_conservative_fallback(self, decision: RouteDecision, *, lang: str | None) -> str:
         """Return a safe fallback when rewrite still fails."""

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -57,7 +57,11 @@ class RAGOrchestrationResult:
     """True when the recursive retrieval path actually executed."""
 
 
-def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
+def _empty_result(
+    prompt_input: str,
+    *,
+    recursive_executed: bool = False,
+) -> RAGOrchestrationResult:
     """Return empty orchestration result (fail-safe fallback)."""
     return RAGOrchestrationResult(
         chunks=[],
@@ -69,7 +73,7 @@ def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
         warnings=[],
         chunks_retrieved=0,
         chunks_filtered=0,
-        recursive_executed=False,
+        recursive_executed=recursive_executed,
     )
 
 
@@ -179,7 +183,10 @@ async def retrieve_and_validate_rag(
             "RAG orchestration failed; returning empty result",
             exc_info=True,
         )
-        return _empty_result(prompt_input)
+        return _empty_result(
+            prompt_input,
+            recursive_executed=recursive_rag_enabled,
+        )
 
 
 async def _run_orchestration(

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -53,6 +53,9 @@ class RAGOrchestrationResult:
     chunks_filtered: int = 0
     """Number of chunks removed by validation."""
 
+    recursive_executed: bool = False
+    """True when the recursive retrieval path actually executed."""
+
 
 def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
     """Return empty orchestration result (fail-safe fallback)."""
@@ -66,6 +69,7 @@ def _empty_result(prompt_input: str) -> RAGOrchestrationResult:
         warnings=[],
         chunks_retrieved=0,
         chunks_filtered=0,
+        recursive_executed=False,
     )
 
 
@@ -220,6 +224,7 @@ async def _run_orchestration(
             warnings=[],
             chunks_retrieved=0,
             chunks_filtered=0,
+            recursive_executed=recursive_enabled,
         )
 
     warnings: list[str] = []
@@ -249,6 +254,7 @@ async def _run_orchestration(
             warnings=warnings,
             chunks_retrieved=len(rag_ctx.chunks),
             chunks_filtered=chunks_filtered,
+            recursive_executed=recursive_enabled,
         )
 
     confidence = _resolve_confidence(
@@ -274,6 +280,7 @@ async def _run_orchestration(
         warnings=warnings,
         chunks_retrieved=len(rag_ctx.chunks),
         chunks_filtered=chunks_filtered,
+        recursive_executed=recursive_enabled,
     )
 
 

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -170,23 +170,13 @@ async def retrieve_and_validate_rag(
     - `recursive_rag_enabled` and `philo_validation_enabled` do not weaken
       tenant isolation; both paths propagate the same `subject_id`
     """
-    try:
-        return await _run_orchestration(
-            prompt_input,
-            max_chunks,
-            philo_validation_enabled,
-            recursive_rag_enabled,
-            subject_id,
-        )
-    except Exception:
-        logger.warning(
-            "RAG orchestration failed; returning empty result",
-            exc_info=True,
-        )
-        return _empty_result(
-            prompt_input,
-            recursive_executed=recursive_rag_enabled,
-        )
+    return await _run_orchestration(
+        prompt_input,
+        max_chunks,
+        philo_validation_enabled,
+        recursive_rag_enabled,
+        subject_id,
+    )
 
 
 async def _run_orchestration(
@@ -197,98 +187,110 @@ async def _run_orchestration(
     subject_id: int | None,
 ) -> RAGOrchestrationResult:
     """Execute RAG retrieval + validation pipeline."""
-    # Lazy imports to preserve fail-safe behavior (missing modules don't crash)
-    from core.rag.formatting import format_rag_chunks_for_prompt
+    recursive_executed = False
+    try:
+        # Lazy imports to preserve fail-safe behavior (missing modules don't crash)
+        from core.rag.formatting import format_rag_chunks_for_prompt
 
-    if recursive_enabled:
-        from core.rag.recursive_retrieval import retrieve_recursive_context_structured
+        if recursive_enabled:
+            from core.rag.recursive_retrieval import retrieve_recursive_context_structured
 
-        rag_ctx = await asyncio.to_thread(
-            retrieve_recursive_context_structured,
-            prompt_input,
-            max_chunks=max_chunks,
-            subject_id=subject_id,
-            philo_validation_enabled=False,
+            rag_ctx = await asyncio.to_thread(
+                retrieve_recursive_context_structured,
+                prompt_input,
+                max_chunks=max_chunks,
+                subject_id=subject_id,
+                philo_validation_enabled=False,
+            )
+            recursive_executed = True
+        else:
+            from core.rag.vector_rag import retrieve_context_structured
+
+            rag_ctx = await asyncio.to_thread(
+                retrieve_context_structured,
+                prompt_input,
+                max_chunks=max_chunks,
+                subject_id=subject_id,
+            )
+
+        if not rag_ctx.chunks:
+            return RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt=prompt_input,
+                rag_actually_used=False,
+                confidence=None,
+                hops=rag_ctx.hops,
+                latency_ms=rag_ctx.latency_ms,
+                warnings=[],
+                chunks_retrieved=0,
+                chunks_filtered=0,
+                recursive_executed=recursive_executed,
+            )
+
+        warnings: list[str] = []
+        chunks_to_use = rag_ctx.chunks
+        chunks_filtered = 0
+
+        if philo_enabled:
+            from core.rag.philosophy_pipeline import run_pipeline
+
+            pipeline_result = run_pipeline(rag_ctx.chunks, query=prompt_input)
+            chunks_to_use = pipeline_result.filtered_chunks
+            chunks_filtered = len(rag_ctx.chunks) - len(pipeline_result.filtered_chunks)
+            warnings = pipeline_result.warnings
+
+            for w in warnings:
+                logger.debug("rag_pipeline: %s", w)
+
+        # If no chunks survived validation
+        if not chunks_to_use:
+            return RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt=prompt_input,
+                rag_actually_used=False,
+                confidence=None,
+                hops=rag_ctx.hops,
+                latency_ms=rag_ctx.latency_ms,
+                warnings=warnings,
+                chunks_retrieved=len(rag_ctx.chunks),
+                chunks_filtered=chunks_filtered,
+                recursive_executed=recursive_executed,
+            )
+
+        confidence = _resolve_confidence(
+            rag_confidence=rag_ctx.confidence,
+            chunks_to_use=chunks_to_use,
+            philo_enabled=philo_enabled,
         )
-    else:
-        from core.rag.vector_rag import retrieve_context_structured
 
-        rag_ctx = await asyncio.to_thread(
-            retrieve_context_structured,
-            prompt_input,
-            max_chunks=max_chunks,
-            subject_id=subject_id,
-        )
+        # Build formatted prompt with RAG context
+        from core.insight.safety import redact_rag_context_for_insight
 
-    if not rag_ctx.chunks:
+        raw_context = format_rag_chunks_for_prompt(chunks_to_use)
+        redacted_context = redact_rag_context_for_insight(raw_context)
+        formatted_prompt = _build_prompt_with_context(prompt_input, redacted_context)
+
         return RAGOrchestrationResult(
-            chunks=[],
-            formatted_prompt=prompt_input,
-            rag_actually_used=False,
-            confidence=None,
-            hops=rag_ctx.hops,
-            latency_ms=rag_ctx.latency_ms,
-            warnings=[],
-            chunks_retrieved=0,
-            chunks_filtered=0,
-            recursive_executed=recursive_enabled,
-        )
-
-    warnings: list[str] = []
-    chunks_to_use = rag_ctx.chunks
-    chunks_filtered = 0
-
-    if philo_enabled:
-        from core.rag.philosophy_pipeline import run_pipeline
-
-        pipeline_result = run_pipeline(rag_ctx.chunks, query=prompt_input)
-        chunks_to_use = pipeline_result.filtered_chunks
-        chunks_filtered = len(rag_ctx.chunks) - len(pipeline_result.filtered_chunks)
-        warnings = pipeline_result.warnings
-
-        for w in warnings:
-            logger.debug("rag_pipeline: %s", w)
-
-    # If no chunks survived validation
-    if not chunks_to_use:
-        return RAGOrchestrationResult(
-            chunks=[],
-            formatted_prompt=prompt_input,
-            rag_actually_used=False,
-            confidence=None,
+            chunks=chunks_to_use,
+            formatted_prompt=formatted_prompt,
+            rag_actually_used=True,
+            confidence=confidence,
             hops=rag_ctx.hops,
             latency_ms=rag_ctx.latency_ms,
             warnings=warnings,
             chunks_retrieved=len(rag_ctx.chunks),
             chunks_filtered=chunks_filtered,
-            recursive_executed=recursive_enabled,
+            recursive_executed=recursive_executed,
         )
-
-    confidence = _resolve_confidence(
-        rag_confidence=rag_ctx.confidence,
-        chunks_to_use=chunks_to_use,
-        philo_enabled=philo_enabled,
-    )
-
-    # Build formatted prompt with RAG context
-    from core.insight.safety import redact_rag_context_for_insight
-
-    raw_context = format_rag_chunks_for_prompt(chunks_to_use)
-    redacted_context = redact_rag_context_for_insight(raw_context)
-    formatted_prompt = _build_prompt_with_context(prompt_input, redacted_context)
-
-    return RAGOrchestrationResult(
-        chunks=chunks_to_use,
-        formatted_prompt=formatted_prompt,
-        rag_actually_used=True,
-        confidence=confidence,
-        hops=rag_ctx.hops,
-        latency_ms=rag_ctx.latency_ms,
-        warnings=warnings,
-        chunks_retrieved=len(rag_ctx.chunks),
-        chunks_filtered=chunks_filtered,
-        recursive_executed=recursive_enabled,
-    )
+    except Exception:
+        logger.warning(
+            "RAG orchestration failed; returning empty result",
+            exc_info=True,
+        )
+        return _empty_result(
+            prompt_input,
+            recursive_executed=recursive_executed,
+        )
 
 
 def _build_prompt_with_context(text: str, context: Optional[str]) -> str:

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -27,3 +27,8 @@ Evidence: `ee5aa57a` stores actual recursive-path execution in `core/rag/orchest
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352786 -> ee5aa57a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352789 -> ee5aa57a
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:31` and `docs/review/PR_1114_FIXED_MAPPING.md:32` already map the second CodeRabbit wave's actionable inline comments to `ee5aa57a`, so the aggregate review-status URL below is a mirror of those same items rather than a separate unresolved change request.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929582286

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -29,6 +29,6 @@ Evidence: `ee5aa57a` stores actual recursive-path execution in `core/rag/orchest
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352789 -> ee5aa57a
 
 Disposition: NOT-A-BUG
-Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:31` and `docs/review/PR_1114_FIXED_MAPPING.md:32` already map the second CodeRabbit wave's actionable inline comments to `ee5aa57a`, so the aggregate review-status URL below is a mirror of those same items rather than a separate unresolved change request.
+Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:28` and `docs/review/PR_1114_FIXED_MAPPING.md:29` already map the second CodeRabbit wave's actionable inline comments to `ee5aa57a`, so the aggregate review-status URL below is a mirror of those same items rather than a separate unresolved change request.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929582286

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -32,3 +32,21 @@ Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:28` and `docs/review/PR_1114_FIXED_MAPPING.md:29` already map the second CodeRabbit wave's actionable inline comments to `ee5aa57a`, so the aggregate review-status URL below is a mirror of those same items rather than a separate unresolved change request.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929582286
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `eb7c861e` corrects the stale line anchors in `docs/review/PR_1114_FIXED_MAPPING.md:32` so the second CodeRabbit-wave mirror evidence now points at the actual mapped entries.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541088 -> eb7c861e
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `e186feca` preserves recursive-path fail-safe metadata in `core/rag/orchestration.py:60` and `core/rag/orchestration.py:186`, surfaces `rag_recursive_path` for executed recursive retrieval even when no usable chunks survive in `core/insight/philosophical_runtime.py:651`, and adds regressions in `tests/test_rag_orchestration.py:74`, `tests/test_rag_orchestration.py:573`, and `tests/test_philosophical_runtime.py:653`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541100 -> e186feca
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541108 -> e186feca
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:40`, `docs/review/PR_1114_FIXED_MAPPING.md:46`, and `docs/review/PR_1114_FIXED_MAPPING.md:47` already capture the actionable cubic items from the latest wave, so the aggregate cubic review URL below is a mirror summary rather than a separate unresolved change request.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929794699

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -20,3 +20,10 @@ Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:4` and `docs/review/PR_1114_FIXED_MAPPING.md:5` already had the required artifact-level discussion-pass boxes checked on head `35e9b983`, so the later checkbox suggestion was stale rather than still actionable.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260796
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `ee5aa57a` stores actual recursive-path execution in `core/rag/orchestration.py:49` and propagates it through `core/insight/philosophical_runtime.py:414` and `core/insight/philosophical_runtime.py:649`, while also tightening the NOT-A-BUG evidence wording in `docs/review/PR_1114_FIXED_MAPPING.md:20` so the later CodeRabbit follow-up is closed on the latest head.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352786 -> ee5aa57a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352789 -> ee5aa57a

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -17,6 +17,6 @@ Evidence: `c97d0a16` moves runtime reason-code assembly outside the Phase 1/2 ga
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929480272 -> c97d0a16
 
 Disposition: NOT-A-BUG
-Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:4` and `docs/review/PR_1114_FIXED_MAPPING.md:5` already had the required checked artifact-level discussion-pass boxes on head `35e9b983`, so the later checkbox suggestion was stale rather than still actionable.
+Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:4` and `docs/review/PR_1114_FIXED_MAPPING.md:5` already had the required artifact-level discussion-pass boxes checked on head `35e9b983`, so the later checkbox suggestion was stale rather than still actionable.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260796

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -5,4 +5,18 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `c97d0a16` moves runtime reason-code assembly outside the Phase 1/2 gate in `core/insight/philosophical_runtime.py:474`, scopes the strict rewrite threshold to actual RAG-backed paths in `core/insight/philosophical_runtime.py:595`, mirrors the verification-first fallback gate for falsifiability in `core/insight/philosophical_runtime.py:624`, adds non-RAG and phase12-disabled regressions in `tests/test_philosophical_runtime.py:519` and `tests/test_philosophical_runtime.py:616`, and adds an explicit JSON content-type assertion in `tests/test_insight_rag_response_fields.py:356`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918257469 -> c97d0a16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918257475 -> c97d0a16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260780 -> c97d0a16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260792 -> c97d0a16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260807 -> c97d0a16
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929480272 -> c97d0a16
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:4` and `docs/review/PR_1114_FIXED_MAPPING.md:5` already had the required checked artifact-level discussion-pass boxes on head `35e9b983`, so the later checkbox suggestion was stale rather than still actionable.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260796

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1114 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Pending PR review cycle.

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -41,12 +41,19 @@ Evidence: `eb7c861e` corrects the stale line anchors in `docs/review/PR_1114_FIX
 
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: `e186feca` preserves recursive-path fail-safe metadata in `core/rag/orchestration.py:60` and `core/rag/orchestration.py:186`, surfaces `rag_recursive_path` for executed recursive retrieval even when no usable chunks survive in `core/insight/philosophical_runtime.py:651`, and adds regressions in `tests/test_rag_orchestration.py:74`, `tests/test_rag_orchestration.py:573`, and `tests/test_philosophical_runtime.py:653`.
+Evidence: `e186feca` surfaces `rag_recursive_path` for executed recursive retrieval even when no usable chunks survive in `core/insight/philosophical_runtime.py:651`, and adds the non-usable-chunk regression in `tests/test_philosophical_runtime.py:653`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541100 -> e186feca
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541108 -> e186feca
 
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `db8d4fd0` moves the fail-safe logging and empty-result fallback into `core/rag/orchestration.py:285` so `recursive_executed` stays false until recursive retrieval is actually confirmed in `core/rag/orchestration.py:205`, while adding split regressions for confirmed vs unconfirmed recursive failures in `tests/test_rag_orchestration.py:574` and `tests/test_rag_orchestration.py:600`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918541100 -> db8d4fd0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918616485 -> db8d4fd0
+
 Disposition: NOT-A-BUG
-Evidence: `docs/review/PR_1114_FIXED_MAPPING.md:40`, `docs/review/PR_1114_FIXED_MAPPING.md:46`, and `docs/review/PR_1114_FIXED_MAPPING.md:47` already capture the actionable cubic items from the latest wave, so the aggregate cubic review URL below is a mirror summary rather than a separate unresolved change request.
+Evidence: the mapped cubic items above already record the docs anchor fix plus the two runtime dispositions for this review wave, so the aggregate cubic review URL below is a mirror summary rather than a separate unresolved change request.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929794699
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929879754

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -1,8 +1,8 @@
 # PR 1114 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-Pending PR review cycle.
+- No actionable review comments.

--- a/docs/review/PR_1114_FIXED_MAPPING.md
+++ b/docs/review/PR_1114_FIXED_MAPPING.md
@@ -5,4 +5,4 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments.
+- No actionable review comments

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -13,6 +13,8 @@ from typing import Any, Optional
 import pytest
 from fastapi.testclient import TestClient
 
+from core.insight import philosophical_runtime as runtime_mod
+
 
 @dataclass
 class _FakeRAGChunk:
@@ -130,6 +132,18 @@ class _EchoProvider:
 
     async def generate(self, text: str) -> str:
         return text
+
+
+@dataclass
+class _SequenceEchoProvider:
+    responses: list[str]
+    name: str = "echo-seq"
+    calls: int = 0
+
+    async def generate(self, text: str) -> str:
+        index = min(self.calls, len(self.responses) - 1)
+        self.calls += 1
+        return self.responses[index]
 
 
 class TestInsightV1RAGFields:
@@ -282,6 +296,71 @@ class TestInsightV1RAGFields:
         assert data["latency_ms"] == 55
         assert data["confidence"] == 0.82
         assert len(data["sources"]) == 1
+
+    def test_recursive_verification_reason_codes_surface_in_response(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        vip_headers: dict[str, str],
+    ) -> None:
+        import llm
+
+        provider = _SequenceEchoProvider(
+            responses=[
+                "Draft answer with weak evidence.",
+                "Rewritten answer with stronger evidence.",
+            ]
+        )
+        verification_reports = iter([0.6, 0.8])
+
+        monkeypatch.setenv("FEATURE_INSIGHT", "true")
+        monkeypatch.setenv("FEATURE_RAG", "true")
+        monkeypatch.setenv("FEATURE_RAG_RECURSIVE", "true")
+        monkeypatch.setenv("FEATURE_PHILOSOPHY_ROUTER", "true")
+        monkeypatch.setenv("FEATURE_PHILOSOPHY_PHASE12", "true")
+        monkeypatch.setenv("FEATURE_PHILOSOPHY_LINGUISTIC", "true")
+        monkeypatch.setattr(llm, "get_provider", lambda: provider, raising=True)
+        monkeypatch.setattr(
+            "core.rag.recursive_retrieval.retrieve_recursive_context_structured",
+            _make_fake_recursive_structured,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "core.insight.philosophical_runtime.VerificationEnforcer.validate",
+            lambda self, answer, citations: runtime_mod.VerificationReport(
+                verification_rate=next(verification_reports),
+                unverified_claims=[],
+            ),
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "core.insight.philosophical_runtime.FalsificationChecker.validate",
+            lambda self, answer: runtime_mod.FalsificationReport(
+                falsifiability_rate=0.9,
+                unfalsifiable_claims=[],
+            ),
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "core.insight.philosophical_runtime.NonContradictionChecker.count",
+            lambda self, answer: 0,
+            raising=True,
+        )
+
+        resp = client.post(
+            "/api/v1/insight",
+            json={"text": "How much protein should I eat for recovery?"},
+            headers=vip_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert provider.calls == 2
+        assert data["rag_used"] is True
+        assert data["verification_rate"] == 0.8
+        assert "rag_recursive_path" in data["reason_codes"]
+        assert "verification_first_rewrite" in data["reason_codes"]
+        assert "verification_first_fallback" not in data["reason_codes"]
 
     def test_insight_text_not_contaminated_by_source_headers(
         self,

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -354,6 +354,7 @@ class TestInsightV1RAGFields:
         )
 
         assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert provider.calls == 2
         assert data["rag_used"] is True

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -650,6 +650,44 @@ class TestPhilosophicalRuntime:
         assert "rag_recursive_path" in result.metadata.reason_codes
         assert "verification_first_rewrite" not in result.metadata.reason_codes
 
+    async def test_recursive_rag_reason_code_surfaces_without_usable_rag_chunks(self) -> None:
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="Answer without usable RAG chunks.")
+
+        async def _rag_retriever(
+            *args: object, **kwargs: object
+        ) -> runtime_mod.rag_orchestration.RAGOrchestrationResult:
+            del args, kwargs
+            return runtime_mod.rag_orchestration.RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="Prompt with no usable chunks",
+                rag_actually_used=False,
+                confidence=None,
+                hops=2,
+                latency_ms=41,
+                recursive_executed=True,
+            )
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=True,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            rag_retriever=_rag_retriever,
+        )
+
+        assert provider.calls == 1
+        assert result.rag_used is False
+        assert "rag_recursive_path" in result.metadata.reason_codes
+        assert "verification_first_rewrite" not in result.metadata.reason_codes
+        assert "verification_first_fallback" not in result.metadata.reason_codes
+
     async def test_rag_backed_answer_rewrites_once_then_succeeds(self) -> None:
         runtime = PhilosophicalRuntime()
         provider = _SequenceProvider(

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -44,6 +44,20 @@ class _StaticProvider:
         return self.response
 
 
+@dataclass
+class _SequenceProvider:
+    """Provider stub that returns a deterministic sequence of responses."""
+
+    responses: list[str]
+    name: str = "sequence"
+    calls: int = 0
+
+    async def generate(self, text: str) -> str:
+        index = min(self.calls, len(self.responses) - 1)
+        self.calls += 1
+        return self.responses[index]
+
+
 class TestPhilosophicalQueryRouter:
     """Router should select cheap deterministic routes when possible."""
 
@@ -426,6 +440,7 @@ class TestPhilosophicalRuntime:
             answer="Use 20-30 grams.",
             query="How much protein should I eat?",
             pragmatic_enabled=False,
+            rag_used=True,
         )
         assert runtime._should_rewrite(
             decision=decision,
@@ -438,6 +453,7 @@ class TestPhilosophicalRuntime:
             answer="Contradictory answer",
             query="How much protein should I eat?",
             pragmatic_enabled=False,
+            rag_used=True,
         )
         assert (
             runtime._should_rewrite(
@@ -451,8 +467,54 @@ class TestPhilosophicalRuntime:
                 answer="First, try a simple breakfast routine that matches your goal.",
                 query="What breakfast routine should I try?",
                 pragmatic_enabled=True,
+                rag_used=False,
             )
             is False
+        )
+        assert (
+            runtime._should_use_conservative_fallback(
+                decision=decision,
+                verification_report=VerificationReport(
+                    verification_rate=0.69, unverified_claims=[]
+                ),
+                falsification_report=FalsificationReport(
+                    falsifiability_rate=0.9,
+                    unfalsifiable_claims=[],
+                ),
+                contradiction_count=0,
+                rag_used=True,
+            )
+            is True
+        )
+        assert (
+            runtime._should_use_conservative_fallback(
+                decision=decision,
+                verification_report=VerificationReport(
+                    verification_rate=0.95, unverified_claims=[]
+                ),
+                falsification_report=FalsificationReport(
+                    falsifiability_rate=0.95,
+                    unfalsifiable_claims=[],
+                ),
+                contradiction_count=1,
+                rag_used=True,
+            )
+            is True
+        )
+        assert (
+            runtime._should_use_conservative_fallback(
+                decision=decision,
+                verification_report=VerificationReport(
+                    verification_rate=0.49, unverified_claims=[]
+                ),
+                falsification_report=FalsificationReport(
+                    falsifiability_rate=0.95,
+                    unfalsifiable_claims=[],
+                ),
+                contradiction_count=0,
+                rag_used=False,
+            )
+            is True
         )
         assert "medical diagnosis" in runtime._build_conservative_fallback(
             RouteDecision(
@@ -465,6 +527,179 @@ class TestPhilosophicalRuntime:
             ),
             lang="en",
         )
+
+    async def test_rag_backed_answer_with_sufficient_evidence_skips_rewrite(self) -> None:
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="Evidence-based recovery guidance.")
+
+        async def _rag_retriever(
+            *args: object, **kwargs: object
+        ) -> runtime_mod.rag_orchestration.RAGOrchestrationResult:
+            del args, kwargs
+            return runtime_mod.rag_orchestration.RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="Evidence-backed prompt",
+                rag_actually_used=True,
+                confidence=0.84,
+                hops=2,
+                latency_ms=41,
+            )
+
+        runtime._verification = SimpleNamespace(
+            validate=lambda answer, citations: VerificationReport(
+                verification_rate=0.85,
+                unverified_claims=[],
+            )
+        )
+        runtime._falsification = SimpleNamespace(
+            validate=lambda answer: FalsificationReport(
+                falsifiability_rate=0.9,
+                unfalsifiable_claims=[],
+            )
+        )
+        runtime._contradictions = SimpleNamespace(count=lambda answer: 0)
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=True,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=True,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            rag_retriever=_rag_retriever,
+        )
+
+        assert provider.calls == 1
+        assert result.provider_name == "static"
+        assert result.metadata.verification_rate == 0.85
+        assert "rag_recursive_path" in result.metadata.reason_codes
+        assert "verification_first_rewrite" not in result.metadata.reason_codes
+        assert "verification_first_fallback" not in result.metadata.reason_codes
+
+    async def test_rag_backed_answer_rewrites_once_then_succeeds(self) -> None:
+        runtime = PhilosophicalRuntime()
+        provider = _SequenceProvider(
+            responses=[
+                "Draft answer with weak evidence.",
+                "Rewritten answer with clearer evidence.",
+            ]
+        )
+
+        async def _rag_retriever(
+            *args: object, **kwargs: object
+        ) -> runtime_mod.rag_orchestration.RAGOrchestrationResult:
+            del args, kwargs
+            return runtime_mod.rag_orchestration.RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="Evidence-backed prompt",
+                rag_actually_used=True,
+                confidence=0.78,
+                hops=2,
+                latency_ms=39,
+            )
+
+        verification_reports = iter(
+            [
+                VerificationReport(verification_rate=0.6, unverified_claims=[]),
+                VerificationReport(verification_rate=0.8, unverified_claims=[]),
+            ]
+        )
+        runtime._verification = SimpleNamespace(
+            validate=lambda answer, citations: next(verification_reports)
+        )
+        runtime._falsification = SimpleNamespace(
+            validate=lambda answer: FalsificationReport(
+                falsifiability_rate=0.9,
+                unfalsifiable_claims=[],
+            )
+        )
+        runtime._contradictions = SimpleNamespace(count=lambda answer: 0)
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=True,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=True,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            rag_retriever=_rag_retriever,
+        )
+
+        assert provider.calls == 2
+        assert result.provider_name == "sequence"
+        assert result.metadata.verification_rate == 0.8
+        assert "rag_recursive_path" in result.metadata.reason_codes
+        assert "verification_first_rewrite" in result.metadata.reason_codes
+        assert "verification_first_fallback" not in result.metadata.reason_codes
+
+    async def test_rag_backed_answer_falls_back_after_failed_rewrite(self) -> None:
+        runtime = PhilosophicalRuntime()
+        provider = _SequenceProvider(
+            responses=[
+                "Draft answer with weak evidence.",
+                "Still weak after rewrite.",
+            ]
+        )
+
+        async def _rag_retriever(
+            *args: object, **kwargs: object
+        ) -> runtime_mod.rag_orchestration.RAGOrchestrationResult:
+            del args, kwargs
+            return runtime_mod.rag_orchestration.RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="Evidence-backed prompt",
+                rag_actually_used=True,
+                confidence=0.71,
+                hops=2,
+                latency_ms=44,
+            )
+
+        verification_reports = iter(
+            [
+                VerificationReport(verification_rate=0.6, unverified_claims=[]),
+                VerificationReport(verification_rate=0.69, unverified_claims=[]),
+            ]
+        )
+        runtime._verification = SimpleNamespace(
+            validate=lambda answer, citations: next(verification_reports)
+        )
+        runtime._falsification = SimpleNamespace(
+            validate=lambda answer: FalsificationReport(
+                falsifiability_rate=0.9,
+                unfalsifiable_claims=[],
+            )
+        )
+        runtime._contradictions = SimpleNamespace(count=lambda answer: 0)
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=True,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=True,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            rag_retriever=_rag_retriever,
+        )
+
+        assert provider.calls == 2
+        assert result.provider_name == "philosophical_runtime"
+        assert "safest concise answer" in result.insight
+        assert result.metadata.verification_rate is None
+        assert "rag_recursive_path" in result.metadata.reason_codes
+        assert "verification_first_rewrite" in result.metadata.reason_codes
+        assert "verification_first_fallback" in result.metadata.reason_codes
 
     async def test_resolve_local_direct_answer_handles_missing_and_valid_bmi_inputs(self) -> None:
         runtime = PhilosophicalRuntime()

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -516,6 +516,39 @@ class TestPhilosophicalRuntime:
             )
             is True
         )
+        assert (
+            runtime._should_rewrite(
+                decision=decision,
+                verification_report=VerificationReport(
+                    verification_rate=0.69, unverified_claims=[]
+                ),
+                falsification_report=FalsificationReport(
+                    falsifiability_rate=0.9,
+                    unfalsifiable_claims=[],
+                ),
+                contradiction_count=0,
+                answer="Answer without retrieved context.",
+                query="How much protein should I eat?",
+                pragmatic_enabled=False,
+                rag_used=False,
+            )
+            is False
+        )
+        assert (
+            runtime._should_use_conservative_fallback(
+                decision=decision,
+                verification_report=VerificationReport(
+                    verification_rate=0.95, unverified_claims=[]
+                ),
+                falsification_report=FalsificationReport(
+                    falsifiability_rate=0.69,
+                    unfalsifiable_claims=[],
+                ),
+                contradiction_count=0,
+                rag_used=True,
+            )
+            is True
+        )
         assert "medical diagnosis" in runtime._build_conservative_fallback(
             RouteDecision(
                 route_type=RouteType.SAFE_WELLNESS_DISCLAIMER,
@@ -579,6 +612,41 @@ class TestPhilosophicalRuntime:
         assert "rag_recursive_path" in result.metadata.reason_codes
         assert "verification_first_rewrite" not in result.metadata.reason_codes
         assert "verification_first_fallback" not in result.metadata.reason_codes
+
+    async def test_recursive_rag_reason_code_surfaces_without_phase12(self) -> None:
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="Evidence-based recovery guidance.")
+
+        async def _rag_retriever(
+            *args: object, **kwargs: object
+        ) -> runtime_mod.rag_orchestration.RAGOrchestrationResult:
+            del args, kwargs
+            return runtime_mod.rag_orchestration.RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="Evidence-backed prompt",
+                rag_actually_used=True,
+                confidence=0.84,
+                hops=2,
+                latency_ms=41,
+            )
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=True,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            rag_retriever=_rag_retriever,
+        )
+
+        assert provider.calls == 1
+        assert "rag_recursive_path" in result.metadata.reason_codes
+        assert "verification_first_rewrite" not in result.metadata.reason_codes
 
     async def test_rag_backed_answer_rewrites_once_then_succeeds(self) -> None:
         runtime = PhilosophicalRuntime()

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -576,6 +576,7 @@ class TestPhilosophicalRuntime:
                 confidence=0.84,
                 hops=2,
                 latency_ms=41,
+                recursive_executed=True,
             )
 
         runtime._verification = SimpleNamespace(
@@ -628,6 +629,7 @@ class TestPhilosophicalRuntime:
                 confidence=0.84,
                 hops=2,
                 latency_ms=41,
+                recursive_executed=True,
             )
 
         result = await runtime.generate_insight(
@@ -668,6 +670,7 @@ class TestPhilosophicalRuntime:
                 confidence=0.78,
                 hops=2,
                 latency_ms=39,
+                recursive_executed=True,
             )
 
         verification_reports = iter(
@@ -728,6 +731,7 @@ class TestPhilosophicalRuntime:
                 confidence=0.71,
                 hops=2,
                 latency_ms=44,
+                recursive_executed=True,
             )
 
         verification_reports = iter(

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -573,6 +573,32 @@ class TestRetrieveAndValidateRag:
     @pytest.mark.asyncio
     async def test_recursive_failsafe_preserves_execution_metadata(self) -> None:
         """Recursive fail-safe should preserve that the recursive path executed."""
+        rag_ctx = _make_rag_context(chunks=[_make_chunk("c1", score=0.9)], confidence=0.9, hops=2)
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.recursive_retrieval.retrieve_recursive_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                side_effect=RuntimeError("formatting failed after retrieval"),
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "test prompt",
+                recursive_rag_enabled=True,
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "test prompt"
+        assert result.chunks == []
+        assert result.recursive_executed is True
+
+    @pytest.mark.asyncio
+    async def test_recursive_failsafe_does_not_mark_execution_without_confirmation(self) -> None:
+        """Recursive fail-safe must keep execution false when retrieval never completes."""
         with patch(
             "asyncio.to_thread",
             new_callable=AsyncMock,
@@ -586,7 +612,7 @@ class TestRetrieveAndValidateRag:
         assert result.rag_actually_used is False
         assert result.formatted_prompt == "test prompt"
         assert result.chunks == []
-        assert result.recursive_executed is True
+        assert result.recursive_executed is False
 
     @pytest.mark.asyncio
     async def test_prompt_formatted_with_redacted_context(self) -> None:

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -69,6 +69,13 @@ class TestEmptyResult:
         assert result.confidence is None
         assert result.hops == 0
         assert result.latency_ms == 0
+        assert result.recursive_executed is False
+
+    def test_empty_result_preserves_recursive_execution_flag(self) -> None:
+        result = _empty_result("my prompt", recursive_executed=True)
+
+        assert result.formatted_prompt == "my prompt"
+        assert result.recursive_executed is True
 
 
 class TestBuildPromptWithContext:
@@ -561,6 +568,25 @@ class TestRetrieveAndValidateRag:
         assert result.rag_actually_used is False
         assert result.formatted_prompt == "test prompt"
         assert result.chunks == []
+        assert result.recursive_executed is False
+
+    @pytest.mark.asyncio
+    async def test_recursive_failsafe_preserves_execution_metadata(self) -> None:
+        """Recursive fail-safe should preserve that the recursive path executed."""
+        with patch(
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("RAG retrieval failed"),
+        ):
+            result = await retrieve_and_validate_rag(
+                "test prompt",
+                recursive_rag_enabled=True,
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "test prompt"
+        assert result.chunks == []
+        assert result.recursive_executed is True
 
     @pytest.mark.asyncio
     async def test_prompt_formatted_with_redacted_context(self) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

Implement a verification-first Reliability v2 pass for RAG-backed insight generation without changing the public `InsightResponse` shape.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
- [x] Linked issues/PRs: `#1102` (PR5 handoff), `#1107` (PR6 reliability v1 baseline)

Applied changes in this PR:
- add a verification-first rewrite/fallback gate for RAG-backed factual and deep reasoning insight paths
- keep provider budget bounded to one initial generation plus exactly one rewrite attempt
- expose deterministic runtime `reason_codes` for recursive RAG, verification-first rewrite, and verification-first fallback paths
- add focused runtime and API regression coverage for pass / rewrite / fallback scenarios

## Risk & Impact

- [x] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [x] Performance-sensitive

Notes:
- runtime scope is limited to `core/insight/philosophical_runtime.py`
- no public API contract changes
- no database or migration changes
- provider-call budget remains capped at 2 generations per request on this path

## Test Plan

- [x] Unit tests updated/added
- [x] Integration/slow tests (if applicable)
- [x] Manual verification steps

Commands run locally:
- `python3 -m scripts.orchestration.check_preflight`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `. .venv/bin/activate && pytest -q tests/test_philosophical_runtime.py tests/test_insight_rag_response_fields.py tests/test_rag_orchestration.py tests/test_recursive_rag.py`
- `. .venv/bin/activate && pytest -q tests/test_cbt_insight_api.py`
- `pre-commit run --all-files`
- `make verify`

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [x] Diff coverage ≥ 97% on changed lines

Local result:
- `make verify` passed
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=97` passed with `Coverage: 100%` on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Disposition: FIXED  
Commit: `c97d0a16`, mirrored in canonical artifact `docs/review/PR_1114_FIXED_MAPPING.md`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918257469 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918257475 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260780 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260792 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260807 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#pullrequestreview-3929480272 -> c97d0a16
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918260796
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352786 -> ee5aa57a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1114#discussion_r2918352789 -> ee5aa57a

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): [P2: Eliminate PR body and mapping artifact phase2 drift](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-phase2-body-artifact-sync)
- [x] Ledger item(s): [P2: Restore deterministic clean-clone dependency parity for local verify](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-clean-clone-dependency-parity)
- [x] Ledger item(s): [P2: Filter superseded GitHub check noise in merge triage](docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gh-checks-current-head-filter)
- [x] GitHub issue(s): None

## Notes

### For Simple Changes

- [x] No database/schema/migration changes
- [x] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Why this is not a simple change:
- runtime rewrite/fallback policy changed in `core/insight/philosophical_runtime.py`
- new deterministic response metadata paths are exercised at both runtime and API level
- targeted regressions were added for verification-first pass / rewrite / fallback behavior

Rollback / Feature flag (brief):

- How to revert: revert commit `5669529d` if the PR is merged without squash; for squash merge, revert the resulting merge SHA
- Feature flag/toggle (if any): behavior is active only when the existing philosophy/rag feature flags route through the RAG-backed runtime path
- Owner for emergency contact: @katsiaryna_kavaleuskaya

### For Complex/High-Risk Changes

#### Deployment Strategy

- [x] Deployment order for multi-service changes (if services depend on each other)
- [x] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

Deployment notes:
- single-service backend deploy only
- behavior rides existing RAG / philosophy flags
- safe rollback is git revert; no data migration rollback needed

#### Database & Data Changes

- [x] Database migrations required (Alembic version, backwards compatibility)
- [x] Data migration/backfill steps (scripts, rollback procedures)
- [x] Data cleanup steps (if removing deprecated data)
- [x] Backwards compatibility guarantees (old clients still work)

Details:
- no DB migrations required
- no data migration or cleanup required
- response shape remains backward compatible; only internal acceptance policy changes

#### Monitoring & Observability

- [x] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [x] Dashboards to create/update (Grafana, DataDog, etc.)
- [x] Logging changes (new log levels, structured logs, correlation IDs)
- [x] Health check endpoints affected

Details:
- none required for this bounded runtime reliability pass
- explainability is surfaced through existing public metadata fields and `reason_codes`

#### Post-Deploy Verification

- [x] Manual verification checklist (specific endpoints, user flows)
- [x] Smoke tests to run (automated or manual)
- [x] Performance benchmarks to verify (latency, throughput)
- [x] Rollback triggers (what conditions require immediate rollback)

Checklist:
- rerun `make verify`
- rerun the targeted insight/RAG regression suites if any review fix touches the runtime seam
- rollback if RAG-backed insight generation exceeds two provider generations or loses conservative fallback behavior

#### Additional Context

- [x] Breaking changes (API contracts, response formats)
- [x] Dependencies updated (requirements.txt, package versions)
- [x] Configuration changes (env vars, secrets, feature toggles)
- [x] Documentation updates needed (README, API docs, runbooks)

Details:
- no breaking changes
- no dependency/config changes
- no public docs changes required for this bounded runtime pass

<!-- markdownlint-enable MD013 MD033 -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds verification-first Reliability v2 for RAG-backed insights with stricter validation and deterministic reason codes, now also surfacing recursive retrieval even on fail-safe paths. Keeps InsightResponse unchanged and the provider-call budget capped.

- **New Features**
  - Apply stricter checks only to RAG-backed factual/deep paths: rewrite if verification or falsifiability < 0.7; after rewrite, fallback on contradictions or either metric < 0.7; non‑RAG paths keep 0.5 thresholds.
  - Cap provider calls to one initial generation plus one rewrite.
  - Emit deterministic reason codes: "rag_recursive_path" (based on actual recursive execution and surfaced even without Phase 1/2 or usable chunks), "verification_first_rewrite", "verification_first_fallback".

- **Bug Fixes**
  - Build reason codes outside Phase 1/2 so they always surface.
  - Preserve and propagate `recursive_executed` through orchestration, including formatting failures and empty results; keep it false when recursive retrieval never completes, ensuring accurate "rag_recursive_path".

<sup>Written for commit a36f303d2af791ea7081a7cc0dc4e301d66947bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Runtime now emits richer, deterministic reason codes, uses path-aware verification gating with refined thresholds, integrates conservative-fallback behavior, and surfaces runtime diagnostics in final metadata; RAG results now indicate whether a recursive retrieval path was executed.

* **Tests**
  * Added and expanded tests covering recursive RAG verification, rewrite and conservative-fallback scenarios, and reason-code/metadata propagation; new test helpers support deterministic response sequences.

* **Documentation**
  * Added a concise review/notes document summarizing the PR and mapping fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



