### PR TITLE
docs(ledger): normalize PR5 closeout

### DIFF
--- a/docs/review/PR_1120_FIXED_MAPPING.md
+++ b/docs/review/PR_1120_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 1ecfc4be
+Evidence: `1ecfc4be` keeps the PR5 CV lane itself marked as merged in `docs/roadmap/BACKLOG_LEDGER.md:5766-5771`, but moves the docs-only normalization tail back to an honest open state in `docs/roadmap/BACKLOG_LEDGER.md:5919-5929`, so PR `#1120` is tracked as in progress instead of being recorded as closed before merge.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920718670 -> 1ecfc4be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932238299 -> 1ecfc4be
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1120_FIXED_MAPPING.md
+++ b/docs/review/PR_1120_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1120 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments.
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1120_FIXED_MAPPING.md
+++ b/docs/review/PR_1120_FIXED_MAPPING.md
@@ -6,11 +6,13 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
-Commit: 1ecfc4be
-Evidence: `1ecfc4be` keeps the PR5 CV lane itself marked as merged in `docs/roadmap/BACKLOG_LEDGER.md:5766-5771`, but moves the docs-only normalization tail back to an honest open state in `docs/roadmap/BACKLOG_LEDGER.md:5919-5929`, so PR `#1120` is tracked as in progress instead of being recorded as closed before merge.
+Commit: 031d33a4
+Evidence: `031d33a4` makes the parent follow-up line merge-safe in `docs/roadmap/BACKLOG_LEDGER.md:5771` and marks the docs-only child tail as implemented-with-merge effect in `docs/roadmap/BACKLOG_LEDGER.md:5919-5929`, which keeps the wording truthful during review and non-stale after PR `#1120` merges.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920718670 -> 1ecfc4be
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932238299 -> 1ecfc4be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920718670 -> 031d33a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932238299 -> 031d33a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920751634 -> 031d33a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932274725 -> 031d33a4
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1120_FIXED_MAPPING.md
+++ b/docs/review/PR_1120_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments.
+- No actionable review comments
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5763,11 +5763,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No hidden-memory path bypasses KPP promotion
 
 <a id="ledger-p1-agent-experiment-cv-lane"></a>
-- [ ] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
+- [x] P1: PR5 CV experimentation and evaluation lane (docs/eval only)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
-  - Status: 🟡 Delivered in PR `#1102` on 2026-03-11 (`55783414`; CV overlay + packet schema extension + orchestration drift audit shipped), but canonical ledger closeout remains pending the docs-only normalization follow-up tracked in [P2: Normalize PR5 ledger closeout via docs-only follow-up PR](#ledger-p2-pr5-ledger-closeout-docs-only)
+  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`) with canonical ledger closeout normalized in PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)
@@ -5915,7 +5915,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Final merge checklist references the filtered current-head view
 
 <a id="ledger-p2-pr5-ledger-closeout-docs-only"></a>
-- [ ] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
+- [x] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
   - Target PR: PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
@@ -5925,6 +5925,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`
     - `docs/roadmap/BACKLOG_LEDGER.md`
     - `docs/review/PR_1102_FIXED_MAPPING.md`
+  - Status: ✅ Closed by PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
   - DoD:
     - A docs-only follow-up PR updates the PR5 ledger closeout in canonical form
     - The follow-up PR references PR `#1102` and this deferred remediation item

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5767,7 +5767,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
-  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`) with canonical ledger closeout normalized in PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
+  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`) with canonical ledger closeout normalized in PR `#1120`
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)
@@ -5918,14 +5918,14 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
+  - Target PR: PR `#1120`
   - Area: orchestration / ledger governance
   - Reason: `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md` requires a docs-only follow-up PR when a merged PR closes a ledger item. PR5 closeout was captured during the mixed-scope PR6 kickoff sequence, so it needs a narrow docs-only normalization PR instead of widening PR6 further.
   - Links:
     - `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`
     - `docs/roadmap/BACKLOG_LEDGER.md`
     - `docs/review/PR_1102_FIXED_MAPPING.md`
-  - Status: ✅ Closed by PR_TBD_PR5_LEDGER_CLOSEOUT_DOCS_ONLY
+  - Status: ✅ Closed by PR `#1120`
   - DoD:
     - A docs-only follow-up PR updates the PR5 ledger closeout in canonical form
     - The follow-up PR references PR `#1102` and this deferred remediation item

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5767,7 +5767,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
-  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`) with canonical ledger closeout normalized in PR `#1120`
+  - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`)
+  - Follow-up: Canonical ledger closeout normalization is tracked in open PR `#1120` and should be recorded as closed only after that PR merges.
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)
@@ -5915,7 +5916,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Final merge checklist references the filtered current-head view
 
 <a id="ledger-p2-pr5-ledger-closeout-docs-only"></a>
-- [x] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
+- [ ] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
   - Target PR: PR `#1120`
@@ -5925,7 +5926,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`
     - `docs/roadmap/BACKLOG_LEDGER.md`
     - `docs/review/PR_1102_FIXED_MAPPING.md`
-  - Status: ✅ Closed by PR `#1120`
+  - Status: 🟡 In progress (tracked by open PR `#1120`; close after merge)
   - DoD:
     - A docs-only follow-up PR updates the PR5 ledger closeout in canonical form
     - The follow-up PR references PR `#1102` and this deferred remediation item

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5768,7 +5768,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Priority: P1 (future multimodal track, no runtime integration yet)
   - Target PR: #1102
   - Status: ✅ Merged on 2026-03-11 (`55783414`; PR `#1102`)
-  - Follow-up: Canonical ledger closeout normalization is tracked in open PR `#1120` and should be recorded as closed only after that PR merges.
+  - Follow-up: Canonical ledger closeout normalization is implemented in PR `#1120` (this docs-only follow-up) and becomes canonical on merge.
   - Dependencies:
     - [P1 Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
     - [CV (photo → food): contract schema + uncertainty/degrade UX states + privacy packet](#ledger-p2-cv-photo-food)
@@ -5916,7 +5916,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Final merge checklist references the filtered current-head view
 
 <a id="ledger-p2-pr5-ledger-closeout-docs-only"></a>
-- [ ] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
+- [x] P2: Normalize PR5 ledger closeout via docs-only follow-up PR
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
   - Target PR: PR `#1120`
@@ -5926,7 +5926,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md`
     - `docs/roadmap/BACKLOG_LEDGER.md`
     - `docs/review/PR_1102_FIXED_MAPPING.md`
-  - Status: 🟡 In progress (tracked by open PR `#1120`; close after merge)
+  - Status: ✅ Implemented in PR `#1120` (this docs-only follow-up); canonical closeout takes effect on merge.
   - DoD:
     - A docs-only follow-up PR updates the PR5 ledger closeout in canonical form
     - The follow-up PR references PR `#1102` and this deferred remediation item


### PR DESCRIPTION
## Summary
- normalizes the canonical ledger closeout wording for PR5 (`#1102`)
- makes the PR5 parent follow-up and the docs-only child tail merge-safe
- keeps the ledger truthful during review and non-stale after merge

## Scope
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1120_FIXED_MAPPING.md`

## Validation
- `python3 -m scripts.orchestration.check_preflight`
- `pre-commit run --all-files`
- `make verify`

## Carryover
- none

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Deferred/follow-up items mirrored in backlog when applicable

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1120_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920718670 -> 031d33a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932238299 -> 031d33a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#discussion_r2920751634 -> 031d33a4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1120#pullrequestreview-3932274725 -> 031d33a4

## Merge Readiness
- [x] local hard gate passed (`make verify`)
- [x] docs-only scope
- [ ] bot reviews addressed
- [ ] merge-readiness gate green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a PR review checklist documenting discussion pass, mapping of fixes to commits, and merge-readiness checkboxes.
  * Updated the backlog ledger to reflect matured statuses and explicit PR references for follow-ups and closeouts, improving tracking and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->