### PR TITLE
docs(fitchef): add umbrella initiative foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,6 +554,16 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 - Allowlist: `tests/guards/wellness_language_allowlist.txt`; in-file marker: `pulseplate-allow:blocker-example`
 - LLM outputs used in product copy/coaching must pass `philosophy_validator` (BLOCKER = rewrite). See `core.insight.philosophy_validator.validate_llm_output`.
 
+**FitChef initiative policy (Hard rule):**
+
+- The current live FitChef public canon remains `/api/v1/insight/fitchef*`; do not rename, migrate, or deprecate these routes in foundation or visual-lane PRs.
+- FitChef must never implement nutrition math, entitlement truth, or planner truth outside canonical backend engines and guards.
+- LLM output is advisory text only and must never become domain source of truth for targets, tiers, or action availability.
+- FREE tier must not expose open-ended FitChef coaching runtime.
+- FitChef UI surfaces must render structured DTOs or approved response envelopes; do not parse raw prose into product state or navigation.
+- Every FitChef action must resolve to an existing routed product flow before the action is exposed in UI.
+- Template/fallback responses are mandatory whenever LLM execution is unavailable, disallowed, or feature-gated.
+
 **❌ Forbidden in `legacy_app.py`:**
 
 - `warn, high = (94, 102)` or similar

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -19,7 +19,7 @@
 
 - Current live FitChef public routes remain `/api/v1/insight/fitchef*`; new FitChef work must preserve these routes and add future structured-coach surfaces additively.
 - Foundation or visual-lane PRs must not migrate FitChef traffic to `/api/v1/pro/fitchef/*` or `/api/v1/vip/fitchef/*` until a dedicated contract PR freezes those paths.
-- Keep FitChef guard order deterministic: input guard -> feature/tier guard -> quota -> provider/tool execution.
+- Keep FitChef guard order aligned with the live mascot routers: tier/feature gate -> execution-mode gate -> input guard -> provider/tool execution. Do not change this precedence in docs-only PRs.
 - FREE tier must not receive open-ended FitChef runtime; bounded or static guidance only.
 - Route handlers must return structured response models or frozen response envelopes; UI clients must not depend on parsing raw model prose.
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -15,6 +15,14 @@
 - Lint/format: `make lint`, `make fmt`, `make fmt-check`
 - Pre-commit: `make pre-commit`
 
+## FitChef route and runtime policy
+
+- Current live FitChef public routes remain `/api/v1/insight/fitchef*`; new FitChef work must preserve these routes and add future structured-coach surfaces additively.
+- Foundation or visual-lane PRs must not migrate FitChef traffic to `/api/v1/pro/fitchef/*` or `/api/v1/vip/fitchef/*` until a dedicated contract PR freezes those paths.
+- Keep FitChef guard order deterministic: input guard -> feature/tier guard -> quota -> provider/tool execution.
+- FREE tier must not receive open-ended FitChef runtime; bounded or static guidance only.
+- Route handlers must return structured response models or frozen response envelopes; UI clients must not depend on parsing raw model prose.
+
 ## Health endpoints contract (PR-504)
 
 | Endpoint | Purpose | DB I/O | Response |

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -48,6 +48,13 @@ If a test fails due to typing:
   or `SessionLocal.configure()` in `core/`.
   DB lifecycle is controlled by test fixtures and application startup.
 
+## FitChef domain invariants
+
+- FitChef domain code must consume canonical backend outputs; it must not recreate nutrition math, entitlement logic, or planner truth in `core/fitchef/*`.
+- LLM-generated text is not a domain oracle. Domain state, actions, and limits must be decided before any provider call.
+- FitChef fallback/templates are mandatory and deterministic so bounded guidance still works when LLM execution is disabled or unavailable.
+- Core FitChef interfaces should prefer typed structured payloads over free-form strings whenever the result drives UI actions or navigation.
+
 ## Feature map
 - See `app/AGENTS.md` for the full backend feature map covering `core/` + `app/`.
 

--- a/docs/contracts/API_CANONICAL_MAP.md
+++ b/docs/contracts/API_CANONICAL_MAP.md
@@ -22,6 +22,7 @@ Billing evidence note:
 3. Planned routes must stay marked as planned or additive until runtime rollout and OpenAPI exposure are real.
 4. README may summarize capability areas, but this file is the operator-facing route map.
 5. Web and iOS remain thin adapters and must not invent alternative route semantics.
+6. FitChef umbrella foundation work must preserve the live `/api/v1/insight/fitchef*` canon until a dedicated additive contract PR promotes future structured-coach paths.
 
 ## Canonical Runtime Now
 
@@ -46,6 +47,11 @@ These routes are the current canonical operator surface.
 | FitChef mascot insight | `/api/v1/insight/fitchef` | POST | VIP-only (`require_vip_tier()`) | Canonical FitChef mascot coaching route under the insight namespace; feature-gated by `FEATURE_FITCHEF_MASCOT` |
 | FitChef weekly reflection | `/api/v1/insight/fitchef/weekly-reflection` | POST | VIP-only (`require_vip_tier()`) | Canonical FitChef weekly reflection route under the insight namespace; feature-gated by `FEATURE_FITCHEF_MASCOT` |
 | FitChef slip support | `/api/v1/insight/fitchef/slip-support` | POST | VIP-only (`require_vip_tier()`) | Canonical FitChef slip-support route under the insight namespace; feature-gated by `FEATURE_FITCHEF_MASCOT` |
+
+FitChef initiative note:
+- The live mascot routes above remain canonical during the FitChef umbrella foundation and visual/App Store waves.
+- Future structured-coach surfaces under `/api/v1/pro/fitchef/*` and `/api/v1/vip/fitchef/*` remain planned-only until a dedicated additive contract PR lands.
+- Canonical reference: `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
 
 ## Deprecated Alias / Proxy-Only Surface
 
@@ -79,6 +85,7 @@ These routes remain for compatibility and migration. They must not be described 
 - OpenAPI workflow hardening for backend/frontend split targets: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-openapi-decoupling-split`
 - `docker compose` v2 migration for repo command surfaces: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-compose-v2-migration`
 - AI runtime extraction into a dedicated bounded context: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ai-bounded-context-extraction`
+- FitChef umbrella foundation and preserved live-canon policy: `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
 
 ## Legacy Compatibility Guidance
 

--- a/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
+++ b/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
@@ -1,0 +1,131 @@
+# FitChef Initiative Foundation
+
+**Status:** Umbrella initiative foundation contract
+**Date:** 2026-03-12
+**Owner:** @katsiaryna_kavaleuskaya
+
+## Summary
+
+This foundation contract opens the next FitChef initiative as a governed
+umbrella without breaking the current live mascot canon.
+
+The immediate goal is to separate work into clean PR families:
+
+1. foundation and backlog governance
+2. visual and App Store system work
+3. structured coach contracts and runtime
+
+The initiative is additive. It does not migrate or rename the existing public
+FitChef mascot routes during the foundation or visual waves.
+
+## Current live canon
+
+The live public FitChef routes remain:
+
+- `POST /api/v1/insight/fitchef`
+- `POST /api/v1/insight/fitchef/weekly-reflection`
+- `POST /api/v1/insight/fitchef/slip-support`
+
+These routes are already registered under the canonical insight namespace in
+`app/routers/fitchef_insight.py:45`, `app/routers/fitchef_insight.py:58`,
+`app/routers/fitchef_insight.py:133`, and `app/routers/fitchef_insight.py:214`.
+
+The current runtime anchor remains `app/services/fitchef_runtime.py:17` through
+`app/services/fitchef_runtime.py:66` and the weekly-plan adapter seam remains
+live in `app/services/fitchef_runtime.py:127` through
+`app/services/fitchef_runtime.py:208`.
+
+## Foundation invariants
+
+- FitChef must not implement nutrition math outside canonical backend engines.
+- LLM output is not product truth for tiers, targets, planner state, or action
+  availability.
+- FREE tier must not expose open-ended FitChef coaching runtime.
+- UI clients must render structured DTOs or approved response envelopes instead
+  of parsing raw prose into product state.
+- Every FitChef action exposed to UI must map to an existing routed product
+  flow.
+- Template and fallback responses are mandatory whenever LLM execution is
+  unavailable, disallowed, or disabled.
+
+## Rollout order
+
+### PR-0 foundation
+
+- backlog umbrella entry
+- root and scoped AGENTS updates
+- preserved live-canon documentation
+
+### PR-1 visual system and App Store contract
+
+- canonical screenshot blueprint
+- safe-area and export rules
+- App Store-safe copy rules
+- `EN` first-wave localization only
+
+### PR-2 mascot asset taxonomy
+
+- canonical mascot asset naming
+- portrait and emotion variants
+- App Icon relation rules
+- screenshot-safe asset usage rules
+
+### PR-3 App Store production pack
+
+- metadata starter pack
+- screenshot package contract
+- preview storyboard
+- upload checklist
+
+### PR-4 structured coach contract
+
+Planned-only additive routes:
+
+- `POST /api/v1/pro/fitchef/explain`
+- `POST /api/v1/pro/fitchef/recommend`
+- `POST /api/v1/vip/fitchef/insight`
+- `POST /api/v1/vip/fitchef/chat`
+- `POST /api/v1/vip/fitchef/week-repair`
+
+This phase is contract-only and must not migrate the live mascot routes.
+
+### PR-5 through PR-7 runtime follow-up
+
+- domain shell
+- PRO structured coach runtime
+- VIP runtime expansion
+
+## Artifact and asset governance
+
+- Foundation and contract PRs must remain docs-only.
+- Mascot or App Icon binary promotion must land only in dedicated asset-focused
+  PRs.
+- Local or dirty asset diffs must not be bundled into governance or contract
+  branches.
+
+## Localization policy
+
+- First App Store wave: `EN`
+- Follow-up localization waves: `RU`, `ES`
+
+`RU` and `ES` stay in backlog until the `EN` visual contract and production pack
+are governed.
+
+## Explicit non-goals for this foundation wave
+
+- migrating `/api/v1/insight/fitchef*` to a new namespace
+- shipping production screenshot binaries
+- shipping mascot or App Icon binaries
+- adding new runtime behavior
+- adding structured coach routes before the contract phase
+
+## Evidence anchors
+
+- `app/routers/fitchef_insight.py:45`
+- `app/routers/fitchef_insight.py:58`
+- `app/routers/fitchef_insight.py:133`
+- `app/routers/fitchef_insight.py:214`
+- `app/services/fitchef_runtime.py:17`
+- `app/services/fitchef_runtime.py:127`
+- `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md:16`
+- `docs/contracts/API_CANONICAL_MAP.md:46`

--- a/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
+++ b/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
@@ -106,7 +106,7 @@ This phase is contract-only and must not migrate the live mascot routes.
 ## Localization policy
 
 - First App Store wave: `EN`
-- Follow-up localization waves: `RU`, `ES`
+- Follow-up localization waves: `RU` (`PR-TBD-FITCHEF-LOCALIZATION-RU`), `ES` (`PR-TBD-FITCHEF-LOCALIZATION-ES`)
 
 `RU` and `ES` stay in backlog until the `EN` visual contract and production pack
 are governed.

--- a/docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md
+++ b/docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md
@@ -11,6 +11,12 @@ existing FitChef Phase 1 backend runtime. This wave adds text-only mascot
 coaching surfaces under the canonical insight namespace and keeps all broader
 automation work explicitly deferred.
 
+## Relationship to the umbrella initiative
+
+- The broader FitChef umbrella initiative must preserve this live mascot canon during foundation and visual/App Store waves.
+- Future structured-coach surfaces are additive follow-up work and do not change the status of `/api/v1/insight/fitchef*` in this contract.
+- Canonical initiative reference: `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
+
 ## Canonical namespace and policy
 
 - Canonical route family: `/api/v1/insight/fitchef*`

--- a/docs/review/PR_1140_FIXED_MAPPING.md
+++ b/docs/review/PR_1140_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1140 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1140_FIXED_MAPPING.md
+++ b/docs/review/PR_1140_FIXED_MAPPING.md
@@ -5,6 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1140#pullrequestreview-3937470817
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_1140_FIXED_MAPPING.md:12
+Evidence: docs/review/PR_1140_FIXED_MAPPING.md:19
+Reason: The CodeRabbit review-shell actionable is satisfied by the individually mapped thread fixes recorded below; no separate code or docs change remains outside those resolved inline comments.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1140#discussion_r2925370538 -> edd0f527
 Disposition: FIXED
 Commit: edd0f527

--- a/docs/review/PR_1140_FIXED_MAPPING.md
+++ b/docs/review/PR_1140_FIXED_MAPPING.md
@@ -5,7 +5,21 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1140#discussion_r2925370538 -> edd0f527
+Disposition: FIXED
+Commit: edd0f527
+Evidence: app/AGENTS.md:22
+Evidence: app/routers/fitchef_insight.py:78
+Reason: The scoped app policy now matches the live mascot router precedence instead of documenting an incorrect input-first order.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1140#discussion_r2925378102 -> edd0f527
+Disposition: FIXED
+Commit: edd0f527
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:1260
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:1287
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:1302
+Evidence: docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md:109
+Reason: `RU` and `ES` follow-ups are now explicitly anchored as deferred backlog items with distinct target PR placeholders.
 
 ## Merge Readiness
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1257,7 +1257,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef umbrella initiative foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (orchestration / brand / App Store / coaching)
-  - Target PR: PR-TBD-FITCHEF-UMBRELLA-FOUNDATION -> PR-TBD-FITCHEF-VISUAL-CONTRACT -> PR-TBD-FITCHEF-ASSET-TAXONOMY -> PR-TBD-FITCHEF-APP-STORE-PACK -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
+  - Target PR: PR-TBD-FITCHEF-UMBRELLA-FOUNDATION -> PR-TBD-FITCHEF-VISUAL-CONTRACT -> PR-TBD-FITCHEF-ASSET-TAXONOMY -> PR-TBD-FITCHEF-APP-STORE-PACK-EN -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
   - Status: 📋 Planned
   - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
   - Links:
@@ -1279,8 +1279,39 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Umbrella initiative contract exists and explicitly preserves the live `/api/v1/insight/fitchef*` canon
     - Root and scoped `AGENTS.md` files encode FitChef invariants: no duplicate nutrition math, no LLM source-of-truth, no FREE open-ended coach runtime, structured DTO rendering, routed actions only, mandatory fallback templates
     - Follow-up PR chain is explicit for visual/App Store and structured-coach/runtime lanes
-    - First App Store localization wave is fixed as `EN` only, with `RU` and `ES` tracked as follow-ups
+    - First App Store localization wave is fixed as `EN` only
+    - `RU` and `ES` localization follow-ups are anchored as separate backlog items with their own target PR placeholders
     - Foundation/docs PRs remain docs-only and do not carry mascot or App Icon binary asset promotion
+
+
+- [ ] P2: FitChef App Store localization RU
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (ASO / localization)
+  - Target PR: PR-TBD-FITCHEF-LOCALIZATION-RU
+  - Status: 📋 Planned
+  - Reason (EN): The first FitChef App Store wave is intentionally `EN` only. Russian localization must remain deferred until the `EN` visual contract and production pack are frozen so copy, screenshot ordering, and safe-area rules do not drift.
+  - Links:
+    - `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-umbrella-foundation`
+  - DoD:
+    - `RU` screenshot headlines and subtext are derived from the approved `EN` App Store contract
+    - `RU` metadata pack is tracked under its own follow-up PR and does not change the canonical `EN` layout rules
+    - Any `RU` asset/export work remains separated from governance-only PRs
+
+
+- [ ] P2: FitChef App Store localization ES
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (ASO / localization)
+  - Target PR: PR-TBD-FITCHEF-LOCALIZATION-ES
+  - Status: 📋 Planned
+  - Reason (EN): Spanish localization is a follow-up wave after the `EN` contract/pack. It must stay explicitly deferred so future ASO copy, screenshot exports, and review metadata remain traceable in the canonical backlog.
+  - Links:
+    - `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-umbrella-foundation`
+  - DoD:
+    - `ES` screenshot headlines and subtext are derived from the approved `EN` App Store contract
+    - `ES` metadata pack is tracked under its own follow-up PR and does not change the canonical `EN` layout rules
+    - Any `ES` asset/export work remains separated from governance-only PRs
 
 
 - [ ] Optional: tighten guard false-positives (comment stripping / pattern tuning)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1253,6 +1253,36 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - A minimal starter pack exists (at least 3 states) and is used in one Web screen and one iOS screen
 
 
+<a id="ledger-p1-fitchef-umbrella-foundation"></a>
+- [ ] P1: FitChef umbrella initiative foundation
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (orchestration / brand / App Store / coaching)
+  - Target PR: PR-TBD-FITCHEF-UMBRELLA-FOUNDATION -> PR-TBD-FITCHEF-VISUAL-CONTRACT -> PR-TBD-FITCHEF-ASSET-TAXONOMY -> PR-TBD-FITCHEF-APP-STORE-PACK -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
+  - Status: 📋 Planned
+  - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
+  - Links:
+    - `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
+    - `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md`
+    - `docs/contracts/API_CANONICAL_MAP.md`
+    - `app/routers/fitchef_insight.py`
+    - `app/services/fitchef_runtime.py`
+    - `AGENTS.md`
+  - Subtracks:
+    - FitChef visual identity and mascot system
+    - App Store screenshot and preview pack
+    - FitChef structured coach contract
+    - FitChef PRO structured coach runtime
+    - FitChef VIP deep-coach runtime
+    - FitChef analytics and action routing
+    - FitChef localization wave EN -> RU -> ES
+  - DoD:
+    - Umbrella initiative contract exists and explicitly preserves the live `/api/v1/insight/fitchef*` canon
+    - Root and scoped `AGENTS.md` files encode FitChef invariants: no duplicate nutrition math, no LLM source-of-truth, no FREE open-ended coach runtime, structured DTO rendering, routed actions only, mandatory fallback templates
+    - Follow-up PR chain is explicit for visual/App Store and structured-coach/runtime lanes
+    - First App Store localization wave is fixed as `EN` only, with `RU` and `ES` tracked as follow-ups
+    - Foundation/docs PRs remain docs-only and do not carry mascot or App Icon binary asset promotion
+
+
 - [ ] Optional: tighten guard false-positives (comment stripping / pattern tuning)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -49,6 +49,13 @@ npm run build
 - Root policy: `AGENTS.md` (Thin HTTP Adapter Policy)
 - Audit: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
 
+## FitChef web client policy
+
+- Web FitChef surfaces must stay thin adapters over backend contracts; no client-side nutrition math, entitlement inference, or action synthesis.
+- Current live FitChef mascot routes remain `/api/v1/insight/fitchef*`; any future `/api/v1/pro/fitchef/*` or `/api/v1/vip/fitchef/*` usage must follow additive contract rollout.
+- UI must render structured DTO fields or frozen response envelopes; do not parse free-form prose to derive routing, badges, or gated states.
+- FREE-tier web surfaces may show bounded/static FitChef guidance, but must not expose open-ended coach runtime.
+
 ---
 
 ## Realtime WebSocket adapter policy

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -26,6 +26,8 @@
   `docs/design/LUXURY_UI_REVIEW_CHECKLIST.md`.
 - For button-level visual execution and prompt references, use the canonical root section in
   `AGENTS.md` (matrix + prompt playbook links are maintained there to avoid duplicated scoped text).
+- App Store and mascot packaging for FitChef follows the initiative foundation contract:
+  `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
 
 ## CI: Greenlight iOS preflight (P0 report-only)
 
@@ -70,6 +72,14 @@
 - ✅ Map backend token to UI label (e.g., `category` → "Normal" for display), **without computing from bmi**
 
 **Contract note:** `category` is treated as display string (may be localized or token). iOS does not infer thresholds.
+
+## FitChef thin client policy
+
+- iOS must treat FitChef as a thin presentation layer over backend contracts; no local coaching logic, nutrition math, or entitlement inference in Swift.
+- Current live FitChef mascot routes remain `/api/v1/insight/fitchef*`; future structured-coach routes must be additive and schema-driven.
+- FitChef screens/cards must render structured DTO fields or approved response envelopes; do not parse raw prose to decide navigation, state transitions, or action visibility.
+- FREE-tier iOS surfaces may show bounded/static FitChef guidance, but must not expose open-ended coach runtime.
+- Mascot or App Store asset changes must land through dedicated asset-focused PRs; docs/policy PRs must not mix in binary asset promotion.
 
 ## Enforced CI Rules (Anti-Duplication)
 


### PR DESCRIPTION
## Summary
- add the FitChef umbrella foundation contract for the docs-only PR-0 lane
- record the FitChef umbrella backlog epic and the follow-up PR chain
- preserve the live `/api/v1/insight/fitchef*` canon while adding scoped policy rules for future visual and structured-coach work

## Scope
- root and scoped `AGENTS.md` policy updates for FitChef invariants
- canonical FitChef initiative foundation contract
- backlog and route-map documentation updates only
- no runtime, API behavior, or binary asset changes

## Validation
- `pre-commit run --all-files`
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$(cat /tmp/fitchef_pr0_body.md)" --pr-number 1140`
- docs-only changed-files guard

## Deferred / Follow-ups
- `PR-1`: visual system and App Store contract
- `PR-2`: mascot asset taxonomy
- `PR-3`: App Store production pack
- `PR-4`: structured coach contract
- `PR-5` to `PR-7`: domain shell and runtime rollout

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical SoT: `docs/review/PR_1140_FIXED_MAPPING.md`
- No actionable review comments

## Merge Readiness
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FitChef Initiative Foundation docs describing governance, rollout phases, preserved live mascot routes, and phase-based PR sequence
  * Introduced FitChef route, runtime, domain-invariant, and thin-client policies across app, core, frontend, and iOS docs
  * Updated API canonical mapping and related contracts to preserve current FitChef routes and planned additive surfaces
  * Documented tighter BMI/legacy-compatibility handling rules, backlog entries, and a PR review status page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->