### PR TITLE
fix(api): sanitize runtime error details

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -917,7 +917,7 @@
         "filename": "tests/test_enhanced_plate_api.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 33
       }
     ],
     "tests/test_export_endpoints.py": [
@@ -1543,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-12T06:11:37Z"
+  "generated_at": "2026-03-13T21:54:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -703,7 +703,7 @@
         "filename": "tests/test_app_missing_lines_extra.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 16
       }
     ],
     "tests/test_app_real_coverage_97.py": [
@@ -917,7 +917,7 @@
         "filename": "tests/test_enhanced_plate_api.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 37
       }
     ],
     "tests/test_export_endpoints.py": [
@@ -1536,5 +1536,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-13T21:54:46Z"
+  "generated_at": "2026-03-13T22:39:25Z"
 }

--- a/app/http_error_details.py
+++ b/app/http_error_details.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+# Shared client-facing error details for sanitized HTTP responses.
+# These values are part of the stable response contract and must stay
+# consistent across routers, legacy shims, and tests.
+
+INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL = "invalid_weekly_plan_adapter_payload"
+CREATE_ORDER_CONFLICT_DETAIL = "client_event_id conflict: payload mismatch"
+ORDER_ACCESS_FORBIDDEN_DETAIL = "order access forbidden"
+ORDER_GONE_DETAIL = "order gone"
+CONFIRM_ORDER_CONFLICT_DETAIL = "client_event_id conflict: confirm payload mismatch"
+INVALID_ORDER_TRANSITION_DETAIL = "invalid transition"
+SHARE_ACCESS_FORBIDDEN_DETAIL = "share access forbidden"
+PARTNER_CONSENT_REQUIRED_DETAIL = "partner consent required"
+INVALID_HANDOFF_PAYLOAD_DETAIL = "invalid_handoff_payload"
+SHARE_REVOKED_DETAIL = "share revoked"
+SHARE_EXPIRED_DETAIL = "share expired"
+
+TRANSPORT_AUTH_REQUIRED_DETAIL = "transport_auth_required"
+DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL = "deterministic_activation_conflict"
+ACTIVATION_ACCESS_FORBIDDEN_DETAIL = "activation_access_forbidden"
+
+INVALID_SUBMISSION_DETAIL = "Invalid submission"
+INVALID_SUBMISSION_TRANSITION_DETAIL = "Invalid submission transition"
+MALFORMED_BARCODE_DETAIL = "Malformed barcode"
+INVALID_BMI_INPUT_DETAIL = "Invalid BMI input"
+
+INVALID_PREMIUM_PLATE_INPUT_DETAIL = "Invalid premium plate input"
+ENHANCED_PLATE_GENERATION_FAILED_DETAIL = "Enhanced plate generation failed"

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -193,7 +193,10 @@ def bmi_pro(req: BMIProRequest) -> BMIProResponse:
         # Adapt Pro tier Dict response to BMIProResponse format (risk_level, notes)
         risk_level, notes = _adapt_pro_stage_to_response(stage_dict, req.lang)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=INVALID_BMI_INPUT_DETAIL) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=INVALID_BMI_INPUT_DETAIL,
+        ) from exc
     card = BMIProCard(
         bmi=bmi_val,
         whtr=v_whtr,

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional, Protocol, cast
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from app.http_error_details import INVALID_BMI_INPUT_DETAIL
 from app.middleware.api_tiers import require_pro_tier
 from app.routers._helpers import _build_soft_paywall_hook, _normalize_bool_flag
 from app.schemas.bmi import (
@@ -34,7 +35,6 @@ from core.bmi.engine import BMICalculateResult as EngineBMICalculateResult
 from core.i18n import Language, normalize_lang, t
 
 logger = logging.getLogger(__name__)
-INVALID_BMI_INPUT_DETAIL = "Invalid BMI input"
 
 
 # Import engine (same pattern as bmi.py)

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -64,7 +64,8 @@ def _get_engine_calculator() -> CalculateBmiResult | None:
     try:
         from core.bmi.engine import calculate_bmi_result  # noqa: WPS433 (local import by design)
 
-        return calculate_bmi_result
+        engine_calculator: CalculateBmiResult = calculate_bmi_result
+        return engine_calculator
     except ImportError:
         return None
 

--- a/app/routers/bmi_pro.py
+++ b/app/routers/bmi_pro.py
@@ -34,6 +34,7 @@ from core.bmi.engine import BMICalculateResult as EngineBMICalculateResult
 from core.i18n import Language, normalize_lang, t
 
 logger = logging.getLogger(__name__)
+INVALID_BMI_INPUT_DETAIL = "Invalid BMI input"
 
 
 # Import engine (same pattern as bmi.py)
@@ -190,8 +191,8 @@ def bmi_pro(req: BMIProRequest) -> BMIProResponse:
         )
         # Adapt Pro tier Dict response to BMIProResponse format (risk_level, notes)
         risk_level, notes = _adapt_pro_stage_to_response(stage_dict, req.lang)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=INVALID_BMI_INPUT_DETAIL) from exc
     card = BMIProCard(
         bmi=bmi_val,
         whtr=v_whtr,

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -9,6 +9,7 @@ from app.schemas.food import FoodHit, FoodItem
 from app.services import food_store
 
 router = APIRouter(tags=["foods"])
+MALFORMED_BARCODE_DETAIL = "Malformed barcode"
 
 
 class FoodStore(Protocol):
@@ -98,7 +99,8 @@ def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)
         row = store.get_food_by_barcode(barcode)
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=MALFORMED_BARCODE_DETAIL,
         ) from exc
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Food not found")

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -25,13 +25,20 @@ class _FoodStoreCompat:
 
     def search_foods(self, query: str, limit: int, offset: int) -> Sequence[Mapping[str, Any]]:
         backend = food_store.get_search_backend()
-        return backend.search_foods(query=query, limit=limit, offset=offset)
+        rows: Sequence[Mapping[str, Any]] = backend.search_foods(
+            query=query,
+            limit=limit,
+            offset=offset,
+        )
+        return rows
 
     def get_food(self, food_id: str) -> Mapping[str, Any] | None:
-        return food_store.get_food(food_id)
+        row: Mapping[str, Any] | None = food_store.get_food(food_id)
+        return row
 
     def get_food_by_barcode(self, barcode: str) -> Mapping[str, Any] | None:
-        return food_store.get_food_by_barcode(barcode)
+        row: Mapping[str, Any] | None = food_store.get_food_by_barcode(barcode)
+        return row
 
 
 _FOOD_STORE_COMPAT: FoodStore = _FoodStoreCompat()

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -5,11 +5,11 @@ from typing import Any, Callable, Mapping, Protocol, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from app.http_error_details import MALFORMED_BARCODE_DETAIL
 from app.schemas.food import FoodHit, FoodItem
 from app.services import food_store
 
 router = APIRouter(tags=["foods"])
-MALFORMED_BARCODE_DETAIL = "Malformed barcode"
 
 
 class FoodStore(Protocol):

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -28,6 +28,9 @@ router = APIRouter(
     prefix="/api/v1/pro/payments",
     tags=["pro", "payments"],
 )
+TRANSPORT_AUTH_REQUIRED_DETAIL = "transport_auth_required"
+DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL = "deterministic_activation_conflict"
+ACTIVATION_ACCESS_FORBIDDEN_DETAIL = "activation_access_forbidden"
 
 
 def _payment_error_response(
@@ -98,19 +101,19 @@ def activate_subscription(
             user_id=current_user.user_id,
             payload=payload,
         )
-    except ActivationTransportUnauthorizedError as exc:
+    except ActivationTransportUnauthorizedError:
         return _payment_error_response(
             status_code=status.HTTP_401_UNAUTHORIZED,
             code="activation_transport_unauthorized",
             message="Transport protection required",
-            detail=str(exc),
+            detail=TRANSPORT_AUTH_REQUIRED_DETAIL,
         )
-    except payments_activation.IdempotencyConflictError as exc:
+    except payments_activation.IdempotencyConflictError:
         return _payment_error_response(
             status_code=status.HTTP_409_CONFLICT,
             code="idempotency_conflict",
             message="Deterministic activation conflict",
-            detail=str(exc),
+            detail=DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL,
         )
 
     response.status_code = status.HTTP_200_OK
@@ -147,19 +150,19 @@ def get_subscription_activation(
             activation_id,
             user_id=current_user.user_id,
         )
-    except ActivationTransportUnauthorizedError as exc:
+    except ActivationTransportUnauthorizedError:
         return _payment_error_response(
             status_code=status.HTTP_401_UNAUTHORIZED,
             code="activation_transport_unauthorized",
             message="Transport protection required",
-            detail=str(exc),
+            detail=TRANSPORT_AUTH_REQUIRED_DETAIL,
         )
-    except payments_activation.ActivationAccessForbiddenError as exc:
+    except payments_activation.ActivationAccessForbiddenError:
         return _payment_error_response(
             status_code=status.HTTP_403_FORBIDDEN,
             code="forbidden",
             message="Activation access forbidden",
-            detail=str(exc),
+            detail=ACTIVATION_ACCESS_FORBIDDEN_DETAIL,
         )
 
     if activation is None:

--- a/app/routers/pro_payments.py
+++ b/app/routers/pro_payments.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Response, Security, status
 from fastapi.responses import JSONResponse
 
+from app.http_error_details import (
+    ACTIVATION_ACCESS_FORBIDDEN_DETAIL,
+    DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL,
+    TRANSPORT_AUTH_REQUIRED_DETAIL,
+)
 from app.middleware.api_tiers import CurrentUser, derive_subject_id_from_api_key
 from app.routers.api_key import api_key_header
 from app.schemas.payments import (
@@ -28,9 +33,6 @@ router = APIRouter(
     prefix="/api/v1/pro/payments",
     tags=["pro", "payments"],
 )
-TRANSPORT_AUTH_REQUIRED_DETAIL = "transport_auth_required"
-DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL = "deterministic_activation_conflict"
-ACTIVATION_ACCESS_FORBIDDEN_DETAIL = "activation_access_forbidden"
 
 
 def _payment_error_response(

--- a/app/routers/pro_restaurant_partner.py
+++ b/app/routers/pro_restaurant_partner.py
@@ -12,6 +12,19 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
+from app.http_error_details import (
+    CONFIRM_ORDER_CONFLICT_DETAIL,
+    CREATE_ORDER_CONFLICT_DETAIL,
+    INVALID_HANDOFF_PAYLOAD_DETAIL,
+    INVALID_ORDER_TRANSITION_DETAIL,
+    INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL,
+    ORDER_ACCESS_FORBIDDEN_DETAIL,
+    ORDER_GONE_DETAIL,
+    PARTNER_CONSENT_REQUIRED_DETAIL,
+    SHARE_ACCESS_FORBIDDEN_DETAIL,
+    SHARE_EXPIRED_DETAIL,
+    SHARE_REVOKED_DETAIL,
+)
 from app.middleware.api_tiers import require_pro_tier
 from app.security.rate_limit import RATE_LIMIT_429_RESPONSES, RATE_LIMIT_EXPORTS, limit_if_available
 from app.schemas.restaurant_partner import (
@@ -30,17 +43,6 @@ from app.services import restaurant_partner_orders
 
 _ISSUER_LOCK = threading.Lock()
 _ISSUER_BY_API_KEY: dict[str, str] = {}
-INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL = "invalid_weekly_plan_adapter_payload"
-CREATE_ORDER_CONFLICT_DETAIL = "client_event_id conflict: payload mismatch"
-ORDER_ACCESS_FORBIDDEN_DETAIL = "order access forbidden"
-ORDER_GONE_DETAIL = "order gone"
-CONFIRM_ORDER_CONFLICT_DETAIL = "client_event_id conflict: confirm payload mismatch"
-INVALID_ORDER_TRANSITION_DETAIL = "invalid transition"
-SHARE_ACCESS_FORBIDDEN_DETAIL = "share access forbidden"
-PARTNER_CONSENT_REQUIRED_DETAIL = "partner consent required"
-INVALID_HANDOFF_PAYLOAD_DETAIL = "invalid_handoff_payload"
-SHARE_REVOKED_DETAIL = "share revoked"
-SHARE_EXPIRED_DETAIL = "share expired"
 
 router = APIRouter(
     prefix="/api/v1/pro/restaurants/partner",

--- a/app/routers/pro_restaurant_partner.py
+++ b/app/routers/pro_restaurant_partner.py
@@ -30,6 +30,17 @@ from app.services import restaurant_partner_orders
 
 _ISSUER_LOCK = threading.Lock()
 _ISSUER_BY_API_KEY: dict[str, str] = {}
+INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL = "invalid_weekly_plan_adapter_payload"
+CREATE_ORDER_CONFLICT_DETAIL = "client_event_id conflict: payload mismatch"
+ORDER_ACCESS_FORBIDDEN_DETAIL = "order access forbidden"
+ORDER_GONE_DETAIL = "order gone"
+CONFIRM_ORDER_CONFLICT_DETAIL = "client_event_id conflict: confirm payload mismatch"
+INVALID_ORDER_TRANSITION_DETAIL = "invalid transition"
+SHARE_ACCESS_FORBIDDEN_DETAIL = "share access forbidden"
+PARTNER_CONSENT_REQUIRED_DETAIL = "partner consent required"
+INVALID_HANDOFF_PAYLOAD_DETAIL = "invalid_handoff_payload"
+SHARE_REVOKED_DETAIL = "share revoked"
+SHARE_EXPIRED_DETAIL = "share expired"
 
 router = APIRouter(
     prefix="/api/v1/pro/restaurants/partner",
@@ -100,7 +111,7 @@ def preview_partner_order_from_weekly_plan(
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
+            detail=INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL,
         ) from exc
     return restaurant_partner_orders.preview_order(draft)
 
@@ -136,7 +147,10 @@ def create_partner_order(
             client_event_id=payload.client_event_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=CREATE_ORDER_CONFLICT_DETAIL,
+        ) from exc
     if not is_new:
         response.status_code = status.HTTP_200_OK
     return created
@@ -168,9 +182,15 @@ def get_partner_order(
     try:
         order = restaurant_partner_orders.get_order(order_id, issuer=issuer)
     except restaurant_partner_orders.OrderAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ORDER_ACCESS_FORBIDDEN_DETAIL,
+        ) from exc
     except restaurant_partner_orders.OrderGoneError as exc:
-        raise HTTPException(status_code=status.HTTP_410_GONE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=ORDER_GONE_DETAIL,
+        ) from exc
     if order is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
     return order
@@ -221,15 +241,24 @@ def confirm_partner_order(
             status_code=status.HTTP_404_NOT_FOUND, detail="Order not found"
         ) from exc
     except restaurant_partner_orders.OrderAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ORDER_ACCESS_FORBIDDEN_DETAIL,
+        ) from exc
     except restaurant_partner_orders.OrderGoneError as exc:
-        raise HTTPException(status_code=status.HTTP_410_GONE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=ORDER_GONE_DETAIL,
+        ) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=CONFIRM_ORDER_CONFLICT_DETAIL,
+        ) from exc
     except RuntimeError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
+            detail=INVALID_ORDER_TRANSITION_DETAIL,
         ) from exc
     return confirmed
 
@@ -279,13 +308,19 @@ def issue_handoff_share(
             status_code=status.HTTP_404_NOT_FOUND, detail="Order not found"
         ) from exc
     except restaurant_partner_orders.ShareAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=SHARE_ACCESS_FORBIDDEN_DETAIL,
+        ) from exc
     except restaurant_partner_orders.PartnerConsentRequiredError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=PARTNER_CONSENT_REQUIRED_DETAIL,
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
+            detail=INVALID_HANDOFF_PAYLOAD_DETAIL,
         ) from exc
     return issued
 
@@ -322,11 +357,20 @@ def get_handoff_share_status(
             status_code=status.HTTP_404_NOT_FOUND, detail="Share not found"
         ) from exc
     except restaurant_partner_orders.ShareAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=SHARE_ACCESS_FORBIDDEN_DETAIL,
+        ) from exc
     except restaurant_partner_orders.ShareRevokedError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=SHARE_REVOKED_DETAIL,
+        ) from exc
     except restaurant_partner_orders.ShareExpiredError as exc:
-        raise HTTPException(status_code=status.HTTP_410_GONE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=SHARE_EXPIRED_DETAIL,
+        ) from exc
 
 
 @router.post(
@@ -357,4 +401,7 @@ def revoke_handoff_share(
             status_code=status.HTTP_404_NOT_FOUND, detail="Share not found"
         ) from exc
     except restaurant_partner_orders.ShareAccessForbiddenError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=SHARE_ACCESS_FORBIDDEN_DETAIL,
+        ) from exc

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Any, Mapping, Protocol, Sequence, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -50,10 +50,16 @@ class _RestaurantStoreCompat:
     def search_restaurants(
         self, query: str, limit: int, offset: int
     ) -> Sequence[Mapping[str, Any]]:
-        return restaurant_store.search_restaurants(query=query, limit=limit, offset=offset)
+        return cast(
+            Sequence[Mapping[str, Any]],
+            restaurant_store.search_restaurants(query=query, limit=limit, offset=offset),
+        )
 
     def get_restaurant_menu(self, chain_id: str, limit: int) -> Sequence[Mapping[str, Any]]:
-        return restaurant_store.get_restaurant_menu(chain_id=chain_id, limit=limit)
+        return cast(
+            Sequence[Mapping[str, Any]],
+            restaurant_store.get_restaurant_menu(chain_id=chain_id, limit=limit),
+        )
 
     def create_submission(
         self,
@@ -64,24 +70,30 @@ class _RestaurantStoreCompat:
         off_url: str | None,
         entity_type: str,
     ) -> Mapping[str, Any]:
-        return restaurant_store.create_submission(
-            canonical_name=canonical_name,
-            payload=payload,
-            barcode=barcode,
-            off_url=off_url,
-            entity_type=entity_type,
+        return cast(
+            Mapping[str, Any],
+            restaurant_store.create_submission(
+                canonical_name=canonical_name,
+                payload=payload,
+                barcode=barcode,
+                off_url=off_url,
+                entity_type=entity_type,
+            ),
         )
 
     def get_submission(self, submission_id: str) -> Mapping[str, Any] | None:
-        return restaurant_store.get_submission(submission_id)
+        return cast(Mapping[str, Any] | None, restaurant_store.get_submission(submission_id))
 
     def review_submission(
         self, submission_id: str, *, status: str, reviewer_notes: str | None
     ) -> Mapping[str, Any] | None:
-        return restaurant_store.review_submission(
-            submission_id,
-            status=status,
-            reviewer_notes=reviewer_notes,
+        return cast(
+            Mapping[str, Any] | None,
+            restaurant_store.review_submission(
+                submission_id,
+                status=status,
+                reviewer_notes=reviewer_notes,
+            ),
         )
 
 

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -5,6 +5,10 @@ from typing import Any, Mapping, Protocol, Sequence, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from app.http_error_details import (
+    INVALID_SUBMISSION_DETAIL,
+    INVALID_SUBMISSION_TRANSITION_DETAIL,
+)
 from app.schemas.restaurants import (
     RestaurantHit,
     RestaurantMenuItem,
@@ -16,8 +20,6 @@ from app.services import restaurant_store
 
 router = APIRouter(tags=["restaurants"])
 moderation_router = APIRouter(tags=["restaurants"])
-INVALID_SUBMISSION_DETAIL = "Invalid submission"
-INVALID_SUBMISSION_TRANSITION_DETAIL = "Invalid submission transition"
 
 
 class RestaurantStore(Protocol):

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -16,6 +16,8 @@ from app.services import restaurant_store
 
 router = APIRouter(tags=["restaurants"])
 moderation_router = APIRouter(tags=["restaurants"])
+INVALID_SUBMISSION_DETAIL = "Invalid submission"
+INVALID_SUBMISSION_TRANSITION_DETAIL = "Invalid submission transition"
 
 
 class RestaurantStore(Protocol):
@@ -147,7 +149,8 @@ def create_restaurant_submission(
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=INVALID_SUBMISSION_DETAIL,
         ) from exc
     result: RestaurantSubmission = RestaurantSubmission.model_validate(created)
     return result
@@ -189,7 +192,8 @@ def review_restaurant_submission(
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=INVALID_SUBMISSION_TRANSITION_DETAIL,
         ) from exc
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -33,6 +33,13 @@ Reason: The review-level CodeRabbit follow-up is now fully addressed by post-com
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947270364 -> a67c1a7b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947357781 -> a67c1a7b
 
+Disposition: FIXED
+Commit: 14d44dc3
+Evidence: tests/test_pro_restaurant_partner_api.py:214, tests/test_pro_restaurant_partner_api.py:723
+Reason: The latest CodeRabbit follow-up asked for explicit negative assertions proving that injected sensitive substrings never leak anywhere in the serialized HTTP body. The affected partner-order sanitization regressions now assert that the private weekly-plan path and private share token are absent from `response.text`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947423084 -> 14d44dc3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934184565 -> 14d44dc3
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -11,6 +11,20 @@ Evidence: app/http_error_details.py:1, tests/test_pro_restaurant_partner_api.py:
 Reason: Sanitized client-facing error details are now centralized in a shared canonical module, and the touched regression tests assert against imported contract constants instead of duplicated string literals.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947251638 -> 89ba21b1
 
+Disposition: FIXED
+Commit: eb540717
+Evidence: tests/test_app_missing_lines_extra.py:166, tests/test_bmi_pro_router.py:206, tests/test_enhanced_plate_api.py:305, tests/test_foods_router_additional.py:176
+Reason: The error-path tests now assert JSON Content-Type before parsing response bodies, and the foods router regression uses the shared module-level constant instead of a duplicated literal.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055735 -> eb540717
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055738 -> eb540717
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055742 -> eb540717
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055746 -> eb540717
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_pro_restaurant_partner_api.py:174, tests/test_pro_restaurant_partner_api.py:375, tests/test_pro_restaurant_partner_api.py:928, tests/test_pro_restaurant_partner_api.py:1137
+Reason: The direct router-call tests intentionally assert raw `HTTPException.detail` before FastAPI serialization for deterministic branch-level sanitization coverage, while the same file already covers live JSON response envelopes for the corresponding partner-order and handoff-share HTTP surfaces via `TestClient`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055750
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -5,7 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 89ba21b1
+Evidence: app/http_error_details.py:1, tests/test_pro_restaurant_partner_api.py:10, tests/test_subscription_activation_api.py:14
+Reason: Sanitized client-facing error details are now centralized in a shared canonical module, and the touched regression tests assert against imported contract constants instead of duplicated string literals.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947251638 -> 89ba21b1
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1161 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -26,6 +26,13 @@ Evidence: tests/test_pro_restaurant_partner_api.py:169, tests/test_pro_restauran
 Reason: The previously direct router-call regressions for the partner order and handoff-share error paths now exercise the live HTTP endpoints via `TestClient`, asserting JSON content type and the sanitized response envelope exactly as requested by the review.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055750 -> e3dc7abb
 
+Disposition: FIXED
+Commit: a67c1a7b
+Evidence: tests/test_subscription_activation_api.py:710, tests/test_subscription_activation_api.py:727
+Reason: The review-level CodeRabbit follow-up is now fully addressed by post-comment code commits: the partner-order sanitization cases were moved onto live `TestClient` coverage, the BMI route uses `status.HTTP_400_BAD_REQUEST`, and the missing-transport activation regression now also asserts that the sanitized detail omits leaking auth/header internals.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947270364 -> a67c1a7b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#pullrequestreview-3947357781 -> a67c1a7b
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1161_FIXED_MAPPING.md
+++ b/docs/review/PR_1161_FIXED_MAPPING.md
@@ -20,10 +20,11 @@ Reason: The error-path tests now assert JSON Content-Type before parsing respons
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055742 -> eb540717
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055746 -> eb540717
 
-Disposition: NOT-A-BUG
-Evidence: tests/test_pro_restaurant_partner_api.py:174, tests/test_pro_restaurant_partner_api.py:375, tests/test_pro_restaurant_partner_api.py:928, tests/test_pro_restaurant_partner_api.py:1137
-Reason: The direct router-call tests intentionally assert raw `HTTPException.detail` before FastAPI serialization for deterministic branch-level sanitization coverage, while the same file already covers live JSON response envelopes for the corresponding partner-order and handoff-share HTTP surfaces via `TestClient`.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055750
+Disposition: FIXED
+Commit: e3dc7abb
+Evidence: tests/test_pro_restaurant_partner_api.py:169, tests/test_pro_restaurant_partner_api.py:202, tests/test_pro_restaurant_partner_api.py:484, tests/test_pro_restaurant_partner_api.py:681, tests/test_pro_restaurant_partner_api.py:714
+Reason: The previously direct router-call regressions for the partner order and handoff-share error paths now exercise the live HTTP endpoints via `TestClient`, asserting JSON content type and the sanitized response envelope exactly as requested by the review.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1161#discussion_r2934055750 -> e3dc7abb
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -3985,7 +3985,7 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
                 diet_flags=diet_flags_str,
             )
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=400, detail="Invalid premium plate input") from exc
 
         # Sanitize plate data
         plate_data = sanitize_plate_data(plate_data_raw)
@@ -4081,16 +4081,12 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
         if _is_missing_nh3_error(e):
             _raise_missing_nh3_http_error(e)
         logger.error("premium_plate validation error: %s", e)
-        raise HTTPException(
-            status_code=400, detail=f"Enhanced plate generation failed: {str(e)}"
-        ) from e
+        raise HTTPException(status_code=400, detail="Enhanced plate generation failed") from e
     except Exception as e:
         if _is_missing_nh3_error(e):
             _raise_missing_nh3_http_error(e)
         logger.error(f"premium_plate error: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Enhanced plate generation failed: {str(e)}"
-        ) from e
+        raise HTTPException(status_code=500, detail="Enhanced plate generation failed") from e
 
 
 @app.post(

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -48,6 +48,10 @@ from settings import get_runtime_env_name, is_explicit_developer_env, is_product
 
 from app.bootstrap.startup_guards import run_startup_guards
 from app.dependencies import validate_template_dir
+from app.http_error_details import (
+    ENHANCED_PLATE_GENERATION_FAILED_DETAIL,
+    INVALID_PREMIUM_PLATE_INPUT_DETAIL,
+)
 from app.routers.api_key import api_key_header
 from app.routers.bmi import router as bmi_router
 from app.routers.bmi_pro import router as bmi_pro_router
@@ -3985,7 +3989,7 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
                 diet_flags=diet_flags_str,
             )
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail="Invalid premium plate input") from exc
+            raise HTTPException(status_code=400, detail=INVALID_PREMIUM_PLATE_INPUT_DETAIL) from exc
 
         # Sanitize plate data
         plate_data = sanitize_plate_data(plate_data_raw)
@@ -4081,12 +4085,12 @@ async def _compute_premium_plate(req: PlateRequest) -> PlateResponse:
         if _is_missing_nh3_error(e):
             _raise_missing_nh3_http_error(e)
         logger.error("premium_plate validation error: %s", e)
-        raise HTTPException(status_code=400, detail="Enhanced plate generation failed") from e
+        raise HTTPException(status_code=400, detail=ENHANCED_PLATE_GENERATION_FAILED_DETAIL) from e
     except Exception as e:
         if _is_missing_nh3_error(e):
             _raise_missing_nh3_http_error(e)
         logger.error(f"premium_plate error: {e}")
-        raise HTTPException(status_code=500, detail="Enhanced plate generation failed") from e
+        raise HTTPException(status_code=500, detail=ENHANCED_PLATE_GENERATION_FAILED_DETAIL) from e
 
 
 @app.post(

--- a/tests/test_app_missing_lines_extra.py
+++ b/tests/test_app_missing_lines_extra.py
@@ -140,6 +140,31 @@ class TestAppMissingLinesExtra:
             assert r.status_code == 418
             assert "teapot" in r.json().get("detail", "")
 
+    def test_premium_plate_value_error_is_sanitized(self):
+        with (
+            patch.object(app_mod, "calculate_all_bmr", return_value={"mifflin": 1600}),
+            patch.object(app_mod, "calculate_all_tdee", return_value={"mifflin": 2200}),
+            patch.object(
+                app_mod,
+                "make_plate",
+                side_effect=ValueError("goal maintain failed at /tmp/internal/plate"),
+            ),
+        ):
+            payload = {
+                "sex": "male",
+                "age": 30,
+                "height_cm": 175.0,
+                "weight_kg": 70.0,
+                "activity": "light",
+                "goal": "maintain",
+            }
+            r = self.client.post(
+                "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
+            )
+            assert r.status_code == 400
+            assert r.json()["detail"] == "Invalid premium plate input"
+            assert "/tmp/internal/plate" not in r.json()["detail"]
+
     def test_premium_plate_missing_bmr_tdee_check(self):
         # Force the early 503 guard (974)
         with (

--- a/tests/test_app_missing_lines_extra.py
+++ b/tests/test_app_missing_lines_extra.py
@@ -141,7 +141,7 @@ class TestAppMissingLinesExtra:
             assert r.status_code == 418
             assert "teapot" in r.json().get("detail", "")
 
-    def test_premium_plate_value_error_is_sanitized(self):
+    def test_premium_plate_value_error_is_sanitized(self) -> None:
         with (
             patch.object(app_mod, "calculate_all_bmr", return_value={"mifflin": 1600}),
             patch.object(app_mod, "calculate_all_tdee", return_value={"mifflin": 2200}),
@@ -163,6 +163,7 @@ class TestAppMissingLinesExtra:
                 "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
             )
             assert r.status_code == 400
+            assert r.headers.get("content-type", "").startswith("application/json")
             assert r.json()["detail"] == INVALID_PREMIUM_PLATE_INPUT_DETAIL
             assert "/tmp/internal/plate" not in r.json()["detail"]
 

--- a/tests/test_app_missing_lines_extra.py
+++ b/tests/test_app_missing_lines_extra.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 import app as app_mod
+from app.http_error_details import INVALID_PREMIUM_PLATE_INPUT_DETAIL
 from app.middleware.api_tiers import TEST_KEY_VIP
 
 
@@ -162,7 +163,7 @@ class TestAppMissingLinesExtra:
                 "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
             )
             assert r.status_code == 400
-            assert r.json()["detail"] == "Invalid premium plate input"
+            assert r.json()["detail"] == INVALID_PREMIUM_PLATE_INPUT_DETAIL
             assert "/tmp/internal/plate" not in r.json()["detail"]
 
     def test_premium_plate_missing_bmr_tdee_check(self):

--- a/tests/test_bmi_pro_router.py
+++ b/tests/test_bmi_pro_router.py
@@ -202,7 +202,7 @@ class TestBMIProRouter:
         )
 
         assert response.status_code == 400
-        assert "Invalid calculation" in response.json()["detail"]
+        assert response.json()["detail"] == "Invalid BMI input"
 
     def test_bmi_pro_request_model(self) -> None:
         """Test BMIProRequest model validation."""

--- a/tests/test_bmi_pro_router.py
+++ b/tests/test_bmi_pro_router.py
@@ -203,6 +203,7 @@ class TestBMIProRouter:
         )
 
         assert response.status_code == 400
+        assert response.headers["content-type"].startswith("application/json")
         assert response.json()["detail"] == INVALID_BMI_INPUT_DETAIL
 
     def test_bmi_pro_request_model(self) -> None:

--- a/tests/test_bmi_pro_router.py
+++ b/tests/test_bmi_pro_router.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.http_error_details import INVALID_BMI_INPUT_DETAIL
 from app.routers.bmi_pro import BMIProRequest, BMIProResponse, router
 
 
@@ -202,7 +203,7 @@ class TestBMIProRouter:
         )
 
         assert response.status_code == 400
-        assert response.json()["detail"] == "Invalid BMI input"
+        assert response.json()["detail"] == INVALID_BMI_INPUT_DETAIL
 
     def test_bmi_pro_request_model(self) -> None:
         """Test BMIProRequest model validation."""

--- a/tests/test_bmi_pro_router.py
+++ b/tests/test_bmi_pro_router.py
@@ -188,7 +188,7 @@ class TestBMIProRouter:
     @patch("app.routers.bmi_pro.calc_bmi")
     def test_bmi_pro_calculation_error(self, mock_calc_bmi: MagicMock) -> None:
         """Test BMI Pro endpoint with calculation error."""
-        mock_calc_bmi.side_effect = ValueError("Invalid calculation")
+        mock_calc_bmi.side_effect = ValueError("trace /srv/pulseplate/private-bmi.json")
 
         response = self.client.post(
             "/api/v1/pro/bmi",
@@ -205,6 +205,7 @@ class TestBMIProRouter:
         assert response.status_code == 400
         assert response.headers["content-type"].startswith("application/json")
         assert response.json()["detail"] == INVALID_BMI_INPUT_DETAIL
+        assert "/srv/pulseplate/private-bmi.json" not in response.text
 
     def test_bmi_pro_request_model(self) -> None:
         """Test BMIProRequest model validation."""

--- a/tests/test_enhanced_plate_api.py
+++ b/tests/test_enhanced_plate_api.py
@@ -13,10 +13,11 @@ Tests cover:
 """
 
 import os
-import sys
 
 import pytest
 from fastapi.testclient import TestClient
+
+import app as app_mod
 
 # Import the FastAPI app from the app package
 from app import app
@@ -297,7 +298,32 @@ class TestEnhancedPlateAPI:
         )
 
         assert response.status_code == 400
-        assert "Enhanced plate generation failed" in response.text
+        assert response.json()["detail"] == "Enhanced plate generation failed"
+        assert "custom_bad" not in response.text
+
+    def test_plate_error_hygiene_does_not_leak_raw_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise_sensitive_value_error(*_args: object, **_kwargs: object) -> dict[str, object]:
+            raise ValueError("secret provider trace at /srv/pulseplate/plate.py")
+
+        monkeypatch.setattr(app_mod, "make_plate", _raise_sensitive_value_error)
+
+        payload = {
+            "sex": "female",
+            "age": 30,
+            "height_cm": 170,
+            "weight_kg": 65,
+            "activity": "moderate",
+            "goal": "maintain",
+        }
+        response = client.post(
+            "/api/v1/premium/plate", json=payload, headers={"X-API-Key": "test_key"}
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid premium plate input"
+        assert "/srv/pulseplate/plate.py" not in response.text
 
     def test_plate_goal_specific_differences(self) -> None:
         """Test different goals produce appropriate macro distributions."""

--- a/tests/test_enhanced_plate_api.py
+++ b/tests/test_enhanced_plate_api.py
@@ -302,6 +302,7 @@ class TestEnhancedPlateAPI:
         )
 
         assert response.status_code == 400
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json()["detail"] == ENHANCED_PLATE_GENERATION_FAILED_DETAIL
         assert "custom_bad" not in response.text
 
@@ -326,6 +327,7 @@ class TestEnhancedPlateAPI:
         )
 
         assert response.status_code == 400
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json()["detail"] == INVALID_PREMIUM_PLATE_INPUT_DETAIL
         assert "/srv/pulseplate/plate.py" not in response.text
 

--- a/tests/test_enhanced_plate_api.py
+++ b/tests/test_enhanced_plate_api.py
@@ -21,6 +21,10 @@ import app as app_mod
 
 # Import the FastAPI app from the app package
 from app import app
+from app.http_error_details import (
+    ENHANCED_PLATE_GENERATION_FAILED_DETAIL,
+    INVALID_PREMIUM_PLATE_INPUT_DETAIL,
+)
 
 client = TestClient(app)
 
@@ -298,7 +302,7 @@ class TestEnhancedPlateAPI:
         )
 
         assert response.status_code == 400
-        assert response.json()["detail"] == "Enhanced plate generation failed"
+        assert response.json()["detail"] == ENHANCED_PLATE_GENERATION_FAILED_DETAIL
         assert "custom_bad" not in response.text
 
     def test_plate_error_hygiene_does_not_leak_raw_value_error(
@@ -322,7 +326,7 @@ class TestEnhancedPlateAPI:
         )
 
         assert response.status_code == 400
-        assert response.json()["detail"] == "Invalid premium plate input"
+        assert response.json()["detail"] == INVALID_PREMIUM_PLATE_INPUT_DETAIL
         assert "/srv/pulseplate/plate.py" not in response.text
 
     def test_plate_goal_specific_differences(self) -> None:

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
+from app.http_error_details import MALFORMED_BARCODE_DETAIL
 from app.routers import foods
 from app.schemas.food import FoodHit, FoodItem
 
@@ -173,7 +174,7 @@ def test_get_food_by_barcode_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         foods.get_food_by_barcode("123", store=foods.get_food_store())
 
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Malformed barcode"
+    assert exc.value.detail == MALFORMED_BARCODE_DETAIL
 
 
 def test_get_food_by_barcode_invalid_sanitizes_unexpected_detail(
@@ -188,7 +189,7 @@ def test_get_food_by_barcode_invalid_sanitizes_unexpected_detail(
         foods.get_food_by_barcode("123", store=foods.get_food_store())
 
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Malformed barcode"
+    assert exc.value.detail == MALFORMED_BARCODE_DETAIL
     assert "/tmp/off-cache.json" not in exc.value.detail
 
 

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -5,7 +5,6 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
-from app.http_error_details import MALFORMED_BARCODE_DETAIL
 from app.routers import foods
 from app.schemas.food import FoodHit, FoodItem
 
@@ -174,7 +173,7 @@ def test_get_food_by_barcode_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         foods.get_food_by_barcode("123", store=foods.get_food_store())
 
     assert exc.value.status_code == 422
-    assert exc.value.detail == MALFORMED_BARCODE_DETAIL
+    assert exc.value.detail == foods.MALFORMED_BARCODE_DETAIL
 
 
 def test_get_food_by_barcode_invalid_sanitizes_unexpected_detail(
@@ -189,7 +188,7 @@ def test_get_food_by_barcode_invalid_sanitizes_unexpected_detail(
         foods.get_food_by_barcode("123", store=foods.get_food_store())
 
     assert exc.value.status_code == 422
-    assert exc.value.detail == MALFORMED_BARCODE_DETAIL
+    assert exc.value.detail == foods.MALFORMED_BARCODE_DETAIL
     assert "/tmp/off-cache.json" not in exc.value.detail
 
 

--- a/tests/test_foods_router_additional.py
+++ b/tests/test_foods_router_additional.py
@@ -173,7 +173,23 @@ def test_get_food_by_barcode_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         foods.get_food_by_barcode("123", store=foods.get_food_store())
 
     assert exc.value.status_code == 422
-    assert exc.value.detail == "barcode must have length in [8,14]"
+    assert exc.value.detail == "Malformed barcode"
+
+
+def test_get_food_by_barcode_invalid_sanitizes_unexpected_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_invalid(_: str) -> None:
+        raise ValueError("barcode secret path /tmp/off-cache.json")
+
+    monkeypatch.setattr(foods.food_store, "get_food_by_barcode", _raise_invalid)
+
+    with pytest.raises(HTTPException) as exc:
+        foods.get_food_by_barcode("123", store=foods.get_food_store())
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Malformed barcode"
+    assert "/tmp/off-cache.json" not in exc.value.detail
 
 
 def test_get_food_by_barcode_route_documents_404() -> None:

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -171,6 +171,8 @@ def test_preview_partner_order_from_weekly_plan_invalid_shape_422() -> None:
     from app.routers import pro_restaurant_partner
     from app.schemas.restaurant_partner import PartnerOrderWeeklyAdapterRequest
 
+    # Direct router invocation is intentional here: this test asserts the raw
+    # HTTPException detail before FastAPI serializes the error envelope.
     payload = PartnerOrderWeeklyAdapterRequest.model_validate(
         {
             "restaurant_id": "resto-weekly-2",

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from fastapi import HTTPException, Response
 from fastapi.testclient import TestClient
 import pytest
+
+TEST_PRO_TIER_TOKEN = "pro-tier-token"
 
 
 @pytest.fixture(autouse=True)
@@ -152,21 +155,55 @@ def test_preview_partner_order_from_weekly_plan_happy_path(
     ]
 
 
-def test_preview_partner_order_from_weekly_plan_invalid_shape_422(
-    client: TestClient,
-    pro_headers: dict[str, str],
-) -> None:
-    response = client.post(
-        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
-        headers=pro_headers,
-        json={
+def test_preview_partner_order_from_weekly_plan_invalid_shape_422() -> None:
+    from app.routers import pro_restaurant_partner
+    from app.schemas.restaurant_partner import PartnerOrderWeeklyAdapterRequest
+
+    payload = PartnerOrderWeeklyAdapterRequest.model_validate(
+        {
             "restaurant_id": "resto-weekly-2",
             "week_plan": {"menu": {}},
             "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "invalid_weekly_plan_adapter_payload"
+    assert "days/menu.days/data.daily_menus" not in exc_info.value.detail
+
+
+def test_preview_partner_order_from_weekly_plan_sanitizes_unexpected_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import pro_restaurant_partner
+    from app.schemas.restaurant_partner import PartnerOrderWeeklyAdapterRequest
+    from app.services import restaurant_partner_export_adapter
+
+    def _raise_sensitive_error(**_kwargs: object) -> dict[str, object]:
+        raise ValueError("adapter trace /srv/pulseplate/private-weekly-plan.json")
+
+    monkeypatch.setattr(
+        restaurant_partner_export_adapter,
+        "build_order_draft_from_weekly_plan",
+        _raise_sensitive_error,
+    )
+
+    payload = PartnerOrderWeeklyAdapterRequest.model_validate(
+        {
+            "restaurant_id": "resto-weekly-sensitive",
+            "week_plan": {"days": [{"meals": [{"items": [{"name": "Oats", "qty": 1}]}]}]},
+            "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
         },
     )
-    assert response.status_code == 422
-    assert "days/menu.days/data.daily_menus" in _json(response)["detail"]
+
+    with pytest.raises(HTTPException) as exc_info:
+        pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "invalid_weekly_plan_adapter_payload"
 
 
 def test_preview_partner_order_from_weekly_plan_invalid_currency_422(
@@ -433,30 +470,38 @@ def test_confirm_partner_order_idempotent_replay(
     assert second_payload["confirmed_by"] == first_payload["confirmed_by"]
 
 
-def test_confirm_partner_order_invalid_transition_422(
-    client: TestClient,
-    pro_headers: dict[str, str],
-) -> None:
-    created = client.post(
-        "/api/v1/pro/restaurants/partner/orders",
-        headers=pro_headers,
-        json={"draft": _sample_draft(), "client_event_id": "evt-create-6"},
-    )
-    order_id = _json(created)["id"]
+def test_confirm_partner_order_invalid_transition_422() -> None:
+    from app.routers import pro_restaurant_partner
+    from app.schemas.restaurant_partner import PartnerOrderConfirmRequest, PartnerOrderCreateRequest
 
-    first = client.post(
-        f"/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
-        headers=pro_headers,
-        json={"confirmed_by": "partner-user-3"},
+    create_payload = PartnerOrderCreateRequest.model_validate(
+        {"draft": _sample_draft(), "client_event_id": "evt-create-6"}
     )
-    assert first.status_code == 200, first.text
+    response = Response()
+    created = pro_restaurant_partner.create_partner_order(
+        create_payload,
+        response,
+        x_api_key=TEST_PRO_TIER_TOKEN,
+    )
+    order_id = created.id
 
-    second = client.post(
-        f"/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
-        headers=pro_headers,
-        json={"confirmed_by": "partner-user-3"},
+    first_payload = PartnerOrderConfirmRequest.model_validate({"confirmed_by": "partner-user-3"})
+    pro_restaurant_partner.confirm_partner_order(
+        order_id,
+        first_payload,
+        x_api_key=TEST_PRO_TIER_TOKEN,
     )
-    assert second.status_code == 422
+
+    second_payload = PartnerOrderConfirmRequest.model_validate({"confirmed_by": "partner-user-3"})
+    with pytest.raises(HTTPException) as exc_info:
+        pro_restaurant_partner.confirm_partner_order(
+            order_id,
+            second_payload,
+            x_api_key=TEST_PRO_TIER_TOKEN,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "invalid transition"
 
 
 def test_confirm_partner_order_not_found_404(
@@ -619,6 +664,59 @@ def test_confirm_partner_order_idempotency_conflict_409(
     )
     assert second.status_code == 409
     assert _json(second)["detail"] == "client_event_id conflict: confirm payload mismatch"
+
+
+def test_create_partner_order_sanitizes_unexpected_conflict_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import pro_restaurant_partner
+    from app.schemas.restaurant_partner import PartnerOrderCreateRequest
+    from app.services import restaurant_partner_orders
+
+    def _raise_sensitive_conflict(**_kwargs: object) -> tuple[dict[str, object], bool]:
+        raise ValueError("client_event_id conflict: leaked /srv/orders.db")
+
+    monkeypatch.setattr(restaurant_partner_orders, "create_order", _raise_sensitive_conflict)
+
+    payload = PartnerOrderCreateRequest.model_validate(
+        {"draft": _sample_draft(), "client_event_id": "evt-sensitive-conflict"}
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        pro_restaurant_partner.create_partner_order(
+            payload,
+            Response(),
+            x_api_key=TEST_PRO_TIER_TOKEN,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "client_event_id conflict: payload mismatch"
+
+
+def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import pro_restaurant_partner
+    from app.services import restaurant_partner_orders
+
+    def _raise_sensitive_forbidden(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise restaurant_partner_orders.ShareAccessForbiddenError(
+            "share access forbidden: /srv/private-share-token"
+        )
+
+    monkeypatch.setattr(
+        restaurant_partner_orders,
+        "get_handoff_share_status",
+        _raise_sensitive_forbidden,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        pro_restaurant_partner.get_handoff_share_status(
+            "share-sensitive",
+            x_api_key=TEST_PRO_TIER_TOKEN,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "share access forbidden"
 
 
 def test_preview_partner_order_invalid_currency_422(

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import HTTPException, Response
 from fastapi.testclient import TestClient
 import pytest
 
@@ -167,33 +166,31 @@ def test_preview_partner_order_from_weekly_plan_happy_path(
     ]
 
 
-def test_preview_partner_order_from_weekly_plan_invalid_shape_422() -> None:
-    from app.routers import pro_restaurant_partner
-    from app.schemas.restaurant_partner import PartnerOrderWeeklyAdapterRequest
-
-    # Direct router invocation is intentional here: this test asserts the raw
-    # HTTPException detail before FastAPI serializes the error envelope.
-    payload = PartnerOrderWeeklyAdapterRequest.model_validate(
-        {
+def test_preview_partner_order_from_weekly_plan_invalid_shape_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json={
             "restaurant_id": "resto-weekly-2",
             "week_plan": {"menu": {}},
             "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
-        }
+        },
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
-
-    assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
-    assert "days/menu.days/data.daily_menus" not in exc_info.value.detail
+    assert response.status_code == 422
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.json()["detail"] == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
+    assert "days/menu.days/data.daily_menus" not in response.json()["detail"]
 
 
 def test_preview_partner_order_from_weekly_plan_sanitizes_unexpected_value_error(
+    client: TestClient,
+    pro_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.routers import pro_restaurant_partner
-    from app.schemas.restaurant_partner import PartnerOrderWeeklyAdapterRequest
     from app.services import restaurant_partner_export_adapter
 
     def _raise_sensitive_error(**_kwargs: object) -> dict[str, object]:
@@ -205,19 +202,19 @@ def test_preview_partner_order_from_weekly_plan_sanitizes_unexpected_value_error
         _raise_sensitive_error,
     )
 
-    payload = PartnerOrderWeeklyAdapterRequest.model_validate(
-        {
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders/adapt/preview",
+        headers=pro_headers,
+        json={
             "restaurant_id": "resto-weekly-sensitive",
             "week_plan": {"days": [{"meals": [{"items": [{"name": "Oats", "qty": 1}]}]}]},
             "consent": {"consent_share_with_partner": True, "consent_version": "v1"},
         },
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
-
-    assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
+    assert response.status_code == 422
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.json()["detail"] == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
 
 
 def test_preview_partner_order_from_weekly_plan_invalid_currency_422(
@@ -484,38 +481,34 @@ def test_confirm_partner_order_idempotent_replay(
     assert second_payload["confirmed_by"] == first_payload["confirmed_by"]
 
 
-def test_confirm_partner_order_invalid_transition_422() -> None:
-    from app.routers import pro_restaurant_partner
-    from app.schemas.restaurant_partner import PartnerOrderConfirmRequest, PartnerOrderCreateRequest
-
-    create_payload = PartnerOrderCreateRequest.model_validate(
-        {"draft": _sample_draft(), "client_event_id": "evt-create-6"}
+def test_confirm_partner_order_invalid_transition_422(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    created = client.post(
+        "/api/v1/pro/restaurants/partner/orders",
+        headers=pro_headers,
+        json={"draft": _sample_draft(), "client_event_id": "evt-create-6"},
     )
-    response = Response()
-    created = pro_restaurant_partner.create_partner_order(
-        create_payload,
-        response,
-        x_api_key=TEST_PRO_TIER_TOKEN,
+    assert created.status_code == 201, created.text
+    order_id = _json(created)["id"]
+
+    first = client.post(
+        f"/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
+        headers=pro_headers,
+        json={"confirmed_by": "partner-user-3"},
     )
-    order_id = created.id
+    assert first.status_code == 200, first.text
 
-    first_payload = PartnerOrderConfirmRequest.model_validate({"confirmed_by": "partner-user-3"})
-    pro_restaurant_partner.confirm_partner_order(
-        order_id,
-        first_payload,
-        x_api_key=TEST_PRO_TIER_TOKEN,
+    second = client.post(
+        f"/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
+        headers=pro_headers,
+        json={"confirmed_by": "partner-user-3"},
     )
 
-    second_payload = PartnerOrderConfirmRequest.model_validate({"confirmed_by": "partner-user-3"})
-    with pytest.raises(HTTPException) as exc_info:
-        pro_restaurant_partner.confirm_partner_order(
-            order_id,
-            second_payload,
-            x_api_key=TEST_PRO_TIER_TOKEN,
-        )
-
-    assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == INVALID_ORDER_TRANSITION_DETAIL
+    assert second.status_code == 422
+    assert second.headers.get("content-type", "").startswith("application/json")
+    assert second.json()["detail"] == INVALID_ORDER_TRANSITION_DETAIL
 
 
 def test_confirm_partner_order_not_found_404(
@@ -681,10 +674,10 @@ def test_confirm_partner_order_idempotency_conflict_409(
 
 
 def test_create_partner_order_sanitizes_unexpected_conflict_detail(
+    client: TestClient,
+    pro_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.routers import pro_restaurant_partner
-    from app.schemas.restaurant_partner import PartnerOrderCreateRequest
     from app.services import restaurant_partner_orders
 
     def _raise_sensitive_conflict(**_kwargs: object) -> tuple[dict[str, object], bool]:
@@ -692,24 +685,22 @@ def test_create_partner_order_sanitizes_unexpected_conflict_detail(
 
     monkeypatch.setattr(restaurant_partner_orders, "create_order", _raise_sensitive_conflict)
 
-    payload = PartnerOrderCreateRequest.model_validate(
-        {"draft": _sample_draft(), "client_event_id": "evt-sensitive-conflict"}
+    response = client.post(
+        "/api/v1/pro/restaurants/partner/orders",
+        headers=pro_headers,
+        json={"draft": _sample_draft(), "client_event_id": "evt-sensitive-conflict"},
     )
-    with pytest.raises(HTTPException) as exc_info:
-        pro_restaurant_partner.create_partner_order(
-            payload,
-            Response(),
-            x_api_key=TEST_PRO_TIER_TOKEN,
-        )
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == CREATE_ORDER_CONFLICT_DETAIL
+    assert response.status_code == 409
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.json()["detail"] == CREATE_ORDER_CONFLICT_DETAIL
 
 
 def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
+    client: TestClient,
+    pro_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.routers import pro_restaurant_partner
     from app.services import restaurant_partner_orders
 
     def _raise_sensitive_forbidden(*_args: object, **_kwargs: object) -> dict[str, object]:
@@ -723,14 +714,14 @@ def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
         _raise_sensitive_forbidden,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        pro_restaurant_partner.get_handoff_share_status(
-            "share-sensitive",
-            x_api_key=TEST_PRO_TIER_TOKEN,
-        )
+    response = client.get(
+        "/api/v1/pro/restaurants/partner/handoff/shares/share-sensitive/status",
+        headers=pro_headers,
+    )
 
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == SHARE_ACCESS_FORBIDDEN_DETAIL
+    assert response.status_code == 403
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.json()["detail"] == SHARE_ACCESS_FORBIDDEN_DETAIL
 
 
 def test_preview_partner_order_invalid_currency_422(

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -183,6 +183,8 @@ def test_preview_partner_order_from_weekly_plan_invalid_shape_422(
     assert response.status_code == 422
     assert response.headers.get("content-type", "").startswith("application/json")
     assert response.json()["detail"] == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
+    assert "/srv/pulseplate/private-weekly-plan.json" not in response.text
+    assert "adapter trace /srv/pulseplate/private-weekly-plan.json" not in response.text
     assert "days/menu.days/data.daily_menus" not in response.json()["detail"]
 
 
@@ -694,6 +696,7 @@ def test_create_partner_order_sanitizes_unexpected_conflict_detail(
     assert response.status_code == 409
     assert response.headers.get("content-type", "").startswith("application/json")
     assert response.json()["detail"] == CREATE_ORDER_CONFLICT_DETAIL
+    assert "/srv/orders.db" not in response.text
 
 
 def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
@@ -722,6 +725,7 @@ def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
     assert response.status_code == 403
     assert response.headers.get("content-type", "").startswith("application/json")
     assert response.json()["detail"] == SHARE_ACCESS_FORBIDDEN_DETAIL
+    assert "/srv/private-share-token" not in response.text
 
 
 def test_preview_partner_order_invalid_currency_422(

--- a/tests/test_pro_restaurant_partner_api.py
+++ b/tests/test_pro_restaurant_partner_api.py
@@ -7,6 +7,18 @@ from fastapi import HTTPException, Response
 from fastapi.testclient import TestClient
 import pytest
 
+from app.http_error_details import (
+    CONFIRM_ORDER_CONFLICT_DETAIL,
+    CREATE_ORDER_CONFLICT_DETAIL,
+    INVALID_ORDER_TRANSITION_DETAIL,
+    INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL,
+    ORDER_GONE_DETAIL,
+    PARTNER_CONSENT_REQUIRED_DETAIL,
+    SHARE_ACCESS_FORBIDDEN_DETAIL,
+    SHARE_EXPIRED_DETAIL,
+    SHARE_REVOKED_DETAIL,
+)
+
 TEST_PRO_TIER_TOKEN = "pro-tier-token"
 
 
@@ -171,7 +183,7 @@ def test_preview_partner_order_from_weekly_plan_invalid_shape_422() -> None:
         pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
 
     assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == "invalid_weekly_plan_adapter_payload"
+    assert exc_info.value.detail == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
     assert "days/menu.days/data.daily_menus" not in exc_info.value.detail
 
 
@@ -203,7 +215,7 @@ def test_preview_partner_order_from_weekly_plan_sanitizes_unexpected_value_error
         pro_restaurant_partner.preview_partner_order_from_weekly_plan(object(), payload)
 
     assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == "invalid_weekly_plan_adapter_payload"
+    assert exc_info.value.detail == INVALID_WEEKLY_PLAN_ADAPTER_PAYLOAD_DETAIL
 
 
 def test_preview_partner_order_from_weekly_plan_invalid_currency_422(
@@ -397,14 +409,14 @@ def test_get_partner_order_gone_410_for_terminal_status(
         headers=pro_headers,
     )
     assert response.status_code == 410
-    assert _json(response) == {"detail": "order gone"}
+    assert _json(response) == {"detail": ORDER_GONE_DETAIL}
 
     replay_response = client.get(
         f"/api/v1/pro/restaurants/partner/orders/{order_id}",
         headers=pro_headers,
     )
     assert replay_response.status_code == 410
-    assert _json(replay_response) == {"detail": "order gone"}
+    assert _json(replay_response) == {"detail": ORDER_GONE_DETAIL}
 
 
 def test_confirm_partner_order_happy_path(
@@ -501,7 +513,7 @@ def test_confirm_partner_order_invalid_transition_422() -> None:
         )
 
     assert exc_info.value.status_code == 422
-    assert exc_info.value.detail == "invalid transition"
+    assert exc_info.value.detail == INVALID_ORDER_TRANSITION_DETAIL
 
 
 def test_confirm_partner_order_not_found_404(
@@ -586,7 +598,7 @@ def test_confirm_partner_order_gone_410_for_terminal_status(
         json={"confirmed_by": "partner-user-gone", "client_event_id": "evt-confirm-gone"},
     )
     assert confirm.status_code == 410
-    assert _json(confirm) == {"detail": "order gone"}
+    assert _json(confirm) == {"detail": ORDER_GONE_DETAIL}
 
     replay = client.post(
         f"/api/v1/pro/restaurants/partner/orders/{order_id}/confirm",
@@ -594,7 +606,7 @@ def test_confirm_partner_order_gone_410_for_terminal_status(
         json={"confirmed_by": "partner-user-gone", "client_event_id": "evt-confirm-gone"},
     )
     assert replay.status_code == 410
-    assert _json(replay) == {"detail": "order gone"}
+    assert _json(replay) == {"detail": ORDER_GONE_DETAIL}
 
 
 def test_confirm_partner_order_idempotent_replay_after_terminal_transition(
@@ -663,7 +675,7 @@ def test_confirm_partner_order_idempotency_conflict_409(
         },
     )
     assert second.status_code == 409
-    assert _json(second)["detail"] == "client_event_id conflict: confirm payload mismatch"
+    assert _json(second)["detail"] == CONFIRM_ORDER_CONFLICT_DETAIL
 
 
 def test_create_partner_order_sanitizes_unexpected_conflict_detail(
@@ -689,7 +701,7 @@ def test_create_partner_order_sanitizes_unexpected_conflict_detail(
         )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == "client_event_id conflict: payload mismatch"
+    assert exc_info.value.detail == CREATE_ORDER_CONFLICT_DETAIL
 
 
 def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
@@ -716,7 +728,7 @@ def test_get_handoff_share_status_sanitizes_unexpected_forbidden_detail(
         )
 
     assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "share access forbidden"
+    assert exc_info.value.detail == SHARE_ACCESS_FORBIDDEN_DETAIL
 
 
 def test_preview_partner_order_invalid_currency_422(
@@ -911,7 +923,7 @@ def test_issue_handoff_share_forbidden_for_other_issuer_403(
         },
     )
     assert issue.status_code == 403
-    assert _json(issue) == {"detail": "share access forbidden"}
+    assert _json(issue) == {"detail": SHARE_ACCESS_FORBIDDEN_DETAIL}
 
 
 def test_get_handoff_share_status_revoked_403(
@@ -946,7 +958,7 @@ def test_get_handoff_share_status_revoked_403(
         headers=pro_headers,
     )
     assert status_resp.status_code == 403
-    assert _json(status_resp) == {"detail": "share revoked"}
+    assert _json(status_resp) == {"detail": SHARE_REVOKED_DETAIL}
 
 
 def test_get_handoff_share_status_active_200(
@@ -1040,7 +1052,7 @@ def test_get_handoff_share_status_forbidden_for_other_issuer_403(
         headers=vip_headers,
     )
     assert status_resp.status_code == 403
-    assert _json(status_resp) == {"detail": "share access forbidden"}
+    assert _json(status_resp) == {"detail": SHARE_ACCESS_FORBIDDEN_DETAIL}
 
 
 def test_revoke_handoff_share_forbidden_for_other_issuer_403(
@@ -1072,7 +1084,7 @@ def test_revoke_handoff_share_forbidden_for_other_issuer_403(
         headers=vip_headers,
     )
     assert revoke.status_code == 403
-    assert _json(revoke) == {"detail": "share access forbidden"}
+    assert _json(revoke) == {"detail": SHARE_ACCESS_FORBIDDEN_DETAIL}
 
 
 def test_revoke_handoff_share_not_found_404(
@@ -1121,7 +1133,7 @@ def test_get_handoff_share_status_expired_410(
         headers=pro_headers,
     )
     assert status_resp.status_code == 410
-    assert _json(status_resp) == {"detail": "share expired"}
+    assert _json(status_resp) == {"detail": SHARE_EXPIRED_DETAIL}
 
     # RU: W3-R3 — семантика Gone должна быть стабильна при повторе запроса.
     # EN: W3-R3 — Gone semantics must stay stable on replay.
@@ -1130,7 +1142,7 @@ def test_get_handoff_share_status_expired_410(
         headers=pro_headers,
     )
     assert replay_resp.status_code == 410
-    assert _json(replay_resp) == {"detail": "share expired"}
+    assert _json(replay_resp) == {"detail": SHARE_EXPIRED_DETAIL}
 
 
 def test_get_handoff_share_status_not_found_404(
@@ -1172,7 +1184,7 @@ def test_issue_handoff_share_requires_partner_consent_403(
         },
     )
     assert issue.status_code == 403
-    assert _json(issue) == {"detail": "partner consent required"}
+    assert _json(issue) == {"detail": PARTNER_CONSENT_REQUIRED_DETAIL}
 
 
 def test_issue_handoff_share_service_ttl_guard_value_error(

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -7,6 +7,10 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
+from app.http_error_details import (
+    INVALID_SUBMISSION_DETAIL,
+    INVALID_SUBMISSION_TRANSITION_DETAIL,
+)
 from app.routers import restaurants
 from app.schemas.restaurants import (
     RestaurantSubmissionCreate,
@@ -197,7 +201,7 @@ def test_create_submission_validation_error_maps_422() -> None:
     with pytest.raises(HTTPException) as exc:
         restaurants.create_restaurant_submission(payload, store=store)
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Invalid submission"
+    assert exc.value.detail == INVALID_SUBMISSION_DETAIL
 
 
 def test_create_submission_validation_error_sanitizes_unexpected_detail() -> None:
@@ -206,7 +210,7 @@ def test_create_submission_validation_error_sanitizes_unexpected_detail() -> Non
     with pytest.raises(HTTPException) as exc:
         restaurants.create_restaurant_submission(payload, store=store)
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Invalid submission"
+    assert exc.value.detail == INVALID_SUBMISSION_DETAIL
     assert "sqlite" not in exc.value.detail
 
 
@@ -288,7 +292,7 @@ def test_review_submission_validation_error_maps_422() -> None:
     with pytest.raises(HTTPException) as exc:
         restaurants.review_restaurant_submission("s1", payload, store=store)
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Invalid submission transition"
+    assert exc.value.detail == INVALID_SUBMISSION_TRANSITION_DETAIL
 
 
 def test_review_submission_validation_error_sanitizes_unexpected_detail() -> None:
@@ -297,7 +301,7 @@ def test_review_submission_validation_error_sanitizes_unexpected_detail() -> Non
     with pytest.raises(HTTPException) as exc:
         restaurants.review_restaurant_submission("s1", payload, store=store)
     assert exc.value.status_code == 422
-    assert exc.value.detail == "Invalid submission transition"
+    assert exc.value.detail == INVALID_SUBMISSION_TRANSITION_DETAIL
     assert "/srv/review" not in exc.value.detail
 
 

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -197,7 +197,17 @@ def test_create_submission_validation_error_maps_422() -> None:
     with pytest.raises(HTTPException) as exc:
         restaurants.create_restaurant_submission(payload, store=store)
     assert exc.value.status_code == 422
-    assert exc.value.detail == "canonical_name is required"
+    assert exc.value.detail == "Invalid submission"
+
+
+def test_create_submission_validation_error_sanitizes_unexpected_detail() -> None:
+    store = _StubStore(create_error=ValueError("sqlite:///tmp/private.db"))
+    payload = RestaurantSubmissionCreate(canonical_name="abc", payload={})
+    with pytest.raises(HTTPException) as exc:
+        restaurants.create_restaurant_submission(payload, store=store)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Invalid submission"
+    assert "sqlite" not in exc.value.detail
 
 
 def test_create_submission_success() -> None:
@@ -278,6 +288,17 @@ def test_review_submission_validation_error_maps_422() -> None:
     with pytest.raises(HTTPException) as exc:
         restaurants.review_restaurant_submission("s1", payload, store=store)
     assert exc.value.status_code == 422
+    assert exc.value.detail == "Invalid submission transition"
+
+
+def test_review_submission_validation_error_sanitizes_unexpected_detail() -> None:
+    store = _StubStore(review_error=ValueError("internal reviewer path /srv/review"))
+    payload = SubmissionReviewRequest(status=SubmissionReviewStatus.REJECTED)
+    with pytest.raises(HTTPException) as exc:
+        restaurants.review_restaurant_submission("s1", payload, store=store)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Invalid submission transition"
+    assert "/srv/review" not in exc.value.detail
 
 
 def test_review_submission_not_found_maps_404() -> None:

--- a/tests/test_subscription_activation_api.py
+++ b/tests/test_subscription_activation_api.py
@@ -208,6 +208,8 @@ def test_activate_subscription_requires_transport_auth(client: TestClient) -> No
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
+    assert payload["detail"] == "transport_auth_required"
+    assert "X-API-Key" not in payload["detail"]
 
 
 def test_activate_subscription_blank_transport_header_returns_401(client: TestClient) -> None:
@@ -220,6 +222,8 @@ def test_activate_subscription_blank_transport_header_returns_401(client: TestCl
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
+    assert payload["detail"] == "transport_auth_required"
+    assert "blank" not in payload["detail"].lower()
 
 
 def test_ios_verified_happy_path_persists_subscription(
@@ -615,6 +619,8 @@ def test_manual_source_conflict_returns_409(
     payload = _json(conflict)
     assert payload["status"] == "error"
     assert payload["code"] == "idempotency_conflict"
+    assert payload["detail"] == "deterministic_activation_conflict"
+    assert "deterministic activation key conflict" not in payload["detail"]
 
 
 def test_activate_subscription_malformed_body_returns_422(
@@ -692,6 +698,8 @@ def test_get_activation_wrong_user_returns_403(
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "forbidden"
+    assert payload["detail"] == "activation_access_forbidden"
+    assert "activation access forbidden" not in payload["detail"]
 
 
 def test_get_activation_missing_transport_protection_returns_401(
@@ -711,6 +719,7 @@ def test_get_activation_missing_transport_protection_returns_401(
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
+    assert payload["detail"] == "transport_auth_required"
 
 
 def test_get_activation_not_found_returns_404(

--- a/tests/test_subscription_activation_api.py
+++ b/tests/test_subscription_activation_api.py
@@ -12,6 +12,11 @@ import pytest
 from sqlalchemy import create_engine, inspect, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
+from app.http_error_details import (
+    ACTIVATION_ACCESS_FORBIDDEN_DETAIL,
+    DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL,
+    TRANSPORT_AUTH_REQUIRED_DETAIL,
+)
 from app.models import Subscription, SubscriptionActivationAudit
 from app.schemas.payments import (
     ActivateSubscriptionRequest,
@@ -208,7 +213,7 @@ def test_activate_subscription_requires_transport_auth(client: TestClient) -> No
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
-    assert payload["detail"] == "transport_auth_required"
+    assert payload["detail"] == TRANSPORT_AUTH_REQUIRED_DETAIL
     assert "X-API-Key" not in payload["detail"]
 
 
@@ -222,7 +227,7 @@ def test_activate_subscription_blank_transport_header_returns_401(client: TestCl
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
-    assert payload["detail"] == "transport_auth_required"
+    assert payload["detail"] == TRANSPORT_AUTH_REQUIRED_DETAIL
     assert "blank" not in payload["detail"].lower()
 
 
@@ -619,7 +624,7 @@ def test_manual_source_conflict_returns_409(
     payload = _json(conflict)
     assert payload["status"] == "error"
     assert payload["code"] == "idempotency_conflict"
-    assert payload["detail"] == "deterministic_activation_conflict"
+    assert payload["detail"] == DETERMINISTIC_ACTIVATION_CONFLICT_DETAIL
     assert "deterministic activation key conflict" not in payload["detail"]
 
 
@@ -698,7 +703,7 @@ def test_get_activation_wrong_user_returns_403(
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "forbidden"
-    assert payload["detail"] == "activation_access_forbidden"
+    assert payload["detail"] == ACTIVATION_ACCESS_FORBIDDEN_DETAIL
     assert "activation access forbidden" not in payload["detail"]
 
 
@@ -719,7 +724,7 @@ def test_get_activation_missing_transport_protection_returns_401(
     payload = _json(response)
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
-    assert payload["detail"] == "transport_auth_required"
+    assert payload["detail"] == TRANSPORT_AUTH_REQUIRED_DETAIL
 
 
 def test_get_activation_not_found_returns_404(

--- a/tests/test_subscription_activation_api.py
+++ b/tests/test_subscription_activation_api.py
@@ -725,6 +725,9 @@ def test_get_activation_missing_transport_protection_returns_401(
     assert payload["status"] == "error"
     assert payload["code"] == "activation_transport_unauthorized"
     assert payload["detail"] == TRANSPORT_AUTH_REQUIRED_DETAIL
+    assert "unauthorized" not in payload["detail"].lower()
+    assert "x-api-key" not in payload["detail"].lower()
+    assert "internal" not in payload["detail"].lower()
 
 
 def test_get_activation_not_found_returns_404(


### PR DESCRIPTION
## Summary
- Sanitizes client-facing runtime error details across live HTTP surfaces without changing status codes or response models.
- Keeps full exception context server-side while returning stable safe `detail` values to clients.
- Includes the required pre-commit baseline refresh in a separate commit and a follow-up typing fix needed by the real pre-push mypy gate.

## Scope
- `app/routers/pro_restaurant_partner.py`
- `app/routers/pro_payments.py`
- `app/routers/restaurants.py`
- `app/routers/foods.py`
- `app/routers/bmi_pro.py`
- `legacy_app.py`
- focused regression tests for the touched HTTP surfaces

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files`
- `make lint`
- `make typecheck`
- `make test-fast`
- `pytest -q tests/test_repo_policy_guards.py`
- `make diff-cov`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Local hard gate passed (`make verify` equivalent via canonical split gates: lint + typecheck + test-fast + diff-cov)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed

## Summary by Sourcery

Санитизировать детали ошибок выполнения, отображаемых клиенту, во множественных HTTP API, при этом сохранив коды статусов и структуру ответов.

Bug Fixes:
- Предотвратить утечку внутренних путей к файлам и чувствительных деталей реализации в ответах с ошибками от эндпоинтов pro restaurant partner, payments, restaurants, foods, BMI Pro и premium plate.

Enhancements:
- Ввести стабильные, константные строки описания ошибок для распространённых случаев отказов в partner orders, handoff sharing, restaurant submissions, barcode lookup, subscription activation, BMI Pro и premium plate generation.
- Ужесточить уровни совместимости типов в роутерах restaurants и foods, чтобы удовлетворить более строгие проверки mypy.

Tests:
- Расширить и скорректировать API‑тесты, чтобы проверять санитизированные значения деталей ошибок и гарантировать, что «сырые» сообщения исключений больше не появляются в HTTP‑ответах.

Chores:
- Обновить конфигурацию для baseline секретов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize client-facing runtime error details across multiple HTTP APIs while preserving status codes and response shapes.

Bug Fixes:
- Prevent leakage of internal file paths and sensitive implementation details in error responses from pro restaurant partner, payments, restaurants, foods, BMI Pro, and premium plate endpoints.

Enhancements:
- Introduce stable, constant error detail strings for common failure cases in partner orders, handoff sharing, restaurant submissions, barcode lookup, subscription activation, BMI Pro, and premium plate generation.
- Tighten typing compatibility layers in restaurants and foods routers to satisfy stricter mypy checks.

Tests:
- Extend and adjust API tests to assert sanitized error detail values and ensure raw exception messages no longer appear in HTTP responses.

Chores:
- Refresh the secrets baseline configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and standardized client-facing error messages across many endpoints to prevent leaking internal details and ensure consistent, user-friendly error payloads.

* **Tests**
  * Added and updated tests to assert JSON error details, validate sanitized messages, and confirm sensitive internal values are not exposed.

* **Documentation**
  * Added a PR review checklist documenting verification steps for these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->