### PR TITLE
feat(fitchef): add EN App Store production pack

### DIFF
--- a/appstore/fitchef/en-US/iphone-6.9/preview/README.md
+++ b/appstore/fitchef/en-US/iphone-6.9/preview/README.md
@@ -1,0 +1,8 @@
+# FitChef EN Preview Pack
+
+This folder stores the governed App Preview storyboard and script for the
+first `EN` App Store lane.
+
+PR-3 does not commit a final video binary. It stores a deterministic storyboard
+and script that stay anchored to the seven-shot screenshot sequence and the
+canonical product surfaces already present in the repo.

--- a/appstore/fitchef/en-US/iphone-6.9/preview/preview_script.md
+++ b/appstore/fitchef/en-US/iphone-6.9/preview/preview_script.md
@@ -1,0 +1,34 @@
+# FitChef EN App Preview Script
+
+## Duration
+
+22 seconds target total
+
+## Script
+
+0s-3s
+PulsePlate appears with FitChef as a calm supporting brand cue.
+
+3s-6s
+Show the dashboard and daily nutrition overview.
+Caption: `Smart nutrition, powered by AI.`
+
+6s-9s
+Move into macro and micronutrient analysis.
+Caption: `Understand what your day really looks like.`
+
+9s-12s
+Show the weekly meal planner.
+Caption: `Plan meals around your real goals.`
+
+12s-15s
+Show grocery support.
+Caption: `Turn your plan into a practical shopping list.`
+
+15s-18s
+Show progress and habit insight.
+Caption: `Track balance, consistency, and progress over time.`
+
+18s-22s
+Finish on FitChef insight guidance.
+Caption: `Stay guided with calm, data-grounded support.`

--- a/appstore/fitchef/en-US/iphone-6.9/preview/preview_script.md
+++ b/appstore/fitchef/en-US/iphone-6.9/preview/preview_script.md
@@ -7,27 +7,27 @@
 ## Script
 
 0s-3s
-PulsePlate appears with FitChef as a calm supporting brand cue.
+PulsePlate opens with the core value frame and FitChef as a calm supporting cue.
 
 3s-6s
-Show the dashboard and daily nutrition overview.
-Caption: `Smart nutrition, powered by AI.`
-
-6s-9s
-Move into macro and micronutrient analysis.
+Show macro and micronutrient analysis.
 Caption: `Understand what your day really looks like.`
 
-9s-12s
+6s-9s
 Show the weekly meal planner.
 Caption: `Plan meals around your real goals.`
 
-12s-15s
+9s-12s
 Show grocery support.
 Caption: `Turn your plan into a practical shopping list.`
 
-15s-18s
+12s-15s
 Show progress and habit insight.
 Caption: `Track balance, consistency, and progress over time.`
+
+15s-18s
+Show personalization and profile setup.
+Caption: `Adapt PulsePlate to your goals and preferences.`
 
 18s-22s
 Finish on FitChef insight guidance.

--- a/appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json
+++ b/appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json
@@ -1,0 +1,56 @@
+{
+  "locale": "en-US",
+  "device_class": "iPhone 6.9",
+  "target_duration_seconds": 22,
+  "scenes": [
+    {
+      "id": "scene-01",
+      "shot_id": "shot-01",
+      "start_second": 0,
+      "end_second": 3,
+      "focus": "PulsePlate logo lockup and FitChef-led opening frame"
+    },
+    {
+      "id": "scene-02",
+      "shot_id": "shot-01",
+      "start_second": 3,
+      "end_second": 6,
+      "focus": "Dashboard and daily nutrition overview"
+    },
+    {
+      "id": "scene-03",
+      "shot_id": "shot-02",
+      "start_second": 6,
+      "end_second": 9,
+      "focus": "Macro and micronutrient analysis"
+    },
+    {
+      "id": "scene-04",
+      "shot_id": "shot-03",
+      "start_second": 9,
+      "end_second": 12,
+      "focus": "Weekly meal planning"
+    },
+    {
+      "id": "scene-05",
+      "shot_id": "shot-04",
+      "start_second": 12,
+      "end_second": 15,
+      "focus": "Shopping list generation"
+    },
+    {
+      "id": "scene-06",
+      "shot_id": "shot-05",
+      "start_second": 15,
+      "end_second": 18,
+      "focus": "Progress and habit insight"
+    },
+    {
+      "id": "scene-07",
+      "shot_id": "shot-07",
+      "start_second": 18,
+      "end_second": 22,
+      "focus": "FitChef insight / AI assistant finish"
+    }
+  ]
+}

--- a/appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json
+++ b/appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json
@@ -12,38 +12,38 @@
     },
     {
       "id": "scene-02",
-      "shot_id": "shot-01",
+      "shot_id": "shot-02",
       "start_second": 3,
       "end_second": 6,
-      "focus": "Dashboard and daily nutrition overview"
-    },
-    {
-      "id": "scene-03",
-      "shot_id": "shot-02",
-      "start_second": 6,
-      "end_second": 9,
       "focus": "Macro and micronutrient analysis"
     },
     {
-      "id": "scene-04",
+      "id": "scene-03",
       "shot_id": "shot-03",
-      "start_second": 9,
-      "end_second": 12,
+      "start_second": 6,
+      "end_second": 9,
       "focus": "Weekly meal planning"
     },
     {
-      "id": "scene-05",
+      "id": "scene-04",
       "shot_id": "shot-04",
-      "start_second": 12,
-      "end_second": 15,
+      "start_second": 9,
+      "end_second": 12,
       "focus": "Shopping list generation"
     },
     {
-      "id": "scene-06",
+      "id": "scene-05",
       "shot_id": "shot-05",
+      "start_second": 12,
+      "end_second": 15,
+      "focus": "Progress and habit insight"
+    },
+    {
+      "id": "scene-06",
+      "shot_id": "shot-06",
       "start_second": 15,
       "end_second": 18,
-      "focus": "Progress and habit insight"
+      "focus": "Personalized goals and profile setup"
     },
     {
       "id": "scene-07",

--- a/appstore/fitchef/en-US/iphone-6.9/screenshots/README.md
+++ b/appstore/fitchef/en-US/iphone-6.9/screenshots/README.md
@@ -1,0 +1,10 @@
+# FitChef EN Screenshot Pack
+
+This folder stores the governed screenshot manifest for the first `EN`
+App Store launch wave.
+
+PR-3 intentionally keeps screenshot outputs as manifest-defined, capture-ready
+artifacts instead of committing fake or manually mocked PNG exports. Each shot
+must still map to a real product surface and a canonical FitChef asset key.
+
+The expected export order and filenames live in `shot_manifest.json`.

--- a/appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json
+++ b/appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json
@@ -152,7 +152,7 @@
       "expected_filename": "07_ai-assistant.png",
       "headline": [
         "Your Personal",
-        "AI Nutrition Coach"
+        "AI Nutrition Guide"
       ],
       "supporting_copy": [
         "Guidance",

--- a/appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json
+++ b/appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json
@@ -1,0 +1,174 @@
+{
+  "locale": "en-US",
+  "device_class": "iPhone 6.9",
+  "canvas_px": {
+    "width": 1320,
+    "height": 2868
+  },
+  "safe_area_px": {
+    "top": 260,
+    "bottom": 260,
+    "left_right": 120
+  },
+  "shots": [
+    {
+      "id": "shot-01",
+      "expected_filename": "01_core-value.png",
+      "headline": [
+        "Smart Nutrition",
+        "Powered by AI"
+      ],
+      "supporting_copy": [
+        "Track nutrients",
+        "plan meals",
+        "improve health"
+      ],
+      "product_surface": "dashboard / daily overview",
+      "repo_source_refs": [
+        "ios/PulsePlate/Views/HomeView.swift",
+        "frontend/src/pages/Home.tsx"
+      ],
+      "contract_emotion": "calm",
+      "approved_mascot_asset_key": "FitChefOnboardingWelcome",
+      "asset_rationale": "The launch-value shot uses the canonical welcoming FitChef variant that stays inside the existing asset taxonomy.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-02",
+      "expected_filename": "02_nutrition-analysis.png",
+      "headline": [
+        "Understand Your",
+        "Nutrition"
+      ],
+      "supporting_copy": [
+        "Macros",
+        "Micronutrients",
+        "Daily balance"
+      ],
+      "product_surface": "nutrition analysis / result view",
+      "repo_source_refs": [
+        "frontend/src/pages/NutritionSetup/ResultView.tsx",
+        "frontend/src/pages/NutritionSetup/MacroCards.tsx",
+        "frontend/src/pages/NutritionSetup/MicrosGrid.tsx"
+      ],
+      "contract_emotion": "explaining",
+      "approved_mascot_asset_key": "FitChefThinking",
+      "asset_rationale": "No dedicated explaining variant exists in PR-2; the thinking asset is the closest canon-safe explanatory fallback.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-03",
+      "expected_filename": "03_meal-planner.png",
+      "headline": [
+        "AI Meal Planning",
+        "For Your Goals"
+      ],
+      "supporting_copy": [
+        "Weight loss",
+        "Muscle gain",
+        "Healthy balance"
+      ],
+      "product_surface": "weekly planner",
+      "repo_source_refs": [
+        "ios/PulsePlate/Views/WeeklyPlan/WeeklyPlanReaderView.swift",
+        "ios/PulsePlate/ViewModels/WeeklyPlanReaderViewModel.swift",
+        "frontend/src/features/weekly-plan/hooks/useWeeklyPlan.ts"
+      ],
+      "contract_emotion": "cooking",
+      "approved_mascot_asset_key": "FitChefThinking",
+      "asset_rationale": "PR-2 has no cooking-specific mascot variant, so the canonical fallback remains the thinking bucket until a later mascot wave adds a cooking pose.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-04",
+      "expected_filename": "04_grocery-list.png",
+      "headline": [
+        "Smart Grocery",
+        "Lists"
+      ],
+      "supporting_copy": [
+        "Auto-generated",
+        "from your meals"
+      ],
+      "product_surface": "shopping list",
+      "repo_source_refs": [
+        "frontend/src/features/shoplist/ShoplistPreview.tsx",
+        "ios/PulsePlate/ViewModels/ShoppingListReaderViewModel.swift",
+        "ios/PulsePlate/Views/HomeView.swift"
+      ],
+      "contract_emotion": "helpful",
+      "approved_mascot_asset_key": "FitChef",
+      "asset_rationale": "The default neutral FitChef asset is the canon-safe helpful fallback when no basket/helper variant exists.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-05",
+      "expected_filename": "05_health-progress.png",
+      "headline": [
+        "See Your",
+        "Progress"
+      ],
+      "supporting_copy": [
+        "Habits",
+        "Nutrition balance",
+        "Weekly insights"
+      ],
+      "product_surface": "progress and weekly analytics",
+      "repo_source_refs": [
+        "ios/PulsePlate/Views/ProgressView.swift",
+        "ios/PulsePlate/Views/WeeklyProgressView.swift",
+        "frontend/src/pages/Progress.tsx"
+      ],
+      "contract_emotion": "proud",
+      "approved_mascot_asset_key": "FitChefWink",
+      "asset_rationale": "The wink variant is the closest canonical proud/celebratory mascot surface currently available.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-06",
+      "expected_filename": "06_personalization.png",
+      "headline": [
+        "Nutrition",
+        "For You"
+      ],
+      "supporting_copy": [
+        "Goals",
+        "Preferences",
+        "Diet types"
+      ],
+      "product_surface": "profile and setup",
+      "repo_source_refs": [
+        "ios/PulsePlate/Views/ProfileView.swift",
+        "frontend/src/pages/Profile.tsx",
+        "frontend/src/pages/NutritionSetup/SetupForm.tsx"
+      ],
+      "contract_emotion": "thinking",
+      "approved_mascot_asset_key": "FitChefThinking",
+      "asset_rationale": "This shot matches the existing thinking asset directly.",
+      "output_status": "source-approved"
+    },
+    {
+      "id": "shot-07",
+      "expected_filename": "07_ai-assistant.png",
+      "headline": [
+        "Your Personal",
+        "AI Nutrition Coach"
+      ],
+      "supporting_copy": [
+        "Guidance",
+        "Recommendations",
+        "Insights"
+      ],
+      "product_surface": "bounded assistant / insight view",
+      "repo_source_refs": [
+        "ios/PulsePlate/Views/AIInsightView.swift",
+        "frontend/src/pages/Home.tsx",
+        "app/routers/fitchef_insight.py"
+      ],
+      "contract_emotion": "guiding",
+      "approved_mascot_asset_key": "FitChef",
+      "asset_rationale": "The default neutral asset remains the safest guiding fallback until a dedicated guided-coach variant exists.",
+      "output_status": "source-approved"
+    }
+  ]
+}

--- a/appstore/fitchef/en-US/metadata/app_store_metadata.json
+++ b/appstore/fitchef/en-US/metadata/app_store_metadata.json
@@ -1,0 +1,26 @@
+{
+  "locale": "en-US",
+  "product_name": "PulsePlate",
+  "brand_mascot": "FitChef",
+  "subtitle": "AI nutrition with FitChef",
+  "keywords": [
+    "nutrition",
+    "meal planner",
+    "diet tracker",
+    "food log",
+    "macros",
+    "grocery list",
+    "health goals"
+  ],
+  "promo_text": "Track nutrients, plan meals, and stay consistent with FitChef guidance grounded in your real PulsePlate data.",
+  "description_paragraphs": [
+    "PulsePlate helps you understand your nutrition, keep meals aligned with your goals, and build healthier routines with calm, data-grounded guidance.",
+    "Review macro and micronutrient balance, explore progress trends, and stay organized with weekly planning and grocery support.",
+    "FitChef adds friendly coaching cues that stay anchored to real product data instead of hype, fake UI, or medical promises."
+  ],
+  "compliance_notes": [
+    "App Store EN-first pack only",
+    "No medical diagnosis or guaranteed-outcome claims",
+    "All copy must stay grounded in shipped or canon-governed product capability"
+  ]
+}

--- a/appstore/fitchef/en-US/metadata/icon_source_inventory.json
+++ b/appstore/fitchef/en-US/metadata/icon_source_inventory.json
@@ -1,0 +1,40 @@
+{
+  "locale": "en-US",
+  "promotion_policy": "canonical-main-assets-only",
+  "app_icon": {
+    "primary_source_path": "ios/icon_luxury_1024.png",
+    "catalog_marketing_icon_path": "ios/PulsePlate/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png",
+    "catalog_contents_path": "ios/PulsePlate/Assets.xcassets/AppIcon.appiconset/Contents.json"
+  },
+  "mascot_assets": [
+    {
+      "asset_key": "FitChef",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChef.imageset/Contents.json"
+    },
+    {
+      "asset_key": "FitChefOnboardingWelcome",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChefOnboardingWelcome.imageset/Contents.json"
+    },
+    {
+      "asset_key": "FitChefThinking",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChefThinking.imageset/Contents.json"
+    },
+    {
+      "asset_key": "FitChefWink",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChefWink.imageset/Contents.json"
+    },
+    {
+      "asset_key": "FitChefSurprised",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChefSurprised.imageset/Contents.json"
+    },
+    {
+      "asset_key": "FitChefSleepy",
+      "catalog_path": "ios/PulsePlate/Assets.xcassets/FitChefSleepy.imageset/Contents.json"
+    }
+  ],
+  "decision_log": [
+    "PR-3 does not promote dirty local root assets blindly.",
+    "The approved EN production pack references the canonical source set already present on main after PR-2.",
+    "Any future binary refresh must land through a dedicated reviewed PR against the same canonical asset keys."
+  ]
+}

--- a/appstore/fitchef/en-US/metadata/source_of_truth.md
+++ b/appstore/fitchef/en-US/metadata/source_of_truth.md
@@ -1,0 +1,20 @@
+# FitChef EN App Store Pack SoT
+
+## Governing order
+
+1. `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
+2. `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md`
+3. `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md`
+4. canonical token and asset sources already on `main`
+5. this `appstore/fitchef/en-US/...` pack
+
+## Operating rules
+
+- `EN` is the only language allowed in this pack.
+- Screenshot manifests must reference real product surfaces already represented
+  in repo code/docs.
+- Final screenshot/video binaries are not committed unless they are reviewed
+  outputs from a governed capture path.
+- FitChef acts as a supporting brand/mascot layer and must not replace or fake
+  core UI.
+- Copy stays benefit-led, non-clinical, and free of unverifiable superlatives.

--- a/appstore/fitchef/en-US/metadata/upload_checklist.md
+++ b/appstore/fitchef/en-US/metadata/upload_checklist.md
@@ -1,0 +1,12 @@
+# App Store Connect Upload Checklist
+
+- Confirm locale is `en-US` only for this pack.
+- Confirm target device baseline is `iPhone 6.9"` (`1320x2868` or compatible allowed size).
+- Confirm screenshot order matches `shot_manifest.json` exactly from shot `01` to `07`.
+- Confirm every headline/subtext pair stays inside the governed safe area.
+- Confirm FitChef placement stays non-blocking and uses only canonical asset keys.
+- Confirm metadata matches `app_store_metadata.json`.
+- Confirm no claim implies diagnosis, treatment, or guaranteed results.
+- Confirm no screenshot or preview scene shows fake UI, placeholder lorem ipsum, or off-canon feature states.
+- Confirm the App Store marketing icon traces back to the approved icon source inventory.
+- Confirm `RU` / `ES` assets are not mixed into this `EN` upload set.

--- a/appstore/fitchef/en-US/metadata/upload_checklist.md
+++ b/appstore/fitchef/en-US/metadata/upload_checklist.md
@@ -1,12 +1,12 @@
 # App Store Connect Upload Checklist
 
-- Confirm locale is `en-US` only for this pack.
-- Confirm target device baseline is `iPhone 6.9"` (`1320x2868` or compatible allowed size).
-- Confirm screenshot order matches `shot_manifest.json` exactly from shot `01` to `07`.
-- Confirm every headline/subtext pair stays inside the governed safe area.
-- Confirm FitChef placement stays non-blocking and uses only canonical asset keys.
-- Confirm metadata matches `app_store_metadata.json`.
-- Confirm no claim implies diagnosis, treatment, or guaranteed results.
-- Confirm no screenshot or preview scene shows fake UI, placeholder lorem ipsum, or off-canon feature states.
-- Confirm the App Store marketing icon traces back to the approved icon source inventory.
-- Confirm `RU` / `ES` assets are not mixed into this `EN` upload set.
+- Locale: `en-US` only for this pack.
+- Target device baseline: `iPhone 6.9"` (`1320x2868` or compatible allowed size).
+- Screenshot order matches `shot_manifest.json` exactly from shot `01` to `07`.
+- Headlines and subtext stay inside the governed safe area.
+- FitChef placement stays non-blocking and uses only canonical asset keys.
+- Metadata matches `app_store_metadata.json`.
+- No claim implies diagnosis, treatment, or guaranteed results.
+- No screenshot or preview scene shows fake UI, placeholder lorem ipsum, or off-canon feature states.
+- The App Store marketing icon traces back to the approved icon source inventory.
+- `RU` / `ES` assets are not mixed into this `EN` upload set.

--- a/docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md
+++ b/docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md
@@ -1,0 +1,127 @@
+# FitChef EN App Store Production Pack
+
+**Status:** PR-3 EN production pack
+**Date:** 2026-03-13
+**Owner:** @katsiaryna_kavaleuskaya
+
+## Summary
+
+This contract opens the first governed App Store production-pack lane for
+FitChef/PulsePlate after the foundation, visual contract, and mascot taxonomy
+waves.
+
+PR-3 is additive and remains non-runtime. It does not change live
+`/api/v1/insight/fitchef*` routes, add Fastlane automation, or mix `RU` / `ES`
+localization work into the first `EN` pack.
+
+The pack is capture-ready and review-ready inside the repo. It stores governed
+metadata, screenshot manifests, preview storyboard/script, upload checklist,
+and approved source inventories anchored to real repo surfaces and canonical
+FitChef/App Icon assets.
+
+## Scope
+
+This PR-3 contract defines and/or populates:
+
+- `/appstore/fitchef/en-US/iphone-6.9/screenshots/`
+- `/appstore/fitchef/en-US/iphone-6.9/preview/`
+- `/appstore/fitchef/en-US/metadata/`
+- deterministic tests for App Store pack integrity
+- backlog/governance sync after merged PR-2
+
+This PR-3 contract explicitly does not add:
+
+- Fastlane or export automation
+- final screenshot PNG exports generated from a simulator/device pipeline
+- final preview video binaries
+- `RU` or `ES` App Store localization assets
+- backend/frontend runtime changes
+
+## Production-pack policy
+
+### Source order
+
+Approved source order for this lane:
+
+1. `docs/contracts/*` FitChef contracts
+2. token/runtime SoT already on `main`
+3. canonical FitChef/App Icon assets already governed by PR-2
+4. review-ready App Store metadata and capture manifests in `/appstore`
+
+### Truthfulness and safety
+
+- Screenshot manifests must point to real product surfaces already represented
+  in repo code/docs.
+- Copy must remain App Store-safe and wellness-safe.
+- The pack must not invent fake UI states or unverifiable claims.
+- If a screenshot or preview export does not yet exist as a reviewed repo
+  output, the pack stores a capture-ready manifest instead of a fake binary.
+
+## Pack contents
+
+### Metadata
+
+`/appstore/fitchef/en-US/metadata/` contains:
+
+- `app_store_metadata.json`
+- `icon_source_inventory.json`
+- `source_of_truth.md`
+- `upload_checklist.md`
+
+### Screenshots
+
+`/appstore/fitchef/en-US/iphone-6.9/screenshots/` contains:
+
+- `README.md`
+- `shot_manifest.json`
+
+The manifest must define exactly seven `EN` launch shots aligned with the
+PR-1 visual contract.
+
+### Preview
+
+`/appstore/fitchef/en-US/iphone-6.9/preview/` contains:
+
+- `README.md`
+- `storyboard.json`
+- `preview_script.md`
+
+The preview pack remains script/storyboard only in PR-3. Final video binary
+export is intentionally outside this governed repo lane until a deterministic
+capture/export path exists.
+
+## Asset policy for PR-3
+
+- `FitChef` remains the stable default mascot asset key.
+- Only canonical PR-2 FitChef-prefixed variants may be referenced.
+- Only canonical `AppIcon-*` files from the governed asset catalog may be
+  referenced.
+- Dirty local asset diffs outside the PR-3 worktree are not promoted blindly.
+- If an asset candidate is not already canon-clean, it must be deferred instead
+  of forced into the pack.
+
+For this PR-3 lane, the approved source inventory stays on the canonical assets
+already present on `main`; no extra binary promotion is required for pack
+integrity.
+
+## Acceptance checklist
+
+- `EN` App Store pack folder contract is populated
+- metadata starter pack exists and stays App Store-safe
+- screenshot manifest defines seven governed shots
+- preview storyboard/script exists and stays under 30 seconds
+- icon/mascot source inventory references only canonical assets
+- deterministic tests validate pack structure and references
+- backlog reflects merged PR-2 and active PR-3
+- no runtime/API behavior changes are introduced
+
+## Evidence anchors
+
+- `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md:76`
+- `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md:219`
+- `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md:11`
+- `appstore/fitchef/en-US/metadata/app_store_metadata.json:1`
+- `appstore/fitchef/en-US/metadata/icon_source_inventory.json:1`
+- `appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json:1`
+- `appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:1`
+- `tests/test_fitchef_app_store_pack.py:1`

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -24,8 +24,14 @@ Evidence: tests/test_fitchef_app_store_pack.py:98
 Reason: The preview integrity test now enforces exact ordered storyboard coverage instead of set-membership only, so duplicate shot IDs or missing governed shots fail deterministically.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944355243 -> 0d69605f
 
+Disposition: FIXED
+Commit: PENDING_LOCAL_GATE_COMMIT
+Evidence: docs/review/PR_1154_FIXED_MAPPING.md:33
+Reason: The local hard-gate checkbox remains unchecked until a real post-fix `make verify` pass completes; it is only marked complete after that verify run succeeds.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> PENDING_LOCAL_GATE_COMMIT
+
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
+- [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -39,7 +39,7 @@ Reason: The local hard-gate checkbox remains unchecked until a real post-fix `ma
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> 536b4f40
 
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
+- [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -5,10 +5,27 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 0d69605f
+Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15
+Reason: The preview storyboard now maps `shot-01` through `shot-07` exactly once and restores the governed seven-shot sequence for the EN App Store preview lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931241438 -> 0d69605f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246422 -> 0d69605f
+
+Disposition: FIXED
+Commit: 0d69605f
+Evidence: appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json:155
+Reason: Shot 07 now uses bounded copy, `AI Nutrition Guide`, instead of the stronger `AI Nutrition Coach` claim.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246430 -> 0d69605f
+
+Disposition: FIXED
+Commit: 0d69605f
+Evidence: tests/test_fitchef_app_store_pack.py:98
+Reason: The preview integrity test now enforces exact ordered storyboard coverage instead of set-membership only, so duplicate shot IDs or missing governed shots fail deterministically.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944355243 -> 0d69605f
 
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -38,6 +38,28 @@ Evidence: docs/review/PR_1154_FIXED_MAPPING.md:33
 Reason: The local hard-gate checkbox remains unchecked until a real post-fix `make verify` pass completes; it is only marked complete after that verify run succeeds.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> 536b4f40
 
+Disposition: NOT-A-BUG
+Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15, appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json:155, appstore/fitchef/en-US/metadata/upload_checklist.md:3, tests/test_fitchef_app_store_pack.py:114
+Reason: This aggregate CodeRabbit review only summarizes underlying inline findings that are already dispositioned above; it does not add a standalone unresolved defect once the mapped thread URLs are closed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944090112
+
+Disposition: NOT-A-BUG
+Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15, tests/test_fitchef_app_store_pack.py:31, tests/test_fitchef_app_store_pack.py:114
+Reason: This cubic summary review aggregates underlying findings already mapped in the canonical artifact, so the review-level URL itself does not require an additional standalone code change.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944109244
+
+Disposition: FIXED
+Commit: e508e2fc
+Evidence: tests/test_fitchef_app_store_pack.py:26
+Reason: `_load_json()` now uses the stricter `dict[str, Any]` return type expected by the review nitpick.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946665221 -> e508e2fc
+
+Disposition: FIXED
+Commit: e508e2fc
+Evidence: tests/test_fitchef_app_store_pack.py:14, tests/test_fitchef_app_store_pack.py:37
+Reason: The guard test now documents the mascot taxonomy source of truth and makes the `relative_to()` containment check explicit with `_ = ...`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946770483 -> e508e2fc
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -25,10 +25,10 @@ Reason: The preview integrity test now enforces exact ordered storyboard coverag
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944355243 -> 0d69605f
 
 Disposition: FIXED
-Commit: PENDING_LOCAL_GATE_COMMIT
+Commit: 536b4f40
 Evidence: docs/review/PR_1154_FIXED_MAPPING.md:33
 Reason: The local hard-gate checkbox remains unchecked until a real post-fix `make verify` pass completes; it is only marked complete after that verify run succeeds.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> PENDING_LOCAL_GATE_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> 536b4f40
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1154 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -11,6 +11,8 @@ Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15
 Reason: The preview storyboard now maps `shot-01` through `shot-07` exactly once and restores the governed seven-shot sequence for the EN App Store preview lane.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931241438 -> 0d69605f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246422 -> 0d69605f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264427 -> 0d69605f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264436 -> 0d69605f
 
 Disposition: FIXED
 Commit: 0d69605f
@@ -25,13 +27,19 @@ Reason: The preview integrity test now enforces exact ordered storyboard coverag
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944355243 -> 0d69605f
 
 Disposition: FIXED
+Commit: b42fb823
+Evidence: tests/test_fitchef_app_store_pack.py:28
+Reason: `_repo_path()` now rejects absolute paths and `..` escapes by resolving against `REPO_ROOT` and requiring the normalized path to stay inside the repository.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264433 -> b42fb823
+
+Disposition: FIXED
 Commit: 536b4f40
 Evidence: docs/review/PR_1154_FIXED_MAPPING.md:33
 Reason: The local hard-gate checkbox remains unchecked until a real post-fix `make verify` pass completes; it is only marked complete after that verify run succeeds.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> 536b4f40
 
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1154_FIXED_MAPPING.md
+++ b/docs/review/PR_1154_FIXED_MAPPING.md
@@ -60,9 +60,15 @@ Evidence: tests/test_fitchef_app_store_pack.py:14, tests/test_fitchef_app_store_
 Reason: The guard test now documents the mascot taxonomy source of truth and makes the `relative_to()` containment check explicit with `_ = ...`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946770483 -> e508e2fc
 
+Disposition: FIXED
+Commit: f65db89b
+Evidence: tests/test_fitchef_app_store_pack.py:74
+Reason: The metadata blocked-term guard now reports the offending terms explicitly, which closes the latest CodeRabbit debugging nitpick.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946855116 -> f65db89b
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
-- [ ] Required checks PASS with no pending required jobs
-- [ ] No unresolved review threads
-- [ ] No actionable bot comments
-- [ ] Final post-bot wait cycle completed
+- [x] Required checks PASS with no pending required jobs
+- [x] No unresolved review threads
+- [x] No actionable bot comments
+- [x] Final post-bot wait cycle completed

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1368,7 +1368,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef umbrella initiative foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (orchestration / brand / App Store / coaching)
-  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR-TBD-FITCHEF-APP-STORE-PACK-EN -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
+  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR #1154 -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
   - Status: 🚧 In progress
   - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
   - Links:
@@ -1611,8 +1611,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: FitChef icon source cleanup after PR-2 selective promotion
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (asset hygiene / App Store readiness)
-  - Target PR: PR-TBD-FITCHEF-APP-STORE-PACK-EN
-  - Status: 📋 Planned
+  - Target PR: PR #1154
+  - Status: 🟡 In progress (active PR `#1154`)
   - Reason (EN): PR-2 intentionally normalizes the icon catalog and keeps only canonical referenced AppIcon files, but non-canonical local source files with spaces or duplicate generator naming are not promoted automatically. The remaining icon-source cleanup must stay explicit for the App Store production lane.
   - Links:
     - `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1368,13 +1368,14 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef umbrella initiative foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (orchestration / brand / App Store / coaching)
-  - Target PR: PR #1140 -> PR #1143 -> PR-TBD-FITCHEF-ASSET-TAXONOMY -> PR-TBD-FITCHEF-APP-STORE-PACK-EN -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
+  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR-TBD-FITCHEF-APP-STORE-PACK-EN -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
   - Status: 🚧 In progress
   - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
   - Links:
     - `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`
     - `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md`
     - `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md`
+    - `docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md`
     - `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md`
     - `docs/contracts/API_CANONICAL_MAP.md`
     - `app/routers/fitchef_insight.py`
@@ -1383,8 +1384,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Progress:
     - `PR #1140` merged on March 12, 2026 for the foundation/docs-only lane
     - `PR #1143` merged on March 12, 2026 for the visual/App Store contract lane
-    - `PR-2` mascot asset taxonomy starts from clean `origin/main` after those merges
-    - `PR-2` scope is limited to taxonomy + selective promotion; non-canonical icon source files remain explicit follow-up work
+    - `PR #1150` merged on March 13, 2026 for the mascot asset taxonomy lane
+    - `PR-3` App Store production pack is the active lane from a clean worktree off `origin/main`
+    - `PR-3` scope is limited to the governed `EN` production pack: metadata, screenshot manifests, preview storyboard/script, upload checklist, and approved canonical source inventories
   - Subtracks:
     - FitChef visual identity and mascot system
     - App Store screenshot and preview pack

--- a/tests/test_fitchef_app_store_pack.py
+++ b/tests/test_fitchef_app_store_pack.py
@@ -75,7 +75,8 @@ def test_app_store_metadata_stays_en_only_and_within_practical_limits() -> None:
     flattened = " ".join(
         [payload["subtitle"], payload["promo_text"], *payload["description_paragraphs"]]
     ).lower()
-    assert all(term not in flattened for term in blocked_terms)
+    offending_terms = sorted(term for term in blocked_terms if term in flattened)
+    assert not offending_terms, f"Blocked term(s) found in metadata: {offending_terms}"
 
 
 def test_screenshot_manifest_defines_seven_governed_shots_with_real_refs() -> None:

--- a/tests/test_fitchef_app_store_pack.py
+++ b/tests/test_fitchef_app_store_pack.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,6 +11,8 @@ PACK_ROOT = REPO_ROOT / "appstore" / "fitchef" / "en-US"
 SCREENSHOTS_DIR = PACK_ROOT / "iphone-6.9" / "screenshots"
 PREVIEW_DIR = PACK_ROOT / "iphone-6.9" / "preview"
 METADATA_DIR = PACK_ROOT / "metadata"
+# Source of truth: docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md
+# ALLOWED_MASCOT_KEYS mirrors the canonical FitChef taxonomy for this pack guard.
 ALLOWED_MASCOT_KEYS = {
     "FitChef",
     "FitChefOnboardingWelcome",
@@ -20,7 +23,7 @@ ALLOWED_MASCOT_KEYS = {
 }
 
 
-def _load_json(path: Path) -> dict:
+def _load_json(path: Path) -> dict[str, Any]:
     """Load a UTF-8 JSON file from the governed App Store pack."""
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -31,7 +34,7 @@ def _repo_path(relative_path: str) -> Path:
     assert not source_path.is_absolute(), f"Absolute path not allowed: {relative_path}"
 
     resolved_path = (REPO_ROOT / source_path).resolve()
-    resolved_path.relative_to(REPO_ROOT.resolve())
+    _ = resolved_path.relative_to(REPO_ROOT.resolve())
     return resolved_path
 
 

--- a/tests/test_fitchef_app_store_pack.py
+++ b/tests/test_fitchef_app_store_pack.py
@@ -95,16 +95,18 @@ def test_preview_storyboard_is_bounded_and_reuses_manifest_shot_ids() -> None:
     """Keep the preview script aligned with the screenshot sequence and time cap."""
     manifest = _load_json(SCREENSHOTS_DIR / "shot_manifest.json")
     storyboard = _load_json(PREVIEW_DIR / "storyboard.json")
-    valid_shot_ids = {shot["id"] for shot in manifest["shots"]}
+    expected_shot_ids = [shot["id"] for shot in manifest["shots"]]
 
     assert storyboard["locale"] == "en-US"
     assert storyboard["device_class"] == "iPhone 6.9"
     assert storyboard["target_duration_seconds"] <= 30
     assert len(storyboard["scenes"]) == 7
 
+    actual_shot_ids = [scene["shot_id"] for scene in storyboard["scenes"]]
+    assert actual_shot_ids == expected_shot_ids
+
     last_end_second = 0
     for scene in storyboard["scenes"]:
-        assert scene["shot_id"] in valid_shot_ids
         assert scene["start_second"] < scene["end_second"]
         assert scene["start_second"] == last_end_second
         last_end_second = scene["end_second"]

--- a/tests/test_fitchef_app_store_pack.py
+++ b/tests/test_fitchef_app_store_pack.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACK_ROOT = REPO_ROOT / "appstore" / "fitchef" / "en-US"
 SCREENSHOTS_DIR = PACK_ROOT / "iphone-6.9" / "screenshots"
@@ -24,8 +26,22 @@ def _load_json(path: Path) -> dict:
 
 
 def _repo_path(relative_path: str) -> Path:
-    """Resolve a repo-relative source path used by the App Store pack."""
-    return REPO_ROOT / relative_path
+    """Resolve a governed repo-relative path and fail closed outside the repo."""
+    source_path = Path(relative_path)
+    assert not source_path.is_absolute(), f"Absolute path not allowed: {relative_path}"
+
+    resolved_path = (REPO_ROOT / source_path).resolve()
+    resolved_path.relative_to(REPO_ROOT.resolve())
+    return resolved_path
+
+
+def test_repo_path_rejects_absolute_and_parent_escape_refs() -> None:
+    """Keep App Store pack source references bounded to the current repository."""
+    with pytest.raises(AssertionError, match="Absolute path not allowed"):
+        _repo_path("/tmp/outside.json")
+
+    with pytest.raises(ValueError):
+        _repo_path("../outside.json")
 
 
 def test_fitchef_app_store_pack_folder_contract_exists() -> None:

--- a/tests/test_fitchef_app_store_pack.py
+++ b/tests/test_fitchef_app_store_pack.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK_ROOT = REPO_ROOT / "appstore" / "fitchef" / "en-US"
+SCREENSHOTS_DIR = PACK_ROOT / "iphone-6.9" / "screenshots"
+PREVIEW_DIR = PACK_ROOT / "iphone-6.9" / "preview"
+METADATA_DIR = PACK_ROOT / "metadata"
+ALLOWED_MASCOT_KEYS = {
+    "FitChef",
+    "FitChefOnboardingWelcome",
+    "FitChefThinking",
+    "FitChefWink",
+    "FitChefSurprised",
+    "FitChefSleepy",
+}
+
+
+def _load_json(path: Path) -> dict:
+    """Load a UTF-8 JSON file from the governed App Store pack."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _repo_path(relative_path: str) -> Path:
+    """Resolve a repo-relative source path used by the App Store pack."""
+    return REPO_ROOT / relative_path
+
+
+def test_fitchef_app_store_pack_folder_contract_exists() -> None:
+    """Keep the governed EN pack folder structure stable."""
+    assert SCREENSHOTS_DIR.exists()
+    assert PREVIEW_DIR.exists()
+    assert METADATA_DIR.exists()
+    assert (SCREENSHOTS_DIR / "README.md").exists()
+    assert (PREVIEW_DIR / "README.md").exists()
+    assert (PREVIEW_DIR / "preview_script.md").exists()
+    assert (METADATA_DIR / "source_of_truth.md").exists()
+    assert (METADATA_DIR / "upload_checklist.md").exists()
+
+
+def test_app_store_metadata_stays_en_only_and_within_practical_limits() -> None:
+    """Validate locale, keyword budget, and safe subtitle constraints."""
+    payload = _load_json(METADATA_DIR / "app_store_metadata.json")
+
+    assert payload["locale"] == "en-US"
+    assert payload["product_name"] == "PulsePlate"
+    assert payload["brand_mascot"] == "FitChef"
+    assert len(payload["subtitle"]) <= 30
+    assert len(",".join(payload["keywords"])) <= 100
+    assert len(payload["promo_text"]) <= 170
+    assert len(payload["description_paragraphs"]) == 3
+
+    blocked_terms = ("diagnose", "diagnosis", "treat", "cure", "#1", "best app")
+    flattened = " ".join(
+        [payload["subtitle"], payload["promo_text"], *payload["description_paragraphs"]]
+    ).lower()
+    assert all(term not in flattened for term in blocked_terms)
+
+
+def test_screenshot_manifest_defines_seven_governed_shots_with_real_refs() -> None:
+    """Require exactly seven EN screenshot manifests tied to real repo surfaces."""
+    payload = _load_json(SCREENSHOTS_DIR / "shot_manifest.json")
+    shots = payload["shots"]
+
+    assert payload["locale"] == "en-US"
+    assert payload["device_class"] == "iPhone 6.9"
+    assert payload["canvas_px"] == {"width": 1320, "height": 2868}
+    assert len(shots) == 7
+    assert [shot["id"] for shot in shots] == [
+        "shot-01",
+        "shot-02",
+        "shot-03",
+        "shot-04",
+        "shot-05",
+        "shot-06",
+        "shot-07",
+    ]
+
+    filenames = [shot["expected_filename"] for shot in shots]
+    assert len(filenames) == len(set(filenames))
+    assert all(filename.endswith(".png") for filename in filenames)
+
+    for shot in shots:
+        assert shot["approved_mascot_asset_key"] in ALLOWED_MASCOT_KEYS
+        assert shot["output_status"] == "source-approved"
+        assert len(shot["headline"]) == 2
+        assert 2 <= len(shot["supporting_copy"]) <= 3
+        for source_ref in shot["repo_source_refs"]:
+            assert _repo_path(source_ref).exists(), f"Missing source ref: {source_ref}"
+
+
+def test_preview_storyboard_is_bounded_and_reuses_manifest_shot_ids() -> None:
+    """Keep the preview script aligned with the screenshot sequence and time cap."""
+    manifest = _load_json(SCREENSHOTS_DIR / "shot_manifest.json")
+    storyboard = _load_json(PREVIEW_DIR / "storyboard.json")
+    valid_shot_ids = {shot["id"] for shot in manifest["shots"]}
+
+    assert storyboard["locale"] == "en-US"
+    assert storyboard["device_class"] == "iPhone 6.9"
+    assert storyboard["target_duration_seconds"] <= 30
+    assert len(storyboard["scenes"]) == 7
+
+    last_end_second = 0
+    for scene in storyboard["scenes"]:
+        assert scene["shot_id"] in valid_shot_ids
+        assert scene["start_second"] < scene["end_second"]
+        assert scene["start_second"] == last_end_second
+        last_end_second = scene["end_second"]
+
+    assert last_end_second == storyboard["target_duration_seconds"]
+
+
+def test_icon_source_inventory_references_only_canonical_local_assets() -> None:
+    """App Store pack must point only to governed icon/mascot sources."""
+    payload = _load_json(METADATA_DIR / "icon_source_inventory.json")
+
+    assert payload["locale"] == "en-US"
+    assert payload["promotion_policy"] == "canonical-main-assets-only"
+
+    app_icon = payload["app_icon"]
+    assert _repo_path(app_icon["primary_source_path"]).exists()
+    assert _repo_path(app_icon["catalog_marketing_icon_path"]).exists()
+    assert _repo_path(app_icon["catalog_contents_path"]).exists()
+
+    referenced_catalog_paths = []
+    for asset in payload["mascot_assets"]:
+        assert asset["asset_key"] in ALLOWED_MASCOT_KEYS
+        catalog_path = _repo_path(asset["catalog_path"])
+        assert catalog_path.exists()
+        referenced_catalog_paths.append(asset["catalog_path"])
+
+    assert len(referenced_catalog_paths) == len(set(referenced_catalog_paths))


### PR DESCRIPTION
## Summary
- add governed `EN` App Store production pack for FitChef/PulsePlate under `/appstore/fitchef/en-US/...`
- add PR-3 contract doc, metadata starter pack, screenshot manifest, preview storyboard/script, and upload checklist
- add deterministic pack-integrity tests and sync FitChef umbrella backlog after merged PR-2

## Scope
- non-runtime PR; no changes to live `/api/v1/insight/fitchef*`
- no Fastlane/export automation
- `EN` only; `RU` and `ES` remain deferred
- no fake screenshot/video binaries with unclear provenance

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m pytest -q tests/test_fitchef_asset_taxonomy.py tests/test_fitchef_app_store_pack.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: 0d69605f
Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15
Reason: The preview storyboard now maps `shot-01` through `shot-07` exactly once and restores the governed seven-shot sequence for the EN App Store preview lane.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931241438 -> 0d69605f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246422 -> 0d69605f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264427 -> 0d69605f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264436 -> 0d69605f

Disposition: FIXED
Commit: 0d69605f
Evidence: appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json:155
Reason: Shot 07 now uses bounded copy, `AI Nutrition Guide`, instead of the stronger `AI Nutrition Coach` claim.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246430 -> 0d69605f

Disposition: FIXED
Commit: 0d69605f
Evidence: tests/test_fitchef_app_store_pack.py:98
Reason: The preview integrity test now enforces exact ordered storyboard coverage instead of set-membership only, so duplicate shot IDs or missing governed shots fail deterministically.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944355243 -> 0d69605f

Disposition: FIXED
Commit: b42fb823
Evidence: tests/test_fitchef_app_store_pack.py:28
Reason: `_repo_path()` now rejects absolute paths and `..` escapes by resolving against `REPO_ROOT` and requiring the normalized path to stay inside the repository.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931264433 -> b42fb823

Disposition: FIXED
Commit: 536b4f40
Evidence: docs/review/PR_1154_FIXED_MAPPING.md:33
Reason: The local hard-gate checkbox remains unchecked until a real post-fix `make verify` pass completes; it is only marked complete after that verify run succeeds.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#discussion_r2931246446 -> 536b4f40

Disposition: NOT-A-BUG
Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15, appstore/fitchef/en-US/iphone-6.9/screenshots/shot_manifest.json:155, appstore/fitchef/en-US/metadata/upload_checklist.md:3, tests/test_fitchef_app_store_pack.py:114
Reason: This aggregate CodeRabbit review only summarizes underlying inline findings that are already dispositioned above; it does not add a standalone unresolved defect once the mapped thread URLs are closed.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944090112

Disposition: NOT-A-BUG
Evidence: appstore/fitchef/en-US/iphone-6.9/preview/storyboard.json:15, tests/test_fitchef_app_store_pack.py:31, tests/test_fitchef_app_store_pack.py:114
Reason: This cubic summary review aggregates underlying findings already mapped in the canonical artifact, so the review-level URL itself does not require an additional standalone code change.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3944109244

Disposition: FIXED
Commit: e508e2fc
Evidence: tests/test_fitchef_app_store_pack.py:26
Reason: `_load_json()` now uses the stricter `dict[str, Any]` return type expected by the review nitpick.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946665221 -> e508e2fc

Disposition: FIXED
Commit: e508e2fc
Evidence: tests/test_fitchef_app_store_pack.py:14, tests/test_fitchef_app_store_pack.py:37
Reason: The guard test now documents the mascot taxonomy source of truth and makes the `relative_to()` containment check explicit with `_ = ...`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946770483 -> e508e2fc

Disposition: FIXED
Commit: f65db89b
Evidence: tests/test_fitchef_app_store_pack.py:74
Reason: The metadata blocked-term guard now reports the offending terms explicitly, which closes the latest CodeRabbit debugging nitpick.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1154#pullrequestreview-3946855116 -> f65db89b

## Merge Readiness
- [x] Local hard gate passed (`make verify`)
- [x] Required checks PASS with no pending required jobs
- [x] No unresolved review threads
- [x] No actionable bot comments
- [x] Final post-bot wait cycle completed
## Summary by Sourcery

Добавлен управляемый production-пакет EN App Store для FitChef/PulsePlate, включающий контракты, ассеты и тесты целостности, а также синхронизация бэклога инициативы FitChef с учётом нового lane.

Новые возможности:
- Введена структура production-пакета EN-only App Store в `appstore/fitchef/en-US` с подпапками `metadata`, `screenshot` и `preview` для PulsePlate/FitChef.

Улучшения:
- Определён формальный документ-контракт для EN App Store production-пакета FitChef, проясняющий объём работ, политики и критерии приёмки.
- Задокументирован порядок source-of-truth и чек-лист загрузки для управления тем, как App Store ассеты фиксируются, валидируются и загружаются.
- Обновлён единый бэклог FitChef (umbrella backlog ledger) для отражения объединения таксономии маскотов и нового lane `PR-3` для production-пакета.

Тесты:
- Добавлены детерминированные тесты, проверяющие структуру папок EN App Store пакета FitChef, ограничения метаданных, целостность манифеста скриншотов, границы preview storyboard и канонические ссылки на ассеты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a governed EN App Store production pack for FitChef/PulsePlate, including contracts, assets, and integrity tests, while syncing the FitChef initiative backlog to reflect the new lane.

New Features:
- Introduce an EN-only App Store production pack structure under appstore/fitchef/en-US with metadata, screenshot, and preview subfolders for PulsePlate/FitChef.

Enhancements:
- Define a formal contract document for the FitChef EN App Store production pack clarifying scope, policies, and acceptance criteria.
- Document source-of-truth ordering and upload checklist to govern how App Store assets are captured, validated, and uploaded.
- Update the FitChef umbrella backlog ledger to record the mascot taxonomy merge and the new PR-3 production-pack lane.

Tests:
- Add deterministic tests that verify the FitChef EN App Store pack folder structure, metadata constraints, screenshot manifest integrity, preview storyboard bounds, and canonical asset references.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the governed EN App Store production pack for FitChef/PulsePlate with metadata, a 7-shot screenshot manifest, a 22s preview storyboard/script, and deterministic integrity tests. No runtime changes; this prepares capture-ready assets for App Store Connect.

- **Bug Fixes**
  - Preview storyboard maps `shot-01`–`shot-07` exactly once, in order, with contiguous timing; tests enforce ordered coverage and a sub-30s cap (22s target).
  - Softened shot-07 headline to “AI Nutrition Guide” and kept copy EN-only and non-clinical; tests validate copy limits and block risky terms with explicit reporting.
  - Integrity hardening: tests reject absolute/parent-escape repo path refs, enforce EN metadata length budgets, and require canonical app icon/mascot inventory references.

<sup>Written for commit 948485f8c8dfd1f2930c59cd00c913f006b5c1e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added English App Store listing metadata, icon inventory, canonical screenshots, README guards, and a scripted 22‑second app preview storyboard for iPhone 6.9.
* **Tests**
  * Added validation tests enforcing pack structure, metadata bounds (en‑US), seven‑shot screenshot/storyboard consistency, canonical asset references, and repo‑bounded asset paths.
* **Documentation**
  * Added governance docs: source‑of‑truth, upload checklist, production‑pack contract, review notes, and backlog/roadmap updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



