### PR TITLE
fix(security): harden MCP and business auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -733,15 +733,6 @@
         "line_number": 289
       }
     ],
-    "tests/test_business_router_coverage.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_business_router_coverage.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
     "tests/test_comprehensive_bayesian_analyzer.py": [
       {
         "type": "Secret Keyword",

--- a/app/routers/api_key.py
+++ b/app/routers/api_key.py
@@ -1,4 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import Depends, HTTPException, status
 from fastapi.security import APIKeyHeader
+
+from core.utils import resolve_attr
 
 # Shared API key header for all routers
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+logger = logging.getLogger(__name__)
+
+
+def require_app_api_key(api_key: str = Depends(api_key_header)) -> str:
+    """Validate app-level API key access for protected routes."""
+
+    app_get_api_key = resolve_attr("get_api_key", None)
+    if not callable(app_get_api_key):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        )
+    try:
+        result = app_get_api_key(api_key)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception("App API key validation failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        ) from exc
+    if not isinstance(result, str):
+        logger.error("App API key guard returned non-string result")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation unavailable",
+        )
+    return result

--- a/app/routers/api_key.py
+++ b/app/routers/api_key.py
@@ -13,8 +13,14 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 logger = logging.getLogger(__name__)
 
 
-def require_app_api_key(api_key: str = Depends(api_key_header)) -> str:
+def require_app_api_key(api_key: str | None = Depends(api_key_header)) -> str:
     """Validate app-level API key access for protected routes."""
+
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Missing API Key",
+        )
 
     app_get_api_key = resolve_attr("get_api_key", None)
     if not callable(app_get_api_key):

--- a/app/routers/api_key.py
+++ b/app/routers/api_key.py
@@ -18,6 +18,10 @@ def require_app_api_key(api_key: str = Depends(api_key_header)) -> str:
 
     app_get_api_key = resolve_attr("get_api_key", None)
     if not callable(app_get_api_key):
+        logger.error(
+            "App API key validation unavailable: 'get_api_key' could not be resolved "
+            "to a callable (check settings / environment configuration)"
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key validation unavailable",

--- a/app/routers/business.py
+++ b/app/routers/business.py
@@ -83,7 +83,8 @@ def _localized_error(locale: Optional[str], key: str) -> str:
         Localized error message
     """
     lang = normalize_lang(locale)
-    return t(lang, key)
+    message: str = t(lang, key)
+    return message
 
 
 @router.post("/analyze", response_model=list[BusinessAnalysisResponse])

--- a/app/routers/business.py
+++ b/app/routers/business.py
@@ -7,7 +7,7 @@ from anyio import to_thread
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from app.routers.api_key import api_key_header
+from app.routers.api_key import require_app_api_key
 from core.business_bayesian_analyzer import BusinessBayesianAnalyzer
 from core.i18n import normalize_lang, t
 
@@ -89,7 +89,7 @@ def _localized_error(locale: Optional[str], key: str) -> str:
 @router.post("/analyze", response_model=list[BusinessAnalysisResponse])
 async def analyze_business_code(
     request: BusinessAnalysisRequest,
-    _api_key: str = Depends(api_key_header),
+    _api_key: str = Depends(require_app_api_key),
 ) -> list[BusinessAnalysisResponse]:
     """
     Analyze code from a business perspective.

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -25,7 +25,6 @@ T = TypeVar("T")
 
 def _require_users_api_key(api_key: str = Depends(api_key_header)) -> str:
     """Validate app-level API key access for the users CRUD surface."""
-
     app_get_api_key = resolve_attr("get_api_key", None)
     if not callable(app_get_api_key):
         raise HTTPException(

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1164 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- Local gates passed before PR open:
+  - `pre-commit run --all-files`
+  - `make lint`
+  - `make typecheck`
+  - `make test-fast`
+  - `.venv/bin/coverage erase && .venv/bin/coverage run -m pytest -q && .venv/bin/coverage xml -o coverage_verify.xml && .venv/bin/diff-cover coverage_verify.xml --compare-branch=origin/main --fail-under=97`

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -30,7 +30,7 @@ Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:8`, `docs/review/PR_1164_FIXED_M
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948328323
 
 ## Merge Readiness
-- [ ] Local gates passed on current head
+- [x] Local gates passed on current head
 - [ ] All required checks green
 - [ ] No unresolved review threads remain
 - [ ] CodeRabbit PASS / no-actionables

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -2,7 +2,7 @@
 
 ## Discussion Thread Pass
 - [x] Initial PR body aligned to project canon
-- [ ] Discussion-thread pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -2,7 +2,7 @@
 
 ## Discussion Thread Pass
 - [x] Initial PR body aligned to project canon
-- [x] Discussion-thread pass completed
+- [ ] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
@@ -29,10 +29,25 @@ Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:8`, `docs/review/PR_1164_FIXED_M
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948326367
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948328323
 
+Disposition: FIXED
+Commit: 7bbc8a6b
+Evidence: `app/routers/api_key.py:16`, `app/routers/api_key.py:19`, `tests/test_business_router.py:153`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901526 -> 7bbc8a6b
+
+Disposition: FIXED
+Commit: <pending-docs-commit>
+Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:33`, `docs/review/PR_1164_FIXED_MAPPING.md:35`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901527 -> <pending-docs-commit>
+
+Disposition: NOT-A-BUG
+Reason: This review-level CodeRabbit summary only aggregates the two inline findings above and does not introduce a separate actionable beyond those mapped threads.
+Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:25`, `docs/review/PR_1164_FIXED_MAPPING.md:31`, `docs/review/PR_1164_FIXED_MAPPING.md:35`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948385258
+
 ## Merge Readiness
-- [x] Local gates passed on current head
+- [ ] Local gates passed on current head
 - [ ] All required checks green
-- [x] No unresolved review threads remain
+- [ ] No unresolved review threads remain
 - [ ] CodeRabbit PASS / no-actionables
 - [ ] Sourcery PASS / no-actionables
 - [ ] Cubic PASS / no-actionables

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -35,9 +35,9 @@ Evidence: `app/routers/api_key.py:16`, `app/routers/api_key.py:19`, `tests/test_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901526 -> 7bbc8a6b
 
 Disposition: FIXED
-Commit: <pending-docs-commit>
-Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:33`, `docs/review/PR_1164_FIXED_MAPPING.md:35`
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901527 -> <pending-docs-commit>
+Commit: f9bcb72a
+Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:47`, `docs/review/PR_1164_FIXED_MAPPING.md:50`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901527 -> f9bcb72a
 
 Disposition: NOT-A-BUG
 Reason: This review-level CodeRabbit summary only aggregates the two inline findings above and does not introduce a separate actionable beyond those mapped threads.

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -1,16 +1,46 @@
 # PR 1164 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass completed
+- [x] Initial PR body aligned to project canon
+- [ ] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-## Fixed in Commit Mapping
-- No actionable review comments
+### Fixed in Commit Mapping
+Disposition: FIXED
+Commit: be6d29a5
+Evidence: `app/routers/api_key.py:19`, `app/routers/api_key.py:21`, `tests/test_business_router.py:142`, `tests/test_business_router_coverage.py:79`, `tests/test_business_router_coverage.py:87`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934851690 -> be6d29a5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934854342 -> be6d29a5
+
+Disposition: FIXED
+Commit: be6d29a5
+Evidence: `tests/test_business_router.py:93`, `tests/test_business_router.py:97`, `tests/test_business_router_coverage.py:87`, `tests/test_business_router_coverage.py:201`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934856658 -> be6d29a5
+
+Disposition: NOT-A-BUG
+Reason: This PR centralizes app-level API key validation in `app/routers/api_key.py` and reuses that helper from the business router. The remaining duplication concern in other legacy routers predates this lane and was not introduced by the current diff.
+Evidence: `app/routers/api_key.py:16`, `app/routers/business.py:10`, `app/routers/business.py:93`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934854343
+
+Disposition: NOT-A-BUG
+Reason: These review-level bot comments are aggregate summaries of inline findings that are already dispositioned above and do not add separate unfixed obligations.
+Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:8`, `docs/review/PR_1164_FIXED_MAPPING.md:13`, `docs/review/PR_1164_FIXED_MAPPING.md:18`, `docs/review/PR_1164_FIXED_MAPPING.md:23`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948322337
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948326367
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948328323
 
 ## Merge Readiness
-- Local gates passed before PR open:
-  - `pre-commit run --all-files`
-  - `make lint`
-  - `make typecheck`
-  - `make test-fast`
-  - `.venv/bin/coverage erase && .venv/bin/coverage run -m pytest -q && .venv/bin/coverage xml -o coverage_verify.xml && .venv/bin/diff-cover coverage_verify.xml --compare-branch=origin/main --fail-under=97`
+- [ ] Local gates passed on current head
+- [ ] All required checks green
+- [ ] No unresolved review threads remain
+- [ ] CodeRabbit PASS / no-actionables
+- [ ] Sourcery PASS / no-actionables
+- [ ] Cubic PASS / no-actionables
+- [ ] Wait-window after latest bot/review activity observed
+
+Local gate baseline before current discussion-thread pass:
+- `pre-commit run --all-files`
+- `make lint`
+- `make typecheck`
+- `make test-fast`
+- `.venv/bin/coverage erase && .venv/bin/coverage run -m pytest -q && .venv/bin/coverage xml -o coverage_verify.xml && .venv/bin/diff-cover coverage_verify.xml --compare-branch=origin/main --fail-under=97`

--- a/docs/review/PR_1164_FIXED_MAPPING.md
+++ b/docs/review/PR_1164_FIXED_MAPPING.md
@@ -2,7 +2,7 @@
 
 ## Discussion Thread Pass
 - [x] Initial PR body aligned to project canon
-- [ ] Discussion-thread pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
@@ -32,7 +32,7 @@ Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:8`, `docs/review/PR_1164_FIXED_M
 ## Merge Readiness
 - [x] Local gates passed on current head
 - [ ] All required checks green
-- [ ] No unresolved review threads remain
+- [x] No unresolved review threads remain
 - [ ] CodeRabbit PASS / no-actionables
 - [ ] Sourcery PASS / no-actionables
 - [ ] Cubic PASS / no-actionables

--- a/mcp_pulseplate_server.py
+++ b/mcp_pulseplate_server.py
@@ -24,6 +24,9 @@ DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 
 JsonRpcId = int | str | None
 _SAFE_CODE_LANGUAGE_RE = re.compile(r"^[a-z0-9][a-z0-9+_.-]{0,29}$")
+ERROR_INTERNAL = "internal_error"
+ERROR_PARSE = "parse_error"
+ERROR_TOOL_EXECUTION_FAILED = "tool_execution_failed"
 
 
 @dataclass(frozen=True)
@@ -91,6 +94,12 @@ class PulsePlateMCPServer:
 
     # Alias static whitelist used by older code/tests to the fallback list.
     ALLOWED_MODELS = FALLBACK_ALLOWED_MODELS
+
+    @staticmethod
+    def _safe_tool_error(error_code: str = ERROR_TOOL_EXECUTION_FAILED) -> Dict[str, str]:
+        """Return a stable client-safe tool error payload."""
+
+        return {"error": error_code}
 
     @classmethod
     def _fetch_available_models(cls) -> set[str]:
@@ -284,8 +293,9 @@ class PulsePlateMCPServer:
                 return await self._call_tool(params)
             return RpcError(code=-32601, message="Method not found", data={"method": method})
 
-        except Exception as e:
-            return RpcError(code=-32603, message="Internal error", data={"error": str(e)})
+        except Exception:
+            logger.exception("Unhandled MCP request failure")
+            return RpcError(code=-32603, message="Internal error", data={"error": ERROR_INTERNAL})
 
     async def _list_tools(self) -> Dict[str, Any]:
         """List available tools"""
@@ -548,8 +558,9 @@ Please provide a helpful response considering the PulsePlate project context.
 
             return {"content": [{"type": "text", "text": response.choices[0].message.content}]}
 
-        except Exception as e:
-            return {"error": f"ChatGPT query failed: {str(e)}"}
+        except Exception:
+            logger.exception("MCP chatgpt_query execution failed")
+            return self._safe_tool_error()
 
     async def _code_review(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Review code with ChatGPT"""
@@ -590,8 +601,9 @@ Please provide a helpful response considering the PulsePlate project context.
 
             return {"content": [{"type": "text", "text": response.choices[0].message.content}]}
 
-        except Exception as e:
-            return {"error": f"Code review failed: {str(e)}"}
+        except Exception:
+            logger.exception("MCP code_review execution failed")
+            return self._safe_tool_error()
 
     async def _generate_code(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Generate code with ChatGPT"""
@@ -634,8 +646,9 @@ Requirements:
 
             return {"content": [{"type": "text", "text": response.choices[0].message.content}]}
 
-        except Exception as e:
-            return {"error": f"Code generation failed: {str(e)}"}
+        except Exception:
+            logger.exception("MCP generate_code execution failed")
+            return self._safe_tool_error()
 
 
 async def main() -> None:
@@ -650,7 +663,8 @@ async def main() -> None:
 
         try:
             request = json.loads(line)
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
+            logger.exception("Invalid JSON-RPC payload")
             print(
                 json.dumps(
                     {
@@ -659,7 +673,7 @@ async def main() -> None:
                         "error": {
                             "code": -32700,
                             "message": "Parse error",
-                            "data": {"error": str(e)},
+                            "data": {"error": ERROR_PARSE},
                         },
                     }
                 )
@@ -733,7 +747,7 @@ async def main() -> None:
             print(json.dumps(response))
             sys.stdout.flush()
 
-        except Exception as e:
+        except Exception:
             logger.exception("Internal JSON-RPC error")
             safe_id = (
                 request_id if isinstance(request_id, (int, str)) or request_id is None else None
@@ -746,7 +760,7 @@ async def main() -> None:
                         "error": {
                             "code": -32603,
                             "message": "Internal error",
-                            "data": {"error": str(e)},
+                            "data": {"error": ERROR_INTERNAL},
                         },
                     }
                 )

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 
@@ -49,9 +49,18 @@ class TestBusinessRouterIsolated:
 
     def _auth_ok(self) -> None:
         """Override API key dependency to bypass real auth checks."""
-        from app.routers.api_key import api_key_header
+        from app.routers.api_key import require_app_api_key
 
-        self.app.dependency_overrides[api_key_header] = lambda: "test-api-key"
+        self.app.dependency_overrides[require_app_api_key] = lambda: "test_key"
+
+    def _auth_forbidden(self, detail: str = "Invalid API Key") -> None:
+        """Override API key dependency to enforce fail-closed auth in isolated tests."""
+        from app.routers.api_key import require_app_api_key
+
+        def _raise_forbidden() -> str:
+            raise HTTPException(status_code=403, detail=detail)
+
+        self.app.dependency_overrides[require_app_api_key] = _raise_forbidden
 
     def test_status_enabled_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
@@ -73,6 +82,101 @@ class TestBusinessRouterIsolated:
 
         resp = self.client.post("/api/v1/business/analyze", json={"test_name": "t1"})
         assert resp.status_code == 422
+
+    def test_analyze_403_when_api_key_guard_rejects(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._auth_forbidden()
+        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+
+        resp = self.client.post(
+            "/api/v1/business/analyze",
+            json={"code": "print('x')", "test_name": "t1"},
+        )
+        assert resp.status_code == 403
+        assert resp.json() == {"detail": "Invalid API Key"}
+
+    def test_require_app_api_key_accepts_valid_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        def _resolve_attr(name: str, default: object) -> object:
+            if name == "get_api_key":
+                return lambda api_key: api_key.strip()
+            return default
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
+
+        assert api_key_mod.require_app_api_key(" expected-key ") == "expected-key"
+
+    def test_require_app_api_key_rejects_invalid_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.routers import api_key as api_key_mod
+
+        def _raise_invalid(_api_key: str) -> str:
+            raise HTTPException(status_code=403, detail="Invalid API Key")
+
+        def _resolve_attr(name: str, default: object) -> object:
+            if name == "get_api_key":
+                return _raise_invalid
+            return default
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.require_app_api_key("wrong-key")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Invalid API Key"
+
+    def test_require_app_api_key_rejects_missing_validator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", lambda _name, default: default)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.require_app_api_key("test-key")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "API key validation unavailable"
+
+    def test_require_app_api_key_rejects_non_string_result(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        def _resolve_attr(name: str, default: object) -> object:
+            if name == "get_api_key":
+                return lambda _api_key: object()
+            return default
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.require_app_api_key("test-key")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "API key validation unavailable"
+        assert "App API key guard returned non-string result" in caplog.text
+
+    def test_require_app_api_key_rejects_missing_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.routers import api_key as api_key_mod
+
+        def _raise_missing(_api_key: str) -> str:
+            raise HTTPException(status_code=403, detail="Missing API Key")
+
+        def _resolve_attr(name: str, default: object) -> object:
+            if name == "get_api_key":
+                return _raise_missing
+            return default
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.require_app_api_key("")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Missing API Key"
 
     def test_analyze_503_when_module_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -51,7 +51,10 @@ class TestBusinessRouterIsolated:
         """Override API key dependency to bypass real auth checks."""
         from app.routers.api_key import require_app_api_key
 
-        self.app.dependency_overrides[require_app_api_key] = lambda: "test_key"
+        def _return_test_key() -> str:
+            return "test_key"
+
+        self.app.dependency_overrides[require_app_api_key] = _return_test_key
 
     def _auth_forbidden(self, detail: str = "Invalid API Key") -> None:
         """Override API key dependency to enforce fail-closed auth in isolated tests."""
@@ -92,6 +95,7 @@ class TestBusinessRouterIsolated:
             json={"code": "print('x')", "test_name": "t1"},
         )
         assert resp.status_code == 403
+        assert resp.headers.get("content-type", "").startswith("application/json")
         assert resp.json() == {"detail": "Invalid API Key"}
 
     def test_require_app_api_key_accepts_valid_result(
@@ -99,9 +103,12 @@ class TestBusinessRouterIsolated:
     ) -> None:
         from app.routers import api_key as api_key_mod
 
+        def _strip_key(api_key: str) -> str:
+            return api_key.strip()
+
         def _resolve_attr(name: str, default: object) -> object:
             if name == "get_api_key":
-                return lambda api_key: api_key.strip()
+                return _strip_key
             return default
 
         monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
@@ -132,7 +139,10 @@ class TestBusinessRouterIsolated:
     ) -> None:
         from app.routers import api_key as api_key_mod
 
-        monkeypatch.setattr(api_key_mod, "resolve_attr", lambda _name, default: default)
+        def _resolve_attr_passthrough(_name: str, default: object) -> object:
+            return default
+
+        monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr_passthrough)
 
         with pytest.raises(HTTPException) as exc_info:
             api_key_mod.require_app_api_key("test-key")
@@ -145,9 +155,12 @@ class TestBusinessRouterIsolated:
     ) -> None:
         from app.routers import api_key as api_key_mod
 
+        def _non_string_guard_result(_api_key: str) -> object:
+            return object()
+
         def _resolve_attr(name: str, default: object) -> object:
             if name == "get_api_key":
-                return lambda _api_key: object()
+                return _non_string_guard_result
             return default
 
         monkeypatch.setattr(api_key_mod, "resolve_attr", _resolve_attr)
@@ -181,10 +194,14 @@ class TestBusinessRouterIsolated:
     def test_analyze_503_when_module_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
         monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", False)
+
+        def _business_module_disabled(_locale: object, _key: object) -> str:
+            return "business_module_disabled"
+
         monkeypatch.setattr(
             self.mod,
             "_localized_error",
-            lambda _locale, _key: "business_module_disabled",
+            _business_module_disabled,
         )
 
         resp = self.client.post(
@@ -197,10 +214,14 @@ class TestBusinessRouterIsolated:
     def test_analyze_413_payload_too_large(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
         monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+
+        def _payload_too_large(_locale: object, _key: object) -> str:
+            return "business_payload_too_large"
+
         monkeypatch.setattr(
             self.mod,
             "_localized_error",
-            lambda _locale, _key: "business_payload_too_large",
+            _payload_too_large,
         )
 
         big_code = "a" * 100_001

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -150,6 +150,15 @@ class TestBusinessRouterIsolated:
         assert exc_info.value.status_code == 500
         assert exc_info.value.detail == "API key validation unavailable"
 
+    def test_require_app_api_key_rejects_none_key(self) -> None:
+        from app.routers import api_key as api_key_mod
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.require_app_api_key(None)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Missing API Key"
+
     def test_require_app_api_key_rejects_non_string_result(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_business_router_coverage.py
+++ b/tests/test_business_router_coverage.py
@@ -8,9 +8,11 @@ Tests verify:
 - HTTPException pass-through
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
 
 from tests._helpers.api_headers import API_KEY_HEADERS
 
@@ -48,7 +50,7 @@ class TestBusinessAnalysisEndpoint:
                     "test_name": "revenue_analysis",
                     "locale": "en",
                 },
-                headers={"X-API-Key": "test_key"},
+                headers=API_KEY_HEADERS,
             )
 
             assert response.status_code == 200
@@ -74,14 +76,16 @@ class TestBusinessAnalysisEndpoint:
 
         main_app.dependency_overrides[require_app_api_key] = _reject_missing
         try:
-            response = test_client.post(
-                "/api/v1/business/analyze",
-                json={"code": "def test(): pass", "test_name": "missing_key"},
-            )
+            with TestClient(main_app) as isolated_client:
+                response = isolated_client.post(
+                    "/api/v1/business/analyze",
+                    json={"code": "def test(): pass", "test_name": "missing_key"},
+                )
         finally:
             main_app.dependency_overrides.pop(require_app_api_key, None)
 
         assert response.status_code == 403
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json() == {"detail": "Missing API Key"}
 
     def test_business_module_disabled_returns_503(self, test_client, monkeypatch) -> None:
@@ -91,7 +95,7 @@ class TestBusinessAnalysisEndpoint:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def test(): pass", "test_name": "test"},
-            headers={"X-API-Key": "test_key"},
+            headers=API_KEY_HEADERS,
         )
 
         assert response.status_code == 503
@@ -107,7 +111,7 @@ class TestBusinessAnalysisEndpoint:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": oversized_code, "test_name": "dos_test"},
-            headers={"X-API-Key": "test_key"},
+            headers=API_KEY_HEADERS,
         )
 
         # Manual payload check returns 413 (Content Too Large)
@@ -167,7 +171,7 @@ def test_exactly_100kb_payload_accepted(test_client, monkeypatch) -> None:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": max_allowed_code, "test_name": "edge_case"},
-            headers={"X-API-Key": "test_key"},
+            headers=API_KEY_HEADERS,
         )
 
         # Should succeed
@@ -186,14 +190,16 @@ def test_business_analysis_invalid_api_key_rejected(test_client, monkeypatch) ->
 
     main_app.dependency_overrides[require_app_api_key] = _reject_invalid
     try:
-        response = test_client.post(
-            "/api/v1/business/analyze",
-            json={"code": "def test(): pass", "test_name": "auth_fail"},
-        )
+        with TestClient(main_app) as isolated_client:
+            response = isolated_client.post(
+                "/api/v1/business/analyze",
+                json={"code": "def test(): pass", "test_name": "auth_fail"},
+            )
     finally:
         main_app.dependency_overrides.pop(require_app_api_key, None)
 
     assert response.status_code == 403
+    assert response.headers.get("content-type", "").startswith("application/json")
     assert "invalid api key" in response.json()["detail"].lower()
 
 
@@ -213,7 +219,7 @@ def test_analyzer_exception_wrapped_as_500(test_client, monkeypatch, caplog) -> 
             response = test_client.post(
                 "/api/v1/business/analyze",
                 json={"code": "def crash(): raise Exception()", "test_name": "crash_test"},
-                headers={"X-API-Key": "test_key"},
+                headers=API_KEY_HEADERS,
             )
 
         assert response.status_code == 500
@@ -237,7 +243,7 @@ def test_http_exception_passed_through_unchanged(test_client, monkeypatch) -> No
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def test(): pass", "test_name": "auth_test"},
-            headers={"X-API-Key": "test_key"},
+            headers=API_KEY_HEADERS,
         )
 
         # Should preserve original HTTPException

--- a/tests/test_business_router_coverage.py
+++ b/tests/test_business_router_coverage.py
@@ -12,6 +12,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 from fastapi import HTTPException, status
 
+from tests._helpers.api_headers import API_KEY_HEADERS
+
 
 class TestBusinessAnalysisEndpoint:
     """Test business analysis endpoint with real logic verification."""
@@ -46,7 +48,7 @@ class TestBusinessAnalysisEndpoint:
                     "test_name": "revenue_analysis",
                     "locale": "en",
                 },
-                headers={"X-API-Key": "test-api-key"},
+                headers={"X-API-Key": "test_key"},
             )
 
             assert response.status_code == 200
@@ -62,6 +64,26 @@ class TestBusinessAnalysisEndpoint:
             MockAnalyzer.assert_called_once_with(locale="en")
             mock_instance.analyze.assert_called_once()
 
+    def test_business_analysis_rejects_missing_api_key(self, test_client) -> None:
+        """Missing API key must fail closed through the app-level guard."""
+        from app.main import app as main_app
+        from app.routers.api_key import require_app_api_key
+
+        def _reject_missing() -> str:
+            raise HTTPException(status_code=403, detail="Missing API Key")
+
+        main_app.dependency_overrides[require_app_api_key] = _reject_missing
+        try:
+            response = test_client.post(
+                "/api/v1/business/analyze",
+                json={"code": "def test(): pass", "test_name": "missing_key"},
+            )
+        finally:
+            main_app.dependency_overrides.pop(require_app_api_key, None)
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Missing API Key"}
+
     def test_business_module_disabled_returns_503(self, test_client, monkeypatch) -> None:
         """When module disabled, should return 503 before attempting analysis."""
         monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", False)
@@ -69,7 +91,7 @@ class TestBusinessAnalysisEndpoint:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def test(): pass", "test_name": "test"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         assert response.status_code == 503
@@ -85,7 +107,7 @@ class TestBusinessAnalysisEndpoint:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": oversized_code, "test_name": "dos_test"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         # Manual payload check returns 413 (Content Too Large)
@@ -112,7 +134,10 @@ async def test_analyze_business_code_oversized_payload_internal(
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await analyze_business_code(request, _api_key="test-key")
+        await analyze_business_code(
+            request,
+            _api_key=API_KEY_HEADERS["X-API-Key"],
+        )
 
     assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
     assert "too large" in str(exc_info.value.detail).lower()
@@ -142,11 +167,34 @@ def test_exactly_100kb_payload_accepted(test_client, monkeypatch) -> None:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": max_allowed_code, "test_name": "edge_case"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         # Should succeed
         assert response.status_code == 200
+
+
+def test_business_analysis_invalid_api_key_rejected(test_client, monkeypatch) -> None:
+    """Business analysis must fail closed on invalid API keys."""
+    from app.main import app as main_app
+    from app.routers.api_key import require_app_api_key
+
+    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+
+    def _reject_invalid() -> str:
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+
+    main_app.dependency_overrides[require_app_api_key] = _reject_invalid
+    try:
+        response = test_client.post(
+            "/api/v1/business/analyze",
+            json={"code": "def test(): pass", "test_name": "auth_fail"},
+        )
+    finally:
+        main_app.dependency_overrides.pop(require_app_api_key, None)
+
+    assert response.status_code == 403
+    assert "invalid api key" in response.json()["detail"].lower()
 
 
 def test_analyzer_exception_wrapped_as_500(test_client, monkeypatch, caplog) -> None:
@@ -165,7 +213,7 @@ def test_analyzer_exception_wrapped_as_500(test_client, monkeypatch, caplog) -> 
             response = test_client.post(
                 "/api/v1/business/analyze",
                 json={"code": "def crash(): raise Exception()", "test_name": "crash_test"},
-                headers={"X-API-Key": "test-key"},
+                headers={"X-API-Key": "test_key"},
             )
 
         assert response.status_code == 500
@@ -189,7 +237,7 @@ def test_http_exception_passed_through_unchanged(test_client, monkeypatch) -> No
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def test(): pass", "test_name": "auth_test"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         # Should preserve original HTTPException
@@ -240,7 +288,7 @@ def test_error_type_handling_when_analyzer_returns_error(test_client, monkeypatc
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def bad_pricing(): price = -10", "test_name": "failed_test"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         assert response.status_code == 200
@@ -287,7 +335,7 @@ def test_multiple_results_returned_as_list(test_client, monkeypatch) -> None:
         response = test_client.post(
             "/api/v1/business/analyze",
             json={"code": "def optimize(): pass", "test_name": "multi_aspect"},
-            headers={"X-API-Key": "test-key"},
+            headers={"X-API-Key": "test_key"},
         )
 
         assert response.status_code == 200
@@ -315,7 +363,7 @@ def test_log_injection_prevented_in_error_logging(test_client, monkeypatch, capl
             response = test_client.post(
                 "/api/v1/business/analyze",
                 json={"code": "def test(): pass", "test_name": malicious_test_name},
-                headers={"X-API-Key": "test-key"},
+                headers={"X-API-Key": "test_key"},
             )
 
         assert response.status_code == 500

--- a/tests/test_coverage_boost_final.py
+++ b/tests/test_coverage_boost_final.py
@@ -71,33 +71,38 @@ class TestCoverageFinalBoost:
         self, test_client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Cover business router edge cases."""
+        from app.routers.api_key import require_app_api_key
+
         monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+        test_client.app.dependency_overrides[require_app_api_key] = lambda: "test-api-key"
+        try:
+            with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
+                # Test with None error_type
+                mock_instance = MockAnalyzer.return_value
+                mock_result = MagicMock()
+                mock_result.test_name = "test"
+                mock_result.success = True
+                mock_result.business_category = MagicMock(value="optimization")
+                mock_result.error_type = None  # None case
+                mock_result.error_message = None
+                mock_result.revenue_impact = "low"
+                mock_result.cost_impact = "low"
+                mock_result.customer_impact = "neutral"
+                mock_result.optimization_potential = None
+                mock_instance.analyze.return_value = [mock_result]
 
-        with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
-            # Test with None error_type
-            mock_instance = MockAnalyzer.return_value
-            mock_result = MagicMock()
-            mock_result.test_name = "test"
-            mock_result.success = True
-            mock_result.business_category = MagicMock(value="optimization")
-            mock_result.error_type = None  # None case
-            mock_result.error_message = None
-            mock_result.revenue_impact = "low"
-            mock_result.cost_impact = "low"
-            mock_result.customer_impact = "neutral"
-            mock_result.optimization_potential = None
-            mock_instance.analyze.return_value = [mock_result]
+                response = test_client.post(
+                    "/api/v1/business/analyze",
+                    json={"code": "def test(): pass", "test_name": "test"},
+                    headers={"X-API-Key": "test-api-key"},
+                )
 
-            response = test_client.post(
-                "/api/v1/business/analyze",
-                json={"code": "def test(): pass", "test_name": "test"},
-                headers={"X-API-Key": "test-key"},
-            )
-
-            assert response.status_code == 200
-            data = response.json()[0]
-            # When error_type is None, should default to "unknown"
-            assert data["error_type"] == "unknown"
+                assert response.status_code == 200
+                data = response.json()[0]
+                # When error_type is None, should default to "unknown"
+                assert data["error_type"] == "unknown"
+        finally:
+            test_client.app.dependency_overrides.pop(require_app_api_key, None)
 
     def test_users_retry_edge_cases(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test users router retry edge cases."""

--- a/tests/test_mcp_pulseplate_server_coverage.py
+++ b/tests/test_mcp_pulseplate_server_coverage.py
@@ -580,7 +580,7 @@ class TestMcpPulseplateServerCoverage:
                     assert isinstance(response, mcp_pulseplate_server.RpcError)
                     assert response.code == -32603
                     assert response.message == "Internal error"
-                    assert response.data == {"error": "Test error"}
+                    assert response.data == {"error": mcp_pulseplate_server.ERROR_INTERNAL}
 
     @pytest.mark.asyncio
     async def test_list_tools(self):
@@ -843,8 +843,8 @@ class TestMcpPulseplateServerCoverage:
                 args = {"query": "test query"}
                 response = await server._chatgpt_query(args)
 
-                assert "error" in response
-                assert "ChatGPT query failed: API Error" in response["error"]
+                assert response == {"error": mcp_pulseplate_server.ERROR_TOOL_EXECUTION_FAILED}
+                assert "API Error" not in response["error"]
 
     @pytest.mark.asyncio
     async def test_chatgpt_query_direct_call_blocks_unsafe_input(self) -> None:
@@ -1013,8 +1013,8 @@ class TestMcpPulseplateServerCoverage:
                 args = {"code": "print('hello')"}
                 response = await server._code_review(args)
 
-                assert "error" in response
-                assert "Code review failed: API Error" in response["error"]
+                assert response == {"error": mcp_pulseplate_server.ERROR_TOOL_EXECUTION_FAILED}
+                assert "API Error" not in response["error"]
 
     @pytest.mark.asyncio
     async def test_generate_code_success(self):
@@ -1050,8 +1050,8 @@ class TestMcpPulseplateServerCoverage:
                 args = {"description": "create a function"}
                 response = await server._generate_code(args)
 
-                assert "error" in response
-                assert "Code generation failed: API Error" in response["error"]
+                assert response == {"error": mcp_pulseplate_server.ERROR_TOOL_EXECUTION_FAILED}
+                assert "API Error" not in response["error"]
 
     @pytest.mark.asyncio
     async def test_generate_code_direct_call_blocks_unsafe_description(self) -> None:
@@ -1113,6 +1113,10 @@ class TestMcpPulseplateServerCoverage:
                             assert payload["jsonrpc"] == "2.0"
                             assert payload["id"] is None
                             assert payload["error"]["code"] == -32700
+                            assert payload["error"]["data"] == {
+                                "error": mcp_pulseplate_server.ERROR_PARSE
+                            }
+                            assert "invalid json" not in printed.lower()
 
     @pytest.mark.asyncio
     async def test_main_function_internal_error_preserves_id(self) -> None:
@@ -1143,7 +1147,10 @@ class TestMcpPulseplateServerCoverage:
                         assert payload["jsonrpc"] == "2.0"
                         assert payload["id"] == 123
                         assert payload["error"]["code"] == -32603
-                        assert payload["error"]["data"]["error"] == "boom"
+                        assert payload["error"]["data"] == {
+                            "error": mcp_pulseplate_server.ERROR_INTERNAL
+                        }
+                        assert "boom" not in printed
 
     @pytest.mark.asyncio
     async def test_main_function_notification_exception_logs(self) -> None:

--- a/tests/test_users_router.py
+++ b/tests/test_users_router.py
@@ -207,7 +207,7 @@ class TestUsersRouter:
 
     @pytest.mark.parametrize("validator", [None, lambda _: object()])
     def test_users_api_key_guard_fail_closed_behavior(self, validator: object) -> None:
-        with patch.object(users_mod, "resolve_attr", return_value=validator):
+        with patch("app.routers.users.resolve_attr", return_value=validator):
             resp = self.client.get("/api/v1/users", headers=self.headers)
 
         assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- promote the stale local security hardening lane from a fresh `origin/main` branch
- tighten MCP/business auth surfaces and refresh the related regression tests
- complete a second discussion-thread pass for the latest CodeRabbit follow-up

## Carryover
- supersedes the stale local lane `worktree/security-p0-mcp-business-auth`
- replacement branch created from fresh `origin/main` per `AGENTS.md` / `RUNBOOK_AGENT.md`

## Discussion Thread Pass
- [x] Initial PR body aligned to project canon
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: `be6d29a5`
Evidence: `app/routers/api_key.py:19`, `app/routers/api_key.py:21`, `tests/test_business_router.py:142`, `tests/test_business_router_coverage.py:79`, `tests/test_business_router_coverage.py:87`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934851690 -> `be6d29a5`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934854342 -> `be6d29a5`

Disposition: FIXED
Commit: `be6d29a5`
Evidence: `tests/test_business_router.py:93`, `tests/test_business_router.py:97`, `tests/test_business_router_coverage.py:87`, `tests/test_business_router_coverage.py:201`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934856658 -> `be6d29a5`

Disposition: NOT-A-BUG
Reason: This PR centralizes app-level API key validation in `app/routers/api_key.py` and reuses that helper from the business router. The remaining duplication concern in other legacy routers predates this lane and was not introduced by the current diff.
Evidence: `app/routers/api_key.py:16`, `app/routers/business.py:10`, `app/routers/business.py:93`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934854343

Disposition: NOT-A-BUG
Reason: These review-level bot comments are aggregate summaries of inline findings that are already dispositioned above and do not add separate unfixed obligations.
Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:8`, `docs/review/PR_1164_FIXED_MAPPING.md:13`, `docs/review/PR_1164_FIXED_MAPPING.md:18`, `docs/review/PR_1164_FIXED_MAPPING.md:23`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948322337
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948326367
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948328323

Disposition: FIXED
Commit: `7bbc8a6b`
Evidence: `app/routers/api_key.py:16`, `app/routers/api_key.py:19`, `tests/test_business_router.py:153`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901526 -> `7bbc8a6b`

Disposition: FIXED
Commit: `f9bcb72a`
Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:47`, `docs/review/PR_1164_FIXED_MAPPING.md:50`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#discussion_r2934901527 -> `f9bcb72a`

Disposition: NOT-A-BUG
Reason: This review-level CodeRabbit summary only aggregates the two inline findings above and does not introduce a separate actionable beyond those mapped threads.
Evidence: `docs/review/PR_1164_FIXED_MAPPING.md:25`, `docs/review/PR_1164_FIXED_MAPPING.md:31`, `docs/review/PR_1164_FIXED_MAPPING.md:35`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1164#pullrequestreview-3948385258

## Merge Readiness
- [ ] Local gates passed on current head
- [ ] All required checks green
- [ ] No unresolved review threads remain
- [ ] CodeRabbit PASS / no-actionables
- [ ] Sourcery PASS / no-actionables
- [ ] Cubic PASS / no-actionables
- [ ] Wait-window after latest bot/review activity observed

## Validation
- `pre-commit run --all-files`
- `make verify`

## Deferred / Follow-ups
- none
