### PR TITLE
fix(orchestration): add first-class cv routing

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -348,11 +348,13 @@ RAG architecture, recursive verification, and budgets/stop conditions for ground
 
 Computer vision pipeline contracts (photo → items → confidence → mapping) and privacy boundaries.
 
-PR5 note: route CV experimentation through the existing `ml` domain and keep `cv-agent`
-as an advisory specialist. For CV experiment design, pair it with
-`data-scientist-agent` and `bayesian-uq-agent` as advisory tracks under the same
-`ml` routing domain. Runtime client ownership for future CV UX is deferred and
-must be tracked explicitly before implementation.
+PR13 note: route generic CV-first coordinator tasks through the canonical `cv`
+domain in the `ml` cluster, with `cv-agent` as the graph-primary owner. Keep
+governed experimentation packets backward-compatible under the existing `ml`
+domain until the experiment packet contract is migrated explicitly. For CV
+experiment design, pair `cv-agent` with `data-scientist-agent` and
+`bayesian-uq-agent` as advisory tracks. Runtime client ownership for future CV
+UX remains deferred and must be tracked explicitly before implementation.
 
 Rollout / rollback note:
 - Roll forward only when CV work stays docs/eval-only and uses the governed

--- a/.cursor/agents/cv-agent.md
+++ b/.cursor/agents/cv-agent.md
@@ -18,6 +18,7 @@ Design a CV pipeline that is:
 - **Explicitly uncertain** (confidence at each stage)
 - **Privacy-safe** (no surprise logging/retention)
 - **Deterministically testable** (benchmarks + schema checks)
+- **Coordinator-routable** (`domain=cv`, `cluster=ml` for generic CV-first tasks)
 
 ## Hard boundaries
 
@@ -33,6 +34,7 @@ Design a CV pipeline that is:
 2. Drafting response schemas and confidence semantics
 3. Auditing privacy/logging/retention constraints for user images
 4. Planning evaluation/benchmarks and acceptance criteria (future PRs)
+5. Acting as the graph-primary agent for coordinator-routed CV tasks
 
 ## Required pre-flight (SoT)
 

--- a/docs/orchestration/AGENT_CAPABILITY_MATRIX.md
+++ b/docs/orchestration/AGENT_CAPABILITY_MATRIX.md
@@ -52,7 +52,7 @@ Slug-first: first column = canonical agent slug (aligns with inventory and routi
 | **data-scientist-agent** | Data Scientist | `docs/`, experiments (future) | Metrics, eval design, offline benchmarks | — | Coordinator, ML Engineer |
 | **ml-engineer-agent** | ML Engineer | `providers/`, infra seams (future) | Productionization, latency/cost budgets, caching | Architecture | Coordinator |
 | **bayesian-uq-agent** | Bayesian / UQ Agent | `core/`, `providers/` | Uncertainty quantification, calibration, reliability metrics | — | Coordinator, AI Innovation |
-| **cv-agent** | CV Agent | `core/`, `providers/` | Food recognition pipeline, confidence scoring, privacy boundaries | — | Coordinator, Security |
+| **cv-agent** | CV Agent | `core/`, `providers/` | CV routing domain, food recognition pipeline, confidence scoring, privacy boundaries | — | Coordinator, Security |
 | **philosophy-agent** | Philosophy Agent | `docs/` (cross-cutting) | Claim semantics, falsifiability, wellness language boundaries | — | Coordinator |
 | **logic-agent** | Logic Agent | `docs/`, `core/` (cross-cutting) | Contradiction checks, invariants for recommendations | — | Coordinator, Bug Hunter (for testability) |
 | **nutritionist-agent** | Nutritionist Agent | `docs/`, `core/` | Nutrition domain constraints, safe wording, rule definitions | — | Coordinator |

--- a/docs/orchestration/AGENT_CONTEXT_MAP.md
+++ b/docs/orchestration/AGENT_CONTEXT_MAP.md
@@ -457,6 +457,9 @@ This map reduces “missing context” failures by making required inputs explic
 
 - Uncertainty/confidence must be explicit for recognition outputs
 - Privacy/logging constraints for user images (policy-only here)
+- Generic coordinator routing resolves CV-first tasks to `domain=cv` inside the
+  `ml` cluster; governed experimentation packets stay `ml`-scoped until that
+  packet contract is migrated explicitly.
 - When specifying future degrade UX states, also load:
   - `frontend/AGENTS.md`
   - `ios/AGENTS.md`

--- a/docs/orchestration/AGENT_INVENTORY.md
+++ b/docs/orchestration/AGENT_INVENTORY.md
@@ -45,7 +45,7 @@
 | **data-scientist-agent** | Evals, metrics, offline experiments, measurement plans |
 | **ml-engineer-agent** | Productionization, latency/cost budgets, caching, infra seams |
 | **bayesian-uq-agent** | Uncertainty quantification, calibration, confidence contracts |
-| **cv-agent** | CV pipeline contracts (photo→items→confidence→nutrition) |
+| **cv-agent** | CV pipeline contracts (photo→items→confidence→nutrition); graph-primary for routing domain `cv` |
 
 ---
 

--- a/docs/orchestration/AGENT_NON_ROUTABLE_SPECIALISTS.md
+++ b/docs/orchestration/AGENT_NON_ROUTABLE_SPECIALISTS.md
@@ -6,7 +6,6 @@ but are not required to appear in `AGENT_ROUTING_GRAPH.md` as primary/secondary/
 - `ai-app-architect`
 - `bayesian-uq-agent`
 - `cbt-psychologist-agent`
-- `cv-agent`
 - `data-scientist-agent`
 - `designer-artist-agent`
 - `epistemology-discovery-agent`

--- a/docs/orchestration/AGENT_ROUTING_GRAPH.md
+++ b/docs/orchestration/AGENT_ROUTING_GRAPH.md
@@ -24,6 +24,7 @@
 | Infrastructure | infra    |
 | Security       | security |
 | AI / ML        | ml       |
+| Computer Vision | cv      |
 | Design         | design   |
 | Documentation  | docs     |
 | Research       | research |
@@ -62,6 +63,7 @@ Enforcement evidence: `scripts/orchestration/routing_graph_loader.py:121-169`, `
 | infra    | ops      | dev-operator             | architecture-specialist         | security-auditor        |
 | security | ops      | security-auditor         | architecture-specialist         | agent-coordinator       |
 | ml       | ml       | ai-innovation-specialist | rag-systems-agent               | architecture-specialist |
+| cv       | ml       | cv-agent                 | data-scientist-agent            | security-auditor        |
 | docs     | ops      | web-research-agent       | cursor-specialist-agent         | qa-engineer-agent       |
 | design   | platform | creative-designer        | frontend-engineer               | qa-engineer-agent       |
 | research | ml       | web-research-agent       | ai-innovation-specialist        | agent-coordinator       |
@@ -88,6 +90,7 @@ Enforcement evidence: `scripts/orchestration/routing_graph_loader.py:121-169`, `
 10. **Cluster-first routing:** coordinator resolves `cluster` first for metrics and packaging, then selects domain-level primary/secondary/reviewer.
 11. **Skills after routing:** once primary domain is resolved, coordinator selects `recommended_skills` via `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md` and task bootstrap artifacts.
 12. **`creative_research` sub-lane:** route through `research` first, then apply phase-specific role mapping from `docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md`. The sub-lane refines execution inside the experimentation umbrella; it does not replace this routing graph.
+13. **CV routing invariant:** generic coordinator/task packets route CV-first work through `domain=cv`, `cluster=ml`. Governed experimentation packets may remain `ml`-scoped until their contract is migrated explicitly.
 
 Audit evidence: `scripts/orchestration/check_agent_consistency.py:103-209`, `tests/test_routing_graph_loader.py:159-315`, `tests/guards/test_agent_consistency_guard.py:179-216`.
 

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -59,8 +59,10 @@ For experimentation tasks, the bootstrap packet should also reference:
 
 CV routing note:
 
-- PR5 keeps graph-level routing under `ml`.
-- `cv-agent` remains an advisory specialist for experimentation packets; this policy does not create a first-class `cv` routing domain.
+- PR13 promotes `cv` to a first-class coordinator routing domain inside cluster `ml`.
+- Generic coordinator task packets should emit `domain: "cv"` for CV-first work.
+- Governed experimentation packets remain backward-compatible under `domain: "ml"` until the experiment packet contract is migrated explicitly.
+- `cv-agent` is graph-primary for routed CV tasks; runtime/client ownership still stays out of scope here and is tracked separately.
 
 ---
 

--- a/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md
@@ -40,7 +40,6 @@ feature activation.
 - Storage or retention of raw user images.
 - Client-side CV UX implementation in `frontend/` or `ios/`.
 - Model-hosting decisions, inference budgets, or serving providers.
-- First-class `cv` routing domain changes in `AGENT_ROUTING_GRAPH.md`.
 
 ---
 
@@ -151,11 +150,13 @@ Default posture for PR5:
 
 ## 6. Routing and ownership
 
-For PR5:
+For PR13 and later:
 
-- graph-level routing remains `ml`
-- `cv-agent` stays advisory, not the graph-primary owner
-- `data-scientist-agent` and `bayesian-uq-agent` are expected secondary/advisory tracks
+- generic coordinator routing resolves CV-first work through `domain=cv`,
+  `cluster=ml`
+- governed experimentation packets remain `ml`-scoped for backward compatibility
+- `cv-agent` is graph-primary for routed CV tasks
+- `data-scientist-agent` and `bayesian-uq-agent` remain expected secondary/advisory tracks
 
 When defining future degrade UX states, required context expands to:
 
@@ -164,4 +165,4 @@ When defining future degrade UX states, required context expands to:
 - `docs/orchestration/IOS_FRONTEND_MULTIAGENT_PLAYBOOK.md`
 
 This is a documentation requirement only. It does not assign runtime implementation
-ownership in PR5.
+ownership in PR13.

--- a/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md
@@ -4,7 +4,7 @@
 
 **Purpose:** Define the canonical CV-specific overlay for governed experimentation packets.
 
-**Status:** Canonical overlay for PR5. This file extends, and does not replace,
+**Status:** Canonical overlay for the governed CV experimentation lane. This file extends, and does not replace,
 `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`.
 
 **Hard rule:** This protocol is offline-evaluation-only. It does not authorize runtime
@@ -73,7 +73,7 @@ Rule:
 
 ## 3. Uncertainty and degrade rules
 
-### Qualitative confidence only for PR5
+### Qualitative confidence only for this lane
 
 CV confidence remains qualitative in this phase:
 
@@ -82,7 +82,7 @@ CV confidence remains qualitative in this phase:
 - `low`
 - `unknown`
 
-PR5 does not canonize numeric thresholds, calibration cutoffs, or production scoring
+This lane does not canonize numeric thresholds, calibration cutoffs, or production scoring
 policy. Those remain future evaluation hooks only.
 
 ### Canonical degrade states
@@ -97,7 +97,7 @@ Every CV packet must carry the full deterministic degrade-state set:
 
 Interpretation:
 
-- PR5 defines the states and their semantics only.
+- This protocol defines the states and their semantics only.
 - Future frontend/iOS/runtime PRs may map these states to concrete UI and API flows.
 - Runtime ownership for client-visible CV UX remains deferred and must be tracked in
   `docs/roadmap/BACKLOG_LEDGER.md`.
@@ -139,7 +139,7 @@ Every CV packet must include a privacy packet with, at minimum:
 - consent policy
 - deletion policy
 
-Default posture for PR5:
+Default posture for this lane:
 
 - raw user images are sensitive by default
 - raw-image retention defaults to none

--- a/docs/review/PR_1149_FIXED_MAPPING.md
+++ b/docs/review/PR_1149_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1149 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local hard gate passed (`make lint`, `make typecheck`, `make test-fast`, `make diff-cov`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1149_FIXED_MAPPING.md
+++ b/docs/review/PR_1149_FIXED_MAPPING.md
@@ -5,7 +5,15 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- FIXED
+  - cubic found issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623106` -> `bf9cd8b8`
+  - Evidence: [CV_EXPERIMENTATION_PROTOCOL.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md)
+- FIXED
+  - cubic found issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623525` -> `bf9cd8b8`
+  - Evidence: [skill_router.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/scripts/orchestration/skill_router.py), [test_skill_router.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/tests/test_skill_router.py)
+- FIXED
+  - Codex connector issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927620695` -> `4a7eeb82`
+  - Evidence: [context_pack.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/scripts/orchestration/context_pack.py), [test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/tests/test_task_bootstrap.py)
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make lint`, `make typecheck`, `make test-fast`, `make diff-cov`)

--- a/docs/review/PR_1149_FIXED_MAPPING.md
+++ b/docs/review/PR_1149_FIXED_MAPPING.md
@@ -24,6 +24,13 @@ Evidence: `scripts/orchestration/context_pack.py:181`, `tests/test_task_bootstra
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3941545710 -> e9f02799
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2928969047 -> e9f02799
 
+Disposition: FIXED
+Commit: 32be3151
+Evidence: `scripts/orchestration/context_pack.py:181`, `scripts/orchestration/context_pack.py:212`, `tests/test_task_bootstrap.py:121`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3941566425 -> 32be3151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3941577891 -> 32be3151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2929001961 -> 32be3151
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make lint`, `make typecheck`, `make test-fast`, `make diff-cov`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1149_FIXED_MAPPING.md
+++ b/docs/review/PR_1149_FIXED_MAPPING.md
@@ -5,15 +5,16 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- FIXED
-  - cubic found issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623106` -> `bf9cd8b8`
-  - Evidence: [CV_EXPERIMENTATION_PROTOCOL.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md)
-- FIXED
-  - cubic found issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623525` -> `bf9cd8b8`
-  - Evidence: [skill_router.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/scripts/orchestration/skill_router.py), [test_skill_router.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/tests/test_skill_router.py)
-- FIXED
-  - Codex connector issue: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927620695` -> `4a7eeb82`
-  - Evidence: [context_pack.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/scripts/orchestration/context_pack.py), [test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean_pr2_20260310_165139/tests/test_task_bootstrap.py)
+Disposition: FIXED
+Commit: bf9cd8b8
+Evidence: `docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md:5`, `docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md:65`, `scripts/orchestration/skill_router.py:72`, `tests/test_skill_router.py:179`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623106 -> bf9cd8b8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623525 -> bf9cd8b8
+
+Disposition: FIXED
+Commit: 4a7eeb82
+Evidence: `scripts/orchestration/context_pack.py:171`, `tests/test_task_bootstrap.py:63`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927620695 -> 4a7eeb82
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make lint`, `make typecheck`, `make test-fast`, `make diff-cov`)

--- a/docs/review/PR_1149_FIXED_MAPPING.md
+++ b/docs/review/PR_1149_FIXED_MAPPING.md
@@ -8,13 +8,21 @@
 Disposition: FIXED
 Commit: bf9cd8b8
 Evidence: `docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md:5`, `docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md:65`, `scripts/orchestration/skill_router.py:72`, `tests/test_skill_router.py:179`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3940000434 -> bf9cd8b8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623106 -> bf9cd8b8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3940000924 -> bf9cd8b8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927623525 -> bf9cd8b8
 
 Disposition: FIXED
 Commit: 4a7eeb82
 Evidence: `scripts/orchestration/context_pack.py:171`, `tests/test_task_bootstrap.py:63`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2927620695 -> 4a7eeb82
+
+Disposition: FIXED
+Commit: e9f02799
+Evidence: `scripts/orchestration/context_pack.py:181`, `tests/test_task_bootstrap.py:106`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#pullrequestreview-3941545710 -> e9f02799
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1149#discussion_r2928969047 -> e9f02799
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make lint`, `make typecheck`, `make test-fast`, `make diff-cov`)

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -178,13 +178,13 @@ def resolve_domain(
     normalized_goal = normalize_text(goal or "")
     normalized_task_class = task_class.strip().lower()
 
-    if _has_cv_path_hint(normalized_paths):
-        return "cv"
     if (
         normalized_task_class in TASK_CLASS_DOMAIN_HINTS
         and normalized_task_class not in CV_ROUTABLE_TASK_CLASSES
     ):
         return TASK_CLASS_DOMAIN_HINTS[normalized_task_class]
+    if _has_cv_path_hint(normalized_paths):
+        return "cv"
     if _is_cv_goal_hint(normalized_goal):
         return "cv"
     if normalized_task_class in TASK_CLASS_DOMAIN_HINTS:
@@ -212,7 +212,10 @@ def _has_cv_path_hint(normalized_paths: list[str] | tuple[str, ...]) -> bool:
     for path in normalized_paths:
         lowered_path = path.lower()
         for prefix in CV_PATH_DOMAIN_HINTS:
-            if lowered_path == prefix.rstrip("/") or lowered_path.startswith(prefix):
+            lowered_prefix = prefix.lower()
+            if lowered_path == lowered_prefix.rstrip("/") or lowered_path.startswith(
+                lowered_prefix
+            ):
                 return True
     return False
 

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -178,12 +178,14 @@ def resolve_domain(
     normalized_goal = normalize_text(goal or "")
     normalized_task_class = task_class.strip().lower()
 
+    if _has_cv_path_hint(normalized_paths):
+        return "cv"
     if (
         normalized_task_class in TASK_CLASS_DOMAIN_HINTS
         and normalized_task_class not in CV_ROUTABLE_TASK_CLASSES
     ):
         return TASK_CLASS_DOMAIN_HINTS[normalized_task_class]
-    if _is_cv_goal_hint(normalized_goal) or _has_cv_path_hint(normalized_paths):
+    if _is_cv_goal_hint(normalized_goal):
         return "cv"
     if normalized_task_class in TASK_CLASS_DOMAIN_HINTS:
         return TASK_CLASS_DOMAIN_HINTS[normalized_task_class]

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -47,6 +47,8 @@ TASK_CLASS_DOMAIN_HINTS: dict[str, str] = {
     "agent enablement": "orchestration",
 }
 
+CV_ROUTABLE_TASK_CLASSES = frozenset({"ai / ml", "ai/ml", "computer vision", "cv"})
+
 CV_PATH_DOMAIN_HINTS: tuple[str, ...] = (
     ".cursor/agents/cv-agent.md",
     "docs/orchestration/cv_",
@@ -176,6 +178,11 @@ def resolve_domain(
     normalized_goal = normalize_text(goal or "")
     normalized_task_class = task_class.strip().lower()
 
+    if (
+        normalized_task_class in TASK_CLASS_DOMAIN_HINTS
+        and normalized_task_class not in CV_ROUTABLE_TASK_CLASSES
+    ):
+        return TASK_CLASS_DOMAIN_HINTS[normalized_task_class]
     if _is_cv_goal_hint(normalized_goal) or _has_cv_path_hint(normalized_paths):
         return "cv"
     if normalized_task_class in TASK_CLASS_DOMAIN_HINTS:

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -7,6 +7,7 @@ EN: Shared helpers for deterministic context packs and path-based routing.
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -32,6 +33,8 @@ TASK_CLASS_DOMAIN_HINTS: dict[str, str] = {
     "security": "security",
     "ai / ml": "ml",
     "ai/ml": "ml",
+    "computer vision": "cv",
+    "cv": "cv",
     "design": "design",
     "documentation": "docs",
     "research": "research",
@@ -43,6 +46,31 @@ TASK_CLASS_DOMAIN_HINTS: dict[str, str] = {
     "orchestration": "orchestration",
     "agent enablement": "orchestration",
 }
+
+CV_PATH_DOMAIN_HINTS: tuple[str, ...] = (
+    ".cursor/agents/cv-agent.md",
+    "docs/orchestration/cv_",
+    "docs/orchestration/contracts/cv_",
+    "core/insight/cv_",
+    "core/rag/cv_",
+    "core/cv_",
+    "core/cv/",
+    "providers/cv_",
+    "providers/cv/",
+    "tests/test_cv_",
+)
+
+CV_GOAL_PHRASES: tuple[str, ...] = (
+    "computer vision",
+    "food image",
+    "food images",
+    "food photo",
+    "food photos",
+    "image recognition",
+    "photo recognition",
+    "vision model",
+    "vision eval",
+)
 
 PATH_DOMAIN_HINTS: tuple[tuple[str, str], ...] = (
     (".cursor/agents/", "orchestration"),
@@ -140,23 +168,55 @@ def resolve_domain(
     *,
     task_class: str,
     candidate_paths: list[str] | tuple[str, ...],
+    goal: str | None = None,
 ) -> str:
     """Resolve dominant domain from task_class and candidate paths."""
 
+    normalized_paths = repo_relative_paths(candidate_paths)
+    normalized_goal = normalize_text(goal or "")
     normalized_task_class = task_class.strip().lower()
+
+    if _is_cv_goal_hint(normalized_goal) or _has_cv_path_hint(normalized_paths):
+        return "cv"
     if normalized_task_class in TASK_CLASS_DOMAIN_HINTS:
         return TASK_CLASS_DOMAIN_HINTS[normalized_task_class]
 
     counts: dict[str, int] = {}
-    for path in repo_relative_paths(candidate_paths):
+    for path in normalized_paths:
+        lowered_path = path.lower()
         for prefix, domain in PATH_DOMAIN_HINTS:
-            if path == prefix.rstrip("/") or path.startswith(prefix):
+            lowered_prefix = prefix.lower()
+            if lowered_path == lowered_prefix.rstrip("/") or lowered_path.startswith(
+                lowered_prefix
+            ):
                 counts[domain] = counts.get(domain, 0) + 1
                 break
 
     if counts:
         return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
     return "orchestration"
+
+
+def _has_cv_path_hint(normalized_paths: list[str] | tuple[str, ...]) -> bool:
+    """Return True when candidate paths clearly belong to the CV routing seam."""
+
+    for path in normalized_paths:
+        lowered_path = path.lower()
+        for prefix in CV_PATH_DOMAIN_HINTS:
+            if lowered_path == prefix.rstrip("/") or lowered_path.startswith(prefix):
+                return True
+    return False
+
+
+def _is_cv_goal_hint(normalized_goal: str) -> bool:
+    """Return True when goal text uses boundary-safe CV wording."""
+
+    if re.search(r"(?<!\w)cv(?!\w)", normalized_goal):
+        return True
+    return any(
+        re.search(rf"(?<!\w){re.escape(phrase)}(?!\w)", normalized_goal)
+        for phrase in CV_GOAL_PHRASES
+    )
 
 
 def compute_task_packet_id(

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -115,7 +115,7 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="repo-tracked",
         rationale="Backend/API tasks should follow endpoint skill constraints and deterministic tests.",
         min_score=3,
-        domain_weights={"backend": 3, "ml": 2},
+        domain_weights={"backend": 3, "ml": 2, "cv": 2},
         path_prefixes=("app/", "core/", "providers/", "legacy_app.py"),
         keywords=("endpoint", "api", "router", "schema", "fastapi", "provider"),
     ),

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -52,7 +52,7 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="global",
         rationale="Keep orchestration, runbooks, and product docs aligned with the implementation.",
         min_score=3,
-        domain_weights={"docs": 2, "orchestration": 2, "research": 1, "ml": 1},
+        domain_weights={"docs": 2, "orchestration": 2, "research": 1, "ml": 1, "cv": 1},
         path_prefixes=("docs/", "README.md", ".cursor/agents/"),
         keywords=(
             "doc",
@@ -83,7 +83,7 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="repo-tracked",
         rationale="Run PulsePlate quality gates for code, docs, and contract-safe changes.",
         min_score=2,
-        domain_weights={"backend": 1, "frontend": 1, "orchestration": 1, "qa": 2},
+        domain_weights={"backend": 1, "frontend": 1, "orchestration": 1, "qa": 2, "cv": 1},
         path_prefixes=("app/", "core/", "frontend/", "tests/", "scripts/", "docs/orchestration/"),
         keywords=(
             "test",
@@ -218,7 +218,7 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="global",
         rationale="OpenAI product/API questions should use official docs-first guidance.",
         min_score=5,
-        domain_weights={"ml": 1},
+        domain_weights={"ml": 1, "cv": 1},
         keywords=("openai", "chatgpt", "responses api", "realtime api", "codex api"),
     ),
     SkillRule(

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -52,7 +52,11 @@ def build_task_packet(
     """Build a deterministic task packet for orchestration tooling."""
 
     normalized_paths = repo_relative_paths(candidate_paths)
-    domain = resolve_domain(task_class=task_class, candidate_paths=normalized_paths)
+    domain = resolve_domain(
+        task_class=task_class,
+        candidate_paths=normalized_paths,
+        goal=goal,
+    )
     routing = load_routing_graph()
     decision = route(
         domain,
@@ -63,7 +67,7 @@ def build_task_packet(
     packet_id = compute_task_packet_id(
         goal=goal,
         task_class=task_class,
-        domain=domain,
+        domain=decision.domain,
         candidate_paths=normalized_paths,
     )
     context_pack = collect_context_pack(

--- a/tests/test_experiment_bootstrap.py
+++ b/tests/test_experiment_bootstrap.py
@@ -100,6 +100,7 @@ def test_build_experiment_packet_adds_cv_agent_for_cv_intent() -> None:
     )
 
     assert "cv-agent" in packet["recommended_agents"]
+    assert packet["domain"] == "ml"
     assert "ml-engineer-agent" in packet["recommended_agents"]
     assert packet["cv_context"]["dataset"]["id"] == "food-101"
     assert packet["cv_context"]["privacy_packet"]["raw_image_retention"] == "none"

--- a/tests/test_routing_graph_loader.py
+++ b/tests/test_routing_graph_loader.py
@@ -197,6 +197,7 @@ def test_parses_all_known_domains() -> None:
         "infra",
         "security",
         "ml",
+        "cv",
         "docs",
         "design",
         "research",
@@ -208,6 +209,19 @@ def test_parses_all_known_domains() -> None:
         "orchestration",
     }
     assert expected.issubset(set(routes.keys()))
+
+
+def test_parses_cv_domain_with_ml_cluster() -> None:
+    """CV should be a first-class domain under the existing ML cluster."""
+
+    routes = load_routing_graph()
+
+    assert routes["cv"] == DomainRoute(
+        cluster="ml",
+        primary="cv-agent",
+        secondary="data-scientist-agent",
+        reviewer="security-auditor",
+    )
 
 
 def test_domain_normalized_to_lowercase() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -268,3 +268,19 @@ def test_skill_router_selects_default_cv_routing_stack() -> None:
     assert "pulseplate-workflow" in skills
     assert "pulseplate-gates" in skills
     assert "docs-sync" in skills
+
+
+def test_skill_router_keeps_backend_endpoint_lane_for_cv_domain() -> None:
+    """CV backend/provider work should still inherit the backend endpoint skill lane."""
+
+    skills = select_recommended_skills(
+        goal="Add provider-backed CV endpoint contract for food image analysis",
+        task_class="AI / ML",
+        candidate_paths=[
+            "providers/cv_adapter.py",
+            "app/routers/cv.py",
+        ],
+        domain="cv",
+    )
+
+    assert "pulseplate-backend-endpoints" in skills

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -250,3 +250,21 @@ def test_skill_router_selects_experimentation_lane_skills_for_cv_eval() -> None:
     assert "pulseplate-workflow" in skills
     assert "pulseplate-gates" in skills
     assert "docs-sync" in skills
+
+
+def test_skill_router_selects_default_cv_routing_stack() -> None:
+    """First-class CV domain should still receive the default orchestration stack."""
+
+    skills = select_recommended_skills(
+        goal="Review CV food image confidence drift for governed offline eval",
+        task_class="AI / ML",
+        candidate_paths=[
+            ".cursor/agents/cv-agent.md",
+            "docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md",
+        ],
+        domain="cv",
+    )
+
+    assert "pulseplate-workflow" in skills
+    assert "pulseplate-gates" in skills
+    assert "docs-sync" in skills

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -103,6 +103,23 @@ def test_task_bootstrap_preserves_explicit_security_task_class_over_cv_goal_hint
     assert packet["domain"] == "security"
 
 
+def test_task_bootstrap_routes_cv_path_hints_before_non_cv_task_class() -> None:
+    """CV-specific paths should route to CV even for docs-style task classes."""
+
+    packet = build_task_packet(
+        goal="Refresh CV protocol references",
+        task_class="Documentation",
+        candidate_paths=[
+            "docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md",
+            ".cursor/agents/cv-agent.md",
+        ],
+    )
+
+    assert packet["domain"] == "cv"
+    assert packet["cluster"] == "ml"
+    assert packet["primary_agent"] == "cv-agent"
+
+
 def test_normalize_repo_path_preserves_dot_cursor_prefix() -> None:
     """Leading './' removal must not strip the '.cursor' directory name."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -58,6 +58,39 @@ def test_task_bootstrap_includes_scoped_agents_only_once() -> None:
     assert "pulseplate-frontend-ui" in packet["recommended_skills"]
 
 
+def test_task_bootstrap_routes_cv_tasks_to_cv_domain() -> None:
+    """CV-first tasks should route to the graph-primary CV domain under ML."""
+
+    packet = build_task_packet(
+        goal="Evaluate food image recognition reliability for offline CV review",
+        task_class="AI / ML",
+        candidate_paths=[
+            ".cursor/agents/cv-agent.md",
+            "docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md",
+        ],
+    )
+
+    assert packet["domain"] == "cv"
+    assert packet["cluster"] == "ml"
+    assert packet["primary_agent"] == "cv-agent"
+    assert packet["secondary_agents"] == ["data-scientist-agent"]
+    assert packet["reviewer"] == "security-auditor"
+    assert "docs-sync" in packet["recommended_skills"]
+    assert "pulseplate-gates" in packet["recommended_skills"]
+
+
+def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
+    """Security acronyms must not trigger the CV routing domain."""
+
+    packet = build_task_packet(
+        goal="Audit CVE and CVSS handling for auth failures",
+        task_class="Security",
+        candidate_paths=["app/security/auth.py"],
+    )
+
+    assert packet["domain"] == "security"
+
+
 def test_normalize_repo_path_preserves_dot_cursor_prefix() -> None:
     """Leading './' removal must not strip the '.cursor' directory name."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -103,8 +103,25 @@ def test_task_bootstrap_preserves_explicit_security_task_class_over_cv_goal_hint
     assert packet["domain"] == "security"
 
 
-def test_task_bootstrap_routes_cv_path_hints_before_non_cv_task_class() -> None:
-    """CV-specific paths should route to CV even for docs-style task classes."""
+def test_task_bootstrap_routes_cv_path_hints_for_cv_routable_task_class() -> None:
+    """CV-specific paths should route to CV for ML/CV-class tasks."""
+
+    packet = build_task_packet(
+        goal="Refresh CV protocol references",
+        task_class="AI / ML",
+        candidate_paths=[
+            "docs/orchestration/CV_EXPERIMENTATION_PROTOCOL.md",
+            ".cursor/agents/cv-agent.md",
+        ],
+    )
+
+    assert packet["domain"] == "cv"
+    assert packet["cluster"] == "ml"
+    assert packet["primary_agent"] == "cv-agent"
+
+
+def test_task_bootstrap_preserves_docs_task_class_over_cv_path_hint() -> None:
+    """Explicit docs tasks must not be re-routed by CV-specific candidate paths."""
 
     packet = build_task_packet(
         goal="Refresh CV protocol references",
@@ -115,9 +132,8 @@ def test_task_bootstrap_routes_cv_path_hints_before_non_cv_task_class() -> None:
         ],
     )
 
-    assert packet["domain"] == "cv"
-    assert packet["cluster"] == "ml"
-    assert packet["primary_agent"] == "cv-agent"
+    assert packet["domain"] == "docs"
+    assert packet["cluster"] == "ops"
 
 
 def test_normalize_repo_path_preserves_dot_cursor_prefix() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -91,6 +91,18 @@ def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
     assert packet["domain"] == "security"
 
 
+def test_task_bootstrap_preserves_explicit_security_task_class_over_cv_goal_hint() -> None:
+    """Explicit non-CV task classes must win over generic CV goal wording."""
+
+    packet = build_task_packet(
+        goal="Audit CV controls for image upload abuse paths",
+        task_class="Security",
+        candidate_paths=["app/security/auth.py"],
+    )
+
+    assert packet["domain"] == "security"
+
+
 def test_normalize_repo_path_preserves_dot_cursor_prefix() -> None:
     """Leading './' removal must not strip the '.cursor' directory name."""
 


### PR DESCRIPTION
## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1149_FIXED_MAPPING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CV-first tasks now route to a dedicated CV domain in the ML cluster with the CV agent as graph-primary; governed experimentation packets remain ML-scoped until migrated.

* **Documentation**
  * Orchestration, routing, and experimentation docs updated with CV routing, ownership, degrade rules, and rollout/rollback guidance.

* **Refactor**
  * Domain resolution enhanced to detect CV intent and prefer CV routing when applicable.

* **Tests**
  * Added tests covering CV routing, precedence, and routing-stack selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->