### PR TITLE
refactor(ai): tighten creative research domain typing

### DIFF
--- a/app/services/creative_research_runtime.py
+++ b/app/services/creative_research_runtime.py
@@ -36,6 +36,7 @@ from app.security.server_salt import require_server_salt
 from app.telemetry.genai import finalize_llm_span, llm_span, set_attributes
 from core.compliance import get_transparency_registry
 from core.creative_research import (
+    CONFIDENCE_LEVELS,
     SCHEMA_VERSION,
     TASK_CLASS,
     CreativeResearchBundleRecord,
@@ -153,7 +154,7 @@ def _normalize_provider_candidate(
     """Normalize provider output into the creative-research contract."""
 
     confidence = str(candidate.get("confidence", "unknown")).strip().lower() or "unknown"
-    if confidence not in {"low", "medium", "high", "unknown"}:
+    if confidence not in CONFIDENCE_LEVELS:
         confidence = "unknown"
     normalized_confidence = cast(CreativeResearchConfidence, confidence)
     known_risks_raw = candidate.get("known_risks", [])

--- a/app/services/creative_research_runtime.py
+++ b/app/services/creative_research_runtime.py
@@ -11,7 +11,7 @@ import hashlib
 import json
 import logging
 import os
-from typing import Any
+from typing import cast
 
 from fastapi import HTTPException, status
 from fastapi.concurrency import run_in_threadpool
@@ -35,7 +35,14 @@ from app.security.llm_monthly_quota import attempt_consume_llm_monthly_quota
 from app.security.server_salt import require_server_salt
 from app.telemetry.genai import finalize_llm_span, llm_span, set_attributes
 from core.compliance import get_transparency_registry
-from core.creative_research import SCHEMA_VERSION, TASK_CLASS, evaluate_bundle
+from core.creative_research import (
+    SCHEMA_VERSION,
+    TASK_CLASS,
+    CreativeResearchBundleRecord,
+    CreativeResearchCandidateRecord,
+    CreativeResearchConfidence,
+    evaluate_bundle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +123,7 @@ Reference corpus:
 """.strip()
 
 
-def _extract_json_payload(raw_message: str) -> dict[str, Any]:
+def _extract_json_payload(raw_message: str) -> dict[str, object]:
     """Extract the first JSON object from provider text, tolerating fenced output."""
 
     stripped = raw_message.strip()
@@ -138,40 +145,46 @@ def _extract_json_payload(raw_message: str) -> dict[str, Any]:
     return loaded
 
 
-def _normalize_provider_candidate(candidate: dict[str, Any], *, index: int) -> dict[str, Any]:
+def _normalize_provider_candidate(
+    candidate: dict[str, object],
+    *,
+    index: int,
+) -> CreativeResearchCandidateRecord:
     """Normalize provider output into the creative-research contract."""
 
     confidence = str(candidate.get("confidence", "unknown")).strip().lower() or "unknown"
     if confidence not in {"low", "medium", "high", "unknown"}:
         confidence = "unknown"
+    normalized_confidence = cast(CreativeResearchConfidence, confidence)
     known_risks_raw = candidate.get("known_risks", [])
     if isinstance(known_risks_raw, list):
         known_risks = [str(item).strip() for item in known_risks_raw if str(item).strip()]
     else:
         known_risks = []
-    return {
+    candidate_record: CreativeResearchCandidateRecord = {
         "candidate_id": str(candidate.get("candidate_id", "")).strip() or f"candidate-{index}",
         "claim": str(candidate.get("claim", "")).strip(),
         "mechanism": str(candidate.get("mechanism", "")).strip(),
         "evidence_needed": str(candidate.get("evidence_needed", "")).strip(),
         "falsifier": str(candidate.get("falsifier", "")).strip(),
-        "confidence": confidence,
+        "confidence": normalized_confidence,
         "known_risks": known_risks,
         "wellness_boundary": (
             str(candidate.get("wellness_boundary", "")).strip()
             or "Wellness only; not diagnosis, treatment, or medical advice."
         ),
     }
+    return candidate_record
 
 
 def _normalize_provider_bundle(
-    payload: dict[str, Any],
+    payload: dict[str, object],
     *,
     prompt_seed: str,
     reference_corpus: list[str],
     candidate_count: int,
     bundle_id: str,
-) -> dict[str, Any]:
+) -> CreativeResearchBundleRecord:
     """Normalize provider JSON into the canonical evaluation bundle."""
 
     raw_candidates = payload.get("candidates", payload)
@@ -188,7 +201,7 @@ def _normalize_provider_bundle(
         raise ValueError("Provider response candidates must be objects.")
     if len(normalized_candidates) < candidate_count:
         raise ValueError("Provider returned fewer valid candidates than requested.")
-    return {
+    bundle_record: CreativeResearchBundleRecord = {
         "schema_version": SCHEMA_VERSION,
         "bundle_id": str(payload.get("bundle_id", "")).strip() or bundle_id,
         "task_class": TASK_CLASS,
@@ -197,6 +210,7 @@ def _normalize_provider_bundle(
         "reference_corpus": reference_corpus[:MAX_RETRIEVAL_HOPS],
         "candidates": normalized_candidates,
     }
+    return bundle_record
 
 
 def _persist_privileged_action_audit(
@@ -230,7 +244,7 @@ async def _generate_provider_bundle(
     *,
     prompt: str,
     bundle_id: str,
-) -> dict[str, Any]:
+) -> CreativeResearchBundleRecord:
     """Generate one bounded provider-backed creative-research bundle."""
 
     try:

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -415,14 +415,15 @@ def classify_output(
 ) -> tuple[CreativeResearchOutputClass, list[str]]:
     """Return the deterministic output class and triggered control labels."""
 
+    candidate_required_values = {
+        "mechanism": candidate["mechanism"],
+        "evidence_needed": candidate["evidence_needed"],
+        "falsifier": candidate["falsifier"],
+    }
     missing_required = [
         field_name
-        for field_name, value in (
-            ("mechanism", candidate["mechanism"]),
-            ("evidence_needed", candidate["evidence_needed"]),
-            ("falsifier", candidate["falsifier"]),
-        )
-        if not value.strip()
+        for field_name in DISCOVERY_REQUIRED_FIELDS
+        if not candidate_required_values[field_name].strip()
     ]
     controls: list[str] = []
     if missing_required:

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -10,22 +10,108 @@ paths.
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Literal, TypedDict, cast
 
 from core.insight.philosophy_validator import validate_llm_output
 
 SCHEMA_VERSION = "1.0"
 TASK_CLASS = "creative_research"
-VALID_PHASES: tuple[str, ...] = ("divergence", "convergence", "verification")
-CONFIDENCE_LEVELS: tuple[str, ...] = ("low", "medium", "high", "unknown")
-OUTPUT_CLASSES: tuple[str, ...] = (
+CreativeResearchPhase = Literal["divergence", "convergence", "verification"]
+CreativeResearchConfidence = Literal["low", "medium", "high", "unknown"]
+CreativeResearchOutputClass = Literal[
+    "mechanistic_hypothesis",
+    "experimental_proposal",
+    "anomaly_explanation_candidate",
+    "creative_ideation",
+]
+CreativeResearchPromotionDecision = Literal["promote", "defer", "discard"]
+
+VALID_PHASES: tuple[CreativeResearchPhase, ...] = ("divergence", "convergence", "verification")
+CONFIDENCE_LEVELS: tuple[CreativeResearchConfidence, ...] = ("low", "medium", "high", "unknown")
+OUTPUT_CLASSES: tuple[CreativeResearchOutputClass, ...] = (
     "mechanistic_hypothesis",
     "experimental_proposal",
     "anomaly_explanation_candidate",
     "creative_ideation",
 )
-PROMOTION_DECISIONS: tuple[str, ...] = ("promote", "defer", "discard")
+PROMOTION_DECISIONS: tuple[CreativeResearchPromotionDecision, ...] = (
+    "promote",
+    "defer",
+    "discard",
+)
 DISCOVERY_REQUIRED_FIELDS: tuple[str, ...] = ("mechanism", "evidence_needed", "falsifier")
+
+
+class CreativeResearchCandidateRecord(TypedDict):
+    """Validated creative-research candidate record."""
+
+    candidate_id: str
+    claim: str
+    mechanism: str
+    evidence_needed: str
+    falsifier: str
+    confidence: CreativeResearchConfidence
+    known_risks: list[str]
+    wellness_boundary: str
+
+
+class CreativeResearchBundleRecord(TypedDict):
+    """Validated creative-research bundle record."""
+
+    schema_version: str
+    bundle_id: str
+    task_class: str
+    phase: CreativeResearchPhase
+    prompt_seed: str
+    reference_corpus: list[str]
+    candidates: list[CreativeResearchCandidateRecord]
+
+
+class CreativeResearchScorecardRecord(TypedDict):
+    """Deterministic creative-research scorecard record."""
+
+    originality: int
+    flexibility: int
+    mechanism_specificity: int
+    groundedness: int
+    falsifiability: int
+    wellness_safety: int
+    hallucination_risk: int
+
+
+class CreativeResearchEvaluatedCandidateRecord(CreativeResearchCandidateRecord):
+    """Evaluated candidate record with deterministic outputs."""
+
+    output_class: CreativeResearchOutputClass
+    reference_overlap: float
+    peer_overlap: float
+    negative_controls_triggered: list[str]
+    scorecard: CreativeResearchScorecardRecord
+    promotion_decision: CreativeResearchPromotionDecision
+    presentation_label: str | None
+
+
+class CreativeResearchEvaluationSummaryRecord(TypedDict):
+    """Aggregate promote/defer/discard counts for one bundle."""
+
+    candidate_count: int
+    promote: int
+    defer: int
+    discard: int
+
+
+class CreativeResearchEvaluationResultRecord(TypedDict):
+    """Fully evaluated creative-research bundle record."""
+
+    schema_version: str
+    bundle_id: str
+    task_class: str
+    phase: CreativeResearchPhase
+    prompt_seed: str
+    reference_corpus_size: int
+    summary: CreativeResearchEvaluationSummaryRecord
+    candidates: list[CreativeResearchEvaluatedCandidateRecord]
+
 
 TOKEN_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
 STOPWORDS = {
@@ -136,14 +222,27 @@ def normalize_creative_research_text(*parts: str) -> str:
     return " ".join(raw.split())
 
 
-def _require_non_empty_string(payload: dict[str, Any], *, key: str, label: str) -> str:
+def _require_object_mapping(
+    raw: object,
+    *,
+    label: str,
+    expected_phrase: str = "an object",
+) -> dict[str, object]:
+    """Validate raw object payloads before domain normalization."""
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"{label} must be {expected_phrase}.")
+    return {str(key): value for key, value in raw.items()}
+
+
+def _require_non_empty_string(payload: dict[str, object], *, key: str, label: str) -> str:
     value = str(payload.get(key, "")).strip()
     if not value:
         raise ValueError(f"{label} must include a non-empty {key}.")
     return value
 
 
-def _normalize_string_list(raw: Any, *, label: str) -> list[str]:
+def _normalize_string_list(raw: object, *, label: str) -> list[str]:
     if not isinstance(raw, list):
         raise ValueError(f"{label} must be a list.")
     values = [str(item).strip() for item in raw if str(item).strip()]
@@ -202,13 +301,16 @@ def _contains_any(text: str, hints: tuple[str, ...]) -> bool:
     return _count_hints(text, hints) > 0
 
 
-def validate_bundle(payload: Any) -> dict[str, Any]:
+def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
     """Validate and normalize a creative research bundle."""
 
-    if not isinstance(payload, dict):
-        raise ValueError("Creative research eval bundle must be a JSON object.")
+    payload_dict = _require_object_mapping(
+        payload,
+        label="Creative research eval bundle",
+        expected_phrase="a JSON object",
+    )
 
-    schema_version = str(payload.get("schema_version", "")).strip()
+    schema_version = str(payload_dict.get("schema_version", "")).strip()
     if schema_version != SCHEMA_VERSION:
         raise ValueError(
             f"Creative research eval bundle schema_version must equal {SCHEMA_VERSION!r}, "
@@ -216,12 +318,12 @@ def validate_bundle(payload: Any) -> dict[str, Any]:
         )
 
     bundle_id = _require_non_empty_string(
-        payload,
+        payload_dict,
         key="bundle_id",
         label="Creative research eval bundle",
     )
     task_class = _require_non_empty_string(
-        payload,
+        payload_dict,
         key="task_class",
         label="Creative research eval bundle",
     ).lower()
@@ -229,7 +331,7 @@ def validate_bundle(payload: Any) -> dict[str, Any]:
         raise ValueError(f"Creative research eval bundle task_class must equal {TASK_CLASS!r}.")
 
     phase = _require_non_empty_string(
-        payload,
+        payload_dict,
         key="phase",
         label="Creative research eval bundle",
     ).lower()
@@ -238,26 +340,28 @@ def validate_bundle(payload: Any) -> dict[str, Any]:
         raise ValueError(f"Creative research eval bundle phase must be one of: {allowed}.")
 
     prompt_seed = _require_non_empty_string(
-        payload,
+        payload_dict,
         key="prompt_seed",
         label="Creative research eval bundle",
     )
     reference_corpus = _normalize_string_list(
-        payload.get("reference_corpus", []),
+        payload_dict.get("reference_corpus", []),
         label="Creative research eval bundle reference_corpus",
     )
 
-    candidates_raw = payload.get("candidates")
+    candidates_raw = payload_dict.get("candidates")
     if not isinstance(candidates_raw, list) or not candidates_raw:
         raise ValueError("Creative research eval bundle candidates must be a non-empty list.")
 
-    candidates: list[dict[str, Any]] = []
+    candidates: list[CreativeResearchCandidateRecord] = []
     for index, candidate_raw in enumerate(candidates_raw, start=1):
-        if not isinstance(candidate_raw, dict):
-            raise ValueError(f"Creative research candidate #{index} must be an object.")
+        candidate_payload = _require_object_mapping(
+            candidate_raw,
+            label=f"Creative research candidate #{index}",
+        )
         label = f"Creative research candidate #{index}"
         confidence = _require_non_empty_string(
-            candidate_raw,
+            candidate_payload,
             key="confidence",
             label=label,
         ).lower()
@@ -265,50 +369,60 @@ def validate_bundle(payload: Any) -> dict[str, Any]:
             allowed = ", ".join(CONFIDENCE_LEVELS)
             raise ValueError(f"{label} confidence must be one of: {allowed}.")
 
-        candidates.append(
-            {
-                "candidate_id": _require_non_empty_string(
-                    candidate_raw,
-                    key="candidate_id",
-                    label=label,
-                ),
-                "claim": _require_non_empty_string(
-                    candidate_raw,
-                    key="claim",
-                    label=label,
-                ),
-                "mechanism": str(candidate_raw.get("mechanism", "")).strip(),
-                "evidence_needed": str(candidate_raw.get("evidence_needed", "")).strip(),
-                "falsifier": str(candidate_raw.get("falsifier", "")).strip(),
-                "confidence": confidence,
-                "known_risks": _normalize_string_list(
-                    candidate_raw.get("known_risks", []),
-                    label=f"{label} known_risks",
-                ),
-                "wellness_boundary": _require_non_empty_string(
-                    candidate_raw,
-                    key="wellness_boundary",
-                    label=label,
-                ),
-            }
-        )
+        normalized_confidence = cast(CreativeResearchConfidence, confidence)
+        candidate: CreativeResearchCandidateRecord = {
+            "candidate_id": _require_non_empty_string(
+                candidate_payload,
+                key="candidate_id",
+                label=label,
+            ),
+            "claim": _require_non_empty_string(
+                candidate_payload,
+                key="claim",
+                label=label,
+            ),
+            "mechanism": str(candidate_payload.get("mechanism", "")).strip(),
+            "evidence_needed": str(candidate_payload.get("evidence_needed", "")).strip(),
+            "falsifier": str(candidate_payload.get("falsifier", "")).strip(),
+            "confidence": normalized_confidence,
+            "known_risks": _normalize_string_list(
+                candidate_payload.get("known_risks", []),
+                label=f"{label} known_risks",
+            ),
+            "wellness_boundary": _require_non_empty_string(
+                candidate_payload,
+                key="wellness_boundary",
+                label=label,
+            ),
+        }
+        candidates.append(candidate)
 
-    return {
+    normalized_phase = cast(CreativeResearchPhase, phase)
+    bundle_record: CreativeResearchBundleRecord = {
         "schema_version": schema_version,
         "bundle_id": bundle_id,
         "task_class": task_class,
-        "phase": phase,
+        "phase": normalized_phase,
         "prompt_seed": prompt_seed,
         "reference_corpus": reference_corpus,
         "candidates": candidates,
     }
+    return bundle_record
 
 
-def classify_output(candidate: dict[str, Any]) -> tuple[str, list[str]]:
+def classify_output(
+    candidate: CreativeResearchCandidateRecord,
+) -> tuple[CreativeResearchOutputClass, list[str]]:
     """Return the deterministic output class and triggered control labels."""
 
     missing_required = [
-        field_name for field_name in DISCOVERY_REQUIRED_FIELDS if not candidate[field_name].strip()
+        field_name
+        for field_name, value in (
+            ("mechanism", candidate["mechanism"]),
+            ("evidence_needed", candidate["evidence_needed"]),
+            ("falsifier", candidate["falsifier"]),
+        )
+        if not value.strip()
     ]
     controls: list[str] = []
     if missing_required:
@@ -316,7 +430,8 @@ def classify_output(candidate: dict[str, Any]) -> tuple[str, list[str]]:
         return "creative_ideation", controls
 
     classification_text = normalize_creative_research_text(
-        candidate["claim"], candidate["mechanism"]
+        candidate["claim"],
+        candidate["mechanism"],
     )
     if _contains_any(classification_text, ANOMALY_HINTS):
         return "anomaly_explanation_candidate", controls
@@ -326,13 +441,13 @@ def classify_output(candidate: dict[str, Any]) -> tuple[str, list[str]]:
 
 
 def build_scorecard(
-    candidate: dict[str, Any],
+    candidate: CreativeResearchCandidateRecord,
     *,
-    output_class: str,
+    output_class: CreativeResearchOutputClass,
     reference_overlap: float,
     peer_overlap: float,
     duplicate_candidate: bool,
-) -> tuple[dict[str, int], list[str]]:
+) -> tuple[CreativeResearchScorecardRecord, list[str]]:
     """Compute deterministic scorecard values and triggered controls."""
 
     combined_text = " ".join(
@@ -425,7 +540,7 @@ def build_scorecard(
     if not report.ok:
         hallucination_risk = 5
 
-    scorecard = {
+    scorecard: CreativeResearchScorecardRecord = {
         "originality": originality,
         "flexibility": flexibility,
         "mechanism_specificity": mechanism_specificity,
@@ -439,10 +554,10 @@ def build_scorecard(
 
 def select_promotion_decision(
     *,
-    output_class: str,
-    scorecard: dict[str, int],
+    output_class: CreativeResearchOutputClass,
+    scorecard: CreativeResearchScorecardRecord,
     negative_controls: list[str],
-) -> tuple[str, str | None]:
+) -> tuple[CreativeResearchPromotionDecision, str | None]:
     """Return deterministic promote/defer/discard plus optional degrade label."""
 
     if (
@@ -467,7 +582,7 @@ def select_promotion_decision(
     return "defer", "interesting but unverified hypothesis"
 
 
-def evaluate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
+def evaluate_bundle(bundle: object) -> CreativeResearchEvaluationResultRecord:
     """Evaluate a normalized creative research bundle into deterministic results."""
 
     validated = validate_bundle(bundle)
@@ -481,7 +596,7 @@ def evaluate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
         )
         for candidate in validated["candidates"]
     ]
-    evaluated_candidates: list[dict[str, Any]] = []
+    evaluated_candidates: list[CreativeResearchEvaluatedCandidateRecord] = []
 
     for index, candidate in enumerate(validated["candidates"]):
         output_class, controls = classify_output(candidate)
@@ -508,36 +623,41 @@ def evaluate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
             scorecard=scorecard,
             negative_controls=negative_controls,
         )
-        evaluated_candidates.append(
-            {
-                **candidate,
-                "output_class": output_class,
-                "reference_overlap": reference_overlap,
-                "peer_overlap": peer_overlap,
-                "negative_controls_triggered": negative_controls,
-                "scorecard": scorecard,
-                "promotion_decision": promotion_decision,
-                "presentation_label": degrade_label,
-            }
-        )
+        evaluated_candidate: CreativeResearchEvaluatedCandidateRecord = {
+            **candidate,
+            "output_class": output_class,
+            "reference_overlap": reference_overlap,
+            "peer_overlap": peer_overlap,
+            "negative_controls_triggered": negative_controls,
+            "scorecard": scorecard,
+            "promotion_decision": promotion_decision,
+            "presentation_label": degrade_label,
+        }
+        evaluated_candidates.append(evaluated_candidate)
 
-    decision_counts = {decision: 0 for decision in PROMOTION_DECISIONS}
+    decision_counts: dict[CreativeResearchPromotionDecision, int] = {
+        decision: 0 for decision in PROMOTION_DECISIONS
+    }
     for candidate in evaluated_candidates:
         decision_counts[candidate["promotion_decision"]] += 1
 
-    return {
+    summary: CreativeResearchEvaluationSummaryRecord = {
+        "candidate_count": len(evaluated_candidates),
+        "promote": decision_counts["promote"],
+        "defer": decision_counts["defer"],
+        "discard": decision_counts["discard"],
+    }
+    result: CreativeResearchEvaluationResultRecord = {
         "schema_version": SCHEMA_VERSION,
         "bundle_id": validated["bundle_id"],
         "task_class": validated["task_class"],
         "phase": validated["phase"],
         "prompt_seed": validated["prompt_seed"],
         "reference_corpus_size": len(validated["reference_corpus"]),
-        "summary": {
-            "candidate_count": len(evaluated_candidates),
-            **decision_counts,
-        },
+        "summary": summary,
         "candidates": evaluated_candidates,
     }
+    return result
 
 
 __all__ = [
@@ -548,6 +668,16 @@ __all__ = [
     "SCHEMA_VERSION",
     "TASK_CLASS",
     "VALID_PHASES",
+    "CreativeResearchBundleRecord",
+    "CreativeResearchCandidateRecord",
+    "CreativeResearchConfidence",
+    "CreativeResearchEvaluatedCandidateRecord",
+    "CreativeResearchEvaluationResultRecord",
+    "CreativeResearchEvaluationSummaryRecord",
+    "CreativeResearchOutputClass",
+    "CreativeResearchPhase",
+    "CreativeResearchPromotionDecision",
+    "CreativeResearchScorecardRecord",
     "_count_hints",
     "build_scorecard",
     "classify_output",

--- a/docs/review/PR_1124_FIXED_MAPPING.md
+++ b/docs/review/PR_1124_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1124 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- None yet.
+
+## Merge Readiness
+- [x] Local gates passed on current head
+- [ ] All required checks green
+- [ ] All actionable review threads resolved with dispositions
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] Wait-window after latest bot/review activity observed

--- a/docs/review/PR_1124_FIXED_MAPPING.md
+++ b/docs/review/PR_1124_FIXED_MAPPING.md
@@ -1,8 +1,8 @@
 # PR 1124 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 - None yet.

--- a/docs/review/PR_1124_FIXED_MAPPING.md
+++ b/docs/review/PR_1124_FIXED_MAPPING.md
@@ -5,7 +5,15 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- None yet.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#discussion_r2921144714 -> ae40177f
+Disposition: FIXED
+Commit: ae40177f
+Evidence: `docs/review/PR_1124_FIXED_MAPPING.md:4`, `docs/review/PR_1124_FIXED_MAPPING.md:5`, `scripts/orchestration/review_mapping_artifact.py:94`, `scripts/orchestration/review_mapping_artifact.py:97`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#discussion_r2921144720
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1124_FIXED_MAPPING.md:19`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:89`
+Reason: `Local gates passed on current head` is already true for PR `#1124` because `pre-commit run --all-files` and `make verify` were re-run and passed on head `fbd8e08f`; the active merge-readiness conditions that remain intentionally unchecked are the external GitHub-cycle items below it.
 
 ## Merge Readiness
 - [x] Local gates passed on current head

--- a/docs/review/PR_1124_FIXED_MAPPING.md
+++ b/docs/review/PR_1124_FIXED_MAPPING.md
@@ -5,6 +5,16 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#pullrequestreview-3932672115 -> 8b7e8647
+Disposition: FIXED
+Commit: 8b7e8647
+Evidence: `core/creative_research.py:418`, `core/creative_research.py:425`, `app/services/creative_research_runtime.py:156`, `app/services/creative_research_runtime.py:157`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#pullrequestreview-3932705104
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1124_FIXED_MAPPING.md:12`, `docs/review/PR_1124_FIXED_MAPPING.md:17`
+Reason: this CodeRabbit review entry is the summary shell for the two actionable child comments dispositioned individually immediately below.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#discussion_r2921144714 -> ae40177f
 Disposition: FIXED
 Commit: ae40177f

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5877,8 +5877,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Tighten creative research core domain typing
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_CREATIVE_RESEARCH_TYPED_DOMAIN
-  - Status: 🟡 Deferred from PR `#1118`
+  - Target PR: PR `#1124`
+  - Status: 🟢 In progress in PR `#1124`
   - Reason (EN): `core/creative_research.py` is the shared SoT for the creative
     research lane, but it still exposes `Any` and `dict[str, Any]` at validated
     boundaries. Tighten the domain contract with explicit typed structures
@@ -5888,6 +5888,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `app/schemas/creative_research.py`
     - `docs/orchestration/CREATIVE_RESEARCH_INTERNAL_PILOT_CONTRACT.md`
     - `docs/review/PR_1118_FIXED_MAPPING.md`
+    - `docs/review/PR_1124_FIXED_MAPPING.md`
   - DoD:
     - Replace `Any` at the public core creative-research validation boundary
       with `object` plus explicit typed domain structures
@@ -5895,11 +5896,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Preserve deterministic creative-research eval and pilot tests
 
 <a id="ledger-p2-pr1118-governance-closeout"></a>
-- [ ] P2: PR #1118 governance closeout for review-thread mapping and final merge-readiness pass
+- [x] P2: PR #1118 governance closeout for review-thread mapping and final merge-readiness pass
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
   - Target PR: PR `#1118`
-  - Status: 🟡 Deferred until the current bot/review cycle settles
+  - Status: ✅ Completed in merged PR `#1118` on March 11, 2026
   - Reason (EN): PR `#1118` intentionally postpones final artifact closeout until
     the remaining review dispositions settle; the canonical mapping artifact,
     discussion-thread pass markers, and final merge-readiness / wait-window

--- a/scripts/orchestration/creative_research_eval_contract.py
+++ b/scripts/orchestration/creative_research_eval_contract.py
@@ -8,6 +8,16 @@ from __future__ import annotations
 
 from core.creative_research import (
     CONFIDENCE_LEVELS,
+    CreativeResearchBundleRecord,
+    CreativeResearchCandidateRecord,
+    CreativeResearchConfidence,
+    CreativeResearchEvaluatedCandidateRecord,
+    CreativeResearchEvaluationResultRecord,
+    CreativeResearchEvaluationSummaryRecord,
+    CreativeResearchOutputClass,
+    CreativeResearchPhase,
+    CreativeResearchPromotionDecision,
+    CreativeResearchScorecardRecord,
     DISCOVERY_REQUIRED_FIELDS,
     OUTPUT_CLASSES,
     PROMOTION_DECISIONS,
@@ -25,6 +35,16 @@ from core.creative_research import (
 
 __all__ = [
     "CONFIDENCE_LEVELS",
+    "CreativeResearchBundleRecord",
+    "CreativeResearchCandidateRecord",
+    "CreativeResearchConfidence",
+    "CreativeResearchEvaluatedCandidateRecord",
+    "CreativeResearchEvaluationResultRecord",
+    "CreativeResearchEvaluationSummaryRecord",
+    "CreativeResearchOutputClass",
+    "CreativeResearchPhase",
+    "CreativeResearchPromotionDecision",
+    "CreativeResearchScorecardRecord",
     "DISCOVERY_REQUIRED_FIELDS",
     "OUTPUT_CLASSES",
     "PROMOTION_DECISIONS",

--- a/tests/test_creative_research_eval_contract.py
+++ b/tests/test_creative_research_eval_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -132,7 +133,7 @@ def test_normalize_text_and_similarity_cover_empty_inputs() -> None:
     ],
 )
 def test_validate_bundle_rejects_additional_invalid_shapes(
-    bundle_mutator: object,
+    bundle_mutator: Callable[[dict[str, object]], None],
     message: str,
 ) -> None:
     """Validation must fail closed on malformed bundles and candidates."""


### PR DESCRIPTION
## Summary
- tighten `core/creative_research.py` validated boundaries from loose `Any` / `dict[str, Any]` to explicit typed domain records
- align the internal runtime adapter and offline eval shim with the typed core contract without changing behavior
- reuse shared creative-research constants in core/runtime to remove post-review drift

## Testing
- `pytest -q tests/test_creative_research_eval_contract.py tests/test_creative_research_runtime_helpers.py`
- `pytest -q tests/test_creative_research_pilot_api.py tests/test_creative_research_runtime_helpers.py`
- `pre-commit run --all-files`
- `make verify`

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#pullrequestreview-3932672115` -> `8b7e8647`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#pullrequestreview-3932705104`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#discussion_r2921144714` -> `ae40177f`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124#discussion_r2921144720`

## Merge Readiness
- [x] Local gates passed on current head
- [ ] All required checks green
- [ ] All actionable review threads resolved with dispositions
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] Wait-window after latest bot/review activity observed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened type consistency across creative research domain operations with improved structural validation for research bundles and candidate evaluations.
  * Enhanced method signatures to enforce stricter typing throughout the evaluation workflow.

* **Documentation**
  * Added internal review documentation to track quality assurance progress.
  * Updated development backlog ledger with current project status and mapping references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->