### PR TITLE
fix(ci): make phase2 artifact-first

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -254,7 +254,7 @@ Run before merge after latest commit and latest bot/review activity:
 1. `python scripts/orchestration/check_merge_ready.py --pr-number <PR_NUMBER> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
 2. `gh pr view <PR_NUMBER> --json mergeStateStatus,reviewDecision,isDraft`
 3. **Zero bot comments (hard rule):** Merge only when (a) **0 unresolved review threads** and (b) **every actionable bot comment is mapped** in the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`. PR body is mirror-only when `pr_number` is available. **Do not** report "0 comments" or "ready to merge" based only on unresolved thread count — new bot comments can appear after a check; use the canonical script (below) and re-run after bot activity.
-4. Confirm PR body sections are complete:
+4. When a human-readable PR-body mirror is kept, confirm these sections are complete:
    - `## Discussion Thread Pass`
    - `### Fixed in Commit Mapping`
    - `## Merge Readiness`

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -261,10 +261,11 @@ Run before merge after latest commit and latest bot/review activity:
 5. CI `Merge readiness gate` must be green on latest PR commit.
 
 **Phase2 PR body gates (CI):** To pass `check_pr_body_phase2_gates.py` and merge-readiness:
-- In PR description, under **Discussion Thread Pass**: check `[x] Discussion-thread pass completed` and `[x] Fixed in commit mapping completed`.
+- In PR description, if you keep a human-readable mirror, under **Discussion Thread Pass**: check `[x] Discussion-thread pass completed` and `[x] Fixed in commit mapping completed`.
 - In the canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`: list each bot comment as `- <comment-url> -> <commit-sha>` or `- <comment-url>` depending on disposition, or use exactly `- No actionable review comments`.
-- Under **### Fixed in Commit Mapping** in the PR body: keep the mirror section present; mapping-line duplication is optional once the artifact exists.
-- Local check (no API): `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"` (use the same body as on the PR).
+- Under **### Fixed in Commit Mapping** in the PR body: the mirror block is optional once the canonical artifact exists; if you keep it, generate it from the artifact helper instead of hand-maintaining mapping lines.
+- Local artifact-first check: `python scripts/ci/check_pr_body_phase2_gates.py --pr-number <PR_NUMBER>`
+- Local body-only fallback check: `python scripts/ci/check_pr_body_phase2_gates.py --body "$(cat .github/pr_body_*.md)"`
 
 **Canonical verification (required before claiming "0 comments" or "ready to merge"):** Run the orchestration wrapper so Phase 2, merge-readiness, and disposition proof are checked together. Policy: see `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`.
 

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -42,7 +42,7 @@ Canonical operator entrypoint:
 
 Canonical source: `docs/review/PR_<N>_FIXED_MAPPING.md`.
 
-PR body **must mirror** the same review-governance sections for human review and fallback runs:
+PR body **may mirror** the same review-governance sections for human review and fallback runs:
 
 - `## Discussion Thread Pass`
 - `### Fixed in Commit Mapping`
@@ -50,7 +50,7 @@ PR body **must mirror** the same review-governance sections for human review and
 - full URL→SHA mapping lines are required only in the canonical artifact when `pr_number` is available
 
 Canonical runtime behavior is artifact-first when `pr_number` is available.
-PR-body parsing is a temporary compatibility seam for local/body-only checks and human-readable review context. When `pr_number` is available, Phase 2 treats the artifact as authoritative and validates the PR body as a mirror-only contract.
+PR-body parsing is a temporary compatibility seam for local/body-only checks and human-readable review context. When `pr_number` is available, Phase 2 treats the artifact as authoritative and the PR body as an optional mirror-only surface.
 
 Temporary seam tracking:
 
@@ -63,11 +63,12 @@ Exit criteria for removing PR-body fallback:
 2. Local tooling supports deterministic artifact lookup without PR-body parsing.
 3. The fallback branch in `scripts/ci/check_pr_body_phase2_gates.py` can be removed without losing local validation ergonomics.
 
-Required sections (artifact and PR-body mirror):
+Required sections:
 
 - `## Discussion Thread Pass`
 - Checkbox contract (completed / mapping completed)
-- `## Fixed in Commit Mapping`
+- `## Fixed in Commit Mapping` in the canonical artifact
+- `### Fixed in Commit Mapping` in the optional PR-body mirror
 
 Valid mapping forms in the canonical artifact:
 
@@ -75,7 +76,7 @@ Valid mapping forms in the canonical artifact:
 - `- <url>`
 - `- No actionable review comments`
 
-PR body mirror requires the section headings and completed checkboxes. Mapping-line duplication in the body is optional once the canonical artifact exists.
+PR body mirror requires the section headings and completed checkboxes only when the mirror is present. Mapping-line duplication in the body is optional once the canonical artifact exists. Use `render_phase2_body_mirror()` to generate the mirror block from the canonical artifact path.
 
 Evidence:
 - `scripts/orchestration/review_mapping_artifact.py:44`

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -26,12 +26,12 @@ Evidence:
 
 ## 3. Governance Phases
 
-| Phase   | Gate              | Artifact                                | Blocks Merge |
-| ------- | ----------------- | --------------------------------------- | ------------ |
-| Phase 1 | CI hygiene        | workflows/checks                        | yes          |
-| Phase 2 | PR body mirror contract | canonical artifact + PR body mirror | yes          |
-| Phase 3 | Merge readiness   | unresolved threads + actionable mapping | yes          |
-| Phase 4 | Disposition proof | script semantics                        | yes          |
+| Phase   | Gate                    | Artifact                                                         | Blocks Merge |
+| ------- | ----------------------- | ---------------------------------------------------------------- | ------------ |
+| Phase 1 | CI hygiene              | workflows/checks                                                 | yes          |
+| Phase 2 | artifact-first contract | canonical artifact (authoritative) + optional PR body mirror     | yes          |
+| Phase 3 | Merge readiness         | unresolved threads + actionable mapping                          | yes          |
+| Phase 4 | Disposition proof       | script semantics                                                 | yes          |
 
 Canonical operator entrypoint:
 

--- a/docs/review/PR_1139_FIXED_MAPPING.md
+++ b/docs/review/PR_1139_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 8db15dab
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186733 -> 8db15dab
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186741 -> 8db15dab
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186743 -> 8db15dab
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#pullrequestreview-3937248057 -> 8db15dab
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1139_FIXED_MAPPING.md
+++ b/docs/review/PR_1139_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1139 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1139_FIXED_MAPPING.md
+++ b/docs/review/PR_1139_FIXED_MAPPING.md
@@ -6,7 +6,9 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
-Commit: 8db15dab
+Commit: see mapping entries below
+Evidence: `8db15dab` updates `scripts/orchestration/review_mapping_artifact.py:206` to validate the canonical artifact before rendering the PR-body mirror, aligns the Phase 2 contract wording in `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:28` and `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:42`, relaxes the pre-merge checklist wording in `RUNBOOK_AGENT.md:261`, and adds invalid-artifact regression coverage in `tests/test_review_mapping_artifact.py:30`.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186733 -> 8db15dab
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186741 -> 8db15dab
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1139#discussion_r2925186743 -> 8db15dab

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -210,16 +210,17 @@ def main() -> int:
         artifact_checked = True
         artifact_errors.extend(validate_mapping_artifact_text(artifact_text))
 
-    if not body.strip():
+    if body.strip():
+        body_checked = True
+        body_errors.extend(
+            check_pr_body_phase2_gates(
+                body=body,
+                mode=_select_body_validation_mode(artifact_checked=artifact_checked),
+            )
+        )
+    elif not artifact_checked:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
-    body_checked = True
-    body_errors.extend(
-        check_pr_body_phase2_gates(
-            body=body,
-            mode=_select_body_validation_mode(artifact_checked=artifact_checked),
-        )
-    )
 
     errors = [*artifact_errors, *body_errors]
     if errors:
@@ -232,8 +233,14 @@ def main() -> int:
             print(f"- {item}")
         return 1
 
-    if artifact_checked:
+    if artifact_checked and body_checked:
         print("phase2-pr-body-gates: canonical mapping artifact and PR body mirror passed.")
+        return 0
+    if artifact_checked:
+        print(
+            "phase2-pr-body-gates: canonical mapping artifact passed "
+            "(PR body mirror optional in artifact-first mode)."
+        )
         return 0
 
     print("phase2-pr-body-gates: passed.")

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -34,13 +34,6 @@ class GateResult:
     stderr: str
 
 
-@dataclass(frozen=True)
-class PreGateFailure:
-    """Deterministic pre-execution gate failure before a subprocess can run."""
-
-    message: str
-
-
 def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     """Enforce CI vs local mode contract for the wrapper CLI."""
 
@@ -151,15 +144,12 @@ def _fetch_pr_body(pr_number: int, repo: str) -> str:
     return result.stdout
 
 
-def _phase2_args(args: argparse.Namespace) -> list[str] | PreGateFailure:
+def _phase2_args(args: argparse.Namespace) -> list[str]:
     if args.event_path:
         return ["--event-path", args.event_path]
-    try:
-        body = args.body if args.body else _fetch_pr_body(args.pr_number, args.repo)
-    except (RuntimeError, subprocess.TimeoutExpired) as exc:
-        return PreGateFailure(str(exc))
     phase2_args = ["--pr-number", str(args.pr_number)]
-    phase2_args.extend(["--body", body])
+    if args.body:
+        phase2_args.extend(["--body", args.body])
     return phase2_args
 
 
@@ -233,18 +223,6 @@ def _print_gate_output(result: GateResult) -> None:
         print(result.stderr)
 
 
-def _pre_gate_failure_result(name: str, argv: list[str], failure: PreGateFailure) -> GateResult:
-    """Convert local preparation failure into normal gate output."""
-
-    return GateResult(
-        name=name,
-        argv=argv,
-        returncode=1,
-        stdout="",
-        stderr=failure.message,
-    )
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Run canonical PR governance gates and emit a single merge verdict."
@@ -278,15 +256,7 @@ def main(argv: list[str] | None = None) -> int:
     _validate_args(parsed, parser)
 
     phase2_args = _phase2_args(parsed)
-    phase2_result = (
-        _pre_gate_failure_result(
-            "phase2-pr-body-gates",
-            [sys.executable, str(PHASE2_GATE)],
-            phase2_args,
-        )
-        if isinstance(phase2_args, PreGateFailure)
-        else _run_gate("phase2-pr-body-gates", PHASE2_GATE, phase2_args)
-    )
+    phase2_result = _run_gate("phase2-pr-body-gates", PHASE2_GATE, phase2_args)
 
     gate_results = [
         phase2_result,

--- a/scripts/orchestration/review_mapping_artifact.py
+++ b/scripts/orchestration/review_mapping_artifact.py
@@ -203,3 +203,19 @@ def parse_fixed_mapping_entries(section: str) -> dict[str, str]:
 def has_no_actionable_marker(section: str) -> bool:
     """True if section contains 'No actionable review comments'."""
     return NO_ACTIONABLE_LINE in section
+
+
+def render_phase2_body_mirror(pr_number: int) -> str:
+    """Render the canonical PR-body mirror block from the artifact source of truth."""
+
+    artifact_ref = f"docs/review/PR_{pr_number}_FIXED_MAPPING.md"
+    return "\n".join(
+        [
+            DISCUSSION_THREAD_PASS_HEADING,
+            CHECKBOX_DISCUSSION_PASS,
+            CHECKBOX_FIXED_MAPPING,
+            "",
+            "### Fixed in Commit Mapping",
+            f"- canonical artifact: `{artifact_ref}`",
+        ]
+    )

--- a/scripts/orchestration/review_mapping_artifact.py
+++ b/scripts/orchestration/review_mapping_artifact.py
@@ -208,6 +208,12 @@ def has_no_actionable_marker(section: str) -> bool:
 def render_phase2_body_mirror(pr_number: int) -> str:
     """Render the canonical PR-body mirror block from the artifact source of truth."""
 
+    artifact_text = read_mapping_artifact(pr_number)
+    errors = validate_mapping_artifact_text(artifact_text)
+    if errors:
+        joined_errors = "; ".join(errors)
+        raise RuntimeError(f"Cannot render PR body mirror for PR #{pr_number}: {joined_errors}")
+
     artifact_ref = f"docs/review/PR_{pr_number}_FIXED_MAPPING.md"
     return "\n".join(
         [

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -55,7 +55,7 @@ def test_local_mode_runs_all_gates_in_order(monkeypatch: pytest.MonkeyPatch) -> 
     ]
 
 
-def test_local_mode_fetches_pr_body_when_not_provided(
+def test_local_mode_uses_artifact_first_phase2_args_when_body_not_provided(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, list[str]]] = []
@@ -65,26 +65,13 @@ def test_local_mode_fetches_pr_body_when_not_provided(
         return _ok_result(name, [str(script_path), *extra_args])
 
     monkeypatch.setattr(merge_ready, "_run_gate", fake_run_gate)
-    monkeypatch.setattr(
-        merge_ready,
-        "_fetch_pr_body",
-        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
-    )
 
     exit_code = merge_ready.main(
         ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
     )
 
     assert exit_code == 0
-    assert calls[0] == (
-        "phase2-pr-body-gates",
-        [
-            "--pr-number",
-            "1005",
-            "--body",
-            "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
-        ],
-    )
+    assert calls[0] == ("phase2-pr-body-gates", ["--pr-number", "1005"])
 
 
 def test_fetch_pr_body_uses_gh_auth_status_when_env_token_is_missing(
@@ -115,68 +102,28 @@ def test_fetch_pr_body_uses_gh_auth_status_when_env_token_is_missing(
     assert run_calls[1][:4] == ["/usr/local/bin/gh", "pr", "view", "1129"]
 
 
-def test_local_mode_turns_fetch_pr_body_failure_into_gate_failure(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+def test_local_mode_does_not_fetch_pr_body_when_body_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    results = {
-        "merge-readiness-gate": _ok_result("merge-readiness-gate", []),
-        "current-head-checks": _ok_result("current-head-checks", []),
-        "review-threads-disposition": _ok_result("review-threads-disposition", []),
-    }
+    calls: list[tuple[str, list[str]]] = []
 
-    monkeypatch.setattr(
-        merge_ready,
-        "_run_gate",
-        lambda name, script_path, extra_args: results[name],
-    )
+    def fake_run_gate(name: str, script_path, extra_args: list[str]) -> merge_ready.GateResult:
+        calls.append((name, extra_args))
+        return _ok_result(name, [str(script_path), *extra_args])
+
+    monkeypatch.setattr(merge_ready, "_run_gate", fake_run_gate)
     monkeypatch.setattr(
         merge_ready,
         "_fetch_pr_body",
-        lambda pr_number, repo: (_ for _ in ()).throw(RuntimeError("gh auth failed")),
+        lambda pr_number, repo: (_ for _ in ()).throw(RuntimeError("should not be called")),
     )
 
     exit_code = merge_ready.main(
         ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
     )
 
-    captured = capsys.readouterr()
-    assert exit_code == 1
-    assert "[FAIL] phase2-pr-body-gates" in captured.out
-    assert "gh auth failed" in captured.out
-    assert "Failing gates: phase2-pr-body-gates" in captured.out
-
-
-def test_local_mode_turns_fetch_pr_body_timeout_into_gate_failure(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    results = {
-        "merge-readiness-gate": _ok_result("merge-readiness-gate", []),
-        "current-head-checks": _ok_result("current-head-checks", []),
-        "review-threads-disposition": _ok_result("review-threads-disposition", []),
-    }
-
-    monkeypatch.setattr(
-        merge_ready,
-        "_run_gate",
-        lambda name, script_path, extra_args: results[name],
-    )
-
-    def raise_timeout(pr_number: int, repo: str) -> str:
-        raise merge_ready.subprocess.TimeoutExpired(
-            cmd=["gh", "pr", "view", str(pr_number)],
-            timeout=merge_ready.RUN_TIMEOUT_SEC,
-        )
-
-    monkeypatch.setattr(merge_ready, "_fetch_pr_body", raise_timeout)
-
-    exit_code = merge_ready.main(
-        ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
-    )
-
-    captured = capsys.readouterr()
-    assert exit_code == 1
-    assert "[FAIL] phase2-pr-body-gates" in captured.out
-    assert "Command '['gh', 'pr', 'view', '1005']' timed out" in captured.out
+    assert exit_code == 0
+    assert calls[0] == ("phase2-pr-body-gates", ["--pr-number", "1005"])
 
 
 def test_event_mode_passes_require_auth_only_to_disposition(
@@ -262,12 +209,6 @@ def test_wrapper_surfaces_failing_gate_names(
         "_run_gate",
         lambda name, script_path, extra_args: results[name],
     )
-    monkeypatch.setattr(
-        merge_ready,
-        "_fetch_pr_body",
-        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
-    )
-
     exit_code = merge_ready.main(
         ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
     )
@@ -318,12 +259,6 @@ def test_wrapper_fails_when_disposition_gate_skips_in_advisory_mode(
         "_run_gate",
         lambda name, script_path, extra_args: results[name],
     )
-    monkeypatch.setattr(
-        merge_ready,
-        "_fetch_pr_body",
-        lambda pr_number, repo: "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n### Fixed in Commit Mapping\n- [x] Fixed in commit mapping completed\n- No actionable review comments\n",
-    )
-
     exit_code = merge_ready.main(
         ["--pr-number", "1005", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
     )

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -280,8 +280,8 @@ Commit: abc1234
     assert "canonical mapping artifact and PR body mirror passed" in result.stdout
 
 
-def test_phase2_rejects_empty_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
-    """Artifact-first mode still requires a non-empty body mirror."""
+def test_phase2_accepts_empty_pr_body_when_artifact_is_valid(tmp_path: Path) -> None:
+    """Artifact-first mode does not fail solely because the body mirror is omitted."""
     event = {"pull_request": {"number": 998, "body": ""}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
@@ -310,8 +310,8 @@ Commit: abc1234
         cwd=str(repo_root),
         env=env,
     )
-    assert result.returncode == 1
-    assert "ERROR: Empty PR body." in result.stdout
+    assert result.returncode == 0
+    assert "canonical mapping artifact passed" in result.stdout
 
 
 def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
@@ -347,6 +347,39 @@ Commit: abc1234
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
     assert "Missing required section" in result.stdout
+
+
+def test_phase2_accepts_pr_number_without_explicit_body_when_artifact_is_valid(
+    tmp_path: Path,
+) -> None:
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--pr-number",
+            "998",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "canonical mapping artifact passed" in result.stdout
 
 
 def test_phase2_failure_output_only_reports_failing_scope(tmp_path: Path) -> None:

--- a/tests/test_review_mapping_artifact.py
+++ b/tests/test_review_mapping_artifact.py
@@ -27,7 +27,11 @@ def test_mapping_artifact_path() -> None:
     assert "docs" in str(p998) and "review" in str(p998)
 
 
-def test_render_phase2_body_mirror_is_stable() -> None:
+def test_render_phase2_body_mirror_is_stable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(FIXTURE_ARTIFACT, encoding="utf-8")
+    monkeypatch.setattr(artifact, "_review_dir", lambda: tmp_path)
     body = artifact.render_phase2_body_mirror(998)
     assert body == (
         "## Discussion Thread Pass\n"
@@ -36,6 +40,19 @@ def test_render_phase2_body_mirror_is_stable() -> None:
         "### Fixed in Commit Mapping\n"
         "- canonical artifact: `docs/review/PR_998_FIXED_MAPPING.md`"
     )
+
+
+def test_render_phase2_body_mirror_fails_for_invalid_artifact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(
+        "## Discussion Thread Pass\n- [x] Discussion-thread pass completed\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(artifact, "_review_dir", lambda: tmp_path)
+
+    with pytest.raises(RuntimeError, match="Cannot render PR body mirror for PR #998"):
+        artifact.render_phase2_body_mirror(998)
 
 
 def test_read_mapping_artifact_existing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_review_mapping_artifact.py
+++ b/tests/test_review_mapping_artifact.py
@@ -27,6 +27,17 @@ def test_mapping_artifact_path() -> None:
     assert "docs" in str(p998) and "review" in str(p998)
 
 
+def test_render_phase2_body_mirror_is_stable() -> None:
+    body = artifact.render_phase2_body_mirror(998)
+    assert body == (
+        "## Discussion Thread Pass\n"
+        "- [x] Discussion-thread pass completed\n"
+        "- [x] Fixed in commit mapping completed\n\n"
+        "### Fixed in Commit Mapping\n"
+        "- canonical artifact: `docs/review/PR_998_FIXED_MAPPING.md`"
+    )
+
+
 def test_read_mapping_artifact_existing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Read artifact from temp dir to avoid coupling to real repo file."""
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(FIXTURE_ARTIFACT, encoding="utf-8")


### PR DESCRIPTION
## Summary
Artifact-first Phase2 sync: canonical review artifact becomes the only merge-blocking SoT when `pr_number` is available. PR body remains human-readable mirror/fallback only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1139_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Local hard gates passed
- [ ] Review comments mapped in canonical artifact
- [ ] 0 unresolved threads



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow guidance to make PR body mirrors optional when canonical artifacts exist.
  * Added local verification check commands for artifact-first and body-only fallback scenarios.

* **New Features**
  * Introduced optional PR body mirror generation from canonical artifacts, eliminating the need for manual maintenance.

* **Tests**
  * Updated test suite to reflect new artifact-first validation approach where PR body presence is conditional rather than mandatory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->