### PR TITLE
docs(figma): polish bmi and onboarding slice

### DIFF
--- a/docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md
+++ b/docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md
@@ -22,14 +22,14 @@ Current workspace blocker:
 
 | Canonical screen ID | nodeId | Proposed label | Activation status |
 | --- | --- | --- | --- |
-| `iOS_Onboarding_01_Welcome` | `25:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_Onboarding_02_Value_Usage` | `20:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_Home` | `11:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_Paywall_Pro_VIP` | `17:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_ShoppingList` | `18:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_WeeklyPlan_Reader` | `15:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_Profile` | `13:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_BMI` | `24:2` | `SwiftUI` | ready_for_suggestions |
+| `iOS_Onboarding_01_Welcome` | `25:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_Onboarding_02_Value_Usage` | `20:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_Home` | `11:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_Paywall_Pro_VIP` | `17:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_ShoppingList` | `18:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_WeeklyPlan_Reader` | `15:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_Profile` | `13:2` | `SwiftUI` | blocked_by_plan |
+| `iOS_BMI` | `24:2` | `SwiftUI` | blocked_by_plan |
 
 ## Preconditions
 

--- a/docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md
+++ b/docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md
@@ -22,14 +22,14 @@ Current workspace blocker:
 
 | Canonical screen ID | nodeId | Proposed label | Activation status |
 | --- | --- | --- | --- |
-| `iOS_Onboarding_01_Welcome` | `1:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_Onboarding_02_Value_Usage` | `3:2` | `SwiftUI` | ready_for_suggestions |
+| `iOS_Onboarding_01_Welcome` | `25:2` | `SwiftUI` | ready_for_suggestions |
+| `iOS_Onboarding_02_Value_Usage` | `20:2` | `SwiftUI` | ready_for_suggestions |
 | `iOS_Home` | `11:2` | `SwiftUI` | ready_for_suggestions |
 | `iOS_Paywall_Pro_VIP` | `17:2` | `SwiftUI` | ready_for_suggestions |
 | `iOS_ShoppingList` | `18:2` | `SwiftUI` | ready_for_suggestions |
 | `iOS_WeeklyPlan_Reader` | `15:2` | `SwiftUI` | ready_for_suggestions |
 | `iOS_Profile` | `13:2` | `SwiftUI` | ready_for_suggestions |
-| `iOS_BMI` | `8:2` | `SwiftUI` | ready_for_suggestions |
+| `iOS_BMI` | `24:2` | `SwiftUI` | ready_for_suggestions |
 
 ## Preconditions
 
@@ -44,14 +44,14 @@ Current workspace blocker:
    - `ios/PulsePlate/Screens/PaywallScreen.swift`
    - `ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift`
    - `ios/PulsePlate/Screens/ShoppingListReaderScreen.swift`
-   - `ios/PulsePlate/Views/Profile/ProfileView.swift`
-   - `ios/PulsePlate/Views/BMICalculatorView.swift`
+   - `ios/PulsePlate/Views/ProfileView.swift`
+   - `ios/PulsePlate/Screens/BMICalculatorScreen.swift`
 
 ## Activation checklist
 
 1. Confirm seat capability:
    - run `mcp__figma__whoami`
-   - run `mcp__figma__get_code_connect_suggestions(fileKey="AhyS6u4dZXMRHVUDO3Cfn6", nodeId="1:2")`
+   - run `mcp__figma__get_code_connect_suggestions(fileKey="AhyS6u4dZXMRHVUDO3Cfn6", nodeId="25:2")`
    - continue only if the response is not plan-blocked
 2. Verify node accessibility for all eight screens:
    - run `mcp__figma__get_metadata(fileKey, nodeId)` for each node in the
@@ -67,7 +67,7 @@ Current workspace blocker:
    - `Shopping List` -> primary `ShoppingListReaderScreen.swift`
    - `Weekly Plan` -> primary `WeeklyPlanReaderView.swift`
    - `Profile` -> primary `ProfileView.swift`
-   - `BMI` -> primary `BMICalculatorView.swift`
+   - `BMI` -> primary `BMICalculatorScreen.swift`
 5. Persist approved mappings:
    - use `mcp__figma__send_code_connect_mappings(...)` for batched saves
    - use `mcp__figma__add_code_connect_map(...)` only if an explicit manual map

--- a/docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md
+++ b/docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md
@@ -25,14 +25,14 @@ Repo sources used:
 
 | Canonical screen ID | nodeId | Status |
 | --- | --- | --- |
-| `iOS_Onboarding_01_Welcome` | `1:2` | reconciled |
-| `iOS_Paywall_Pro_VIP` | `2:2` | reconciled |
-| `iOS_Onboarding_02_Value_Usage` | `3:2` | reconciled |
-| `iOS_Home` | `4:2` | reconciled |
-| `iOS_ShoppingList` | `5:2` | reconciled |
-| `iOS_WeeklyPlan_Reader` | `6:2` | reconciled |
-| `iOS_Profile` | `7:2` | reconciled |
-| `iOS_BMI` | `8:2` | reconciled |
+| `iOS_Onboarding_01_Welcome` | `25:2` | reconciled |
+| `iOS_Paywall_Pro_VIP` | `17:2` | reconciled |
+| `iOS_Onboarding_02_Value_Usage` | `20:2` | reconciled |
+| `iOS_Home` | `11:2` | reconciled |
+| `iOS_ShoppingList` | `18:2` | reconciled |
+| `iOS_WeeklyPlan_Reader` | `15:2` | reconciled |
+| `iOS_Profile` | `13:2` | reconciled |
+| `iOS_BMI` | `24:2` | reconciled |
 
 ## Component-by-Component Gaps
 
@@ -63,6 +63,14 @@ Repo sources used:
   implied only by a gated home row (`ios/PulsePlate/Screens/ShoppingListReaderScreen.swift:50-93`).
 - BMI now has a design-reference surface that preserves the runtime sequence:
   input -> result -> optional soft paywall hook (`ios/PulsePlate/Screens/BMICalculatorScreen.swift:46-85`, `docs/figma/PULSEPLATE_FIGMA_DESIGN_SPECIFICATION.md:954-969`).
+- Onboarding now uses the localized iOS value/usage copy as the content spine
+  instead of prototype-only copy that drifted away from runtime strings.
+- On March 12, 2026 the BMI + onboarding slice was re-captured again into
+  nodes `24:2`, `20:2`, and `25:2` to lock the current calmer brand copy and
+  stronger form anatomy into the canonical handoff map.
+- BMI now uses field/picker anatomy closer to the actual `BMICalculatorScreen`
+  instead of generic editable quick rows, and the optional hook mirrors the
+  backend default title/body/CTA contract (`ios/PulsePlate/Screens/BMICalculatorScreen.swift:46-85`, `docs/figma/PULSEPLATE_FIGMA_DESIGN_SPECIFICATION.md:954-969`).
 - Profile now exists as a calm PRO-setup surface rather than remaining only a
   technical form implementation (`ios/PulsePlate/Views/ProfileView.swift:19-80`, `docs/figma/PULSEPLATE_FIGMA_DESIGN_SPECIFICATION.md:1041-1049`).
 - Home no longer relies on the temporary `PRO active` chip; it now uses a
@@ -84,6 +92,8 @@ Repo sources used:
   exact runtime state machines for `idle/loading/empty/error`.
 - BMI and Profile still simplify some runtime detail states to keep the design
   reference focused on the main UX path.
+- Onboarding still compresses the real app into two calm screens and does not
+  model later branching states beyond the primary continuation path.
 
 ## Decision Log
 
@@ -98,12 +108,14 @@ Repo sources used:
 
 ## Next Promotion Path
 
-1. Reconcile `Weekly Plan` and `Shopping List` further against runtime empty/error states.
-2. Add `Plate` and `Progress` parity if the next slice expands beyond the current iOS funnel.
-3. If Code Connect becomes available, use
+1. Re-capture `BMI` and `Onboarding` after the polish pass and refresh the
+   canonical `screen ID -> nodeId` map if MCP changes top-level frame IDs.
+2. Reconcile `Weekly Plan` and `Shopping List` further against runtime empty/error states.
+3. Add `Plate` and `Progress` parity if the next slice expands beyond the current iOS funnel.
+4. If Code Connect becomes available, use
    `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md` and map the
    reconciled frames rather than the raw prototype file, while linking the new
    activation session log back to
    `docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md`.
-4. Keep the `screen ID -> nodeId` map current whenever a new MCP capture
+5. Keep the `screen ID -> nodeId` map current whenever a new MCP capture
    refresh changes top-level frame IDs.

--- a/docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md
+++ b/docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md
@@ -108,8 +108,8 @@ Repo sources used:
 
 ## Next Promotion Path
 
-1. Re-capture `BMI` and `Onboarding` after the polish pass and refresh the
-   canonical `screen ID -> nodeId` map if MCP changes top-level frame IDs.
+1. If a future MCP refresh changes top-level frame IDs again, re-capture `BMI`
+   and `Onboarding` and refresh the canonical `screen ID -> nodeId` map.
 2. Reconcile `Weekly Plan` and `Shopping List` further against runtime empty/error states.
 3. Add `Plate` and `Progress` parity if the next slice expands beyond the current iOS funnel.
 4. If Code Connect becomes available, use

--- a/docs/figma/ios_prototype_v2/README.md
+++ b/docs/figma/ios_prototype_v2/README.md
@@ -29,14 +29,14 @@ Generated Figma artifact:
 
 Current canonical screen map:
 
-- `iOS_Onboarding_01_Welcome` -> `1:2`
-- `iOS_Onboarding_02_Value_Usage` -> `3:2`
-- `iOS_Home` -> `4:2`
-- `iOS_Paywall_Pro_VIP` -> `2:2`
-- `iOS_WeeklyPlan_Reader` -> `6:2`
-- `iOS_ShoppingList` -> `5:2`
-- `iOS_Profile` -> `7:2`
-- `iOS_BMI` -> `8:2`
+- `iOS_Onboarding_01_Welcome` -> `25:2`
+- `iOS_Onboarding_02_Value_Usage` -> `20:2`
+- `iOS_Home` -> `11:2`
+- `iOS_Paywall_Pro_VIP` -> `17:2`
+- `iOS_WeeklyPlan_Reader` -> `15:2`
+- `iOS_ShoppingList` -> `18:2`
+- `iOS_Profile` -> `13:2`
+- `iOS_BMI` -> `24:2`
 
 Follow-up artifacts:
 
@@ -48,3 +48,7 @@ Note:
 
 - Figma MCP HTML capture auto-generated frame names as `Main Content (...)`.
 - Treat the canonical screen ID + `nodeId` mapping above as the implementation-safe reference.
+- On March 12, 2026 the `BMI + Onboarding` slice was re-captured into the same
+  file after dedicated polish passes; the older node IDs (`1:2`, `3:2`,
+  `8:2`, `23:2`, `22:2`, `21:2`) remain historical only and should not be used
+  as the latest handoff reference.

--- a/docs/figma/ios_prototype_v2/bmi.html
+++ b/docs/figma/ios_prototype_v2/bmi.html
@@ -16,43 +16,64 @@
 
       <div class="top-row">
         <span class="screen-label">iOS_BMI</span>
-        <span class="ghost-chip">Soft paywall</span>
+        <span class="ghost-chip">Body metrics</span>
       </div>
 
       <section class="glass-card">
         <p class="eyebrow">BMI calculator</p>
         <h1 class="headline">BMI</h1>
         <p class="subheadline">
-          Минимальный, спокойный flow: ввести ключевые значения, получить понятный результат и
-          показать soft paywall только когда его вернул backend.
+          Быстрый вход в базовые метрики: ввести ключевые значения, получить
+          понятный результат и при необходимости мягко открыть PRO через
+          дополнительный hook, не ломая основной flow.
         </p>
+        <div class="summary-strip">
+          <span class="summary-pill success">Weight</span>
+          <span class="summary-pill">Height</span>
+          <span class="summary-pill">Age + context</span>
+        </div>
       </section>
 
-      <section class="quick-list">
-        <div class="quick-row">
-          <div class="icon">⚖</div>
-          <div>
-            <h4>Вес</h4>
-            <p>70 кг</p>
-          </div>
-          <span class="trail">edit</span>
+      <section class="glass-card">
+        <div class="section-heading-row">
+          <h2>Input</h2>
+          <span class="row-badge blue">Step 1</span>
         </div>
-        <div class="quick-row">
-          <div class="icon">↕</div>
-          <div>
-            <h4>Рост</h4>
-            <p>175 см</p>
+        <div class="form-grid">
+          <div class="field-card">
+            <p class="field-label">Weight (kg)</p>
+            <p class="field-value">70</p>
+            <p class="field-support">Decimal input</p>
           </div>
-          <span class="trail">edit</span>
-        </div>
-        <div class="quick-row">
-          <div class="icon">◔</div>
-          <div>
-            <h4>Возраст / пол</h4>
-            <p>30 лет · male · ru</p>
+          <div class="field-card">
+            <p class="field-label">Height (cm)</p>
+            <p class="field-value">175</p>
+            <p class="field-support">Decimal input</p>
           </div>
-          <span class="trail">edit</span>
+          <div class="field-card">
+            <p class="field-label">Age</p>
+            <p class="field-value">30</p>
+            <p class="field-support">Whole number</p>
+          </div>
+          <div class="field-card">
+            <p class="field-label">Gender</p>
+            <div class="field-chip-row">
+              <span class="field-chip">female</span>
+              <span class="field-chip active">male</span>
+            </div>
+          </div>
+          <div class="field-card field-card-full">
+            <p class="field-label">Language</p>
+            <div class="field-chip-row">
+              <span class="field-chip">en</span>
+              <span class="field-chip active">ru</span>
+              <span class="field-chip">es</span>
+            </div>
+          </div>
         </div>
+        <p class="screen-footer-note">
+          Анатомия формы повторяет реальный экран: сначала поля, потом pickers и только затем CTA.
+        </p>
       </section>
 
       <div class="button-stack">
@@ -71,20 +92,40 @@
             <p class="status-value"><span class="status-dot"></span>Normal</p>
           </div>
         </div>
-        <p class="section-copy">
-          Group: healthy range. Interpretation should stay readable and non-clinical.
-        </p>
+        <div class="status-grid status-grid.single-column compact">
+          <div class="status-tile">
+            <p class="status-kicker">Interpretation</p>
+            <p class="status-value">Healthy range</p>
+            <p class="section-copy">
+              Group: healthy range. The explanation stays readable, calm, and clearly wellness-framed.
+            </p>
+          </div>
+        </div>
+        <div class="scale-card" aria-label="BMI visualization summary">
+          <div class="scale-track">
+            <span class="scale-stop"></span>
+            <span class="scale-stop"></span>
+            <span class="scale-stop active"></span>
+            <span class="scale-stop"></span>
+          </div>
+          <div class="scale-meta">
+            <span>visualization.ranges</span>
+            <span>4 segments</span>
+          </div>
+        </div>
       </section>
 
       <section class="glass-card gold-outline">
-        <h2>Soft paywall hook</h2>
+        <p class="eyebrow">Optional hook</p>
+        <h2>Более точная интерпретация</h2>
         <p class="section-copy">
-          Render only when backend returns hook data. The CTA leads into the reconciled `PRO / VIP`
-          surface rather than inventing a separate monetization layout.
+          BMI не учитывает распределение жира и контекст. Хотите более точную
+          интерпретацию рисков (wellness)?
         </p>
         <div class="button-stack">
-          <a class="secondary-button" href="./paywall-pro-vip.html">Unlock more detailed insights</a>
+          <a class="secondary-button" href="./paywall-pro-vip.html">Открыть PRO</a>
         </div>
+        <p class="screen-footer-note">Показывается только если backend вернул `soft_paywall`.</p>
       </section>
     </main>
   </body>

--- a/docs/figma/ios_prototype_v2/bmi.html
+++ b/docs/figma/ios_prototype_v2/bmi.html
@@ -77,7 +77,7 @@
       </section>
 
       <div class="button-stack">
-        <a class="primary-button" href="./paywall-pro-vip.html">Calculate</a>
+        <button class="primary-button" type="button">Calculate</button>
       </div>
 
       <section class="glass-card">
@@ -92,7 +92,7 @@
             <p class="status-value"><span class="status-dot"></span>Normal</p>
           </div>
         </div>
-        <div class="status-grid status-grid.single-column compact">
+        <div class="status-grid single-column compact">
           <div class="status-tile">
             <p class="status-kicker">Interpretation</p>
             <p class="status-value">Healthy range</p>

--- a/docs/figma/ios_prototype_v2/onboarding-value-usage.html
+++ b/docs/figma/ios_prototype_v2/onboarding-value-usage.html
@@ -16,51 +16,61 @@
 
       <div class="top-row">
         <span class="screen-label">iOS_Onboarding_02_Value_Usage</span>
-        <span class="ghost-chip">Назад</span>
+        <a class="ghost-chip" href="./onboarding-welcome.html">Назад</a>
       </div>
 
       <section class="hero hero-left">
         <p class="eyebrow">How to use it</p>
-        <h1 class="headline">Сначала BMI.<br />Затем Plate.<br />Потом планы.</h1>
+        <h1 class="headline">Как пользоваться<br />спокойно и по шагам</h1>
         <p class="subheadline">
-          Мы не просим длинную анкету в первый экран. Начните с базовых метрик,
-          а потом открывайте PRO и VIP-инструменты тогда, когда они реально нужны.
+          Начните с BMI, затем уточните через Plate и профиль PRO. Маленькие
+          вводы → понятные следующие шаги.
         </p>
       </section>
 
       <section class="glass-card">
-        <h2>Порядок использования</h2>
+        <h2>Путь по продукту</h2>
         <div class="feature-list">
           <div class="comparison-row">
             <span class="check">✓</span>
             <div>
               <strong>BMI Calculator</strong>
-              <span>Быстрый вход, мягкий paywall hook и понятная отправная точка.</span>
+              <span>Быстрый старт с базовыми метриками и спокойной отправной точкой.</span>
             </div>
           </div>
           <div class="comparison-row">
             <span class="check">✓</span>
             <div>
               <strong>Plate + Profile</strong>
-              <span>Дневной сплит и персональные цели без лишней сложности.</span>
+              <span>Дневной сплит и персональные цели без перегруза и лишней настройки.</span>
             </div>
           </div>
           <div class="comparison-row">
             <span class="check">✓</span>
             <div>
               <strong>Недельный план и список покупок</strong>
-              <span>PRO-вход на домашнем экране, VIP-апгрейд там, где он действительно объясним.</span>
+              <span>PRO появляется на Home, а VIP раскрывается там, где его ценность уже объяснима.</span>
             </div>
           </div>
         </div>
       </section>
 
       <section class="glass-card">
-        <h2>Что важно в v2</h2>
-        <p class="section-copy">
-          Новый прототип собирается как набор чистых экранов без длинных scroll-capture дублей,
-          поэтому дальше его можно безопасно использовать как implementation reference.
-        </p>
+        <h2>Что откроется дальше</h2>
+        <div class="summary-strip">
+          <span class="summary-pill success">PRO profile</span>
+          <span class="summary-pill">Weekly plan</span>
+          <span class="summary-pill warn">VIP follow-up</span>
+        </div>
+        <div class="fitchef-inline">
+          <div class="fitchef-mark small" aria-hidden="true">
+            <div class="fitchef-heart"></div>
+          </div>
+          <div>
+            <strong>FitChef</strong>
+            <span>Помогает держать тон спокойным: без давления, без “чудо-результатов”, только ясный следующий шаг.</span>
+          </div>
+        </div>
       </section>
 
       <div class="progress-dots" aria-label="Шаг 2 из 2">

--- a/docs/figma/ios_prototype_v2/onboarding-welcome.html
+++ b/docs/figma/ios_prototype_v2/onboarding-welcome.html
@@ -16,7 +16,7 @@
 
       <div class="top-row">
         <span class="screen-label">iOS_Onboarding_01_Welcome</span>
-        <a class="top-link" href="#" aria-label="Пропустить onboarding">Пропустить</a>
+        <a class="top-link" href="./home.html" aria-label="Пропустить onboarding">Пропустить</a>
       </div>
 
       <section class="hero">
@@ -25,29 +25,43 @@
         </div>
 
         <p class="eyebrow">Wellness companion</p>
-        <h1 class="headline">Добро пожаловать в<br />PulsePlate</h1>
+        <h1 class="headline">PulsePlate —<br />питание без<br />лишнего шума</h1>
         <p class="subheadline">
-          Понимайте свои показатели, выстраивайте устойчивое питание и двигайтесь
-          по одному спокойному шагу за раз.
+          Отслеживайте показатели, понимайте результат и держите план, который
+          реально выполнять — спокойно и по шагам.
         </p>
+        <div class="summary-strip centered-strip" aria-label="Core product surfaces">
+          <span class="summary-pill success">BMI</span>
+          <span class="summary-pill">Plate</span>
+          <span class="summary-pill">Plans</span>
+        </div>
       </section>
 
       <section class="glass-card">
-        <h2>Почему это ощущается проще</h2>
+        <h2>Что делает вход спокойным</h2>
         <div class="feature-list">
           <div class="feature-item">
             <span class="bullet">1</span>
             <div>
-              <strong>Одна ясная задача на экран</strong>
-              <span>Без перегруза, без медицинского шума, только понятный следующий шаг.</span>
+              <strong>Один понятный экран за раз</strong>
+              <span>Никакой длинной анкеты на старте, только следующая полезная задача.</span>
             </div>
           </div>
           <div class="feature-item">
             <span class="bullet">2</span>
             <div>
               <strong>Реальная ежедневная польза</strong>
-              <span>BMI, Plate, недельный план и покупки складываются в один спокойный флоу.</span>
+              <span>BMI, Plate, недельный план и покупки собираются в один устойчивый ритм.</span>
             </div>
+          </div>
+        </div>
+        <div class="fitchef-inline">
+          <div class="fitchef-mark small" aria-hidden="true">
+            <div class="fitchef-heart"></div>
+          </div>
+          <div>
+            <strong>FitChef</strong>
+            <span>Тёплый бренд-слой, который поддерживает, а не отвлекает от основного шага.</span>
           </div>
         </div>
       </section>

--- a/docs/figma/ios_prototype_v2/styles.css
+++ b/docs/figma/ios_prototype_v2/styles.css
@@ -444,6 +444,10 @@ body {
   margin-top: 16px;
 }
 
+.centered-strip {
+  justify-content: center;
+}
+
 .summary-pill {
   display: inline-flex;
   align-items: center;
@@ -841,4 +845,107 @@ body {
   font-size: 12px;
   line-height: 1.45;
   color: rgba(240, 244, 248, 0.46);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.field-card {
+  min-height: 104px;
+  padding: 14px;
+  border-radius: var(--pp-radius-md);
+  border: 1px solid var(--pp-border);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.field-card-full {
+  grid-column: 1 / -1;
+  min-height: unset;
+}
+
+.field-label {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(240, 244, 248, 0.54);
+}
+
+.field-value {
+  margin: 0 0 6px;
+  font-size: 28px;
+  line-height: 1;
+  font-weight: 760;
+  letter-spacing: -0.04em;
+}
+
+.field-support {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--pp-text-soft);
+}
+
+.field-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.field-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--pp-text-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.field-chip.active {
+  border-color: rgba(51, 159, 255, 0.38);
+  background: rgba(51, 159, 255, 0.16);
+  color: #d8ecff;
+}
+
+.scale-card {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: var(--pp-radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.scale-track {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.scale-stop {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.scale-stop.active {
+  background: linear-gradient(180deg, rgba(32, 201, 151, 0.94), rgba(32, 201, 151, 0.62));
+}
+
+.scale-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--pp-text-soft);
 }

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -5,13 +5,38 @@
 - [ ] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-No resolved review threads yet.
+Disposition: FIXED
+Commit: 4a375a3c
+Evidence: `docs/figma/ios_prototype_v2/bmi.html:79` keeps the BMI CTA on-page as a button instead of navigating away before the result block, and `docs/figma/ios_prototype_v2/bmi.html:95` splits the malformed class token into the canonical `status-grid single-column` pair so the single-column layout rule applies.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157885 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924165845 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184146 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184161 -> 4a375a3c
 
-Record each actionable review item here with one of the required disposition
-keywords: `FIXED`, `NOT-A-BUG`, or `DEFERRED`.
+Disposition: FIXED
+Commit: 4a375a3c
+Evidence: `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md:25` through `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md:32` now use the canonical `blocked_by_plan` status for every mapped screen while the workspace remains seat-blocked.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157893 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3936032596 -> 4a375a3c
+
+Disposition: FIXED
+Commit: 4a375a3c
+Evidence: `docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md:110` now makes the BMI/onboarding recapture step explicitly conditional on future MCP node-id drift instead of listing already-completed work as pending.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184144 -> 4a375a3c
+
+Disposition: NOT-A-BUG
+Evidence: `git diff --name-only worktree/figma-ios-screen-polish...HEAD` shows the current stacked PR diff contains only `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md`, `docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md`, `docs/figma/ios_prototype_v2/README.md`, `docs/figma/ios_prototype_v2/bmi.html`, `docs/figma/ios_prototype_v2/onboarding-value-usage.html`, `docs/figma/ios_prototype_v2/onboarding-welcome.html`, `docs/figma/ios_prototype_v2/styles.css`, `docs/review/PR_1135_FIXED_MAPPING.md`, and `docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md`.
+Reason: After changing PR `#1135` to base `worktree/figma-ios-screen-polish`, the old parent-diff comments on `.cursor/mcp.json.example`, `docs/figma/MCP_SETUP_GUIDE.md`, `docs/figma/ios_prototype_v2/weekly-plan-reader.html`, `docs/review/PR_1132_FIXED_MAPPING.md`, `docs/roadmap/BACKLOG_LEDGER.md`, and `docs/runbooks/FIGMA_MCP_RUNTIME_MATRIX.md` no longer apply to this isolated `BMI + Onboarding` slice; those files stay owned by the parent lanes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184138
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184171
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184177
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184180
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184183
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184187
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3936064055
 
 ## Merge Readiness
-- [x] Local gates passed on current head
+- [ ] Local gates passed on current head
 - [ ] All required checks green
 - [ ] No unresolved review threads remain
 - [ ] CodeRabbit PASS / no-actionables

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR 1135 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+No resolved review threads yet.
+
+Add each actionable review item here with one of the required dispositions:
+- `Disposition: FIXED`
+- `Disposition: NOT-A-BUG`
+- `Disposition: DEFERRED`
+
+## Merge Readiness
+- [x] Local gates passed on current head
+- [ ] All required checks green
+- [ ] No unresolved review threads remain
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] Wait-window after latest bot/review activity observed

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -37,7 +37,7 @@ Reason: After changing PR `#1135` to base `worktree/figma-ios-screen-polish`, th
 
 Disposition: FIXED
 Commit: e5d974d8c72613030ec13940084c7628069b0d12
-Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:7`, `docs/review/PR_1135_FIXED_MAPPING.md:14`, and `docs/review/PR_1135_FIXED_MAPPING.md:20` now record full 40-character commit SHAs instead of abbreviated hashes, keeping the canonical artifact stable for later audit and review tooling.
+Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:9`, `docs/review/PR_1135_FIXED_MAPPING.md:17`, `docs/review/PR_1135_FIXED_MAPPING.md:23`, and `docs/review/PR_1135_FIXED_MAPPING.md:39` now record full 40-character commit SHAs instead of abbreviated hashes, keeping the canonical artifact stable for later audit and review tooling.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943636463 -> e5d974d8c72613030ec13940084c7628069b0d12
 
 ## Merge Readiness

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -48,6 +48,12 @@ Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:44` now cites the actual `Commit
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2931006735 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943816941 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
 
+Disposition: FIXED
+Commit: f3cac13cc77612b613ee5d0792d77b2e5d20b9c9
+Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:45` now points to the actual `Commit:` declaration line for the previous FIXED block, so the audit proof no longer references an `Evidence:` row by mistake.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2931083665 -> f3cac13cc77612b613ee5d0792d77b2e5d20b9c9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943904728 -> f3cac13cc77612b613ee5d0792d77b2e5d20b9c9
+
 ## Merge Readiness
 - [ ] Local gates passed on current head
 - [ ] All required checks green

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -7,10 +7,8 @@
 ### Fixed in Commit Mapping
 No resolved review threads yet.
 
-Add each actionable review item here with one of the required dispositions:
-- `Disposition: FIXED`
-- `Disposition: NOT-A-BUG`
-- `Disposition: DEFERRED`
+Record each actionable review item here with one of the required disposition
+keywords: `FIXED`, `NOT-A-BUG`, or `DEFERRED`.
 
 ## Merge Readiness
 - [x] Local gates passed on current head

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -42,7 +42,7 @@ Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:9`, `docs/review/PR_1135_FIXED_M
 
 Disposition: FIXED
 Commit: c58693c76bdc292d6fd94c17216a1c92ceefea1d
-Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:40` now cites the actual `Commit:` declaration lines in the same artifact, so the audit proof points to the full-SHA entries rather than unrelated header or mapping rows.
+Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:44` now cites the actual `Commit:` declaration line in the same artifact, so the audit proof points to the full-SHA entry rather than an unrelated evidence row.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2930998589 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943806426 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2931006735 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -6,23 +6,23 @@
 
 ### Fixed in Commit Mapping
 Disposition: FIXED
-Commit: 4a375a3c
+Commit: 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 Evidence: `docs/figma/ios_prototype_v2/bmi.html:79` keeps the BMI CTA on-page as a button instead of navigating away before the result block, and `docs/figma/ios_prototype_v2/bmi.html:95` splits the malformed class token into the canonical `status-grid single-column` pair so the single-column layout rule applies.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157885 -> 4a375a3c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924165845 -> 4a375a3c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184146 -> 4a375a3c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184161 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157885 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924165845 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184146 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184161 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 
 Disposition: FIXED
-Commit: 4a375a3c
+Commit: 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 Evidence: `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md:25` through `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md:32` now use the canonical `blocked_by_plan` status for every mapped screen while the workspace remains seat-blocked.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157893 -> 4a375a3c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3936032596 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924157893 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3936032596 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 
 Disposition: FIXED
-Commit: 4a375a3c
+Commit: 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 Evidence: `docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md:110` now makes the BMI/onboarding recapture step explicitly conditional on future MCP node-id drift instead of listing already-completed work as pending.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184144 -> 4a375a3c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184144 -> 4a375a3c4170c44f7cb6412f567a91787d7fdfa3
 
 Disposition: NOT-A-BUG
 Evidence: `git diff --name-only worktree/figma-ios-screen-polish...HEAD` shows the current stacked PR diff contains only `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md`, `docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md`, `docs/figma/ios_prototype_v2/README.md`, `docs/figma/ios_prototype_v2/bmi.html`, `docs/figma/ios_prototype_v2/onboarding-value-usage.html`, `docs/figma/ios_prototype_v2/onboarding-welcome.html`, `docs/figma/ios_prototype_v2/styles.css`, `docs/review/PR_1135_FIXED_MAPPING.md`, and `docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md`.
@@ -34,6 +34,11 @@ Reason: After changing PR `#1135` to base `worktree/figma-ios-screen-polish`, th
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184183
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2924184187
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3936064055
+
+Disposition: FIXED
+Commit: e5d974d8c72613030ec13940084c7628069b0d12
+Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:7`, `docs/review/PR_1135_FIXED_MAPPING.md:14`, and `docs/review/PR_1135_FIXED_MAPPING.md:20` now record full 40-character commit SHAs instead of abbreviated hashes, keeping the canonical artifact stable for later audit and review tooling.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943636463 -> e5d974d8c72613030ec13940084c7628069b0d12
 
 ## Merge Readiness
 - [ ] Local gates passed on current head

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -40,6 +40,14 @@ Commit: e5d974d8c72613030ec13940084c7628069b0d12
 Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:9`, `docs/review/PR_1135_FIXED_MAPPING.md:17`, `docs/review/PR_1135_FIXED_MAPPING.md:23`, and `docs/review/PR_1135_FIXED_MAPPING.md:39` now record full 40-character commit SHAs instead of abbreviated hashes, keeping the canonical artifact stable for later audit and review tooling.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943636463 -> e5d974d8c72613030ec13940084c7628069b0d12
 
+Disposition: FIXED
+Commit: c58693c76bdc292d6fd94c17216a1c92ceefea1d
+Evidence: `docs/review/PR_1135_FIXED_MAPPING.md:40` now cites the actual `Commit:` declaration lines in the same artifact, so the audit proof points to the full-SHA entries rather than unrelated header or mapping rows.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2930998589 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943806426 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#discussion_r2931006735 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1135#pullrequestreview-3943816941 -> c58693c76bdc292d6fd94c17216a1c92ceefea1d
+
 ## Merge Readiness
 - [ ] Local gates passed on current head
 - [ ] All required checks green

--- a/docs/review/PR_1135_FIXED_MAPPING.md
+++ b/docs/review/PR_1135_FIXED_MAPPING.md
@@ -1,8 +1,8 @@
 # PR 1135 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
 Disposition: FIXED

--- a/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md
+++ b/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md
@@ -338,30 +338,14 @@
   - success
   - visual sanity-check passed for the refreshed slice
 
-## Refreshed Canonical Node Map
-
-- `iOS_Onboarding_01_Welcome` -> `25:2`
-- `iOS_Onboarding_02_Value_Usage` -> `20:2`
-- `iOS_BMI` -> `24:2`
-
 ## Notes
 
 - Previous node IDs for the same three screens (`1:2`, `3:2`, `8:2`,
   `23:2`, `22:2`, `21:2`) remain historical evidence only.
 - Shared capture script remains in HTML per MCP guidance for re-capture safety.
-
-## Stable Screen Map
-
-| Canonical screen ID | Figma nodeId | Imported frame name | Source basis |
-| --- | --- | --- | --- |
-| `iOS_Onboarding_01_Welcome` | `25:2` | `iOS Onboarding Welcome` | iOS prototype mood + Design System typography |
-| `iOS_Onboarding_02_Value_Usage` | `20:2` | `iOS Onboarding Value Usage` | web onboarding structure + iOS-native rewrite |
-| `iOS_Home` | `11:2` | `iOS Home` | Design System + iOS Home CTA matrix |
-| `iOS_Paywall_Pro_VIP` | `17:2` | `iOS Paywall Pro VIP` | Paywall tier reconciliation from repo SoT |
-| `iOS_ShoppingList` | `18:2` | `iOS Shopping List` | Shopping list runtime + weekly-plan continuity |
-| `iOS_WeeklyPlan_Reader` | `15:2` | `iOS Weekly Plan Reader` | Weekly plan runtime + VIP follow-up hooks |
-| `iOS_Profile` | `13:2` | `iOS Profile` | PRO profile runtime + legal/language layer |
-| `iOS_BMI` | `24:2` | `iOS BMI` | BMI runtime + result + soft paywall hook |
+- The current canonical `screen ID -> nodeId` map lives in:
+  - `docs/figma/ios_prototype_v2/README.md`
+  - `docs/figma/FIGMA_IOS_PROTOTYPE_V2_RECONCILIATION.md`
 
 ## Structural QA
 

--- a/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md
+++ b/docs/runbooks/sessions/FIGMA_MCP_SESSION_2026-03-11_ios-prototype-check.md
@@ -238,20 +238,130 @@
 - Result:
   - success
   - screenshot verifies onboarding, value, paywall, and home screens exist in one clean v2 file
-  - home screen verifies required CTA matrix is present
+
+---
+
+# Follow-up Execution: BMI + Onboarding Polish Refresh
+
+## Session Metadata
+
+- Date: 2026-03-12
+- Operator: Codex agent + user session
+- Branch: `worktree/figma-ios-bmi-onboarding-polish`
+- Local capture source root:
+  - `docs/figma/ios_prototype_v2/`
+- Existing Figma file:
+  - file key: `AhyS6u4dZXMRHVUDO3Cfn6`
+  - URL: `https://www.figma.com/design/AhyS6u4dZXMRHVUDO3Cfn6`
+
+## Scope
+
+- refresh `iOS_Onboarding_01_Welcome`
+- refresh `iOS_Onboarding_02_Value_Usage`
+- refresh `iOS_BMI`
+
+## Execution
+
+### Request 14 (BMI slice local polish)
+
+- Local source updates:
+  - `docs/figma/ios_prototype_v2/onboarding-welcome.html`
+  - `docs/figma/ios_prototype_v2/onboarding-value-usage.html`
+  - `docs/figma/ios_prototype_v2/bmi.html`
+  - `docs/figma/ios_prototype_v2/styles.css`
+- Result:
+  - onboarding copy aligned to runtime localization keys
+  - FitChef label restored as supporting brand element
+  - BMI surface moved from generic editable rows to form/picker anatomy closer to `BMICalculatorScreen`
+  - optional BMI hook now mirrors backend default title/body/CTA contract
+
+### Request 15 (existing-file recapture: BMI)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=0:1`
+- Source URL:
+  - `http://127.0.0.1:4174/bmi.html`
+- Result:
+  - success
+  - created refreshed BMI frame `21:2`
+
+### Request 16 (existing-file recapture: value/usage onboarding)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=0:1`
+- Source URL:
+  - `http://127.0.0.1:4174/onboarding-value-usage.html`
+- Result:
+  - success
+  - created refreshed onboarding value/usage frame `22:2`
+
+### Request 17 (existing-file recapture: welcome onboarding)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=0:1`
+- Source URL:
+  - `http://127.0.0.1:4174/onboarding-welcome.html`
+- Result:
+  - success
+  - created refreshed onboarding welcome frame `23:2`
+
+### Request 18 (metadata verification)
+
+- Tool: `mcp__figma__get_metadata`
+- Arguments:
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=21:2`
+  - `nodeId=22:2`
+  - `nodeId=23:2`
+- Result:
+  - success
+  - verified canonical refreshed nodes for BMI + onboarding slice
+
+### Request 19 (screenshot verification)
+
+- Tool: `mcp__figma__get_screenshot`
+- Arguments:
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=21:2`
+  - `nodeId=22:2`
+  - `nodeId=23:2`
+- Result:
+  - success
+  - visual sanity-check passed for the refreshed slice
+
+## Refreshed Canonical Node Map
+
+- `iOS_Onboarding_01_Welcome` -> `25:2`
+- `iOS_Onboarding_02_Value_Usage` -> `20:2`
+- `iOS_BMI` -> `24:2`
+
+## Notes
+
+- Previous node IDs for the same three screens (`1:2`, `3:2`, `8:2`,
+  `23:2`, `22:2`, `21:2`) remain historical evidence only.
+- Shared capture script remains in HTML per MCP guidance for re-capture safety.
 
 ## Stable Screen Map
 
 | Canonical screen ID | Figma nodeId | Imported frame name | Source basis |
 | --- | --- | --- | --- |
-| `iOS_Onboarding_01_Welcome` | `1:2` | `Main Content (iOS Onboarding Welcome)` | iOS prototype mood + Design System typography |
-| `iOS_Onboarding_02_Value_Usage` | `3:2` | `Main Content (iOS Onboarding Value Usage)` | web onboarding structure + iOS-native rewrite |
-| `iOS_Home` | `11:2` | `Main Content (iOS Home)` | Design System + iOS Home CTA matrix |
-| `iOS_Paywall_Pro_VIP` | `17:2` | `Main Content (iOS Paywall Pro VIP)` | Paywall tier reconciliation from repo SoT |
-| `iOS_ShoppingList` | `18:2` | `Main Content (iOS Shopping List)` | Shopping list runtime + weekly-plan continuity |
-| `iOS_WeeklyPlan_Reader` | `15:2` | `Main Content (iOS Weekly Plan Reader)` | Weekly plan runtime + VIP follow-up hooks |
-| `iOS_Profile` | `13:2` | `Main Content (iOS Profile)` | PRO profile runtime + legal/language layer |
-| `iOS_BMI` | `8:2` | `Main Content (iOS BMI)` | BMI runtime + result + soft paywall hook |
+| `iOS_Onboarding_01_Welcome` | `25:2` | `iOS Onboarding Welcome` | iOS prototype mood + Design System typography |
+| `iOS_Onboarding_02_Value_Usage` | `20:2` | `iOS Onboarding Value Usage` | web onboarding structure + iOS-native rewrite |
+| `iOS_Home` | `11:2` | `iOS Home` | Design System + iOS Home CTA matrix |
+| `iOS_Paywall_Pro_VIP` | `17:2` | `iOS Paywall Pro VIP` | Paywall tier reconciliation from repo SoT |
+| `iOS_ShoppingList` | `18:2` | `iOS Shopping List` | Shopping list runtime + weekly-plan continuity |
+| `iOS_WeeklyPlan_Reader` | `15:2` | `iOS Weekly Plan Reader` | Weekly plan runtime + VIP follow-up hooks |
+| `iOS_Profile` | `13:2` | `iOS Profile` | PRO profile runtime + legal/language layer |
+| `iOS_BMI` | `24:2` | `iOS BMI` | BMI runtime + result + soft paywall hook |
 
 ## Structural QA
 
@@ -296,6 +406,68 @@
   `docs/figma/FIGMA_IOS_PROTOTYPE_V2_CODE_CONNECT_READINESS.md`
 - Activation source stays pinned to:
   - file key: `AhyS6u4dZXMRHVUDO3Cfn6`
-  - node IDs: `1:2`, `3:2`, `11:2`, `17:2`, `18:2`, `15:2`, `13:2`, `8:2`
+  - node IDs: `25:2`, `20:2`, `11:2`, `17:2`, `18:2`, `15:2`, `13:2`, `24:2`
 - Code Connect is still not active in this session because the workspace remains
   blocked by seat/plan.
+
+## Follow-up Execution: BMI + Onboarding Polish Refresh (Round 2)
+
+### Request 20 (existing-file recapture: onboarding value/usage)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+- Source URL:
+  - `http://127.0.0.1:4174/onboarding-value-usage.html`
+- Result:
+  - success
+  - created refreshed onboarding value/usage frame `20:2`
+
+### Request 21 (existing-file recapture: BMI)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+- Source URL:
+  - `http://127.0.0.1:4174/bmi.html`
+- Result:
+  - success
+  - created refreshed BMI frame `24:2`
+
+### Request 22 (existing-file recapture: welcome onboarding)
+
+- Tool: `mcp__figma__generate_figma_design`
+- Arguments:
+  - `outputMode=existingFile`
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+- Source URL:
+  - `http://127.0.0.1:4174/onboarding-welcome.html`
+- Result:
+  - success
+  - created refreshed onboarding welcome frame `25:2`
+
+### Request 23 (metadata verification)
+
+- Tool: `mcp__figma__get_metadata`
+- Arguments:
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=20:2`
+  - `nodeId=24:2`
+  - `nodeId=25:2`
+- Result:
+  - success
+  - verified the latest canonical refreshed nodes for BMI + onboarding slice
+
+### Request 24 (screenshot verification)
+
+- Tool: `mcp__figma__get_screenshot`
+- Arguments:
+  - `fileKey=AhyS6u4dZXMRHVUDO3Cfn6`
+  - `nodeId=20:2`
+  - `nodeId=24:2`
+  - `nodeId=25:2`
+- Result:
+  - success
+  - visual sanity-check passed for the current refreshed slice


### PR DESCRIPTION
## Summary
- polish the `BMI + Onboarding` slice inside `ios prototype v2`
- keep the lane separate from `#1125` and `#1132`
- refresh the canonical Figma node map after MCP re-capture

## Figma Artifact
- file: `ios prototype v2`
- url: `https://www.figma.com/design/AhyS6u4dZXMRHVUDO3Cfn6`
- refreshed nodes: `25:2`, `20:2`, `24:2`

## Scope
- `iOS_Onboarding_01_Welcome`
- `iOS_Onboarding_02_Value_Usage`
- `iOS_BMI`

## What Changed
- rewrote onboarding copy to align with calmer runtime/localized product messaging
- restored `FitChef` as a supporting brand layer instead of a dominant hero element
- rebuilt BMI as form/picker anatomy closer to `BMICalculatorScreen`
- aligned the optional BMI hook to the backend default title/body/CTA contract
- refreshed canonical `screen ID -> nodeId` documentation after MCP capture

## Validation
- `pre-commit run --all-files`
- `make verify`
- `git diff --check`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1135_FIXED_MAPPING.md`

## Merge Readiness
- [x] Local gates passed on current head
- [ ] All required checks green
- [x] No unresolved review threads remain
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] Wait-window after latest bot/review activity observed

## Deferred / Follow-ups
- wait for the new bot cycle after the PR base switch to `worktree/figma-ios-screen-polish`, then re-check discussion-thread mapping against the current diff only
- deeper downstream onboarding branch parity remains out of scope for this slice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated iOS prototype screen mappings, readiness/reconciliation docs, runbook session, and added a PR review mapping guide; canonical screen IDs were remapped and capture/reconciliation steps clarified.
* **New Features / UX**
  * Redesigned BMI flow with grid inputs, Calculate CTA, richer results/visualization and optional PRO hook (bilingual); refreshed onboarding content and summary strips.
* **Style**
  * Added comprehensive styles for form grids, field cards, chips and scale/visual components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
