### PR TITLE
fix(ci): filter current-head check noise

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -251,7 +251,7 @@ Run from repo root before any push/PR:
 
 Run before merge after latest commit and latest bot/review activity:
 
-1. `gh pr checks <PR_NUMBER>` -> no failed/pending required checks
+1. `python scripts/orchestration/check_merge_ready.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
 2. `gh pr view <PR_NUMBER> --json mergeStateStatus,reviewDecision,isDraft`
 3. **Zero bot comments (hard rule):** Merge only when (a) **0 unresolved review threads** and (b) **every actionable bot comment is mapped** in the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`. PR body is mirror-only when `pr_number` is available. **Do not** report "0 comments" or "ready to merge" based only on unresolved thread count — new bot comments can appear after a check; use the canonical script (below) and re-run after bot activity.
 4. Confirm PR body sections are complete:
@@ -286,6 +286,10 @@ python scripts/orchestration/check_merge_ready.py \
   --require-auth
 ```
 Exit 0 = Phase 2 + merge-readiness + disposition proof all pass. Exit 1 = do not merge; fix and re-run.
+
+Raw `gh pr checks <PR_NUMBER>` remains diagnostic only. It can include superseded
+historical failures from older runs, so final merge triage must rely on the
+filtered current-head view emitted by `check_merge_ready.py`.
 
 **Optional: unresolved thread count only** (not sufficient alone):
 

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -54,17 +54,21 @@ Underlying enforcement scripts remain canonical for their own domains:
 
 - `scripts/ci/check_pr_body_phase2_gates.py`
 - `scripts/ci/check_pr_merge_readiness.py`
+- `scripts/ci/check_current_head_pr_checks.py`
 - `scripts/orchestration/check_review_threads_disposition.py`
 
 **CI:** The same wrapper runs with `--event-path "$GITHUB_EVENT_PATH"`. For local/agent usage, use `--pr-number` and `--repo` instead.
+Raw `gh pr checks` output remains diagnostic only because it can include
+superseded historical failures after the latest PR head is already clean. The
+wrapper is the canonical filtered current-head view.
 
 ---
 
 ## 4. Coordinator orchestration checklist (before saying "ready to merge" or "0 comments")
 
 1. **Run the wrapper** (section 3) for the PR.
-2. **If exit code is not 0:** Do **not** report "0 comments" or "ready to merge". Report the script output (unresolved count, UNMAPPED comment URLs) and instruct to fix and re-run.
-3. **If exit code is 0:** You may state that the PR satisfies the zero-comments policy **at the time of the run**. Prefer: "Orchestration merge-check passed: Phase 2, merge-readiness, and disposition proof are all green."
+2. **If exit code is not 0:** Do **not** report "0 comments" or "ready to merge". Report the script output (unresolved count, UNMAPPED comment URLs, or blocking current-head checks) and instruct to fix and re-run.
+3. **If exit code is 0:** You may state that the PR satisfies the zero-comments policy **at the time of the run**. Prefer: "Orchestration merge-check passed: Phase 2, merge-readiness, current-head checks, and disposition proof are all green."
 4. **After new bot activity:** If the user or system reports new bot comments (e.g. CodeRabbit, Sourcery), **re-run the wrapper** before any merge decision; do not assume previous pass still holds.
 
 **Loop until zero:** Full cycle (commit → push → watch CI → new comment → fix → re-check) is in `RUNBOOK_AGENT.md` (sections "Pre-merge readiness pass" ~line 121, "Loop until zero comments (canonical cycle)" ~line 160). Repeat until script exit 0 and CI green.
@@ -89,4 +93,5 @@ See `RUNBOOK_AGENT.md` (Pre-merge readiness pass ~line 121, Phase2 PR body gates
 - **Procedure:** `RUNBOOK_AGENT.md` (Pre-merge readiness pass ~line 121, Loop until zero ~line 160, Verify zero unresolved review threads).
 - **Canonical operator entrypoint:** `scripts/orchestration/check_merge_ready.py`.
 - **CI gate:** `scripts/ci/check_pr_merge_readiness.py` (merge-readiness sub-gate).
+- **Current-head filter:** `scripts/ci/check_current_head_pr_checks.py`.
 - **Phase2 body check:** `scripts/ci/check_pr_body_phase2_gates.py`.

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -12,6 +12,17 @@ Evidence: `56a49c9f` treats `StatusContext.state=EXPECTED` as pending in `script
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934249599 -> 56a49c9f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922561675 -> 56a49c9f
 
+Disposition: FIXED
+Commit: 5ad198f4
+Evidence: `5ad198f4` removes the false-negative path identified by cubic by using `mergeStateStatus` only when required-check metadata is unavailable in `scripts/ci/check_current_head_pr_checks.py:157-371`, hardens `_api_request()` with guaranteed connection cleanup in `scripts/ci/check_current_head_pr_checks.py:32-65`, updates the active backlog item to point at PR `#1129` in `docs/roadmap/BACKLOG_LEDGER.md:6032-6039`, and adds deterministic draft / missing-token / HTTP-error / metadata-unavailable regression coverage in `tests/test_current_head_pr_checks.py:157-292`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934252786 -> 5ad198f4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922564734 -> 5ad198f4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934263739 -> 5ad198f4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922575286 -> 5ad198f4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922575288 -> 5ad198f4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922575292 -> 5ad198f4
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -62,6 +62,12 @@ Commit: 1b4effa1
 Evidence: `1b4effa1` closes the final CodeRabbit review wave in the canonical artifact after the merge-state fallback fix (`ce5a5e69`) and readiness-checkbox correction (`42a914b9`) were both pushed, so the review-level mapping now reflects the complete late-wave disposition set in one post-comment commit.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934399077 -> 1b4effa1
 
+Disposition: FIXED
+Commit: 2ae1a8d3
+Evidence: `2ae1a8d3` removes `details_url` from same-workflow recency ordering in `scripts/ci/check_current_head_pr_checks.py:279-337`, so equal-timestamp entries are no longer misclassified as newer solely because of URL ordering, and adds regression coverage for the equal-timestamp edge case in `tests/test_current_head_pr_checks.py:55-110`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934961598 -> 2ae1a8d3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2923212464 -> 2ae1a8d3
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -34,6 +34,12 @@ Evidence: `53a0f896` lets local wrapper auth fall back to `gh auth status` befor
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934316276 -> 53a0f896
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922616515 -> 53a0f896
 
+Disposition: FIXED
+Commit: d755d262
+Evidence: `d755d262` extends the local pre-gate failure seam so `_phase2_args()` collapses `subprocess.TimeoutExpired` into `PreGateFailure` instead of leaking a traceback in `scripts/orchestration/check_merge_ready.py:144-166`, and adds an explicit timeout regression test in `tests/test_orchestration_merge_ready.py:128-160`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934386867 -> d755d262
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922679718 -> d755d262
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -45,6 +45,11 @@ Commit: ce5a5e69
 Evidence: `ce5a5e69` narrows `mergeStateStatus` blocking to the metadata-unavailable fallback path in `scripts/ci/check_current_head_pr_checks.py:380-387`, while preserving current-head blocking for required pending or failed checks, and adds regression coverage for the clean-required / non-clean-merge-state pass case plus the metadata-unavailable failure case in `tests/test_current_head_pr_checks.py:139-211`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690699 -> ce5a5e69
 
+Disposition: FIXED
+Commit: 42a914b9
+Evidence: `42a914b9` keeps the merge-readiness checkbox `Local hard gate passed (\`make verify\`)` unchecked in `docs/review/PR_1129_FIXED_MAPPING.md:49-52` until the actual final merge cycle, which matches the review-governance contract and prevents premature readiness claims inside the canonical artifact.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690697 -> 42a914b9
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -8,14 +8,12 @@
 Disposition: FIXED
 Commit: 56a49c9f
 Evidence: `56a49c9f` treats `StatusContext.state=EXPECTED` as pending in `scripts/ci/check_current_head_pr_checks.py:232-244`, so waiting status contexts no longer read as false failures, and it makes the local wrapper fetch the live PR body before invoking the Phase2 gate in `scripts/orchestration/check_merge_ready.py:89-140`, which removes the empty-body regression revealed by the current-head wrapper path. Regression coverage was added in `tests/test_current_head_pr_checks.py:202-214` and `tests/test_orchestration_merge_ready.py:58-87,173-238`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934249599 -> 56a49c9f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922561675 -> 56a49c9f
 
 Disposition: FIXED
 Commit: 5ad198f4
 Evidence: `5ad198f4` removes the false-negative path identified by cubic by using `mergeStateStatus` only when required-check metadata is unavailable in `scripts/ci/check_current_head_pr_checks.py:157-371`, hardens `_api_request()` with guaranteed connection cleanup in `scripts/ci/check_current_head_pr_checks.py:32-65`, updates the active backlog item to point at PR `#1129` in `docs/roadmap/BACKLOG_LEDGER.md:6032-6039`, and adds deterministic draft / missing-token / HTTP-error / metadata-unavailable regression coverage in `tests/test_current_head_pr_checks.py:157-292`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934252786 -> 5ad198f4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922564734 -> 5ad198f4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934263739 -> 5ad198f4
@@ -26,13 +24,11 @@ Evidence: `5ad198f4` removes the false-negative path identified by cubic by usin
 Disposition: NOT-A-BUG
 Evidence: `scripts/ci/check_current_head_pr_checks.py:337-362`
 Reason: The concern is valid in the abstract, but the current implementation already distinguishes “required check metadata unavailable” from “no required checks configured”, falls back to `mergeStateStatus` only in the unavailable case, and prints advisory checks without blocking on non-required runs.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922616508
 
 Disposition: FIXED
 Commit: 53a0f896
 Evidence: `53a0f896` lets local wrapper auth fall back to `gh auth status` before `gh pr view` in `scripts/orchestration/check_merge_ready.py:97-136`, converts pre-gate PR-body fetch failures into deterministic gate failures via `PreGateFailure` in `scripts/orchestration/check_merge_ready.py:25-194`, and adds focused regression coverage for both behaviors in `tests/test_orchestration_merge_ready.py:58-137`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934298012 -> 53a0f896
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922602995 -> 53a0f896
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934316276 -> 53a0f896

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1129 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 56a49c9f
+Evidence: `56a49c9f` treats `StatusContext.state=EXPECTED` as pending in `scripts/ci/check_current_head_pr_checks.py:232-244`, so waiting status contexts no longer read as false failures, and it makes the local wrapper fetch the live PR body before invoking the Phase2 gate in `scripts/orchestration/check_merge_ready.py:89-140`, which removes the empty-body regression revealed by the current-head wrapper path. Regression coverage was added in `tests/test_current_head_pr_checks.py:202-214` and `tests/test_orchestration_merge_ready.py:58-87,173-238`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934249599 -> 56a49c9f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922561675 -> 56a49c9f
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -23,8 +23,23 @@ Evidence: `5ad198f4` removes the false-negative path identified by cubic by usin
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922575288 -> 5ad198f4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922575292 -> 5ad198f4
 
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/check_current_head_pr_checks.py:337-362`
+Reason: The concern is valid in the abstract, but the current implementation already distinguishes “required check metadata unavailable” from “no required checks configured”, falls back to `mergeStateStatus` only in the unavailable case, and prints advisory checks without blocking on non-required runs.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922616508
+
+Disposition: FIXED
+Commit: 53a0f896
+Evidence: `53a0f896` lets local wrapper auth fall back to `gh auth status` before `gh pr view` in `scripts/orchestration/check_merge_ready.py:97-136`, converts pre-gate PR-body fetch failures into deterministic gate failures via `PreGateFailure` in `scripts/orchestration/check_merge_ready.py:25-194`, and adds focused regression coverage for both behaviors in `tests/test_orchestration_merge_ready.py:58-137`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934298012 -> 53a0f896
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922602995 -> 53a0f896
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934316276 -> 53a0f896
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922616515 -> 53a0f896
+
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
+- [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -40,8 +40,13 @@ Evidence: `d755d262` extends the local pre-gate failure seam so `_phase2_args()`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934386867 -> d755d262
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922679718 -> d755d262
 
+Disposition: FIXED
+Commit: ce5a5e69
+Evidence: `ce5a5e69` narrows `mergeStateStatus` blocking to the metadata-unavailable fallback path in `scripts/ci/check_current_head_pr_checks.py:380-387`, while preserving current-head blocking for required pending or failed checks, and adds regression coverage for the clean-required / non-clean-merge-state pass case plus the metadata-unavailable failure case in `tests/test_current_head_pr_checks.py:139-211`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690699 -> ce5a5e69
+
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1129_FIXED_MAPPING.md
+++ b/docs/review/PR_1129_FIXED_MAPPING.md
@@ -46,9 +46,21 @@ Evidence: `ce5a5e69` narrows `mergeStateStatus` blocking to the metadata-unavail
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690699 -> ce5a5e69
 
 Disposition: FIXED
+Commit: 1a7a0fc3
+Evidence: `1a7a0fc3` records the late timeout-fix review wave after the underlying deterministic pre-gate timeout handling was already landed in `scripts/orchestration/check_merge_ready.py:144-166` and covered in `tests/test_orchestration_merge_ready.py:128-160`; this satisfies the post-comment mapping requirement for the resolved timeout threads identified by cubic and CodeRabbit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934395461 -> 1a7a0fc3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922687341 -> 1a7a0fc3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690706 -> 1a7a0fc3
+
+Disposition: FIXED
 Commit: 42a914b9
 Evidence: `42a914b9` keeps the merge-readiness checkbox `Local hard gate passed (\`make verify\`)` unchecked in `docs/review/PR_1129_FIXED_MAPPING.md:49-52` until the actual final merge cycle, which matches the review-governance contract and prevents premature readiness claims inside the canonical artifact.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#discussion_r2922690697 -> 42a914b9
+
+Disposition: FIXED
+Commit: 1b4effa1
+Evidence: `1b4effa1` closes the final CodeRabbit review wave in the canonical artifact after the merge-state fallback fix (`ce5a5e69`) and readiness-checkbox correction (`42a914b9`) were both pushed, so the review-level mapping now reflects the complete late-wave disposition set in one post-comment commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1129#pullrequestreview-3934399077 -> 1b4effa1
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6032,7 +6032,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Filter superseded GitHub check noise in merge triage
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #TBD (`fix/pr11-gh-checks-current-head-filter`)
+  - Target PR: PR #1129 (`fix/pr11-gh-checks-current-head-filter`)
   - Area: orchestration / GitHub governance
   - Reason: PR5 merge triage repeatedly showed stale failed `test-pr` and `coverage-pr` lines from superseded runs in `gh pr checks`, even after the current head became `CLEAN`. This creates false negatives and slows final merge decisions.
   - Kickoff: PR10 closeout completed on 12 March 2026; PR11 branch created from synced `main` after PR #1127 merge.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6011,12 +6011,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - CI guidance explicitly distinguishes canonical SoT vs human-readable mirror
 
 <a id="ledger-p2-clean-clone-dependency-parity"></a>
-- [ ] P2: Restore deterministic clean-clone dependency parity for local verify
+- [x] P2: Restore deterministic clean-clone dependency parity for local verify
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_CLEAN_CLONE_DEPENDENCY_PARITY
+  - Target PR: PR #1127 (`fix/pr10-clean-clone-dependency-parity`)
   - Area: tooling / developer-experience
   - Reason: Final PR5 local `make verify` failed in the clean clone because `.venv` was missing locked `opentelemetry-*` packages required by `tests/test_genai_tracing.py`, even though `requirements.txt` already declared them. This is an environment parity gap, not a code regression, but it weakens merge confidence.
+  - Status: ✅ Merged via PR #1127 on 12 March 2026 (`09f600ff0db47f6ef1e3e9ba00f0368959b16488`)
   - Links:
     - `Makefile`
     - `requirements.txt`
@@ -6031,9 +6032,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Filter superseded GitHub check noise in merge triage
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_GH_CHECKS_CURRENT_HEAD_FILTER
+  - Target PR: PR #TBD (`fix/pr11-gh-checks-current-head-filter`)
   - Area: orchestration / GitHub governance
   - Reason: PR5 merge triage repeatedly showed stale failed `test-pr` and `coverage-pr` lines from superseded runs in `gh pr checks`, even after the current head became `CLEAN`. This creates false negatives and slows final merge decisions.
+  - Kickoff: PR10 closeout completed on 12 March 2026; PR11 branch created from synced `main` after PR #1127 merge.
   - Links:
     - `scripts/ci/check_pr_merge_readiness.py`
     - `RUNBOOK_AGENT.md`

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -377,9 +377,11 @@ def main(argv: list[str] | None = None) -> int:
             print(_format_entry(entry))
 
     blocking_entries = [entry for entry in current_required if entry.state in {"pending", "failed"}]
-    if merge_state != "CLEAN" or blocking_entries:
+    fallback_merge_blocked = not required_metadata_available and merge_state != "CLEAN"
+    if fallback_merge_blocked or blocking_entries:
         print("ERROR: current-head check filter failed.")
-        print(f"- GitHub mergeStateStatus={merge_state or 'UNKNOWN'}")
+        if fallback_merge_blocked:
+            print(f"- GitHub mergeStateStatus={merge_state or 'UNKNOWN'}")
         if blocking_entries:
             print("- Blocking current-head checks remain pending or failed.")
         return 1

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -59,10 +59,12 @@ def _api_request(
         path = f"{path}?{parsed.query}"
 
     conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
-    conn.request(method=method, url=path, body=data, headers=headers)
-    response = conn.getresponse()
-    body = response.read().decode("utf-8")
-    conn.close()
+    try:
+        conn.request(method=method, url=path, body=data, headers=headers)
+        response = conn.getresponse()
+        body = response.read().decode("utf-8")
+    finally:
+        conn.close()
 
     if response.status >= 400:
         raise urllib.error.HTTPError(
@@ -167,10 +169,15 @@ def _fetch_pr_metadata(
     return is_draft, merge_state, base_ref, nodes
 
 
-def _fetch_required_check_names(repo: str, base_ref: str, token: str) -> set[str]:
-    """Fetch required check names from branch protection."""
+def _fetch_required_check_names(repo: str, base_ref: str, token: str) -> tuple[set[str], bool]:
+    """Fetch required check names from branch protection.
+
+    Returns `(required_names, metadata_available)`.
+    `metadata_available=False` means GitHub did not expose branch-protection data,
+    so the caller must not treat non-required checks as blocking.
+    """
     if not base_ref:
-        return set()
+        return set(), False
     owner, name = repo.split("/", maxsplit=1)
     url = (
         f"https://api.github.com/repos/{owner}/{name}/branches/"
@@ -180,7 +187,7 @@ def _fetch_required_check_names(repo: str, base_ref: str, token: str) -> set[str
         data = _api_request(url, token=token)
     except urllib.error.HTTPError as exc:
         if exc.code in {403, 404}:
-            return set()
+            return set(), False
         raise
 
     required: set[str] = set()
@@ -191,7 +198,7 @@ def _fetch_required_check_names(repo: str, base_ref: str, token: str) -> set[str
         context = str((item or {}).get("context") or "").strip()
         if context:
             required.add(context)
-    return required
+    return required, True
 
 
 def _normalize_node(node: dict[str, Any]) -> CheckEntry:
@@ -296,6 +303,17 @@ def _format_entry(entry: CheckEntry) -> str:
     return f"- {entry.name}: {entry.state}{source}{url}"
 
 
+def _print_entries(title: str, entries: list[CheckEntry]) -> None:
+    """Print a deterministic check-entry section."""
+
+    print(title)
+    if not entries:
+        print("- none")
+        return
+    for entry in sorted(entries, key=lambda item: item.name):
+        print(_format_entry(entry))
+
+
 def main(argv: list[str] | None = None) -> int:
     """Validate current-head checks and filter superseded noise."""
     parser = argparse.ArgumentParser(
@@ -328,7 +346,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         is_draft, merge_state, base_ref, nodes = _fetch_pr_metadata(pr_number, repo, token)
-        required_names = _fetch_required_check_names(repo, base_ref, token)
+        required_names, required_metadata_available = _fetch_required_check_names(
+            repo, base_ref, token
+        )
     except urllib.error.HTTPError as exc:
         print(f"ERROR: failed to query GitHub check state: HTTP {exc.code}")
         return 1
@@ -339,12 +359,16 @@ def main(argv: list[str] | None = None) -> int:
 
     latest, superseded = _latest_entries([_normalize_node(node) for node in nodes if node])
     current_required = (
-        _required_snapshot(latest, required_names) if required_names else list(latest.values())
+        _required_snapshot(latest, required_names) if required_metadata_available else []
     )
+    _print_entries("Current-head required checks:", current_required)
 
-    print("Current-head required checks:")
-    for entry in sorted(current_required, key=lambda item: item.name):
-        print(_format_entry(entry))
+    if not required_metadata_available:
+        print(
+            "Required check metadata unavailable; merge gating falls back to GitHub "
+            "mergeStateStatus and reports current-head checks as advisory only."
+        )
+        _print_entries("Current-head advisory checks:", list(latest.values()))
 
     noisy_superseded = [entry for entry in superseded if entry.state != "passed"]
     if noisy_superseded:

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -315,22 +315,21 @@ def _suppress_stale_latest_entries_with_newer_workflow_activity(
     emitted that exact job name yet.
     """
 
-    newest_workflow_marker: dict[str, tuple[str, str]] = {}
+    newest_workflow_timestamp: dict[str, str] = {}
     for entry in entries:
         if not entry.workflow_name:
             continue
-        marker = (entry.timestamp, entry.details_url)
-        previous = newest_workflow_marker.get(entry.workflow_name)
-        if previous is None or marker >= previous:
-            newest_workflow_marker[entry.workflow_name] = marker
+        previous = newest_workflow_timestamp.get(entry.workflow_name)
+        if previous is None or entry.timestamp >= previous:
+            newest_workflow_timestamp[entry.workflow_name] = entry.timestamp
 
     filtered_latest = dict(latest)
     updated_superseded = list(superseded)
     for name, entry in list(filtered_latest.items()):
         if not entry.workflow_name:
             continue
-        latest_workflow_marker = newest_workflow_marker.get(entry.workflow_name)
-        if latest_workflow_marker and latest_workflow_marker > (entry.timestamp, entry.details_url):
+        latest_workflow_timestamp = newest_workflow_timestamp.get(entry.workflow_name)
+        if latest_workflow_timestamp and latest_workflow_timestamp > entry.timestamp:
             updated_superseded.append(entry)
             del filtered_latest[name]
     return filtered_latest, updated_superseded

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -300,19 +300,19 @@ def _required_snapshot(
     return snapshot
 
 
-def _suppress_cancelled_latest_entries_with_newer_workflow_activity(
+def _suppress_stale_latest_entries_with_newer_workflow_activity(
     entries: list[CheckEntry],
     latest: dict[str, CheckEntry],
     superseded: list[CheckEntry],
 ) -> tuple[dict[str, CheckEntry], list[CheckEntry]]:
-    """Demote cancelled latest entries when a newer run from the same workflow exists.
+    """Demote stale latest entries when a newer run from the same workflow exists.
 
-    RU: Если job из текущего head был отменен из-за concurrency, но тот же workflow
-    уже успел выпустить более новый activity на этом же SHA, cancelled status не
-    должен считаться latest signal для merge triage.
-    EN: If a current-head job was cancelled by workflow concurrency, but the same
-    workflow has already emitted newer activity on the same SHA, that cancelled
-    status is stale noise and should move to the superseded bucket.
+    RU: Если у того же workflow на этом же SHA уже есть более новый activity,
+    older status из предыдущего workflow run не должен считаться latest signal
+    даже если новое выполнение ещё не выпустило тот же job name.
+    EN: If the same workflow has newer activity on the same SHA, an older status
+    from a previous workflow run is stale noise even when the newer run has not
+    emitted that exact job name yet.
     """
 
     newest_workflow_marker: dict[str, tuple[str, str]] = {}
@@ -327,7 +327,7 @@ def _suppress_cancelled_latest_entries_with_newer_workflow_activity(
     filtered_latest = dict(latest)
     updated_superseded = list(superseded)
     for name, entry in list(filtered_latest.items()):
-        if entry.conclusion != "CANCELLED" or not entry.workflow_name:
+        if not entry.workflow_name:
             continue
         latest_workflow_marker = newest_workflow_marker.get(entry.workflow_name)
         if latest_workflow_marker and latest_workflow_marker > (entry.timestamp, entry.details_url):
@@ -399,7 +399,7 @@ def main(argv: list[str] | None = None) -> int:
 
     normalized_entries = [_normalize_node(node) for node in nodes if node]
     latest, superseded = _latest_entries(normalized_entries)
-    latest, superseded = _suppress_cancelled_latest_entries_with_newer_workflow_activity(
+    latest, superseded = _suppress_stale_latest_entries_with_newer_workflow_activity(
         normalized_entries,
         latest,
         superseded,

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Filter GitHub PR checks down to the latest current-head view for merge triage."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import urllib.error
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CheckEntry:
+    """Normalized status-check entry for deterministic filtering."""
+
+    name: str
+    source_kind: str
+    state: str
+    timestamp: str
+    details_url: str
+    workflow_name: str
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _github_token() -> str:
+    """Return the preferred GitHub token from environment."""
+    return os.getenv("GH_TOKEN", "").strip() or os.getenv("GITHUB_TOKEN", "").strip()
+
+
+def _api_request(
+    url: str, token: str, method: str = "GET", payload: dict[str, Any] | None = None
+) -> Any:
+    """Perform one GitHub API request and decode JSON response."""
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pulseplate-current-head-checks",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+        raise ValueError(f"Unsupported API URL: {url}")
+
+    path = parsed.path
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+    conn.request(method=method, url=path, body=data, headers=headers)
+    response = conn.getresponse()
+    body = response.read().decode("utf-8")
+    conn.close()
+
+    if response.status >= 400:
+        raise urllib.error.HTTPError(
+            url=url,
+            code=response.status,
+            msg=response.reason,
+            hdrs=response.headers,
+            fp=None,
+        )
+    return json.loads(body)
+
+
+def _extract_pr_context(event_path: Path) -> tuple[int, str]:
+    """Read event payload and return (pr_number, repo)."""
+    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    pr = payload.get("pull_request") or {}
+    number = int(pr.get("number", 0))
+    repo = str((payload.get("repository") or {}).get("full_name", ""))
+    return number, repo
+
+
+def _fetch_pr_metadata(
+    pr_number: int, repo: str, token: str
+) -> tuple[bool, str, str, list[dict[str, Any]]]:
+    """Fetch draft state, merge state, base branch, and raw status-check nodes."""
+    owner, name = repo.split("/", maxsplit=1)
+    query = """
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          isDraft
+          mergeStateStatus
+          baseRefName
+          statusCheckRollup {
+            contexts(first: 100, after: $cursor) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                __typename
+                ... on CheckRun {
+                  name
+                  status
+                  conclusion
+                  startedAt
+                  completedAt
+                  detailsUrl
+                  checkSuite {
+                    workflowRun {
+                      workflow {
+                        name
+                      }
+                    }
+                  }
+                }
+                ... on StatusContext {
+                  context
+                  state
+                  createdAt
+                  targetUrl
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    cursor: str | None = None
+    nodes: list[dict[str, Any]] = []
+    is_draft = False
+    merge_state = ""
+    base_ref = ""
+    while True:
+        response = _api_request(
+            "https://api.github.com/graphql",
+            token=token,
+            method="POST",
+            payload={
+                "query": query,
+                "variables": {
+                    "owner": owner,
+                    "name": name,
+                    "number": pr_number,
+                    "cursor": cursor,
+                },
+            },
+        )
+        pr = response.get("data", {}).get("repository", {}).get("pullRequest", {})
+        is_draft = bool(pr.get("isDraft", False))
+        merge_state = str(pr.get("mergeStateStatus") or "")
+        base_ref = str(pr.get("baseRefName") or "")
+        contexts = ((pr.get("statusCheckRollup") or {}).get("contexts") or {})
+        nodes.extend(contexts.get("nodes") or [])
+        page_info = contexts.get("pageInfo") or {}
+        if not page_info.get("hasNextPage", False):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return is_draft, merge_state, base_ref, nodes
+
+
+def _fetch_required_check_names(repo: str, base_ref: str, token: str) -> set[str]:
+    """Fetch required check names from branch protection."""
+    if not base_ref:
+        return set()
+    owner, name = repo.split("/", maxsplit=1)
+    url = (
+        f"https://api.github.com/repos/{owner}/{name}/branches/"
+        f"{urllib.parse.quote(base_ref, safe='')}/protection/required_status_checks"
+    )
+    try:
+        data = _api_request(url, token=token)
+    except urllib.error.HTTPError as exc:
+        if exc.code in {403, 404}:
+            return set()
+        raise
+
+    required: set[str] = set()
+    for item in data.get("contexts") or []:
+        if isinstance(item, str) and item.strip():
+            required.add(item.strip())
+    for item in data.get("checks") or []:
+        context = str((item or {}).get("context") or "").strip()
+        if context:
+            required.add(context)
+    return required
+
+
+def _normalize_node(node: dict[str, Any]) -> CheckEntry:
+    """Normalize a GraphQL check node into a deterministic entry."""
+    node_type = str(node.get("__typename") or "")
+    if node_type == "CheckRun":
+        name = str(node.get("name") or "").strip()
+        status = str(node.get("status") or "").strip().upper()
+        conclusion = str(node.get("conclusion") or "").strip().upper()
+        if status in {"QUEUED", "IN_PROGRESS", "PENDING", "REQUESTED", "WAITING"}:
+            state = "pending"
+        elif conclusion in {
+            "FAILURE",
+            "TIMED_OUT",
+            "CANCELLED",
+            "ACTION_REQUIRED",
+            "STALE",
+            "STARTUP_FAILURE",
+        }:
+            state = "failed"
+        else:
+            state = "passed"
+        workflow_name = str(
+            (((node.get("checkSuite") or {}).get("workflowRun") or {}).get("workflow") or {}).get(
+                "name"
+            )
+            or ""
+        ).strip()
+        timestamp = str(node.get("completedAt") or node.get("startedAt") or "")
+        return CheckEntry(
+            name=name,
+            source_kind="check_run",
+            state=state,
+            timestamp=timestamp,
+            details_url=str(node.get("detailsUrl") or ""),
+            workflow_name=workflow_name,
+        )
+
+    name = str(node.get("context") or "").strip()
+    raw_state = str(node.get("state") or "").strip().upper()
+    state = "passed" if raw_state == "SUCCESS" else "pending" if raw_state == "PENDING" else "failed"
+    return CheckEntry(
+        name=name,
+        source_kind="status_context",
+        state=state,
+        timestamp=str(node.get("createdAt") or ""),
+        details_url=str(node.get("targetUrl") or ""),
+        workflow_name="",
+    )
+
+
+def _latest_entries(entries: list[CheckEntry]) -> tuple[dict[str, CheckEntry], list[CheckEntry]]:
+    """Split latest-per-name entries from superseded historical entries."""
+    latest: dict[str, CheckEntry] = {}
+    superseded: list[CheckEntry] = []
+    for entry in sorted(entries, key=lambda item: (item.name, item.timestamp, item.details_url)):
+        previous = latest.get(entry.name)
+        if previous is None or (entry.timestamp, entry.details_url) >= (
+            previous.timestamp,
+            previous.details_url,
+        ):
+            if previous is not None:
+                superseded.append(previous)
+            latest[entry.name] = entry
+        else:
+            superseded.append(entry)
+    return latest, superseded
+
+
+def _required_snapshot(
+    latest_entries: dict[str, CheckEntry], required_names: set[str]
+) -> list[CheckEntry]:
+    """Build required-check snapshot, inserting pending placeholders when missing."""
+    snapshot: list[CheckEntry] = []
+    for name in sorted(required_names):
+        entry = latest_entries.get(name)
+        if entry is None:
+            snapshot.append(
+                CheckEntry(
+                    name=name,
+                    source_kind="missing",
+                    state="pending",
+                    timestamp="",
+                    details_url="",
+                    workflow_name="",
+                )
+            )
+        else:
+            snapshot.append(entry)
+    return snapshot
+
+
+def _format_entry(entry: CheckEntry) -> str:
+    """Render one check entry for terminal output."""
+    source = f" [{entry.workflow_name}]" if entry.workflow_name else ""
+    url = f" -> {entry.details_url}" if entry.details_url else ""
+    return f"- {entry.name}: {entry.state}{source}{url}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate current-head checks and filter superseded noise."""
+    parser = argparse.ArgumentParser(
+        description="Filter GitHub PR checks to the latest current-head view."
+    )
+    parser.add_argument("--event-path", default="", help="GitHub event payload path.")
+    parser.add_argument("--pr-number", type=int, help="PR number for local runs.")
+    parser.add_argument("--repo", default="", help="Repo owner/name for local runs.")
+    args = parser.parse_args(argv)
+
+    if args.event_path and (args.pr_number is not None or args.repo.strip()):
+        parser.error("Use either --event-path or --pr-number/--repo, not both.")
+    if (args.pr_number is not None) != bool(args.repo.strip()):
+        parser.error("For local mode provide both --pr-number and --repo.")
+
+    token = _github_token()
+    if not token:
+        print("ERROR: GH_TOKEN or GITHUB_TOKEN is required for current-head check filtering.")
+        return 1
+
+    if args.event_path:
+        pr_number, repo = _extract_pr_context(Path(args.event_path))
+    else:
+        pr_number = args.pr_number or 0
+        repo = args.repo.strip()
+
+    if not pr_number or not repo:
+        print("current-head-checks: no PR context found; skipping.")
+        return 0
+
+    try:
+        is_draft, merge_state, base_ref, nodes = _fetch_pr_metadata(pr_number, repo, token)
+        required_names = _fetch_required_check_names(repo, base_ref, token)
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: failed to query GitHub check state: HTTP {exc.code}")
+        return 1
+
+    if is_draft:
+        print("current-head-checks: PR is draft; skipping strict checks.")
+        return 0
+
+    latest, superseded = _latest_entries([_normalize_node(node) for node in nodes if node])
+    current_required = (
+        _required_snapshot(latest, required_names) if required_names else list(latest.values())
+    )
+
+    print("Current-head required checks:")
+    for entry in sorted(current_required, key=lambda item: item.name):
+        print(_format_entry(entry))
+
+    noisy_superseded = [entry for entry in superseded if entry.state != "passed"]
+    if noisy_superseded:
+        print("Superseded non-blocking checks:")
+        for entry in sorted(noisy_superseded, key=lambda item: (item.name, item.timestamp)):
+            print(_format_entry(entry))
+
+    blocking_entries = [
+        entry for entry in current_required if entry.state in {"pending", "failed"}
+    ]
+    if merge_state != "CLEAN" or blocking_entries:
+        print("ERROR: current-head check filter failed.")
+        print(f"- GitHub mergeStateStatus={merge_state or 'UNKNOWN'}")
+        if blocking_entries:
+            print("- Blocking current-head checks remain pending or failed.")
+        return 1
+
+    # RU/EN: superseded failures stay visible but non-blocking once latest head is clean.
+    print("current-head-checks: passed.")
+    print("Superseded historical failures are visible above but treated as non-blocking.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -27,6 +27,7 @@ class CheckEntry:
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PENDING_STATUS_CONTEXT_STATES = {"EXPECTED", "PENDING"}
 
 
 def _github_token() -> str:
@@ -155,7 +156,7 @@ def _fetch_pr_metadata(
         is_draft = bool(pr.get("isDraft", False))
         merge_state = str(pr.get("mergeStateStatus") or "")
         base_ref = str(pr.get("baseRefName") or "")
-        contexts = ((pr.get("statusCheckRollup") or {}).get("contexts") or {})
+        contexts = (pr.get("statusCheckRollup") or {}).get("contexts") or {}
         nodes.extend(contexts.get("nodes") or [])
         page_info = contexts.get("pageInfo") or {}
         if not page_info.get("hasNextPage", False):
@@ -231,7 +232,12 @@ def _normalize_node(node: dict[str, Any]) -> CheckEntry:
 
     name = str(node.get("context") or "").strip()
     raw_state = str(node.get("state") or "").strip().upper()
-    state = "passed" if raw_state == "SUCCESS" else "pending" if raw_state == "PENDING" else "failed"
+    if raw_state == "SUCCESS":
+        state = "passed"
+    elif raw_state in PENDING_STATUS_CONTEXT_STATES:
+        state = "pending"
+    else:
+        state = "failed"
     return CheckEntry(
         name=name,
         source_kind="status_context",
@@ -346,9 +352,7 @@ def main(argv: list[str] | None = None) -> int:
         for entry in sorted(noisy_superseded, key=lambda item: (item.name, item.timestamp)):
             print(_format_entry(entry))
 
-    blocking_entries = [
-        entry for entry in current_required if entry.state in {"pending", "failed"}
-    ]
+    blocking_entries = [entry for entry in current_required if entry.state in {"pending", "failed"}]
     if merge_state != "CLEAN" or blocking_entries:
         print("ERROR: current-head check filter failed.")
         print(f"- GitHub mergeStateStatus={merge_state or 'UNKNOWN'}")

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -24,6 +24,7 @@ class CheckEntry:
     timestamp: str
     details_url: str
     workflow_name: str
+    conclusion: str
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -235,6 +236,7 @@ def _normalize_node(node: dict[str, Any]) -> CheckEntry:
             timestamp=timestamp,
             details_url=str(node.get("detailsUrl") or ""),
             workflow_name=workflow_name,
+            conclusion=conclusion,
         )
 
     name = str(node.get("context") or "").strip()
@@ -252,6 +254,7 @@ def _normalize_node(node: dict[str, Any]) -> CheckEntry:
         timestamp=str(node.get("createdAt") or ""),
         details_url=str(node.get("targetUrl") or ""),
         workflow_name="",
+        conclusion="",
     )
 
 
@@ -289,11 +292,48 @@ def _required_snapshot(
                     timestamp="",
                     details_url="",
                     workflow_name="",
+                    conclusion="",
                 )
             )
         else:
             snapshot.append(entry)
     return snapshot
+
+
+def _suppress_cancelled_latest_entries_with_newer_workflow_activity(
+    entries: list[CheckEntry],
+    latest: dict[str, CheckEntry],
+    superseded: list[CheckEntry],
+) -> tuple[dict[str, CheckEntry], list[CheckEntry]]:
+    """Demote cancelled latest entries when a newer run from the same workflow exists.
+
+    RU: Если job из текущего head был отменен из-за concurrency, но тот же workflow
+    уже успел выпустить более новый activity на этом же SHA, cancelled status не
+    должен считаться latest signal для merge triage.
+    EN: If a current-head job was cancelled by workflow concurrency, but the same
+    workflow has already emitted newer activity on the same SHA, that cancelled
+    status is stale noise and should move to the superseded bucket.
+    """
+
+    newest_workflow_marker: dict[str, tuple[str, str]] = {}
+    for entry in entries:
+        if not entry.workflow_name:
+            continue
+        marker = (entry.timestamp, entry.details_url)
+        previous = newest_workflow_marker.get(entry.workflow_name)
+        if previous is None or marker >= previous:
+            newest_workflow_marker[entry.workflow_name] = marker
+
+    filtered_latest = dict(latest)
+    updated_superseded = list(superseded)
+    for name, entry in list(filtered_latest.items()):
+        if entry.conclusion != "CANCELLED" or not entry.workflow_name:
+            continue
+        latest_workflow_marker = newest_workflow_marker.get(entry.workflow_name)
+        if latest_workflow_marker and latest_workflow_marker > (entry.timestamp, entry.details_url):
+            updated_superseded.append(entry)
+            del filtered_latest[name]
+    return filtered_latest, updated_superseded
 
 
 def _format_entry(entry: CheckEntry) -> str:
@@ -357,7 +397,13 @@ def main(argv: list[str] | None = None) -> int:
         print("current-head-checks: PR is draft; skipping strict checks.")
         return 0
 
-    latest, superseded = _latest_entries([_normalize_node(node) for node in nodes if node])
+    normalized_entries = [_normalize_node(node) for node in nodes if node]
+    latest, superseded = _latest_entries(normalized_entries)
+    latest, superseded = _suppress_cancelled_latest_entries_with_newer_workflow_activity(
+        normalized_entries,
+        latest,
+        superseded,
+    )
     current_required = (
         _required_snapshot(latest, required_names) if required_metadata_available else []
     )

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
 
 PHASE2_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_body_phase2_gates.py"
 MERGE_GATE = REPO_ROOT / "scripts" / "ci" / "check_pr_merge_readiness.py"
+CURRENT_HEAD_CHECKS_GATE = REPO_ROOT / "scripts" / "ci" / "check_current_head_pr_checks.py"
 DISPOSITION_GATE = REPO_ROOT / "scripts" / "orchestration" / "check_review_threads_disposition.py"
 RUN_TIMEOUT_SEC = 120
 
@@ -93,6 +94,12 @@ def _phase2_args(args: argparse.Namespace) -> list[str]:
 
 
 def _merge_gate_args(args: argparse.Namespace) -> list[str]:
+    if args.event_path:
+        return ["--event-path", args.event_path]
+    return ["--pr-number", str(args.pr_number), "--repo", args.repo]
+
+
+def _current_head_checks_args(args: argparse.Namespace) -> list[str]:
     if args.event_path:
         return ["--event-path", args.event_path]
     return ["--pr-number", str(args.pr_number), "--repo", args.repo]
@@ -191,6 +198,11 @@ def main(argv: list[str] | None = None) -> int:
     gate_results = [
         _run_gate("phase2-pr-body-gates", PHASE2_GATE, _phase2_args(parsed)),
         _run_gate("merge-readiness-gate", MERGE_GATE, _merge_gate_args(parsed)),
+        _run_gate(
+            "current-head-checks",
+            CURRENT_HEAD_CHECKS_GATE,
+            _current_head_checks_args(parsed),
+        ),
         _run_gate(
             "review-threads-disposition",
             DISPOSITION_GATE,

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -34,6 +34,13 @@ class GateResult:
     stderr: str
 
 
+@dataclass(frozen=True)
+class PreGateFailure:
+    """Deterministic pre-execution gate failure before a subprocess can run."""
+
+    message: str
+
+
 def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     """Enforce CI vs local mode contract for the wrapper CLI."""
 
@@ -100,9 +107,23 @@ def _fetch_pr_body(pr_number: int, repo: str) -> str:
 
     env = os.environ.copy()
     if not (env.get("GH_TOKEN") or env.get("GITHUB_TOKEN")):
-        raise RuntimeError(
-            "GH_TOKEN or GITHUB_TOKEN is required to fetch PR body for local merge checks."
+        auth_status = subprocess.run(  # nosec B603: absolute gh path with fixed auth-status argv (remove-by: 2026-06-30, ref: PR-1129)
+            [_github_cli_path(), "auth", "status"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=RUN_TIMEOUT_SEC,
+            env=env,
         )
+        if auth_status.returncode != 0:
+            stderr = (
+                auth_status.stderr.strip() or auth_status.stdout.strip() or "unknown gh auth error"
+            )
+            raise RuntimeError(
+                "GH_TOKEN/GITHUB_TOKEN is unset and gh auth status failed; "
+                f"run `gh auth login` or export GH_TOKEN. Details: {stderr}"
+            )
     argv = [
         _github_cli_path(),
         "pr",
@@ -130,10 +151,13 @@ def _fetch_pr_body(pr_number: int, repo: str) -> str:
     return result.stdout
 
 
-def _phase2_args(args: argparse.Namespace) -> list[str]:
+def _phase2_args(args: argparse.Namespace) -> list[str] | PreGateFailure:
     if args.event_path:
         return ["--event-path", args.event_path]
-    body = args.body if args.body else _fetch_pr_body(args.pr_number, args.repo)
+    try:
+        body = args.body if args.body else _fetch_pr_body(args.pr_number, args.repo)
+    except RuntimeError as exc:
+        return PreGateFailure(str(exc))
     phase2_args = ["--pr-number", str(args.pr_number)]
     phase2_args.extend(["--body", body])
     return phase2_args
@@ -209,6 +233,18 @@ def _print_gate_output(result: GateResult) -> None:
         print(result.stderr)
 
 
+def _pre_gate_failure_result(name: str, argv: list[str], failure: PreGateFailure) -> GateResult:
+    """Convert local preparation failure into normal gate output."""
+
+    return GateResult(
+        name=name,
+        argv=argv,
+        returncode=1,
+        stdout="",
+        stderr=failure.message,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Run canonical PR governance gates and emit a single merge verdict."
@@ -241,8 +277,19 @@ def main(argv: list[str] | None = None) -> int:
     parsed = parser.parse_args(argv)
     _validate_args(parsed, parser)
 
+    phase2_args = _phase2_args(parsed)
+    phase2_result = (
+        _pre_gate_failure_result(
+            "phase2-pr-body-gates",
+            [sys.executable, str(PHASE2_GATE)],
+            phase2_args,
+        )
+        if isinstance(phase2_args, PreGateFailure)
+        else _run_gate("phase2-pr-body-gates", PHASE2_GATE, phase2_args)
+    )
+
     gate_results = [
-        _run_gate("phase2-pr-body-gates", PHASE2_GATE, _phase2_args(parsed)),
+        phase2_result,
         _run_gate("merge-readiness-gate", MERGE_GATE, _merge_gate_args(parsed)),
         _run_gate(
             "current-head-checks",

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -156,7 +156,7 @@ def _phase2_args(args: argparse.Namespace) -> list[str] | PreGateFailure:
         return ["--event-path", args.event_path]
     try:
         body = args.body if args.body else _fetch_pr_body(args.pr_number, args.repo)
-    except RuntimeError as exc:
+    except (RuntimeError, subprocess.TimeoutExpired) as exc:
         return PreGateFailure(str(exc))
     phase2_args = ["--pr-number", str(args.pr_number)]
     phase2_args.extend(["--body", body])

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import subprocess  # nosec B404: wrapper executes fixed repo scripts only (remove-by: 2026-06-30, ref: PR-1005)
 import sys
 from dataclasses import dataclass
@@ -84,12 +86,56 @@ def _run_gate(name: str, script_path: Path, extra_args: list[str]) -> GateResult
     )
 
 
+def _github_cli_path() -> str:
+    """Resolve gh binary path for read-only PR metadata access."""
+
+    gh_path = shutil.which("gh")
+    if not gh_path:
+        raise RuntimeError("GitHub CLI `gh` is required to fetch PR body in local mode.")
+    return gh_path
+
+
+def _fetch_pr_body(pr_number: int, repo: str) -> str:
+    """Fetch live PR body so Phase2 mirror checks work in local wrapper mode."""
+
+    env = os.environ.copy()
+    if not (env.get("GH_TOKEN") or env.get("GITHUB_TOKEN")):
+        raise RuntimeError(
+            "GH_TOKEN or GITHUB_TOKEN is required to fetch PR body for local merge checks."
+        )
+    argv = [
+        _github_cli_path(),
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "body",
+        "--jq",
+        ".body",
+    ]
+    result = subprocess.run(  # nosec B603: absolute gh path with fixed read-only argv (remove-by: 2026-06-30, ref: PR-1129)
+        argv,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=RUN_TIMEOUT_SEC,
+        env=env,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "unknown gh error"
+        raise RuntimeError(f"Failed to fetch PR body for #{pr_number}: {stderr}")
+    return result.stdout
+
+
 def _phase2_args(args: argparse.Namespace) -> list[str]:
     if args.event_path:
         return ["--event-path", args.event_path]
+    body = args.body if args.body else _fetch_pr_body(args.pr_number, args.repo)
     phase2_args = ["--pr-number", str(args.pr_number)]
-    if args.body:
-        phase2_args.extend(["--body", args.body])
+    phase2_args.extend(["--body", body])
     return phase2_args
 
 

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -136,7 +136,7 @@ def test_main_fails_when_latest_required_check_is_pending(
     assert "Blocking current-head checks remain pending or failed." in captured.out
 
 
-def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes(
+def test_main_passes_when_merge_state_is_not_clean_but_required_snapshot_is_clean(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -163,6 +163,44 @@ def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes
     )
     monkeypatch.setattr(
         current_head_checks, "_fetch_required_check_names", lambda *args: ({"build"}, True)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "current-head-checks: passed." in captured.out
+
+
+def test_main_fails_when_merge_state_is_not_clean_and_required_metadata_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "UNSTABLE",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "build",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": "2026-03-12T05:09:03Z",
+                    "detailsUrl": "https://example.invalid/passed",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Docker Image CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), False)
     )
 
     exit_code = current_head_checks.main(

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -85,6 +85,41 @@ def test_stale_latest_entry_is_demoted_when_same_workflow_has_newer_activity() -
     assert stale_latest in updated_superseded
 
 
+def test_same_timestamp_does_not_demote_latest_entry_on_details_url_only() -> None:
+    candidate_latest = current_head_checks.CheckEntry(
+        name="coverage-pr",
+        source_kind="check_run",
+        state="failed",
+        timestamp="2026-03-12T08:36:42Z",
+        details_url="https://example.invalid/current-candidate",
+        workflow_name="CI",
+        conclusion="FAILURE",
+    )
+    same_timestamp_other_job = current_head_checks.CheckEntry(
+        name="Docs Phase1 gates",
+        source_kind="check_run",
+        state="passed",
+        timestamp="2026-03-12T08:36:42Z",
+        details_url="https://example.invalid/other-job",
+        workflow_name="CI",
+        conclusion="SUCCESS",
+    )
+
+    latest, superseded = current_head_checks._latest_entries(
+        [candidate_latest, same_timestamp_other_job]
+    )
+    filtered_latest, updated_superseded = (
+        current_head_checks._suppress_stale_latest_entries_with_newer_workflow_activity(
+            [candidate_latest, same_timestamp_other_job],
+            latest,
+            superseded,
+        )
+    )
+
+    assert filtered_latest["coverage-pr"] == candidate_latest
+    assert candidate_latest not in updated_superseded
+
+
 def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_superseded(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -82,9 +82,7 @@ def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_supers
             ],
         ),
     )
-    monkeypatch.setattr(
-        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
-    )
+    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -122,9 +120,7 @@ def test_main_fails_when_latest_required_check_is_pending(
             ],
         ),
     )
-    monkeypatch.setattr(
-        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
-    )
+    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -161,9 +157,7 @@ def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes
             ],
         ),
     )
-    monkeypatch.setattr(
-        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
-    )
+    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -205,3 +199,17 @@ def test_main_uses_all_latest_checks_when_required_set_is_unavailable(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "- CodeRabbit: passed" in captured.out
+
+
+def test_status_context_expected_is_treated_as_pending() -> None:
+    entry = current_head_checks._normalize_node(
+        {
+            "__typename": "StatusContext",
+            "context": "CodeRabbit",
+            "state": "EXPECTED",
+            "createdAt": "2026-03-12T05:02:15Z",
+            "targetUrl": "https://example.invalid/pending",
+        }
+    )
+
+    assert entry.state == "pending"

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci import check_current_head_pr_checks as current_head_checks
+
+
+def test_latest_entries_prefers_newest_duplicate_and_marks_older_superseded() -> None:
+    older = current_head_checks.CheckEntry(
+        name="build",
+        source_kind="check_run",
+        state="failed",
+        timestamp="2026-03-12T04:48:16Z",
+        details_url="https://example.invalid/older",
+        workflow_name="Docker Image CI",
+    )
+    newer = current_head_checks.CheckEntry(
+        name="build",
+        source_kind="check_run",
+        state="passed",
+        timestamp="2026-03-12T05:05:00Z",
+        details_url="https://example.invalid/newer",
+        workflow_name="Docker Image CI",
+    )
+
+    latest, superseded = current_head_checks._latest_entries([newer, older])
+
+    assert latest["build"] == newer
+    assert superseded == [older]
+
+
+def test_required_snapshot_adds_pending_placeholder_for_missing_required_check() -> None:
+    snapshot = current_head_checks._required_snapshot(
+        latest_entries={},
+        required_names={"Merge readiness gate"},
+    )
+
+    assert snapshot == [
+        current_head_checks.CheckEntry(
+            name="Merge readiness gate",
+            source_kind="missing",
+            state="pending",
+            timestamp="",
+            details_url="",
+            workflow_name="",
+        )
+    ]
+
+
+def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_superseded(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "CLEAN",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "build",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "startedAt": "2026-03-12T04:48:16Z",
+                    "completedAt": "2026-03-12T04:48:49Z",
+                    "detailsUrl": "https://example.invalid/failed",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Docker Image CI"}}},
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "build",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": "2026-03-12T05:09:03Z",
+                    "detailsUrl": "https://example.invalid/passed",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Docker Image CI"}}},
+                },
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Current-head required checks:" in captured.out
+    assert "Superseded non-blocking checks:" in captured.out
+    assert "current-head-checks: passed." in captured.out
+
+
+def test_main_fails_when_latest_required_check_is_pending(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "UNSTABLE",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "build",
+                    "status": "IN_PROGRESS",
+                    "conclusion": None,
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": None,
+                    "detailsUrl": "https://example.invalid/pending",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Docker Image CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "ERROR: current-head check filter failed." in captured.out
+    assert "Blocking current-head checks remain pending or failed." in captured.out
+
+
+def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "UNSTABLE",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "build",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": "2026-03-12T05:09:03Z",
+                    "detailsUrl": "https://example.invalid/passed",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Docker Image CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: {"build"}
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "GitHub mergeStateStatus=UNSTABLE" in captured.out
+
+
+def test_main_uses_all_latest_checks_when_required_set_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "CLEAN",
+            "main",
+            [
+                {
+                    "__typename": "StatusContext",
+                    "context": "CodeRabbit",
+                    "state": "SUCCESS",
+                    "createdAt": "2026-03-12T05:02:15Z",
+                    "targetUrl": "",
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: set())
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "- CodeRabbit: passed" in captured.out

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -13,6 +13,7 @@ def test_latest_entries_prefers_newest_duplicate_and_marks_older_superseded() ->
         timestamp="2026-03-12T04:48:16Z",
         details_url="https://example.invalid/older",
         workflow_name="Docker Image CI",
+        conclusion="FAILURE",
     )
     newer = current_head_checks.CheckEntry(
         name="build",
@@ -21,6 +22,7 @@ def test_latest_entries_prefers_newest_duplicate_and_marks_older_superseded() ->
         timestamp="2026-03-12T05:05:00Z",
         details_url="https://example.invalid/newer",
         workflow_name="Docker Image CI",
+        conclusion="SUCCESS",
     )
 
     latest, superseded = current_head_checks._latest_entries([newer, older])
@@ -43,8 +45,44 @@ def test_required_snapshot_adds_pending_placeholder_for_missing_required_check()
             timestamp="",
             details_url="",
             workflow_name="",
+            conclusion="",
         )
     ]
+
+
+def test_cancelled_latest_is_demoted_when_same_workflow_has_newer_activity() -> None:
+    cancelled_latest = current_head_checks.CheckEntry(
+        name="coverage-pr",
+        source_kind="check_run",
+        state="failed",
+        timestamp="2026-03-12T08:36:42Z",
+        details_url="https://example.invalid/cancelled",
+        workflow_name="CI",
+        conclusion="CANCELLED",
+    )
+    newer_workflow_activity = current_head_checks.CheckEntry(
+        name="Docs Phase1 gates",
+        source_kind="check_run",
+        state="passed",
+        timestamp="2026-03-12T08:40:32Z",
+        details_url="https://example.invalid/newer-workflow-activity",
+        workflow_name="CI",
+        conclusion="SUCCESS",
+    )
+
+    latest, superseded = current_head_checks._latest_entries(
+        [cancelled_latest, newer_workflow_activity]
+    )
+    filtered_latest, updated_superseded = (
+        current_head_checks._suppress_cancelled_latest_entries_with_newer_workflow_activity(
+            [cancelled_latest, newer_workflow_activity],
+            latest,
+            superseded,
+        )
+    )
+
+    assert "coverage-pr" not in filtered_latest
+    assert cancelled_latest in updated_superseded
 
 
 def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_superseded(

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -50,15 +50,15 @@ def test_required_snapshot_adds_pending_placeholder_for_missing_required_check()
     ]
 
 
-def test_cancelled_latest_is_demoted_when_same_workflow_has_newer_activity() -> None:
-    cancelled_latest = current_head_checks.CheckEntry(
+def test_stale_latest_entry_is_demoted_when_same_workflow_has_newer_activity() -> None:
+    stale_latest = current_head_checks.CheckEntry(
         name="coverage-pr",
         source_kind="check_run",
         state="failed",
         timestamp="2026-03-12T08:36:42Z",
         details_url="https://example.invalid/cancelled",
         workflow_name="CI",
-        conclusion="CANCELLED",
+        conclusion="FAILURE",
     )
     newer_workflow_activity = current_head_checks.CheckEntry(
         name="Docs Phase1 gates",
@@ -71,18 +71,18 @@ def test_cancelled_latest_is_demoted_when_same_workflow_has_newer_activity() -> 
     )
 
     latest, superseded = current_head_checks._latest_entries(
-        [cancelled_latest, newer_workflow_activity]
+        [stale_latest, newer_workflow_activity]
     )
     filtered_latest, updated_superseded = (
-        current_head_checks._suppress_cancelled_latest_entries_with_newer_workflow_activity(
-            [cancelled_latest, newer_workflow_activity],
+        current_head_checks._suppress_stale_latest_entries_with_newer_workflow_activity(
+            [stale_latest, newer_workflow_activity],
             latest,
             superseded,
         )
     )
 
     assert "coverage-pr" not in filtered_latest
-    assert cancelled_latest in updated_superseded
+    assert stale_latest in updated_superseded
 
 
 def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_superseded(

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -82,7 +82,9 @@ def test_main_passes_when_latest_current_head_is_clean_and_old_failure_is_supers
             ],
         ),
     )
-    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: ({"build"}, True)
+    )
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -120,7 +122,9 @@ def test_main_fails_when_latest_required_check_is_pending(
             ],
         ),
     )
-    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: ({"build"}, True)
+    )
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -157,7 +161,9 @@ def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes
             ],
         ),
     )
-    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: {"build"})
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: ({"build"}, True)
+    )
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -168,7 +174,7 @@ def test_main_fails_when_merge_state_is_not_clean_even_if_latest_snapshot_passes
     assert "GitHub mergeStateStatus=UNSTABLE" in captured.out
 
 
-def test_main_uses_all_latest_checks_when_required_set_is_unavailable(
+def test_main_passes_when_required_check_set_is_empty_but_available(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -190,7 +196,9 @@ def test_main_uses_all_latest_checks_when_required_set_is_unavailable(
             ],
         ),
     )
-    monkeypatch.setattr(current_head_checks, "_fetch_required_check_names", lambda *args: set())
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), True)
+    )
 
     exit_code = current_head_checks.main(
         ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -198,7 +206,8 @@ def test_main_uses_all_latest_checks_when_required_set_is_unavailable(
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "- CodeRabbit: passed" in captured.out
+    assert "Current-head required checks:" in captured.out
+    assert "- none" in captured.out
 
 
 def test_status_context_expected_is_treated_as_pending() -> None:
@@ -213,3 +222,104 @@ def test_status_context_expected_is_treated_as_pending() -> None:
     )
 
     assert entry.state == "pending"
+
+
+def test_main_passes_for_draft_pr_without_strict_checks(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (True, "DRAFT", "main", []),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: ({"build"}, True)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1129", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "current-head-checks: PR is draft; skipping strict checks." in captured.out
+
+
+def test_main_fails_when_token_is_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "")
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1129", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "GH_TOKEN or GITHUB_TOKEN is required" in captured.out
+
+
+def test_main_fails_when_github_metadata_query_errors(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+
+    def raise_http_error(*args, **kwargs):
+        raise current_head_checks.urllib.error.HTTPError(
+            url="https://api.github.com/graphql",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(current_head_checks, "_fetch_pr_metadata", raise_http_error)
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1129", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "ERROR: failed to query GitHub check state: HTTP 503" in captured.out
+
+
+def test_main_uses_merge_state_only_when_required_check_metadata_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "CLEAN",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "optional-e2e",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": "2026-03-12T05:09:03Z",
+                    "detailsUrl": "https://example.invalid/failed-optional",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "Optional CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), False)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1129", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Required check metadata unavailable" in captured.out
+    assert "Current-head advisory checks:" in captured.out
+    assert "- optional-e2e: failed [Optional CI]" in captured.out

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -146,6 +146,39 @@ def test_local_mode_turns_fetch_pr_body_failure_into_gate_failure(
     assert "Failing gates: phase2-pr-body-gates" in captured.out
 
 
+def test_local_mode_turns_fetch_pr_body_timeout_into_gate_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = {
+        "merge-readiness-gate": _ok_result("merge-readiness-gate", []),
+        "current-head-checks": _ok_result("current-head-checks", []),
+        "review-threads-disposition": _ok_result("review-threads-disposition", []),
+    }
+
+    monkeypatch.setattr(
+        merge_ready,
+        "_run_gate",
+        lambda name, script_path, extra_args: results[name],
+    )
+
+    def raise_timeout(pr_number: int, repo: str) -> str:
+        raise merge_ready.subprocess.TimeoutExpired(
+            cmd=["gh", "pr", "view", str(pr_number)],
+            timeout=merge_ready.RUN_TIMEOUT_SEC,
+        )
+
+    monkeypatch.setattr(merge_ready, "_fetch_pr_body", raise_timeout)
+
+    exit_code = merge_ready.main(
+        ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "[FAIL] phase2-pr-body-gates" in captured.out
+    assert "Command '['gh', 'pr', 'view', '1005']' timed out" in captured.out
+
+
 def test_event_mode_passes_require_auth_only_to_disposition(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -87,6 +87,65 @@ def test_local_mode_fetches_pr_body_when_not_provided(
     )
 
 
+def test_fetch_pr_body_uses_gh_auth_status_when_env_token_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        run_calls.append(argv)
+        if argv[-2:] == ["auth", "status"]:
+            return merge_ready.subprocess.CompletedProcess(argv, 0, stdout="logged in", stderr="")
+        return merge_ready.subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(merge_ready, "_github_cli_path", lambda: "/usr/local/bin/gh")
+    monkeypatch.setattr(merge_ready.subprocess, "run", fake_run)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    body = merge_ready._fetch_pr_body(1129, "Katsiarynakavaleuskaya/PulsePlate")
+
+    assert body.startswith("## Discussion Thread Pass")
+    assert run_calls[0] == ["/usr/local/bin/gh", "auth", "status"]
+    assert run_calls[1][:4] == ["/usr/local/bin/gh", "pr", "view", "1129"]
+
+
+def test_local_mode_turns_fetch_pr_body_failure_into_gate_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = {
+        "merge-readiness-gate": _ok_result("merge-readiness-gate", []),
+        "current-head-checks": _ok_result("current-head-checks", []),
+        "review-threads-disposition": _ok_result("review-threads-disposition", []),
+    }
+
+    monkeypatch.setattr(
+        merge_ready,
+        "_run_gate",
+        lambda name, script_path, extra_args: results[name],
+    )
+    monkeypatch.setattr(
+        merge_ready,
+        "_fetch_pr_body",
+        lambda pr_number, repo: (_ for _ in ()).throw(RuntimeError("gh auth failed")),
+    )
+
+    exit_code = merge_ready.main(
+        ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "[FAIL] phase2-pr-body-gates" in captured.out
+    assert "gh auth failed" in captured.out
+    assert "Failing gates: phase2-pr-body-gates" in captured.out
+
+
 def test_event_mode_passes_require_auth_only_to_disposition(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -47,6 +47,10 @@ def test_local_mode_runs_all_gates_in_order(monkeypatch: pytest.MonkeyPatch) -> 
             "merge-readiness-gate",
             ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"],
         ),
+        (
+            "current-head-checks",
+            ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"],
+        ),
         ("review-threads-disposition", ["--pr-number", "1005"]),
     ]
 
@@ -76,6 +80,7 @@ def test_event_mode_passes_require_auth_only_to_disposition(
     assert calls == [
         ("phase2-pr-body-gates", ["--event-path", str(event_path)]),
         ("merge-readiness-gate", ["--event-path", str(event_path)]),
+        ("current-head-checks", ["--event-path", str(event_path)]),
         ("review-threads-disposition", ["--pr-number", "1007", "--require-auth"]),
     ]
 
@@ -117,6 +122,13 @@ def test_wrapper_surfaces_failing_gate_names(
             argv=[],
             returncode=0,
             stdout="disposition ok",
+            stderr="",
+        ),
+        "current-head-checks": merge_ready.GateResult(
+            name="current-head-checks",
+            argv=[],
+            returncode=0,
+            stdout="current head ok",
             stderr="",
         ),
     }
@@ -161,6 +173,13 @@ def test_wrapper_fails_when_disposition_gate_skips_in_advisory_mode(
             argv=[],
             returncode=0,
             stdout="SKIP: no usable gh auth for advisory local run.",
+            stderr="",
+        ),
+        "current-head-checks": merge_ready.GateResult(
+            name="current-head-checks",
+            argv=[],
+            returncode=0,
+            stdout="current head ok",
             stderr="",
         ),
     }

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -55,6 +55,38 @@ def test_local_mode_runs_all_gates_in_order(monkeypatch: pytest.MonkeyPatch) -> 
     ]
 
 
+def test_local_mode_fetches_pr_body_when_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_run_gate(name: str, script_path, extra_args: list[str]) -> merge_ready.GateResult:
+        calls.append((name, extra_args))
+        return _ok_result(name, [str(script_path), *extra_args])
+
+    monkeypatch.setattr(merge_ready, "_run_gate", fake_run_gate)
+    monkeypatch.setattr(
+        merge_ready,
+        "_fetch_pr_body",
+        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
+    )
+
+    exit_code = merge_ready.main(
+        ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    assert exit_code == 0
+    assert calls[0] == (
+        "phase2-pr-body-gates",
+        [
+            "--pr-number",
+            "1005",
+            "--body",
+            "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
+        ],
+    )
+
+
 def test_event_mode_passes_require_auth_only_to_disposition(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -138,6 +170,11 @@ def test_wrapper_surfaces_failing_gate_names(
         "_run_gate",
         lambda name, script_path, extra_args: results[name],
     )
+    monkeypatch.setattr(
+        merge_ready,
+        "_fetch_pr_body",
+        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
+    )
 
     exit_code = merge_ready.main(
         ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
@@ -188,6 +225,11 @@ def test_wrapper_fails_when_disposition_gate_skips_in_advisory_mode(
         merge_ready,
         "_run_gate",
         lambda name, script_path, extra_args: results[name],
+    )
+    monkeypatch.setattr(
+        merge_ready,
+        "_fetch_pr_body",
+        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
     )
 
     exit_code = merge_ready.main(


### PR DESCRIPTION
## Summary
- filter merge-triage check output down to the latest current-head view
- keep superseded historical failures visible but explicitly non-blocking
- wire the filtered current-head stage into the canonical orchestration merge wrapper
- update runbook guidance away from raw `gh pr checks` as the final merge signal

## Testing
- `pytest -q tests/test_current_head_pr_checks.py tests/test_orchestration_merge_ready.py tests/test_pr_merge_readiness_gate.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1129_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Local hard gate passed (`make verify`)
- [ ] Pre-commit passed (`pre-commit run --all-files`)
- [ ] PR scope is narrow and single-purpose
- [ ] Carryover / deferred work recorded if needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters GitHub check noise by showing only the latest current‑head status, suppressing stale same‑workflow and cancelled same‑head runs, and treating superseded failures as non‑blocking. Adds a hard gate for this filtered view and hardens the local wrapper with deterministic auth, live PR body fetch, and timeout handling.

- **Bug Fixes**
  - Added `scripts/ci/check_current_head_pr_checks.py` to keep the latest per check, read required checks from branch protection, and fail on pending/failed required checks; when metadata isn’t available, fall back to `mergeStateStatus` and emit advisory current‑head checks. Treat `StatusContext.state=EXPECTED` as pending; skip strict checks for drafts; suppress `CANCELLED` noise when a newer run from the same workflow exists; suppress stale latest entries when newer activity from the same workflow exists and fix equal‑timestamp ordering to avoid false demotions; block on `mergeStateStatus` only when required‑check metadata is unavailable.
  - Integrated as `current-head-checks` in `scripts/orchestration/check_merge_ready.py`; the local wrapper now fetches the live PR body, falls back to `gh auth status` before `gh pr view`, and converts fetch and timeout failures into deterministic gate failures.
  - Updated runbook/rules to make `gh pr checks` diagnostic‑only and point to the filtered current‑head view; added `docs/review/PR_1129_FIXED_MAPPING.md`; expanded tests to cover equal‑timestamp ordering, stale‑workflow suppression, cancelled‑run suppression, auth fallback, pre‑gate failures, required‑check fallback, superseded checks, EXPECTED handling, draft/advisory paths, timeout errors, and the narrowed merge‑state fallback.

- **Migration**
  - Use `python scripts/orchestration/check_merge_ready.py --pr-number <PR_NUMBER> --repo <OWNER>/<REPO> --require-auth` as the final merge signal; `gh pr checks` is diagnostic only.

<sup>Written for commit 560bbcfac72ceb2aa03f0262fb8f099627a32b8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filtered "current-head" PR checks view and integrated it as a merge-readiness gate; supports local-mode PR body retrieval for deterministic merge triage.

* **Documentation**
  * Clarified merge-readiness guidance to treat the filtered current-head view as the canonical triage output; added a PR mapping review doc and updated backlog/status entries.

* **Tests**
  * Added unit and orchestration tests covering current-head filtering, merge verification flows, and gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->