### PR TITLE
fix(tests): stabilize app.main runtime resolution

### DIFF
--- a/docs/review/PR_1122_FIXED_MAPPING.md
+++ b/docs/review/PR_1122_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1122 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: ac870e54
+Evidence: `tests/test_websocket_security_api.py:607`, `tests/test_websocket_security_api.py:608`, `tests/test_websocket_security_api.py:620` keep `_assert_no_duplicate_ws_route` bound to the runtime-resolved `app.main` module, so the patched `main_mod.app` and the asserted guard function stay synchronized in purge/reload-sensitive flows.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920875349 -> ac870e54
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920896727 -> ac870e54
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1122_FIXED_MAPPING.md
+++ b/docs/review/PR_1122_FIXED_MAPPING.md
@@ -8,6 +8,8 @@
 Disposition: FIXED
 Commit: ac870e54
 Evidence: `tests/test_websocket_security_api.py:607`, `tests/test_websocket_security_api.py:608`, `tests/test_websocket_security_api.py:620` keep `_assert_no_duplicate_ws_route` bound to the runtime-resolved `app.main` module, so the patched `main_mod.app` and the asserted guard function stay synchronized in purge/reload-sensitive flows.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#pullrequestreview-3932408563 -> ac870e54
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#pullrequestreview-3932431155 -> ac870e54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920875349 -> ac870e54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920896727 -> ac870e54
 

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 import app
 import pytest
+from tests.helpers.module_resolve import resolve_module
 
 
 class TestAppImport:
@@ -64,9 +65,8 @@ class TestAppImport:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Facade access must reapply additive bootstrap when legacy_app.app changes."""
-        import app.main as main_module
-
-        legacy_module = importlib.import_module("legacy_app")
+        main_module = resolve_module("app.main")
+        legacy_module = resolve_module("legacy_app")
 
         original_main_app = main_module.app
         replacement_app = FastAPI()

--- a/tests/test_main_ws_registration_guard.py
+++ b/tests/test_main_ws_registration_guard.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from tests.helpers.module_resolve import resolve_module
 
 
 def test_ws_duplicate_registration_guard_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     """Duplicate /ws path must fail fast to prevent silent route shadowing."""
-    import app.main as main_module
+    main_module = resolve_module("app.main")
 
     fake_app = SimpleNamespace(
         routes=[
@@ -25,7 +26,7 @@ def test_ws_duplicate_registration_guard_raises(monkeypatch: pytest.MonkeyPatch)
 def test_ws_duplicate_registration_guard_passes_without_ws_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import app.main as main_module
+    main_module = resolve_module("app.main")
 
     fake_app = SimpleNamespace(
         routes=[

--- a/tests/test_vip_shoplist_daily.py
+++ b/tests/test_vip_shoplist_daily.py
@@ -17,6 +17,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from tests.conftest import _disable_vip, _enable_vip
+from tests.helpers.module_resolve import resolve_module
 
 
 def _payload_one_item() -> dict:
@@ -86,7 +87,7 @@ def test_daily_missing_api_key_returns_401_or_403(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Missing API key should return 401 or 403."""
-    import app.main as app_main_module
+    app_main_module = resolve_module("app.main")
 
     _enable_vip(monkeypatch)
 

--- a/tests/test_vip_shoplist_router_hardening.py
+++ b/tests/test_vip_shoplist_router_hardening.py
@@ -18,9 +18,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-import app.main as app_main_module
 from core.shoplist_engine.models import FoodRef, PackPlan, Quantity, Unit
 from core.shoplist_engine.packager import PackagingResult
+from tests.helpers.module_resolve import resolve_module
 
 
 def _enable_vip(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -259,6 +259,7 @@ def test_generate_missing_api_key_returns_401_or_403(
     Статус может быть 401 или 403 — не фиксируем жёстко.
     """
     _enable_vip(monkeypatch)
+    app_main_module = resolve_module("app.main")
 
     # Create client WITHOUT VIP access (no dependency override)
     client = TestClient(app_main_module.app)
@@ -286,6 +287,7 @@ def test_generate_invalid_api_key_tier_returns_403(
 ) -> None:
     """Invalid API key (insufficient tier) should return 403 Forbidden."""
     _enable_vip(monkeypatch)
+    app_main_module = resolve_module("app.main")
 
     # Create client WITHOUT VIP access override
     client = TestClient(app_main_module.app)

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -603,8 +603,9 @@ def test_duplicate_ws_route_detection_raises_runtime_error(
 ) -> None:
     """Test that duplicate WS route registration raises RuntimeError for both paths."""
     from app.main import _assert_no_duplicate_ws_route
+    from tests.helpers.module_resolve import resolve_module
 
-    import app.main as main_mod
+    main_mod = resolve_module("app.main")
 
     mock_routes = [type("Route", (), {"path": ws_path})()]
 

--- a/tests/test_websocket_security_api.py
+++ b/tests/test_websocket_security_api.py
@@ -602,10 +602,10 @@ def test_duplicate_ws_route_detection_raises_runtime_error(
     ws_path: str,
 ) -> None:
     """Test that duplicate WS route registration raises RuntimeError for both paths."""
-    from app.main import _assert_no_duplicate_ws_route
     from tests.helpers.module_resolve import resolve_module
 
     main_mod = resolve_module("app.main")
+    assert_no_duplicate_ws_route = main_mod._assert_no_duplicate_ws_route
 
     mock_routes = [type("Route", (), {"path": ws_path})()]
 
@@ -617,4 +617,4 @@ def test_duplicate_ws_route_detection_raises_runtime_error(
     monkeypatch.setattr(main_mod, "app", MockApp())
 
     with pytest.raises(RuntimeError, match="Duplicate"):
-        _assert_no_duplicate_ws_route()
+        assert_no_duplicate_ws_route()


### PR DESCRIPTION
## Summary
- fix the `main` CI regression from run `22971371401`
- replace stale `app.main` module references in purge/reload-sensitive tests with runtime module resolution
- finish the websocket duplicate-route test so the guard function is read from the same runtime-resolved module object
- keep the fix isolated to the test layer and review-governance metadata

## Root Cause
`test-main (3.11)` and `test-main (3.12)` were failing on:
- `tests/test_app_basic_combined.py::TestAppImport::test_app_package_rehydrates_bootstrap_after_legacy_app_swap`

The failing path depended on direct `app.main` module references inside purge/reload-sensitive suites. A follow-up review then found that one websocket test still mixed direct symbol import with runtime module resolution, leaving a stale-reference hole in the test fix itself.

## Changes
- use `tests.helpers.module_resolve.resolve_module("app.main")` in the failing regression test and adjacent purge/reload-sensitive tests
- remove one module-level `app.main` import from VIP shoplist router hardening tests
- resolve `_assert_no_duplicate_ws_route` from the same runtime-resolved `app.main` module in `tests/test_websocket_security_api.py`
- add the canonical review mapping artifact for PR `#1122`

## Validation
- `pytest -q tests/test_websocket_security_api.py -k duplicate_ws_route_detection_raises_runtime_error -q`
- `make verify`
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: ac870e54
Evidence: `tests/test_websocket_security_api.py:607`, `tests/test_websocket_security_api.py:608`, `tests/test_websocket_security_api.py:620` keep `_assert_no_duplicate_ws_route` bound to the runtime-resolved `app.main` module so the patched `main_mod.app` and asserted guard function stay synchronized.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#pullrequestreview-3932408563 -> ac870e54
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#pullrequestreview-3932431155 -> ac870e54
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920875349 -> ac870e54
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1122#discussion_r2920896727 -> ac870e54

## Merge Readiness
- [x] Local hard gate passed (`make verify`)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test setup to resolve modules at runtime, reducing import side‑effects and stabilizing test execution.

* **Documentation**
  * Added review documentation mapping fixes to commits, with supporting evidence and a merge‑readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
