### PR TITLE
docs(fitchef): freeze structured coach contract

### DIFF
--- a/docs/contracts/API_CANONICAL_MAP.md
+++ b/docs/contracts/API_CANONICAL_MAP.md
@@ -50,8 +50,10 @@ These routes are the current canonical operator surface.
 
 FitChef initiative note:
 - The live mascot routes above remain canonical during the FitChef umbrella foundation and visual/App Store waves.
-- Future structured-coach surfaces under `/api/v1/pro/fitchef/*` and `/api/v1/vip/fitchef/*` remain planned-only until a dedicated additive contract PR lands.
+- The live mascot routes above remain canonical after the structured-coach contract freeze as well; they are not migrated by that phase.
+- Future structured-coach surfaces under `/api/v1/pro/fitchef/*` and `/api/v1/vip/fitchef/*` are contract-frozen additive surfaces only, pending later runtime PRs.
 - Canonical reference: `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
+- Contract freeze reference: `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md`.
 
 ## Deprecated Alias / Proxy-Only Surface
 

--- a/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
+++ b/docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md
@@ -79,10 +79,15 @@ live in `app/services/fitchef_runtime.py:127` through
 - screenshot package contract
 - preview storyboard
 - upload checklist
+- contract artifact: `docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md`
 
 ### PR-4 structured coach contract
 
-Planned-only additive routes:
+Contract artifact:
+
+- `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md`
+
+Contract-frozen additive routes:
 
 - `POST /api/v1/pro/fitchef/explain`
 - `POST /api/v1/pro/fitchef/recommend`
@@ -138,3 +143,5 @@ are governed.
 - `docs/contracts/API_CANONICAL_MAP.md:46`
 - `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md:1`
 - `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md:1`
+- `docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md:1`
+- `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:1`

--- a/docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md
+++ b/docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md
@@ -15,6 +15,7 @@ automation work explicitly deferred.
 
 - The broader FitChef umbrella initiative must preserve this live mascot canon during foundation and visual/App Store waves.
 - Future structured-coach surfaces are additive follow-up work and do not change the status of `/api/v1/insight/fitchef*` in this contract.
+- The structured-coach route family is frozen separately in `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` and must coexist with this live mascot envelope.
 - Canonical initiative reference: `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
 
 ## Canonical namespace and policy

--- a/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
+++ b/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
@@ -1,0 +1,176 @@
+# FitChef Structured Coach Contract
+
+**Status:** Contract freeze for additive structured coach surfaces
+**Date:** 2026-03-14
+**Owner:** @katsiaryna_kavaleuskaya
+
+## Summary
+
+This contract freezes the next additive FitChef route family without changing
+the live mascot canon.
+
+The current public mascot routes under `/api/v1/insight/fitchef*` remain live,
+canonical, and unmigrated in this phase. PR-4 defines future structured coach
+surfaces under `/api/v1/pro/fitchef/*` and `/api/v1/vip/fitchef/*` so later
+runtime PRs can implement them without reopening route naming, tier semantics,
+or client-envelope rules.
+
+This is a docs-only contract phase. It does not add runtime behavior, OpenAPI
+paths, or client integrations yet.
+
+## Relationship to the live mascot canon
+
+- Live mascot routes remain canonical:
+  - `POST /api/v1/insight/fitchef`
+  - `POST /api/v1/insight/fitchef/weekly-reflection`
+  - `POST /api/v1/insight/fitchef/slip-support`
+- This contract is additive. It does not rename, deprecate, or proxy-migrate
+  the live mascot family.
+- The live mascot family remains governed by:
+  - `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md`
+  - `docs/contracts/API_CANONICAL_MAP.md`
+  - `app/routers/fitchef_insight.py`
+
+## Route family freeze
+
+### PRO structured coach surfaces
+
+- `POST /api/v1/pro/fitchef/explain`
+- `POST /api/v1/pro/fitchef/recommend`
+
+### VIP structured coach surfaces
+
+- `POST /api/v1/vip/fitchef/insight`
+- `POST /api/v1/vip/fitchef/chat`
+- `POST /api/v1/vip/fitchef/week-repair`
+
+These paths are contract-frozen for future implementation PRs and must stay
+additive to the live mascot family.
+
+## Tier policy freeze
+
+- `FREE`
+  - may receive only bounded static or template guidance outside this route
+    family
+  - must not receive open-ended FitChef coach runtime
+- `PRO`
+  - may use `explain` and `recommend`
+  - must not receive VIP-only long-form insight, open-ended chat, or week
+    repair
+- `VIP`
+  - may use `insight`, `chat`, and `week-repair`
+  - may depend on PRO-calculated domain context, but must not replace canonical
+    nutrition or planner engines
+
+## Guard and execution policy
+
+Future implementation PRs must keep the current FitChef guard precedence
+aligned with the live mascot routers:
+
+1. tier and feature gate
+2. execution-mode gate
+3. input guard
+4. quota / policy / provider path
+
+Additional freeze points:
+
+- live mascot routes remain on `RATE_LIMIT_INSIGHT`
+- expensive structured coach surfaces must stay fail-closed on rate limit,
+  quota, provider unavailability, and unsafe input
+- future runtime paths must preserve explicit `429`, `503`, and `504`
+  documentation and deterministic tests
+
+## Structured response direction
+
+Future public FitChef structured-coach responses must be schema-driven and
+renderable by thin clients without parsing prose into product state.
+
+### Required top-level direction
+
+- `mode`
+- `title`
+- `summary`
+- `bullets`
+- `actions`
+- `source_modules`
+- `used_llm`
+- `disclaimers`
+- `transparency_notice_id`
+- `wellness_boundary`
+
+### Action contract
+
+`actions` must be typed and routable, not free-form text. Each action must map
+to an existing product flow.
+
+Minimum direction:
+
+- `type: str`
+- `label: str`
+- `payload: object`
+
+### Client contract rules
+
+- UI must render structured DTOs or frozen response envelopes only.
+- UI must not infer entitlement, planner truth, or route navigation by parsing
+  raw prose.
+- Web and iOS clients must treat future OpenAPI schemas as the source for
+  generated request/response types once implementation begins.
+
+## Runtime boundary freeze
+
+Future structured coach implementation must:
+
+- reuse canonical backend outputs for targets, planner state, adherence, and
+  shopping context
+- avoid any new nutrition math outside canonical engines
+- keep LLM output advisory and non-authoritative
+- keep fallback or template responses available whenever LLM execution is
+  unavailable, disallowed, or disabled
+
+## Implementation follow-up order
+
+### PR-5 domain shell
+
+- context builder
+- policy layer
+- template and fallback layer
+- safety layer
+- service orchestration shell
+
+### PR-6 PRO runtime
+
+- `POST /api/v1/pro/fitchef/explain`
+- `POST /api/v1/pro/fitchef/recommend`
+- deterministic route tests
+- analytics and action-routing contracts
+
+### PR-7 VIP runtime
+
+- `POST /api/v1/vip/fitchef/insight`
+- `POST /api/v1/vip/fitchef/chat`
+- `POST /api/v1/vip/fitchef/week-repair`
+- entitlement, quota, and degraded-mode guarantees
+
+## Explicit non-goals
+
+- renaming or migrating `/api/v1/insight/fitchef*`
+- shipping runtime code in this PR
+- adding OpenAPI paths in this PR
+- adding frontend or iOS FitChef runtime consumers
+- mixing website brand rollout or App Store assets into this contract lane
+
+## Evidence anchors
+
+- `app/routers/fitchef_insight.py:45`
+- `app/routers/fitchef_insight.py:58`
+- `app/routers/fitchef_insight.py:133`
+- `app/routers/fitchef_insight.py:214`
+- `app/routers/cbt_insight.py:87`
+- `app/services/fitchef_runtime.py:264`
+- `app/services/fitchef_runtime.py:435`
+- `app/schemas/fitchef.py:33`
+- `app/schemas/fitchef.py:121`
+- `app/schemas/fitchef_coaching.py:60`
+- `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md:21`
+- `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md:11`

--- a/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
+++ b/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
@@ -1,7 +1,7 @@
 # FitChef Structured Coach Contract
 
 **Status:** Contract freeze for additive structured coach surfaces
-**Date:** 2026-03-14
+**Date:** 2026-03-13
 **Owner:** @katsiaryna_kavaleuskaya
 
 ## Summary

--- a/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
+++ b/docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md
@@ -9,6 +9,11 @@
 This contract freezes the next additive FitChef route family without changing
 the live mascot canon.
 
+Identifier note:
+
+- umbrella rollout lane: `PR-4`
+- GitHub review artifact for this lane: `PR #1159`
+
 The current public mascot routes under `/api/v1/insight/fitchef*` remain live,
 canonical, and unmigrated in this phase. PR-4 defines future structured coach
 surfaces under `/api/v1/pro/fitchef/*` and `/api/v1/vip/fitchef/*` so later
@@ -62,6 +67,27 @@ additive to the live mascot family.
   - may depend on PRO-calculated domain context, but must not replace canonical
     nutrition or planner engines
 
+### Cross-tier and disallowed-access semantics
+
+Future implementations must keep cross-tier access fail-closed:
+
+- disallowed tier or missing entitlement:
+  - `403`
+  - JSON error envelope with stable `detail`
+- feature-disabled or execution-disabled route:
+  - `503`
+  - JSON error envelope with stable `detail`
+- rate-limit rejection:
+  - `429`
+  - JSON error envelope with stable `detail`
+- provider timeout or unavailable downstream:
+  - `504` or `503`
+  - JSON error envelope with stable `detail`
+
+The contract direction for those failures is the same safe JSON envelope style
+already used by the live mascot family: no raw provider traces, no client-side
+inference from prose, and no fail-open downgrade to a broader tier.
+
 ## Guard and execution policy
 
 Future implementation PRs must keep the current FitChef guard precedence
@@ -87,16 +113,16 @@ renderable by thin clients without parsing prose into product state.
 
 ### Required top-level direction
 
-- `mode`
-- `title`
-- `summary`
-- `bullets`
-- `actions`
-- `source_modules`
-- `used_llm`
-- `disclaimers`
-- `transparency_notice_id`
-- `wellness_boundary`
+- `mode: str`
+- `title: str`
+- `summary: str`
+- `bullets: list[str]`
+- `actions: list[FitChefStructuredAction]`
+- `source_modules: list[str]`
+- `used_llm: bool`
+- `disclaimers: list[str]`
+- `transparency_notice_id: str`
+- `wellness_boundary: str`
 
 ### Action contract
 
@@ -108,6 +134,39 @@ Minimum direction:
 - `type: str`
 - `label: str`
 - `payload: object`
+
+### Minimal schema sketch
+
+```json
+{
+  "mode": "pro_structured" ,
+  "title": "Protein below target",
+  "summary": "Your lunch pattern is the main driver today.",
+  "bullets": [
+    "Lunch protein remained below the daily target.",
+    "Dinner still has room for a corrective swap."
+  ],
+  "actions": [
+    {
+      "type": "open_meal",
+      "label": "Review dinner",
+      "payload": {
+        "meal_slot": "dinner"
+      }
+    }
+  ],
+  "source_modules": [
+    "nutrition.targets",
+    "planner.daily"
+  ],
+  "used_llm": false,
+  "disclaimers": [
+    "General wellness guidance only"
+  ],
+  "transparency_notice_id": "fitchef_structured_v1",
+  "wellness_boundary": "non_diagnostic_guidance"
+}
+```
 
 ### Client contract rules
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -1,7 +1,7 @@
 # 📊 PulsePlate — Canonical Product Tier Map (v1)
 
 **Status:** Canonical (audit-driven, based on actual codebase)
-**Last updated:** 2026-01-11
+**Last updated:** 2026-03-14
 **Canonical reference (derived from code):** `app/middleware/api_tiers.py`, `app/routers/*.py`, `legacy_app.py`
 
 ---
@@ -109,6 +109,15 @@
 * `pro_registration.py` = **технический модуль регистрации**, не бизнес-уровень
 * `premium_week.py` = **deprecated**, мигрирует на `pro.py`
 
+### FitChef structured coach follow-up (contract-frozen, not live)
+
+| Функция | Endpoint | Статус | Требует tier | Canonical reference |
+| --- | --- | --- | --- | --- |
+| FitChef explain | `/api/v1/pro/fitchef/explain` | 🧭 contract-frozen | PRO | `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` |
+| FitChef recommend | `/api/v1/pro/fitchef/recommend` | 🧭 contract-frozen | PRO | `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` |
+
+> Эти endpoints ещё не реализованы. PR-4 фиксирует только route family и tier semantics для будущего PRO structured coach runtime.
+
 ---
 
 ## 3️⃣ VIP — Weekly / Micro / Shoplist
@@ -161,6 +170,16 @@
 * VIP может зависеть от PRO данных
 * ❌ PRO не может реализовывать VIP-логику
 * VIP endpoints используют `require_vip_tier()` middleware
+
+### FitChef structured coach follow-up (contract-frozen, not live)
+
+| Функция | Endpoint | Статус | Требует tier | Canonical reference |
+| --- | --- | --- | --- | --- |
+| FitChef insight | `/api/v1/vip/fitchef/insight` | 🧭 contract-frozen | VIP | `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` |
+| FitChef chat | `/api/v1/vip/fitchef/chat` | 🧭 contract-frozen | VIP | `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` |
+| FitChef week repair | `/api/v1/vip/fitchef/week-repair` | 🧭 contract-frozen | VIP | `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md` |
+
+> Эти endpoints ещё не реализованы. PR-4 фиксирует additive structured coach contract, при этом live `/api/v1/insight/fitchef*` family остаётся каноном.
 
 ---
 

--- a/docs/contracts/PRODUCT_TIER_MAP.md
+++ b/docs/contracts/PRODUCT_TIER_MAP.md
@@ -1,7 +1,7 @@
 # 📊 PulsePlate — Canonical Product Tier Map (v1)
 
 **Status:** Canonical (audit-driven, based on actual codebase)
-**Last updated:** 2026-03-14
+**Last updated:** 2026-03-13
 **Canonical reference (derived from code):** `app/middleware/api_tiers.py`, `app/routers/*.py`, `legacy_app.py`
 
 ---
@@ -25,9 +25,9 @@
 
 ### Бизнес-смысл
 
-* Бесплатный вход
-* Диагностика / скрининг
-* Основа всей системы
+- Бесплатный вход
+- Диагностика / скрининг
+- Основа всей системы
 
 ### Канонический домен
 
@@ -45,9 +45,9 @@
 
 ### Правила
 
-* ❌ никакой логики вне `core/bmi`
-* ❌ никаких premium/vip зависимостей
-* ✅ legacy endpoints = thin proxy
+- ❌ никакой логики вне `core/bmi`
+- ❌ никаких premium/vip зависимостей
+- ✅ legacy endpoints = thin proxy
 
 ---
 
@@ -57,10 +57,10 @@
 
 ### Бизнес-смысл
 
-* Питание
-* Калории / нутриенты
-* Day-level планы
-* Без микро-ремонта и shoplist
+- Питание
+- Калории / нутриенты
+- Day-level планы
+- Без микро-ремонта и shoplist
 
 ### Канонический домен
 
@@ -99,15 +99,15 @@
 
 ### Что НЕ входит
 
-* ❌ weekly plan с авто-ремонтом (это VIP)
-* ❌ shoplist с региональной логикой (это VIP)
-* ❌ микро-constraints (это VIP)
+- ❌ weekly plan с авто-ремонтом (это VIP)
+- ❌ shoplist с региональной логикой (это VIP)
+- ❌ микро-constraints (это VIP)
 
 ### Правила
 
-* PRO endpoints используют `require_pro_tier()` middleware
-* `pro_registration.py` = **технический модуль регистрации**, не бизнес-уровень
-* `premium_week.py` = **deprecated**, мигрирует на `pro.py`
+- PRO endpoints используют `require_pro_tier()` middleware
+- `pro_registration.py` = **технический модуль регистрации**, не бизнес-уровень
+- `premium_week.py` = **deprecated**, мигрирует на `pro.py`
 
 ### FitChef structured coach follow-up (contract-frozen, not live)
 
@@ -126,11 +126,11 @@
 
 ### Бизнес-смысл
 
-* Weekly plan с микро-constraints
-* Auto-repair
-* Shoplist / region
-* Recipe synthesis
-* Exports
+- Weekly plan с микро-constraints
+- Auto-repair
+- Shoplist / region
+- Recipe synthesis
+- Exports
 
 ### Канонический домен
 
@@ -166,10 +166,10 @@
 
 ### Правила
 
-* VIP ≠ PRO
-* VIP может зависеть от PRO данных
-* ❌ PRO не может реализовывать VIP-логику
-* VIP endpoints используют `require_vip_tier()` middleware
+- VIP ≠ PRO
+- VIP может зависеть от PRO данных
+- ❌ PRO не может реализовывать VIP-логику
+- VIP endpoints используют `require_vip_tier()` middleware
 
 ### FitChef structured coach follow-up (contract-frozen, not live)
 
@@ -187,15 +187,15 @@
 
 ### Что сюда относится
 
-* `legacy_app.py` endpoints
-* `/premium_*` (без `/api/v1/`)
-* `/plan`, `/api/nutrition/{date}`
-* `/bmi`, `/premium_bmr`
+- `legacy_app.py` endpoints
+- `/premium_*` (без `/api/v1/`)
+- `/plan`, `/api/nutrition/{date}`
+- `/bmi`, `/premium_bmr`
 
 ### Назначение
 
-* Совместимость
-* Переходный слой
+- Совместимость
+- Переходный слой
 
 ### Жёсткое правило
 
@@ -323,7 +323,7 @@ For action items, PR sequencing, and remediation steps, see:
 
 ## 🔟 Связь с другими документами
 
-* `docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md` — детальный анализ legacy_app.py
-* `docs/audit/API_ALIGNMENT_CHECKLIST.md` — checklist для alignment
-* `docs/contracts/API_CANONICAL_MAP.md` — текущий операторский mapping
-* `app/middleware/api_tiers.py` — source of truth для уровней подписки
+- `docs/audit/PR_510_AUDIT_EVIDENCE_PACK.md` — детальный анализ legacy_app.py
+- `docs/audit/API_ALIGNMENT_CHECKLIST.md` — checklist для alignment
+- `docs/contracts/API_CANONICAL_MAP.md` — текущий операторский mapping
+- `app/middleware/api_tiers.py` — source of truth для уровней подписки

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -5,7 +5,17 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- Pending current review wave.
+Disposition: FIXED
+Commit: e6a2038c
+Evidence: docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:12, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:70, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:114, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:138
+Reason: The structured coach contract now normalizes the lane identifier against GitHub PR #1159, freezes cross-tier error semantics, and adds a concrete minimal DTO schema sketch for future runtime and client implementors.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947252841 -> e6a2038c
+
+Disposition: FIXED
+Commit: e6a2038c
+Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:10
+Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -48,8 +48,8 @@ Reason: The follow-up anchor refresh moves the self-referential proof lines to t
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947485528 -> 5ca2aa2f
 
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
-- [ ] Required checks PASS with no pending required jobs
-- [ ] No unresolved review threads
-- [ ] No actionable bot comments
+- [x] Local hard gate passed (`make verify`)
+- [x] Required checks PASS with no pending required jobs
+- [x] No unresolved review threads
+- [x] No actionable bot comments
 - [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Reason: The structured coach contract now normalizes the lane identifier against
 
 Disposition: FIXED
 Commit: e6a2038c
-Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:37
+Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:44
 Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
@@ -28,14 +28,14 @@ Reason: The structured coach contract header date now matches the actual non-fut
 
 Disposition: FIXED
 Commit: be559a86
-Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:37
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:44
 Reason: The canonical artifact now points the evidence anchor at the actual unchecked merge-readiness proof line instead of a stale self-reference, so the FIXED block's proof matches the claim it makes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934139273 -> be559a86
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947368416 -> be559a86
 
 Disposition: FIXED
 Commit: 7e24a997
-Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:37
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:44
 Reason: The canonical artifact refresh now points the second FIXED block at the actual unchecked merge-readiness proof line and keeps the self-anchor proof explicit, removing the stale line-number drift identified by cubic.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934186737 -> 7e24a997
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947425330 -> 7e24a997

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -52,4 +52,4 @@ Reason: The follow-up anchor refresh moves the self-referential proof lines to t
 - [x] Required checks PASS with no pending required jobs
 - [x] No unresolved review threads
 - [x] No actionable bot comments
-- [ ] Final post-bot wait cycle completed
+- [x] Final post-bot wait cycle completed

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1159 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass initialized
+- [x] Fixed in commit mapping initialized
+
+## Fixed in Commit Mapping
+- Pending PR review. No actionable review threads are recorded yet.
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -5,10 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- Pending current review wave.
 
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Reason: The structured coach contract now normalizes the lane identifier against
 
 Disposition: FIXED
 Commit: e6a2038c
-Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:30
+Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:37
 Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
@@ -28,7 +28,7 @@ Reason: The structured coach contract header date now matches the actual non-fut
 
 Disposition: FIXED
 Commit: be559a86
-Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:37
 Reason: The canonical artifact now points the evidence anchor at the actual unchecked merge-readiness proof line instead of a stale self-reference, so the FIXED block's proof matches the claim it makes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934139273 -> be559a86
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947368416 -> be559a86

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Reason: The structured coach contract now normalizes the lane identifier against
 
 Disposition: FIXED
 Commit: e6a2038c
-Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:44
+Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:51
 Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
@@ -28,17 +28,24 @@ Reason: The structured coach contract header date now matches the actual non-fut
 
 Disposition: FIXED
 Commit: be559a86
-Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:44
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:51
 Reason: The canonical artifact now points the evidence anchor at the actual unchecked merge-readiness proof line instead of a stale self-reference, so the FIXED block's proof matches the claim it makes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934139273 -> be559a86
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947368416 -> be559a86
 
 Disposition: FIXED
 Commit: 7e24a997
-Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:44
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:51
 Reason: The canonical artifact refresh now points the second FIXED block at the actual unchecked merge-readiness proof line and keeps the self-anchor proof explicit, removing the stale line-number drift identified by cubic.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934186737 -> 7e24a997
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947425330 -> 7e24a997
+
+Disposition: FIXED
+Commit: 5ca2aa2f
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:38, docs/review/PR_1159_FIXED_MAPPING.md:51
+Reason: The follow-up anchor refresh moves the self-referential proof lines to the actual unchecked merge-readiness checkbox after the later cubic mapping expansion, removing the remaining stale `:37` reference identified by cubic.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934231919 -> 5ca2aa2f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947485528 -> 5ca2aa2f
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1159 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass initialized
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- Pending PR review. No actionable review threads are recorded yet.
+- No actionable review comments
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -33,6 +33,13 @@ Reason: The canonical artifact now points the evidence anchor at the actual unch
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934139273 -> be559a86
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947368416 -> be559a86
 
+Disposition: FIXED
+Commit: 7e24a997
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17, docs/review/PR_1159_FIXED_MAPPING.md:31, docs/review/PR_1159_FIXED_MAPPING.md:37
+Reason: The canonical artifact refresh now points the second FIXED block at the actual unchecked merge-readiness proof line and keeps the self-anchor proof explicit, removing the stale line-number drift identified by cubic.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934186737 -> 7e24a997
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947425330 -> 7e24a997
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -9,12 +9,14 @@ Disposition: FIXED
 Commit: e6a2038c
 Evidence: docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:12, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:70, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:114, docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:138
 Reason: The structured coach contract now normalizes the lane identifier against GitHub PR #1159, freezes cross-tier error semantics, and adds a concrete minimal DTO schema sketch for future runtime and client implementors.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046929 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947252841 -> e6a2038c
 
 Disposition: FIXED
 Commit: e6a2038c
 Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:10
 Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
 
 ## Merge Readiness

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -19,6 +19,13 @@ Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, re
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c
 
+Disposition: FIXED
+Commit: d40e1d3b
+Evidence: docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md:4
+Reason: The structured coach contract header date now matches the actual non-future edit date for this docs-only lane, eliminating chronology drift in the contract metadata.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934126299 -> d40e1d3b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947351306 -> d40e1d3b
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Reason: The structured coach contract now normalizes the lane identifier against
 
 Disposition: FIXED
 Commit: e6a2038c
-Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:10
+Evidence: docs/contracts/PRODUCT_TIER_MAP.md:4, docs/contracts/PRODUCT_TIER_MAP.md:28, docs/roadmap/BACKLOG_LEDGER.md:1371, docs/review/PR_1159_FIXED_MAPPING.md:30
 Reason: The follow-up docs fix normalizes the `PRODUCT_TIER_MAP` update date, resolves markdown list-style drift, switches the active lane text to concrete PR `#1159`, and keeps the local hard-gate checkbox unchecked until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934046931 -> e6a2038c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947261976 -> e6a2038c

--- a/docs/review/PR_1159_FIXED_MAPPING.md
+++ b/docs/review/PR_1159_FIXED_MAPPING.md
@@ -26,6 +26,13 @@ Reason: The structured coach contract header date now matches the actual non-fut
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934126299 -> d40e1d3b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947351306 -> d40e1d3b
 
+Disposition: FIXED
+Commit: be559a86
+Evidence: docs/review/PR_1159_FIXED_MAPPING.md:17
+Reason: The canonical artifact now points the evidence anchor at the actual unchecked merge-readiness proof line instead of a stale self-reference, so the FIXED block's proof matches the claim it makes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#discussion_r2934139273 -> be559a86
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1159#pullrequestreview-3947368416 -> be559a86
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1368,7 +1368,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef umbrella initiative foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (orchestration / brand / App Store / coaching)
-  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR #1154 -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME
+  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR #1154 -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES
   - Status: 🚧 In progress
   - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
   - Links:
@@ -1376,6 +1376,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md`
     - `docs/contracts/FITCHEF_MASCOT_ASSET_TAXONOMY.md`
     - `docs/contracts/FITCHEF_APP_STORE_PRODUCTION_PACK_EN.md`
+    - `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md`
     - `docs/contracts/FITCHEF_MASCOT_PHASE2_CONTRACT.md`
     - `docs/contracts/API_CANONICAL_MAP.md`
     - `app/routers/fitchef_insight.py`
@@ -1385,8 +1386,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `PR #1140` merged on March 12, 2026 for the foundation/docs-only lane
     - `PR #1143` merged on March 12, 2026 for the visual/App Store contract lane
     - `PR #1150` merged on March 13, 2026 for the mascot asset taxonomy lane
-    - `PR-3` App Store production pack is the active lane from a clean worktree off `origin/main`
-    - `PR-3` scope is limited to the governed `EN` production pack: metadata, screenshot manifests, preview storyboard/script, upload checklist, and approved canonical source inventories
+    - `PR #1154` merged on March 13, 2026 for the governed `EN` App Store production pack lane
+    - `PR-4` structured coach contract is the active lane from a clean worktree off `origin/main`
+    - `PR-4` scope is docs-only: additive route family freeze, DTO direction, tier semantics, and coexistence rules with the live mascot canon
   - Subtracks:
     - FitChef visual identity and mascot system
     - App Store screenshot and preview pack

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1368,7 +1368,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef umbrella initiative foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (orchestration / brand / App Store / coaching)
-  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR #1154 -> PR-TBD-FITCHEF-STRUCTURED-CONTRACT -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES
+  - Target PR: PR #1140 -> PR #1143 -> PR #1150 -> PR #1154 -> PR #1159 (structured coach contract freeze) -> PR-TBD-FITCHEF-DOMAIN-SHELL -> PR-TBD-FITCHEF-PRO-RUNTIME -> PR-TBD-FITCHEF-VIP-RUNTIME -> PR-TBD-FITCHEF-LOCALIZATION-RU -> PR-TBD-FITCHEF-LOCALIZATION-ES
   - Status: 🚧 In progress
   - Reason (EN): FitChef already exists as a live VIP mascot/coaching surface under `/api/v1/insight/fitchef*`, but the next product wave needs one governed umbrella epic that preserves the current canon while splitting future work into clean PR families: visual/App Store, then structured coaching/runtime. This foundation also isolates mascot/App Icon asset promotion from docs/contracts work so local asset diffs never leak into governance PRs.
   - Links:
@@ -1387,8 +1387,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `PR #1143` merged on March 12, 2026 for the visual/App Store contract lane
     - `PR #1150` merged on March 13, 2026 for the mascot asset taxonomy lane
     - `PR #1154` merged on March 13, 2026 for the governed `EN` App Store production pack lane
-    - `PR-4` structured coach contract is the active lane from a clean worktree off `origin/main`
-    - `PR-4` scope is docs-only: additive route family freeze, DTO direction, tier semantics, and coexistence rules with the live mascot canon
+    - `PR #1159` structured coach contract is the active lane from a clean worktree off `origin/main`
+    - `PR #1159` scope is docs-only: additive route family freeze, DTO direction, tier semantics, and coexistence rules with the live mascot canon
   - Subtracks:
     - FitChef visual identity and mascot system
     - App Store screenshot and preview pack


### PR DESCRIPTION
## Summary
- freeze the additive FitChef structured coach route family as a docs-only PR
- preserve the live `/api/v1/insight/fitchef*` mascot canon without migration
- sync foundation, API map, tier map, and backlog progress after merged PR-3

## Scope
- add `docs/contracts/FITCHEF_STRUCTURED_COACH_CONTRACT.md`
- update FitChef rollout references in foundation/API/tier/ledger docs
- keep runtime, OpenAPI, frontend, and iOS behavior unchanged

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1159_FIXED_MAPPING.md`

## Merge Readiness
- [x] Local hard gates passed (`make verify`)
- [x] Review threads resolved and mapped in canonical artifact
- [x] CodeRabbit / Sourcery / Cubic no-actionables confirmed
- [x] Required checks PASS with no pending required jobs
- [x] Final post-bot wait cycle completed
