### PR TITLE
docs(ledger): close PR12 phase2 sync

### DIFF
--- a/docs/review/PR_1142_FIXED_MAPPING.md
+++ b/docs/review/PR_1142_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1142 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6123,19 +6123,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Final merge-readiness / wait-window evidence is recorded before merge
 
 <a id="ledger-p2-phase2-body-artifact-sync"></a>
-- [ ] P2: Eliminate PR body and mapping artifact phase2 drift
+- [x] P2: Eliminate PR body and mapping artifact phase2 drift
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_PHASE2_BODY_ARTIFACT_SYNC
+  - Target PR: PR #1139 (`fix/pr12-phase2-artifact-sync`)
   - Area: orchestration / CI governance
   - Reason: PR5 closeout exposed a hidden governance fragility: `check_pr_body_phase2_gates.py` requires both the canonical mapping artifact and the PR body mirror to carry checked discussion/mapping markers plus at least one mapping entry, which creates avoidable double-maintenance drift during late review cycles.
+  - Status: ✅ Merged via PR #1139 on 12 March 2026 (`ff834517548bfb5bc4d59cb67f9f42da2db09cf7`)
   - Links:
     - `scripts/ci/check_pr_body_phase2_gates.py`
+    - `scripts/orchestration/check_merge_ready.py`
+    - `scripts/orchestration/review_mapping_artifact.py`
     - `docs/review/PR_1102_FIXED_MAPPING.md`
+    - `docs/review/PR_1139_FIXED_MAPPING.md`
     - `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
+    - `RUNBOOK_AGENT.md`
   - DoD:
-    - Phase2 body mirror is generated or validated from a single canonical source
-    - Late review-cycle updates no longer require manual duplication of mapping lines
+    - Phase2 artifact is the merge-blocking SoT when `pr_number` is available
+    - PR body mirror is optional and no longer creates late-cycle mapping duplication failures
+    - The mirror helper validates the canonical artifact before rendering a PR-body block
     - CI guidance explicitly distinguishes canonical SoT vs human-readable mirror
 
 <a id="ledger-p2-clean-clone-dependency-parity"></a>


### PR DESCRIPTION
## Summary
Backlog closeout for merged PR #1139. Marks `ledger-p2-phase2-body-artifact-sync` as delivered and records the canonical merge SHA.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [ ] Local hard gates passed
- [ ] Review comments mapped in canonical artifact
- [ ] 0 unresolved threads

## Summary by Sourcery

Документация:
- Обновить документацию по невыполненным задачам в журнале (ledger backlog), чтобы отразить завершение работ по синхронизации «phase2 body–artifact», включая целевой PR, статус слияния и обновлённое определение готовности (definition of done).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the ledger backlog documentation to reflect completion of the phase2 body–artifact sync work, including target PR, merge status, and updated definition of done.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes out the PR12 phase2 artifact sync by marking `ledger-p2-phase2-body-artifact-sync` as delivered, linking it to PR #1139, and recording merged status. Adds `docs/review/PR_1142_FIXED_MAPPING.md` (bootstrap mapping and merge‑readiness checklist), and updates the DoD to make the phase2 artifact the merge‑blocking source of truth, make the PR‑body mirror optional, and link to `scripts/orchestration/check_merge_ready.py`, `scripts/orchestration/review_mapping_artifact.py`, `docs/review/PR_1139_FIXED_MAPPING.md`, and `RUNBOOK_AGENT.md`.

<sup>Written for commit 3a8db28e6e5b41f3225a88598a0f3b643325397f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new review status tracking documentation.
  * Updated project backlog documentation to reflect completion of internal process synchronization efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->