### PR TITLE
feat(design): add code-first UI vocabulary and strengthen instruction generation

### DIFF
--- a/.cursor/agents/creative-designer.md
+++ b/.cursor/agents/creative-designer.md
@@ -280,7 +280,8 @@ When given a design task:
 
 - Check existing design tokens (`frontend/src/styles/tokens.ts`, iOS color assets)
 - Resolve canonical component names in `docs/design/UI_COMPONENT_VOCABULARY.md`
-- Assemble the screen brief with `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+- Draft the screen brief with `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
+- Assemble the final design spec with `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 - Review similar screens/components in codebase
 - Reference platform guidelines (Apple HIG, Material Design, Web standards)
 - Check brand assets (FitChef illustrations, logo variations)

--- a/.cursor/agents/creative-designer.md
+++ b/.cursor/agents/creative-designer.md
@@ -23,6 +23,10 @@ Before doing any work:
 - Follow `docs/orchestration/workflow.md` → “Canonical Pre-flight Checklist (SoT)”.
 - Load required context for this role from `docs/orchestration/AGENT_CONTEXT_MAP.md`.
 - Always include root `AGENTS.md` + nearest module `AGENTS.md` for any files you touch.
+- For code-first UI tasks, also load:
+  - `docs/design/UI_COMPONENT_VOCABULARY.md`
+  - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+  - `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
 
 When applicable:
 
@@ -47,6 +51,25 @@ You are a senior creative designer and visual identity specialist for **PulsePla
 5. **Optimize for App Store** (screenshots, preview videos, icons)
 6. **Design marketing materials** (landing pages, email templates, banners)
 7. **Create design system components** (buttons, cards, forms, charts)
+
+## Code-first UI vocabulary protocol
+
+Before generating UI concepts, screen specs, or prompt packs:
+
+1. Normalize UI nouns into canonical component names from
+   `docs/design/UI_COMPONENT_VOCABULARY.md`.
+2. Prefer existing repo components when a vocabulary entry maps to an existing
+   implementation.
+3. If the primitive is missing, keep the canonical name and mark it as a
+   missing primitive instead of inventing a new synonym.
+4. Draft the screen brief with `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`.
+5. Assemble the final design spec with
+   `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`.
+
+Hard rule:
+
+- Do not let external tools, vague prompts, or ad-hoc naming override the
+  canonical vocabulary or token source of truth.
 
 ## Core Brand Identity
 
@@ -256,6 +279,8 @@ When given a design task:
 ### 2. Research & Reference
 
 - Check existing design tokens (`frontend/src/styles/tokens.ts`, iOS color assets)
+- Resolve canonical component names in `docs/design/UI_COMPONENT_VOCABULARY.md`
+- Assemble the screen brief with `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 - Review similar screens/components in codebase
 - Reference platform guidelines (Apple HIG, Material Design, Web standards)
 - Check brand assets (FitChef illustrations, logo variations)
@@ -265,6 +290,7 @@ When given a design task:
 **For UI Components:**
 
 - Sketch wireframe (mental model or written description)
+- Choose canonical PulsePlate primitives before describing the layout
 - Define component structure (SwiftUI views, React components, HTML/CSS)
 - Apply brand colors and typography
 - Ensure accessibility (contrast, touch targets, screen readers)
@@ -287,6 +313,7 @@ When given a design task:
 
 **Provide:**
 
+- Canonical component names used (from PulsePlate vocabulary)
 - Code snippets (SwiftUI, React, CSS)
 - Asset specifications (sizes, formats, naming)
 - Design tokens used (colors, spacing, typography)
@@ -388,6 +415,7 @@ For each design request, provide:
 ## Best Practices
 
 - **Consistency**: Use design tokens from `frontend/src/styles/tokens.ts` and iOS color assets
+- **Naming**: Normalize vague UI language into canonical PulsePlate vocabulary before proposing design/code
 - **Accessibility First**: WCAG AA compliance, Dynamic Type, VoiceOver
 - **Platform Native**: Follow iOS HIG / Material Design / Web standards
 - **Brand Identity**: FitChef mascot, navy/blue/green palette, minimalism

--- a/.cursor/agents/creative-designer.md
+++ b/.cursor/agents/creative-designer.md
@@ -25,8 +25,8 @@ Before doing any work:
 - Always include root `AGENTS.md` + nearest module `AGENTS.md` for any files you touch.
 - For code-first UI tasks, also load:
   - `docs/design/UI_COMPONENT_VOCABULARY.md`
-  - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
   - `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
+  - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 
 When applicable:
 
@@ -62,8 +62,9 @@ Before generating UI concepts, screen specs, or prompt packs:
    implementation.
 3. If the primitive is missing, keep the canonical name and mark it as a
    missing primitive instead of inventing a new synonym.
-4. Draft the screen brief with `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`.
-5. Assemble the final design spec with
+4. Draft the screen brief first with
+   `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`.
+5. Assemble the final design spec second with
    `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`.
 
 Hard rule:

--- a/.cursor/agents/frontend-engineer.md
+++ b/.cursor/agents/frontend-engineer.md
@@ -37,10 +37,12 @@ Before doing any work:
    - `frontend/src/styles/tokens.css`
    - `frontend/src/styles/tokens.ts`
    - `frontend/tailwind.config.ts`
-2. Reuse or extend existing UI components.
-3. Enforce thin-client networking:
+2. Resolve naming via `docs/design/UI_COMPONENT_VOCABULARY.md`.
+3. Build the screen/component spec via `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`.
+4. Reuse or extend existing UI components.
+5. Enforce thin-client networking:
    - No direct `fetch()` outside `frontend/src/api/client.ts`
-4. Validate with:
+6. Validate with:
    - `cd frontend && npm test`
    - `cd frontend && npm run build`
 
@@ -49,6 +51,7 @@ Before doing any work:
 Always return:
 
 - `Summary`: UI/API integration changes.
+- `Canonical components`: vocabulary names selected for the touched UI.
 - `Token usage`: semantic tokens and style decisions.
 - `Policy checks`: thin-client compliance status.
 - `Validation`: test/build outcomes.
@@ -57,6 +60,7 @@ Always return:
 ## Guardrails
 
 - No ad-hoc color literals when semantic tokens exist.
+- No vague component naming when the vocabulary provides a canonical primitive.
 - No direct networking outside adapter policy.
 - Do not introduce DTO drift from backend contract.
 - Do not mark complete without local test/build evidence.
@@ -68,5 +72,7 @@ Always return:
 - `frontend/src/styles/tokens.css`
 - `frontend/src/styles/tokens.ts`
 - `frontend/tailwind.config.ts`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 - `frontend/src/api/client.ts`
 - `frontend/src/api/__tests__/thin-client-guards.test.ts`

--- a/docs/architecture/ADR_DESIGN_EXECUTION_ADAPTER_SEAM_2026-03-11.md
+++ b/docs/architecture/ADR_DESIGN_EXECUTION_ADAPTER_SEAM_2026-03-11.md
@@ -1,0 +1,58 @@
+# ADR: Design Execution Adapter Seam (2026-03-11)
+
+- Status: Accepted (temporary seam)
+- Date: 2026-03-11
+- Owner: @katsiaryna_kavaleuskaya
+
+## Context
+
+PulsePlate is moving toward code-first design generation, but this PR does not
+introduce a live external design executor yet. The current branch only exposes a
+deterministic adapter seam:
+
+- `scripts/design/execution_adapters.py:5`
+- `scripts/design/execution_adapters.py:18`
+- `scripts/design/execute_design.py:72`
+
+That seam is useful for deterministic validation and manifest/verification
+contracts, but it is still temporary because no reviewed live adapter exists and
+the repo has not yet promoted a code-native canvas runtime as the execution
+target.
+
+## Decision
+
+Keep `scripts/design/execution_adapters.py` as the temporary execution seam for
+Phase 1 contract work:
+
+1. `deterministic_stub` remains the only active adapter on this branch.
+2. Instruction generation, execution, and verification must all flow through
+   the adapter seam even in deterministic mode.
+3. Future live or code-native adapters must preserve the same instruction and
+   manifest contract before they can replace the seam.
+
+## Exit Criteria
+
+Retire this temporary seam only when ALL are true:
+
+1. A reviewed non-stub adapter exists for the design runtime target.
+2. The replacement adapter preserves instruction, manifest, and verification
+   contracts already validated by `scripts/design/contracts.py:81` and
+   `scripts/design/verify_design.py:58`.
+3. Local deterministic tests cover the replacement path without depending on a
+   live external design tool.
+4. `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md` is updated so the runtime
+   baseline no longer describes `deterministic_stub` as the only implemented
+   adapter.
+
+## Backlog Link (SoT)
+
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-design-execution-adapter-seam`
+
+## Consequences
+
+- Positive: PR1 can harden contracts and verification without pretending live
+  execution already exists.
+- Positive: future PRs can add a code-native or external adapter behind a known
+  seam.
+- Negative: the docs must keep calling out that `deterministic_stub` is a
+  temporary implementation, not the end-state runtime.

--- a/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+++ b/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
@@ -42,13 +42,15 @@ Use `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md` when drafting the brief.
 
 Every assembled spec must return these sections in this order:
 
-1. `Layout`
-2. `Component Tree`
-3. `State List`
-4. `Token Usage`
-5. `Interaction Notes`
-6. `Accessibility Notes`
-7. `Implementation Handoff`
+1. `Layout Archetype`
+2. `Layout`
+3. `Layout Sections`
+4. `Component Tree`
+5. `State List`
+6. `Token Usage`
+7. `Interaction Notes`
+8. `Accessibility Notes`
+9. `Implementation Handoff`
 
 ## 4. Assembly procedure
 
@@ -81,6 +83,14 @@ Allowed default archetypes for v1:
 - `empty-state-center`
 - `modal-overlay`
 - `split-summary-detail`
+
+Then derive a more specific `layout_pattern` for the actual screen, for example:
+
+- archetype: `hero-plus-sections`
+- pattern: `hero-plus-quick-actions`
+
+Executable instruction payloads may normalize the archetype into a stable
+runtime family such as `hero_shell`, `content_shell`, or `dashboard_shell`.
 
 ### Step 4. Bind states
 
@@ -191,6 +201,16 @@ forbidden_generic_patterns:
 ### Output spec
 
 #### Layout
+
+`hero-plus-sections`
+
+Top-level archetype keeps the screen in the right family before visual detail
+is added.
+
+#### Layout Sections
+
+- `hero-band`: hero, trust framing, visible progress context
+- `quick-actions`: dominant next step and one supporting action
 
 Top hero block, trust summary beneath it, discrete progress rail, primary
 button pinned within comfortable thumb reach.

--- a/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+++ b/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
@@ -1,0 +1,253 @@
+# Code-First UI Prompt Cookbook
+
+Date created: March 11, 2026 (America/New_York)
+Status: Active cookbook
+Scope: Assemble deterministic UI specs from canonical vocabulary
+
+## 1. Purpose
+
+This cookbook converts a loose UI request into a governed screen specification.
+
+Use it after selecting canonical component names from:
+
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/ui_component_vocabulary.json`
+
+It is the default prompt assembly layer for code-first design work in
+PulsePlate.
+
+## 2. Required input contract
+
+Every brief must include these fields:
+
+- `screen_name`
+- `surface`
+- `goal`
+- `user_action_priority`
+- `primary_components`
+- `supporting_components`
+- `states`
+- `layout_pattern`
+- `interaction_model`
+- `visual_mood`
+- `token_profile`
+- `token_constraints`
+- `a11y_constraints`
+- `constraints`
+- `forbidden_generic_patterns`
+
+Use `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md` when drafting the brief.
+
+## 3. Output contract
+
+Every assembled spec must return these sections in this order:
+
+1. `Layout`
+2. `Component Tree`
+3. `State List`
+4. `Token Usage`
+5. `Interaction Notes`
+6. `Accessibility Notes`
+7. `Implementation Handoff`
+
+## 4. Assembly procedure
+
+### Step 1. Lock surface and goal
+
+Start with:
+
+- platform: `web-first, iOS-aware` by default
+- primary job to be done
+- main CTA or user action
+
+### Step 2. Choose canonical components
+
+Choose named primitives from `ui_component_vocabulary.json`.
+
+Rules:
+
+- existing repo component wins
+- missing primitives must be called by canonical name
+- no new synonyms inside the spec
+
+### Step 3. Choose one layout archetype
+
+Allowed default archetypes for v1:
+
+- `stacked-dashboard`
+- `form-stack`
+- `hero-plus-sections`
+- `wizard-flow`
+- `empty-state-center`
+- `modal-overlay`
+- `split-summary-detail`
+
+### Step 4. Bind states
+
+List explicit UI states, not just happy path:
+
+- loading
+- empty
+- active
+- validation error
+- locked or premium
+- success feedback
+
+### Step 5. Bind tokens
+
+Use semantic token intent, not raw visual adjectives:
+
+- `surface`: `--color-surface`
+- `text`: `--color-text`
+- `primary action`: `--color-primary`
+- `success accent`: `--color-success`
+- `error tone`: `--color-error`
+- radius/shadow from token system only
+
+### Step 6. Ban vague language
+
+Do not use these as primary design nouns:
+
+- `menu`
+- `box`
+- `nice card`
+- `cool button`
+- `popup`
+- `section thing`
+- `tile`
+
+Replace them with canonical names before proceeding.
+
+## 5. Default authoring template
+
+```text
+screen_name: <screen name>
+surface: <web mobile | web desktop | ios | shared>
+goal: <what the screen helps the user achieve>
+user_action_priority: <primary CTA or decision>
+primary_components:
+  - <canonical component>
+supporting_components:
+  - <canonical component>
+states:
+  - <state>
+layout_pattern: <one allowed archetype>
+interaction_model: <tap-first | form-first | browse-first | mixed>
+visual_mood: <luxury-clean | minimal-cozy | progress-focused>
+token_profile:
+  - <semantic token intent>
+token_constraints:
+  - use repo semantic tokens only
+a11y_constraints:
+  - visible focus
+  - keyboard path
+  - screen-reader label
+constraints:
+  - no hidden naming drift
+forbidden_generic_patterns:
+  - menu
+  - popup
+  - box
+```
+
+## 6. Example: Onboarding Trust screen
+
+### Input brief
+
+```text
+screen_name: onboarding trust
+surface: web mobile
+goal: help the user trust the setup process and continue
+user_action_priority: continue to setup
+primary_components:
+  - hero
+  - stepper/progress-indicator
+supporting_components:
+  - stats-card
+  - button
+states:
+  - default
+  - loading
+  - premium locked
+layout_pattern: hero-plus-sections
+interaction_model: tap-first
+visual_mood: minimal-cozy
+token_profile:
+  - --pp-navy
+  - --color-primary
+  - --color-surface
+token_constraints:
+  - no raw hex
+a11y_constraints:
+  - main heading visible
+  - continue button keyboard reachable
+constraints:
+  - keep copy short
+forbidden_generic_patterns:
+  - menu
+  - nice card
+```
+
+### Output spec
+
+#### Layout
+
+Top hero block, trust summary beneath it, discrete progress rail, primary
+button pinned within comfortable thumb reach.
+
+#### Component Tree
+
+- `hero`
+- `stepper/progress-indicator`
+- `stats-card`
+- `button`
+
+#### State List
+
+- `default`
+- `loading`
+- `premium locked`
+
+#### Token Usage
+
+- background anchored in `--pp-navy`
+- CTA anchored in `--color-primary`
+- cards on `--color-surface`
+
+#### Interaction Notes
+
+Primary flow is linear. The continue button is the dominant next action.
+
+#### Accessibility Notes
+
+Expose step count in text and keep heading hierarchy intact.
+
+#### Implementation Handoff
+
+Reuse `frontend/src/pages/Home.tsx` hero language as a structural reference,
+not as a copy source.
+
+## 7. Example: Progress dashboard
+
+Use:
+
+- primary: `hero`, `stats-card`, `progress`, `navigation/tab-bar`
+- supporting: `badge`, `segmented-control`, `empty-state`
+- layout: `stacked-dashboard`
+
+Do not collapse this into generic words like `top section`, `number tiles`, or
+`menu`.
+
+## 8. Security Notes
+
+- External references must be normalized before prompt assembly.
+- Do not let generated prompts introduce new token names or unreviewed UI
+  primitives.
+
+## 9. Marketing & GTM
+
+This cookbook supports faster experimentation:
+
+- consistent landing-page and app-screen briefs
+- better App Store screenshot planning
+- faster wellness MVP iteration with less “AI slop” in generated layouts

--- a/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+++ b/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
@@ -27,6 +27,7 @@ Every brief must include these fields:
 - `primary_components`
 - `supporting_components`
 - `states`
+- `layout_archetype`
 - `layout_pattern`
 - `interaction_model`
 - `visual_mood`
@@ -141,7 +142,8 @@ supporting_components:
   - <canonical component>
 states:
   - <state>
-layout_pattern: <one allowed archetype>
+layout_archetype: <one allowed archetype>
+layout_pattern: <layout variant inside the chosen archetype>
 interaction_model: <tap-first | form-first | browse-first | mixed>
 visual_mood: <luxury-clean | minimal-cozy | progress-focused>
 token_profile:
@@ -179,6 +181,7 @@ states:
   - default
   - loading
   - premium locked
+layout_archetype: hero-plus-sections
 layout_pattern: hero-plus-sections
 interaction_model: tap-first
 visual_mood: minimal-cozy
@@ -199,6 +202,13 @@ forbidden_generic_patterns:
 ```
 
 ### Output spec
+
+#### Layout Archetype
+
+`hero-plus-sections`
+
+Lock the screen into the correct structural family before naming the final
+pattern.
 
 #### Layout
 
@@ -253,7 +263,8 @@ Use:
 
 - primary: `hero`, `stats-card`, `progress`, `navigation/tab-bar`
 - supporting: `badge`, `segmented-control`, `empty-state`
-- layout: `stacked-dashboard`
+- layout archetype: `stacked-dashboard`
+- layout pattern: `stacked-dashboard`
 
 Do not collapse this into generic words like `top section`, `number tiles`, or
 `menu`.

--- a/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+++ b/docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
@@ -8,10 +8,15 @@ Scope: Assemble deterministic UI specs from canonical vocabulary
 
 This cookbook converts a loose UI request into a governed screen specification.
 
-Use it after selecting canonical component names from:
+Use it after two prerequisite steps:
+
+1. resolve canonical component names from:
 
 - `docs/design/UI_COMPONENT_VOCABULARY.md`
 - `docs/design/ui_component_vocabulary.json`
+2. draft the brief with:
+
+- `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
 
 It is the default prompt assembly layer for code-first design work in
 PulsePlate.
@@ -37,7 +42,8 @@ Every brief must include these fields:
 - `constraints`
 - `forbidden_generic_patterns`
 
-Use `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md` when drafting the brief.
+Hard rule: the screen brief template is filled first, then this cookbook is
+used to assemble the final governed spec.
 
 ## 3. Output contract
 
@@ -57,7 +63,7 @@ Every assembled spec must return these sections in this order:
 
 ### Step 1. Lock surface and goal
 
-Start with:
+Start from the completed screen brief template and then lock:
 
 - platform: `web-first, iOS-aware` by default
 - primary job to be done

--- a/docs/design/DESIGN_SYSTEM_FOR_CODE.md
+++ b/docs/design/DESIGN_SYSTEM_FOR_CODE.md
@@ -37,6 +37,9 @@
 **Аудит «что добавить»:** `docs/audit/FRONTEND_MODERN_COMPONENTS_AUDIT.md`
 **Быстрый старт по компонентам:** `docs/audit/FRONTEND_COMPONENTS_QUICK_START.md`
 **Сравнение с Component Gallery:** `docs/audit/DESIGN_SYSTEM_COMPONENT_GALLERY_AUDIT.md`
+**Канонический словарь компонентов:** `docs/design/UI_COMPONENT_VOCABULARY.md`
+**Machine-readable реестр:** `docs/design/ui_component_vocabulary.json`
+**Code-first cookbook:** `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 
 Кнопки (варианты и состояния): `docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md`, CTA реестр — в полной спецификации Figma/Figr (12 разделов).
 
@@ -56,7 +59,8 @@
 | «Нужна дизайн-система под код» | Этот файл + путь к `frontend/src/styles/tokens.css` (или выдержку из него) |
 | «Цвета/отступы для вёрстки» | `tokens.css` + `TOKENS_SOT.md` |
 | «Правила по виду и контрасту» | `PULSEPLATE_LUXURY_WEB_IOS_VISUAL_GUIDELINES.md` |
-| «Какие компоненты есть / чего не хватает» | `FRONTEND_MODERN_COMPONENTS_AUDIT.md` или `FRONTEND_COMPONENTS_QUICK_START.md` |
+| «Какие компоненты есть / чего не хватает» | `UI_COMPONENT_VOCABULARY.md` + `ui_component_vocabulary.json` + `FRONTEND_MODERN_COMPONENTS_AUDIT.md` |
+| «Как собирать дизайн по коду, а не по расплывчатому описанию» | `CODE_FIRST_UI_PROMPT_COOKBOOK.md` + `UI_SCREEN_BRIEF_TEMPLATES.md` + `UI_VOCABULARY_EVALS.md` |
 | «Полная спецификация» | Ссылка на артефакт Figr + при необходимости выдержки из пунктов 1–3 выше |
 
 Если дизайнер уточнит задачу (токены, компоненты, экраны, стиль), по этому указателю можно сразу выбрать нужный документ или кусок кода.

--- a/docs/design/UI_COMPONENT_VOCABULARY.md
+++ b/docs/design/UI_COMPONENT_VOCABULARY.md
@@ -74,8 +74,9 @@ Naming convention:
 
 - `id` is the programmatic identifier and uses underscores, for example
   `radio_group` or `form_field`
-- `canonical_name` is the human-facing normalized reference and uses hyphens,
-  for example `radio-group` or `form-field`
+- `canonical_name` is the human-facing normalized reference; use hyphens for
+  single primitives and `/` for hierarchical families, for example
+  `radio-group`, `form-field`, or `navigation/tab-bar`
 
 ## 4. Status semantics
 

--- a/docs/design/UI_COMPONENT_VOCABULARY.md
+++ b/docs/design/UI_COMPONENT_VOCABULARY.md
@@ -70,6 +70,13 @@ Every component entry in `ui_component_vocabulary.json` includes:
 - `anti_generic_terms`
 - `stitch_normalization_hint`
 
+Naming convention:
+
+- `id` is the programmatic identifier and uses underscores, for example
+  `radio_group` or `form_field`
+- `canonical_name` is the human-facing normalized reference and uses hyphens,
+  for example `radio-group` or `form-field`
+
 ## 4. Status semantics
 
 Use these `missing_status` values exactly as written:

--- a/docs/design/UI_COMPONENT_VOCABULARY.md
+++ b/docs/design/UI_COMPONENT_VOCABULARY.md
@@ -1,0 +1,191 @@
+# UI Component Vocabulary
+
+Date created: March 11, 2026 (America/New_York)
+Status: Active vocabulary contract
+Scope: Canonical naming and normalization layer for code-first UI design
+
+## 1. Purpose
+
+This document defines the canonical UI vocabulary for PulsePlate.
+
+It exists to prevent vague prompts like `menu`, `button`, or `box` from
+becoming hidden design decisions. Use it to normalize UI ideas into named
+primitives before generating:
+
+- code
+- design specs
+- Figma instructions
+- prompt packs
+- external reference intake notes
+
+This document does not replace design/token governance.
+
+Authoritative source precedence remains:
+
+- repo code, docs, and tests
+- `docs/design/TOKENS_SOT.md`
+- `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`
+
+Machine-readable contract:
+
+- `docs/design/ui_component_vocabulary.json`
+
+## 2. Operating model
+
+Use this sequence for all code-first UI work:
+
+1. Define the screen goal and target surface.
+2. Select canonical component names from `ui_component_vocabulary.json`.
+3. Map to existing repo components first.
+4. Mark any missing primitive as `missing` or `missing-primitive-existing-flow`.
+5. Build the screen brief via `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`.
+6. Assemble the full design spec via `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`.
+7. Generate code, visual prompts, or Figma instructions from that brief.
+
+Hard rule:
+
+- Existing repo component naming wins over external naming.
+- Canonical vocabulary wins over external tool wording.
+- External reference wording must be normalized before implementation.
+
+## 3. Canonical schema
+
+Every component entry in `ui_component_vocabulary.json` includes:
+
+- `id`
+- `canonical_name`
+- `aliases`
+- `intent`
+- `when_to_use`
+- `when_not_to_use`
+- `anatomy`
+- `states`
+- `accessibility_notes`
+- `token_guidance`
+- `react_mapping`
+- `swiftui_mapping`
+- `existing_repo_component`
+- `missing_status`
+- `prompt_terms`
+- `anti_generic_terms`
+- `stitch_normalization_hint`
+
+## 4. Status semantics
+
+Use these `missing_status` values exactly as written:
+
+- `existing`: generic repo primitive already exists
+- `specialized-existing`: repo has a concrete implementation, but not yet a
+  generic primitive
+- `missing`: no governed primitive exists in repo today
+- `missing-primitive-existing-flow`: the product surface exists, but the
+  reusable primitive should still be separated
+
+## 5. P0/P1 component set
+
+### Form and action primitives
+
+| Canonical name | Repo status | Existing repo component |
+| --- | --- | --- |
+| `button` | existing | `frontend/src/components/ui/Button.tsx` |
+| `input` | existing | `frontend/src/components/ui/Input.tsx` |
+| `select` | missing | none |
+| `textarea` | missing | none |
+| `checkbox` | missing | none |
+| `radio-group` | missing | none |
+| `form-field` | existing | `frontend/src/components/ui/FormField.tsx` |
+| `toggle` | existing | `frontend/src/components/ui/Toggle.tsx` |
+
+### Structure and feedback primitives
+
+| Canonical name | Repo status | Existing repo component |
+| --- | --- | --- |
+| `card` | existing | `frontend/src/components/ui/Card.tsx` |
+| `alert` | missing | none |
+| `badge` | specialized-existing | `frontend/src/components/VipBadge.tsx` |
+| `dialog` | existing | `frontend/src/components/ui/Dialog.tsx` |
+| `dropdown-menu` | missing | none |
+| `tabs` | missing | none |
+| `progress` | specialized-existing | `frontend/src/features/progress/LiveProgressIndicator.tsx` |
+| `tooltip` | missing | none |
+| `empty-state` | existing | `frontend/src/components/ui/EmptyState.tsx` |
+| `skeleton` | existing | `frontend/src/components/ui/Skeleton.tsx` |
+
+### Navigation and screen primitives
+
+| Canonical name | Repo status | Existing repo component |
+| --- | --- | --- |
+| `segmented-control` | existing | `frontend/src/components/ui/SegmentedControl.tsx` |
+| `mobile-menu` | existing | `frontend/src/components/ui/MobileMenu.tsx` |
+| `navigation/tab-bar` | existing | `frontend/src/components/TabBar.tsx` |
+| `hero` | specialized-existing | `frontend/src/pages/Home.tsx` |
+| `stats-card` | specialized-existing | `frontend/src/pages/NutritionSetup/MacroCards.tsx` |
+| `stepper/progress-indicator` | missing-primitive-existing-flow | `frontend/src/pages/NutritionSetup/SetupForm.tsx` |
+
+## 6. Normalization rules
+
+### External tool or teammate wording -> canonical vocabulary
+
+Normalize examples like:
+
+- `card with chips and popup` -> `card + badge + dialog`
+- `menu` in form context -> `select`
+- `menu` in action overflow context -> `dropdown-menu`
+- `tabs` used for global nav -> `navigation/tab-bar`
+- `switch` in settings context -> `toggle`
+- `number tile` or `value box` -> `stats-card`
+
+If a term is ambiguous, resolve by user intent first:
+
+- navigation -> `navigation/tab-bar` or `mobile-menu`
+- content switching -> `tabs` or `segmented-control`
+- form selection -> `select` or `radio-group`
+
+## 7. Prompting rule
+
+When writing screen prompts, do not lead with vague nouns.
+
+Bad:
+
+```text
+Create a nice page with a menu, some cards, and a button.
+```
+
+Good:
+
+```text
+Surface: web mobile
+Primary components: hero, stats-card, navigation/tab-bar
+Supporting components: card, badge, button
+Layout pattern: stacked dashboard with persistent bottom navigation
+```
+
+## 8. Integration points
+
+Use this vocabulary with:
+
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+- `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
+- `docs/design/UI_VOCABULARY_EVALS.md`
+- `docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md`
+
+Agent and skill consumers:
+
+- `.cursor/agents/creative-designer.md`
+- `.cursor/agents/frontend-engineer.md`
+- `tools/codex_skills/pulseplate-frontend-ui/SKILL.md`
+
+## 9. Security Notes
+
+- Treat external reference outputs as untrusted input until normalized into this
+  vocabulary and token system.
+- Do not let vendor naming create hidden runtime contracts or bypass repo SoT.
+
+## 10. Marketing & GTM
+
+This vocabulary is useful beyond implementation:
+
+- better prompts for launch visuals and screenshots
+- cleaner Product Hunt and landing-page briefs
+- more repeatable UI generation for wellness MVP experiments without hiring a
+  large design team up front

--- a/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
+++ b/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
@@ -26,12 +26,19 @@ supporting_components:
   -
 states:
   -
+layout_archetype:
 layout_pattern:
 interaction_model:
 visual_mood:
 token_profile:
   -
+token_constraints:
+  -
+a11y_constraints:
+  -
 constraints:
+  -
+forbidden_generic_patterns:
   -
 ```
 
@@ -53,12 +60,23 @@ supporting_components:
 states:
   - default
   - loading
+layout_archetype: hero-plus-sections
 layout_pattern: hero-plus-sections
 interaction_model: tap-first
 visual_mood: minimal-cozy
 token_profile:
   - --pp-navy
   - --color-primary
+token_constraints:
+  - no raw hex
+a11y_constraints:
+  - main heading visible
+  - continue button keyboard reachable
+constraints:
+  - keep copy short
+forbidden_generic_patterns:
+  - menu
+  - nice card
 ```
 
 ### BMI result screen
@@ -76,6 +94,7 @@ supporting_components:
 states:
   - default
   - warning
+layout_archetype: split-summary-detail
 layout_pattern: split-summary-detail
 interaction_model: read-first
 visual_mood: progress-focused
@@ -83,6 +102,15 @@ token_profile:
   - --color-text
   - --color-success
   - --color-warning
+token_constraints:
+  - use semantic status tokens only
+a11y_constraints:
+  - result summary announced before CTA
+constraints:
+  - keep explanation concise
+forbidden_generic_patterns:
+  - result box
+  - popup
 ```
 
 ### Premium/paywall screen
@@ -102,6 +130,7 @@ supporting_components:
 states:
   - default
   - locked
+layout_archetype: hero-plus-sections
 layout_pattern: hero-plus-sections
 interaction_model: tap-first
 visual_mood: luxury-clean
@@ -109,6 +138,15 @@ token_profile:
   - --pp-navy
   - --pp-gold
   - --color-primary
+token_constraints:
+  - premium accents must still use repo tokens
+a11y_constraints:
+  - unlock CTA visible in focus order
+constraints:
+  - avoid generic SaaS pricing language
+forbidden_generic_patterns:
+  - pricing box
+  - popup
 ```
 
 ### Progress dashboard
@@ -129,6 +167,7 @@ states:
   - default
   - empty
   - loading
+layout_archetype: stacked-dashboard
 layout_pattern: stacked-dashboard
 interaction_model: browse-first
 visual_mood: progress-focused
@@ -136,6 +175,15 @@ token_profile:
   - --color-surface
   - --color-primary
   - --color-success
+token_constraints:
+  - no raw hex
+a11y_constraints:
+  - summary values exposed as text
+constraints:
+  - keep charts secondary to headline stats
+forbidden_generic_patterns:
+  - number tiles
+  - top section
 ```
 
 ### Setup form
@@ -156,6 +204,7 @@ states:
   - default
   - error
   - loading
+layout_archetype: form-stack
 layout_pattern: form-stack
 interaction_model: form-first
 visual_mood: minimal-cozy
@@ -163,6 +212,15 @@ token_profile:
   - --color-border
   - --color-text
   - --radius-md
+token_constraints:
+  - field chrome must use semantic border tokens
+a11y_constraints:
+  - labels persist above inputs
+constraints:
+  - one primary action per step
+forbidden_generic_patterns:
+  - form thing
+  - input box
 ```
 
 ### Empty state
@@ -180,12 +238,22 @@ supporting_components:
 states:
   - default
   - retry
+layout_archetype: empty-state-center
 layout_pattern: empty-state-center
 interaction_model: tap-first
 visual_mood: minimal-cozy
 token_profile:
   - --color-surface
   - --color-text-muted
+token_constraints:
+  - use muted semantic text tokens only
+a11y_constraints:
+  - empty-state message announced before CTA
+constraints:
+  - recovery CTA must stay explicit
+forbidden_generic_patterns:
+  - blank page
+  - empty box
 ```
 
 ### Mobile menu and navigation
@@ -204,12 +272,22 @@ states:
   - default
   - open
   - active
+layout_archetype: modal-overlay
 layout_pattern: modal-overlay
 interaction_model: tap-first
 visual_mood: minimal-cozy
 token_profile:
   - --color-surface
   - --color-text
+token_constraints:
+  - navigation surface uses shared semantic tokens
+a11y_constraints:
+  - active destination announced
+constraints:
+  - keep secondary nav compact
+forbidden_generic_patterns:
+  - menu
+  - nav popup
 ```
 
 ### Export success feedback
@@ -226,12 +304,22 @@ supporting_components:
   - button
 states:
   - success
+layout_archetype: stacked-dashboard
 layout_pattern: stacked-dashboard
 interaction_model: tap-first
 visual_mood: progress-focused
 token_profile:
   - --color-success
   - --color-surface
+token_constraints:
+  - success messaging must use semantic success tokens
+a11y_constraints:
+  - confirmation message announced before next action
+constraints:
+  - keep next step visible without scroll
+forbidden_generic_patterns:
+  - success popup
+  - alert box
 ```
 
 ## 4. Security Notes

--- a/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
+++ b/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
@@ -1,0 +1,250 @@
+# UI Screen Brief Templates
+
+Date created: March 11, 2026 (America/New_York)
+Status: Active templates
+Scope: Canonical input briefs for code-first UI work
+
+## 1. Purpose
+
+Use these templates before invoking:
+
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+
+Every new screen brief should start from this structure instead of raw prose.
+
+## 2. Base template
+
+```text
+screen_name:
+surface:
+goal:
+user_action_priority:
+primary_components:
+  -
+supporting_components:
+  -
+states:
+  -
+layout_pattern:
+interaction_model:
+visual_mood:
+token_profile:
+  -
+constraints:
+  -
+```
+
+## 3. Control briefs
+
+### Onboarding trust screen
+
+```text
+screen_name: onboarding trust
+surface: web mobile
+goal: increase trust and move the user into setup
+user_action_priority: continue setup
+primary_components:
+  - hero
+  - stepper/progress-indicator
+supporting_components:
+  - stats-card
+  - button
+states:
+  - default
+  - loading
+layout_pattern: hero-plus-sections
+interaction_model: tap-first
+visual_mood: minimal-cozy
+token_profile:
+  - --pp-navy
+  - --color-primary
+```
+
+### BMI result screen
+
+```text
+screen_name: bmi result
+surface: web mobile
+goal: explain the result and point to the next action
+user_action_priority: continue to next health-safe step
+primary_components:
+  - stats-card
+  - alert
+supporting_components:
+  - button
+states:
+  - default
+  - warning
+layout_pattern: split-summary-detail
+interaction_model: read-first
+visual_mood: progress-focused
+token_profile:
+  - --color-text
+  - --color-success
+  - --color-warning
+```
+
+### Premium/paywall screen
+
+```text
+screen_name: premium paywall
+surface: web mobile
+goal: communicate value and unlock premium
+user_action_priority: unlock premium
+primary_components:
+  - hero
+  - card
+  - button
+supporting_components:
+  - badge
+  - dialog
+states:
+  - default
+  - locked
+layout_pattern: hero-plus-sections
+interaction_model: tap-first
+visual_mood: luxury-clean
+token_profile:
+  - --pp-navy
+  - --pp-gold
+  - --color-primary
+```
+
+### Progress dashboard
+
+```text
+screen_name: progress dashboard
+surface: web mobile
+goal: show momentum and keep the user engaged
+user_action_priority: inspect progress details
+primary_components:
+  - hero
+  - stats-card
+  - progress
+supporting_components:
+  - segmented-control
+  - navigation/tab-bar
+states:
+  - default
+  - empty
+  - loading
+layout_pattern: stacked-dashboard
+interaction_model: browse-first
+visual_mood: progress-focused
+token_profile:
+  - --color-surface
+  - --color-primary
+  - --color-success
+```
+
+### Setup form
+
+```text
+screen_name: setup form
+surface: web mobile
+goal: collect setup inputs with low friction
+user_action_priority: submit the current step
+primary_components:
+  - form-field
+  - input
+  - select
+supporting_components:
+  - button
+  - stepper/progress-indicator
+states:
+  - default
+  - error
+  - loading
+layout_pattern: form-stack
+interaction_model: form-first
+visual_mood: minimal-cozy
+token_profile:
+  - --color-border
+  - --color-text
+  - --radius-md
+```
+
+### Empty state
+
+```text
+screen_name: progress empty state
+surface: web mobile
+goal: help the user recover from no data and start the right action
+user_action_priority: start tracking
+primary_components:
+  - empty-state
+supporting_components:
+  - button
+  - badge
+states:
+  - default
+  - retry
+layout_pattern: empty-state-center
+interaction_model: tap-first
+visual_mood: minimal-cozy
+token_profile:
+  - --color-surface
+  - --color-text-muted
+```
+
+### Mobile menu and navigation
+
+```text
+screen_name: mobile navigation
+surface: web mobile
+goal: keep primary navigation persistent and secondary nav compact
+user_action_priority: move to another top-level destination
+primary_components:
+  - navigation/tab-bar
+  - mobile-menu
+supporting_components:
+  - button
+states:
+  - default
+  - open
+  - active
+layout_pattern: modal-overlay
+interaction_model: tap-first
+visual_mood: minimal-cozy
+token_profile:
+  - --color-surface
+  - --color-text
+```
+
+### Export success feedback
+
+```text
+screen_name: export success feedback
+surface: web mobile
+goal: confirm the export and offer the next action
+user_action_priority: share or continue
+primary_components:
+  - alert
+supporting_components:
+  - badge
+  - button
+states:
+  - success
+layout_pattern: stacked-dashboard
+interaction_model: tap-first
+visual_mood: progress-focused
+token_profile:
+  - --color-success
+  - --color-surface
+```
+
+## 4. Security Notes
+
+- Use these templates only after normalizing external references into canonical
+  vocabulary.
+- Do not let raw vendor wording bypass the brief structure.
+
+## 5. Marketing & GTM
+
+These briefs are reusable for:
+
+- in-product surfaces
+- screenshot planning
+- landing-page sections
+- lightweight wellness MVP experiments

--- a/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
+++ b/docs/design/UI_SCREEN_BRIEF_TEMPLATES.md
@@ -6,12 +6,17 @@ Scope: Canonical input briefs for code-first UI work
 
 ## 1. Purpose
 
-Use these templates before invoking:
+Use these templates first, before invoking:
 
 - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
-- `docs/design/UI_COMPONENT_VOCABULARY.md`
 
 Every new screen brief should start from this structure instead of raw prose.
+Canonical flow is:
+
+1. normalize component names with `docs/design/UI_COMPONENT_VOCABULARY.md`
+2. fill this screen brief template
+3. assemble the governed spec with
+   `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 
 ## 2. Base template
 

--- a/docs/design/UI_VOCABULARY_EVALS.md
+++ b/docs/design/UI_VOCABULARY_EVALS.md
@@ -1,0 +1,121 @@
+# UI Vocabulary Evals
+
+Date created: March 11, 2026 (America/New_York)
+Status: Deterministic evaluation pack
+Scope: Evaluate whether screen briefs use canonical UI vocabulary instead of generic wording
+
+## 1. Purpose
+
+This document defines the manual but deterministic evaluation set for the
+code-first UI vocabulary layer.
+
+Pass condition:
+
+- the brief uses canonical names
+- the component tree is derivable without extra design decisions
+- the brief binds tokens and states explicitly
+
+## 2. Eval cases
+
+### 1. Onboarding trust screen
+
+- Expected component vocabulary: `hero`, `stepper/progress-indicator`, `stats-card`, `button`
+- Banned vague words: `top section`, `nice banner`, `menu`
+- Expected layout pattern: `hero-plus-sections`
+- Required token use: `--pp-navy`, `--color-primary`, `--color-surface`
+- Expected repo reuse: `frontend/src/pages/Home.tsx`
+- Pass example: "hero + stepper/progress-indicator + button"
+- Fail example: "banner + progress thing + CTA box"
+
+### 2. BMI result screen
+
+- Expected component vocabulary: `hero`, `stats-card`, `alert`, `button`
+- Banned vague words: `result box`, `value tile`
+- Expected layout pattern: `split-summary-detail`
+- Required token use: `--color-text`, `--color-success` or `--color-warning`
+- Expected repo reuse: `frontend/src/pages/BMI/BMICalculatePage.tsx`
+- Pass example: "stats-card for BMI value plus alert for guidance"
+- Fail example: "big number card and colored note"
+
+### 3. Premium/paywall screen
+
+- Expected component vocabulary: `hero`, `card`, `badge`, `button`, `dialog`
+- Banned vague words: `offer block`, `popup`, `gold section`
+- Expected layout pattern: `hero-plus-sections`
+- Required token use: `--pp-navy`, `--color-primary`, `--pp-gold`
+- Expected repo reuse: `frontend/src/components/PremiumGate.tsx`
+- Pass example: "hero + feature cards + premium badge + unlock button"
+- Fail example: "premium banner with popup"
+
+### 4. Progress dashboard
+
+- Expected component vocabulary: `hero`, `stats-card`, `progress`, `navigation/tab-bar`
+- Banned vague words: `number tiles`, `bottom menu`
+- Expected layout pattern: `stacked-dashboard`
+- Required token use: `--color-surface`, `--color-primary`, `--color-success`
+- Expected repo reuse: `frontend/src/features/progress/LiveProgressIndicator.tsx`
+- Pass example: "stats-card grid with progress and persistent navigation/tab-bar"
+- Fail example: "dashboard top area with bars and footer nav"
+
+### 5. Setup form
+
+- Expected component vocabulary: `form-field`, `input`, `select`, `button`, `stepper/progress-indicator`
+- Banned vague words: `form box`, `dropdown menu`, `wizard line`
+- Expected layout pattern: `form-stack`
+- Required token use: `--color-border`, `--color-text`, `--radius-md`
+- Expected repo reuse: `frontend/src/components/ui/FormField.tsx`
+- Pass example: "form-field wrappers around input/select controls"
+- Fail example: "stack of fields with dropdown menu"
+
+### 6. Empty state
+
+- Expected component vocabulary: `empty-state`, `button`, `badge`
+- Banned vague words: `blank page`, `placeholder page`
+- Expected layout pattern: `empty-state-center`
+- Required token use: `--color-surface`, `--color-text-muted`
+- Expected repo reuse: `frontend/src/components/ui/EmptyState.tsx`
+- Pass example: "empty-state with retry button"
+- Fail example: "empty card with message"
+
+### 7. Mobile menu/navigation
+
+- Expected component vocabulary: `mobile-menu`, `navigation/tab-bar`, `button`
+- Banned vague words: `hamburger thing`, `bottom buttons`
+- Expected layout pattern: `modal-overlay`
+- Required token use: `--color-surface`, `--color-text`
+- Expected repo reuse: `frontend/src/components/ui/MobileMenu.tsx`, `frontend/src/components/TabBar.tsx`
+- Pass example: "mobile-menu for overflow nav plus navigation/tab-bar for primary destinations"
+- Fail example: "menu and footer nav"
+
+### 8. Export success feedback
+
+- Expected component vocabulary: `alert`, `badge`, `button`
+- Banned vague words: `success popup`, `green box`
+- Expected layout pattern: `stacked-dashboard`
+- Required token use: `--color-success`, `--color-surface`
+- Expected repo reuse: `frontend/src/features/progress/ProgressCharts.tsx`
+- Pass example: "inline alert with export success badge"
+- Fail example: "green popup with done icon"
+
+## 3. Acceptance criteria
+
+The vocabulary layer is working when:
+
+- new briefs no longer use vague nouns as primary spec
+- agent outputs cite canonical components and states
+- external reference intake is normalized before implementation
+- web-first outputs remain compatible with iOS-aware mapping
+
+## 4. Security Notes
+
+- External layout references must pass through normalization before evaluation.
+- Do not accept pretty but unnamed UI fragments as valid output.
+
+## 5. Marketing & GTM
+
+These evals help produce cleaner:
+
+- Product Hunt visuals
+- landing-page briefs
+- App Store screenshot concepts
+- wellness MVP experiments with lower design drift

--- a/docs/design/VISUAL_IMPLEMENTATION_MAP.md
+++ b/docs/design/VISUAL_IMPLEMENTATION_MAP.md
@@ -16,6 +16,8 @@ Canonical governance references:
 - `docs/sora/PULSEPLATE_SORA_PROMPT_ENGINEERING_PLAYBOOK.md`
 - `docs/sora/SORA_STYLE_QA_CHECKLIST.md`
 - `docs/design/PULSEPLATE_LUXURY_WEB_IOS_VISUAL_GUIDELINES.md`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 
 ## 2) Mapping Table (with Evidence Anchors)
 
@@ -45,6 +47,12 @@ Use these canonical templates/checklists instead of defining local rule copies h
 1. P0 bundle first.
 2. P1 bundle only after P0 consistency pass.
 3. P2 bundle only as optional toggle/campaign layer.
+
+Before visual planning or prompt-pack execution:
+
+1. Resolve canonical component names through `docs/design/ui_component_vocabulary.json`.
+2. Build the screen brief using `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`.
+3. Then map the visual element to page ownership and prompt-pack execution.
 
 ## 5) Security and GTM References
 

--- a/docs/design/ui_component_vocabulary.json
+++ b/docs/design/ui_component_vocabulary.json
@@ -1,0 +1,698 @@
+[
+  {
+    "id": "button",
+    "canonical_name": "button",
+    "aliases": ["cta", "action button"],
+    "intent": "Initiate a primary or secondary action with clear affordance.",
+    "when_to_use": ["Single next action", "Submit or confirm flows", "Toolbar or card actions"],
+    "when_not_to_use": ["Persistent navigation shell", "Binary state toggles", "Long-form text entry"],
+    "anatomy": ["label", "hit area", "variant", "state feedback"],
+    "states": ["default", "hover", "focus", "active", "disabled", "loading"],
+    "accessibility_notes": [
+      "Use semantic button element with accessible label.",
+      "Keep visible focus ring and minimum touch target."
+    ],
+    "token_guidance": ["--color-primary", "--color-text", "--radius-md", "--shadow-sm"],
+    "react_mapping": {
+      "component": "Button",
+      "repo_path": "frontend/src/components/ui/Button.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "Button",
+      "notes": "Prefer Button with variant-specific buttonStyle and token-backed colors."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Button.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["primary button", "secondary button", "button row", "loading button"],
+    "anti_generic_terms": ["nice button", "cool button", "random CTA"],
+    "stitch_normalization_hint": "Normalize call-to-action controls to button plus explicit variant and state."
+  },
+  {
+    "id": "input",
+    "canonical_name": "input",
+    "aliases": ["text input", "text field"],
+    "intent": "Collect short-form text or single-line structured input.",
+    "when_to_use": ["Names and labels", "Short queries", "Single-line form fields"],
+    "when_not_to_use": ["Long notes", "Single-choice selection", "Numeric-only entry with custom parsing"],
+    "anatomy": ["label", "field", "placeholder", "help text", "error text"],
+    "states": ["default", "focus", "filled", "error", "disabled", "readonly"],
+    "accessibility_notes": [
+      "Associate label and error text with the field.",
+      "Do not rely on placeholder as the only label."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--color-text", "--radius-md"],
+    "react_mapping": {
+      "component": "Input",
+      "repo_path": "frontend/src/components/ui/Input.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "TextField",
+      "notes": "Use TextField with label, prompt, and validation copy."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Input.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["single-line input", "labeled text field", "inline validation"],
+    "anti_generic_terms": ["input box", "typing area", "text thing"],
+    "stitch_normalization_hint": "Map generic text fields to input unless the concept explicitly requires multiline text."
+  },
+  {
+    "id": "select",
+    "canonical_name": "select",
+    "aliases": ["dropdown select", "picker"],
+    "intent": "Choose one option from a structured list.",
+    "when_to_use": ["Finite option sets", "Known categories", "Form-driven settings"],
+    "when_not_to_use": ["Open-ended text entry", "Binary on/off", "High-frequency tab navigation"],
+    "anatomy": ["label", "trigger", "selected value", "option list", "helper text"],
+    "states": ["default", "open", "selected", "focus", "error", "disabled"],
+    "accessibility_notes": [
+      "Expose selected value and expanded state.",
+      "Support keyboard navigation through options."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--color-text", "--radius-md"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "Picker",
+      "notes": "Use Picker or Menu depending on platform density."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["select field", "option picker", "single-choice dropdown"],
+    "anti_generic_terms": ["menu", "chooser thing", "list picker maybe"],
+    "stitch_normalization_hint": "Normalize dropdown-like form controls to select, not navigation menu."
+  },
+  {
+    "id": "textarea",
+    "canonical_name": "textarea",
+    "aliases": ["multiline input", "text area"],
+    "intent": "Capture longer free-form text in a form context.",
+    "when_to_use": ["Notes", "Journal or reflection fields", "Longer messages"],
+    "when_not_to_use": ["Short labels", "Single-select options", "Hidden metadata"],
+    "anatomy": ["label", "multiline field", "helper text", "error text"],
+    "states": ["default", "focus", "filled", "error", "disabled", "readonly"],
+    "accessibility_notes": [
+      "Keep a visible label and clear description of expected length.",
+      "Preserve resize or multiline affordance."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--color-text", "--radius-md"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "TextEditor",
+      "notes": "Use TextEditor with external label and validation hints."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["multiline field", "reflection textarea", "long-form input"],
+    "anti_generic_terms": ["big input", "writing space", "message box"],
+    "stitch_normalization_hint": "Normalize long-form fields to textarea when the content spans more than one line."
+  },
+  {
+    "id": "checkbox",
+    "canonical_name": "checkbox",
+    "aliases": ["check box", "multi-select control"],
+    "intent": "Capture an independent yes/no or multiple non-exclusive selections.",
+    "when_to_use": ["Consent", "Preferences", "Multiple independent options"],
+    "when_not_to_use": ["Single mutually exclusive choice", "Immediate settings toggle", "Primary actions"],
+    "anatomy": ["control", "label", "help text"],
+    "states": ["unchecked", "checked", "indeterminate", "focus", "disabled", "error"],
+    "accessibility_notes": [
+      "Keep label clickable and announce checked or indeterminate state.",
+      "Use grouped fieldset when multiple checkboxes appear together."
+    ],
+    "token_guidance": ["--color-primary", "--color-border", "--color-surface", "--radius-sm"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "Toggle",
+      "notes": "For checklist patterns prefer custom row with selected state rather than standard switch."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["checkbox row", "consent checkbox", "multi-select checklist"],
+    "anti_generic_terms": ["tick option", "little square", "choice box"],
+    "stitch_normalization_hint": "Normalize checkable square list items to checkbox when options are non-exclusive."
+  },
+  {
+    "id": "radio_group",
+    "canonical_name": "radio-group",
+    "aliases": ["radio buttons", "single-select control"],
+    "intent": "Choose exactly one option from a visible set.",
+    "when_to_use": ["Short mutually exclusive sets", "Tone or plan selection", "Inline choice groups"],
+    "when_not_to_use": ["Large option lists", "Multiple selection", "Binary toggle"],
+    "anatomy": ["group label", "options", "selection indicator", "help text"],
+    "states": ["unselected", "selected", "focus", "disabled", "error"],
+    "accessibility_notes": [
+      "Expose the group label and option count.",
+      "Use arrow-key navigation between options."
+    ],
+    "token_guidance": ["--color-primary", "--color-border", "--color-text", "--radius-full"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "Picker",
+      "notes": "Use picker or custom radio rows depending on density."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["radio group", "single-choice options", "inline option set"],
+    "anti_generic_terms": ["selection buttons", "pick one list", "toggle list"],
+    "stitch_normalization_hint": "Normalize mutually exclusive visible options to radio-group unless the surface clearly behaves like tabs."
+  },
+  {
+    "id": "card",
+    "canonical_name": "card",
+    "aliases": ["panel", "surface card"],
+    "intent": "Group related content and actions inside a bounded surface.",
+    "when_to_use": ["Dashboard modules", "Feature summaries", "Containerized content blocks"],
+    "when_not_to_use": ["Global page shell", "Inline status messages", "Transient tooltips"],
+    "anatomy": ["container", "header", "body", "optional footer or actions"],
+    "states": ["default", "hover", "selected", "disabled"],
+    "accessibility_notes": [
+      "Do not make the whole card clickable unless the affordance is explicit.",
+      "Preserve heading hierarchy inside the card."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--radius-lg", "--shadow-base"],
+    "react_mapping": {
+      "component": "Card",
+      "repo_path": "frontend/src/components/ui/Card.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "RoundedRectangle container",
+      "notes": "Use token-backed background, corner radius, and shadow."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Card.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["content card", "dashboard card", "card with actions"],
+    "anti_generic_terms": ["box", "container thing", "panel maybe"],
+    "stitch_normalization_hint": "Normalize generic grouped surfaces to card unless the surface is explicitly modal or navigation."
+  },
+  {
+    "id": "alert",
+    "canonical_name": "alert",
+    "aliases": ["notification", "inline alert"],
+    "intent": "Show important feedback in a prominent but local surface.",
+    "when_to_use": ["Errors", "Warnings", "Inline success or info feedback"],
+    "when_not_to_use": ["Ephemeral background toast only", "Primary content cards", "Blocking modal confirmations"],
+    "anatomy": ["tone indicator", "title", "message", "optional action"],
+    "states": ["info", "success", "warning", "error", "dismissed"],
+    "accessibility_notes": [
+      "Use live region only when the message is time-sensitive.",
+      "Ensure color is not the sole tone indicator."
+    ],
+    "token_guidance": ["--color-success", "--color-warning", "--color-error", "--color-info", "--radius-md"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "Custom alert banner",
+      "notes": "Prefer inline status banner; reserve Alert for blocking system confirmations."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["inline alert", "status banner", "warning message"],
+    "anti_generic_terms": ["message block", "colored notice", "feedback thing"],
+    "stitch_normalization_hint": "Normalize prominent inline feedback to alert, not card or toast."
+  },
+  {
+    "id": "badge",
+    "canonical_name": "badge",
+    "aliases": ["pill", "status badge"],
+    "intent": "Show compact status, tier, or categorical metadata.",
+    "when_to_use": ["Premium state", "Small labels", "Status chips"],
+    "when_not_to_use": ["Primary CTA", "Long descriptions", "Navigation tabs"],
+    "anatomy": ["label", "optional icon", "tone"],
+    "states": ["default", "accent", "success", "warning", "disabled"],
+    "accessibility_notes": [
+      "Keep text readable at small sizes.",
+      "Do not communicate critical information only through the badge tone."
+    ],
+    "token_guidance": ["--color-primary", "--color-success", "--color-warning", "--radius-full"],
+    "react_mapping": {
+      "component": "VipBadge",
+      "repo_path": "frontend/src/components/VipBadge.tsx",
+      "status": "specialized-existing"
+    },
+    "swiftui_mapping": {
+      "component": "Text with capsule background",
+      "notes": "Use capsule shape and semantic tone."
+    },
+    "existing_repo_component": "frontend/src/components/VipBadge.tsx",
+    "missing_status": "specialized-existing",
+    "prompt_terms": ["status badge", "tier pill", "small metadata chip"],
+    "anti_generic_terms": ["little label", "chip thing", "marker bubble"],
+    "stitch_normalization_hint": "Normalize compact chips to badge unless they are interactive filters."
+  },
+  {
+    "id": "dialog",
+    "canonical_name": "dialog",
+    "aliases": ["modal", "popup dialog"],
+    "intent": "Present blocking or focused overlay content that interrupts the current task.",
+    "when_to_use": ["Confirmations", "Focused forms", "Critical details or upsell overlays"],
+    "when_not_to_use": ["Inline details", "Small hover help", "Persistent navigation"],
+    "anatomy": ["overlay", "panel", "title", "body", "actions", "dismiss affordance"],
+    "states": ["open", "closing", "error", "disabled action"],
+    "accessibility_notes": [
+      "Trap focus when open and restore it on close.",
+      "Provide explicit title and dismiss action."
+    ],
+    "token_guidance": ["--color-surface", "--color-text", "--radius-xl", "--shadow-lg"],
+    "react_mapping": {
+      "component": "Dialog",
+      "repo_path": "frontend/src/components/ui/Dialog.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "sheet or custom overlay",
+      "notes": "Use sheet for native flows or custom overlay for branded modal presentations."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Dialog.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["modal dialog", "blocking overlay", "confirmation dialog"],
+    "anti_generic_terms": ["popup", "window", "overlay thing"],
+    "stitch_normalization_hint": "Normalize blocking overlays to dialog; reserve dropdown-menu for anchored action lists."
+  },
+  {
+    "id": "dropdown_menu",
+    "canonical_name": "dropdown-menu",
+    "aliases": ["menu", "context menu"],
+    "intent": "Reveal a short anchored list of actions or options on demand.",
+    "when_to_use": ["Overflow actions", "Secondary menu actions", "Compact option lists"],
+    "when_not_to_use": ["Primary page navigation", "Large hierarchical settings", "Single-choice form field with label"],
+    "anatomy": ["trigger", "anchored surface", "items", "optional section labels"],
+    "states": ["closed", "open", "highlighted item", "disabled item"],
+    "accessibility_notes": [
+      "Expose expanded state on the trigger.",
+      "Support arrow-key navigation and dismiss on escape."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--color-text", "--radius-md", "--shadow-md"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "Menu",
+      "notes": "Use Menu for anchored action lists."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["anchored action menu", "overflow dropdown", "context menu"],
+    "anti_generic_terms": ["menu list", "popup options", "action popup"],
+    "stitch_normalization_hint": "Normalize anchored overflow action lists to dropdown-menu, not select or dialog."
+  },
+  {
+    "id": "tabs",
+    "canonical_name": "tabs",
+    "aliases": ["tab set", "content tabs"],
+    "intent": "Switch between sibling content sections within the same screen.",
+    "when_to_use": ["Parallel content categories", "Settings subsections", "Segmented content views"],
+    "when_not_to_use": ["Global app navigation", "Binary toggles", "Long vertical filters"],
+    "anatomy": ["tab list", "tab", "active indicator", "tabpanel"],
+    "states": ["default", "active", "focus", "disabled"],
+    "accessibility_notes": [
+      "Expose selected state and link each tab to its panel.",
+      "Support keyboard traversal across tabs."
+    ],
+    "token_guidance": ["--color-primary", "--color-text", "--radius-md", "--color-border"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "custom segmented tab view",
+      "notes": "Use segmented controls or custom tab containers for in-screen content switching."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["content tabs", "tabbed panel", "section tabs"],
+    "anti_generic_terms": ["menu tabs", "switching buttons", "tab buttons"],
+    "stitch_normalization_hint": "Normalize in-screen sibling content switches to tabs, not navigation/tab-bar."
+  },
+  {
+    "id": "progress",
+    "canonical_name": "progress",
+    "aliases": ["progress bar", "completion bar"],
+    "intent": "Show completion or current progress toward a known range.",
+    "when_to_use": ["Setup completion", "Goals", "Loading or completion states"],
+    "when_not_to_use": ["Discrete steps with labels only", "Static charts", "Status badges"],
+    "anatomy": ["track", "fill", "label", "optional value"],
+    "states": ["0%", "in-progress", "complete", "indeterminate"],
+    "accessibility_notes": [
+      "Expose current value and range when determinate.",
+      "Pair color with text or numeric context."
+    ],
+    "token_guidance": ["--color-primary", "--color-success", "--color-surface", "--radius-full"],
+    "react_mapping": {
+      "component": "LiveProgressIndicator",
+      "repo_path": "frontend/src/features/progress/LiveProgressIndicator.tsx",
+      "status": "specialized-existing"
+    },
+    "swiftui_mapping": {
+      "component": "ProgressView",
+      "notes": "Use ProgressView or a token-backed custom bar."
+    },
+    "existing_repo_component": "frontend/src/features/progress/LiveProgressIndicator.tsx",
+    "missing_status": "specialized-existing",
+    "prompt_terms": ["progress bar", "completion indicator", "goal progress"],
+    "anti_generic_terms": ["loading line", "progress thing", "meter maybe"],
+    "stitch_normalization_hint": "Normalize linear completion surfaces to progress; map labeled steps separately to stepper/progress-indicator."
+  },
+  {
+    "id": "tooltip",
+    "canonical_name": "tooltip",
+    "aliases": ["hint", "hover hint"],
+    "intent": "Provide short supplemental information anchored to a control.",
+    "when_to_use": ["Icon explanations", "Short clarifications", "Dense toolbars"],
+    "when_not_to_use": ["Critical instructions", "Mobile-only hidden content", "Long-form education"],
+    "anatomy": ["trigger", "anchored bubble", "short copy"],
+    "states": ["hidden", "visible", "dismissed"],
+    "accessibility_notes": [
+      "Do not hide essential information only inside the tooltip.",
+      "Support focus-triggered reveal, not hover only."
+    ],
+    "token_guidance": ["--color-navy-900", "--color-text", "--radius-md", "--shadow-md"],
+    "react_mapping": {
+      "component": null,
+      "repo_path": null,
+      "status": "missing"
+    },
+    "swiftui_mapping": {
+      "component": "popover or custom hint bubble",
+      "notes": "Prefer popover or inline helper on touch surfaces."
+    },
+    "existing_repo_component": null,
+    "missing_status": "missing",
+    "prompt_terms": ["tooltip", "context hint", "anchored helper bubble"],
+    "anti_generic_terms": ["little popup", "hover message", "small bubble"],
+    "stitch_normalization_hint": "Normalize tiny anchored helper bubbles to tooltip unless the content becomes instructional."
+  },
+  {
+    "id": "empty_state",
+    "canonical_name": "empty-state",
+    "aliases": ["no data state", "blank state"],
+    "intent": "Guide the user when content is absent or a surface has no results yet.",
+    "when_to_use": ["First-run surfaces", "No results", "No progress yet"],
+    "when_not_to_use": ["Error recovery with technical failure", "Loaded content surfaces", "Blocking modal states"],
+    "anatomy": ["headline", "supporting copy", "illustration or icon", "next action"],
+    "states": ["default", "actionable", "retry", "premium tease"],
+    "accessibility_notes": [
+      "Keep the next action explicit and reachable by keyboard.",
+      "Avoid decorative art that hides the main message."
+    ],
+    "token_guidance": ["--color-surface", "--color-text", "--color-text-muted", "--radius-lg"],
+    "react_mapping": {
+      "component": "EmptyState",
+      "repo_path": "frontend/src/components/ui/EmptyState.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "VStack empty state",
+      "notes": "Use illustration plus CTA inside a centered stack."
+    },
+    "existing_repo_component": "frontend/src/components/ui/EmptyState.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["empty state", "first-run empty surface", "no results screen"],
+    "anti_generic_terms": ["placeholder page", "empty box", "nothing here"],
+    "stitch_normalization_hint": "Normalize no-content onboarding or retry surfaces to empty-state when they include guidance and next action."
+  },
+  {
+    "id": "segmented_control",
+    "canonical_name": "segmented-control",
+    "aliases": ["button group", "segmented tabs"],
+    "intent": "Switch between a small set of peer options in one horizontal control.",
+    "when_to_use": ["2-4 quick view modes", "Range switches", "Compact filter toggles"],
+    "when_not_to_use": ["Large content categories", "Primary app navigation", "Independent action buttons"],
+    "anatomy": ["segment list", "segment", "selected indicator"],
+    "states": ["default", "selected", "focus", "disabled"],
+    "accessibility_notes": [
+      "Expose selected segment and support keyboard navigation.",
+      "Keep labels short enough to avoid truncation."
+    ],
+    "token_guidance": ["--color-surface", "--color-primary", "--color-border", "--radius-full"],
+    "react_mapping": {
+      "component": "SegmentedControl",
+      "repo_path": "frontend/src/components/ui/SegmentedControl.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "Picker segmented style",
+      "notes": "Use segmented Picker for small peer options."
+    },
+    "existing_repo_component": "frontend/src/components/ui/SegmentedControl.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["segmented control", "range switch", "inline mode switcher"],
+    "anti_generic_terms": ["button row", "multi button switch", "tiny tabs"],
+    "stitch_normalization_hint": "Normalize compact equal-weight option switches to segmented-control, not tabs."
+  },
+  {
+    "id": "toggle",
+    "canonical_name": "toggle",
+    "aliases": ["switch", "on-off control"],
+    "intent": "Turn a single setting on or off with immediate state clarity.",
+    "when_to_use": ["Preferences", "Feature enablement", "Binary settings"],
+    "when_not_to_use": ["Multi-choice selection", "Primary actions", "Consent checklists"],
+    "anatomy": ["track", "thumb", "label", "optional helper text"],
+    "states": ["off", "on", "focus", "disabled"],
+    "accessibility_notes": [
+      "Announce on/off state explicitly.",
+      "Do not use for irreversible or destructive actions."
+    ],
+    "token_guidance": ["--color-primary", "--color-surface", "--color-border", "--radius-full"],
+    "react_mapping": {
+      "component": "Toggle",
+      "repo_path": "frontend/src/components/ui/Toggle.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "Toggle",
+      "notes": "Use native Toggle with custom tint when possible."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Toggle.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["toggle switch", "binary setting", "preference switch"],
+    "anti_generic_terms": ["switch button", "yes no slider", "toggle thing"],
+    "stitch_normalization_hint": "Normalize binary immediate settings to toggle, not checkbox."
+  },
+  {
+    "id": "skeleton",
+    "canonical_name": "skeleton",
+    "aliases": ["loading placeholder", "shimmer"],
+    "intent": "Preview layout structure while data is loading.",
+    "when_to_use": ["Async loading states", "Card grids", "Chart placeholders"],
+    "when_not_to_use": ["Error states", "Unknown layout", "Long blocking flows without context"],
+    "anatomy": ["shape placeholders", "layout mimic", "motion or pulse"],
+    "states": ["loading", "completed"],
+    "accessibility_notes": [
+      "Hide decorative placeholder shapes from assistive tech if needed.",
+      "Pair long loading with a textual status."
+    ],
+    "token_guidance": ["--color-surface", "--color-border", "--radius-md"],
+    "react_mapping": {
+      "component": "Skeleton",
+      "repo_path": "frontend/src/components/ui/Skeleton.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "redacted placeholder",
+      "notes": "Use redacted placeholders or custom shimmer blocks."
+    },
+    "existing_repo_component": "frontend/src/components/ui/Skeleton.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["skeleton loading", "layout placeholder", "shimmer state"],
+    "anti_generic_terms": ["loading shapes", "placeholder lines", "fake content"],
+    "stitch_normalization_hint": "Normalize gray placeholder replicas to skeleton, not empty-state."
+  },
+  {
+    "id": "mobile_menu",
+    "canonical_name": "mobile-menu",
+    "aliases": ["drawer menu", "nav sheet"],
+    "intent": "Expose compact navigation or actions on small screens.",
+    "when_to_use": ["Mobile nav overflow", "Small-screen action groups", "Responsive nav patterns"],
+    "when_not_to_use": ["Desktop global nav", "Single overflow action", "Primary tab navigation"],
+    "anatomy": ["trigger", "overlay or sheet", "nav items", "dismiss affordance"],
+    "states": ["closed", "open", "active item", "disabled item"],
+    "accessibility_notes": [
+      "Trap focus while open and expose active navigation item.",
+      "Support escape and explicit dismiss action."
+    ],
+    "token_guidance": ["--color-surface", "--color-text", "--radius-lg", "--shadow-lg"],
+    "react_mapping": {
+      "component": "MobileMenu",
+      "repo_path": "frontend/src/components/ui/MobileMenu.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "sheet or navigation drawer",
+      "notes": "Use sheet-style presentation for compact mobile menus."
+    },
+    "existing_repo_component": "frontend/src/components/ui/MobileMenu.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["mobile menu", "drawer navigation", "small-screen nav sheet"],
+    "anti_generic_terms": ["hamburger thing", "slide menu", "phone menu"],
+    "stitch_normalization_hint": "Normalize slide-in or sheet-based mobile navigation to mobile-menu."
+  },
+  {
+    "id": "navigation_tab_bar",
+    "canonical_name": "navigation/tab-bar",
+    "aliases": ["tab bar", "bottom navigation"],
+    "intent": "Provide persistent primary navigation across major app sections.",
+    "when_to_use": ["Core app shell navigation", "3-5 top-level destinations", "Mobile-first primary nav"],
+    "when_not_to_use": ["In-screen content switching", "Overflow menus", "One-off actions"],
+    "anatomy": ["nav container", "tab items", "icon", "label", "active state"],
+    "states": ["default", "active", "disabled", "locked"],
+    "accessibility_notes": [
+      "Use nav semantics and expose current destination.",
+      "Keep labels stable and concise."
+    ],
+    "token_guidance": ["--color-surface", "--color-text", "--color-primary", "--shadow-sm"],
+    "react_mapping": {
+      "component": "TabBar",
+      "repo_path": "frontend/src/components/TabBar.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "TabView",
+      "notes": "Use TabView for persistent primary navigation."
+    },
+    "existing_repo_component": "frontend/src/components/TabBar.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["bottom tab bar", "primary navigation", "persistent tab navigation"],
+    "anti_generic_terms": ["navigation menu", "bottom buttons", "footer nav thing"],
+    "stitch_normalization_hint": "Normalize bottom persistent nav to navigation/tab-bar, not tabs or dropdown-menu."
+  },
+  {
+    "id": "hero",
+    "canonical_name": "hero",
+    "aliases": ["hero section", "headline banner"],
+    "intent": "Establish the page promise, tone, and primary action in the top viewport.",
+    "when_to_use": ["Landing areas", "Home summary", "Campaign or premium entry points"],
+    "when_not_to_use": ["Dense admin forms", "Secondary detail pages", "Repeated cards inside lists"],
+    "anatomy": ["headline", "supporting copy", "primary action", "supporting visual"],
+    "states": ["default", "premium", "empty", "loading"],
+    "accessibility_notes": [
+      "Keep a clear heading hierarchy and avoid decorative overload.",
+      "Ensure the primary CTA is not hidden below the fold on mobile."
+    ],
+    "token_guidance": ["--pp-navy", "--color-primary", "--color-text", "--shadow-base"],
+    "react_mapping": {
+      "component": "Home page hero",
+      "repo_path": "frontend/src/pages/Home.tsx",
+      "status": "specialized-existing"
+    },
+    "swiftui_mapping": {
+      "component": "top summary stack",
+      "notes": "Use a prominent top summary block with clear action hierarchy."
+    },
+    "existing_repo_component": "frontend/src/pages/Home.tsx",
+    "missing_status": "specialized-existing",
+    "prompt_terms": ["hero section", "headline block", "primary above-the-fold summary"],
+    "anti_generic_terms": ["top area", "main banner", "intro block"],
+    "stitch_normalization_hint": "Normalize first-view marketing or dashboard summary sections to hero."
+  },
+  {
+    "id": "stats_card",
+    "canonical_name": "stats-card",
+    "aliases": ["metric card", "kpi card"],
+    "intent": "Show one compact metric with supporting label or trend.",
+    "when_to_use": ["Progress dashboards", "Summary metrics", "Goal snapshots"],
+    "when_not_to_use": ["Long-form explanations", "Primary navigation", "Blocking feedback"],
+    "anatomy": ["metric value", "label", "trend or status", "optional micro-copy"],
+    "states": ["default", "positive", "warning", "loading"],
+    "accessibility_notes": [
+      "Expose metric meaning in text, not only visual emphasis.",
+      "Keep the trend language understandable without charts."
+    ],
+    "token_guidance": ["--color-surface", "--color-text", "--color-success", "--shadow-base"],
+    "react_mapping": {
+      "component": "MacroCards or WaterCard",
+      "repo_path": "frontend/src/pages/NutritionSetup/MacroCards.tsx",
+      "status": "specialized-existing"
+    },
+    "swiftui_mapping": {
+      "component": "metric summary card",
+      "notes": "Use VStack with emphasized metric and supporting label."
+    },
+    "existing_repo_component": "frontend/src/pages/NutritionSetup/MacroCards.tsx",
+    "missing_status": "specialized-existing",
+    "prompt_terms": ["metric card", "summary stat", "dashboard KPI card"],
+    "anti_generic_terms": ["number tile", "value box", "stat thing"],
+    "stitch_normalization_hint": "Normalize compact value-focused cards to stats-card when the dominant content is one metric."
+  },
+  {
+    "id": "form_field",
+    "canonical_name": "form-field",
+    "aliases": ["field wrapper", "input field group"],
+    "intent": "Wrap label, control, hint, and validation into one reusable field block.",
+    "when_to_use": ["Forms with consistent spacing", "Validation-heavy inputs", "Stacked field groups"],
+    "when_not_to_use": ["Standalone bare control without label", "Navigation", "Display-only cards"],
+    "anatomy": ["label", "control", "description", "error"],
+    "states": ["default", "required", "error", "disabled", "readonly"],
+    "accessibility_notes": [
+      "Programmatically associate label, description, and error with the control.",
+      "Do not bury required state only in color."
+    ],
+    "token_guidance": ["--color-text", "--color-text-muted", "--spacing-3", "--spacing-4"],
+    "react_mapping": {
+      "component": "FormField",
+      "repo_path": "frontend/src/components/ui/FormField.tsx",
+      "status": "existing"
+    },
+    "swiftui_mapping": {
+      "component": "LabeledContent or VStack field wrapper",
+      "notes": "Use wrapper views to keep label, help, and error consistent."
+    },
+    "existing_repo_component": "frontend/src/components/ui/FormField.tsx",
+    "missing_status": "existing",
+    "prompt_terms": ["form field block", "labeled input group", "field with validation"],
+    "anti_generic_terms": ["input wrapper", "field box", "label plus input"],
+    "stitch_normalization_hint": "Normalize labeled input clusters to form-field plus the underlying control."
+  },
+  {
+    "id": "stepper_progress_indicator",
+    "canonical_name": "stepper/progress-indicator",
+    "aliases": ["step rail", "stepper"],
+    "intent": "Show discrete multi-step progress through a flow.",
+    "when_to_use": ["Onboarding", "Setup flows", "Guided checklists"],
+    "when_not_to_use": ["Continuous goal tracking", "Background loading only", "Primary nav"],
+    "anatomy": ["step list", "current step", "completed steps", "labels", "connector"],
+    "states": ["upcoming", "current", "completed", "error"],
+    "accessibility_notes": [
+      "Expose total steps and current position in text.",
+      "Keep current step label explicit."
+    ],
+    "token_guidance": ["--color-primary", "--color-success", "--color-surface", "--radius-full"],
+    "react_mapping": {
+      "component": "Setup completion step rail",
+      "repo_path": "frontend/src/pages/NutritionSetup/SetupForm.tsx",
+      "status": "missing-primitive-existing-flow"
+    },
+    "swiftui_mapping": {
+      "component": "custom stepper rail",
+      "notes": "Use HStack or VStack progress rail for guided flows."
+    },
+    "existing_repo_component": "frontend/src/pages/NutritionSetup/SetupForm.tsx",
+    "missing_status": "missing-primitive-existing-flow",
+    "prompt_terms": ["stepper", "multi-step progress", "setup step rail"],
+    "anti_generic_terms": ["progress steps", "wizard line", "flow tracker"],
+    "stitch_normalization_hint": "Normalize discrete flow progress with labeled steps to stepper/progress-indicator."
+  }
+]

--- a/docs/design/ui_component_vocabulary.json
+++ b/docs/design/ui_component_vocabulary.json
@@ -135,8 +135,8 @@
       "status": "missing"
     },
     "swiftui_mapping": {
-      "component": "Toggle",
-      "notes": "For checklist patterns prefer custom row with selected state rather than standard switch."
+      "component": "CheckboxRow",
+      "notes": "Implement as a custom checkbox row with explicit checked and indeterminate visuals rather than Toggle switch semantics."
     },
     "existing_repo_component": null,
     "missing_status": "missing",

--- a/docs/orchestration/AGENT_CONTEXT_MAP.md
+++ b/docs/orchestration/AGENT_CONTEXT_MAP.md
@@ -153,6 +153,7 @@ This map reduces “missing context” failures by making required inputs explic
 - `ios/AGENTS.md` — iOS UI constraints
 - `AGENTS.md` (root) — accessibility + thin-client guardrails (where applicable)
 - `docs/design/UI_COMPONENT_VOCABULARY.md` — canonical component naming and normalization
+- `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md` — canonical screen-brief drafting template
 - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md` — code-first brief assembly contract
 
 ---

--- a/docs/orchestration/AGENT_CONTEXT_MAP.md
+++ b/docs/orchestration/AGENT_CONTEXT_MAP.md
@@ -152,6 +152,8 @@ This map reduces “missing context” failures by making required inputs explic
 - `frontend/AGENTS.md` — web UI constraints
 - `ios/AGENTS.md` — iOS UI constraints
 - `AGENTS.md` (root) — accessibility + thin-client guardrails (where applicable)
+- `docs/design/UI_COMPONENT_VOCABULARY.md` — canonical component naming and normalization
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md` — code-first brief assembly contract
 
 ---
 
@@ -213,11 +215,14 @@ This map reduces “missing context” failures by making required inputs explic
 - `frontend/src/styles/tokens.css`
 - `frontend/src/styles/tokens.ts`
 - `frontend/tailwind.config.ts`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 
 **Must know:**
 
 - Thin-client adapter policy (`frontend/src/api/client.ts` as network boundary)
 - UI style SoT is token-driven; avoid ad-hoc literals
+- UI naming/spec flow is vocabulary-driven before component or page generation
 
 ---
 

--- a/docs/review/PR_1117_FIXED_MAPPING.md
+++ b/docs/review/PR_1117_FIXED_MAPPING.md
@@ -48,6 +48,27 @@ Evidence: `tests/test_design_generation_pipeline.py:11`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850462 -> 3db018a4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850465 -> 3db018a4
 
+Disposition: FIXED
+Commit: 3827b81b
+Evidence: `docs/design/UI_COMPONENT_VOCABULARY.md:53`
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:375`
+Evidence: `scripts/design/contracts.py:179`
+Evidence: `scripts/design/contracts.py:249`
+Evidence: `scripts/design/contracts.py:330`
+Evidence: `scripts/design/generate_figma_instructions.py:133`
+Evidence: `scripts/design/generate_figma_instructions.py:557`
+Evidence: `scripts/design/generate_figma_instructions.py:880`
+Evidence: `tests/test_design_generation_pipeline.py:49`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921041219 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046582 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046586 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046590 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046598 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046602 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046604 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046609 -> 3827b81b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046621 -> 3827b81b
+
 Disposition: NOT-A-BUG
 Evidence: Individual actionable threads from the CodeRabbit review batch are mapped explicitly in this artifact.
 Evidence: `scripts/design/execute_design.py:67`

--- a/docs/review/PR_1117_FIXED_MAPPING.md
+++ b/docs/review/PR_1117_FIXED_MAPPING.md
@@ -69,6 +69,27 @@ Evidence: `tests/test_design_generation_pipeline.py:49`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046609 -> 3827b81b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921046621 -> 3827b81b
 
+Disposition: FIXED
+Commit: 19ab8875
+Evidence: `docs/design/UI_COMPONENT_VOCABULARY.md:77`
+Evidence: `scripts/design/generate_figma_instructions.py:133`
+Evidence: `scripts/design/generate_figma_instructions.py:973`
+Evidence: `scripts/design/generate_figma_instructions.py:1040`
+Evidence: `scripts/design/generate_figma_instructions.py:1073`
+Evidence: `scripts/design/generate_figma_instructions.py:1107`
+Evidence: `scripts/design/instructions/ios_home.json:4`
+Evidence: `scripts/design/instructions/ios_home.json:143`
+Evidence: `scripts/design/instructions/ios_plate.json:4`
+Evidence: `scripts/design/instructions/ios_plate.json:229`
+Evidence: `scripts/design/instructions/ios_progress.json:4`
+Evidence: `scripts/design/instructions/ios_progress.json:198`
+Evidence: `tests/test_design_generation_pipeline.py:15`
+Evidence: `tests/test_design_generation_pipeline.py:149`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921142754 -> 19ab8875
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921144994 -> 19ab8875
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921145010 -> 19ab8875
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2921145013 -> 19ab8875
+
 Disposition: NOT-A-BUG
 Evidence: Individual actionable threads from the CodeRabbit review batch are mapped explicitly in this artifact.
 Evidence: `scripts/design/execute_design.py:67`
@@ -77,6 +98,7 @@ Evidence: `scripts/design/generate_figma_instructions.py:1087`
 Reason: This review-level wrapper aggregates already-mapped inline findings; the remaining architectural notes in the wrapper are advisory and do not require a separate fix beyond the mapped thread dispositions on the current head.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932379652
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932586855
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932705509
 
 Disposition: NOT-A-BUG
 Evidence: Individual actionable threads identified by cubic are mapped explicitly in this artifact.
@@ -86,6 +108,7 @@ Evidence: `scripts/design/generate_figma_instructions.py:898`
 Reason: This cubic aggregate review is a wrapper over the mapped inline findings; no separate unresolved change remains once the listed thread URLs are dispositioned.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932382558
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932581060
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932702982
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1117_FIXED_MAPPING.md
+++ b/docs/review/PR_1117_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1117 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1117_FIXED_MAPPING.md
+++ b/docs/review/PR_1117_FIXED_MAPPING.md
@@ -5,7 +5,64 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 3db018a4
+Evidence: `.cursor/agents/creative-designer.md:283`
+Evidence: `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md:21`
+Evidence: `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md:19`
+Evidence: `docs/orchestration/AGENT_CONTEXT_MAP.md:155`
+Evidence: `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md:74`
+Evidence: `docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md:50`
+Evidence: `docs/design/ui_component_vocabulary.json:137`
+Evidence: `tests/test_ui_component_vocabulary_contract.py:97`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920847774 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920847777 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920847779 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920847790 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920847791 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850421 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850431 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850437 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850440 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850444 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850448 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850451 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850453 -> 3db018a4
+
+Disposition: FIXED
+Commit: 3db018a4
+Evidence: `scripts/design/contracts.py:70`
+Evidence: `scripts/design/contracts.py:125`
+Evidence: `scripts/design/contracts.py:360`
+Evidence: `scripts/design/execute_design.py:67`
+Evidence: `scripts/design/execution_adapters.py:6`
+Evidence: `scripts/design/generate_figma_instructions.py:898`
+Evidence: `scripts/design/generate_figma_instructions.py:1023`
+Evidence: `scripts/design/generate_figma_instructions.py:1087`
+Evidence: `tests/test_design_generation_pipeline.py:11`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850409 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850412 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850415 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850418 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850459 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850462 -> 3db018a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#discussion_r2920850465 -> 3db018a4
+
+Disposition: NOT-A-BUG
+Evidence: Individual actionable threads from the CodeRabbit review batch are mapped explicitly in this artifact.
+Evidence: `scripts/design/execute_design.py:67`
+Evidence: `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md:74`
+Evidence: `scripts/design/generate_figma_instructions.py:1087`
+Reason: This review-level wrapper aggregates already-mapped inline findings; the remaining architectural notes in the wrapper are advisory and do not require a separate fix beyond the mapped thread dispositions on the current head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932379652
+
+Disposition: NOT-A-BUG
+Evidence: Individual actionable threads identified by cubic are mapped explicitly in this artifact.
+Evidence: `scripts/design/contracts.py:125`
+Evidence: `docs/design/ui_component_vocabulary.json:137`
+Evidence: `scripts/design/generate_figma_instructions.py:898`
+Reason: This cubic aggregate review is a wrapper over the mapped inline findings; no separate unresolved change remains once the listed thread URLs are dispositioned.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932382558
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1117_FIXED_MAPPING.md
+++ b/docs/review/PR_1117_FIXED_MAPPING.md
@@ -76,6 +76,7 @@ Evidence: `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md:74`
 Evidence: `scripts/design/generate_figma_instructions.py:1087`
 Reason: This review-level wrapper aggregates already-mapped inline findings; the remaining architectural notes in the wrapper are advisory and do not require a separate fix beyond the mapped thread dispositions on the current head.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932379652
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932586855
 
 Disposition: NOT-A-BUG
 Evidence: Individual actionable threads identified by cubic are mapped explicitly in this artifact.
@@ -84,6 +85,7 @@ Evidence: `docs/design/ui_component_vocabulary.json:137`
 Evidence: `scripts/design/generate_figma_instructions.py:898`
 Reason: This cubic aggregate review is a wrapper over the mapped inline findings; no separate unresolved change remains once the listed thread URLs are dispositioned.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932382558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1117#pullrequestreview-3932581060
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -344,6 +344,34 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - If figma-manifest unification is chosen, the schema/version/validation owner is documented; if not chosen, docs explicitly keep it informational
     - Active design-system docs continue to reference one governance path only
 
+<a id="ledger-p1-design-execution-adapter-seam"></a>
+- [ ] P1: Design execution adapter seam promotion beyond deterministic stub
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (design runtime governance)
+  - Target PR: PR #1117 (`feat(design): add code-first UI vocabulary and strengthen instruction generation`) -> PR-TBD-DESIGN-RUNTIME-ADAPTER
+  - Status: 📋 Deferred after PR #1117 contract hardening
+  - Area: scripts / design-runtime / docs
+  - Finding Type: temporary seam follow-up
+  - Reason: `scripts/design/execution_adapters.py` currently provides only the
+    deterministic `deterministic_stub` adapter for contract validation and
+    manifest verification. The seam is intentional, but it must remain
+    explicitly temporary until a reviewed non-stub adapter preserves the same
+    instruction and verification contract.
+  - Links:
+    - `docs/architecture/ADR_DESIGN_EXECUTION_ADAPTER_SEAM_2026-03-11.md`
+    - `scripts/design/execution_adapters.py`
+    - `scripts/design/execute_design.py`
+    - `scripts/design/verify_design.py`
+  - DoD:
+    - A reviewed non-stub adapter exists for the chosen design runtime target
+    - The replacement preserves instruction, manifest, and verification
+      contracts already enforced in `scripts/design/contracts.py`
+    - Deterministic local tests cover the replacement path without depending on
+      a live external design tool
+    - `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md` is updated so
+      `deterministic_stub` is no longer described as the only implemented
+      adapter
+
 <a id="ledger-p1-design-token-lock-ci"></a>
 - [ ] P1: Design-token lockfile and deterministic CI/build contract
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -372,6 +372,57 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
       `deterministic_stub` is no longer described as the only implemented
       adapter
 
+<a id="ledger-p1-design-runtime-screen-coverage"></a>
+- [ ] P1: Design runtime screen coverage beyond initial six parity screens
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (design runtime expansion)
+  - Target PR: PR #1117 (`feat(design): add code-first UI vocabulary and strengthen instruction generation`) -> PR-TBD-DESIGN-RUNTIME-SCREEN-COVERAGE
+  - Status: 📋 Deferred after PR #1117 contract hardening
+  - Area: scripts / design-runtime / design-docs
+  - Finding Type: deferred scope follow-up
+  - Reason: PR #1117 intentionally hardens the code-first vocabulary and
+    instruction contract around the first six parity screens only
+    (`ios.home`, `ios.plate`, `ios.progress`, `web.home`, `web.plate`,
+    `web.progress`). Additional governed screens must be promoted under the same
+    contract instead of being inferred ad hoc.
+  - Links:
+    - `scripts/design/generate_figma_instructions.py`
+    - `scripts/design/instructions/`
+    - `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md`
+    - `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`
+  - DoD:
+    - New screens are added through the same code-first brief and vocabulary
+      contract
+    - Instruction generation, execution, and verification remain deterministic
+      for each added screen
+    - Manifest/verification docs explicitly list the expanded supported-screen
+      surface
+
+<a id="ledger-p1-design-layout-archetype-templates"></a>
+- [ ] P1: Reusable layout archetype templates beyond current shell families
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (design runtime semantics)
+  - Target PR: PR #1117 (`feat(design): add code-first UI vocabulary and strengthen instruction generation`) -> PR-TBD-DESIGN-LAYOUT-ARCHETYPE-TEMPLATES
+  - Status: 📋 Deferred after PR #1117 contract hardening
+  - Area: scripts / design-runtime / docs
+  - Finding Type: deferred semantics follow-up
+  - Reason: PR #1117 formalizes `layout_archetype`, `layout_pattern`, and
+    section/component hierarchy semantics, but it intentionally keeps the first
+    archetype set small (`hero_shell`, `content_shell`, `dashboard_shell`).
+    Richer reusable archetype families and template semantics should be promoted
+    in a dedicated follow-up instead of expanding the contract implicitly.
+  - Links:
+    - `scripts/design/contracts.py`
+    - `scripts/design/generate_figma_instructions.py`
+    - `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+    - `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`
+  - DoD:
+    - Additional archetype families are named and documented in the cookbook and
+      runtime contract
+    - Validation enforces the promoted archetype set deterministically
+    - Screen-generation templates reuse the promoted archetypes without hidden
+      per-screen exceptions
+
 <a id="ledger-p1-design-token-lock-ci"></a>
 - [ ] P1: Design-token lockfile and deterministic CI/build contract
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
+++ b/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
@@ -3,7 +3,8 @@
 <!-- markdownlint-disable MD013 -->
 
 This document is the canonical operating model for design-tooling work in
-PulsePlate across `Figma`, `Tokens Studio`, `Notion`, `Airweave`, and `Penpot`.
+PulsePlate across `Figma`, `Tokens Studio`, `Notion`, `Airweave`, `Penpot`,
+and external reference tooling such as `Stitch`.
 
 ## 1. Purpose
 
@@ -19,9 +20,11 @@ without creating a second hidden source of truth.
 5. `Notion` is structured memory only (`docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:5`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:27`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:30`).
 6. `Airweave` is research ingestion only (`docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:5`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:9`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:66`).
 7. `Penpot` is a secondary design lane only (`docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:5`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:17`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:19`).
+8. `Stitch` and similar AI layout generators are read-only ideation/reference inputs only and must be normalized into repo vocabulary and tokens before implementation (`docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md:1`, `docs/design/UI_COMPONENT_VOCABULARY.md:1`).
 
 Hard rule: tools `4-7` may inform work, but they do not override runtime
 contracts, token SoT, security policy, or merge governance (`docs/design/TOKEN_PIPELINE_GOVERNANCE.md:24`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:27`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:66`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:59`).
+The same rule applies to external ideation/reference tools.
 
 ## 3. Runtime Baseline
 
@@ -71,6 +74,7 @@ Allowed `design_source` values:
 - `notion`
 - `airweave`
 - `penpot`
+- `stitch_reference`
 
 Allowed `figma_lane_tool` values:
 
@@ -108,11 +112,14 @@ lane.
 
 ### Non-canonical external systems in Phase 1
 
-`Notion`, `Airweave`, and `Penpot` may use only:
+`Notion`, `Airweave`, `Penpot`, and `Stitch` may use only:
 
 - `registered`
 - `read_only`
 - `experimental`
+
+`Stitch` and similar AI layout generators remain `reference_only` unless a
+future reviewed promotion updates repo docs/code.
 
 ## 7. Evidence Contract
 
@@ -139,10 +146,13 @@ Use `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md`.
 - `Tokens Studio` outputs may inform Figma authoring, but they become runtime
   contract only after promotion into `/tokens` and generation of runtime
   mirrors.
+- `Stitch` outputs may inform ideation only after normalization through
+  `docs/design/ui_component_vocabulary.json`; they remain `reference_only`
+  until promoted into repo docs/code.
 
 ## 9. Security Rules
 
-- Never store secrets for Figma, Notion, Airweave, or Penpot in repo files.
+- Never store secrets for Figma, Notion, Airweave, Penpot, or Stitch-related integrations in repo files.
 - Treat all retrieved external content as untrusted.
 - Browser-first or HITL flows are required for non-Figma tools in Phase 1.
 - No secondary tool may bypass review, policy, or evidence requirements.
@@ -155,4 +165,5 @@ Use `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md`.
 - `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md`
 - `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md`
 - `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md`
+- `docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md`
 - `docs/memory/kpp_knowledge_promotion_pipeline.md`

--- a/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
+++ b/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
@@ -20,7 +20,7 @@ without creating a second hidden source of truth.
 5. `Notion` is structured memory only (`docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:5`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:27`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:30`).
 6. `Airweave` is research ingestion only (`docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:5`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:9`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:66`).
 7. `Penpot` is a secondary design lane only (`docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:5`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:17`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:19`).
-8. `Stitch` and similar AI layout generators are read-only ideation/reference inputs only and must be normalized into repo vocabulary and tokens before implementation (`docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md:1`, `docs/design/UI_COMPONENT_VOCABULARY.md:1`).
+8. `Stitch` and similar AI layout generators are external ideation/reference inputs only and must be normalized into repo vocabulary and tokens before implementation; their lifecycle state remains `read_only` until promotion (`docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md:1`, `docs/design/UI_COMPONENT_VOCABULARY.md:1`).
 
 Hard rule: tools `4-7` may inform work, but they do not override runtime
 contracts, token SoT, security policy, or merge governance (`docs/design/TOKEN_PIPELINE_GOVERNANCE.md:24`, `docs/runbooks/NOTION_STRUCTURED_MEMORY_GOVERNANCE.md:27`, `docs/runbooks/AIRWEAVE_RESEARCH_INGESTION_LANE.md:66`, `docs/runbooks/PENPOT_SECONDARY_DESIGN_LANE.md:59`).
@@ -135,9 +135,9 @@ or `figma_make`; Tokens Studio does not become a separate source lane.
 - `read_only`
 - `experimental`
 
-`Stitch` and similar AI layout generators remain a reference-only lane, but the
-lifecycle status stays `read_only` until a reviewed promotion updates repo
-docs/code.
+`Stitch` and similar AI layout generators remain an external reference lane.
+Use lifecycle status `read_only` for those records until a reviewed promotion
+updates repo docs/code.
 
 ## 7. Evidence Contract
 

--- a/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
+++ b/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
@@ -30,6 +30,8 @@ The same rule applies to external ideation/reference tools.
 
 - Primary agent runtime: `Codex + GPT-5.4 Pro`
 - Primary design tool: `Figma MCP`
+- Default executable design adapter seam: `scripts/design/execution_adapters.py`
+  with `deterministic_stub` as the only active adapter in Phase 1
 - Subordinate Figma-lane token tool: `Tokens Studio`
 - Secondary knowledge tool: `Notion`
 - Research ingestion tool: `Airweave`
@@ -93,6 +95,15 @@ Rule: when `figma_lane_tool=tokens_studio`, `design_source` still remains
 lane.
 
 ## 6. Lifecycle Model
+
+### Executable design runtime
+
+- instruction generation must emit explicit `sections`, `component_hierarchy`,
+  and `layout_archetype`
+- execution must flow through the adapter seam, even when the adapter is
+  deterministic-only
+- live MCP adapters are future work and must preserve the same instruction and
+  manifest contract
 
 ### Design source records
 

--- a/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
+++ b/docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md
@@ -30,9 +30,12 @@ The same rule applies to external ideation/reference tools.
 
 - Primary agent runtime: `Codex + GPT-5.4 Pro`
 - Primary design tool: `Figma MCP`
-- Default executable design adapter seam: `scripts/design/execution_adapters.py`
-  with `deterministic_stub` as the only active adapter in Phase 1
-- Subordinate Figma-lane token tool: `Tokens Studio`
+- Current executable design contract surface: `scripts/design/execution_adapters.py`
+  with `deterministic_stub` as the only implemented adapter on this branch
+  (`scripts/design/execution_adapters.py:5`, `scripts/design/execution_adapters.py:18`, `scripts/design/execute_design.py:72`; temporary seam governed by `docs/architecture/ADR_DESIGN_EXECUTION_ADAPTER_SEAM_2026-03-11.md:1` and `docs/roadmap/BACKLOG_LEDGER.md:347`)
+- Subordinate Figma-lane token tool: `Tokens Studio` (documentation-only
+  activation remains governed by `docs/roadmap/BACKLOG_LEDGER.md:322` and
+  `docs/design/TOKEN_PIPELINE_GOVERNANCE.md:120`)
 - Secondary knowledge tool: `Notion`
 - Research ingestion tool: `Airweave`
 - Secondary design workspace: `Penpot`
@@ -65,9 +68,11 @@ Every design-tooling task must define:
 - `source_url`
 - `file_key_or_workspace`
 - `node_id_or_frame_id`
-- `figma_lane_tool`
 - `target_surface`
 - `task_mode`
+
+Additionally, `figma_lane_tool` is required only when `design_source` is
+`figma_design` or `figma_make`.
 
 Allowed `design_source` values:
 
@@ -90,9 +95,10 @@ Allowed `task_mode` values:
 - `implement`
 - `sync`
 
-Rule: when `figma_lane_tool=tokens_studio`, `design_source` still remains
-`figma_design` or `figma_make`; Tokens Studio does not become a separate source
-lane.
+Rule: when `design_source` is non-Figma (`notion`, `airweave`, `penpot`,
+`stitch_reference`), `figma_lane_tool` must be omitted. When
+`figma_lane_tool=tokens_studio`, `design_source` still remains `figma_design`
+or `figma_make`; Tokens Studio does not become a separate source lane.
 
 ## 6. Lifecycle Model
 
@@ -101,9 +107,9 @@ lane.
 - instruction generation must emit explicit `sections`, `component_hierarchy`,
   and `layout_archetype`
 - execution must flow through the adapter seam, even when the adapter is
-  deterministic-only
+  deterministic-only (`docs/architecture/ADR_DESIGN_EXECUTION_ADAPTER_SEAM_2026-03-11.md:1`)
 - live MCP adapters are future work and must preserve the same instruction and
-  manifest contract
+  manifest contract (`docs/roadmap/BACKLOG_LEDGER.md:347`)
 
 ### Design source records
 
@@ -129,8 +135,9 @@ lane.
 - `read_only`
 - `experimental`
 
-`Stitch` and similar AI layout generators remain `reference_only` unless a
-future reviewed promotion updates repo docs/code.
+`Stitch` and similar AI layout generators remain a reference-only lane, but the
+lifecycle status stays `read_only` until a reviewed promotion updates repo
+docs/code.
 
 ## 7. Evidence Contract
 
@@ -158,8 +165,8 @@ Use `docs/runbooks/FIGMA_MCP_SESSION_EVIDENCE_TEMPLATE.md`.
   contract only after promotion into `/tokens` and generation of runtime
   mirrors.
 - `Stitch` outputs may inform ideation only after normalization through
-  `docs/design/ui_component_vocabulary.json`; they remain `reference_only`
-  until promoted into repo docs/code.
+  `docs/design/ui_component_vocabulary.json`; they remain lifecycle
+  `read_only` until promoted into repo docs/code.
 
 ## 9. Security Rules
 

--- a/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
+++ b/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
@@ -9,7 +9,7 @@ Scope: Optional intake of Stitch concepts into PulsePlate's code-first UI workfl
 Define how `Stitch` may inform PulsePlate UI work without becoming a source of
 truth.
 
-This adapter is reference-only. It does not authorize direct promotion of
+This adapter is a reference lane only. It does not authorize direct promotion of
 external outputs into runtime code, token contracts, or design governance.
 
 ## 2. Source precedence
@@ -105,6 +105,7 @@ A card with chips and a popup menu under a hero block.
 
 Normalized output:
 
+- `layout_archetype: hero-plus-sections`
 - `hero`
 - `card`
 - `badge`

--- a/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
+++ b/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
@@ -1,0 +1,136 @@
+# Stitch AI Reference Adapter
+
+Date created: March 11, 2026 (America/New_York)
+Status: Phase 1 read-only adapter
+Scope: Optional intake of Stitch concepts into PulsePlate's code-first UI workflow
+
+## 1. Purpose
+
+Define how `Stitch` may inform PulsePlate UI work without becoming a source of
+truth.
+
+This adapter is reference-only. It does not authorize direct promotion of
+external outputs into runtime code, token contracts, or design governance.
+
+## 2. Source precedence
+
+Authoritative source precedence remains unchanged:
+
+1. repo code, docs, and tests
+2. `Figma` design lane where applicable
+3. `/tokens`
+4. governed runtime mirrors
+
+`Stitch` is an optional ideation and reference lane only.
+
+## 3. Allowed use
+
+`Stitch` may be used for:
+
+- layout ideation
+- information hierarchy exploration
+- visual variation brainstorming
+- terminology discovery before normalization
+
+`Stitch` may not be used as:
+
+- runtime contract
+- token authority
+- component naming authority
+- direct implementation source
+
+## 4. Required normalization contract
+
+Input:
+
+- raw Stitch concept, screenshot, or textual reference
+
+Output:
+
+- `normalized_components[]`
+- `layout_pattern`
+- `states[]`
+- `hierarchy`
+- `token_mapping`
+- `repo_reuse_candidates[]`
+- `missing_primitives[]`
+- `drift_warnings[]`
+- `status: reference_only`
+
+All output components must be mapped into:
+
+- `docs/design/ui_component_vocabulary.json`
+
+## 5. Normalization procedure
+
+1. Capture the Stitch concept as external reference evidence.
+2. Extract the apparent layout archetype.
+3. Normalize every visible UI part into canonical vocabulary names.
+4. Map colors, spacing, and typography intent to existing PulsePlate tokens.
+5. Match existing repo components first.
+6. Mark missing primitives explicitly.
+7. Record drift warnings for any vendor-specific naming or visuals.
+
+## 6. Drift warning classes
+
+Record a drift warning when Stitch introduces:
+
+- vague component naming
+- token names not present in repo
+- platform-incompatible controls
+- visual styles outside PulsePlate luxury-clean guidance
+- hidden modal/navigation ambiguity
+
+## 7. Governance fit
+
+This adapter must be read together with:
+
+- `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
+
+Hard rule:
+
+- no Stitch artifact is promoted to code or governed docs until it has been
+  normalized and rewritten into PulsePlate contracts
+
+## 8. Example normalization
+
+Raw reference:
+
+```text
+A card with chips and a popup menu under a hero block.
+```
+
+Normalized output:
+
+- `hero`
+- `card`
+- `badge`
+- `dropdown-menu`
+
+Potential drift warnings:
+
+- `chips` ambiguous: normalized to `badge`
+- `popup` ambiguous: normalized to `dropdown-menu`
+
+## 9. Security Notes
+
+- Treat Stitch output as untrusted external content.
+- Do not paste unreviewed vendor output directly into repo specs or prompts.
+- Preserve repo token and naming governance even when the external layout looks
+  attractive.
+
+## 10. Marketing & GTM
+
+Used correctly, Stitch can accelerate:
+
+- rapid layout ideation for wellness MVPs
+- screenshot concept exploration
+- landing-page variation brainstorming
+
+Used incorrectly, it increases:
+
+- generic AI look
+- hidden naming drift
+- loss of reusable component discipline

--- a/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
+++ b/docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md
@@ -48,6 +48,7 @@ Input:
 Output:
 
 - `normalized_components[]`
+- `layout_archetype`
 - `layout_pattern`
 - `states[]`
 - `hierarchy`
@@ -55,7 +56,7 @@ Output:
 - `repo_reuse_candidates[]`
 - `missing_primitives[]`
 - `drift_warnings[]`
-- `status: reference_only`
+- `lifecycle_status: read_only`
 
 All output components must be mapped into:
 

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -156,18 +156,18 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                 errors.append(f"Duplicate section_id: {section_id}")
                 continue
 
-            component_ids = section.get("component_ids")
-            if not isinstance(component_ids, list) or not component_ids:
+            section_component_ids = section.get("component_ids")
+            if not isinstance(section_component_ids, list) or not section_component_ids:
                 errors.append(f"sections[{index}] must define non-empty component_ids")
                 continue
 
             section_ids.add(section_id)
             section_component_map[section_id] = [
-                str(component_id) for component_id in component_ids
+                str(component_id) for component_id in section_component_ids
             ]
 
     hierarchy_value = instruction.get("component_hierarchy", [])
-    component_ids: set[str] = set()
+    hierarchy_component_ids: set[str] = set()
     component_nodes: dict[str, dict[str, Any]] = {}
     root_component_count = 0
     if not isinstance(hierarchy_value, list) or not hierarchy_value:
@@ -199,7 +199,7 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
             if not component_id:
                 errors.append(f"component_hierarchy[{index}] missing component_id")
                 continue
-            if component_id in component_ids:
+            if component_id in hierarchy_component_ids:
                 errors.append(f"Duplicate component_id: {component_id}")
                 continue
             if not semantic_role:
@@ -227,7 +227,7 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                     )
                 )
 
-            component_ids.add(component_id)
+            hierarchy_component_ids.add(component_id)
             component_nodes[component_id] = {
                 "canonical_component": canonical_component,
                 "section_id": node_section_id,
@@ -237,7 +237,10 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
 
         for component_id, node in component_nodes.items():
             parent_component_id = node.get("parent_component_id")
-            if isinstance(parent_component_id, str) and parent_component_id not in component_ids:
+            if (
+                isinstance(parent_component_id, str)
+                and parent_component_id not in hierarchy_component_ids
+            ):
                 errors.append(
                     "Unknown parent_component_id for component_hierarchy node "
                     f"{component_id}: {parent_component_id}"
@@ -266,7 +269,7 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
 
         for section_id, referenced_component_ids in section_component_map.items():
             for component_id in referenced_component_ids:
-                if component_id not in component_ids:
+                if component_id not in hierarchy_component_ids:
                     errors.append(
                         "sections reference unknown component_id: "
                         f"{section_id} -> {component_id}"
@@ -307,7 +310,7 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         component_id = str(item.get("component_id", "")).strip()
         if not component_id:
             errors.append(f"{item_type} at instructions[{index}] missing component_id")
-        elif component_ids and component_id not in component_ids:
+        elif hierarchy_component_ids and component_id not in hierarchy_component_ids:
             errors.append(
                 f"{item_type} at instructions[{index}] references unknown component_id: {component_id}"
             )
@@ -330,7 +333,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
 
         parent_component_id = item.get("parent_component_id")
         if parent_component_id not in (None, "") and (
-            not isinstance(parent_component_id, str) or parent_component_id not in component_ids
+            not isinstance(parent_component_id, str)
+            or parent_component_id not in hierarchy_component_ids
         ):
             errors.append(
                 f"{item_type} at instructions[{index}] references unknown parent_component_id"

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -85,8 +85,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         "states",
         "token_constraints",
     ):
-        value = instruction.get(field_name)
-        if not isinstance(value, list) or not value:
+        list_value = instruction.get(field_name)
+        if not isinstance(list_value, list) or not list_value:
             errors.append(f"{field_name} must be a non-empty list")
 
     valid_components = canonical_component_names()

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+VOCABULARY_PATH = PROJECT_ROOT / "docs" / "design" / "ui_component_vocabulary.json"
+INSTRUCTION_DIR = PROJECT_ROOT / "scripts" / "design" / "instructions"
+MANIFEST_PATH = PROJECT_ROOT / "docs" / "design" / "figma-manifest.json"
+
+SUPPORTED_SCREENS = (
+    "ios.home",
+    "ios.plate",
+    "ios.progress",
+    "web.home",
+    "web.plate",
+    "web.progress",
+)
+
+SUPPORTED_INSTRUCTION_TYPES = {
+    "create_frame",
+    "create_button",
+}
+
+REQUIRED_INSTRUCTION_FIELDS = {
+    "screen_id",
+    "page",
+    "platform",
+    "surface",
+    "layout_pattern",
+    "primary_components",
+    "supporting_components",
+    "states",
+    "dimensions",
+    "background_token",
+    "token_constraints",
+    "governance_checks",
+    "context_version",
+    "instructions",
+}
+
+RAW_HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b")
+
+
+def load_vocabulary_components() -> list[dict[str, Any]]:
+    return json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+
+
+def canonical_component_names() -> set[str]:
+    return {str(component["canonical_name"]) for component in load_vocabulary_components()}
+
+
+def instruction_path_for_screen(screen_id: str) -> Path:
+    return INSTRUCTION_DIR / f"{screen_id.replace('.', '_')}.json"
+
+
+def has_raw_hex(value: str) -> bool:
+    return bool(RAW_HEX_RE.search(value))
+
+
+def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    missing_fields = REQUIRED_INSTRUCTION_FIELDS.difference(instruction)
+    if missing_fields:
+        errors.append("Missing required instruction field(s): " + ", ".join(sorted(missing_fields)))
+        return errors
+
+    screen_id = str(instruction["screen_id"])
+    if screen_id not in SUPPORTED_SCREENS:
+        errors.append(f"Unsupported screen_id: {screen_id}")
+
+    for field_name in ("surface", "layout_pattern", "background_token", "context_version"):
+        value = str(instruction.get(field_name, "")).strip()
+        if not value:
+            errors.append(f"Empty {field_name}")
+
+    for field_name in (
+        "primary_components",
+        "supporting_components",
+        "states",
+        "token_constraints",
+    ):
+        value = instruction.get(field_name)
+        if not isinstance(value, list) or not value:
+            errors.append(f"{field_name} must be a non-empty list")
+
+    valid_components = canonical_component_names()
+    for field_name in ("primary_components", "supporting_components"):
+        for component_name in instruction.get(field_name, []):
+            if component_name not in valid_components:
+                errors.append(f"Unknown canonical component in {field_name}: {component_name}")
+
+    background_token = str(instruction.get("background_token", ""))
+    if has_raw_hex(background_token):
+        errors.append(f"Raw hex color used in background_token: {background_token}")
+
+    token_constraints = instruction.get("token_constraints", [])
+    for token_value in token_constraints:
+        token_text = str(token_value).strip()
+        if not token_text:
+            errors.append("Empty token_constraints entry")
+        elif has_raw_hex(token_text):
+            errors.append(f"Raw hex color used in token_constraints: {token_text}")
+
+    instructions_list = instruction.get("instructions", [])
+    if not isinstance(instructions_list, list) or not instructions_list:
+        errors.append("instructions must be a non-empty list")
+        return errors
+
+    frame_count = 0
+    for index, item in enumerate(instructions_list):
+        if not isinstance(item, dict):
+            errors.append(f"instructions[{index}] must be an object")
+            continue
+
+        item_type = str(item.get("type", "")).strip()
+        if item_type not in SUPPORTED_INSTRUCTION_TYPES:
+            errors.append(f"Unsupported instruction type: {item_type or '<empty>'}")
+            continue
+
+        item_name = str(item.get("name", "")).strip()
+        if not item_name:
+            errors.append(f"{item_type} at instructions[{index}] missing name")
+
+        if item_type == "create_frame":
+            frame_count += 1
+            if "background" not in item:
+                errors.append("create_frame missing background")
+
+        if item_type == "create_button":
+            cta_key = str(item.get("cta_key", "")).strip()
+            if not cta_key:
+                errors.append(f"Button {item_name or index} missing cta_key")
+
+            button_states = item.get("states")
+            if not isinstance(button_states, list) or not button_states:
+                errors.append(f"Button {item_name or index} missing states list")
+
+            canonical_component = str(item.get("canonical_component", "")).strip()
+            if canonical_component != "button":
+                errors.append(f"Button {item_name or index} must set canonical_component=button")
+
+    if frame_count != 1:
+        errors.append(f"Instruction must contain exactly one create_frame, got {frame_count}")
+
+    return errors

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -24,21 +24,47 @@ SUPPORTED_INSTRUCTION_TYPES = {
     "create_button",
 }
 
+SUPPORTED_LAYOUT_ARCHETYPES = {
+    "content_shell",
+    "dashboard_shell",
+    "hero_shell",
+}
+
 REQUIRED_INSTRUCTION_FIELDS = {
     "screen_id",
     "page",
     "platform",
     "surface",
     "layout_pattern",
+    "layout_archetype",
     "primary_components",
     "supporting_components",
     "states",
+    "sections",
+    "component_hierarchy",
     "dimensions",
     "background_token",
     "token_constraints",
     "governance_checks",
     "context_version",
     "instructions",
+}
+
+REQUIRED_SECTION_FIELDS = {
+    "section_id",
+    "name",
+    "role",
+    "component_ids",
+}
+
+REQUIRED_COMPONENT_NODE_FIELDS = {
+    "component_id",
+    "canonical_component",
+    "section_id",
+    "parent_component_id",
+    "hierarchy_level",
+    "semantic_role",
+    "source_ref",
 }
 
 RAW_HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b")
@@ -79,6 +105,12 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         if not value:
             errors.append(f"Empty {field_name}")
 
+    layout_archetype = str(instruction.get("layout_archetype", "")).strip()
+    if not layout_archetype:
+        errors.append("Empty layout_archetype")
+    elif layout_archetype not in SUPPORTED_LAYOUT_ARCHETYPES:
+        errors.append(f"Unsupported layout_archetype: {layout_archetype}")
+
     for field_name in (
         "primary_components",
         "supporting_components",
@@ -94,6 +126,151 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         for component_name in instruction.get(field_name, []):
             if component_name not in valid_components:
                 errors.append(f"Unknown canonical component in {field_name}: {component_name}")
+
+    sections_value = instruction.get("sections", [])
+    section_ids: set[str] = set()
+    section_component_map: dict[str, list[str]] = {}
+    if not isinstance(sections_value, list) or not sections_value:
+        errors.append("sections must be a non-empty list")
+    else:
+        for index, section in enumerate(sections_value):
+            if not isinstance(section, dict):
+                errors.append(f"sections[{index}] must be an object")
+                continue
+
+            missing_section_fields = REQUIRED_SECTION_FIELDS.difference(section)
+            if missing_section_fields:
+                errors.append(
+                    "sections[{index}] missing field(s): {fields}".format(
+                        index=index,
+                        fields=", ".join(sorted(missing_section_fields)),
+                    )
+                )
+                continue
+
+            section_id = str(section.get("section_id", "")).strip()
+            if not section_id:
+                errors.append(f"sections[{index}] missing section_id")
+                continue
+            if section_id in section_ids:
+                errors.append(f"Duplicate section_id: {section_id}")
+                continue
+
+            component_ids = section.get("component_ids")
+            if not isinstance(component_ids, list) or not component_ids:
+                errors.append(f"sections[{index}] must define non-empty component_ids")
+                continue
+
+            section_ids.add(section_id)
+            section_component_map[section_id] = [
+                str(component_id) for component_id in component_ids
+            ]
+
+    hierarchy_value = instruction.get("component_hierarchy", [])
+    component_ids: set[str] = set()
+    component_nodes: dict[str, dict[str, Any]] = {}
+    root_component_count = 0
+    if not isinstance(hierarchy_value, list) or not hierarchy_value:
+        errors.append("component_hierarchy must be a non-empty list")
+    else:
+        for index, node in enumerate(hierarchy_value):
+            if not isinstance(node, dict):
+                errors.append(f"component_hierarchy[{index}] must be an object")
+                continue
+
+            missing_node_fields = REQUIRED_COMPONENT_NODE_FIELDS.difference(node)
+            if missing_node_fields:
+                errors.append(
+                    "component_hierarchy[{index}] missing field(s): {fields}".format(
+                        index=index,
+                        fields=", ".join(sorted(missing_node_fields)),
+                    )
+                )
+                continue
+
+            component_id = str(node.get("component_id", "")).strip()
+            canonical_component = str(node.get("canonical_component", "")).strip()
+            node_section_id = str(node.get("section_id", "")).strip()
+            semantic_role = str(node.get("semantic_role", "")).strip()
+            source_ref = str(node.get("source_ref", "")).strip()
+            parent_component_id = node.get("parent_component_id")
+            hierarchy_level = node.get("hierarchy_level")
+
+            if not component_id:
+                errors.append(f"component_hierarchy[{index}] missing component_id")
+                continue
+            if component_id in component_ids:
+                errors.append(f"Duplicate component_id: {component_id}")
+                continue
+            if not semantic_role:
+                errors.append(f"component_hierarchy[{index}] missing semantic_role")
+            if not source_ref:
+                errors.append(f"component_hierarchy[{index}] missing source_ref")
+            if not isinstance(hierarchy_level, int) or hierarchy_level < 0:
+                errors.append(f"component_hierarchy[{index}] hierarchy_level must be integer >= 0")
+            if canonical_component not in valid_components:
+                errors.append(
+                    f"Unknown canonical component in component_hierarchy: {canonical_component}"
+                )
+            if section_ids and node_section_id not in section_ids:
+                errors.append(
+                    "Unknown section_id for component_hierarchy node "
+                    f"{component_id}: {node_section_id}"
+                )
+
+            if parent_component_id in (None, ""):
+                root_component_count += 1
+            elif not isinstance(parent_component_id, str):
+                errors.append(
+                    "component_hierarchy[{index}] parent_component_id must be null or string".format(
+                        index=index
+                    )
+                )
+
+            component_ids.add(component_id)
+            component_nodes[component_id] = {
+                "canonical_component": canonical_component,
+                "section_id": node_section_id,
+                "parent_component_id": parent_component_id,
+                "hierarchy_level": hierarchy_level,
+            }
+
+        for component_id, node in component_nodes.items():
+            parent_component_id = node.get("parent_component_id")
+            if isinstance(parent_component_id, str) and parent_component_id not in component_ids:
+                errors.append(
+                    "Unknown parent_component_id for component_hierarchy node "
+                    f"{component_id}: {parent_component_id}"
+                )
+            parent_node = (
+                component_nodes.get(parent_component_id)
+                if isinstance(parent_component_id, str)
+                else None
+            )
+            if (
+                parent_node is not None
+                and isinstance(parent_node.get("hierarchy_level"), int)
+                and isinstance(node.get("hierarchy_level"), int)
+                and node["hierarchy_level"] <= parent_node["hierarchy_level"]
+            ):
+                errors.append(
+                    "component_hierarchy node must have hierarchy_level greater than parent: "
+                    f"{component_id}"
+                )
+
+        if root_component_count != 1:
+            errors.append(
+                "component_hierarchy must contain exactly one root component, "
+                f"got {root_component_count}"
+            )
+
+        for section_id, referenced_component_ids in section_component_map.items():
+            for component_id in referenced_component_ids:
+                if component_id not in component_ids:
+                    errors.append(
+                        "sections reference unknown component_id: "
+                        f"{section_id} -> {component_id}"
+                    )
 
     background_token = str(instruction.get("background_token", ""))
     if has_raw_hex(background_token):
@@ -127,10 +304,44 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         if not item_name:
             errors.append(f"{item_type} at instructions[{index}] missing name")
 
+        component_id = str(item.get("component_id", "")).strip()
+        if not component_id:
+            errors.append(f"{item_type} at instructions[{index}] missing component_id")
+        elif component_ids and component_id not in component_ids:
+            errors.append(
+                f"{item_type} at instructions[{index}] references unknown component_id: {component_id}"
+            )
+
+        item_section_id = str(item.get("section_id", "")).strip()
+        if not item_section_id:
+            errors.append(f"{item_type} at instructions[{index}] missing section_id")
+        elif section_ids and item_section_id not in section_ids:
+            errors.append(
+                f"{item_type} at instructions[{index}] references unknown section_id: {item_section_id}"
+            )
+
+        order_value = item.get("order")
+        if not isinstance(order_value, int) or order_value < 0:
+            errors.append(f"{item_type} at instructions[{index}] must define integer order >= 0")
+
+        hierarchy_level = item.get("hierarchy_level")
+        if not isinstance(hierarchy_level, int) or hierarchy_level < 0:
+            errors.append(f"{item_type} at instructions[{index}] must define hierarchy_level >= 0")
+
+        parent_component_id = item.get("parent_component_id")
+        if parent_component_id not in (None, "") and (
+            not isinstance(parent_component_id, str) or parent_component_id not in component_ids
+        ):
+            errors.append(
+                f"{item_type} at instructions[{index}] references unknown parent_component_id"
+            )
+
         if item_type == "create_frame":
             frame_count += 1
             if "background" not in item:
                 errors.append("create_frame missing background")
+            if parent_component_id not in (None, ""):
+                errors.append("create_frame must not define parent_component_id")
 
         if item_type == "create_button":
             cta_key = str(item.get("cta_key", "")).strip()
@@ -144,6 +355,12 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
             canonical_component = str(item.get("canonical_component", "")).strip()
             if canonical_component != "button":
                 errors.append(f"Button {item_name or index} must set canonical_component=button")
+
+            hierarchy_node = component_nodes.get(component_id)
+            if hierarchy_node and hierarchy_node.get("canonical_component") != "button":
+                errors.append(
+                    f"Button {item_name or index} must reference a button component_hierarchy node"
+                )
 
     if frame_count != 1:
         errors.append(f"Instruction must contain exactly one create_frame, got {frame_count}")

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -67,11 +67,22 @@ REQUIRED_COMPONENT_NODE_FIELDS = {
     "source_ref",
 }
 
-RAW_HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b")
+RAW_HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b")
 
 
 def load_vocabulary_components() -> list[dict[str, Any]]:
-    payload = json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Vocabulary file not found: {VOCABULARY_PATH}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Vocabulary file is invalid JSON: {VOCABULARY_PATH}: {exc}") from exc
+
+    if not isinstance(payload, list):
+        raise RuntimeError(
+            f"Vocabulary payload must be a list: {VOCABULARY_PATH} (got {type(payload).__name__})"
+        )
+
     return cast(list[dict[str, Any]], payload)
 
 
@@ -110,6 +121,10 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         errors.append("Empty layout_archetype")
     elif layout_archetype not in SUPPORTED_LAYOUT_ARCHETYPES:
         errors.append(f"Unsupported layout_archetype: {layout_archetype}")
+
+    governance_checks = instruction.get("governance_checks")
+    if not isinstance(governance_checks, list) or not governance_checks:
+        errors.append("governance_checks must be a non-empty list")
 
     for field_name in (
         "primary_components",
@@ -293,6 +308,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         return errors
 
     frame_count = 0
+    frame_instruction_component_ids: set[str] = set()
+    root_frame_count = 0
     for index, item in enumerate(instructions_list):
         if not isinstance(item, dict):
             errors.append(f"instructions[{index}] must be an object")
@@ -340,12 +357,41 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                 f"{item_type} at instructions[{index}] references unknown parent_component_id"
             )
 
+        hierarchy_node = component_nodes.get(component_id)
+        if hierarchy_node is not None:
+            if item_section_id and hierarchy_node.get("section_id") != item_section_id:
+                errors.append(
+                    f"{item_type} at instructions[{index}] section_id does not match "
+                    f"component_hierarchy for {component_id}"
+                )
+            if hierarchy_level != hierarchy_node.get("hierarchy_level"):
+                errors.append(
+                    f"{item_type} at instructions[{index}] hierarchy_level does not match "
+                    f"component_hierarchy for {component_id}"
+                )
+
+            expected_parent_component_id = hierarchy_node.get("parent_component_id")
+            normalized_parent_component_id = (
+                None if parent_component_id in (None, "") else parent_component_id
+            )
+            if normalized_parent_component_id != expected_parent_component_id:
+                errors.append(
+                    f"{item_type} at instructions[{index}] parent_component_id does not match "
+                    f"component_hierarchy for {component_id}"
+                )
+
         if item_type == "create_frame":
             frame_count += 1
-            if "background" not in item:
-                errors.append("create_frame missing background")
-            if parent_component_id not in (None, ""):
-                errors.append("create_frame must not define parent_component_id")
+            if component_id:
+                frame_instruction_component_ids.add(component_id)
+            if parent_component_id in (None, ""):
+                root_frame_count += 1
+            if parent_component_id in (None, "") and "background" not in item:
+                errors.append("root create_frame missing background")
+            if hierarchy_node and hierarchy_node.get("canonical_component") == "button":
+                errors.append(
+                    f"create_frame at instructions[{index}] must not reference a button node"
+                )
 
         if item_type == "create_button":
             cta_key = str(item.get("cta_key", "")).strip()
@@ -365,8 +411,35 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                 errors.append(
                     f"Button {item_name or index} must reference a button component_hierarchy node"
                 )
+            if (
+                hierarchy_node
+                and hierarchy_node.get("semantic_role") == "flagged_cta"
+                and isinstance(button_states, list)
+                and "feature-flagged" not in button_states
+            ):
+                errors.append(
+                    f"Button {item_name or index} missing feature-flagged state for flagged_cta"
+                )
 
-    if frame_count != 1:
-        errors.append(f"Instruction must contain exactly one create_frame, got {frame_count}")
+    if frame_count < 1:
+        errors.append("Instruction must contain at least one create_frame")
+    if root_frame_count != 1:
+        errors.append(
+            f"Instruction must contain exactly one root create_frame, got {root_frame_count}"
+        )
+
+    non_button_component_ids = {
+        component_id
+        for component_id, node in component_nodes.items()
+        if node.get("canonical_component") != "button"
+    }
+    missing_frame_component_ids = sorted(
+        non_button_component_ids.difference(frame_instruction_component_ids)
+    )
+    if missing_frame_component_ids:
+        errors.append(
+            "Missing create_frame instructions for component_hierarchy nodes: "
+            + ", ".join(missing_frame_component_ids)
+        )
 
     return errors

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 VOCABULARY_PATH = PROJECT_ROOT / "docs" / "design" / "ui_component_vocabulary.json"
@@ -45,7 +45,8 @@ RAW_HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b")
 
 
 def load_vocabulary_components() -> list[dict[str, Any]]:
-    return json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+    payload = json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+    return cast(list[dict[str, Any]], payload)
 
 
 def canonical_component_names() -> set[str]:
@@ -73,7 +74,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         errors.append(f"Unsupported screen_id: {screen_id}")
 
     for field_name in ("surface", "layout_pattern", "background_token", "context_version"):
-        value = str(instruction.get(field_name, "")).strip()
+        raw_value = instruction.get(field_name, "")
+        value = str(raw_value).strip()
         if not value:
             errors.append(f"Empty {field_name}")
 

--- a/scripts/design/contracts.py
+++ b/scripts/design/contracts.py
@@ -243,11 +243,15 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                 )
 
             hierarchy_component_ids.add(component_id)
+            normalized_parent_component_id = (
+                None if parent_component_id in (None, "") else parent_component_id
+            )
             component_nodes[component_id] = {
                 "canonical_component": canonical_component,
                 "section_id": node_section_id,
-                "parent_component_id": parent_component_id,
+                "parent_component_id": normalized_parent_component_id,
                 "hierarchy_level": hierarchy_level,
+                "semantic_role": semantic_role,
             }
 
         for component_id, node in component_nodes.items():
@@ -290,6 +294,22 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                         f"{section_id} -> {component_id}"
                     )
 
+        for component_id, node in component_nodes.items():
+            node_section_id = str(node.get("section_id", "")).strip()
+            if not node_section_id:
+                continue
+            if node_section_id not in section_component_map:
+                errors.append(
+                    "component_hierarchy node references section missing from sections payload: "
+                    f"{node_section_id} -> {component_id}"
+                )
+                continue
+            if component_id not in section_component_map[node_section_id]:
+                errors.append(
+                    "component_hierarchy node missing from sections.component_ids: "
+                    f"{node_section_id} -> {component_id}"
+                )
+
     background_token = str(instruction.get("background_token", ""))
     if has_raw_hex(background_token):
         errors.append(f"Raw hex color used in background_token: {background_token}")
@@ -309,6 +329,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
 
     frame_count = 0
     frame_instruction_component_ids: set[str] = set()
+    button_instruction_component_ids: set[str] = set()
+    seen_instruction_targets: set[tuple[str, str]] = set()
     root_frame_count = 0
     for index, item in enumerate(instructions_list):
         if not isinstance(item, dict):
@@ -331,6 +353,12 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
             errors.append(
                 f"{item_type} at instructions[{index}] references unknown component_id: {component_id}"
             )
+        else:
+            instruction_target = (item_type, component_id)
+            if instruction_target in seen_instruction_targets:
+                errors.append(f"Duplicate {item_type} instruction for component_id: {component_id}")
+            else:
+                seen_instruction_targets.add(instruction_target)
 
         item_section_id = str(item.get("section_id", "")).strip()
         if not item_section_id:
@@ -359,6 +387,20 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
 
         hierarchy_node = component_nodes.get(component_id)
         if hierarchy_node is not None:
+            item_canonical_component = str(item.get("canonical_component", "")).strip()
+            if item_canonical_component != hierarchy_node.get("canonical_component"):
+                errors.append(
+                    f"{item_type} at instructions[{index}] canonical_component does not match "
+                    f"component_hierarchy for {component_id}"
+                )
+
+            item_semantic_role = str(item.get("semantic_role", "")).strip()
+            if item_semantic_role != hierarchy_node.get("semantic_role"):
+                errors.append(
+                    f"{item_type} at instructions[{index}] semantic_role does not match "
+                    f"component_hierarchy for {component_id}"
+                )
+
             if item_section_id and hierarchy_node.get("section_id") != item_section_id:
                 errors.append(
                     f"{item_type} at instructions[{index}] section_id does not match "
@@ -374,6 +416,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
             normalized_parent_component_id = (
                 None if parent_component_id in (None, "") else parent_component_id
             )
+            if expected_parent_component_id in (None, ""):
+                expected_parent_component_id = None
             if normalized_parent_component_id != expected_parent_component_id:
                 errors.append(
                     f"{item_type} at instructions[{index}] parent_component_id does not match "
@@ -394,6 +438,8 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
                 )
 
         if item_type == "create_button":
+            if component_id:
+                button_instruction_component_ids.add(component_id)
             cta_key = str(item.get("cta_key", "")).strip()
             if not cta_key:
                 errors.append(f"Button {item_name or index} missing cta_key")
@@ -440,6 +486,20 @@ def validate_instruction_contract(instruction: dict[str, Any]) -> list[str]:
         errors.append(
             "Missing create_frame instructions for component_hierarchy nodes: "
             + ", ".join(missing_frame_component_ids)
+        )
+
+    button_component_ids = {
+        component_id
+        for component_id, node in component_nodes.items()
+        if node.get("canonical_component") == "button"
+    }
+    missing_button_component_ids = sorted(
+        button_component_ids.difference(button_instruction_component_ids)
+    )
+    if missing_button_component_ids:
+        errors.append(
+            "Missing create_button instructions for component_hierarchy nodes: "
+            + ", ".join(missing_button_component_ids)
         )
 
     return errors

--- a/scripts/design/execute_design.py
+++ b/scripts/design/execute_design.py
@@ -40,7 +40,7 @@ def load_instruction(screen_id: str) -> dict[str, Any]:
     if not instruction_path.exists():
         raise FileNotFoundError(f"Instruction file not found: {instruction_path}")
 
-    with open(instruction_path) as f:
+    with open(instruction_path, encoding="utf-8") as f:
         return cast(dict[str, Any], json.load(f))
 
 
@@ -67,6 +67,8 @@ def validate_governance(instruction: dict[str, Any]) -> list[str]:
     if "verify_cta_registry_match" in checks:
         instructions_list = instruction.get("instructions", [])
         for inst in instructions_list:
+            if not isinstance(inst, dict):
+                continue
             if inst.get("type") == "create_button":
                 cta_key = inst.get("cta_key", "")
                 if not cta_key:
@@ -90,7 +92,7 @@ def update_manifest(screen_id: str, results: dict[str, Any]) -> None:
         print(f"Warning: Manifest not found at {manifest_path}")
         return
 
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         manifest = json.load(f)
 
     # Add execution results to exports
@@ -123,7 +125,7 @@ def update_manifest(screen_id: str, results: dict[str, Any]) -> None:
         # Add new entry
         manifest["exports"].append(export_entry)
 
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
     print(f"Updated manifest: {manifest_path}")
@@ -137,7 +139,7 @@ def log_execution(screen_id: str, results: dict[str, Any]) -> None:
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
     log_path = logs_dir / f"{timestamp}_{screen_id.replace('.', '_')}.json"
 
-    with open(log_path, "w") as f:
+    with open(log_path, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2)
 
     print(f"Execution log: {log_path}")

--- a/scripts/design/execute_design.py
+++ b/scripts/design/execute_design.py
@@ -22,6 +22,10 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 from scripts.design.contracts import SUPPORTED_SCREENS, validate_instruction_contract
+from scripts.design.execution_adapters import (
+    available_adapter_names,
+    resolve_execution_adapter,
+)
 
 # Project root for resolving paths
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -71,52 +75,11 @@ def validate_governance(instruction: dict[str, Any]) -> list[str]:
     return errors
 
 
-def simulate_mcp_execution(instruction: dict[str, Any]) -> dict[str, Any]:
-    """Simulate MCP execution (placeholder for actual MCP calls).
+def execute_instruction(instruction: dict[str, Any], adapter_name: str) -> dict[str, Any]:
+    """Execute one instruction payload through the configured adapter seam."""
 
-    In production, this would invoke actual Figma MCP tools:
-    - figma.create_frame
-    - figma.create_components
-    - figma.apply_styles
-
-    For now, it returns a simulated result structure.
-    """
-    screen_id = instruction.get("screen_id", "unknown")
-    instructions_list = instruction.get("instructions", [])
-
-    # Simulate node ID generation
-    results = {
-        "screen_id": screen_id,
-        "executed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "status": "simulated",
-        "surface": instruction.get("surface"),
-        "layout_pattern": instruction.get("layout_pattern"),
-        "simulation_mode": "deterministic_contract_stub",
-        "created_nodes": [],
-        "mcp_calls": [],
-    }
-
-    for i, inst in enumerate(instructions_list):
-        inst_type = inst.get("type", "unknown")
-        inst_name = inst.get("name", f"Node_{i}")
-
-        # Simulate MCP call
-        results["mcp_calls"].append(
-            {"tool": f"figma.{inst_type}", "params": {"name": inst_name}, "status": "simulated"}
-        )
-
-        # Simulate created node
-        results["created_nodes"].append(
-            {
-                "type": inst_type,
-                "name": inst_name,
-                "node_id": f"simulated:{screen_id}:{i}",
-                "status": "pending_real_execution",
-                "canonical_component": inst.get("canonical_component"),
-            }
-        )
-
-    return results
+    adapter = resolve_execution_adapter(adapter_name)
+    return adapter.execute(instruction)
 
 
 def update_manifest(screen_id: str, results: dict[str, Any]) -> None:
@@ -142,7 +105,11 @@ def update_manifest(screen_id: str, results: dict[str, Any]) -> None:
         "executed_at": results.get("executed_at"),
         "status": results.get("status"),
         "surface": results.get("surface"),
+        "layout_archetype": results.get("layout_archetype"),
         "layout_pattern": results.get("layout_pattern"),
+        "section_count": results.get("section_count"),
+        "adapter_name": results.get("adapter_name"),
+        "adapter_mode": results.get("adapter_mode"),
         "simulation_mode": results.get("simulation_mode"),
         "node_count": len(results.get("created_nodes", [])),
         "nodes": results.get("created_nodes", []),
@@ -195,6 +162,12 @@ def main() -> int:
         help="Execute instruction via MCP (currently simulated)",
     )
     parser.add_argument(
+        "--adapter",
+        choices=available_adapter_names(),
+        default="deterministic_stub",
+        help="Execution adapter seam to use",
+    )
+    parser.add_argument(
         "--update-manifest",
         action="store_true",
         default=True,
@@ -234,10 +207,11 @@ def main() -> int:
 
     # Execute (currently simulated)
     print("\nExecuting design instructions...")
-    results = simulate_mcp_execution(instruction)
+    results = execute_instruction(instruction, args.adapter)
 
     print("\nExecution results:")
     print(f"  Status: {results.get('status')}")
+    print(f"  Adapter: {results.get('adapter_name')} ({results.get('adapter_mode')})")
     print(f"  Nodes created: {len(results.get('created_nodes', []))}")
     print(f"  MCP calls: {len(results.get('mcp_calls', []))}")
 
@@ -248,8 +222,8 @@ def main() -> int:
     if args.update_manifest:
         update_manifest(args.screen, results)
 
-    print("\nNote: Actual MCP execution requires Figma MCP connection.")
-    print("Current execution is simulated. Connect MCP to create real designs.")
+    print("\nNote: Live MCP-backed execution is intentionally deferred.")
+    print("Current execution uses the deterministic adapter seam.")
 
     return 0
 

--- a/scripts/design/execute_design.py
+++ b/scripts/design/execute_design.py
@@ -79,7 +79,7 @@ def execute_instruction(instruction: dict[str, Any], adapter_name: str) -> dict[
     """Execute one instruction payload through the configured adapter seam."""
 
     adapter = resolve_execution_adapter(adapter_name)
-    return adapter.execute(instruction)
+    return cast(dict[str, Any], adapter.execute(instruction))
 
 
 def update_manifest(screen_id: str, results: dict[str, Any]) -> None:

--- a/scripts/design/execute_design.py
+++ b/scripts/design/execute_design.py
@@ -18,6 +18,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from scripts.design.contracts import SUPPORTED_SCREENS, validate_instruction_contract
+
 # Project root for resolving paths
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -37,7 +42,7 @@ def load_instruction(screen_id: str) -> dict[str, Any]:
 
 def validate_governance(instruction: dict[str, Any]) -> list[str]:
     """Validate instruction against governance rules."""
-    errors = []
+    errors = validate_instruction_contract(instruction)
     checks = instruction.get("governance_checks", [])
 
     # Token usage check
@@ -51,15 +56,7 @@ def validate_governance(instruction: dict[str, Any]) -> list[str]:
     # HPP compliance check
     if "verify_hpp_compliance" in checks:
         screen_id = instruction.get("screen_id", "")
-        valid_screens = [
-            "ios.home",
-            "ios.plate",
-            "ios.progress",
-            "web.home",
-            "web.plate",
-            "web.progress",
-        ]
-        if screen_id not in valid_screens:
+        if screen_id not in SUPPORTED_SCREENS:
             errors.append(f"Screen {screen_id} not in H+P+Pr scope")
 
     # CTA registry check
@@ -92,6 +89,9 @@ def simulate_mcp_execution(instruction: dict[str, Any]) -> dict[str, Any]:
         "screen_id": screen_id,
         "executed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "status": "simulated",
+        "surface": instruction.get("surface"),
+        "layout_pattern": instruction.get("layout_pattern"),
+        "simulation_mode": "deterministic_contract_stub",
         "created_nodes": [],
         "mcp_calls": [],
     }
@@ -112,6 +112,7 @@ def simulate_mcp_execution(instruction: dict[str, Any]) -> dict[str, Any]:
                 "name": inst_name,
                 "node_id": f"simulated:{screen_id}:{i}",
                 "status": "pending_real_execution",
+                "canonical_component": inst.get("canonical_component"),
             }
         )
 
@@ -140,6 +141,9 @@ def update_manifest(screen_id: str, results: dict[str, Any]) -> None:
         "screen_id": screen_id,
         "executed_at": results.get("executed_at"),
         "status": results.get("status"),
+        "surface": results.get("surface"),
+        "layout_pattern": results.get("layout_pattern"),
+        "simulation_mode": results.get("simulation_mode"),
         "node_count": len(results.get("created_nodes", [])),
         "nodes": results.get("created_nodes", []),
     }

--- a/scripts/design/execute_design.py
+++ b/scripts/design/execute_design.py
@@ -16,7 +16,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
@@ -37,12 +37,12 @@ def load_instruction(screen_id: str) -> dict[str, Any]:
         raise FileNotFoundError(f"Instruction file not found: {instruction_path}")
 
     with open(instruction_path) as f:
-        return json.load(f)
+        return cast(dict[str, Any], json.load(f))
 
 
 def validate_governance(instruction: dict[str, Any]) -> list[str]:
     """Validate instruction against governance rules."""
-    errors = validate_instruction_contract(instruction)
+    errors: list[str] = list(validate_instruction_contract(instruction))
     checks = instruction.get("governance_checks", [])
 
     # Token usage check

--- a/scripts/design/execution_adapters.py
+++ b/scripts/design/execution_adapters.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+
+class DesignExecutionAdapter(Protocol):
+    """Stable seam for future design execution backends."""
+
+    adapter_name: str
+    adapter_mode: str
+
+    def execute(self, instruction: dict[str, Any]) -> dict[str, Any]:
+        """Execute one instruction payload and return manifest-safe results."""
+
+
+@dataclass(frozen=True)
+class DeterministicStubExecutionAdapter:
+    """Deterministic local adapter used until live MCP execution is introduced."""
+
+    adapter_name: str = "deterministic_stub"
+    adapter_mode: str = "simulated"
+
+    def execute(self, instruction: dict[str, Any]) -> dict[str, Any]:
+        screen_id = instruction.get("screen_id", "unknown")
+        instructions_list = instruction.get("instructions", [])
+        sections = instruction.get("sections", [])
+
+        results: dict[str, Any] = {
+            "screen_id": screen_id,
+            "executed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "status": "simulated",
+            "surface": instruction.get("surface"),
+            "layout_archetype": instruction.get("layout_archetype"),
+            "layout_pattern": instruction.get("layout_pattern"),
+            "section_count": len(sections) if isinstance(sections, list) else 0,
+            "adapter_name": self.adapter_name,
+            "adapter_mode": self.adapter_mode,
+            "simulation_mode": "deterministic_contract_stub",
+            "created_nodes": [],
+            "mcp_calls": [],
+        }
+
+        for index, inst in enumerate(instructions_list):
+            if not isinstance(inst, dict):
+                continue
+
+            inst_type = inst.get("type", "unknown")
+            inst_name = inst.get("name", f"Node_{index}")
+            results["mcp_calls"].append(
+                {
+                    "adapter": self.adapter_name,
+                    "tool": f"figma.{inst_type}",
+                    "params": {"name": inst_name},
+                    "status": "simulated",
+                }
+            )
+            results["created_nodes"].append(
+                {
+                    "type": inst_type,
+                    "name": inst_name,
+                    "node_id": f"simulated:{screen_id}:{index}",
+                    "status": "pending_real_execution",
+                    "canonical_component": inst.get("canonical_component"),
+                    "component_id": inst.get("component_id"),
+                    "section_id": inst.get("section_id"),
+                    "parent_component_id": inst.get("parent_component_id"),
+                    "hierarchy_level": inst.get("hierarchy_level"),
+                    "semantic_role": inst.get("semantic_role"),
+                    "order": inst.get("order"),
+                }
+            )
+
+        return results
+
+
+_ADAPTER_REGISTRY: dict[str, DesignExecutionAdapter] = {
+    "deterministic_stub": DeterministicStubExecutionAdapter(),
+}
+
+
+def available_adapter_names() -> tuple[str, ...]:
+    """Return supported execution adapter names for CLI wiring."""
+
+    return tuple(sorted(_ADAPTER_REGISTRY))
+
+
+def resolve_execution_adapter(adapter_name: str) -> DesignExecutionAdapter:
+    """Resolve one adapter by name and fail fast on unknown values."""
+
+    try:
+        return _ADAPTER_REGISTRY[adapter_name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported execution adapter: {adapter_name}") from exc

--- a/scripts/design/execution_adapters.py
+++ b/scripts/design/execution_adapters.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Protocol, cast
+
+DETERMINISTIC_EXECUTED_AT = "2026-01-01T00:00:00Z"
 
 
 class DesignExecutionAdapter(Protocol):
@@ -29,7 +30,7 @@ class DeterministicStubExecutionAdapter:
 
         results: dict[str, Any] = {
             "screen_id": screen_id,
-            "executed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "executed_at": DETERMINISTIC_EXECUTED_AT,
             "status": "simulated",
             "surface": instruction.get("surface"),
             "layout_archetype": instruction.get("layout_archetype"),

--- a/scripts/design/execution_adapters.py
+++ b/scripts/design/execution_adapters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 
 class DesignExecutionAdapter(Protocol):
@@ -75,7 +75,7 @@ class DeterministicStubExecutionAdapter:
         return results
 
 
-_ADAPTER_REGISTRY: dict[str, DesignExecutionAdapter] = {
+_ADAPTER_REGISTRY = {
     "deterministic_stub": DeterministicStubExecutionAdapter(),
 }
 
@@ -90,6 +90,6 @@ def resolve_execution_adapter(adapter_name: str) -> DesignExecutionAdapter:
     """Resolve one adapter by name and fail fast on unknown values."""
 
     try:
-        return _ADAPTER_REGISTRY[adapter_name]
+        return cast(DesignExecutionAdapter, _ADAPTER_REGISTRY[adapter_name])
     except KeyError as exc:
         raise ValueError(f"Unsupported execution adapter: {adapter_name}") from exc

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -77,7 +77,7 @@ class LayoutSectionSpec:
     section_id: str
     name: str
     role: str
-    component_ids: list[str]
+    component_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -128,6 +128,11 @@ class ScreenContentModel(TypedDict):
 SCREEN_DIMENSIONS = {
     "ios": {"width": 390, "height": 844},  # iPhone 14 Pro
     "web": {"width": 1440, "height": 900},  # Desktop
+}
+
+PLATFORM_DISPLAY_NAMES = {
+    "IOS": "iOS",
+    "WEB": "Web",
 }
 
 # Page mapping from governance index
@@ -555,6 +560,12 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
         "layout_pattern": "dashboard-detail-stack",
         "layout_sections": [
             {
+                "id": "progress-header",
+                "name": "Progress header",
+                "role": "utility_actions",
+                "components": ["card", "button"],
+            },
+            {
                 "id": "progress-summary",
                 "name": "Progress summary",
                 "role": "summary_metrics",
@@ -576,6 +587,15 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
                 "hierarchy_level": 0,
                 "semantic_role": "surface_shell",
                 "source_ref": "static:web-progress-shell",
+            },
+            {
+                "id": "web-progress-header-utilities",
+                "canonical_component": "card",
+                "section_id": "progress-header",
+                "parent_id": "web-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "utility_cluster",
+                "source_ref": "static:web-progress-header-utilities",
             },
             {
                 "id": "web-progress-stats",
@@ -614,8 +634,8 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
                 "source_ref": "static:web-progress-recovery",
             },
         ],
-        "cta_section_id": "progress-recovery",
-        "cta_parent_id": "web-progress-recovery",
+        "cta_section_id": "progress-header",
+        "cta_parent_id": "web-progress-header-utilities",
         "primary_components": ["progress", "button"],
         "supporting_components": ["stats-card", "tooltip", "alert"],
         "states": ["default", "loading", "empty", "error", "export-success"],
@@ -857,17 +877,21 @@ def get_ctas_for_screen(screen_id: str) -> list[CTASpec]:
     return [cta for cta_id, cta in CTA_REGISTRY.items() if cta_id.startswith(prefix)]
 
 
-def build_layout_sections(content_model: ScreenContentModel) -> list[LayoutSectionSpec]:
+def build_layout_sections(
+    content_model: ScreenContentModel,
+    component_tree: list[ComponentNodeSpec],
+) -> list[LayoutSectionSpec]:
     """Materialize layout sections for the instruction payload."""
+    component_ids_by_section: dict[str, list[str]] = {}
+    for node in component_tree:
+        component_ids_by_section.setdefault(node.section_id, []).append(node.component_id)
+
     return [
         LayoutSectionSpec(
             section_id=section["id"],
             name=section["name"],
             role=section["role"],
-            component_ids=[
-                f"{section['id']}:{component_name.replace('/', '-').replace(' ', '-')}"
-                for component_name in section["components"]
-            ],
+            component_ids=component_ids_by_section.get(section["id"], []),
         )
         for section in content_model["layout_sections"]
     ]
@@ -940,8 +964,8 @@ def generate_screen_instruction(screen_id: str) -> ScreenInstruction:
     if content_model is None:
         raise ValueError(f"No content model found for screen: {screen_id}")
 
-    layout_sections = build_layout_sections(content_model)
     component_tree = build_component_tree(content_model, ctas)
+    layout_sections = build_layout_sections(content_model, component_tree)
 
     return ScreenInstruction(
         screen_id=screen_id,
@@ -1016,7 +1040,10 @@ def build_sections_payload(instruction: ScreenInstruction) -> list[dict[str, Any
 def _frame_instruction_name(instruction: ScreenInstruction, node: ComponentNodeSpec) -> str:
     """Return a stable frame name for one component-hierarchy node."""
     if node.parent_component_id is None:
-        return f"{instruction.platform} {instruction.screen_id.split('.')[1].title()} Screen"
+        platform_name = PLATFORM_DISPLAY_NAMES.get(
+            instruction.platform, instruction.platform.title()
+        )
+        return f"{platform_name} {instruction.screen_id.split('.')[1].title()} Screen"
     return node.component_id
 
 

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -130,9 +130,9 @@ SCREEN_DIMENSIONS = {
     "web": {"width": 1440, "height": 900},  # Desktop
 }
 
-PLATFORM_DISPLAY_NAMES = {
-    "IOS": "iOS",
-    "WEB": "Web",
+PLATFORM_CANONICAL_NAMES = {
+    "ios": "iOS",
+    "web": "Web",
 }
 
 # Page mapping from governance index
@@ -228,7 +228,7 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
         ],
         "cta_section_id": "quick-actions",
         "cta_parent_id": "ios-home-actions",
-        "primary_components": ["hero", "button"],
+        "primary_components": ["hero", "button", "card"],
         "supporting_components": ["stats-card", "navigation/tab-bar", "badge"],
         "states": ["default", "feature-flagged", "loading", "error"],
         "token_constraints": ["Color.navy", "Color.appPrimary", "Color.surface"],
@@ -970,7 +970,7 @@ def generate_screen_instruction(screen_id: str) -> ScreenInstruction:
     return ScreenInstruction(
         screen_id=screen_id,
         page=page,
-        platform=platform.upper(),
+        platform=PLATFORM_CANONICAL_NAMES.get(platform, platform.title()),
         surface=content_model["surface"],
         layout_archetype=content_model["layout_archetype"],
         layout_pattern=content_model["layout_pattern"],
@@ -1040,8 +1040,8 @@ def build_sections_payload(instruction: ScreenInstruction) -> list[dict[str, Any
 def _frame_instruction_name(instruction: ScreenInstruction, node: ComponentNodeSpec) -> str:
     """Return a stable frame name for one component-hierarchy node."""
     if node.parent_component_id is None:
-        platform_name = PLATFORM_DISPLAY_NAMES.get(
-            instruction.platform, instruction.platform.title()
+        platform_name = PLATFORM_CANONICAL_NAMES.get(
+            instruction.platform.lower(), instruction.platform.title()
         )
         return f"{platform_name} {instruction.screen_id.split('.')[1].title()} Screen"
     return node.component_id
@@ -1072,7 +1072,7 @@ def _frame_instruction_payload(
 
 def _button_states_for_node(cta: CTASpec, node: ComponentNodeSpec) -> list[str]:
     """Return explicit button states for one CTA node."""
-    states = list(cta.states)
+    states = [state for state in cta.states if not (cta.platform == "iOS" and state == "hover")]
     if node.semantic_role == "flagged_cta" and "feature-flagged" not in states:
         states.append("feature-flagged")
     return states
@@ -1106,17 +1106,10 @@ def _button_instruction_payload(
 
 def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
     """Convert instruction to JSON-serializable dict."""
-    component_order = {
-        node.component_id: index for index, node in enumerate(instruction.component_hierarchy)
-    }
     ctas_by_source_ref = {f"cta:{cta.cta_id}": cta for cta in instruction.ctas}
 
     instruction_payload: list[dict[str, Any]] = []
-    for node in instruction.component_hierarchy:
-        order = component_order.get(node.component_id)
-        if order is None:
-            raise ValueError(f"Missing component order for {node.component_id}")
-
+    for order, node in enumerate(instruction.component_hierarchy):
         if node.canonical_component == "button":
             cta = ctas_by_source_ref.get(node.source_ref)
             if cta is None:

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -19,6 +19,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from scripts.design.contracts import validate_instruction_contract
+
 # Project root for resolving paths
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -49,8 +54,14 @@ class ScreenInstruction:
     screen_id: str
     page: str
     platform: str
+    surface: str
+    layout_pattern: str
+    primary_components: list[str]
+    supporting_components: list[str]
+    states: list[str]
     dimensions: dict[str, int]
     background_token: str
+    token_constraints: list[str]
     ctas: list[CTASpec]
     governance_checks: list[str]
     context_version: str = ""
@@ -70,6 +81,57 @@ PAGE_MAPPING = {
     "web.home": "20_Web_Parity",
     "web.plate": "20_Web_Parity",
     "web.progress": "20_Web_Parity",
+}
+
+SCREEN_CONTENT_MODEL = {
+    "ios.home": {
+        "surface": "ios_home_screen",
+        "layout_pattern": "hero-plus-quick-actions",
+        "primary_components": ["hero", "button"],
+        "supporting_components": ["stats-card", "navigation/tab-bar", "badge"],
+        "states": ["default", "feature-flagged", "loading", "error"],
+        "token_constraints": ["Color.navy", "Color.appPrimary", "Color.surface"],
+    },
+    "ios.plate": {
+        "surface": "ios_plate_screen",
+        "layout_pattern": "content-card-with-primary-actions",
+        "primary_components": ["card", "button"],
+        "supporting_components": ["badge", "dialog", "progress"],
+        "states": ["default", "issue-recovery", "loading", "error"],
+        "token_constraints": ["Color.navy", "Color.surface", "Color.appPrimary"],
+    },
+    "ios.progress": {
+        "surface": "ios_progress_screen",
+        "layout_pattern": "dashboard-summary-stack",
+        "primary_components": ["progress", "button"],
+        "supporting_components": ["stats-card", "empty-state", "alert"],
+        "states": ["default", "empty", "loading", "error"],
+        "token_constraints": ["Color.navy", "Color.surface", "Color.accentGreen"],
+    },
+    "web.home": {
+        "surface": "web_home_screen",
+        "layout_pattern": "hero-plus-status-grid",
+        "primary_components": ["hero", "button"],
+        "supporting_components": ["stats-card", "navigation/tab-bar", "badge"],
+        "states": ["default", "feature-flagged", "loading", "error"],
+        "token_constraints": ["--pp-navy", "--color-primary", "--color-surface"],
+    },
+    "web.plate": {
+        "surface": "web_plate_screen",
+        "layout_pattern": "content-card-with-upgrade-actions",
+        "primary_components": ["card", "button"],
+        "supporting_components": ["badge", "dialog", "progress"],
+        "states": ["default", "premium-gated", "loading", "error"],
+        "token_constraints": ["--pp-navy", "--color-primary", "--color-surface"],
+    },
+    "web.progress": {
+        "surface": "web_progress_screen",
+        "layout_pattern": "dashboard-detail-stack",
+        "primary_components": ["progress", "button"],
+        "supporting_components": ["stats-card", "tooltip", "alert"],
+        "states": ["default", "loading", "empty", "error", "export-success"],
+        "token_constraints": ["--pp-navy", "--color-success", "--color-surface"],
+    },
 }
 
 # CTA registry parsed from docs/design/PULSEPLATE_BUTTON_ACTION_PROMPT_MATRIX.md
@@ -321,19 +383,31 @@ def generate_screen_instruction(screen_id: str) -> ScreenInstruction:
     dimensions = SCREEN_DIMENSIONS.get(platform, SCREEN_DIMENSIONS["web"])
     page = PAGE_MAPPING.get(screen_id, "20_Web_Parity")
     background_token = "--pp-navy" if platform == "web" else "Color.navy"
+    content_model = SCREEN_CONTENT_MODEL.get(screen_id)
+
+    if content_model is None:
+        raise ValueError(f"No content model found for screen: {screen_id}")
 
     return ScreenInstruction(
         screen_id=screen_id,
         page=page,
         platform=platform.upper(),
+        surface=content_model["surface"],
+        layout_pattern=content_model["layout_pattern"],
+        primary_components=content_model["primary_components"],
+        supporting_components=content_model["supporting_components"],
+        states=content_model["states"],
         dimensions=dimensions,
         background_token=background_token,
+        token_constraints=content_model["token_constraints"],
         ctas=ctas,
         governance_checks=[
             "verify_token_usage",
             "verify_hpp_compliance",
             "verify_cta_registry_match",
+            "verify_instruction_contract",
         ],
+        context_version="code-first-ui-v1",
     )
 
 
@@ -358,6 +432,9 @@ def validate_instruction(instruction: ScreenInstruction) -> list[str]:
     if instruction.dimensions["width"] <= 0 or instruction.dimensions["height"] <= 0:
         errors.append("Invalid screen dimensions")
 
+    instruction_dict = instruction_to_dict(instruction)
+    errors.extend(validate_instruction_contract(instruction_dict))
+
     return errors
 
 
@@ -367,8 +444,14 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
         "screen_id": instruction.screen_id,
         "page": instruction.page,
         "platform": instruction.platform,
+        "surface": instruction.surface,
+        "layout_pattern": instruction.layout_pattern,
+        "primary_components": instruction.primary_components,
+        "supporting_components": instruction.supporting_components,
+        "states": instruction.states,
         "dimensions": instruction.dimensions,
         "background_token": instruction.background_token,
+        "token_constraints": instruction.token_constraints,
         "governance_checks": instruction.governance_checks,
         "context_version": instruction.context_version,
         "instructions": [
@@ -377,6 +460,7 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
                 "name": f"{instruction.platform} {instruction.screen_id.split('.')[1].title()} Screen",
                 "dimensions": instruction.dimensions,
                 "background": instruction.background_token,
+                "canonical_component": "card",
             }
         ]
         + [
@@ -390,6 +474,7 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
                 "figma_node_id": cta.figma_node_id,
                 "prompt_stub": cta.prompt_stub,
                 "states": cta.states,
+                "canonical_component": "button",
             }
             for cta in instruction.ctas
         ],

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -55,7 +55,10 @@ class ScreenInstruction:
     page: str
     platform: str
     surface: str
+    layout_archetype: str
     layout_pattern: str
+    sections: list["LayoutSectionSpec"]
+    component_hierarchy: list["ComponentNodeSpec"]
     primary_components: list[str]
     supporting_components: list[str]
     states: list[str]
@@ -67,9 +70,54 @@ class ScreenInstruction:
     context_version: str = ""
 
 
+@dataclass
+class LayoutSectionSpec:
+    """Declarative section metadata for layout assembly."""
+
+    section_id: str
+    name: str
+    role: str
+    component_ids: list[str]
+
+
+@dataclass
+class ComponentNodeSpec:
+    """Flat component tree node with explicit parent linkage."""
+
+    component_id: str
+    canonical_component: str
+    section_id: str
+    parent_component_id: str | None
+    hierarchy_level: int
+    semantic_role: str
+    source_ref: str
+
+
+class LayoutSectionTemplate(TypedDict):
+    id: str
+    name: str
+    role: str
+    components: list[str]
+
+
+class ComponentNodeTemplate(TypedDict):
+    id: str
+    canonical_component: str
+    section_id: str
+    parent_id: str | None
+    hierarchy_level: int
+    semantic_role: str
+    source_ref: str
+
+
 class ScreenContentModel(TypedDict):
     surface: str
+    layout_archetype: str
     layout_pattern: str
+    layout_sections: list[LayoutSectionTemplate]
+    static_component_tree: list[ComponentNodeTemplate]
+    cta_section_id: str
+    cta_parent_id: str
     primary_components: list[str]
     supporting_components: list[str]
     states: list[str]
@@ -95,7 +143,86 @@ PAGE_MAPPING = {
 SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     "ios.home": {
         "surface": "ios_home_screen",
+        "layout_archetype": "hero_shell",
         "layout_pattern": "hero-plus-quick-actions",
+        "layout_sections": [
+            {
+                "id": "hero-band",
+                "name": "Hero band",
+                "role": "context_summary",
+                "components": ["hero", "badge", "stats-card"],
+            },
+            {
+                "id": "quick-actions",
+                "name": "Quick actions",
+                "role": "primary_actions",
+                "components": ["card", "button"],
+            },
+            {
+                "id": "footer-nav",
+                "name": "Footer navigation",
+                "role": "persistent_navigation",
+                "components": ["navigation/tab-bar"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "ios-home-shell",
+                "canonical_component": "card",
+                "section_id": "hero-band",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:ios-home-shell",
+            },
+            {
+                "id": "ios-home-hero",
+                "canonical_component": "hero",
+                "section_id": "hero-band",
+                "parent_id": "ios-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "primary_message",
+                "source_ref": "static:ios-home-hero",
+            },
+            {
+                "id": "ios-home-badge",
+                "canonical_component": "badge",
+                "section_id": "hero-band",
+                "parent_id": "ios-home-hero",
+                "hierarchy_level": 2,
+                "semantic_role": "status_marker",
+                "source_ref": "static:ios-home-badge",
+            },
+            {
+                "id": "ios-home-summary",
+                "canonical_component": "stats-card",
+                "section_id": "hero-band",
+                "parent_id": "ios-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "summary_metrics",
+                "source_ref": "static:ios-home-summary",
+            },
+            {
+                "id": "ios-home-actions",
+                "canonical_component": "card",
+                "section_id": "quick-actions",
+                "parent_id": "ios-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "action_cluster",
+                "source_ref": "static:ios-home-actions",
+            },
+            {
+                "id": "ios-home-nav",
+                "canonical_component": "navigation/tab-bar",
+                "section_id": "footer-nav",
+                "parent_id": "ios-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "persistent_navigation",
+                "source_ref": "static:ios-home-nav",
+            },
+        ],
+        "cta_section_id": "quick-actions",
+        "cta_parent_id": "ios-home-actions",
         "primary_components": ["hero", "button"],
         "supporting_components": ["stats-card", "navigation/tab-bar", "badge"],
         "states": ["default", "feature-flagged", "loading", "error"],
@@ -103,7 +230,80 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     },
     "ios.plate": {
         "surface": "ios_plate_screen",
+        "layout_archetype": "content_shell",
         "layout_pattern": "content-card-with-primary-actions",
+        "layout_sections": [
+            {
+                "id": "plate-summary",
+                "name": "Plate summary",
+                "role": "content_summary",
+                "components": ["card", "badge", "progress"],
+            },
+            {
+                "id": "plate-actions",
+                "name": "Plate actions",
+                "role": "primary_actions",
+                "components": ["card", "button", "dialog"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "ios-plate-shell",
+                "canonical_component": "card",
+                "section_id": "plate-summary",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:ios-plate-shell",
+            },
+            {
+                "id": "ios-plate-summary-card",
+                "canonical_component": "card",
+                "section_id": "plate-summary",
+                "parent_id": "ios-plate-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "content_container",
+                "source_ref": "static:ios-plate-summary-card",
+            },
+            {
+                "id": "ios-plate-badge",
+                "canonical_component": "badge",
+                "section_id": "plate-summary",
+                "parent_id": "ios-plate-summary-card",
+                "hierarchy_level": 2,
+                "semantic_role": "gate_state",
+                "source_ref": "static:ios-plate-badge",
+            },
+            {
+                "id": "ios-plate-progress",
+                "canonical_component": "progress",
+                "section_id": "plate-summary",
+                "parent_id": "ios-plate-summary-card",
+                "hierarchy_level": 2,
+                "semantic_role": "completion_feedback",
+                "source_ref": "static:ios-plate-progress",
+            },
+            {
+                "id": "ios-plate-action-panel",
+                "canonical_component": "card",
+                "section_id": "plate-actions",
+                "parent_id": "ios-plate-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "action_cluster",
+                "source_ref": "static:ios-plate-action-panel",
+            },
+            {
+                "id": "ios-plate-dialog",
+                "canonical_component": "dialog",
+                "section_id": "plate-actions",
+                "parent_id": "ios-plate-action-panel",
+                "hierarchy_level": 2,
+                "semantic_role": "secondary_details",
+                "source_ref": "static:ios-plate-dialog",
+            },
+        ],
+        "cta_section_id": "plate-actions",
+        "cta_parent_id": "ios-plate-action-panel",
         "primary_components": ["card", "button"],
         "supporting_components": ["badge", "dialog", "progress"],
         "states": ["default", "issue-recovery", "loading", "error"],
@@ -111,7 +311,71 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     },
     "ios.progress": {
         "surface": "ios_progress_screen",
+        "layout_archetype": "dashboard_shell",
         "layout_pattern": "dashboard-summary-stack",
+        "layout_sections": [
+            {
+                "id": "progress-summary",
+                "name": "Progress summary",
+                "role": "summary_metrics",
+                "components": ["stats-card", "progress"],
+            },
+            {
+                "id": "progress-recovery",
+                "name": "Recovery lane",
+                "role": "state_recovery",
+                "components": ["alert", "empty-state", "button"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "ios-progress-shell",
+                "canonical_component": "card",
+                "section_id": "progress-summary",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:ios-progress-shell",
+            },
+            {
+                "id": "ios-progress-stats",
+                "canonical_component": "stats-card",
+                "section_id": "progress-summary",
+                "parent_id": "ios-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "summary_metrics",
+                "source_ref": "static:ios-progress-stats",
+            },
+            {
+                "id": "ios-progress-chart",
+                "canonical_component": "progress",
+                "section_id": "progress-summary",
+                "parent_id": "ios-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "trend_visualization",
+                "source_ref": "static:ios-progress-chart",
+            },
+            {
+                "id": "ios-progress-recovery",
+                "canonical_component": "alert",
+                "section_id": "progress-recovery",
+                "parent_id": "ios-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "recovery_message",
+                "source_ref": "static:ios-progress-recovery",
+            },
+            {
+                "id": "ios-progress-empty",
+                "canonical_component": "empty-state",
+                "section_id": "progress-recovery",
+                "parent_id": "ios-progress-recovery",
+                "hierarchy_level": 2,
+                "semantic_role": "no_data_fallback",
+                "source_ref": "static:ios-progress-empty",
+            },
+        ],
+        "cta_section_id": "progress-recovery",
+        "cta_parent_id": "ios-progress-recovery",
         "primary_components": ["progress", "button"],
         "supporting_components": ["stats-card", "empty-state", "alert"],
         "states": ["default", "empty", "loading", "error"],
@@ -119,7 +383,86 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     },
     "web.home": {
         "surface": "web_home_screen",
+        "layout_archetype": "hero_shell",
         "layout_pattern": "hero-plus-status-grid",
+        "layout_sections": [
+            {
+                "id": "hero-band",
+                "name": "Hero band",
+                "role": "context_summary",
+                "components": ["hero", "badge", "stats-card"],
+            },
+            {
+                "id": "quick-actions",
+                "name": "Quick actions",
+                "role": "primary_actions",
+                "components": ["card", "button"],
+            },
+            {
+                "id": "footer-nav",
+                "name": "Footer navigation",
+                "role": "persistent_navigation",
+                "components": ["navigation/tab-bar"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "web-home-shell",
+                "canonical_component": "card",
+                "section_id": "hero-band",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:web-home-shell",
+            },
+            {
+                "id": "web-home-hero",
+                "canonical_component": "hero",
+                "section_id": "hero-band",
+                "parent_id": "web-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "primary_message",
+                "source_ref": "static:web-home-hero",
+            },
+            {
+                "id": "web-home-badge",
+                "canonical_component": "badge",
+                "section_id": "hero-band",
+                "parent_id": "web-home-hero",
+                "hierarchy_level": 2,
+                "semantic_role": "status_marker",
+                "source_ref": "static:web-home-badge",
+            },
+            {
+                "id": "web-home-summary",
+                "canonical_component": "stats-card",
+                "section_id": "hero-band",
+                "parent_id": "web-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "summary_metrics",
+                "source_ref": "static:web-home-summary",
+            },
+            {
+                "id": "web-home-actions",
+                "canonical_component": "card",
+                "section_id": "quick-actions",
+                "parent_id": "web-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "action_cluster",
+                "source_ref": "static:web-home-actions",
+            },
+            {
+                "id": "web-home-nav",
+                "canonical_component": "navigation/tab-bar",
+                "section_id": "footer-nav",
+                "parent_id": "web-home-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "persistent_navigation",
+                "source_ref": "static:web-home-nav",
+            },
+        ],
+        "cta_section_id": "quick-actions",
+        "cta_parent_id": "web-home-actions",
         "primary_components": ["hero", "button"],
         "supporting_components": ["stats-card", "navigation/tab-bar", "badge"],
         "states": ["default", "feature-flagged", "loading", "error"],
@@ -127,7 +470,80 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     },
     "web.plate": {
         "surface": "web_plate_screen",
+        "layout_archetype": "content_shell",
         "layout_pattern": "content-card-with-upgrade-actions",
+        "layout_sections": [
+            {
+                "id": "plate-summary",
+                "name": "Plate summary",
+                "role": "content_summary",
+                "components": ["card", "badge", "progress"],
+            },
+            {
+                "id": "plate-actions",
+                "name": "Plate actions",
+                "role": "primary_actions",
+                "components": ["card", "button", "dialog"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "web-plate-shell",
+                "canonical_component": "card",
+                "section_id": "plate-summary",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:web-plate-shell",
+            },
+            {
+                "id": "web-plate-summary-card",
+                "canonical_component": "card",
+                "section_id": "plate-summary",
+                "parent_id": "web-plate-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "content_container",
+                "source_ref": "static:web-plate-summary-card",
+            },
+            {
+                "id": "web-plate-badge",
+                "canonical_component": "badge",
+                "section_id": "plate-summary",
+                "parent_id": "web-plate-summary-card",
+                "hierarchy_level": 2,
+                "semantic_role": "premium_state",
+                "source_ref": "static:web-plate-badge",
+            },
+            {
+                "id": "web-plate-progress",
+                "canonical_component": "progress",
+                "section_id": "plate-summary",
+                "parent_id": "web-plate-summary-card",
+                "hierarchy_level": 2,
+                "semantic_role": "completion_feedback",
+                "source_ref": "static:web-plate-progress",
+            },
+            {
+                "id": "web-plate-action-panel",
+                "canonical_component": "card",
+                "section_id": "plate-actions",
+                "parent_id": "web-plate-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "action_cluster",
+                "source_ref": "static:web-plate-action-panel",
+            },
+            {
+                "id": "web-plate-dialog",
+                "canonical_component": "dialog",
+                "section_id": "plate-actions",
+                "parent_id": "web-plate-action-panel",
+                "hierarchy_level": 2,
+                "semantic_role": "upgrade_explainer",
+                "source_ref": "static:web-plate-dialog",
+            },
+        ],
+        "cta_section_id": "plate-actions",
+        "cta_parent_id": "web-plate-action-panel",
         "primary_components": ["card", "button"],
         "supporting_components": ["badge", "dialog", "progress"],
         "states": ["default", "premium-gated", "loading", "error"],
@@ -135,7 +551,71 @@ SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     },
     "web.progress": {
         "surface": "web_progress_screen",
+        "layout_archetype": "dashboard_shell",
         "layout_pattern": "dashboard-detail-stack",
+        "layout_sections": [
+            {
+                "id": "progress-summary",
+                "name": "Progress summary",
+                "role": "summary_metrics",
+                "components": ["stats-card", "progress", "tooltip"],
+            },
+            {
+                "id": "progress-recovery",
+                "name": "Recovery lane",
+                "role": "state_recovery",
+                "components": ["alert", "button"],
+            },
+        ],
+        "static_component_tree": [
+            {
+                "id": "web-progress-shell",
+                "canonical_component": "card",
+                "section_id": "progress-summary",
+                "parent_id": None,
+                "hierarchy_level": 0,
+                "semantic_role": "surface_shell",
+                "source_ref": "static:web-progress-shell",
+            },
+            {
+                "id": "web-progress-stats",
+                "canonical_component": "stats-card",
+                "section_id": "progress-summary",
+                "parent_id": "web-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "summary_metrics",
+                "source_ref": "static:web-progress-stats",
+            },
+            {
+                "id": "web-progress-chart",
+                "canonical_component": "progress",
+                "section_id": "progress-summary",
+                "parent_id": "web-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "trend_visualization",
+                "source_ref": "static:web-progress-chart",
+            },
+            {
+                "id": "web-progress-tooltip",
+                "canonical_component": "tooltip",
+                "section_id": "progress-summary",
+                "parent_id": "web-progress-chart",
+                "hierarchy_level": 2,
+                "semantic_role": "supporting_hint",
+                "source_ref": "static:web-progress-tooltip",
+            },
+            {
+                "id": "web-progress-recovery",
+                "canonical_component": "alert",
+                "section_id": "progress-recovery",
+                "parent_id": "web-progress-shell",
+                "hierarchy_level": 1,
+                "semantic_role": "recovery_message",
+                "source_ref": "static:web-progress-recovery",
+            },
+        ],
+        "cta_section_id": "progress-recovery",
+        "cta_parent_id": "web-progress-recovery",
         "primary_components": ["progress", "button"],
         "supporting_components": ["stats-card", "tooltip", "alert"],
         "states": ["default", "loading", "empty", "error", "export-success"],
@@ -377,6 +857,69 @@ def get_ctas_for_screen(screen_id: str) -> list[CTASpec]:
     return [cta for cta_id, cta in CTA_REGISTRY.items() if cta_id.startswith(prefix)]
 
 
+def build_layout_sections(content_model: ScreenContentModel) -> list[LayoutSectionSpec]:
+    """Materialize layout sections for the instruction payload."""
+    return [
+        LayoutSectionSpec(
+            section_id=section["id"],
+            name=section["name"],
+            role=section["role"],
+            component_ids=[
+                f"{section['id']}:{component_name.replace('/', '-').replace(' ', '-')}"
+                for component_name in section["components"]
+            ],
+        )
+        for section in content_model["layout_sections"]
+    ]
+
+
+def build_component_tree(
+    content_model: ScreenContentModel,
+    ctas: list[CTASpec],
+) -> list[ComponentNodeSpec]:
+    """Build a flat component tree with parent links and CTA nodes."""
+    component_tree = [
+        ComponentNodeSpec(
+            component_id=node["id"],
+            canonical_component=node["canonical_component"],
+            section_id=node["section_id"],
+            parent_component_id=node["parent_id"],
+            hierarchy_level=node["hierarchy_level"],
+            semantic_role=node["semantic_role"],
+            source_ref=node["source_ref"],
+        )
+        for node in content_model["static_component_tree"]
+    ]
+
+    parent_levels = {node.component_id: node.hierarchy_level for node in component_tree}
+    cta_parent_id = content_model["cta_parent_id"]
+    cta_base_level = parent_levels.get(cta_parent_id, 0) + 1
+
+    for cta in ctas:
+        status_text = cta.status.lower()
+        semantic_role = "primary_cta" if cta.variant == "V1" else "secondary_cta"
+        if "blocked" in status_text or "flag" in status_text:
+            semantic_role = "flagged_cta"
+        elif "partial" in status_text or "issue" in cta.cta_id:
+            semantic_role = "recovery_cta"
+        elif "export" in cta.cta_id:
+            semantic_role = "utility_cta"
+
+        component_tree.append(
+            ComponentNodeSpec(
+                component_id=f"node:{cta.cta_id}",
+                canonical_component="button",
+                section_id=content_model["cta_section_id"],
+                parent_component_id=cta_parent_id,
+                hierarchy_level=cta_base_level,
+                semantic_role=semantic_role,
+                source_ref=f"cta:{cta.cta_id}",
+            )
+        )
+
+    return component_tree
+
+
 def generate_screen_instruction(screen_id: str) -> ScreenInstruction:
     """Generate instruction set for a screen."""
     parts = screen_id.split(".")
@@ -397,12 +940,18 @@ def generate_screen_instruction(screen_id: str) -> ScreenInstruction:
     if content_model is None:
         raise ValueError(f"No content model found for screen: {screen_id}")
 
+    layout_sections = build_layout_sections(content_model)
+    component_tree = build_component_tree(content_model, ctas)
+
     return ScreenInstruction(
         screen_id=screen_id,
         page=page,
         platform=platform.upper(),
         surface=content_model["surface"],
+        layout_archetype=content_model["layout_archetype"],
         layout_pattern=content_model["layout_pattern"],
+        sections=layout_sections,
+        component_hierarchy=component_tree,
         primary_components=content_model["primary_components"],
         supporting_components=content_model["supporting_components"],
         states=content_model["states"],
@@ -447,14 +996,58 @@ def validate_instruction(instruction: ScreenInstruction) -> list[str]:
     return errors
 
 
+def build_sections_payload(instruction: ScreenInstruction) -> list[dict[str, Any]]:
+    """Translate internal section specs into the external contract shape."""
+    component_ids_by_section: dict[str, list[str]] = {}
+    for node in instruction.component_hierarchy:
+        component_ids_by_section.setdefault(node.section_id, []).append(node.component_id)
+
+    return [
+        {
+            "section_id": section.section_id,
+            "name": section.name,
+            "role": section.role,
+            "component_ids": component_ids_by_section.get(section.section_id, []),
+        }
+        for section in instruction.sections
+    ]
+
+
 def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
     """Convert instruction to JSON-serializable dict."""
+    root_node = next(
+        (node for node in instruction.component_hierarchy if node.parent_component_id is None),
+        None,
+    )
+    cta_tree_nodes = {
+        node.source_ref: node
+        for node in instruction.component_hierarchy
+        if node.source_ref.startswith("cta:")
+    }
+    component_order = {
+        node.component_id: index for index, node in enumerate(instruction.component_hierarchy)
+    }
+
     return {
         "screen_id": instruction.screen_id,
         "page": instruction.page,
         "platform": instruction.platform,
         "surface": instruction.surface,
+        "layout_archetype": instruction.layout_archetype,
         "layout_pattern": instruction.layout_pattern,
+        "sections": build_sections_payload(instruction),
+        "component_hierarchy": [
+            {
+                "component_id": node.component_id,
+                "canonical_component": node.canonical_component,
+                "section_id": node.section_id,
+                "parent_component_id": node.parent_component_id,
+                "hierarchy_level": node.hierarchy_level,
+                "semantic_role": node.semantic_role,
+                "source_ref": node.source_ref,
+            }
+            for node in instruction.component_hierarchy
+        ],
         "primary_components": instruction.primary_components,
         "supporting_components": instruction.supporting_components,
         "states": instruction.states,
@@ -470,6 +1063,12 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
                 "dimensions": instruction.dimensions,
                 "background": instruction.background_token,
                 "canonical_component": "card",
+                "section_id": root_node.section_id if root_node else "surface",
+                "component_id": root_node.component_id if root_node else "root_frame",
+                "parent_component_id": None,
+                "hierarchy_level": root_node.hierarchy_level if root_node else 0,
+                "semantic_role": root_node.semantic_role if root_node else "surface_shell",
+                "order": component_order.get(root_node.component_id, 0) if root_node else 0,
             }
         ]
         + [
@@ -484,6 +1083,12 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
                 "prompt_stub": cta.prompt_stub,
                 "states": cta.states,
                 "canonical_component": "button",
+                "section_id": cta_tree_nodes[f"cta:{cta.cta_id}"].section_id,
+                "component_id": cta_tree_nodes[f"cta:{cta.cta_id}"].component_id,
+                "parent_component_id": cta_tree_nodes[f"cta:{cta.cta_id}"].parent_component_id,
+                "hierarchy_level": cta_tree_nodes[f"cta:{cta.cta_id}"].hierarchy_level,
+                "semantic_role": cta_tree_nodes[f"cta:{cta.cta_id}"].semantic_role,
+                "order": component_order[cta_tree_nodes[f"cta:{cta.cta_id}"].component_id],
             }
             for cta in instruction.ctas
         ],

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -17,7 +17,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
@@ -67,6 +67,15 @@ class ScreenInstruction:
     context_version: str = ""
 
 
+class ScreenContentModel(TypedDict):
+    surface: str
+    layout_pattern: str
+    primary_components: list[str]
+    supporting_components: list[str]
+    states: list[str]
+    token_constraints: list[str]
+
+
 # Screen dimension presets
 SCREEN_DIMENSIONS = {
     "ios": {"width": 390, "height": 844},  # iPhone 14 Pro
@@ -83,7 +92,7 @@ PAGE_MAPPING = {
     "web.progress": "20_Web_Parity",
 }
 
-SCREEN_CONTENT_MODEL = {
+SCREEN_CONTENT_MODEL: dict[str, ScreenContentModel] = {
     "ios.home": {
         "surface": "ios_home_screen",
         "layout_pattern": "hero-plus-quick-actions",

--- a/scripts/design/generate_figma_instructions.py
+++ b/scripts/design/generate_figma_instructions.py
@@ -900,7 +900,7 @@ def build_component_tree(
         semantic_role = "primary_cta" if cta.variant == "V1" else "secondary_cta"
         if "blocked" in status_text or "flag" in status_text:
             semantic_role = "flagged_cta"
-        elif "partial" in status_text or "issue" in cta.cta_id:
+        elif "issue" in cta.cta_id or "RECOVERY" in cta.placement_zone:
             semantic_role = "recovery_cta"
         elif "export" in cta.cta_id:
             semantic_role = "utility_cta"
@@ -1013,20 +1013,93 @@ def build_sections_payload(instruction: ScreenInstruction) -> list[dict[str, Any
     ]
 
 
+def _frame_instruction_name(instruction: ScreenInstruction, node: ComponentNodeSpec) -> str:
+    """Return a stable frame name for one component-hierarchy node."""
+    if node.parent_component_id is None:
+        return f"{instruction.platform} {instruction.screen_id.split('.')[1].title()} Screen"
+    return node.component_id
+
+
+def _frame_instruction_payload(
+    instruction: ScreenInstruction,
+    node: ComponentNodeSpec,
+    order: int,
+) -> dict[str, Any]:
+    """Serialize one non-button hierarchy node into a create_frame instruction."""
+    payload: dict[str, Any] = {
+        "type": "create_frame",
+        "name": _frame_instruction_name(instruction, node),
+        "canonical_component": node.canonical_component,
+        "section_id": node.section_id,
+        "component_id": node.component_id,
+        "parent_component_id": node.parent_component_id,
+        "hierarchy_level": node.hierarchy_level,
+        "semantic_role": node.semantic_role,
+        "order": order,
+    }
+    if node.parent_component_id is None:
+        payload["dimensions"] = instruction.dimensions
+        payload["background"] = instruction.background_token
+    return payload
+
+
+def _button_states_for_node(cta: CTASpec, node: ComponentNodeSpec) -> list[str]:
+    """Return explicit button states for one CTA node."""
+    states = list(cta.states)
+    if node.semantic_role == "flagged_cta" and "feature-flagged" not in states:
+        states.append("feature-flagged")
+    return states
+
+
+def _button_instruction_payload(
+    cta: CTASpec,
+    node: ComponentNodeSpec,
+    order: int,
+) -> dict[str, Any]:
+    """Serialize one CTA-backed hierarchy node into a create_button instruction."""
+    return {
+        "type": "create_button",
+        "name": cta.ui_label,
+        "cta_key": cta.cta_id,
+        "style": "primary" if cta.variant == "V1" else "secondary",
+        "variant": cta.variant,
+        "placement_zone": cta.placement_zone,
+        "figma_node_id": cta.figma_node_id,
+        "prompt_stub": cta.prompt_stub,
+        "states": _button_states_for_node(cta, node),
+        "canonical_component": "button",
+        "section_id": node.section_id,
+        "component_id": node.component_id,
+        "parent_component_id": node.parent_component_id,
+        "hierarchy_level": node.hierarchy_level,
+        "semantic_role": node.semantic_role,
+        "order": order,
+    }
+
+
 def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
     """Convert instruction to JSON-serializable dict."""
-    root_node = next(
-        (node for node in instruction.component_hierarchy if node.parent_component_id is None),
-        None,
-    )
-    cta_tree_nodes = {
-        node.source_ref: node
-        for node in instruction.component_hierarchy
-        if node.source_ref.startswith("cta:")
-    }
     component_order = {
         node.component_id: index for index, node in enumerate(instruction.component_hierarchy)
     }
+    ctas_by_source_ref = {f"cta:{cta.cta_id}": cta for cta in instruction.ctas}
+
+    instruction_payload: list[dict[str, Any]] = []
+    for node in instruction.component_hierarchy:
+        order = component_order.get(node.component_id)
+        if order is None:
+            raise ValueError(f"Missing component order for {node.component_id}")
+
+        if node.canonical_component == "button":
+            cta = ctas_by_source_ref.get(node.source_ref)
+            if cta is None:
+                raise ValueError(
+                    f"CTA node {node.component_id} references unknown CTA source {node.source_ref}"
+                )
+            instruction_payload.append(_button_instruction_payload(cta, node, order))
+            continue
+
+        instruction_payload.append(_frame_instruction_payload(instruction, node, order))
 
     return {
         "screen_id": instruction.screen_id,
@@ -1056,42 +1129,7 @@ def instruction_to_dict(instruction: ScreenInstruction) -> dict[str, Any]:
         "token_constraints": instruction.token_constraints,
         "governance_checks": instruction.governance_checks,
         "context_version": instruction.context_version,
-        "instructions": [
-            {
-                "type": "create_frame",
-                "name": f"{instruction.platform} {instruction.screen_id.split('.')[1].title()} Screen",
-                "dimensions": instruction.dimensions,
-                "background": instruction.background_token,
-                "canonical_component": "card",
-                "section_id": root_node.section_id if root_node else "surface",
-                "component_id": root_node.component_id if root_node else "root_frame",
-                "parent_component_id": None,
-                "hierarchy_level": root_node.hierarchy_level if root_node else 0,
-                "semantic_role": root_node.semantic_role if root_node else "surface_shell",
-                "order": component_order.get(root_node.component_id, 0) if root_node else 0,
-            }
-        ]
-        + [
-            {
-                "type": "create_button",
-                "name": cta.ui_label,
-                "cta_key": cta.cta_id,
-                "style": "primary" if cta.variant == "V1" else "secondary",
-                "variant": cta.variant,
-                "placement_zone": cta.placement_zone,
-                "figma_node_id": cta.figma_node_id,
-                "prompt_stub": cta.prompt_stub,
-                "states": cta.states,
-                "canonical_component": "button",
-                "section_id": cta_tree_nodes[f"cta:{cta.cta_id}"].section_id,
-                "component_id": cta_tree_nodes[f"cta:{cta.cta_id}"].component_id,
-                "parent_component_id": cta_tree_nodes[f"cta:{cta.cta_id}"].parent_component_id,
-                "hierarchy_level": cta_tree_nodes[f"cta:{cta.cta_id}"].hierarchy_level,
-                "semantic_role": cta_tree_nodes[f"cta:{cta.cta_id}"].semantic_role,
-                "order": component_order[cta_tree_nodes[f"cta:{cta.cta_id}"].component_id],
-            }
-            for cta in instruction.ctas
-        ],
+        "instructions": instruction_payload,
     }
 
 
@@ -1163,7 +1201,7 @@ def main() -> int:
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         instruction_dict = instruction_to_dict(instruction)
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(instruction_dict, f, indent=2)
 
         print(f"\nInstruction written to: {output_path}")

--- a/scripts/design/instructions/ios_home.json
+++ b/scripts/design/instructions/ios_home.json
@@ -175,7 +175,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "IOS Home Screen",
+      "name": "iOS Home Screen",
       "canonical_component": "card",
       "section_id": "hero-band",
       "component_id": "ios-home-shell",

--- a/scripts/design/instructions/ios_home.json
+++ b/scripts/design/instructions/ios_home.json
@@ -3,7 +3,143 @@
   "page": "10_iOS_Home",
   "platform": "IOS",
   "surface": "ios_home_screen",
+  "layout_archetype": "hero_shell",
   "layout_pattern": "hero-plus-quick-actions",
+  "sections": [
+    {
+      "section_id": "hero-band",
+      "name": "Hero band",
+      "role": "context_summary",
+      "component_ids": [
+        "ios-home-shell",
+        "ios-home-hero",
+        "ios-home-badge",
+        "ios-home-summary"
+      ]
+    },
+    {
+      "section_id": "quick-actions",
+      "name": "Quick actions",
+      "role": "primary_actions",
+      "component_ids": [
+        "ios-home-actions",
+        "node:ios.home.bmi_calculator",
+        "node:ios.home.profile_setup",
+        "node:ios.home.open_plate",
+        "node:ios.home.weekly_plan_reader",
+        "node:ios.home.shopping_list_generator"
+      ]
+    },
+    {
+      "section_id": "footer-nav",
+      "name": "Footer navigation",
+      "role": "persistent_navigation",
+      "component_ids": [
+        "ios-home-nav"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "ios-home-shell",
+      "canonical_component": "card",
+      "section_id": "hero-band",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:ios-home-shell"
+    },
+    {
+      "component_id": "ios-home-hero",
+      "canonical_component": "hero",
+      "section_id": "hero-band",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "primary_message",
+      "source_ref": "static:ios-home-hero"
+    },
+    {
+      "component_id": "ios-home-badge",
+      "canonical_component": "badge",
+      "section_id": "hero-band",
+      "parent_component_id": "ios-home-hero",
+      "hierarchy_level": 2,
+      "semantic_role": "status_marker",
+      "source_ref": "static:ios-home-badge"
+    },
+    {
+      "component_id": "ios-home-summary",
+      "canonical_component": "stats-card",
+      "section_id": "hero-band",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "source_ref": "static:ios-home-summary"
+    },
+    {
+      "component_id": "ios-home-actions",
+      "canonical_component": "card",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "source_ref": "static:ios-home-actions"
+    },
+    {
+      "component_id": "ios-home-nav",
+      "canonical_component": "navigation/tab-bar",
+      "section_id": "footer-nav",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "persistent_navigation",
+      "source_ref": "static:ios-home-nav"
+    },
+    {
+      "component_id": "node:ios.home.bmi_calculator",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:ios.home.bmi_calculator"
+    },
+    {
+      "component_id": "node:ios.home.profile_setup",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:ios.home.profile_setup"
+    },
+    {
+      "component_id": "node:ios.home.open_plate",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:ios.home.open_plate"
+    },
+    {
+      "component_id": "node:ios.home.weekly_plan_reader",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "flagged_cta",
+      "source_ref": "cta:ios.home.weekly_plan_reader"
+    },
+    {
+      "component_id": "node:ios.home.shopping_list_generator",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "flagged_cta",
+      "source_ref": "cta:ios.home.shopping_list_generator"
+    }
+  ],
   "primary_components": [
     "hero",
     "button"
@@ -45,7 +181,13 @@
         "height": 844
       },
       "background": "Color.navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "hero-band",
+      "component_id": "ios-home-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -63,7 +205,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:ios.home.bmi_calculator",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 6
     },
     {
       "type": "create_button",
@@ -81,7 +229,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:ios.home.profile_setup",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 7
     },
     {
       "type": "create_button",
@@ -99,7 +253,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:ios.home.open_plate",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 8
     },
     {
       "type": "create_button",
@@ -117,7 +277,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:ios.home.weekly_plan_reader",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "flagged_cta",
+      "order": 9
     },
     {
       "type": "create_button",
@@ -135,7 +301,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:ios.home.shopping_list_generator",
+      "parent_component_id": "ios-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "flagged_cta",
+      "order": 10
     }
   ]
 }

--- a/scripts/design/instructions/ios_home.json
+++ b/scripts/design/instructions/ios_home.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "ios.home",
   "page": "10_iOS_Home",
-  "platform": "IOS",
+  "platform": "iOS",
   "surface": "ios_home_screen",
   "layout_archetype": "hero_shell",
   "layout_pattern": "hero-plus-quick-actions",
@@ -142,7 +142,8 @@
   ],
   "primary_components": [
     "hero",
-    "button"
+    "button",
+    "card"
   ],
   "supporting_components": [
     "stats-card",
@@ -255,7 +256,6 @@
       "prompt_stub": "stub://icon-nav/bmi",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -279,7 +279,6 @@
       "prompt_stub": "stub://icon-nav/profile-setup",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -303,7 +302,6 @@
       "prompt_stub": "stub://icon-nav/open-plate",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -327,7 +325,6 @@
       "prompt_stub": "stub://cta/pro-tool/weekly-plan",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error",
@@ -352,7 +349,6 @@
       "prompt_stub": "stub://cta/pro-tool/shopping-list",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error",

--- a/scripts/design/instructions/ios_home.json
+++ b/scripts/design/instructions/ios_home.json
@@ -1,27 +1,51 @@
 {
   "screen_id": "ios.home",
   "page": "10_iOS_Home",
-  "platform": "iOS",
+  "platform": "IOS",
+  "surface": "ios_home_screen",
+  "layout_pattern": "hero-plus-quick-actions",
+  "primary_components": [
+    "hero",
+    "button"
+  ],
+  "supporting_components": [
+    "stats-card",
+    "navigation/tab-bar",
+    "badge"
+  ],
+  "states": [
+    "default",
+    "feature-flagged",
+    "loading",
+    "error"
+  ],
   "dimensions": {
     "width": 390,
     "height": 844
   },
   "background_token": "Color.navy",
+  "token_constraints": [
+    "Color.navy",
+    "Color.appPrimary",
+    "Color.surface"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "iOS Home Screen",
+      "name": "IOS Home Screen",
       "dimensions": {
         "width": 390,
         "height": 844
       },
-      "background": "Color.navy"
+      "background": "Color.navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +56,14 @@
       "placement_zone": "I_HOME_QUICK_ACTIONS",
       "figma_node_id": "PP/iOS/Home/QuickActions/BMI/Row/Default (TBD)",
       "prompt_stub": "stub://icon-nav/bmi",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -43,7 +74,14 @@
       "placement_zone": "I_HOME_QUICK_ACTIONS",
       "figma_node_id": "PP/iOS/Home/QuickActions/ProfileSetup/Row/Default (TBD)",
       "prompt_stub": "stub://icon-nav/profile-setup",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -54,7 +92,14 @@
       "placement_zone": "I_HOME_QUICK_ACTIONS",
       "figma_node_id": "PP/iOS/Home/QuickActions/OpenPlate/Row/Default (TBD)",
       "prompt_stub": "stub://icon-nav/open-plate",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -65,7 +110,14 @@
       "placement_zone": "I_HOME_PRO_TOOLS",
       "figma_node_id": "PP/iOS/Home/ProTools/WeeklyPlanReader/Row/Flagged (TBD)",
       "prompt_stub": "stub://cta/pro-tool/weekly-plan",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -76,7 +128,14 @@
       "placement_zone": "I_HOME_PRO_TOOLS",
       "figma_node_id": "PP/iOS/Home/ProTools/ShoppingList/Row/Flagged (TBD)",
       "prompt_stub": "stub://cta/pro-tool/shopping-list",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/ios_home.json
+++ b/scripts/design/instructions/ios_home.json
@@ -176,18 +176,73 @@
     {
       "type": "create_frame",
       "name": "IOS Home Screen",
-      "dimensions": {
-        "width": 390,
-        "height": 844
-      },
-      "background": "Color.navy",
       "canonical_component": "card",
       "section_id": "hero-band",
       "component_id": "ios-home-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 390,
+        "height": 844
+      },
+      "background": "Color.navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-home-hero",
+      "canonical_component": "hero",
+      "section_id": "hero-band",
+      "component_id": "ios-home-hero",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "primary_message",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-home-badge",
+      "canonical_component": "badge",
+      "section_id": "hero-band",
+      "component_id": "ios-home-badge",
+      "parent_component_id": "ios-home-hero",
+      "hierarchy_level": 2,
+      "semantic_role": "status_marker",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-home-summary",
+      "canonical_component": "stats-card",
+      "section_id": "hero-band",
+      "component_id": "ios-home-summary",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-home-actions",
+      "canonical_component": "card",
+      "section_id": "quick-actions",
+      "component_id": "ios-home-actions",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "order": 4
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-home-nav",
+      "canonical_component": "navigation/tab-bar",
+      "section_id": "footer-nav",
+      "component_id": "ios-home-nav",
+      "parent_component_id": "ios-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "persistent_navigation",
+      "order": 5
     },
     {
       "type": "create_button",
@@ -275,7 +330,8 @@
         "hover",
         "disabled",
         "loading",
-        "error"
+        "error",
+        "feature-flagged"
       ],
       "canonical_component": "button",
       "section_id": "quick-actions",
@@ -299,7 +355,8 @@
         "hover",
         "disabled",
         "loading",
-        "error"
+        "error",
+        "feature-flagged"
       ],
       "canonical_component": "button",
       "section_id": "quick-actions",

--- a/scripts/design/instructions/ios_plate.json
+++ b/scripts/design/instructions/ios_plate.json
@@ -148,7 +148,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "IOS Plate Screen",
+      "name": "iOS Plate Screen",
       "canonical_component": "card",
       "section_id": "plate-summary",
       "component_id": "ios-plate-shell",

--- a/scripts/design/instructions/ios_plate.json
+++ b/scripts/design/instructions/ios_plate.json
@@ -91,7 +91,7 @@
       "section_id": "plate-actions",
       "parent_component_id": "ios-plate-action-panel",
       "hierarchy_level": 2,
-      "semantic_role": "recovery_cta",
+      "semantic_role": "primary_cta",
       "source_ref": "cta:ios.plate.add_meal"
     },
     {
@@ -100,7 +100,7 @@
       "section_id": "plate-actions",
       "parent_component_id": "ios-plate-action-panel",
       "hierarchy_level": 2,
-      "semantic_role": "recovery_cta",
+      "semantic_role": "secondary_cta",
       "source_ref": "cta:ios.plate.view_details"
     },
     {
@@ -149,18 +149,73 @@
     {
       "type": "create_frame",
       "name": "IOS Plate Screen",
-      "dimensions": {
-        "width": 390,
-        "height": 844
-      },
-      "background": "Color.navy",
       "canonical_component": "card",
       "section_id": "plate-summary",
       "component_id": "ios-plate-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 390,
+        "height": 844
+      },
+      "background": "Color.navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-plate-summary-card",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "component_id": "ios-plate-summary-card",
+      "parent_component_id": "ios-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "content_container",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-plate-badge",
+      "canonical_component": "badge",
+      "section_id": "plate-summary",
+      "component_id": "ios-plate-badge",
+      "parent_component_id": "ios-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "gate_state",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-plate-progress",
+      "canonical_component": "progress",
+      "section_id": "plate-summary",
+      "component_id": "ios-plate-progress",
+      "parent_component_id": "ios-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "completion_feedback",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-plate-action-panel",
+      "canonical_component": "card",
+      "section_id": "plate-actions",
+      "component_id": "ios-plate-action-panel",
+      "parent_component_id": "ios-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "order": 4
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-plate-dialog",
+      "canonical_component": "dialog",
+      "section_id": "plate-actions",
+      "component_id": "ios-plate-dialog",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_details",
+      "order": 5
     },
     {
       "type": "create_button",
@@ -183,7 +238,7 @@
       "component_id": "node:ios.plate.add_meal",
       "parent_component_id": "ios-plate-action-panel",
       "hierarchy_level": 2,
-      "semantic_role": "recovery_cta",
+      "semantic_role": "primary_cta",
       "order": 6
     },
     {
@@ -207,7 +262,7 @@
       "component_id": "node:ios.plate.view_details",
       "parent_component_id": "ios-plate-action-panel",
       "hierarchy_level": 2,
-      "semantic_role": "recovery_cta",
+      "semantic_role": "secondary_cta",
       "order": 7
     },
     {

--- a/scripts/design/instructions/ios_plate.json
+++ b/scripts/design/instructions/ios_plate.json
@@ -1,27 +1,51 @@
 {
   "screen_id": "ios.plate",
   "page": "11_iOS_Plate",
-  "platform": "iOS",
+  "platform": "IOS",
+  "surface": "ios_plate_screen",
+  "layout_pattern": "content-card-with-primary-actions",
+  "primary_components": [
+    "card",
+    "button"
+  ],
+  "supporting_components": [
+    "badge",
+    "dialog",
+    "progress"
+  ],
+  "states": [
+    "default",
+    "issue-recovery",
+    "loading",
+    "error"
+  ],
   "dimensions": {
     "width": 390,
     "height": 844
   },
   "background_token": "Color.navy",
+  "token_constraints": [
+    "Color.navy",
+    "Color.surface",
+    "Color.appPrimary"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "iOS Plate Screen",
+      "name": "IOS Plate Screen",
       "dimensions": {
         "width": 390,
         "height": 844
       },
-      "background": "Color.navy"
+      "background": "Color.navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +56,14 @@
       "placement_zone": "I_PLATE_BOTTOMBAR_PRIMARY",
       "figma_node_id": "PP/iOS/Plate/BottomBar/AddMeal/Button/Default (TBD)",
       "prompt_stub": "stub://cta/primary/add-meal",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -43,7 +74,14 @@
       "placement_zone": "I_PLATE_BOTTOMBAR_PRIMARY",
       "figma_node_id": "PP/iOS/Plate/BottomBar/ViewDetails/Button/Default (TBD)",
       "prompt_stub": "stub://cta/secondary/view-details",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -54,7 +92,14 @@
       "placement_zone": "I_PLATE_ISSUE_RECOVERY",
       "figma_node_id": "PP/iOS/Plate/IssueState/PrimaryAction/Button/Stateful (TBD)",
       "prompt_stub": "stub://cta/error-state/dynamic-issue-action",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/ios_plate.json
+++ b/scripts/design/instructions/ios_plate.json
@@ -3,7 +3,116 @@
   "page": "11_iOS_Plate",
   "platform": "IOS",
   "surface": "ios_plate_screen",
+  "layout_archetype": "content_shell",
   "layout_pattern": "content-card-with-primary-actions",
+  "sections": [
+    {
+      "section_id": "plate-summary",
+      "name": "Plate summary",
+      "role": "content_summary",
+      "component_ids": [
+        "ios-plate-shell",
+        "ios-plate-summary-card",
+        "ios-plate-badge",
+        "ios-plate-progress"
+      ]
+    },
+    {
+      "section_id": "plate-actions",
+      "name": "Plate actions",
+      "role": "primary_actions",
+      "component_ids": [
+        "ios-plate-action-panel",
+        "ios-plate-dialog",
+        "node:ios.plate.add_meal",
+        "node:ios.plate.view_details",
+        "node:ios.plate.issue_action_dynamic"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "ios-plate-shell",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:ios-plate-shell"
+    },
+    {
+      "component_id": "ios-plate-summary-card",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "parent_component_id": "ios-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "content_container",
+      "source_ref": "static:ios-plate-summary-card"
+    },
+    {
+      "component_id": "ios-plate-badge",
+      "canonical_component": "badge",
+      "section_id": "plate-summary",
+      "parent_component_id": "ios-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "gate_state",
+      "source_ref": "static:ios-plate-badge"
+    },
+    {
+      "component_id": "ios-plate-progress",
+      "canonical_component": "progress",
+      "section_id": "plate-summary",
+      "parent_component_id": "ios-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "completion_feedback",
+      "source_ref": "static:ios-plate-progress"
+    },
+    {
+      "component_id": "ios-plate-action-panel",
+      "canonical_component": "card",
+      "section_id": "plate-actions",
+      "parent_component_id": "ios-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "source_ref": "static:ios-plate-action-panel"
+    },
+    {
+      "component_id": "ios-plate-dialog",
+      "canonical_component": "dialog",
+      "section_id": "plate-actions",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_details",
+      "source_ref": "static:ios-plate-dialog"
+    },
+    {
+      "component_id": "node:ios.plate.add_meal",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "source_ref": "cta:ios.plate.add_meal"
+    },
+    {
+      "component_id": "node:ios.plate.view_details",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "source_ref": "cta:ios.plate.view_details"
+    },
+    {
+      "component_id": "node:ios.plate.issue_action_dynamic",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "source_ref": "cta:ios.plate.issue_action_dynamic"
+    }
+  ],
   "primary_components": [
     "card",
     "button"
@@ -45,7 +154,13 @@
         "height": 844
       },
       "background": "Color.navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "component_id": "ios-plate-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -63,7 +178,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:ios.plate.add_meal",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "order": 6
     },
     {
       "type": "create_button",
@@ -81,7 +202,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:ios.plate.view_details",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "order": 7
     },
     {
       "type": "create_button",
@@ -99,7 +226,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:ios.plate.issue_action_dynamic",
+      "parent_component_id": "ios-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "order": 8
     }
   ]
 }

--- a/scripts/design/instructions/ios_plate.json
+++ b/scripts/design/instructions/ios_plate.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "ios.plate",
   "page": "11_iOS_Plate",
-  "platform": "IOS",
+  "platform": "iOS",
   "surface": "ios_plate_screen",
   "layout_archetype": "content_shell",
   "layout_pattern": "content-card-with-primary-actions",
@@ -228,7 +228,6 @@
       "prompt_stub": "stub://cta/primary/add-meal",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -252,7 +251,6 @@
       "prompt_stub": "stub://cta/secondary/view-details",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -276,7 +274,6 @@
       "prompt_stub": "stub://cta/error-state/dynamic-issue-action",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"

--- a/scripts/design/instructions/ios_progress.json
+++ b/scripts/design/instructions/ios_progress.json
@@ -128,7 +128,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "IOS Progress Screen",
+      "name": "iOS Progress Screen",
       "canonical_component": "card",
       "section_id": "progress-summary",
       "component_id": "ios-progress-shell",

--- a/scripts/design/instructions/ios_progress.json
+++ b/scripts/design/instructions/ios_progress.json
@@ -1,27 +1,51 @@
 {
   "screen_id": "ios.progress",
   "page": "12_iOS_Progress",
-  "platform": "iOS",
+  "platform": "IOS",
+  "surface": "ios_progress_screen",
+  "layout_pattern": "dashboard-summary-stack",
+  "primary_components": [
+    "progress",
+    "button"
+  ],
+  "supporting_components": [
+    "stats-card",
+    "empty-state",
+    "alert"
+  ],
+  "states": [
+    "default",
+    "empty",
+    "loading",
+    "error"
+  ],
   "dimensions": {
     "width": 390,
     "height": 844
   },
   "background_token": "Color.navy",
+  "token_constraints": [
+    "Color.navy",
+    "Color.surface",
+    "Color.accentGreen"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "iOS Progress Screen",
+      "name": "IOS Progress Screen",
       "dimensions": {
         "width": 390,
         "height": 844
       },
-      "background": "Color.navy"
+      "background": "Color.navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +56,14 @@
       "placement_zone": "I_PROGRESS_EMPTY_RECOVERY",
       "figma_node_id": "PP/iOS/Progress/EmptyState/Refresh/Button/Default (TBD)",
       "prompt_stub": "stub://cta/loading-state/refresh",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -43,7 +74,14 @@
       "placement_zone": "I_PROGRESS_ISSUE_RECOVERY",
       "figma_node_id": "PP/iOS/Progress/IssueState/PrimaryAction/Button/Stateful (TBD)",
       "prompt_stub": "stub://cta/error-state/dynamic-issue-action",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/ios_progress.json
+++ b/scripts/design/instructions/ios_progress.json
@@ -3,7 +3,96 @@
   "page": "12_iOS_Progress",
   "platform": "IOS",
   "surface": "ios_progress_screen",
+  "layout_archetype": "dashboard_shell",
   "layout_pattern": "dashboard-summary-stack",
+  "sections": [
+    {
+      "section_id": "progress-summary",
+      "name": "Progress summary",
+      "role": "summary_metrics",
+      "component_ids": [
+        "ios-progress-shell",
+        "ios-progress-stats",
+        "ios-progress-chart"
+      ]
+    },
+    {
+      "section_id": "progress-recovery",
+      "name": "Recovery lane",
+      "role": "state_recovery",
+      "component_ids": [
+        "ios-progress-recovery",
+        "ios-progress-empty",
+        "node:ios.progress.refresh",
+        "node:ios.progress.issue_action_dynamic"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "ios-progress-shell",
+      "canonical_component": "card",
+      "section_id": "progress-summary",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:ios-progress-shell"
+    },
+    {
+      "component_id": "ios-progress-stats",
+      "canonical_component": "stats-card",
+      "section_id": "progress-summary",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "source_ref": "static:ios-progress-stats"
+    },
+    {
+      "component_id": "ios-progress-chart",
+      "canonical_component": "progress",
+      "section_id": "progress-summary",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "trend_visualization",
+      "source_ref": "static:ios-progress-chart"
+    },
+    {
+      "component_id": "ios-progress-recovery",
+      "canonical_component": "alert",
+      "section_id": "progress-recovery",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "recovery_message",
+      "source_ref": "static:ios-progress-recovery"
+    },
+    {
+      "component_id": "ios-progress-empty",
+      "canonical_component": "empty-state",
+      "section_id": "progress-recovery",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "no_data_fallback",
+      "source_ref": "static:ios-progress-empty"
+    },
+    {
+      "component_id": "node:ios.progress.refresh",
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:ios.progress.refresh"
+    },
+    {
+      "component_id": "node:ios.progress.issue_action_dynamic",
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "source_ref": "cta:ios.progress.issue_action_dynamic"
+    }
+  ],
   "primary_components": [
     "progress",
     "button"
@@ -45,7 +134,13 @@
         "height": 844
       },
       "background": "Color.navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "progress-summary",
+      "component_id": "ios-progress-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -63,7 +158,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "component_id": "node:ios.progress.refresh",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 5
     },
     {
       "type": "create_button",
@@ -81,7 +182,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "component_id": "node:ios.progress.issue_action_dynamic",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "recovery_cta",
+      "order": 6
     }
   ]
 }

--- a/scripts/design/instructions/ios_progress.json
+++ b/scripts/design/instructions/ios_progress.json
@@ -80,7 +80,7 @@
       "section_id": "progress-recovery",
       "parent_component_id": "ios-progress-recovery",
       "hierarchy_level": 2,
-      "semantic_role": "primary_cta",
+      "semantic_role": "recovery_cta",
       "source_ref": "cta:ios.progress.refresh"
     },
     {
@@ -129,18 +129,62 @@
     {
       "type": "create_frame",
       "name": "IOS Progress Screen",
-      "dimensions": {
-        "width": 390,
-        "height": 844
-      },
-      "background": "Color.navy",
       "canonical_component": "card",
       "section_id": "progress-summary",
       "component_id": "ios-progress-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 390,
+        "height": 844
+      },
+      "background": "Color.navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-progress-stats",
+      "canonical_component": "stats-card",
+      "section_id": "progress-summary",
+      "component_id": "ios-progress-stats",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-progress-chart",
+      "canonical_component": "progress",
+      "section_id": "progress-summary",
+      "component_id": "ios-progress-chart",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "trend_visualization",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-progress-recovery",
+      "canonical_component": "alert",
+      "section_id": "progress-recovery",
+      "component_id": "ios-progress-recovery",
+      "parent_component_id": "ios-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "recovery_message",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "ios-progress-empty",
+      "canonical_component": "empty-state",
+      "section_id": "progress-recovery",
+      "component_id": "ios-progress-empty",
+      "parent_component_id": "ios-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "no_data_fallback",
+      "order": 4
     },
     {
       "type": "create_button",
@@ -163,7 +207,7 @@
       "component_id": "node:ios.progress.refresh",
       "parent_component_id": "ios-progress-recovery",
       "hierarchy_level": 2,
-      "semantic_role": "primary_cta",
+      "semantic_role": "recovery_cta",
       "order": 5
     },
     {

--- a/scripts/design/instructions/ios_progress.json
+++ b/scripts/design/instructions/ios_progress.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "ios.progress",
   "page": "12_iOS_Progress",
-  "platform": "IOS",
+  "platform": "iOS",
   "surface": "ios_progress_screen",
   "layout_archetype": "dashboard_shell",
   "layout_pattern": "dashboard-summary-stack",
@@ -197,7 +197,6 @@
       "prompt_stub": "stub://cta/loading-state/refresh",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"
@@ -221,7 +220,6 @@
       "prompt_stub": "stub://cta/error-state/dynamic-issue-action",
       "states": [
         "default",
-        "hover",
         "disabled",
         "loading",
         "error"

--- a/scripts/design/instructions/web_home.json
+++ b/scripts/design/instructions/web_home.json
@@ -1,27 +1,51 @@
 {
   "screen_id": "web.home",
   "page": "20_Web_Parity",
-  "platform": "Web",
+  "platform": "WEB",
+  "surface": "web_home_screen",
+  "layout_pattern": "hero-plus-status-grid",
+  "primary_components": [
+    "hero",
+    "button"
+  ],
+  "supporting_components": [
+    "stats-card",
+    "navigation/tab-bar",
+    "badge"
+  ],
+  "states": [
+    "default",
+    "feature-flagged",
+    "loading",
+    "error"
+  ],
   "dimensions": {
     "width": 1440,
     "height": 900
   },
   "background_token": "--pp-navy",
+  "token_constraints": [
+    "--pp-navy",
+    "--color-primary",
+    "--color-surface"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "Web Home Screen",
+      "name": "WEB Home Screen",
       "dimensions": {
         "width": 1440,
         "height": 900
       },
-      "background": "--pp-navy"
+      "background": "--pp-navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +56,14 @@
       "placement_zone": "W_HOME_QA_GRID",
       "figma_node_id": "PP/Web/Home/QuickActions/OpenSetup/Button/Default (TBD)",
       "prompt_stub": "stub://cta/primary/setup",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -43,7 +74,14 @@
       "placement_zone": "W_HOME_QA_GRID",
       "figma_node_id": "PP/Web/Home/QuickActions/OpenPlate/Button/Default (TBD)",
       "prompt_stub": "stub://cta/secondary/open-plate",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -54,7 +92,14 @@
       "placement_zone": "W_HOME_QA_GRID",
       "figma_node_id": "PP/Web/Home/QuickActions/OpenProgress/Button/Default (TBD)",
       "prompt_stub": "stub://cta/secondary/open-progress",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -65,7 +110,14 @@
       "placement_zone": "W_HOME_QA_GRID",
       "figma_node_id": "PP/Web/Home/QuickActions/OpenPro/Button/Default (TBD)",
       "prompt_stub": "stub://cta/secondary/open-pro",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/web_home.json
+++ b/scripts/design/instructions/web_home.json
@@ -165,7 +165,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "WEB Home Screen",
+      "name": "Web Home Screen",
       "canonical_component": "card",
       "section_id": "hero-band",
       "component_id": "web-home-shell",

--- a/scripts/design/instructions/web_home.json
+++ b/scripts/design/instructions/web_home.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "web.home",
   "page": "20_Web_Parity",
-  "platform": "WEB",
+  "platform": "Web",
   "surface": "web_home_screen",
   "layout_archetype": "hero_shell",
   "layout_pattern": "hero-plus-status-grid",

--- a/scripts/design/instructions/web_home.json
+++ b/scripts/design/instructions/web_home.json
@@ -166,18 +166,73 @@
     {
       "type": "create_frame",
       "name": "WEB Home Screen",
-      "dimensions": {
-        "width": 1440,
-        "height": 900
-      },
-      "background": "--pp-navy",
       "canonical_component": "card",
       "section_id": "hero-band",
       "component_id": "web-home-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 1440,
+        "height": 900
+      },
+      "background": "--pp-navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "web-home-hero",
+      "canonical_component": "hero",
+      "section_id": "hero-band",
+      "component_id": "web-home-hero",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "primary_message",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "web-home-badge",
+      "canonical_component": "badge",
+      "section_id": "hero-band",
+      "component_id": "web-home-badge",
+      "parent_component_id": "web-home-hero",
+      "hierarchy_level": 2,
+      "semantic_role": "status_marker",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "web-home-summary",
+      "canonical_component": "stats-card",
+      "section_id": "hero-band",
+      "component_id": "web-home-summary",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "web-home-actions",
+      "canonical_component": "card",
+      "section_id": "quick-actions",
+      "component_id": "web-home-actions",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "order": 4
+    },
+    {
+      "type": "create_frame",
+      "name": "web-home-nav",
+      "canonical_component": "navigation/tab-bar",
+      "section_id": "footer-nav",
+      "component_id": "web-home-nav",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "persistent_navigation",
+      "order": 5
     },
     {
       "type": "create_button",

--- a/scripts/design/instructions/web_home.json
+++ b/scripts/design/instructions/web_home.json
@@ -3,7 +3,133 @@
   "page": "20_Web_Parity",
   "platform": "WEB",
   "surface": "web_home_screen",
+  "layout_archetype": "hero_shell",
   "layout_pattern": "hero-plus-status-grid",
+  "sections": [
+    {
+      "section_id": "hero-band",
+      "name": "Hero band",
+      "role": "context_summary",
+      "component_ids": [
+        "web-home-shell",
+        "web-home-hero",
+        "web-home-badge",
+        "web-home-summary"
+      ]
+    },
+    {
+      "section_id": "quick-actions",
+      "name": "Quick actions",
+      "role": "primary_actions",
+      "component_ids": [
+        "web-home-actions",
+        "node:web.home.open_setup",
+        "node:web.home.open_plate",
+        "node:web.home.open_progress",
+        "node:web.home.open_pro"
+      ]
+    },
+    {
+      "section_id": "footer-nav",
+      "name": "Footer navigation",
+      "role": "persistent_navigation",
+      "component_ids": [
+        "web-home-nav"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "web-home-shell",
+      "canonical_component": "card",
+      "section_id": "hero-band",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:web-home-shell"
+    },
+    {
+      "component_id": "web-home-hero",
+      "canonical_component": "hero",
+      "section_id": "hero-band",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "primary_message",
+      "source_ref": "static:web-home-hero"
+    },
+    {
+      "component_id": "web-home-badge",
+      "canonical_component": "badge",
+      "section_id": "hero-band",
+      "parent_component_id": "web-home-hero",
+      "hierarchy_level": 2,
+      "semantic_role": "status_marker",
+      "source_ref": "static:web-home-badge"
+    },
+    {
+      "component_id": "web-home-summary",
+      "canonical_component": "stats-card",
+      "section_id": "hero-band",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "source_ref": "static:web-home-summary"
+    },
+    {
+      "component_id": "web-home-actions",
+      "canonical_component": "card",
+      "section_id": "quick-actions",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "source_ref": "static:web-home-actions"
+    },
+    {
+      "component_id": "web-home-nav",
+      "canonical_component": "navigation/tab-bar",
+      "section_id": "footer-nav",
+      "parent_component_id": "web-home-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "persistent_navigation",
+      "source_ref": "static:web-home-nav"
+    },
+    {
+      "component_id": "node:web.home.open_setup",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:web.home.open_setup"
+    },
+    {
+      "component_id": "node:web.home.open_plate",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "source_ref": "cta:web.home.open_plate"
+    },
+    {
+      "component_id": "node:web.home.open_progress",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "source_ref": "cta:web.home.open_progress"
+    },
+    {
+      "component_id": "node:web.home.open_pro",
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "source_ref": "cta:web.home.open_pro"
+    }
+  ],
   "primary_components": [
     "hero",
     "button"
@@ -45,7 +171,13 @@
         "height": 900
       },
       "background": "--pp-navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "hero-band",
+      "component_id": "web-home-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -63,7 +195,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:web.home.open_setup",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 6
     },
     {
       "type": "create_button",
@@ -81,7 +219,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:web.home.open_plate",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "order": 7
     },
     {
       "type": "create_button",
@@ -99,7 +243,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:web.home.open_progress",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "order": 8
     },
     {
       "type": "create_button",
@@ -117,7 +267,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "quick-actions",
+      "component_id": "node:web.home.open_pro",
+      "parent_component_id": "web-home-actions",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "order": 9
     }
   ]
 }

--- a/scripts/design/instructions/web_plate.json
+++ b/scripts/design/instructions/web_plate.json
@@ -148,7 +148,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "WEB Plate Screen",
+      "name": "Web Plate Screen",
       "canonical_component": "card",
       "section_id": "plate-summary",
       "component_id": "web-plate-shell",

--- a/scripts/design/instructions/web_plate.json
+++ b/scripts/design/instructions/web_plate.json
@@ -149,18 +149,73 @@
     {
       "type": "create_frame",
       "name": "WEB Plate Screen",
-      "dimensions": {
-        "width": 1440,
-        "height": 900
-      },
-      "background": "--pp-navy",
       "canonical_component": "card",
       "section_id": "plate-summary",
       "component_id": "web-plate-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 1440,
+        "height": 900
+      },
+      "background": "--pp-navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "web-plate-summary-card",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "component_id": "web-plate-summary-card",
+      "parent_component_id": "web-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "content_container",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "web-plate-badge",
+      "canonical_component": "badge",
+      "section_id": "plate-summary",
+      "component_id": "web-plate-badge",
+      "parent_component_id": "web-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "premium_state",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "web-plate-progress",
+      "canonical_component": "progress",
+      "section_id": "plate-summary",
+      "component_id": "web-plate-progress",
+      "parent_component_id": "web-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "completion_feedback",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "web-plate-action-panel",
+      "canonical_component": "card",
+      "section_id": "plate-actions",
+      "component_id": "web-plate-action-panel",
+      "parent_component_id": "web-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "order": 4
+    },
+    {
+      "type": "create_frame",
+      "name": "web-plate-dialog",
+      "canonical_component": "dialog",
+      "section_id": "plate-actions",
+      "component_id": "web-plate-dialog",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "upgrade_explainer",
+      "order": 5
     },
     {
       "type": "create_button",

--- a/scripts/design/instructions/web_plate.json
+++ b/scripts/design/instructions/web_plate.json
@@ -3,7 +3,116 @@
   "page": "20_Web_Parity",
   "platform": "WEB",
   "surface": "web_plate_screen",
+  "layout_archetype": "content_shell",
   "layout_pattern": "content-card-with-upgrade-actions",
+  "sections": [
+    {
+      "section_id": "plate-summary",
+      "name": "Plate summary",
+      "role": "content_summary",
+      "component_ids": [
+        "web-plate-shell",
+        "web-plate-summary-card",
+        "web-plate-badge",
+        "web-plate-progress"
+      ]
+    },
+    {
+      "section_id": "plate-actions",
+      "name": "Plate actions",
+      "role": "primary_actions",
+      "component_ids": [
+        "web-plate-action-panel",
+        "web-plate-dialog",
+        "node:web.plate.open_setup",
+        "node:web.plate.open_progress",
+        "node:web.plate.premium_gate_cta"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "web-plate-shell",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:web-plate-shell"
+    },
+    {
+      "component_id": "web-plate-summary-card",
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "parent_component_id": "web-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "content_container",
+      "source_ref": "static:web-plate-summary-card"
+    },
+    {
+      "component_id": "web-plate-badge",
+      "canonical_component": "badge",
+      "section_id": "plate-summary",
+      "parent_component_id": "web-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "premium_state",
+      "source_ref": "static:web-plate-badge"
+    },
+    {
+      "component_id": "web-plate-progress",
+      "canonical_component": "progress",
+      "section_id": "plate-summary",
+      "parent_component_id": "web-plate-summary-card",
+      "hierarchy_level": 2,
+      "semantic_role": "completion_feedback",
+      "source_ref": "static:web-plate-progress"
+    },
+    {
+      "component_id": "web-plate-action-panel",
+      "canonical_component": "card",
+      "section_id": "plate-actions",
+      "parent_component_id": "web-plate-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "action_cluster",
+      "source_ref": "static:web-plate-action-panel"
+    },
+    {
+      "component_id": "web-plate-dialog",
+      "canonical_component": "dialog",
+      "section_id": "plate-actions",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "upgrade_explainer",
+      "source_ref": "static:web-plate-dialog"
+    },
+    {
+      "component_id": "node:web.plate.open_setup",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "source_ref": "cta:web.plate.open_setup"
+    },
+    {
+      "component_id": "node:web.plate.open_progress",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "source_ref": "cta:web.plate.open_progress"
+    },
+    {
+      "component_id": "node:web.plate.premium_gate_cta",
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "source_ref": "cta:web.plate.premium_gate_cta"
+    }
+  ],
   "primary_components": [
     "card",
     "button"
@@ -45,7 +154,13 @@
         "height": 900
       },
       "background": "--pp-navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "plate-summary",
+      "component_id": "web-plate-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -63,7 +178,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:web.plate.open_setup",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "primary_cta",
+      "order": 6
     },
     {
       "type": "create_button",
@@ -81,7 +202,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:web.plate.open_progress",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "order": 7
     },
     {
       "type": "create_button",
@@ -99,7 +226,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "plate-actions",
+      "component_id": "node:web.plate.premium_gate_cta",
+      "parent_component_id": "web-plate-action-panel",
+      "hierarchy_level": 2,
+      "semantic_role": "secondary_cta",
+      "order": 8
     }
   ]
 }

--- a/scripts/design/instructions/web_plate.json
+++ b/scripts/design/instructions/web_plate.json
@@ -1,27 +1,51 @@
 {
   "screen_id": "web.plate",
   "page": "20_Web_Parity",
-  "platform": "Web",
+  "platform": "WEB",
+  "surface": "web_plate_screen",
+  "layout_pattern": "content-card-with-upgrade-actions",
+  "primary_components": [
+    "card",
+    "button"
+  ],
+  "supporting_components": [
+    "badge",
+    "dialog",
+    "progress"
+  ],
+  "states": [
+    "default",
+    "premium-gated",
+    "loading",
+    "error"
+  ],
   "dimensions": {
     "width": 1440,
     "height": 900
   },
   "background_token": "--pp-navy",
+  "token_constraints": [
+    "--pp-navy",
+    "--color-primary",
+    "--color-surface"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "Web Plate Screen",
+      "name": "WEB Plate Screen",
       "dimensions": {
         "width": 1440,
         "height": 900
       },
-      "background": "--pp-navy"
+      "background": "--pp-navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +56,14 @@
       "placement_zone": "W_PLATE_GATE_ACTIONS",
       "figma_node_id": "PP/Web/Plate/ProControls/OpenSetup/Button/Default (TBD)",
       "prompt_stub": "stub://cta/primary/pro-open-setup",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -43,7 +74,14 @@
       "placement_zone": "W_PLATE_GATE_ACTIONS",
       "figma_node_id": "PP/Web/Plate/ProControls/OpenProgress/Button/Default (TBD)",
       "prompt_stub": "stub://cta/secondary/pro-open-progress",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     },
     {
       "type": "create_button",
@@ -54,7 +92,14 @@
       "placement_zone": "W_PLATE_GATE_ACTIONS",
       "figma_node_id": "PP/Web/Plate/PremiumGate/UnlockCTA/Button/Default (TBD)",
       "prompt_stub": "stub://cta/paywall-unlock",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/web_plate.json
+++ b/scripts/design/instructions/web_plate.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "web.plate",
   "page": "20_Web_Parity",
-  "platform": "WEB",
+  "platform": "Web",
   "surface": "web_plate_screen",
   "layout_archetype": "content_shell",
   "layout_pattern": "content-card-with-upgrade-actions",

--- a/scripts/design/instructions/web_progress.json
+++ b/scripts/design/instructions/web_progress.json
@@ -120,18 +120,62 @@
     {
       "type": "create_frame",
       "name": "WEB Progress Screen",
-      "dimensions": {
-        "width": 1440,
-        "height": 900
-      },
-      "background": "--pp-navy",
       "canonical_component": "card",
       "section_id": "progress-summary",
       "component_id": "web-progress-shell",
       "parent_component_id": null,
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
-      "order": 0
+      "order": 0,
+      "dimensions": {
+        "width": 1440,
+        "height": 900
+      },
+      "background": "--pp-navy"
+    },
+    {
+      "type": "create_frame",
+      "name": "web-progress-stats",
+      "canonical_component": "stats-card",
+      "section_id": "progress-summary",
+      "component_id": "web-progress-stats",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
+      "name": "web-progress-chart",
+      "canonical_component": "progress",
+      "section_id": "progress-summary",
+      "component_id": "web-progress-chart",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "trend_visualization",
+      "order": 2
+    },
+    {
+      "type": "create_frame",
+      "name": "web-progress-tooltip",
+      "canonical_component": "tooltip",
+      "section_id": "progress-summary",
+      "component_id": "web-progress-tooltip",
+      "parent_component_id": "web-progress-chart",
+      "hierarchy_level": 2,
+      "semantic_role": "supporting_hint",
+      "order": 3
+    },
+    {
+      "type": "create_frame",
+      "name": "web-progress-recovery",
+      "canonical_component": "alert",
+      "section_id": "progress-recovery",
+      "component_id": "web-progress-recovery",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "recovery_message",
+      "order": 4
     },
     {
       "type": "create_button",

--- a/scripts/design/instructions/web_progress.json
+++ b/scripts/design/instructions/web_progress.json
@@ -3,7 +3,86 @@
   "page": "20_Web_Parity",
   "platform": "WEB",
   "surface": "web_progress_screen",
+  "layout_archetype": "dashboard_shell",
   "layout_pattern": "dashboard-detail-stack",
+  "sections": [
+    {
+      "section_id": "progress-summary",
+      "name": "Progress summary",
+      "role": "summary_metrics",
+      "component_ids": [
+        "web-progress-shell",
+        "web-progress-stats",
+        "web-progress-chart",
+        "web-progress-tooltip"
+      ]
+    },
+    {
+      "section_id": "progress-recovery",
+      "name": "Recovery lane",
+      "role": "state_recovery",
+      "component_ids": [
+        "web-progress-recovery",
+        "node:web.progress.export_pdf"
+      ]
+    }
+  ],
+  "component_hierarchy": [
+    {
+      "component_id": "web-progress-shell",
+      "canonical_component": "card",
+      "section_id": "progress-summary",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "source_ref": "static:web-progress-shell"
+    },
+    {
+      "component_id": "web-progress-stats",
+      "canonical_component": "stats-card",
+      "section_id": "progress-summary",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "summary_metrics",
+      "source_ref": "static:web-progress-stats"
+    },
+    {
+      "component_id": "web-progress-chart",
+      "canonical_component": "progress",
+      "section_id": "progress-summary",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "trend_visualization",
+      "source_ref": "static:web-progress-chart"
+    },
+    {
+      "component_id": "web-progress-tooltip",
+      "canonical_component": "tooltip",
+      "section_id": "progress-summary",
+      "parent_component_id": "web-progress-chart",
+      "hierarchy_level": 2,
+      "semantic_role": "supporting_hint",
+      "source_ref": "static:web-progress-tooltip"
+    },
+    {
+      "component_id": "web-progress-recovery",
+      "canonical_component": "alert",
+      "section_id": "progress-recovery",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "recovery_message",
+      "source_ref": "static:web-progress-recovery"
+    },
+    {
+      "component_id": "node:web.progress.export_pdf",
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "parent_component_id": "web-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "utility_cta",
+      "source_ref": "cta:web.progress.export_pdf"
+    }
+  ],
   "primary_components": [
     "progress",
     "button"
@@ -46,7 +125,13 @@
         "height": 900
       },
       "background": "--pp-navy",
-      "canonical_component": "card"
+      "canonical_component": "card",
+      "section_id": "progress-summary",
+      "component_id": "web-progress-shell",
+      "parent_component_id": null,
+      "hierarchy_level": 0,
+      "semantic_role": "surface_shell",
+      "order": 0
     },
     {
       "type": "create_button",
@@ -64,7 +149,13 @@
         "loading",
         "error"
       ],
-      "canonical_component": "button"
+      "canonical_component": "button",
+      "section_id": "progress-recovery",
+      "component_id": "node:web.progress.export_pdf",
+      "parent_component_id": "web-progress-recovery",
+      "hierarchy_level": 2,
+      "semantic_role": "utility_cta",
+      "order": 5
     }
   ]
 }

--- a/scripts/design/instructions/web_progress.json
+++ b/scripts/design/instructions/web_progress.json
@@ -1,27 +1,52 @@
 {
   "screen_id": "web.progress",
   "page": "20_Web_Parity",
-  "platform": "Web",
+  "platform": "WEB",
+  "surface": "web_progress_screen",
+  "layout_pattern": "dashboard-detail-stack",
+  "primary_components": [
+    "progress",
+    "button"
+  ],
+  "supporting_components": [
+    "stats-card",
+    "tooltip",
+    "alert"
+  ],
+  "states": [
+    "default",
+    "loading",
+    "empty",
+    "error",
+    "export-success"
+  ],
   "dimensions": {
     "width": 1440,
     "height": 900
   },
   "background_token": "--pp-navy",
+  "token_constraints": [
+    "--pp-navy",
+    "--color-success",
+    "--color-surface"
+  ],
   "governance_checks": [
     "verify_token_usage",
     "verify_hpp_compliance",
-    "verify_cta_registry_match"
+    "verify_cta_registry_match",
+    "verify_instruction_contract"
   ],
-  "context_version": "",
+  "context_version": "code-first-ui-v1",
   "instructions": [
     {
       "type": "create_frame",
-      "name": "Web Progress Screen",
+      "name": "WEB Progress Screen",
       "dimensions": {
         "width": 1440,
         "height": 900
       },
-      "background": "--pp-navy"
+      "background": "--pp-navy",
+      "canonical_component": "card"
     },
     {
       "type": "create_button",
@@ -32,7 +57,14 @@
       "placement_zone": "W_PROGRESS_HEADER_UTIL",
       "figma_node_id": "PP/Web/Progress/Header/ExportPDF/Button/Default (TBD)",
       "prompt_stub": "stub://cta/utility/export-pdf",
-      "states": ["default", "hover", "disabled", "loading", "error"]
+      "states": [
+        "default",
+        "hover",
+        "disabled",
+        "loading",
+        "error"
+      ],
+      "canonical_component": "button"
     }
   ]
 }

--- a/scripts/design/instructions/web_progress.json
+++ b/scripts/design/instructions/web_progress.json
@@ -1,7 +1,7 @@
 {
   "screen_id": "web.progress",
   "page": "20_Web_Parity",
-  "platform": "WEB",
+  "platform": "Web",
   "surface": "web_progress_screen",
   "layout_archetype": "dashboard_shell",
   "layout_pattern": "dashboard-detail-stack",

--- a/scripts/design/instructions/web_progress.json
+++ b/scripts/design/instructions/web_progress.json
@@ -7,6 +7,15 @@
   "layout_pattern": "dashboard-detail-stack",
   "sections": [
     {
+      "section_id": "progress-header",
+      "name": "Progress header",
+      "role": "utility_actions",
+      "component_ids": [
+        "web-progress-header-utilities",
+        "node:web.progress.export_pdf"
+      ]
+    },
+    {
       "section_id": "progress-summary",
       "name": "Progress summary",
       "role": "summary_metrics",
@@ -22,8 +31,7 @@
       "name": "Recovery lane",
       "role": "state_recovery",
       "component_ids": [
-        "web-progress-recovery",
-        "node:web.progress.export_pdf"
+        "web-progress-recovery"
       ]
     }
   ],
@@ -36,6 +44,15 @@
       "hierarchy_level": 0,
       "semantic_role": "surface_shell",
       "source_ref": "static:web-progress-shell"
+    },
+    {
+      "component_id": "web-progress-header-utilities",
+      "canonical_component": "card",
+      "section_id": "progress-header",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "utility_cluster",
+      "source_ref": "static:web-progress-header-utilities"
     },
     {
       "component_id": "web-progress-stats",
@@ -76,8 +93,8 @@
     {
       "component_id": "node:web.progress.export_pdf",
       "canonical_component": "button",
-      "section_id": "progress-recovery",
-      "parent_component_id": "web-progress-recovery",
+      "section_id": "progress-header",
+      "parent_component_id": "web-progress-header-utilities",
       "hierarchy_level": 2,
       "semantic_role": "utility_cta",
       "source_ref": "cta:web.progress.export_pdf"
@@ -119,7 +136,7 @@
   "instructions": [
     {
       "type": "create_frame",
-      "name": "WEB Progress Screen",
+      "name": "Web Progress Screen",
       "canonical_component": "card",
       "section_id": "progress-summary",
       "component_id": "web-progress-shell",
@@ -135,6 +152,17 @@
     },
     {
       "type": "create_frame",
+      "name": "web-progress-header-utilities",
+      "canonical_component": "card",
+      "section_id": "progress-header",
+      "component_id": "web-progress-header-utilities",
+      "parent_component_id": "web-progress-shell",
+      "hierarchy_level": 1,
+      "semantic_role": "utility_cluster",
+      "order": 1
+    },
+    {
+      "type": "create_frame",
       "name": "web-progress-stats",
       "canonical_component": "stats-card",
       "section_id": "progress-summary",
@@ -142,7 +170,7 @@
       "parent_component_id": "web-progress-shell",
       "hierarchy_level": 1,
       "semantic_role": "summary_metrics",
-      "order": 1
+      "order": 2
     },
     {
       "type": "create_frame",
@@ -153,7 +181,7 @@
       "parent_component_id": "web-progress-shell",
       "hierarchy_level": 1,
       "semantic_role": "trend_visualization",
-      "order": 2
+      "order": 3
     },
     {
       "type": "create_frame",
@@ -164,7 +192,7 @@
       "parent_component_id": "web-progress-chart",
       "hierarchy_level": 2,
       "semantic_role": "supporting_hint",
-      "order": 3
+      "order": 4
     },
     {
       "type": "create_frame",
@@ -175,7 +203,7 @@
       "parent_component_id": "web-progress-shell",
       "hierarchy_level": 1,
       "semantic_role": "recovery_message",
-      "order": 4
+      "order": 5
     },
     {
       "type": "create_button",
@@ -194,12 +222,12 @@
         "error"
       ],
       "canonical_component": "button",
-      "section_id": "progress-recovery",
+      "section_id": "progress-header",
       "component_id": "node:web.progress.export_pdf",
-      "parent_component_id": "web-progress-recovery",
+      "parent_component_id": "web-progress-header-utilities",
       "hierarchy_level": 2,
       "semantic_role": "utility_cta",
-      "order": 5
+      "order": 6
     }
   ]
 }

--- a/scripts/design/verify_design.py
+++ b/scripts/design/verify_design.py
@@ -15,7 +15,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
@@ -36,7 +36,7 @@ def load_manifest() -> dict[str, Any]:
         raise FileNotFoundError(f"Manifest not found: {manifest_path}")
 
     with open(manifest_path) as f:
-        return json.load(f)
+        return cast(dict[str, Any], json.load(f))
 
 
 def load_instruction(screen_id: str) -> dict[str, Any]:
@@ -49,12 +49,12 @@ def load_instruction(screen_id: str) -> dict[str, Any]:
         raise FileNotFoundError(f"Instruction file not found: {instruction_path}")
 
     with open(instruction_path) as f:
-        return json.load(f)
+        return cast(dict[str, Any], json.load(f))
 
 
 def verify_screen(screen_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
     """Verify a screen's design against its instruction."""
-    result = {
+    result: dict[str, Any] = {
         "screen_id": screen_id,
         "status": "unknown",
         "checks": [],

--- a/scripts/design/verify_design.py
+++ b/scripts/design/verify_design.py
@@ -17,18 +17,15 @@ import sys
 from pathlib import Path
 from typing import Any
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from scripts.design.contracts import SUPPORTED_SCREENS, validate_instruction_contract
+
 # Project root for resolving paths
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Available screens
-AVAILABLE_SCREENS = [
-    "ios.home",
-    "ios.plate",
-    "ios.progress",
-    "web.home",
-    "web.plate",
-    "web.progress",
-]
+AVAILABLE_SCREENS = list(SUPPORTED_SCREENS)
 
 
 def load_manifest() -> dict[str, Any]:
@@ -73,6 +70,15 @@ def verify_screen(screen_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
         result["errors"].append(f"Instruction not found: {e}")
         return result
 
+    contract_errors = validate_instruction_contract(instruction)
+    if contract_errors:
+        result["status"] = "error"
+        result["errors"].extend(contract_errors)
+        result["checks"].append({"check": "instruction_contract", "status": "fail"})
+        return result
+
+    result["checks"].append({"check": "instruction_contract", "status": "pass"})
+
     # Check if screen exists in manifest exports
     exports = manifest.get("exports", [])
     screen_export = next((e for e in exports if e.get("screen_id") == screen_id), None)
@@ -84,6 +90,24 @@ def verify_screen(screen_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
         return result
 
     result["checks"].append({"check": "manifest_entry", "status": "present"})
+
+    if screen_export.get("surface") == instruction.get("surface"):
+        result["checks"].append({"check": "surface", "status": "pass"})
+    else:
+        result["checks"].append({"check": "surface", "status": "fail"})
+        result["errors"].append(
+            "Manifest surface mismatch: "
+            f"expected {instruction.get('surface')}, got {screen_export.get('surface')}"
+        )
+
+    if screen_export.get("layout_pattern") == instruction.get("layout_pattern"):
+        result["checks"].append({"check": "layout_pattern", "status": "pass"})
+    else:
+        result["checks"].append({"check": "layout_pattern", "status": "fail"})
+        result["errors"].append(
+            "Manifest layout_pattern mismatch: "
+            f"expected {instruction.get('layout_pattern')}, got {screen_export.get('layout_pattern')}"
+        )
 
     # Verify instruction count matches
     expected_count = len(instruction.get("instructions", []))

--- a/scripts/design/verify_design.py
+++ b/scripts/design/verify_design.py
@@ -109,6 +109,40 @@ def verify_screen(screen_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
             f"expected {instruction.get('layout_pattern')}, got {screen_export.get('layout_pattern')}"
         )
 
+    if screen_export.get("layout_archetype") == instruction.get("layout_archetype"):
+        result["checks"].append({"check": "layout_archetype", "status": "pass"})
+    else:
+        result["checks"].append({"check": "layout_archetype", "status": "fail"})
+        result["errors"].append(
+            "Manifest layout_archetype mismatch: "
+            f"expected {instruction.get('layout_archetype')}, got {screen_export.get('layout_archetype')}"
+        )
+
+    expected_section_count = len(instruction.get("sections", []))
+    actual_section_count = screen_export.get("section_count")
+    if expected_section_count == actual_section_count:
+        result["checks"].append(
+            {
+                "check": "section_count",
+                "status": "pass",
+                "expected": expected_section_count,
+                "actual": actual_section_count,
+            }
+        )
+    else:
+        result["checks"].append(
+            {
+                "check": "section_count",
+                "status": "fail",
+                "expected": expected_section_count,
+                "actual": actual_section_count,
+            }
+        )
+        result["errors"].append(
+            "Manifest section_count mismatch: "
+            f"expected {expected_section_count}, got {actual_section_count}"
+        )
+
     # Verify instruction count matches
     expected_count = len(instruction.get("instructions", []))
     actual_count = screen_export.get("node_count", 0)
@@ -137,9 +171,25 @@ def verify_screen(screen_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
 
     # Check execution status
     exec_status = screen_export.get("status", "unknown")
+    adapter_name = screen_export.get("adapter_name")
+    adapter_mode = screen_export.get("adapter_mode")
+    if adapter_name:
+        result["checks"].append(
+            {"check": "execution_adapter", "status": "pass", "value": adapter_name}
+        )
+    else:
+        result["warnings"].append("Execution adapter metadata missing in manifest export")
+        result["checks"].append({"check": "execution_adapter", "status": "missing"})
+
     if exec_status == "simulated":
         result["warnings"].append("Design was simulated, not actually created in Figma")
-        result["checks"].append({"check": "execution_status", "status": "simulated"})
+        result["checks"].append(
+            {
+                "check": "execution_status",
+                "status": "simulated",
+                "adapter_mode": adapter_mode,
+            }
+        )
     elif exec_status == "completed":
         result["checks"].append({"check": "execution_status", "status": "pass"})
     else:

--- a/tests/test_design_generation_pipeline.py
+++ b/tests/test_design_generation_pipeline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.design import execute_design, generate_figma_instructions, verify_design
 
 
@@ -25,9 +27,22 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
     assert "token_constraints" in payload
     assert payload["context_version"] == "code-first-ui-v1"
     assert payload["instructions"][0]["type"] == "create_frame"
-    assert payload["instructions"][1]["canonical_component"] == "button"
-    assert payload["instructions"][1]["component_id"].startswith("node:ios.home.")
-    assert payload["instructions"][1]["hierarchy_level"] == 2
+    assert any(
+        item["type"] == "create_frame" and item["component_id"] == "ios-home-actions"
+        for item in payload["instructions"]
+    )
+    assert any(
+        item["canonical_component"] == "button"
+        and item["component_id"].startswith("node:ios.home.")
+        and item["hierarchy_level"] == 2
+        for item in payload["instructions"]
+    )
+    flagged_button = next(
+        item
+        for item in payload["instructions"]
+        if item.get("component_id") == "node:ios.home.weekly_plan_reader"
+    )
+    assert "feature-flagged" in flagged_button["states"]
 
 
 def test_validate_governance_rejects_missing_contract_fields() -> None:
@@ -47,7 +62,10 @@ def test_validate_governance_rejects_missing_contract_fields() -> None:
     assert any("Missing required instruction field" in error for error in errors)
 
 
-def test_update_manifest_records_surface_and_layout_pattern(tmp_path: Path) -> None:
+def test_update_manifest_records_surface_and_layout_pattern(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manifest_path = tmp_path / "docs" / "design" / "figma-manifest.json"
     manifest_path.parent.mkdir(parents=True)
     manifest_path.write_text(
@@ -55,27 +73,23 @@ def test_update_manifest_records_surface_and_layout_pattern(tmp_path: Path) -> N
         encoding="utf-8",
     )
 
-    original_root = execute_design.PROJECT_ROOT
-    execute_design.PROJECT_ROOT = tmp_path
-    try:
-        execute_design.update_manifest(
-            "ios.home",
-            {
-                "screen_id": "ios.home",
-                "executed_at": "2026-03-11T00:00:00Z",
-                "status": "simulated",
-                "surface": "ios_home_screen",
-                "layout_archetype": "hero_shell",
-                "layout_pattern": "hero-plus-quick-actions",
-                "section_count": 3,
-                "adapter_name": "deterministic_stub",
-                "adapter_mode": "simulated",
-                "simulation_mode": "deterministic_contract_stub",
-                "created_nodes": [{"name": "Node", "type": "create_button"}],
-            },
-        )
-    finally:
-        execute_design.PROJECT_ROOT = original_root
+    monkeypatch.setattr(execute_design, "PROJECT_ROOT", tmp_path)
+    execute_design.update_manifest(
+        "ios.home",
+        {
+            "screen_id": "ios.home",
+            "executed_at": "2026-03-11T00:00:00Z",
+            "status": "simulated",
+            "surface": "ios_home_screen",
+            "layout_archetype": "hero_shell",
+            "layout_pattern": "hero-plus-quick-actions",
+            "section_count": 3,
+            "adapter_name": "deterministic_stub",
+            "adapter_mode": "simulated",
+            "simulation_mode": "deterministic_contract_stub",
+            "created_nodes": [{"name": "Node", "type": "create_button"}],
+        },
+    )
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     export = manifest["exports"][0]
@@ -98,13 +112,17 @@ def test_execute_instruction_uses_deterministic_adapter_metadata() -> None:
     assert result["status"] == "simulated"
     assert result["adapter_name"] == "deterministic_stub"
     assert result["adapter_mode"] == "simulated"
+    assert result["executed_at"] == "2026-01-01T00:00:00Z"
     assert result["layout_archetype"] == "dashboard_shell"
     assert any(
         node["component_id"] == "node:web.progress.export_pdf" for node in result["created_nodes"]
     )
 
 
-def test_verify_screen_distinguishes_not_executed(tmp_path: Path) -> None:
+def test_verify_screen_distinguishes_not_executed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     instruction_path = tmp_path / "scripts" / "design" / "instructions" / "ios_home.json"
     instruction_path.parent.mkdir(parents=True)
     payload = generate_figma_instructions.instruction_to_dict(
@@ -112,21 +130,20 @@ def test_verify_screen_distinguishes_not_executed(tmp_path: Path) -> None:
     )
     instruction_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    original_root = verify_design.PROJECT_ROOT
-    verify_design.PROJECT_ROOT = tmp_path
-    try:
-        result = verify_design.verify_screen(
-            "ios.home",
-            {"exports": []},
-        )
-    finally:
-        verify_design.PROJECT_ROOT = original_root
+    monkeypatch.setattr(verify_design, "PROJECT_ROOT", tmp_path)
+    result = verify_design.verify_screen(
+        "ios.home",
+        {"exports": []},
+    )
 
     assert result["status"] == "not_executed"
     assert any(check["check"] == "manifest_entry" for check in result["checks"])
 
 
-def test_verify_screen_detects_manifest_mismatch(tmp_path: Path) -> None:
+def test_verify_screen_detects_manifest_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     instruction_path = tmp_path / "scripts" / "design" / "instructions" / "ios_home.json"
     instruction_path.parent.mkdir(parents=True)
     payload = generate_figma_instructions.instruction_to_dict(
@@ -150,12 +167,8 @@ def test_verify_screen_detects_manifest_mismatch(tmp_path: Path) -> None:
         ]
     }
 
-    original_root = verify_design.PROJECT_ROOT
-    verify_design.PROJECT_ROOT = tmp_path
-    try:
-        result = verify_design.verify_screen("ios.home", manifest)
-    finally:
-        verify_design.PROJECT_ROOT = original_root
+    monkeypatch.setattr(verify_design, "PROJECT_ROOT", tmp_path)
+    result = verify_design.verify_screen("ios.home", manifest)
 
     assert result["status"] == "fail"
     assert any("surface mismatch" in error.lower() for error in result["errors"])
@@ -175,3 +188,32 @@ def test_validate_governance_rejects_invalid_hierarchy_payload() -> None:
 
     assert any("Unknown parent_component_id" in error for error in errors)
     assert any("must define hierarchy_level >= 0" in error for error in errors)
+
+
+def test_validate_governance_rejects_instruction_hierarchy_mismatch() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    target_index = next(
+        index
+        for index, item in enumerate(payload["instructions"])
+        if item["component_id"] == "node:ios.home.bmi_calculator"
+    )
+    payload["instructions"][target_index]["section_id"] = "hero-band"
+
+    errors = execute_design.validate_governance(payload)
+
+    assert any("section_id does not match component_hierarchy" in error for error in errors)
+
+
+def test_validate_governance_requires_frame_instruction_for_static_nodes() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    payload["instructions"] = [
+        item for item in payload["instructions"] if item["component_id"] != "ios-home-actions"
+    ]
+
+    errors = execute_design.validate_governance(payload)
+
+    assert any("Missing create_frame instructions" in error for error in errors)

--- a/tests/test_design_generation_pipeline.py
+++ b/tests/test_design_generation_pipeline.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from scripts.design import execute_design, generate_figma_instructions, verify_design
 
 
@@ -13,6 +11,7 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
     payload = generate_figma_instructions.instruction_to_dict(instruction)
 
     assert payload["surface"] == "ios_home_screen"
+    assert payload["layout_archetype"] == "hero_shell"
     assert payload["layout_pattern"] == "hero-plus-quick-actions"
     assert payload["primary_components"] == ["hero", "button"]
     assert payload["supporting_components"] == [
@@ -20,10 +19,15 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
         "navigation/tab-bar",
         "badge",
     ]
+    assert payload["sections"][0]["section_id"] == "hero-band"
+    assert payload["component_hierarchy"][0]["component_id"] == "ios-home-shell"
+    assert payload["component_hierarchy"][0]["hierarchy_level"] == 0
     assert "token_constraints" in payload
     assert payload["context_version"] == "code-first-ui-v1"
     assert payload["instructions"][0]["type"] == "create_frame"
     assert payload["instructions"][1]["canonical_component"] == "button"
+    assert payload["instructions"][1]["component_id"].startswith("node:ios.home.")
+    assert payload["instructions"][1]["hierarchy_level"] == 2
 
 
 def test_validate_governance_rejects_missing_contract_fields() -> None:
@@ -61,7 +65,11 @@ def test_update_manifest_records_surface_and_layout_pattern(tmp_path: Path) -> N
                 "executed_at": "2026-03-11T00:00:00Z",
                 "status": "simulated",
                 "surface": "ios_home_screen",
+                "layout_archetype": "hero_shell",
                 "layout_pattern": "hero-plus-quick-actions",
+                "section_count": 3,
+                "adapter_name": "deterministic_stub",
+                "adapter_mode": "simulated",
                 "simulation_mode": "deterministic_contract_stub",
                 "created_nodes": [{"name": "Node", "type": "create_button"}],
             },
@@ -72,8 +80,28 @@ def test_update_manifest_records_surface_and_layout_pattern(tmp_path: Path) -> N
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     export = manifest["exports"][0]
     assert export["surface"] == "ios_home_screen"
+    assert export["layout_archetype"] == "hero_shell"
     assert export["layout_pattern"] == "hero-plus-quick-actions"
+    assert export["section_count"] == 3
+    assert export["adapter_name"] == "deterministic_stub"
+    assert export["adapter_mode"] == "simulated"
     assert export["simulation_mode"] == "deterministic_contract_stub"
+
+
+def test_execute_instruction_uses_deterministic_adapter_metadata() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("web.progress")
+    )
+
+    result = execute_design.execute_instruction(payload, "deterministic_stub")
+
+    assert result["status"] == "simulated"
+    assert result["adapter_name"] == "deterministic_stub"
+    assert result["adapter_mode"] == "simulated"
+    assert result["layout_archetype"] == "dashboard_shell"
+    assert any(
+        node["component_id"] == "node:web.progress.export_pdf" for node in result["created_nodes"]
+    )
 
 
 def test_verify_screen_distinguishes_not_executed(tmp_path: Path) -> None:
@@ -112,7 +140,10 @@ def test_verify_screen_detects_manifest_mismatch(tmp_path: Path) -> None:
                 "screen_id": "ios.home",
                 "status": "simulated",
                 "surface": "wrong_surface",
+                "layout_archetype": "wrong_archetype",
                 "layout_pattern": "wrong_layout",
+                "adapter_name": "deterministic_stub",
+                "adapter_mode": "simulated",
                 "node_count": len(payload["instructions"]) - 1,
                 "nodes": [],
             }
@@ -128,5 +159,19 @@ def test_verify_screen_detects_manifest_mismatch(tmp_path: Path) -> None:
 
     assert result["status"] == "fail"
     assert any("surface mismatch" in error.lower() for error in result["errors"])
+    assert any("layout_archetype mismatch" in error.lower() for error in result["errors"])
     assert any("layout_pattern mismatch" in error.lower() for error in result["errors"])
     assert any("Node count mismatch" in error for error in result["errors"])
+
+
+def test_validate_governance_rejects_invalid_hierarchy_payload() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    payload["component_hierarchy"][1]["parent_component_id"] = "missing-parent"
+    payload["instructions"][1]["hierarchy_level"] = -1
+
+    errors = execute_design.validate_governance(payload)
+
+    assert any("Unknown parent_component_id" in error for error in errors)
+    assert any("must define hierarchy_level >= 0" in error for error in errors)

--- a/tests/test_design_generation_pipeline.py
+++ b/tests/test_design_generation_pipeline.py
@@ -12,10 +12,11 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
     instruction = generate_figma_instructions.generate_screen_instruction("ios.home")
     payload = generate_figma_instructions.instruction_to_dict(instruction)
 
+    assert payload["platform"] == "iOS"
     assert payload["surface"] == "ios_home_screen"
     assert payload["layout_archetype"] == "hero_shell"
     assert payload["layout_pattern"] == "hero-plus-quick-actions"
-    assert payload["primary_components"] == ["hero", "button"]
+    assert payload["primary_components"] == ["hero", "button", "card"]
     assert payload["supporting_components"] == [
         "stats-card",
         "navigation/tab-bar",
@@ -42,7 +43,13 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
         for item in payload["instructions"]
         if item.get("component_id") == "node:ios.home.weekly_plan_reader"
     )
+    primary_button = next(
+        item
+        for item in payload["instructions"]
+        if item.get("component_id") == "node:ios.home.bmi_calculator"
+    )
     assert "feature-flagged" in flagged_button["states"]
+    assert "hover" not in primary_button["states"]
     assert payload["instructions"][0]["name"] == "iOS Home Screen"
 
 
@@ -137,6 +144,27 @@ def test_execute_instruction_uses_deterministic_adapter_metadata() -> None:
     assert any(
         node["component_id"] == "node:web.progress.export_pdf" for node in result["created_nodes"]
     )
+
+
+def test_platform_specific_button_states_and_platform_labels() -> None:
+    ios_payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.progress")
+    )
+    web_payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("web.progress")
+    )
+
+    ios_button = next(
+        item for item in ios_payload["instructions"] if item["type"] == "create_button"
+    )
+    web_button = next(
+        item for item in web_payload["instructions"] if item["type"] == "create_button"
+    )
+
+    assert ios_payload["platform"] == "iOS"
+    assert web_payload["platform"] == "Web"
+    assert "hover" not in ios_button["states"]
+    assert "hover" in web_button["states"]
 
 
 def test_verify_screen_distinguishes_not_executed(

--- a/tests/test_design_generation_pipeline.py
+++ b/tests/test_design_generation_pipeline.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.design import execute_design, generate_figma_instructions, verify_design
+
+
+def test_generated_instruction_includes_code_first_contract_fields() -> None:
+    instruction = generate_figma_instructions.generate_screen_instruction("ios.home")
+    payload = generate_figma_instructions.instruction_to_dict(instruction)
+
+    assert payload["surface"] == "ios_home_screen"
+    assert payload["layout_pattern"] == "hero-plus-quick-actions"
+    assert payload["primary_components"] == ["hero", "button"]
+    assert payload["supporting_components"] == [
+        "stats-card",
+        "navigation/tab-bar",
+        "badge",
+    ]
+    assert "token_constraints" in payload
+    assert payload["context_version"] == "code-first-ui-v1"
+    assert payload["instructions"][0]["type"] == "create_frame"
+    assert payload["instructions"][1]["canonical_component"] == "button"
+
+
+def test_validate_governance_rejects_missing_contract_fields() -> None:
+    instruction = {
+        "screen_id": "ios.home",
+        "page": "10_iOS_Home",
+        "platform": "IOS",
+        "dimensions": {"width": 390, "height": 844},
+        "background_token": "Color.navy",
+        "governance_checks": ["verify_instruction_contract"],
+        "context_version": "code-first-ui-v1",
+        "instructions": [],
+    }
+
+    errors = execute_design.validate_governance(instruction)
+
+    assert any("Missing required instruction field" in error for error in errors)
+
+
+def test_update_manifest_records_surface_and_layout_pattern(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "docs" / "design" / "figma-manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps({"manifest_version": "1.0", "exports": []}),
+        encoding="utf-8",
+    )
+
+    original_root = execute_design.PROJECT_ROOT
+    execute_design.PROJECT_ROOT = tmp_path
+    try:
+        execute_design.update_manifest(
+            "ios.home",
+            {
+                "screen_id": "ios.home",
+                "executed_at": "2026-03-11T00:00:00Z",
+                "status": "simulated",
+                "surface": "ios_home_screen",
+                "layout_pattern": "hero-plus-quick-actions",
+                "simulation_mode": "deterministic_contract_stub",
+                "created_nodes": [{"name": "Node", "type": "create_button"}],
+            },
+        )
+    finally:
+        execute_design.PROJECT_ROOT = original_root
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    export = manifest["exports"][0]
+    assert export["surface"] == "ios_home_screen"
+    assert export["layout_pattern"] == "hero-plus-quick-actions"
+    assert export["simulation_mode"] == "deterministic_contract_stub"
+
+
+def test_verify_screen_distinguishes_not_executed(tmp_path: Path) -> None:
+    instruction_path = tmp_path / "scripts" / "design" / "instructions" / "ios_home.json"
+    instruction_path.parent.mkdir(parents=True)
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    instruction_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    original_root = verify_design.PROJECT_ROOT
+    verify_design.PROJECT_ROOT = tmp_path
+    try:
+        result = verify_design.verify_screen(
+            "ios.home",
+            {"exports": []},
+        )
+    finally:
+        verify_design.PROJECT_ROOT = original_root
+
+    assert result["status"] == "not_executed"
+    assert any(check["check"] == "manifest_entry" for check in result["checks"])
+
+
+def test_verify_screen_detects_manifest_mismatch(tmp_path: Path) -> None:
+    instruction_path = tmp_path / "scripts" / "design" / "instructions" / "ios_home.json"
+    instruction_path.parent.mkdir(parents=True)
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    instruction_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    manifest = {
+        "exports": [
+            {
+                "screen_id": "ios.home",
+                "status": "simulated",
+                "surface": "wrong_surface",
+                "layout_pattern": "wrong_layout",
+                "node_count": len(payload["instructions"]) - 1,
+                "nodes": [],
+            }
+        ]
+    }
+
+    original_root = verify_design.PROJECT_ROOT
+    verify_design.PROJECT_ROOT = tmp_path
+    try:
+        result = verify_design.verify_screen("ios.home", manifest)
+    finally:
+        verify_design.PROJECT_ROOT = original_root
+
+    assert result["status"] == "fail"
+    assert any("surface mismatch" in error.lower() for error in result["errors"])
+    assert any("layout_pattern mismatch" in error.lower() for error in result["errors"])
+    assert any("Node count mismatch" in error for error in result["errors"])

--- a/tests/test_design_generation_pipeline.py
+++ b/tests/test_design_generation_pipeline.py
@@ -43,6 +43,26 @@ def test_generated_instruction_includes_code_first_contract_fields() -> None:
         if item.get("component_id") == "node:ios.home.weekly_plan_reader"
     )
     assert "feature-flagged" in flagged_button["states"]
+    assert payload["instructions"][0]["name"] == "iOS Home Screen"
+
+
+def test_generated_web_progress_export_cta_uses_header_container() -> None:
+    instruction = generate_figma_instructions.generate_screen_instruction("web.progress")
+    payload = generate_figma_instructions.instruction_to_dict(instruction)
+
+    export_button = next(
+        item
+        for item in payload["instructions"]
+        if item.get("component_id") == "node:web.progress.export_pdf"
+    )
+
+    assert export_button["section_id"] == "progress-header"
+    assert export_button["parent_component_id"] == "web-progress-header-utilities"
+    assert any(
+        section["section_id"] == "progress-header"
+        and "node:web.progress.export_pdf" in section["component_ids"]
+        for section in payload["sections"]
+    )
 
 
 def test_validate_governance_rejects_missing_contract_fields() -> None:
@@ -217,3 +237,48 @@ def test_validate_governance_requires_frame_instruction_for_static_nodes() -> No
     errors = execute_design.validate_governance(payload)
 
     assert any("Missing create_frame instructions" in error for error in errors)
+
+
+def test_validate_governance_requires_button_instruction_for_button_nodes() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("ios.home")
+    )
+    payload["instructions"] = [
+        item
+        for item in payload["instructions"]
+        if item["component_id"] != "node:ios.home.bmi_calculator"
+    ]
+
+    errors = execute_design.validate_governance(payload)
+
+    assert any("Missing create_button instructions" in error for error in errors)
+
+
+def test_validate_governance_rejects_duplicate_and_mismatched_instruction_metadata() -> None:
+    payload = generate_figma_instructions.instruction_to_dict(
+        generate_figma_instructions.generate_screen_instruction("web.progress")
+    )
+    payload["sections"][0]["component_ids"] = [
+        component_id
+        for component_id in payload["sections"][0]["component_ids"]
+        if component_id != "web-progress-header-utilities"
+    ]
+    duplicated_frame = next(
+        item for item in payload["instructions"] if item["component_id"] == "web-progress-shell"
+    ).copy()
+    payload["instructions"].append(duplicated_frame)
+
+    target_index = next(
+        index
+        for index, item in enumerate(payload["instructions"])
+        if item["component_id"] == "web-progress-header-utilities"
+    )
+    payload["instructions"][target_index]["canonical_component"] = "alert"
+    payload["instructions"][target_index]["semantic_role"] = "recovery_message"
+
+    errors = execute_design.validate_governance(payload)
+
+    assert any("missing from sections.component_ids" in error for error in errors)
+    assert any("Duplicate create_frame instruction" in error for error in errors)
+    assert any("canonical_component does not match" in error for error in errors)
+    assert any("semantic_role does not match" in error for error in errors)

--- a/tests/test_ui_component_vocabulary_contract.py
+++ b/tests/test_ui_component_vocabulary_contract.py
@@ -63,6 +63,9 @@ def test_ui_component_vocabulary_contract_is_valid() -> None:
     assert vocabulary
 
     canonical_names: set[str] = set()
+    all_canonical_names: set[str] = {
+        str(entry["canonical_name"]).strip().lower() for entry in vocabulary
+    }
     aliases: set[str] = set()
 
     for entry in vocabulary:
@@ -97,6 +100,7 @@ def test_ui_component_vocabulary_contract_is_valid() -> None:
             assert normalized_alias
             assert normalized_alias != normalized_canonical_name
             assert normalized_alias not in aliases
+            assert normalized_alias not in all_canonical_names
             aliases.add(normalized_alias)
 
         if existing_repo_component is not None:
@@ -156,6 +160,7 @@ def test_design_and_agent_docs_reference_the_vocabulary_layer() -> None:
         / "orchestration"
         / "AGENT_CONTEXT_MAP.md": [
             "UI_COMPONENT_VOCABULARY.md",
+            "UI_SCREEN_BRIEF_TEMPLATES.md",
             "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
         ],
         REPO_ROOT

--- a/tests/test_ui_component_vocabulary_contract.py
+++ b/tests/test_ui_component_vocabulary_contract.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VOCABULARY_PATH = REPO_ROOT / "docs" / "design" / "ui_component_vocabulary.json"
+REQUIRED_COMPONENTS = {
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "checkbox",
+    "radio-group",
+    "card",
+    "alert",
+    "badge",
+    "dialog",
+    "dropdown-menu",
+    "tabs",
+    "progress",
+    "tooltip",
+    "empty-state",
+    "segmented-control",
+    "toggle",
+    "skeleton",
+    "mobile-menu",
+    "navigation/tab-bar",
+    "hero",
+    "stats-card",
+    "form-field",
+    "stepper/progress-indicator",
+}
+REQUIRED_KEYS = {
+    "id",
+    "canonical_name",
+    "aliases",
+    "intent",
+    "when_to_use",
+    "when_not_to_use",
+    "anatomy",
+    "states",
+    "accessibility_notes",
+    "token_guidance",
+    "react_mapping",
+    "swiftui_mapping",
+    "existing_repo_component",
+    "missing_status",
+    "prompt_terms",
+    "anti_generic_terms",
+    "stitch_normalization_hint",
+}
+
+
+def _load_vocabulary() -> list[dict[str, object]]:
+    return json.loads(VOCABULARY_PATH.read_text(encoding="utf-8"))
+
+
+def test_ui_component_vocabulary_contract_is_valid() -> None:
+    vocabulary = _load_vocabulary()
+
+    assert isinstance(vocabulary, list)
+    assert vocabulary
+
+    canonical_names: set[str] = set()
+    aliases: set[str] = set()
+
+    for entry in vocabulary:
+        assert REQUIRED_KEYS == set(entry.keys())
+
+        canonical_name = str(entry["canonical_name"]).strip()
+        normalized_canonical_name = canonical_name.lower()
+
+        assert canonical_name
+        assert normalized_canonical_name not in canonical_names
+        canonical_names.add(normalized_canonical_name)
+
+        prompt_terms = entry["prompt_terms"]
+        anti_generic_terms = entry["anti_generic_terms"]
+        existing_repo_component = entry["existing_repo_component"]
+
+        assert isinstance(prompt_terms, list)
+        assert prompt_terms
+        assert all(isinstance(term, str) and term.strip() for term in prompt_terms)
+
+        assert isinstance(anti_generic_terms, list)
+        assert anti_generic_terms
+        assert all(isinstance(term, str) and term.strip() for term in anti_generic_terms)
+
+        entry_aliases = entry["aliases"]
+        assert isinstance(entry_aliases, list)
+        assert entry_aliases
+
+        for alias in entry_aliases:
+            normalized_alias = str(alias).strip().lower()
+
+            assert normalized_alias
+            assert normalized_alias != normalized_canonical_name
+            assert normalized_alias not in aliases
+            aliases.add(normalized_alias)
+
+        if existing_repo_component is not None:
+            resolved_path = REPO_ROOT / str(existing_repo_component)
+            assert resolved_path.exists(), str(resolved_path)
+
+
+def test_required_canonical_components_are_present() -> None:
+    vocabulary = _load_vocabulary()
+    canonical_names = {str(entry["canonical_name"]) for entry in vocabulary}
+
+    assert REQUIRED_COMPONENTS == canonical_names
+
+
+def test_design_and_agent_docs_reference_the_vocabulary_layer() -> None:
+    required_references = {
+        REPO_ROOT
+        / "docs"
+        / "design"
+        / "DESIGN_SYSTEM_FOR_CODE.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+            "UI_SCREEN_BRIEF_TEMPLATES.md",
+        ],
+        REPO_ROOT
+        / "docs"
+        / "design"
+        / "VISUAL_IMPLEMENTATION_MAP.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+        ],
+        REPO_ROOT
+        / "docs"
+        / "runbooks"
+        / "DESIGN_TOOLING_OPERATING_MODEL.md": [
+            "STITCH_AI_REFERENCE_ADAPTER.md",
+            "stitch_reference",
+            "ui_component_vocabulary.json",
+        ],
+        REPO_ROOT
+        / ".cursor"
+        / "agents"
+        / "creative-designer.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "UI_SCREEN_BRIEF_TEMPLATES.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+        ],
+        REPO_ROOT
+        / ".cursor"
+        / "agents"
+        / "frontend-engineer.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+        ],
+        REPO_ROOT
+        / "docs"
+        / "orchestration"
+        / "AGENT_CONTEXT_MAP.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+        ],
+        REPO_ROOT
+        / "tools"
+        / "codex_skills"
+        / "pulseplate-workflow"
+        / "SKILL.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+        ],
+        REPO_ROOT
+        / "tools"
+        / "codex_skills"
+        / "pulseplate-frontend-ui"
+        / "SKILL.md": [
+            "UI_COMPONENT_VOCABULARY.md",
+            "CODE_FIRST_UI_PROMPT_COOKBOOK.md",
+            "Canonical components",
+        ],
+    }
+
+    for path, snippets in required_references.items():
+        text = path.read_text(encoding="utf-8")
+
+        for snippet in snippets:
+            assert snippet in text, f"{snippet} missing in {path}"

--- a/tools/codex_skills/pulseplate-frontend-ui/SKILL.md
+++ b/tools/codex_skills/pulseplate-frontend-ui/SKILL.md
@@ -27,19 +27,26 @@ description: Implement frontend UI in PulsePlate style using design tokens and t
    sed -n '1,220p' frontend/tailwind.config.ts
    ```
 
-2. Check existing component patterns:
+2. Load code-first UI naming SoT:
+
+   ```bash
+   sed -n '1,220p' docs/design/UI_COMPONENT_VOCABULARY.md
+   sed -n '1,220p' docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+   ```
+
+3. Check existing component patterns:
 
    ```bash
    find frontend/src/components/ui -maxdepth 2 -type f | sort
    ```
 
-3. Enforce thin HTTP adapter policy:
+4. Enforce thin HTTP adapter policy:
 
    ```bash
    rg -n "fetch\\(" frontend/src --glob '!frontend/src/api/client.ts'
    ```
 
-4. Validate frontend:
+5. Validate frontend:
 
    ```bash
    cd frontend
@@ -51,6 +58,7 @@ description: Implement frontend UI in PulsePlate style using design tokens and t
 ## Output format
 
 - `UI scope`: touched components/pages.
+- `Canonical components`: vocabulary names selected for this UI.
 - `Token usage`: which semantic tokens were applied.
 - `Policy checks`: thin-client and component pattern checks.
 - `Validation`: test/build results.
@@ -65,6 +73,7 @@ On failure include:
 ## Guardrails
 
 - No ad-hoc hex colors when equivalent semantic tokens exist.
+- Normalize vague UI language into canonical component names before implementation.
 - No direct `fetch()` outside `frontend/src/api/client.ts`.
 - Preserve existing visual language and token hierarchy.
 - Do not claim UI done without `npm test` and `npm run build`.
@@ -75,5 +84,7 @@ On failure include:
 - `frontend/src/styles/tokens.css`
 - `frontend/src/styles/tokens.ts`
 - `frontend/tailwind.config.ts`
+- `docs/design/UI_COMPONENT_VOCABULARY.md`
+- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md`
 - `frontend/src/components/ui`
 - `frontend/src/api/client.ts`

--- a/tools/codex_skills/pulseplate-workflow/SKILL.md
+++ b/tools/codex_skills/pulseplate-workflow/SKILL.md
@@ -44,6 +44,13 @@ description: Start any PulsePlate task with the required policy, scope, and qual
 4. Start coordinator-first routing for multi-agent work:
    - Use `.cursor/agents/agent-coordinator.md` as entrypoint.
 
+5. For design/frontend tasks, load the code-first UI naming layer:
+
+   ```bash
+   sed -n '1,220p' docs/design/UI_COMPONENT_VOCABULARY.md
+   sed -n '1,220p' docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md
+   ```
+
 ## Output format
 
 - `Task summary`: one paragraph.


### PR DESCRIPTION
## Summary

Adds a code-first UI vocabulary layer and wires it into the deterministic Figma instruction pipeline so design generation uses canonical component names, explicit layout/state contracts, richer hierarchy semantics, and a future-ready execution adapter seam.

## Scope (IN / OUT)

### IN
- canonical UI vocabulary artifacts under `docs/design/`
- prompt assembly cookbook and screen brief templates
- Stitch reference-only governance runbook
- design/agent/skill docs updated to require vocabulary-first normalization
- `scripts/design/*` contract upgrades for generation, execution, and verification
- explicit `layout_archetype`, `sections`, and `component_hierarchy` semantics in generated instructions
- deterministic execution adapter seam via `scripts/design/execution_adapters.py`
- deterministic tests for vocabulary and design-generation pipeline

### OUT
- live Figma MCP write execution
- networked design execution logic
- Stitch runtime integration
- full autonomous end-to-end design generation

## Brainstorm Origin

Promotes the current local code-first vocabulary/governance work into a clean worktree branch and uses it as the first formal foundation for improving automatic design generation.

## Promotion

Promoted artifacts:
- `docs/design/ui_component_vocabulary.json` as the machine-readable naming contract
- `docs/design/UI_COMPONENT_VOCABULARY.md` as the human normalization guide
- `docs/design/CODE_FIRST_UI_PROMPT_COOKBOOK.md` as the required pre-generation brief contract
- `docs/design/UI_SCREEN_BRIEF_TEMPLATES.md` and `docs/design/UI_VOCABULARY_EVALS.md` as deterministic control inputs
- `docs/runbooks/STITCH_AI_REFERENCE_ADAPTER.md` as `reference_only` intake governance

Pipeline promotion in this PR:
- `scripts/design/generate_figma_instructions.py` now emits `layout_archetype`, `sections`, `component_hierarchy`, and instruction-level parent/component ordering metadata
- `scripts/design/contracts.py` validates the richer instruction contract, including hierarchy and section linkage
- `scripts/design/execution_adapters.py` introduces a deterministic adapter seam with `deterministic_stub` as the only active Phase 1 adapter
- `scripts/design/execute_design.py` now routes execution through the adapter seam and persists adapter/section metadata into the manifest
- `scripts/design/verify_design.py` verifies `layout_archetype`, `layout_pattern`, `section_count`, and adapter-backed manifest state deterministically

Operating model clarified in docs:
- Figma remains the design-intent lane
- `/tokens` remains the token source of truth
- vocabulary is a normalization/spec layer
- Stitch remains `reference_only`
- live MCP adapters stay deferred behind the same instruction/manifest contract

## Validation

Executed locally in `worktrees/design_gen_pr1`:

```bash
pytest -q tests/test_ui_component_vocabulary_contract.py tests/test_design_generation_pipeline.py
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
make design-list
make design-validate SCREEN=ios.home
make design-verify
pre-commit run --all-files
make verify
```

## Deferred / Follow-ups

- real MCP-backed Figma execution adapter ([Backlog](/docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-design-execution-adapter-seam))
- broader screen coverage beyond the initial six supported parity screens ([Backlog](/docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-design-runtime-screen-coverage))
- richer instruction semantics for reusable layout archetypes beyond the current shell families ([Backlog](/docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-design-layout-archetype-templates))

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical UI component vocabulary and code-first UI workflow (screen briefs, prompt cookbook, canonical-first assembly).
  * Pluggable design execution adapters with a deterministic stub seam for predictable execution and verification.

* **Documentation**
  * New comprehensive docs: vocabulary, prompt cookbook, screen brief templates, evaluation guides, visual implementation mapping, runbooks, ADR and tooling guidance.
  * Updated agent/skill and orchestration guidance to reference the vocabulary-driven workflow.

* **Tests**
  * End-to-end tests validating generation, execution, and vocabulary contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
