### PR TITLE
docs(ledger): close PR13 cv routing item

### DIFF
--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -19,7 +19,7 @@ Reason: In artifact-first mode the canonical mapping artifact is the merge-block
 
 Disposition: FIXED
 Commit: ff8e6a62
-Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:11`, `docs/review/PR_1151_FIXED_MAPPING.md:12`
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:23`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930072441 -> ff8e6a62
 
 ## Merge Readiness

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -5,7 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 08364296
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:15`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942632211 -> 08364296
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2929970478 -> 08364296
 
 ## Merge Readiness
 - [ ] Local docs-only sanity passed

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1151 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Pending initial review.
+
+No actionable review threads recorded yet.
+
+## Merge Readiness
+- [x] Local docs-only sanity passed
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 - No actionable review comments
 
 ## Merge Readiness
-- [x] Local docs-only sanity passed
+- [ ] Local docs-only sanity passed
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -11,6 +11,17 @@ Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:11`, `docs/review/PR_1151_FIXED_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942632211 -> 08364296
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2929970478 -> 08364296
 
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:43`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:52`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:79`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:91`
+Reason: In artifact-first mode the canonical mapping artifact is the merge-blocking source of truth, and its merge-readiness checklist must stay unchecked until the final merge cycle. PR body and testing notes are informational mirrors and do not override artifact readiness semantics.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942746365
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930072430
+
+Disposition: FIXED
+Commit: ff8e6a62
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:11`, `docs/review/PR_1151_FIXED_MAPPING.md:12`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930072441 -> ff8e6a62
+
 ## Merge Readiness
 - [ ] Local docs-only sanity passed
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -28,6 +28,12 @@ Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:28`, `docs/review/PR_1151_FIXED_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942819726 -> 25babced
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930143151 -> 25babced
 
+Disposition: FIXED
+Commit: 17b579e5
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:34`, `docs/review/PR_1151_FIXED_MAPPING.md:35`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3943537848 -> 17b579e5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930781857 -> 17b579e5
+
 ## Merge Readiness
 - [ ] Local docs-only sanity passed
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -5,9 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-Pending initial review.
-
-No actionable review threads recorded yet.
+- No actionable review comments
 
 ## Merge Readiness
 - [x] Local docs-only sanity passed

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: 08364296
-Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:15`
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:11`, `docs/review/PR_1151_FIXED_MAPPING.md:12`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942632211 -> 08364296
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2929970478 -> 08364296
 

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -22,6 +22,12 @@ Commit: ff8e6a62
 Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:23`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930072441 -> ff8e6a62
 
+Disposition: FIXED
+Commit: 25babced
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:23`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942819726 -> 25babced
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930143151 -> 25babced
+
 ## Merge Readiness
 - [ ] Local docs-only sanity passed
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1151_FIXED_MAPPING.md
+++ b/docs/review/PR_1151_FIXED_MAPPING.md
@@ -24,7 +24,7 @@ Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:23`
 
 Disposition: FIXED
 Commit: 25babced
-Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:23`
+Evidence: `docs/review/PR_1151_FIXED_MAPPING.md:28`, `docs/review/PR_1151_FIXED_MAPPING.md:29`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#pullrequestreview-3942819726 -> 25babced
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1151#discussion_r2930143151 -> 25babced
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6313,12 +6313,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - The follow-up PR references PR `#1102` and this deferred remediation item
     - No runtime or tooling files are mixed into that normalization PR
 
-- [ ] P2: First-class CV routing domain in orchestration graph
+- [x] P2: First-class CV routing domain in orchestration graph
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR_TBD_CV_ROUTING_DOMAIN
+  - Target PR: PR #1149 (`fix/pr13-cv-routing-domain`)
   - Area: orchestration / routing
   - Reason: PR5 keeps `ml` as the graph-level domain for CV experiments. If future work needs `cv-agent` as graph-primary rather than advisory, `AGENT_ROUTING_GRAPH.md`, `AGENT_CAPABILITY_MATRIX.md`, `AGENT_CONTEXT_MAP.md`, and routing/tooling tests must be updated together.
+  - Status: ✅ Merged via PR #1149 on 13 March 2026 (`9572039eea56f6337d26a35eebe8fb069fedf128`)
   - Links:
     - `docs/orchestration/AGENT_ROUTING_GRAPH.md`
     - `.cursor/agents/cv-agent.md`


### PR DESCRIPTION
## Summary
- record PR13 CV routing domain item as merged in the backlog ledger
- keep post-merge bookkeeping isolated to a docs-only follow-up PR

## Testing
- python3 -m scripts.orchestration.check_preflight
- PRE_COMMIT_HOME=<tempdir> pre-commit run --files docs/roadmap/BACKLOG_LEDGER.md

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1151_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Local docs-only sanity passed
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a review-status document summarizing dispositions (e.g., FIXED, NOT-A-BUG), evidence references, and a Merge Readiness checklist with outstanding items.
  * Updated the roadmap/backlog to mark the CV routing item as completed and merged, replacing its placeholder entry with the resolved merge record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
