### PR TITLE
fix(ci): stabilize py311 app facade rehydration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -69,6 +69,7 @@ def _ensure_canonical_bootstrap() -> None:
 
     if callable(ensure_bootstrap):
         ensure_bootstrap(legacy_app_instance)
+        setattr(main_module, "app", legacy_app_instance)
         return
 
     # RU: Фолбэк только для safety-path; нормальный runtime идёт через

--- a/app/scheduler_helpers.py
+++ b/app/scheduler_helpers.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import inspect
 from contextlib import suppress
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
+
+
+def resolve_app_package(pkg: Any, fallback_pkg: Any) -> Any:
+    """Return the canonical app package when sys.modules churn leaves stale aliases."""
+    for candidate in (pkg, fallback_pkg):
+        if candidate is not None and getattr(candidate, "__path__", None):
+            return candidate
+
+    with suppress(Exception):
+        imported_pkg = importlib.import_module("app")
+        if getattr(imported_pkg, "__path__", None):
+            return imported_pkg
+
+    return pkg or fallback_pkg
 
 
 def resolve_scheduler_starter(
@@ -16,22 +31,24 @@ def resolve_scheduler_starter(
 
     Returns the best available starter callable, falling back to default_starter.
     """
-    starter: Callable[[int], Any] = globs.get(
-        "_scheduler_start_background_updates", default_starter
-    )
-    if starter is default_starter:
-        pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
-        starter = (
-            getattr(alias_pkg, "_scheduler_start_background_updates", None)
-            or (
-                getattr(pkg_appmod, "_scheduler_start_background_updates", None)
-                if pkg_appmod
-                else None
-            )
-            or getattr(pkg, "_scheduler_start_background_updates", None)
-            or default_starter
+    pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
+    starter = (
+        getattr(pkg, "_scheduler_start_background_updates", None)
+        or (
+            getattr(pkg_appmod, "_scheduler_start_background_updates", None) if pkg_appmod else None
         )
-    return starter
+        or getattr(alias_pkg, "_scheduler_start_background_updates", None)
+    )
+    if callable(starter):
+        resolved_starter = cast(Callable[[int], Any], starter)
+        return resolved_starter
+
+    starter = globs.get("_scheduler_start_background_updates", default_starter)
+    if callable(starter) and starter is not default_starter:
+        resolved_starter = cast(Callable[[int], Any], starter)
+        return resolved_starter
+
+    return default_starter
 
 
 def resolve_stop_callable(
@@ -44,20 +61,22 @@ def resolve_stop_callable(
 
     Returns the best available stopper callable, falling back to default_stopper.
     """
-    stopper: Callable[[], Any] = globs.get("_scheduler_stop_background_updates", default_stopper)
-    if stopper is default_stopper:
-        pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
-        stopper = (
-            getattr(alias_pkg, "_scheduler_stop_background_updates", None)
-            or (
-                getattr(pkg_appmod, "_scheduler_stop_background_updates", None)
-                if pkg_appmod
-                else None
-            )
-            or getattr(pkg, "_scheduler_stop_background_updates", None)
-            or default_stopper
-        )
-    return stopper
+    pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
+    stopper = (
+        getattr(pkg, "_scheduler_stop_background_updates", None)
+        or (getattr(pkg_appmod, "_scheduler_stop_background_updates", None) if pkg_appmod else None)
+        or getattr(alias_pkg, "_scheduler_stop_background_updates", None)
+    )
+    if callable(stopper):
+        resolved_stopper = cast(Callable[[], Any], stopper)
+        return resolved_stopper
+
+    stopper = globs.get("_scheduler_stop_background_updates", default_stopper)
+    if callable(stopper) and stopper is not default_stopper:
+        resolved_stopper = cast(Callable[[], Any], stopper)
+        return resolved_stopper
+
+    return default_stopper
 
 
 def handle_sync_test_mode(

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -113,10 +113,11 @@ from core.bmr import (
 )
 from core.export_format import ExportFormat
 from app.scheduler_helpers import (
+    execute_async_starter,
+    handle_sync_test_mode,
+    resolve_app_package,
     resolve_scheduler_starter,
     resolve_stop_callable,
-    handle_sync_test_mode,
-    execute_async_starter,
     safe_stop_with_cleanup,
 )
 from app.utils.helpers import _resolve_app_callable, _short_git_sha
@@ -264,10 +265,7 @@ def start_background_updates(update_interval_hours: int = 24) -> None:
     """
     import sys as _sys
 
-    pkg = _sys.modules.get("app") or _APP_PACKAGE_REF
-    if pkg is not None and not getattr(pkg, "__path__", None) and _APP_PACKAGE_REF is not None:
-        # Prefer the package wrapper when sys.modules['app'] points to app_module
-        pkg = _APP_PACKAGE_REF
+    pkg = resolve_app_package(_sys.modules.get("app"), _APP_PACKAGE_REF)
     alias_pkg = _sys.modules.get("app_module")
 
     _asyncio = getattr(pkg, "asyncio", None) or getattr(alias_pkg, "asyncio", None) or asyncio
@@ -282,26 +280,10 @@ def start_background_updates(update_interval_hours: int = 24) -> None:
             if isinstance(maybe_called, list):
                 caller_called = maybe_called
 
-        pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
-        pkg_attr = pkg.__dict__.get("_scheduler_start_background_updates") if pkg else None
-        candidates = [
-            (
-                pkg_attr
-                if pkg_attr is not None
-                else getattr(pkg, "_scheduler_start_background_updates", None)
-            ),
-            (
-                getattr(pkg_appmod, "_scheduler_start_background_updates", None)
-                if pkg_appmod
-                else None
-            ),
-            globals().get("_scheduler_start_background_updates", None),
-        ]
-        for target in candidates:
-            if not callable(target):
-                continue
-            handle_sync_test_mode(target, update_interval_hours, caller_called)
-            break
+        starter = resolve_scheduler_starter(
+            pkg, alias_pkg, globals(), _scheduler_start_background_updates
+        )
+        handle_sync_test_mode(starter, update_interval_hours, caller_called)
         return None
 
     # Normal mode: resolve starter and execute
@@ -324,9 +306,7 @@ def stop_background_updates() -> None:
     """
     import sys as _sys
 
-    pkg = _sys.modules.get("app") or _APP_PACKAGE_REF
-    if pkg is not None and not getattr(pkg, "__path__", None) and _APP_PACKAGE_REF is not None:
-        pkg = _APP_PACKAGE_REF
+    pkg = resolve_app_package(_sys.modules.get("app"), _APP_PACKAGE_REF)
     alias_pkg = _sys.modules.get("app_module")
 
     _asyncio = getattr(pkg, "asyncio", None) or getattr(alias_pkg, "asyncio", None) or asyncio
@@ -341,22 +321,10 @@ def stop_background_updates() -> None:
             if isinstance(maybe_called, list):
                 caller_called = maybe_called
 
-        pkg_appmod = getattr(pkg, "app_module", None) if pkg else None
-        pkg_attr = pkg.__dict__.get("_scheduler_stop_background_updates") if pkg else None
-        candidates = [
-            (
-                pkg_attr
-                if pkg_attr is not None
-                else getattr(pkg, "_scheduler_stop_background_updates", None)
-            ),
-            getattr(pkg_appmod, "_scheduler_stop_background_updates", None) if pkg_appmod else None,
-            globals().get("_scheduler_stop_background_updates", None),
-        ]
-        for target in candidates:
-            if not callable(target):
-                continue
-            handle_sync_test_mode(target, None, caller_called)
-            break
+        stopper = resolve_stop_callable(
+            pkg, alias_pkg, globals(), _scheduler_stop_background_updates
+        )
+        handle_sync_test_mode(stopper, None, caller_called)
         return None
 
     # Normal mode: resolve stopper and execute

--- a/tests/test_scheduler_helpers.py
+++ b/tests/test_scheduler_helpers.py
@@ -10,8 +10,39 @@ import pytest
 from app import scheduler_helpers
 
 
-def test_resolve_scheduler_starter_prefers_alias_and_pkg_appmod() -> None:
-    """resolve_scheduler_starter should resolve starter from alias/pkg hierarchy."""
+def test_resolve_app_package_import_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolve_app_package should import the canonical package when aliases are stale."""
+
+    fake_pkg = types.SimpleNamespace(__path__=["/tmp/app"])
+
+    monkeypatch.setattr(
+        scheduler_helpers.importlib,
+        "import_module",
+        lambda name: fake_pkg if name == "app" else None,
+    )
+
+    resolved = scheduler_helpers.resolve_app_package(object(), None)
+    assert resolved is fake_pkg
+
+
+def test_resolve_app_package_returns_fallback_when_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_app_package should fall back to the original candidate on import failure."""
+
+    stale_pkg = object()
+
+    def _boom(_name: str) -> None:
+        raise RuntimeError("import failed")
+
+    monkeypatch.setattr(scheduler_helpers.importlib, "import_module", _boom)
+
+    resolved = scheduler_helpers.resolve_app_package(stale_pkg, None)
+    assert resolved is stale_pkg
+
+
+def test_resolve_scheduler_starter_prefers_pkg_before_alias() -> None:
+    """resolve_scheduler_starter should prefer the app package over alias fallbacks."""
 
     def default_starter(interval: int) -> int:
         return interval
@@ -34,22 +65,30 @@ def test_resolve_scheduler_starter_prefers_alias_and_pkg_appmod() -> None:
     globs: Dict[str, Any] = {}
     starter = scheduler_helpers.resolve_scheduler_starter(Pkg(), AliasPkg(), globs, default_starter)
     result = starter(5)
-    # Alias package has highest precedence in the resolution chain.
-    assert result == "alias:5"
+    # The package wrapper must win so package-level monkeypatching stays stable.
+    assert result == "pkg:5"
 
-    # If the global dict provides an override, it should win.
+    # An explicit non-default global override should still win.
     def override_starter(interval: int) -> int:
         return interval * 2
 
+    class EmptyPkg:
+        app_module: Any = object()
+
     globs_override: Dict[str, Any] = {"_scheduler_start_background_updates": override_starter}
     starter_override = scheduler_helpers.resolve_scheduler_starter(
-        Pkg(), AliasPkg(), globs_override, default_starter
+        EmptyPkg(), None, globs_override, default_starter
     )
     assert starter_override is override_starter
 
+    default_only = scheduler_helpers.resolve_scheduler_starter(
+        EmptyPkg(), None, {}, default_starter
+    )
+    assert default_only is default_starter
 
-def test_resolve_stop_callable_prefers_alias_and_pkg_appmod() -> None:
-    """resolve_stop_callable should resolve stopper from alias/pkg hierarchy."""
+
+def test_resolve_stop_callable_prefers_pkg_before_alias() -> None:
+    """resolve_stop_callable should prefer the app package over alias fallbacks."""
 
     def default_stopper() -> str:
         return "default"
@@ -70,14 +109,17 @@ def test_resolve_stop_callable_prefers_alias_and_pkg_appmod() -> None:
 
     globs: Dict[str, Any] = {}
     stopper = scheduler_helpers.resolve_stop_callable(Pkg(), AliasPkg(), globs, default_stopper)
-    assert stopper() == "alias"
+    assert stopper() == "pkg"
 
     def override_stopper() -> str:
         return "override"
 
+    class EmptyPkg:
+        app_module: Any = object()
+
     globs_override: Dict[str, Any] = {"_scheduler_stop_background_updates": override_stopper}
     stopper_override = scheduler_helpers.resolve_stop_callable(
-        Pkg(), AliasPkg(), globs_override, default_stopper
+        EmptyPkg(), None, globs_override, default_stopper
     )
     assert stopper_override is override_stopper
 


### PR DESCRIPTION
## Summary
Stabilize the py311 CI regression on `main` without changing public APIs or route contracts.

## Root Cause
`legacy_app` resolved scheduler helpers through alias/module fallbacks that could outrank the package facade under py311 + xdist. That made package-level monkeypatches unstable and let `app.main.app` drift from the replacement `legacy_app.app` instance after swap-based tests.

## Scope
This PR is intentionally limited to the current red CI on `main` from workflow `CI`, run `22949577067`, job `test-main (3.11)`.

Failing tests addressed:
- `tests/test_app_error_paths_97.py::TestAppErrorPaths97::test_start_background_updates_no_running_loop`
- `tests/test_app_error_paths_97.py::TestAppErrorPaths97::test_stop_background_updates_no_running_loop`
- `tests/test_app_basic_combined.py::TestAppImport::test_app_package_rehydrates_bootstrap_after_legacy_app_swap`

## Changes
- make `app.app` rehydration update `app.main.app` deterministically after bootstrap
- add canonical package resolution helper for scheduler seams
- prefer package facade resolution before alias fallbacks in scheduler start/stop helpers
- keep `legacy_app.py` as a thin compatibility layer and route sync pytest paths through shared helper resolution
- add focused helper tests for package import fallback and precedence

## Validation
- `python -X faulthandler -m pytest -n 4 --dist=loadscope tests/test_app_error_paths_97.py::TestAppErrorPaths97::test_start_background_updates_no_running_loop tests/test_app_error_paths_97.py::TestAppErrorPaths97::test_stop_background_updates_no_running_loop tests/test_app_basic_combined.py::TestAppImport::test_app_package_rehydrates_bootstrap_after_legacy_app_swap -q`
- `python -m pytest tests/test_scheduler_helpers.py -q`
- `make verify`
- `pre-commit run --all-files`

## Security Notes
No auth, tier guard, OpenAPI, env-contract, or runtime security behavior changes. No new bypass or fallback branch was added for tests.

## Marketing & GTM
Not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Python 3.11 CI by making the `app` facade rehydration deterministic and resolving scheduler helpers from the canonical package first. Fixes xdist-related flakiness without changing public APIs or routes.

- **Bug Fixes**
  - After bootstrap, set `app.main.app` to the rehydrated `legacy_app_instance` to keep the facade in sync.
  - Added `resolve_app_package` to pick the canonical `app` package when aliases are stale.
  - Updated `resolve_scheduler_starter` and `resolve_stop_callable` to prefer the package facade, then `app_module`, then explicit non-default globals; fallback to defaults last.
  - Kept `legacy_app` thin and routed start/stop through shared helpers; added focused tests for the new resolution paths.

<sup>Written for commit 4e64dd7a61414fefb84968ade94b855fb20d5204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

