### PR TITLE
docs(ledger): close PR11 merge triage tail

### DIFF
--- a/docs/review/PR_1136_FIXED_MAPPING.md
+++ b/docs/review/PR_1136_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1136 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6061,15 +6061,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - At least one deterministic check guards against silently incomplete clean-clone environments
 
 <a id="ledger-p2-gh-checks-current-head-filter"></a>
-- [ ] P2: Filter superseded GitHub check noise in merge triage
+- [x] P2: Filter superseded GitHub check noise in merge triage
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
   - Target PR: PR #1129 (`fix/pr11-gh-checks-current-head-filter`)
   - Area: orchestration / GitHub governance
   - Reason: PR5 merge triage repeatedly showed stale failed `test-pr` and `coverage-pr` lines from superseded runs in `gh pr checks`, even after the current head became `CLEAN`. This creates false negatives and slows final merge decisions.
   - Kickoff: PR10 closeout completed on 12 March 2026; PR11 branch created from synced `main` after PR #1127 merge.
+  - Status: ✅ Merged via PR #1129 on 12 March 2026 (`4cc4786d87897897428db6ad4a0bb924f25f0bd2`)
   - Links:
     - `scripts/ci/check_pr_merge_readiness.py`
+    - `scripts/ci/check_current_head_pr_checks.py`
+    - `scripts/orchestration/check_merge_ready.py`
     - `RUNBOOK_AGENT.md`
   - DoD:
     - Repo guidance or helper tooling can distinguish current-head required checks from superseded historical failures


### PR DESCRIPTION
## Summary
- close the local post-merge ledger tail for PR #1129 in canonical docs-only form
- keep the PR11 governance backlog item truthful on `main` before the next phase2 tail PR
- avoid mixing runtime, tooling, CV, or creative-research scope

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Local preflight passed
- [x] `pre-commit run --files docs/roadmap/BACKLOG_LEDGER.md`
- [x] Docs-only scope; no runtime files changed

## Summary by Sourcery

Документация:
- Обновить запись в журнале невыполненных задач (backlog ledger) для улучшения merge-triage GitHub checks, чтобы указать, что оно было выполнено (merged), и добавить ссылки на соответствующие CI- и оркестрационные скрипты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the backlog ledger entry for the GitHub checks merge-triage improvement to indicate it has been merged and to reference the relevant CI and orchestration scripts.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs to close the PR11 merge-triage tail and add the PR1136 fixed-in-commit mapping. Marks the P2 “Filter superseded GitHub check noise” as complete with merge status and script links, adds `docs/review/PR_1136_FIXED_MAPPING.md` noting no actionable review comments, and makes no runtime or tooling changes.

<sup>Written for commit 2c601202a5439b6acbe5da9e8a437fd41b80f0ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PR review artifact documentation for tracking approval status and merge readiness.
  * Updated backlog ledger marking completion of GitHub check noise filtering improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->