### PR TITLE
docs(review): backfill creative research lane

### DIFF
--- a/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
+++ b/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
@@ -7,6 +7,7 @@
 
 **Important:** this document is a synthesis artifact for monthly review. Canonical truth for deferred work and closure status remains `docs/roadmap/BACKLOG_LEDGER.md`. GitHub search returns **387 merged PRs** in the raw calendar window (verification: run the raw merged-window query below to reproduce); this report intentionally focuses on the later-wave slice centered on merged PRs in the `#963-#1048` range and the adjacent backlog items they moved.
 **Backfill note:** PR `#1063` merged on `10 March 2026`, one day after the fixed snapshot window. It is referenced below only as a post-window closure backfill for the session-cookie lane, not as a change to the 4 February 2026 through 9 March 2026 review window.
+**Backfill note:** PRs `#1106`, `#1112`, `#1118`, `#1124`, and `#1126` merged on `11 March 2026` and completed the governed creative-research lane after the fixed snapshot window. They are summarized below as a post-window closure backfill and do not change the original February 4, 2026 through March 9, 2026 review scope.
 
 **Repro queries used for this snapshot:**
 - Raw merged-window scan: `gh pr list --state merged --search "merged:>=2026-02-04 merged:<=2026-03-09" --limit 500`
@@ -145,6 +146,20 @@ This section reflects the queue state from `docs/orchestration/TOP20_PR_RECOVERY
 2. **Baseline-before-runtime pattern:** payments and compliance first received contract/control-plane foundations, with runtime follow-through deferred into explicit next PRs.
 3. **Governance overhead was intentional:** merge-readiness, disposition discipline, and ledger sync consumed real throughput, but they also reduced long-term PR entropy.
 4. **Thin-scope discipline:** several larger ideas were kept split into baseline vs runtime vs follow-up, which lowered immediate risk at the cost of more docs/ledger work.
+
+### 2.4 Post-Window Backfill: Creative Research Lane
+
+The governed creative-research lane closed immediately after the fixed snapshot window and is now fully merged in `main`.
+
+| PR | Wave | Backfill status |
+|----|------|-----------------|
+| `#1106` | PR-A docs/protocol | merged on `11 March 2026`; established the governed sub-lane inside the existing experimentation contour |
+| `#1112` | PR-B offline eval | merged on `11 March 2026`; added deterministic offline scoring, contracts, and negative controls |
+| `#1118` | PR-C internal pilot | merged on `11 March 2026`; added the internal-only, feature-flagged pilot surface hidden from public OpenAPI |
+| `#1124` | hardening follow-up | merged on `11 March 2026`; tightened typed core domain contracts without widening runtime scope |
+| `#1126` | ledger closeout | merged on `11 March 2026`; closed the remaining creative-research ledger follow-through and synced the canonical docs trail |
+
+**Why this matters:** this lane landed as a research/moat capability, not as a release-blocker runtime track. It followed the repo's governed experimentation pattern end-to-end: docs/protocol first, offline eval second, internal-only pilot third, then a narrow type-hardening and closeout pass.
 
 ## 3. Planning Signals From the Window
 

--- a/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
+++ b/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
@@ -1,13 +1,13 @@
 # Monthly PR Analysis for PulsePlate (February–March 2026)
 
-**Snapshot date:** 9 March 2026
+**Snapshot date:** 11 March 2026
 **Window covered:** 4 February 2026 to 9 March 2026 (inclusive)
 **Method:** agent-orchestrated repo review + merged PR scan + backlog/top-20 cross-check
 **Primary sources:** `gh pr list`, `git log`, `docs/roadmap/BACKLOG_LEDGER.md`, `docs/orchestration/TOP20_PR_RECOVERY_TASK_PACKETS_2026-03-08.md`, `docs/roadmap/P0_MASTER_CHECKLIST_PHASE_FIT_TRIAGE_2026-03-05.md`
 
 **Important:** this document is a synthesis artifact for monthly review. Canonical truth for deferred work and closure status remains `docs/roadmap/BACKLOG_LEDGER.md`. GitHub search returns **387 merged PRs** in the raw calendar window (verification: run the raw merged-window query below to reproduce); this report intentionally focuses on the later-wave slice centered on merged PRs in the `#963-#1048` range and the adjacent backlog items they moved.
 **Backfill note:** PR `#1063` merged on `10 March 2026`, one day after the fixed snapshot window. It is referenced below only as a post-window closure backfill for the session-cookie lane, not as a change to the 4 February 2026 through 9 March 2026 review window.
-**Backfill note:** PRs `#1106`, `#1112`, `#1118`, `#1124`, and `#1126` merged on `11 March 2026` and completed the governed creative-research lane after the fixed snapshot window. They are summarized below as a post-window closure backfill and do not change the original February 4, 2026 through March 9, 2026 review scope.
+**Backfill note:** [#1106](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1106), [#1112](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112), [#1118](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1118), [#1124](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124), and [#1126](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1126) merged on `11 March 2026` and completed the governed creative-research lane after the fixed snapshot window. They are summarized below as a post-window closure backfill and do not change the original 4 February 2026 to 9 March 2026 review scope.
 
 **Repro queries used for this snapshot:**
 - Raw merged-window scan: `gh pr list --state merged --search "merged:>=2026-02-04 merged:<=2026-03-09" --limit 500`
@@ -211,4 +211,4 @@ The governed creative-research lane closed immediately after the fixed snapshot 
 
 ---
 
-*Generated on 9 March 2026 from repo-local sources and merged PR history. This review summarizes momentum and gaps; it does not replace canonical backlog or merge-governance artifacts.*
+*Generated on 11 March 2026 from repo-local sources and merged PR history. This review summarizes momentum and gaps; it does not replace canonical backlog or merge-governance artifacts.*

--- a/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
+++ b/docs/review/MONTHLY_PR_ANALYSIS_2026-03.md
@@ -7,7 +7,7 @@
 
 **Important:** this document is a synthesis artifact for monthly review. Canonical truth for deferred work and closure status remains `docs/roadmap/BACKLOG_LEDGER.md`. GitHub search returns **387 merged PRs** in the raw calendar window (verification: run the raw merged-window query below to reproduce); this report intentionally focuses on the later-wave slice centered on merged PRs in the `#963-#1048` range and the adjacent backlog items they moved.
 **Backfill note:** PR `#1063` merged on `10 March 2026`, one day after the fixed snapshot window. It is referenced below only as a post-window closure backfill for the session-cookie lane, not as a change to the 4 February 2026 through 9 March 2026 review window.
-**Backfill note:** [#1106](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1106), [#1112](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112), [#1118](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1118), [#1124](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124), and [#1126](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1126) merged on `11 March 2026` and completed the governed creative-research lane after the fixed snapshot window. They are summarized below as a post-window closure backfill and do not change the original 4 February 2026 to 9 March 2026 review scope.
+**Backfill note:** [#1106](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1106), [#1112](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112), [#1118](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1118), [#1124](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1124), and [#1126](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1126) completed the governed creative-research lane after the fixed snapshot window. [#1112](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1112) merged into the PR-A branch on `11 March 2026` and entered `main` through [#1106](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1106); the remaining lane PRs merged directly on `11 March 2026`. They are summarized below as a post-window closure backfill and do not change the original 4 February 2026 to 9 March 2026 review scope.
 
 **Repro queries used for this snapshot:**
 - Raw merged-window scan: `gh pr list --state merged --search "merged:>=2026-02-04 merged:<=2026-03-09" --limit 500`
@@ -154,7 +154,7 @@ The governed creative-research lane closed immediately after the fixed snapshot 
 | PR | Wave | Backfill status |
 |----|------|-----------------|
 | `#1106` | PR-A docs/protocol | merged on `11 March 2026`; established the governed sub-lane inside the existing experimentation contour |
-| `#1112` | PR-B offline eval | merged on `11 March 2026`; added deterministic offline scoring, contracts, and negative controls |
+| `#1112` | PR-B offline eval | merged into the PR-A branch on `11 March 2026`; entered `main` through `#1106` while adding deterministic offline scoring, contracts, and negative controls |
 | `#1118` | PR-C internal pilot | merged on `11 March 2026`; added the internal-only, feature-flagged pilot surface hidden from public OpenAPI |
 | `#1124` | hardening follow-up | merged on `11 March 2026`; tightened typed core domain contracts without widening runtime scope |
 | `#1126` | ledger closeout | merged on `11 March 2026`; closed the remaining creative-research ledger follow-through and synced the canonical docs trail |

--- a/docs/review/PR_1128_FIXED_MAPPING.md
+++ b/docs/review/PR_1128_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1128 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Reviewed all actionable review threads and bot comments
+- [x] Every resolved thread has a disposition recorded below
+
+## Fixed in Commit Mapping
+
+- No actionable review comments.
+
+## Merge Readiness
+
+- [ ] Scope is focused and unchanged after latest review
+- [ ] Local gates passed on current head
+- [ ] Required CI is green on current head
+- [ ] No unresolved review threads remain
+- [ ] CodeRabbit / Sourcery / Cubic actionables are resolved or explicitly dispositioned
+- [ ] Wait-window observed after latest bot/review activity

--- a/docs/review/PR_1128_FIXED_MAPPING.md
+++ b/docs/review/PR_1128_FIXED_MAPPING.md
@@ -1,19 +1,20 @@
-# PR 1128 Fixed in Commit Mapping
+# PR 1128 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 
-- [x] Reviewed all actionable review threads and bot comments
-- [x] Every resolved thread has a disposition recorded below
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments.
+- Pending current review cycle
 
 ## Merge Readiness
 
-- [ ] Scope is focused and unchanged after latest review
 - [ ] Local gates passed on current head
-- [ ] Required CI is green on current head
-- [ ] No unresolved review threads remain
-- [ ] CodeRabbit / Sourcery / Cubic actionables are resolved or explicitly dispositioned
-- [ ] Wait-window observed after latest bot/review activity
+- [ ] All required checks green
+- [ ] All actionable review threads resolved with dispositions
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] Wait-window after latest bot/review activity observed

--- a/docs/review/PR_1128_FIXED_MAPPING.md
+++ b/docs/review/PR_1128_FIXED_MAPPING.md
@@ -27,6 +27,11 @@ Disposition: FIXED
 Commit: 16d17426
 Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:3`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3934264752
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921430267; https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921438428
+Reason: this late CodeRabbit review is a summary shell over two already-dispositioned review concerns. Shared evidence is intentional here because both comments point at the same metadata/backfill correction commit, while the `#1112` wording fix remains separately anchored to `2e2ae11f`.
+
 ## Merge Readiness
 
 - [ ] Local gates passed on current head

--- a/docs/review/PR_1128_FIXED_MAPPING.md
+++ b/docs/review/PR_1128_FIXED_MAPPING.md
@@ -7,7 +7,15 @@
 
 ## Fixed in Commit Mapping
 
-- Pending current review cycle
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3933016626 -> 16d17426
+Disposition: FIXED
+Commit: 16d17426
+Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:10`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3933030530 -> 16d17426
+Disposition: FIXED
+Commit: 16d17426
+Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:3`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1128_FIXED_MAPPING.md
+++ b/docs/review/PR_1128_FIXED_MAPPING.md
@@ -12,7 +12,17 @@ Disposition: FIXED
 Commit: 16d17426
 Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:10`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921430267 -> 2e2ae11f
+Disposition: FIXED
+Commit: 2e2ae11f
+Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:10`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:157`
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3933030530 -> 16d17426
+Disposition: FIXED
+Commit: 16d17426
+Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:3`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921438428 -> 16d17426
 Disposition: FIXED
 Commit: 16d17426
 Evidence: `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:3`, `docs/review/MONTHLY_PR_ANALYSIS_2026-03.md:214`


### PR DESCRIPTION
## Summary
- backfill the March monthly PR analysis with the post-window creative-research lane closure
- record the merged `#1106 -> #1112 -> #1118 -> #1124 -> #1126` chain without changing the original fixed review window
- keep the follow-up docs-only and scoped to review/audit reporting

## Testing
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/review/MONTHLY_PR_ANALYSIS_2026-03.md`
- `pre-commit run --all-files`
- `make verify`

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3933016626 -> 16d17426
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921430267 -> 2e2ae11f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#pullrequestreview-3933030530 -> 16d17426
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1128#discussion_r2921438428 -> 16d17426

## Merge Readiness
- [ ] Local gates passed on current head
- [ ] All required checks green
- [ ] All actionable review threads resolved with dispositions
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] Wait-window after latest bot/review activity observed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated monthly PR analysis snapshot date and closing footer timestamp.
  * Added a "Post-Window Backfill" section summarizing several post-window backfill merges, per-PR wave/backfill statuses, and an explanatory governance note; clarified relationship to the original review scope.
  * Revised backfill note for consistency with post-window changes.
  * Added a new review document detailing a fixed-mapping summary and a merge-readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->