### PR TITLE
fix(ci): make phase2 artifact-first

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -240,7 +240,7 @@ Run before merge after latest commit and latest bot/review activity:
 
 **Phase2 PR body gates (CI):** To pass `check_pr_body_phase2_gates.py` and merge-readiness:
 - In PR description, under **Discussion Thread Pass**: check `[x] Discussion-thread pass completed` and `[x] Fixed in commit mapping completed`.
-- In the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`: list each bot comment as `- <comment-url> -> <commit-sha>` or use exactly `- No actionable review comments`.
+- In the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`: list each bot comment as `- <comment-url> -> <commit-sha>` or `- <comment-url>` depending on disposition, or use exactly `- No actionable review comments`.
 - Under **### Fixed in Commit Mapping** in the PR body: keep the mirror section present; mapping-line duplication is optional once the artifact exists.
 - Local check (no API): `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"` (use the same body as on the PR).
 

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -231,7 +231,7 @@ Run before merge after latest commit and latest bot/review activity:
 
 1. `gh pr checks <PR_NUMBER>` -> no failed/pending required checks
 2. `gh pr view <PR_NUMBER> --json mergeStateStatus,reviewDecision,isDraft`
-3. **Zero bot comments (hard rule):** Merge only when (a) **0 unresolved review threads** and (b) **every actionable bot comment is mapped** in PR body under `### Fixed in Commit Mapping`. **Do not** report "0 comments" or "ready to merge" based only on unresolved thread count — new bot comments can appear after a check; use the canonical script (below) and re-run after bot activity.
+3. **Zero bot comments (hard rule):** Merge only when (a) **0 unresolved review threads** and (b) **every actionable bot comment is mapped** in the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`. PR body is mirror-only when `pr_number` is available. **Do not** report "0 comments" or "ready to merge" based only on unresolved thread count — new bot comments can appear after a check; use the canonical script (below) and re-run after bot activity.
 4. Confirm PR body sections are complete:
    - `## Discussion Thread Pass`
    - `### Fixed in Commit Mapping`
@@ -240,7 +240,8 @@ Run before merge after latest commit and latest bot/review activity:
 
 **Phase2 PR body gates (CI):** To pass `check_pr_body_phase2_gates.py` and merge-readiness:
 - In PR description, under **Discussion Thread Pass**: check `[x] Discussion-thread pass completed` and `[x] Fixed in commit mapping completed`.
-- Under **### Fixed in Commit Mapping**: either list each bot comment as `- <comment-url> -> <commit-sha>`, or use exactly (no extra text): `- No actionable review comments`.
+- In the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`: list each bot comment as `- <comment-url> -> <commit-sha>` or use exactly `- No actionable review comments`.
+- Under **### Fixed in Commit Mapping** in the PR body: keep the mirror section present; mapping-line duplication is optional once the artifact exists.
 - Local check (no API): `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"` (use the same body as on the PR).
 
 **Canonical verification (required before claiming "0 comments" or "ready to merge"):** Run the orchestration wrapper so Phase 2, merge-readiness, and disposition proof are checked together. Policy: see `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`.
@@ -275,14 +276,14 @@ query { repository(owner: "Katsiarynakavaleuskaya", name: "PulsePlate") {
 } }' --jq '.data.repository.pullRequest.reviewThreads | "total: \(.totalCount), unresolved: \([.nodes[] | select(.isResolved == false)] | length)"'
 ```
 
-Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conversation → resolve thread) and map any actionable bot comments under **### Fixed in Commit Mapping** in the PR body.
+Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conversation → resolve thread) and map any actionable bot comments in the canonical artifact.
 
 **Loop until zero comments (canonical cycle):** Repeat until merge-readiness script exits 0 and CI is green:
 
 1. **Commit** (fixes for code/docs); **push** to PR branch.
 2. **Watch CI:** `gh run list --branch "$(git branch --show-current)" --limit 3` then `gh run watch <RUN_ID> --exit-status` (or wait for run completion).
 3. **Check comments/governance:** `python scripts/orchestration/check_merge_ready.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`. If exit 1 → inspect the failing sub-gate output and fix before re-running.
-4. **Fix:** Resolve each new review thread (GitHub UI or GraphQL `resolveReviewThread`); add every UNMAPPED comment URL to PR body under `### Fixed in Commit Mapping` as `- <url> -> <commit-sha>`; if the bot asked for a code/docs change, implement it, commit, push, and use that commit sha in the mapping.
+4. **Fix:** Resolve each new review thread (GitHub UI or GraphQL `resolveReviewThread`); add every UNMAPPED comment URL to `docs/review/PR_<N>_FIXED_MAPPING.md`; if the bot asked for a code/docs change, implement it, commit, push, and use that commit sha in the mapping. Update the PR body mirror only after the canonical artifact is correct.
 5. **Re-run** step 3. If exit 0 and CI green → zero comments; only then is the PR ready for merge per AGENTS.md.
 
 Do not report "ready to merge" or "0 comments" until the script passes and CI is green.

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -14,7 +14,7 @@
 
 - **Do not merge when:**
   - Any review thread is unresolved.
-  - Any bot (CodeRabbit, Sourcery, Cubic, etc.) has posted a comment/review that is "actionable" (e.g. "Actionable comments posted", "Potential issue", "Prompt for AI Agents") and that comment URL is **not** present in the `### Fixed in Commit Mapping` section with a commit that addresses it.
+  - Any bot (CodeRabbit, Sourcery, Cubic, etc.) has posted a comment/review that is "actionable" (e.g. "Actionable comments posted", "Potential issue", "Prompt for AI Agents") and that comment URL is **not** present in the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md` with disposition proof that addresses it.
 
 ---
 

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -10,7 +10,7 @@
 
 - **Merge only when:**
   1. **Zero unresolved review threads** (every review thread on the PR is resolved in GitHub UI).
-  2. **Zero unmapped actionable bot comments** (every bot comment that contains actionable items is listed under `### Fixed in Commit Mapping` in the PR body as `- <comment-url> -> <commit-sha>`).
+  2. **Zero unmapped actionable bot comments** (every bot comment that contains actionable items is listed in the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`).
 
 - **Do not merge when:**
   - Any review thread is unresolved.
@@ -74,10 +74,10 @@ Underlying enforcement scripts remain canonical for their own domains:
 ## 5. PR body requirements (reminder)
 
 - `## Discussion Thread Pass` with checkboxes completed.
-- `### Fixed in Commit Mapping` with either:
-  - One line per actionable comment: `- <comment-url> -> <commit-sha>`, or
-  - Exactly: `- No actionable review comments` (when there are no actionable bot comments).
+- `### Fixed in Commit Mapping` present as a mirror section for human review.
 - `## Merge Readiness` section.
+
+Canonical review-thread mappings live in `docs/review/PR_<N>_FIXED_MAPPING.md`. The PR body no longer needs late-cycle URL→SHA duplication once the canonical artifact exists.
 
 See `RUNBOOK_AGENT.md` (Pre-merge readiness pass ~line 121, Phase2 PR body gates).
 

--- a/docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md
+++ b/docs/orchestration/PR_MERGE_WORKFLOW_MATRIX.md
@@ -8,8 +8,8 @@
 
 - [ ] Fetch and address all review comments (Codex, Sourcery, Cubic, CodeRabbit)
 - [ ] Resolve all review threads (`gh api graphql` resolveReviewThread)
-- [ ] Add Fixed in Commit Mapping: `- <review-url> -> <commit-sha>` for each actionable bot
-- [ ] PR body: Discussion Thread Pass checked, mapping section complete
+- [ ] Add Fixed in Commit Mapping: `- <review-url> -> <commit-sha>` for each actionable bot in `docs/review/PR_<N>_FIXED_MAPPING.md`
+- [ ] PR body: Discussion Thread Pass checked, mirror sections complete
 
 ---
 

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -29,7 +29,7 @@ Evidence:
 | Phase   | Gate              | Artifact                                | Blocks Merge |
 | ------- | ----------------- | --------------------------------------- | ------------ |
 | Phase 1 | CI hygiene        | workflows/checks                        | yes          |
-| Phase 2 | PR body contract  | PR body                                 | yes          |
+| Phase 2 | PR body mirror contract | canonical artifact + PR body mirror | yes          |
 | Phase 3 | Merge readiness   | unresolved threads + actionable mapping | yes          |
 | Phase 4 | Disposition proof | script semantics                        | yes          |
 
@@ -47,9 +47,10 @@ PR body **must mirror** the same review-governance sections for human review and
 - `## Discussion Thread Pass`
 - `### Fixed in Commit Mapping`
 - completed checkboxes matching the artifact
+- full URL→SHA mapping lines are required only in the canonical artifact when `pr_number` is available
 
 Canonical runtime behavior is artifact-first when `pr_number` is available.
-PR-body parsing is a temporary compatibility seam for local/body-only checks and human-readable review context.
+PR-body parsing is a temporary compatibility seam for local/body-only checks and human-readable review context. When `pr_number` is available, Phase 2 treats the artifact as authoritative and validates the PR body as a mirror-only contract.
 
 Temporary seam tracking:
 
@@ -68,11 +69,13 @@ Required sections (artifact and PR-body mirror):
 - Checkbox contract (completed / mapping completed)
 - `## Fixed in Commit Mapping`
 
-Valid mapping forms:
+Valid mapping forms in the canonical artifact:
 
 - `- <url> -> <sha>`
 - `- <url>`
 - `- No actionable review comments`
+
+PR body mirror requires the section headings and completed checkboxes. Mapping-line duplication in the body is optional once the canonical artifact exists.
 
 Evidence:
 - `scripts/orchestration/review_mapping_artifact.py:44`

--- a/docs/review/PR_1123_FIXED_MAPPING.md
+++ b/docs/review/PR_1123_FIXED_MAPPING.md
@@ -9,14 +9,17 @@ Disposition: FIXED
 Commit: f98d5905
 Evidence: `f98d5905` makes artifact-first mode fail closed on empty PR bodies in `scripts/ci/check_pr_body_phase2_gates.py:208-221`, replaces the bare-bool gate switch with explicit `BodyValidationMode` selection in `scripts/ci/check_pr_body_phase2_gates.py:54-125`, and differentiates the previously duplicated integration test in `tests/test_pr_body_phase2_gates.py:95-298`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#pullrequestreview-3932623499 -> f98d5905
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921081885 -> f98d5905
 
 Disposition: FIXED
 Commit: bf760c54
 Evidence: `bf760c54` removes the remaining PR-body/artifact contradiction in `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:13-16`, documents the URL-only artifact form in `RUNBOOK_AGENT.md:241-244`, and fixes the mirror-only local example to include `--pr-number` in `tests/AGENTS.md:437-443`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#pullrequestreview-3932627435 -> bf760c54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921085793 -> bf760c54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921085799 -> f98d5905
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#pullrequestreview-3932650405 -> bf760c54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106791 -> bf760c54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106798 -> bf760c54
 

--- a/docs/review/PR_1123_FIXED_MAPPING.md
+++ b/docs/review/PR_1123_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1123 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1123_FIXED_MAPPING.md
+++ b/docs/review/PR_1123_FIXED_MAPPING.md
@@ -28,6 +28,7 @@ Commit: b6fec9cc
 Evidence: `b6fec9cc` removes the dead `artifact_checked`-only success branch from `scripts/ci/check_pr_body_phase2_gates.py:227-232`, keeping the artifact-first success path reachable only through the enforced non-empty PR body mirror.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#pullrequestreview-3932719737 -> b6fec9cc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921156745 -> b6fec9cc
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1123_FIXED_MAPPING.md
+++ b/docs/review/PR_1123_FIXED_MAPPING.md
@@ -5,7 +5,20 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: f98d5905
+Evidence: `f98d5905` makes artifact-first mode fail closed on empty PR bodies in `scripts/ci/check_pr_body_phase2_gates.py:208-221`, replaces the bare-bool gate switch with explicit `BodyValidationMode` selection in `scripts/ci/check_pr_body_phase2_gates.py:54-125`, and differentiates the previously duplicated integration test in `tests/test_pr_body_phase2_gates.py:95-298`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921081885 -> f98d5905
+
+Disposition: FIXED
+Commit: bf760c54
+Evidence: `bf760c54` removes the remaining PR-body/artifact contradiction in `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:13-16`, documents the URL-only artifact form in `RUNBOOK_AGENT.md:241-244`, and fixes the mirror-only local example to include `--pr-number` in `tests/AGENTS.md:437-443`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921085793 -> bf760c54
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921085799 -> f98d5905
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106791 -> bf760c54
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106798 -> bf760c54
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1123_FIXED_MAPPING.md
+++ b/docs/review/PR_1123_FIXED_MAPPING.md
@@ -23,6 +23,12 @@ Evidence: `bf760c54` removes the remaining PR-body/artifact contradiction in `do
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106791 -> bf760c54
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#discussion_r2921106798 -> bf760c54
 
+Disposition: FIXED
+Commit: b6fec9cc
+Evidence: `b6fec9cc` removes the dead `artifact_checked`-only success branch from `scripts/ci/check_pr_body_phase2_gates.py:227-232`, keeping the artifact-first success path reachable only through the enforced non-empty PR body mirror.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1123#pullrequestreview-3932719737 -> b6fec9cc
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -232,11 +232,8 @@ def main() -> int:
             print(f"- {item}")
         return 1
 
-    if artifact_checked and body_checked:
-        print("phase2-pr-body-gates: canonical mapping artifact and PR body mirror passed.")
-        return 0
     if artifact_checked:
-        print("phase2-pr-body-gates: canonical mapping artifact passed.")
+        print("phase2-pr-body-gates: canonical mapping artifact and PR body mirror passed.")
         return 0
 
     print("phase2-pr-body-gates: passed.")

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -105,7 +105,7 @@ def _extract_mapping_section(text: str) -> str:
     return text[start:end]
 
 
-def check_pr_body_phase2_gates(body: str) -> list[str]:
+def check_pr_body_phase2_gates(body: str, *, require_mapping_details: bool = True) -> list[str]:
     errors: list[str] = []
     cleaned = _strip_fenced_code_blocks(body)
 
@@ -128,22 +128,23 @@ def check_pr_body_phase2_gates(body: str) -> list[str]:
             f"Checklist item must be checked: `{PHASE2_CONFIG['mapping_checkbox_label']}`."
         )
 
-    mapping_section = _extract_mapping_section(cleaned)
-    has_mapping_entries = bool(
-        MAPPING_ENTRY_RE.search(mapping_section) or THREAD_ENTRY_RE.search(mapping_section)
-    )
-    has_na_mapping = bool(MAPPING_NA_RE.search(mapping_section))
-    if not has_mapping_entries and not has_na_mapping:
-        errors.append(
-            "Add at least one review-thread entry "
-            "(`- <review-comment-url>` or `- <review-comment-url> -> <commit-sha>`) "
-            "or `- No actionable review comments`."
+    if require_mapping_details:
+        mapping_section = _extract_mapping_section(cleaned)
+        has_mapping_entries = bool(
+            MAPPING_ENTRY_RE.search(mapping_section) or THREAD_ENTRY_RE.search(mapping_section)
         )
-    if has_mapping_entries and has_na_mapping:
-        errors.append(
-            "Invalid mixed mode: 'No actionable review comments' cannot appear "
-            "together with SHA mappings (use one or the other)."
-        )
+        has_na_mapping = bool(MAPPING_NA_RE.search(mapping_section))
+        if not has_mapping_entries and not has_na_mapping:
+            errors.append(
+                "Add at least one review-thread entry "
+                "(`- <review-comment-url>` or `- <review-comment-url> -> <commit-sha>`) "
+                "or `- No actionable review comments`."
+            )
+        if has_mapping_entries and has_na_mapping:
+            errors.append(
+                "Invalid mixed mode: 'No actionable review comments' cannot appear "
+                "together with SHA mappings (use one or the other)."
+            )
 
     return errors
 
@@ -192,7 +193,12 @@ def main() -> int:
 
     if body.strip():
         body_checked = True
-        body_errors.extend(check_pr_body_phase2_gates(body=body))
+        body_errors.extend(
+            check_pr_body_phase2_gates(
+                body=body,
+                require_mapping_details=not artifact_checked,
+            )
+        )
     elif pr_number is None:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
@@ -209,7 +215,7 @@ def main() -> int:
         return 1
 
     if artifact_checked and body_checked:
-        print("phase2-pr-body-gates: canonical mapping artifact and PR body passed.")
+        print("phase2-pr-body-gates: canonical mapping artifact and PR body mirror passed.")
         return 0
     if artifact_checked:
         print("phase2-pr-body-gates: canonical mapping artifact passed.")

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import re
 import sys
+from enum import Enum
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -47,6 +48,13 @@ MAPPING_ENTRY_RE = re.compile(
 THREAD_ENTRY_RE = re.compile(r"(?im)^\s*-\s*`?(https?://[^\s`]+)`?\s*$")
 _na_alternatives = "|".join(re.escape(a) for a in PHASE2_CONFIG["mapping_na_alternatives"])
 MAPPING_NA_RE = re.compile(rf"(?im)^\s*-\s*(?:{_na_alternatives})\s*$")
+
+
+class BodyValidationMode(str, Enum):
+    """Explicit Phase2 body validation modes for artifact-first vs fallback checks."""
+
+    FULL_MAPPING = "full_mapping"
+    MIRROR_ONLY = "mirror_only"
 
 
 def _strip_fenced_code_blocks(text: str) -> str:
@@ -105,7 +113,18 @@ def _extract_mapping_section(text: str) -> str:
     return text[start:end]
 
 
-def check_pr_body_phase2_gates(body: str, *, require_mapping_details: bool = True) -> list[str]:
+def _select_body_validation_mode(*, artifact_checked: bool) -> BodyValidationMode:
+    """Choose body validation mode from the canonical artifact/body contract."""
+    if artifact_checked:
+        return BodyValidationMode.MIRROR_ONLY
+    return BodyValidationMode.FULL_MAPPING
+
+
+def check_pr_body_phase2_gates(
+    body: str,
+    *,
+    mode: BodyValidationMode = BodyValidationMode.FULL_MAPPING,
+) -> list[str]:
     errors: list[str] = []
     cleaned = _strip_fenced_code_blocks(body)
 
@@ -128,7 +147,7 @@ def check_pr_body_phase2_gates(body: str, *, require_mapping_details: bool = Tru
             f"Checklist item must be checked: `{PHASE2_CONFIG['mapping_checkbox_label']}`."
         )
 
-    if require_mapping_details:
+    if mode is BodyValidationMode.FULL_MAPPING:
         mapping_section = _extract_mapping_section(cleaned)
         has_mapping_entries = bool(
             MAPPING_ENTRY_RE.search(mapping_section) or THREAD_ENTRY_RE.search(mapping_section)
@@ -191,17 +210,16 @@ def main() -> int:
         artifact_checked = True
         artifact_errors.extend(validate_mapping_artifact_text(artifact_text))
 
-    if body.strip():
-        body_checked = True
-        body_errors.extend(
-            check_pr_body_phase2_gates(
-                body=body,
-                require_mapping_details=not artifact_checked,
-            )
-        )
-    elif pr_number is None:
+    if not body.strip():
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
+    body_checked = True
+    body_errors.extend(
+        check_pr_body_phase2_gates(
+            body=body,
+            mode=_select_body_validation_mode(artifact_checked=artifact_checked),
+        )
+    )
 
     errors = [*artifact_errors, *body_errors]
     if errors:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -435,7 +435,7 @@ pytest -q tests/test_repo_policy_guards.py
   - **How to run**:
     ```bash
     pytest -q tests/test_pr_body_phase2_gates.py
-    python scripts/ci/check_pr_body_phase2_gates.py --body "## Discussion Thread Pass
+    python scripts/ci/check_pr_body_phase2_gates.py --pr-number 999 --body "## Discussion Thread Pass
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 ### Fixed in Commit Mapping

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -430,7 +430,8 @@ pytest -q tests/test_repo_policy_guards.py
   - **What it enforces**:
     - PR body contains `## Discussion Thread Pass` and `### Fixed in Commit Mapping`.
     - Checkboxes `Discussion-thread pass completed` and `Fixed in commit mapping completed` are checked.
-    - Mapping contains either comment-to-commit lines (`url -> sha`) or `No actionable review comments`.
+    - In body-only fallback mode, mapping contains either comment-to-commit lines (`url -> sha`) or `No actionable review comments`.
+    - When the canonical artifact exists, PR body is mirror-only and does not need duplicated URL→SHA lines.
   - **How to run**:
     ```bash
     pytest -q tests/test_pr_body_phase2_gates.py
@@ -438,12 +439,12 @@ pytest -q tests/test_repo_policy_guards.py
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 ### Fixed in Commit Mapping
-- No actionable review comments"
+- canonical artifact: docs/review/PR_999_FIXED_MAPPING.md"
     ```
   - **How to fix failures**:
     - Update PR body using template sections exactly (headings + checkbox labels).
     - Mark both checkboxes as completed after discussion-thread pass.
-    - Add explicit mapping entries for each addressed bot review comment.
+    - Add explicit mapping entries for each addressed bot review comment in the canonical artifact.
 
 - **Wellness language BLOCKER guard**: `tests/guards/test_wellness_language_blockers_guard.py`
   - **What it enforces**:

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -95,9 +95,20 @@ def test_phase2_guard_accepts_no_actionable_comments_marker() -> None:
 def test_phase2_guard_accepts_mirror_only_body_when_mapping_details_not_required() -> None:
     errors = gates.check_pr_body_phase2_gates(
         body=VALID_BODY_MIRROR_ONLY,
-        require_mapping_details=False,
+        mode=gates.BodyValidationMode.MIRROR_ONLY,
     )
     assert errors == []
+
+
+def test_select_body_validation_mode_prefers_mirror_when_artifact_exists() -> None:
+    assert (
+        gates._select_body_validation_mode(artifact_checked=True)
+        is gates.BodyValidationMode.MIRROR_ONLY
+    )
+    assert (
+        gates._select_body_validation_mode(artifact_checked=False)
+        is gates.BodyValidationMode.FULL_MAPPING
+    )
 
 
 def test_phase2_guard_rejects_missing_sections() -> None:
@@ -269,9 +280,9 @@ Commit: abc1234
     assert "canonical mapping artifact and PR body mirror passed" in result.stdout
 
 
-def test_phase2_accepts_body_without_mapping_entries_when_artifact_is_valid(tmp_path: Path) -> None:
-    """Artifact-first mode should not require mirrored URL->SHA lines in the PR body."""
-    event = {"pull_request": {"number": 998, "body": VALID_BODY_MIRROR_ONLY}}
+def test_phase2_rejects_empty_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
+    """Artifact-first mode still requires a non-empty body mirror."""
+    event = {"pull_request": {"number": 998, "body": ""}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
 
@@ -299,8 +310,8 @@ Commit: abc1234
         cwd=str(repo_root),
         env=env,
     )
-    assert result.returncode == 0
-    assert "canonical mapping artifact and PR body mirror passed" in result.stdout
+    assert result.returncode == 1
+    assert "ERROR: Empty PR body." in result.stdout
 
 
 def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -21,6 +21,17 @@ Phase2 PR body gate implementation.
 - https://github.com/org/repo/pull/719#issuecomment-123 -> 28069fd4
 """
 
+VALID_BODY_MIRROR_ONLY = """## Summary
+Phase2 PR body gate implementation.
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+- canonical artifact: `docs/review/PR_998_FIXED_MAPPING.md`
+"""
+
 
 def test_phase2_guard_accepts_valid_mapping() -> None:
     errors = gates.check_pr_body_phase2_gates(body=VALID_BODY_WITH_MAPPING)
@@ -78,6 +89,14 @@ def test_phase2_guard_accepts_no_actionable_comments_marker() -> None:
         "- No actionable review comments",
     )
     errors = gates.check_pr_body_phase2_gates(body=body)
+    assert errors == []
+
+
+def test_phase2_guard_accepts_mirror_only_body_when_mapping_details_not_required() -> None:
+    errors = gates.check_pr_body_phase2_gates(
+        body=VALID_BODY_MIRROR_ONLY,
+        require_mapping_details=False,
+    )
     assert errors == []
 
 
@@ -217,8 +236,8 @@ def test_extract_pr_body_returns_empty_for_non_object_pull_request(tmp_path: Pat
 
 
 def test_phase2_uses_artifact_when_pr_number_in_event(tmp_path: Path) -> None:
-    """When event has pr_number, Phase2 validates artifact and mirrored PR body."""
-    event = {"pull_request": {"number": 998, "body": VALID_BODY_WITH_MAPPING}}
+    """When event has pr_number, Phase2 validates the artifact and body mirror."""
+    event = {"pull_request": {"number": 998, "body": VALID_BODY_MIRROR_ONLY}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
 
@@ -247,11 +266,45 @@ Commit: abc1234
         env=env,
     )
     assert result.returncode == 0
-    assert "canonical mapping artifact and PR body passed" in result.stdout
+    assert "canonical mapping artifact and PR body mirror passed" in result.stdout
+
+
+def test_phase2_accepts_body_without_mapping_entries_when_artifact_is_valid(tmp_path: Path) -> None:
+    """Artifact-first mode should not require mirrored URL->SHA lines in the PR body."""
+    event = {"pull_request": {"number": 998, "body": VALID_BODY_MIRROR_ONLY}}
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "canonical mapping artifact and PR body mirror passed" in result.stdout
 
 
 def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
-    """Artifact success must not bypass PR body validation."""
+    """Artifact success must not bypass required body mirror sections."""
     event = {"pull_request": {"number": 998, "body": "minimal"}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping


### PR DESCRIPTION
## Summary
- makes Phase 2 gating artifact-first when a canonical `docs/review/PR_<N>_FIXED_MAPPING.md` artifact exists
- keeps PR body as the required human-readable mirror while removing late-wave URL to SHA duplication pressure
- updates governance docs and tests to preserve strict body-only fallback semantics

## Scope
- `scripts/ci/check_pr_body_phase2_gates.py`
- `tests/test_pr_body_phase2_gates.py`
- `RUNBOOK_AGENT.md`
- `docs/orchestration/*phase2/merge-readiness governance docs`
- `tests/AGENTS.md`
- `docs/review/PR_1123_FIXED_MAPPING.md`

## Validation
- `python3 -m scripts.orchestration.check_preflight`
- `pytest -q tests/test_pr_body_phase2_gates.py tests/test_review_mapping_artifact.py tests/test_orchestration_merge_ready.py tests/test_pr_merge_readiness_gate.py`
- `pre-commit run --all-files`
- `make verify`

## Carryover
- includes the small PR8 wording carryover only where it intersects phase2 artifact-first governance wording; no runtime scope expansion

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Deferred/follow-up items mirrored in backlog when applicable

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1123_FIXED_MAPPING.md`

## Merge Readiness
- [x] local hard gate passed (`make verify`)
- [x] focused internal tooling/docs scope
- [ ] bot reviews addressed
- [ ] merge-readiness gate green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow documentation to reflect support for canonical artifact-based mapping storage.
  * Clarified validation process for PR body content when canonical artifacts are present.

* **Chores**
  * Enhanced validation scripts to support both canonical artifact and PR body review modes.
  * Extended test coverage for mirror-only validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->