### PR TITLE
feat(orchestration): harden requested-agent routing

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -121,6 +121,9 @@ When a task is created:
      first; then choose the routed domain primary/secondary/reviewer
    - Use `docs/orchestration/AGENT_CAPABILITY_MATRIX.md` only as advisory guidance
      inside the already routed domain; it does not define permissions
+   - If the user explicitly requested agent slugs, preserve them in the task packet and
+     honor them when they are compatible with the routed domain slots; otherwise keep them
+     advisory/rejected with explicit rationale instead of dropping them silently
 
 3. **Map to project-fit skills**:
    - If the task packet already includes `recommended_skills` / `skill_routing`, use those outputs as authoritative
@@ -130,6 +133,8 @@ When a task is created:
      `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md` before selecting mutable surfaces
    - Prefer repo-tracked PulsePlate skills before global installed skills
    - Do not auto-select broad scraping workflows for PulsePlate
+   - Apply requested-agent default bundles from `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+     after canonical routing resolves; these bundles are helpers, not authority overrides
    - For design/system tasks, follow the canonical source precedence in
      `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md`
      with default order `Figma -> Notion -> Airweave -> Penpot`
@@ -138,6 +143,9 @@ When a task is created:
    - Single-agent: Direct assignment to best-fit agent
    - Multi-agent: Create workflow with dependencies and handoffs
    - Parallel: Assign independent sub-tasks to multiple agents simultaneously
+   - If touched scope includes `.github/workflows/**`, `ios/fastlane/**`,
+     `scripts/orchestration/**`, or merge-governance docs/scripts, keep
+     `security-auditor` in the review path by default
 
 ### 3. Work Synthesis & Quality Assurance
 

--- a/docs/orchestration/AGENT_NON_ROUTABLE_SPECIALISTS.md
+++ b/docs/orchestration/AGENT_NON_ROUTABLE_SPECIALISTS.md
@@ -3,6 +3,21 @@
 Explicit allowlist for specialist agents that are canonical, indexed, and documented,
 but are not required to appear in `AGENT_ROUTING_GRAPH.md` as primary/secondary/reviewer nodes.
 
+## Override contract
+
+These specialists are **non-routable by default**, not forbidden.
+
+Interpretation:
+
+- Coordinator may keep them **advisory-only** when the canonical routing graph already
+  resolves a better domain primary.
+- If a user explicitly requests one of these specialists, the coordinator must record
+  that request in the task packet and either:
+  - keep the specialist as an advisory collaborator with explicit rationale, or
+  - promote it through a domain-specific follow-up contract introduced in a dedicated PR.
+- Absence from the routing graph means "not graph-primary by default"; it does **not**
+  mean "cannot be requested", "cannot be consulted", or "cannot appear in the task packet".
+
 - `ai-app-architect`
 - `bayesian-uq-agent`
 - `cbt-psychologist-agent`

--- a/docs/orchestration/AGENT_ROUTING_GRAPH.md
+++ b/docs/orchestration/AGENT_ROUTING_GRAPH.md
@@ -57,14 +57,14 @@ Enforcement evidence: `scripts/orchestration/routing_graph_loader.py:121-169`, `
 
 | Domain   | Cluster  | Primary Agent            | Secondary                       | Reviewer                |
 |----------|----------|--------------------------|---------------------------------|-------------------------|
-| backend  | backend  | architecture-specialist  | backend-engineer                | security-auditor        |
+| backend  | backend  | backend-engineer         | architecture-specialist         | security-auditor        |
 | ios      | platform | frontend-engineer        | creative-designer               | qa-engineer-agent       |
 | frontend | platform | frontend-engineer        | creative-designer               | qa-engineer-agent       |
 | infra    | ops      | dev-operator             | architecture-specialist         | security-auditor        |
 | security | ops      | security-auditor         | architecture-specialist         | agent-coordinator       |
 | ml       | ml       | ai-innovation-specialist | rag-systems-agent               | architecture-specialist |
 | cv       | ml       | cv-agent                 | data-scientist-agent            | security-auditor        |
-| docs     | ops      | web-research-agent       | cursor-specialist-agent         | qa-engineer-agent       |
+| docs     | ops      | cursor-specialist-agent  | web-research-agent              | qa-engineer-agent       |
 | design   | platform | creative-designer        | frontend-engineer               | qa-engineer-agent       |
 | research | ml       | web-research-agent       | ai-innovation-specialist        | agent-coordinator       |
 | safety   | safety   | philosophy-agent         | logic-agent                     | agent-coordinator       |
@@ -72,7 +72,7 @@ Enforcement evidence: `scripts/orchestration/routing_graph_loader.py:121-169`, `
 | release  | growth   | app-store-release-agent  | marketing-strategist            | qa-engineer-agent       |
 | wellness | growth   | wellness-analyst-agent   | marketing-strategist            | business-strategist-agent |
 | business | growth   | business-strategist-agent | marketing-strategist           | agent-coordinator       |
-| orchestration | ops | cursor-specialist-agent  | dev-operator                    | architecture-specialist |
+| orchestration | ops | agent-coordinator        | cursor-specialist-agent         | architecture-specialist |
 
 ---
 
@@ -91,6 +91,9 @@ Enforcement evidence: `scripts/orchestration/routing_graph_loader.py:121-169`, `
 11. **Skills after routing:** once primary domain is resolved, coordinator selects `recommended_skills` via `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md` and task bootstrap artifacts.
 12. **`creative_research` sub-lane:** route through `research` first, then apply phase-specific role mapping from `docs/orchestration/CREATIVE_RESEARCH_SUBLANE_PROTOCOL.md`. The sub-lane refines execution inside the experimentation umbrella; it does not replace this routing graph.
 13. **CV routing invariant:** generic coordinator/task packets route CV-first work through `domain=cv`, `cluster=ml`. Governed experimentation packets may remain `ml`-scoped until their contract is migrated explicitly.
+14. **Explicit requested-agent override:** after canonical domain routing resolves, bootstrap may promote a user-requested agent when it already belongs to the routed domain slot set (primary / secondary / reviewer). If the request targets a non-routable specialist, coordinator must keep it as an advisory collaborator unless a separate contract explicitly promotes it.
+15. **Privileged-surface review rule:** tasks touching `.github/workflows/**`, `ios/fastlane/**`, `scripts/orchestration/**`, or merge-governance scripts/docs must include `security-auditor` in the review path, even when the dominant domain is docs/orchestration/release rather than security.
+16. **Docs vs research split:** internal policy/runbook/docs maintenance defaults to `docs` -> `cursor-specialist-agent`; external web/OSS intake remains `research` -> `web-research-agent`.
 
 Audit evidence: `scripts/orchestration/check_agent_consistency.py:103-209`, `tests/test_routing_graph_loader.py:159-315`, `tests/guards/test_agent_consistency_guard.py:179-216`.
 
@@ -121,4 +124,4 @@ SecondaryAgents --> Reviewer
 
 ---
 
-**Last updated:** 2026-03-07 (routing graph refresh)
+**Last updated:** 2026-03-14 (requested-agent + privileged-surface routing refresh)

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -33,6 +33,7 @@
 3. Add repo-tracked PulsePlate skills for the selected domain.
 4. Add global installed skills only when the task explicitly matches their scope.
 5. Exclude low-fit or high-risk skills even if installed.
+6. If the user explicitly requests agent slugs, preserve them in the task packet and apply the corresponding default skill bundles after canonical routing resolves.
 
 Boundary note:
 - `docs/orchestration/AGENT_ROUTING_GRAPH.md` remains the canonical source of truth for agent/domain routing.
@@ -81,6 +82,28 @@ CV routing note:
 
 ---
 
+## 3a. Requested-Agent Default Bundles
+
+When a task packet includes explicit `requested_agents`, coordinator should keep canonical
+domain routing first and then apply these **default helper bundles**:
+
+| Requested agent | Default helper bundle |
+|-----------------|-----------------------|
+| `agent-coordinator` | `docs-sync`, `agents-md`, `pulseplate-gates` |
+| `bug-hunter` | `bug-triage`, `pulseplate-gates`, `pulseplate-guards` |
+| `security-auditor` | `security-best-practices`, `security-threat-model`, `pulseplate-guards` |
+| `backend-engineer` | `pulseplate-backend-endpoints`, `pulseplate-openapi-sync`, `pulseplate-gates` |
+| `qa-engineer-agent` | `bug-triage`, `pulseplate-gates`, `code-review-expert` |
+| `frontend-engineer` | `pulseplate-frontend-ui`, `pulseplate-gates`, `vercel-react-best-practices` |
+| `ml-engineer-agent` | `pulseplate-gates`, `docs-sync`, `openai-docs` |
+| `data-scientist-agent` | `docs-sync`, `pulseplate-gates`, `pulseplate-ai-reports` |
+| `web-research-agent` | `docs-sync`, `pulseplate-ai-reports`, `notion-research-documentation` |
+
+These bundles are bootstrapping helpers, not authority overrides. They do not bypass
+`AGENT_ROUTING_GRAPH.md` or reviewer requirements.
+
+---
+
 ## 4. Installed Skills Policy For This Project
 
 The coordinator may use installed skills when they improve delivery and align with PulsePlate boundaries.
@@ -111,6 +134,22 @@ The coordinator may use installed skills when they improve delivery and align wi
 - deployment skills on non-deploy tasks
 - screenshot/system capture skills on non-visual tasks
 - any broad scraping or “collect everything from the internet” workflow
+
+---
+
+## 4a. Privileged Surface Trigger
+
+The following touched paths must automatically boost security-oriented skills and review:
+
+- `.github/workflows/**`
+- `ios/fastlane/**`
+- `scripts/orchestration/**`
+- merge-governance scripts and docs under `docs/orchestration/`
+
+Expected behavior:
+
+- add `security-best-practices` and/or `pulseplate-guards` when the task packet touches these paths;
+- keep `security-auditor` in the review path even if the dominant domain is docs, release, or orchestration.
 
 ---
 

--- a/docs/orchestration/workflow.md
+++ b/docs/orchestration/workflow.md
@@ -90,6 +90,10 @@ Task
 - [ ] Назначены secondary agents (если multi-domain)
 - [ ] Проставлены зависимости / handoff / sync points (если multi-agent)
 - [ ] Определён `recommended_skills` packet по `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+- [ ] Явно запрошенные пользователем agent slugs сохранены в task packet и либо honor/advisory,
+  либо отклонены с явной причиной
+- [ ] Для privilege-sensitive surfaces (`.github/workflows/**`, `ios/fastlane/**`,
+  `scripts/orchestration/**`, merge-governance docs/scripts) включён security review path
 
 **Stop condition:** если есть хоть один незакрытый пункт — execution запрещён.
 

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -25,6 +25,13 @@ Evidence: `scripts/orchestration/task_bootstrap.py:267` now force-adds `security
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948501266 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992480 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
 
+Disposition: FIXED
+Commit: 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+Evidence: `scripts/orchestration/skill_router.py:341` now treats `docs/review/` plus merge-readiness/review-mapping keywords as privileged security-trigger surfaces, `scripts/orchestration/task_bootstrap.py:167` rewrites stale `honored_primary` dispositions to `honored_secondary` after later promotions, and `tests/test_skill_router.py:289` plus `tests/test_task_bootstrap.py:159` add regression coverage for both behaviors.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948506013 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996806 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996810 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -11,6 +11,7 @@ Evidence: `scripts/orchestration/requested_agents.py:10` now centralizes request
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
 
 Disposition: FIXED
 Commit: d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -5,7 +5,9 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -39,7 +39,7 @@ Evidence: `scripts/orchestration/skill_router.py:341` now treats `docs/review/` 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996810 -> 8532f9dad7d18618719b82cad87d5aa04b801236
 
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -8,6 +8,7 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934990492 -> d165935d
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -11,7 +11,11 @@ Evidence: `scripts/orchestration/requested_agents.py:10` now centralizes request
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
+
+Disposition: FIXED
+Commit: 6c2d15b5e85b17d97913cb3baef2264d3e64ab98
+Evidence: `tests/test_skill_router.py:100` now directly proves duplicate requested-agent slugs collapse to one normalized request and do not stack an extra `pulseplate-gates` bundle boost, which is the exact regression described in `discussion_r2934996808`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 6c2d15b5e85b17d97913cb3baef2264d3e64ab98
 
 Disposition: FIXED
 Commit: d165935dcbabb704abc52728a0ec0dbcb212ae20

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -38,6 +38,12 @@ Evidence: `scripts/orchestration/skill_router.py:341` now treats `docs/review/` 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996806 -> 8532f9dad7d18618719b82cad87d5aa04b801236
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996810 -> 8532f9dad7d18618719b82cad87d5aa04b801236
 
+Disposition: FIXED
+Commit: 79b1403a5194a24eca11586b08b5e5f5ffc5d6ed
+Evidence: `docs/review/PR_1166_FIXED_MAPPING.md:42` now leaves the merge-readiness checklist unchecked until the final readiness pass is actually complete, which resolves the late CodeRabbit governance note about the pre-checked local gate.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948528425 -> 79b1403a5194a24eca11586b08b5e5f5ffc5d6ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2935016320 -> 79b1403a5194a24eca11586b08b5e5f5ffc5d6ed
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -13,9 +13,9 @@ Evidence: `scripts/orchestration/requested_agents.py:10` now centralizes request
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
 
 Disposition: FIXED
-Commit: 6c2d15b5e85b17d97913cb3baef2264d3e64ab98
+Commit: 6c2d15b5df25b78298575e8bb74b061d4085af07
 Evidence: `tests/test_skill_router.py:100` now directly proves duplicate requested-agent slugs collapse to one normalized request and do not stack an extra `pulseplate-gates` bundle boost, which is the exact regression described in `discussion_r2934996808`.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 6c2d15b5e85b17d97913cb3baef2264d3e64ab98
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 6c2d15b5df25b78298575e8bb74b061d4085af07
 
 Disposition: FIXED
 Commit: d165935dcbabb704abc52728a0ec0dbcb212ae20

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -6,32 +6,33 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
-Commit: 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+Commit: 0f5f50e26c9802c72bae8bd186e6404cbf271659
 Evidence: `scripts/orchestration/requested_agents.py:10` now centralizes requested-agent normalization for shared reuse, `scripts/orchestration/skill_router.py:481` consumes that helper for deduplicated router echoes, and `tests/test_skill_router.py:48` plus `tests/test_skill_router.py:80` add router-level regression coverage for bundle boosts and normalized requested-agent output.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996808 -> 0f5f50e26c9802c72bae8bd186e6404cbf271659
 
 Disposition: FIXED
-Commit: d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+Commit: d165935dcbabb704abc52728a0ec0dbcb212ae20
 Evidence: `scripts/orchestration/context_pack.py:234` now folds `requested_agents` into `compute_task_packet_id(...)`, `scripts/orchestration/task_bootstrap.py:245` passes normalized requested agents into the packet-id calculation, and `tests/test_task_bootstrap.py:127` proves distinct requested-agent inputs no longer collide on the same packet id.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948499021 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934990492 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992479 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948499021 -> d165935dcbabb704abc52728a0ec0dbcb212ae20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934990492 -> d165935dcbabb704abc52728a0ec0dbcb212ae20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992479 -> d165935dcbabb704abc52728a0ec0dbcb212ae20
 
 Disposition: FIXED
-Commit: c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
+Commit: c9f2d337bc2bacab37d54145a776e579436779e7
 Evidence: `scripts/orchestration/task_bootstrap.py:267` now force-adds `security-auditor` back into the review path for privileged surfaces after requested-agent overrides, and `tests/test_task_bootstrap.py:145` locks that invariant with a regression test for `scripts/orchestration/**` routing.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948501266 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992480 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948501266 -> c9f2d337bc2bacab37d54145a776e579436779e7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992480 -> c9f2d337bc2bacab37d54145a776e579436779e7
 
 Disposition: FIXED
-Commit: 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+Commit: 8532f9dad7d18618719b82cad87d5aa04b801236
 Evidence: `scripts/orchestration/skill_router.py:341` now treats `docs/review/` plus merge-readiness/review-mapping keywords as privileged security-trigger surfaces, `scripts/orchestration/task_bootstrap.py:167` rewrites stale `honored_primary` dispositions to `honored_secondary` after later promotions, and `tests/test_skill_router.py:289` plus `tests/test_task_bootstrap.py:159` add regression coverage for both behaviors.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948506013 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996806 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996810 -> 8532f9da3ecdf4a4e6116f84d53abb3b85a8c58a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948506013 -> 8532f9dad7d18618719b82cad87d5aa04b801236
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948515087 -> 8532f9dad7d18618719b82cad87d5aa04b801236
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996806 -> 8532f9dad7d18618719b82cad87d5aa04b801236
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934996810 -> 8532f9dad7d18618719b82cad87d5aa04b801236
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1166 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1166_FIXED_MAPPING.md
+++ b/docs/review/PR_1166_FIXED_MAPPING.md
@@ -5,10 +5,25 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934990492 -> d165935d
+Disposition: FIXED
+Commit: 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+Evidence: `scripts/orchestration/requested_agents.py:10` now centralizes requested-agent normalization for shared reuse, `scripts/orchestration/skill_router.py:481` consumes that helper for deduplicated router echoes, and `tests/test_skill_router.py:48` plus `tests/test_skill_router.py:80` add router-level regression coverage for bundle boosts and normalized requested-agent output.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948494983 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986996 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934986999 -> 0f5f50e2c69bca4cf2568355fc0040f1a41bfccb
+
+Disposition: FIXED
+Commit: d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+Evidence: `scripts/orchestration/context_pack.py:234` now folds `requested_agents` into `compute_task_packet_id(...)`, `scripts/orchestration/task_bootstrap.py:245` passes normalized requested agents into the packet-id calculation, and `tests/test_task_bootstrap.py:127` proves distinct requested-agent inputs no longer collide on the same packet id.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948499021 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934990492 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992479 -> d165935d2bbf4c455efc2d1b8d8dbd1ab3ac976f
+
+Disposition: FIXED
+Commit: c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
+Evidence: `scripts/orchestration/task_bootstrap.py:267` now force-adds `security-auditor` back into the review path for privileged surfaces after requested-agent overrides, and `tests/test_task_bootstrap.py:145` locks that invariant with a regression test for `scripts/orchestration/**` routing.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#pullrequestreview-3948501266 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1166#discussion_r2934992480 -> c9f2d33787022ded91e8f4ff45ff624b2ab2c5e5
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -237,6 +237,7 @@ def compute_task_packet_id(
     task_class: str,
     domain: str,
     candidate_paths: list[str] | tuple[str, ...],
+    requested_agents: list[str] | tuple[str, ...] = (),
 ) -> str:
     """Return deterministic short task packet id."""
 
@@ -246,6 +247,7 @@ def compute_task_packet_id(
             task_class.strip(),
             domain.strip(),
             *repo_relative_paths(candidate_paths),
+            *requested_agents,
         ]
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]

--- a/scripts/orchestration/requested_agents.py
+++ b/scripts/orchestration/requested_agents.py
@@ -1,0 +1,21 @@
+"""Shared requested-agent helpers for deterministic orchestration routing.
+
+RU: Общие хелперы для requested-agent routing без дрейфа между entrypoints.
+EN: Shared helpers that keep requested-agent handling aligned across entrypoints.
+"""
+
+from __future__ import annotations
+
+
+def normalize_requested_agents(requested_agents: list[str] | tuple[str, ...]) -> list[str]:
+    """Normalize requested agent slugs while preserving order and uniqueness."""
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_agent in requested_agents:
+        agent = raw_agent.strip().lower()
+        if not agent or agent in seen:
+            continue
+        seen.add(agent)
+        normalized.append(agent)
+    return normalized

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -12,6 +12,7 @@ import re
 from typing import Any
 
 from scripts.orchestration.context_pack import normalize_text, repo_relative_paths
+from scripts.orchestration.requested_agents import normalize_requested_agents
 
 ROUTING_POLICY_VERSION = "2026-03-08"
 SELECTION_MODE = "deterministic-weighted"
@@ -477,9 +478,7 @@ def route_skills(
     normalized_paths = repo_relative_paths(candidate_paths)
     normalized_text = normalize_text(goal, task_class, *normalized_paths)
     normalized_request_text = normalize_text(goal, task_class)
-    normalized_requested_agents = tuple(
-        agent.strip().lower() for agent in requested_agents if agent.strip()
-    )
+    normalized_requested_agents = tuple(normalize_requested_agents(requested_agents))
 
     blocked = [
         {"label": pattern, "reason": reason}

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -385,7 +385,10 @@ SKILL_RULES_BY_SKILL: dict[str, SkillRule] = {rule.skill: rule for rule in SKILL
 def _normalize_lexeme(value: str) -> str:
     """Normalize keyword phrases with the same rules as task text."""
 
-    return normalize_text(value)
+    normalized = normalize_text(value)
+    if not isinstance(normalized, str):  # pragma: no cover - defensive typing guard
+        raise TypeError("normalize_text must return a string")
+    return normalized
 
 
 def _has_prefix(path: str, prefix: str) -> bool:

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -340,6 +340,7 @@ SKILL_RULES: tuple[SkillRule, ...] = (
             "ios/fastlane/",
             "scripts/orchestration/",
             "docs/orchestration/",
+            "docs/review/",
         ),
         keywords=(
             "security",
@@ -351,6 +352,8 @@ SKILL_RULES: tuple[SkillRule, ...] = (
             "workflow",
             "fastlane",
             "secret",
+            "merge-readiness",
+            "review mapping",
         ),
     ),
     SkillRule(

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 import re
-from typing import Any, cast
+from typing import Any
 
 from scripts.orchestration.context_pack import normalize_text, repo_relative_paths
 
@@ -17,6 +17,30 @@ ROUTING_POLICY_VERSION = "2026-03-08"
 SELECTION_MODE = "deterministic-weighted"
 
 ALWAYS_ON_SKILLS: tuple[str, ...] = ("pulseplate-workflow",)
+
+REQUESTED_AGENT_SKILL_BUNDLES: dict[str, tuple[str, ...]] = {
+    "agent-coordinator": ("docs-sync", "agents-md", "pulseplate-gates"),
+    "bug-hunter": ("bug-triage", "pulseplate-gates", "pulseplate-guards"),
+    "security-auditor": ("security-best-practices", "security-threat-model", "pulseplate-guards"),
+    "backend-engineer": (
+        "pulseplate-backend-endpoints",
+        "pulseplate-openapi-sync",
+        "pulseplate-gates",
+    ),
+    "qa-engineer-agent": ("bug-triage", "pulseplate-gates", "code-review-expert"),
+    "frontend-engineer": (
+        "pulseplate-frontend-ui",
+        "pulseplate-gates",
+        "vercel-react-best-practices",
+    ),
+    "ml-engineer-agent": ("pulseplate-gates", "docs-sync", "openai-docs"),
+    "data-scientist-agent": ("docs-sync", "pulseplate-gates", "pulseplate-ai-reports"),
+    "web-research-agent": (
+        "docs-sync",
+        "pulseplate-ai-reports",
+        "notion-research-documentation",
+    ),
+}
 
 SCRAPING_BLOCK_PATTERNS: tuple[tuple[str, str], ...] = (
     ("tiktok", "TikTok scraping is not an approved default for PulsePlate."),
@@ -106,9 +130,18 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="repo-tracked",
         rationale="Handle architecture guards, fail-closed policy checks, and security-oriented invariants.",
         min_score=3,
-        domain_weights={"security": 2, "qa": 2, "orchestration": 1},
-        path_prefixes=("app/security/", "tests/guards/", "scripts/orchestration/"),
-        keywords=("guard", "policy", "invariant", "fail-closed", "rate limit", "quota"),
+        domain_weights={"security": 2, "qa": 2, "orchestration": 1, "backend": 1},
+        path_prefixes=("app/security/", "tests/", "tests/guards/", "scripts/orchestration/"),
+        keywords=(
+            "guard",
+            "policy",
+            "invariant",
+            "fail-closed",
+            "rate limit",
+            "quota",
+            "workflow",
+            "fastlane",
+        ),
     ),
     SkillRule(
         skill="pulseplate-backend-endpoints",
@@ -218,8 +251,16 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="global",
         rationale="OpenAI product/API questions should use official docs-first guidance.",
         min_score=5,
-        domain_weights={"ml": 1, "cv": 1},
-        keywords=("openai", "chatgpt", "responses api", "realtime api", "codex api"),
+        domain_weights={"ml": 1, "cv": 1, "backend": 1},
+        keywords=(
+            "openai",
+            "chatgpt",
+            "responses api",
+            "realtime api",
+            "codex api",
+            "llm",
+            "assistant",
+        ),
     ),
     SkillRule(
         skill="playwright",
@@ -291,8 +332,25 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         category="global",
         rationale="Explicit security hardening work should use the security review skill.",
         min_score=5,
-        domain_weights={"security": 3},
-        keywords=("security", "hardening", "appsec"),
+        domain_weights={"security": 3, "orchestration": 1, "backend": 1, "release": 1},
+        path_prefixes=(
+            "app/security/",
+            ".github/workflows/",
+            "ios/fastlane/",
+            "scripts/orchestration/",
+            "docs/orchestration/",
+        ),
+        keywords=(
+            "security",
+            "hardening",
+            "appsec",
+            "auth",
+            "token",
+            "cve",
+            "workflow",
+            "fastlane",
+            "secret",
+        ),
     ),
     SkillRule(
         skill="security-threat-model",
@@ -302,13 +360,32 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         domain_weights={"security": 3},
         keywords=("threat model", "abuse path", "trust boundary"),
     ),
+    SkillRule(
+        skill="gh-address-comments",
+        category="global",
+        rationale="GitHub review-thread handling should use the dedicated comment workflow.",
+        min_score=4,
+        domain_weights={"qa": 2, "orchestration": 1},
+        keywords=("review comment", "review thread", "address comments", "github comment"),
+    ),
+    SkillRule(
+        skill="vercel-react-best-practices",
+        category="global",
+        rationale="React and Vercel performance guidance should support frontend implementation work.",
+        min_score=4,
+        domain_weights={"frontend": 2, "design": 1},
+        path_prefixes=("frontend/",),
+        keywords=("react", "tsx", "component", "frontend", "web ui", "performance"),
+    ),
 )
+
+SKILL_RULES_BY_SKILL: dict[str, SkillRule] = {rule.skill: rule for rule in SKILL_RULES}
 
 
 def _normalize_lexeme(value: str) -> str:
     """Normalize keyword phrases with the same rules as task text."""
 
-    return cast(str, normalize_text(value))
+    return normalize_text(value)
 
 
 def _has_prefix(path: str, prefix: str) -> bool:
@@ -390,12 +467,16 @@ def route_skills(
     task_class: str,
     candidate_paths: list[str] | tuple[str, ...],
     domain: str,
+    requested_agents: list[str] | tuple[str, ...] = (),
 ) -> dict[str, Any]:
     """Return deterministic skill routing decision with evidence."""
 
     normalized_paths = repo_relative_paths(candidate_paths)
     normalized_text = normalize_text(goal, task_class, *normalized_paths)
     normalized_request_text = normalize_text(goal, task_class)
+    normalized_requested_agents = tuple(
+        agent.strip().lower() for agent in requested_agents if agent.strip()
+    )
 
     blocked = [
         {"label": pattern, "reason": reason}
@@ -417,11 +498,41 @@ def route_skills(
         for result, rule in zip(scored, SKILL_RULES)
         if result["score"] >= rule.min_score or rule.skill in ALWAYS_ON_SKILLS
     ]
+
+    selected_by_skill = {item["skill"]: item for item in selected}
+    for requested_agent in normalized_requested_agents:
+        bundle = REQUESTED_AGENT_SKILL_BUNDLES.get(requested_agent, ())
+        for bundled_skill in bundle:
+            existing = selected_by_skill.get(bundled_skill)
+            if existing is None:
+                rule = SKILL_RULES_BY_SKILL.get(bundled_skill)
+                category = rule.category if rule is not None else "bundle"
+                rationale = (
+                    rule.rationale
+                    if rule is not None
+                    else f"Default skill bundle for requested agent `{requested_agent}`."
+                )
+                selected_by_skill[bundled_skill] = {
+                    "skill": bundled_skill,
+                    "score": 6,
+                    "category": category,
+                    "rationale": rationale,
+                    "reasons": [f"requested-agent:{requested_agent}(+6)"],
+                }
+                continue
+
+            existing["score"] = int(existing["score"]) + 2
+            reason = f"requested-agent:{requested_agent}(+2)"
+            if reason not in existing["reasons"]:
+                existing["reasons"].append(reason)
+
+    selected = list(selected_by_skill.values())
     selected.sort(key=lambda item: (-int(item["score"]), item["skill"]))
 
     return {
         "policy_version": ROUTING_POLICY_VERSION,
         "selection_mode": SELECTION_MODE,
+        "requested_agents": list(normalized_requested_agents),
         "recommended": selected,
         "blocked": blocked,
     }
@@ -433,6 +544,7 @@ def select_recommended_skills(
     task_class: str,
     candidate_paths: list[str] | tuple[str, ...],
     domain: str,
+    requested_agents: list[str] | tuple[str, ...] = (),
 ) -> list[str]:
     """Backward-compatible helper returning only the ordered skill names."""
 
@@ -441,5 +553,6 @@ def select_recommended_skills(
         task_class=task_class,
         candidate_paths=candidate_paths,
         domain=domain,
+        requested_agents=requested_agents,
     )
     return [item["skill"] for item in decision["recommended"]]

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -40,6 +40,11 @@ REQUESTED_AGENT_STATUS_HONORED_PRIMARY = "honored_primary"
 REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE = "advisory_non_routable"
 REQUESTED_AGENT_STATUS_PROMOTED = "promoted_requested_agent"
 REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH = "advisory_domain_mismatch"
+PRIVILEGED_REVIEW_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    "ios/fastlane/",
+    "scripts/orchestration/",
+)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -77,6 +82,18 @@ def _select_independent_reviewer(
     if reviewer_candidate is not None:
         return reviewer_candidate
     return "qa-engineer-agent"
+
+
+def _requires_security_review(candidate_paths: list[str] | tuple[str, ...]) -> bool:
+    """Return True when the task touches privileged surfaces that require security review."""
+
+    return any(
+        any(
+            path == prefix.rstrip("/") or path.startswith(prefix)
+            for prefix in PRIVILEGED_REVIEW_PREFIXES
+        )
+        for path in candidate_paths
+    )
 
 
 def _apply_requested_agent_overrides(
@@ -239,6 +256,16 @@ def build_task_packet(
         requested_agents=normalized_requested_agents,
         routing=routing,
     )
+    if _requires_security_review(normalized_paths):
+        secondary_agents = list(requested_agent_resolution["secondary_agents"])
+        security_in_review_path = "security-auditor" in {
+            requested_agent_resolution["primary_agent"],
+            requested_agent_resolution["reviewer"],
+            *secondary_agents,
+        }
+        if not security_in_review_path:
+            secondary_agents.append("security-auditor")
+        requested_agent_resolution["secondary_agents"] = secondary_agents
     skill_routing = route_skills(
         goal=goal,
         task_class=task_class,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -37,6 +37,7 @@ SCHEMA_VERSION = "2.0"
 TASK_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "task_packets"
 REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN = "rejected_unknown_agent"
 REQUESTED_AGENT_STATUS_HONORED_PRIMARY = "honored_primary"
+REQUESTED_AGENT_STATUS_HONORED_SECONDARY = "honored_secondary"
 REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE = "advisory_non_routable"
 REQUESTED_AGENT_STATUS_PROMOTED = "promoted_requested_agent"
 REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH = "advisory_domain_mismatch"
@@ -177,6 +178,15 @@ def _apply_requested_agent_overrides(
                 ),
                 previous_primary=previous_primary,
             )
+            for disposition in dispositions:
+                if (
+                    disposition["agent"] == previous_primary
+                    and disposition["status"] == REQUESTED_AGENT_STATUS_HONORED_PRIMARY
+                ):
+                    disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
+                    disposition["reason"] = (
+                        "Requested agent stayed honored but moved to secondary after a later promotion."
+                    )
             dispositions.append(
                 _disposition(
                     agent,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -24,6 +24,10 @@ from scripts.orchestration.context_pack import (
     repo_relative_paths,
     resolve_domain,
 )
+from scripts.orchestration.agent_consistency_loader import (
+    load_inventory_agents,
+    load_non_routable_agents,
+)
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import load_routing_graph
 from scripts.orchestration.skill_router import route_skills
@@ -42,16 +46,164 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _normalize_requested_agents(requested_agents: list[str] | tuple[str, ...]) -> list[str]:
+    """Normalize requested agent slugs while preserving order and uniqueness."""
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_agent in requested_agents:
+        agent = raw_agent.strip().lower()
+        if not agent or agent in seen:
+            continue
+        seen.add(agent)
+        normalized.append(agent)
+    return normalized
+
+
+def _select_independent_reviewer(
+    *,
+    primary_agent: str,
+    canonical_reviewer: str,
+    canonical_secondary: str | None,
+    previous_primary: str,
+) -> str:
+    """Keep reviewer independent after requested-agent promotion."""
+
+    for candidate in (
+        canonical_reviewer,
+        canonical_secondary,
+        previous_primary,
+        "agent-coordinator",
+    ):
+        if candidate and candidate != primary_agent:
+            return candidate
+    return "qa-engineer-agent"
+
+
+def _apply_requested_agent_overrides(
+    *,
+    domain: str,
+    primary_agent: str,
+    secondary_agent: str | None,
+    reviewer: str,
+    requested_agents: list[str],
+    routing: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply explicit requested-agent overrides in a deterministic, bounded way."""
+
+    inventory = load_inventory_agents()
+    non_routable = load_non_routable_agents()
+    canonical_route = routing.get(domain)
+
+    resolved_primary = primary_agent
+    resolved_secondary_agents = [agent for agent in [secondary_agent] if agent]
+    dispositions: list[dict[str, str]] = []
+    advisory_agents: list[str] = []
+
+    for agent in requested_agents:
+        if agent not in inventory:
+            dispositions.append(
+                {
+                    "agent": agent,
+                    "status": "rejected_unknown_agent",
+                    "reason": "Agent is not registered in the canonical inventory.",
+                }
+            )
+            continue
+
+        if agent == resolved_primary:
+            dispositions.append(
+                {
+                    "agent": agent,
+                    "status": "honored_primary",
+                    "reason": "Requested agent already matches the routed primary.",
+                }
+            )
+            continue
+
+        if agent in non_routable:
+            if agent not in advisory_agents:
+                advisory_agents.append(agent)
+            dispositions.append(
+                {
+                    "agent": agent,
+                    "status": "advisory_non_routable",
+                    "reason": "Agent is canonical but non-routable; kept as an advisory collaborator.",
+                }
+            )
+            continue
+
+        allowed_promotions = {candidate for candidate in [secondary_agent, reviewer] if candidate}
+        if canonical_route is not None:
+            allowed_promotions.add(canonical_route.primary)
+            if canonical_route.secondary:
+                allowed_promotions.add(canonical_route.secondary)
+            allowed_promotions.add(canonical_route.reviewer)
+
+        if agent in allowed_promotions:
+            previous_primary = resolved_primary
+            resolved_primary = agent
+            resolved_secondary_agents = [
+                candidate
+                for candidate in [previous_primary, *resolved_secondary_agents]
+                if candidate and candidate != resolved_primary
+            ]
+            reviewer = _select_independent_reviewer(
+                primary_agent=resolved_primary,
+                canonical_reviewer=canonical_route.reviewer if canonical_route else reviewer,
+                canonical_secondary=(
+                    canonical_route.secondary if canonical_route else secondary_agent
+                ),
+                previous_primary=previous_primary,
+            )
+            dispositions.append(
+                {
+                    "agent": agent,
+                    "status": "promoted_requested_agent",
+                    "reason": "Requested agent is compatible with the routed domain and was promoted.",
+                }
+            )
+            continue
+
+        if agent not in advisory_agents:
+            advisory_agents.append(agent)
+        dispositions.append(
+            {
+                "agent": agent,
+                "status": "advisory_domain_mismatch",
+                "reason": "Requested agent stays advisory because it is outside the routed domain slot set.",
+            }
+        )
+
+    ordered_secondary_agents: list[str] = []
+    for candidate in [*resolved_secondary_agents, *advisory_agents]:
+        if (
+            candidate
+            and candidate != resolved_primary
+            and candidate not in ordered_secondary_agents
+        ):
+            ordered_secondary_agents.append(candidate)
+
+    return {
+        "primary_agent": resolved_primary,
+        "secondary_agents": ordered_secondary_agents,
+        "reviewer": reviewer,
+        "requested_agent_disposition": dispositions,
+    }
+
+
 def build_task_packet(
     *,
     goal: str,
     task_class: str,
     candidate_paths: list[str],
+    requested_agents: list[str] | tuple[str, ...] = (),
     telemetry_path: Path = TELEMETRY_PATH,
 ) -> dict[str, Any]:
     """Build a deterministic task packet for orchestration tooling."""
 
     normalized_paths = repo_relative_paths(candidate_paths)
+    normalized_requested_agents = _normalize_requested_agents(requested_agents)
     domain = resolve_domain(
         task_class=task_class,
         candidate_paths=normalized_paths,
@@ -74,11 +226,20 @@ def build_task_packet(
         normalized_paths,
         include_orchestration=decision.cluster == "ops" or len(normalized_paths) != 1,
     )
+    requested_agent_resolution = _apply_requested_agent_overrides(
+        domain=decision.domain,
+        primary_agent=decision.primary,
+        secondary_agent=decision.secondary,
+        reviewer=decision.reviewer,
+        requested_agents=normalized_requested_agents,
+        routing=routing,
+    )
     skill_routing = route_skills(
         goal=goal,
         task_class=task_class,
         candidate_paths=normalized_paths,
         domain=decision.domain,
+        requested_agents=normalized_requested_agents,
     )
 
     return {
@@ -89,9 +250,11 @@ def build_task_packet(
         "domain": decision.domain,
         "cluster": decision.cluster,
         "candidate_paths": normalized_paths,
-        "primary_agent": decision.primary,
-        "secondary_agents": [agent for agent in [decision.secondary] if agent],
-        "reviewer": decision.reviewer,
+        "primary_agent": requested_agent_resolution["primary_agent"],
+        "secondary_agents": requested_agent_resolution["secondary_agents"],
+        "reviewer": requested_agent_resolution["reviewer"],
+        "requested_agents": normalized_requested_agents,
+        "requested_agent_disposition": requested_agent_resolution["requested_agent_disposition"],
         "required_context": context_pack,
         "recommended_skills": [item["skill"] for item in skill_routing["recommended"]],
         "skill_routing": skill_routing,
@@ -126,6 +289,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--goal", required=True)
     parser.add_argument("--task-class", required=True)
     parser.add_argument("--path", action="append", default=[])
+    parser.add_argument(
+        "--requested-agent",
+        action="append",
+        default=[],
+        help="Optional requested agent slug. May be repeated.",
+    )
     parser.add_argument("--telemetry", default=str(TELEMETRY_PATH))
     parser.add_argument(
         "--output",
@@ -141,6 +310,7 @@ def main(argv: list[str] | None = None) -> int:
         goal=args.goal,
         task_class=args.task_class,
         candidate_paths=args.path,
+        requested_agents=args.requested_agent,
         telemetry_path=Path(args.telemetry),
     )
     try:
@@ -165,6 +335,7 @@ def main(argv: list[str] | None = None) -> int:
                 "cluster": packet["cluster"],
                 "primary_agent": packet["primary_agent"],
                 "reviewer": packet["reviewer"],
+                "requested_agents": packet["requested_agents"],
                 "recommended_skills": packet["recommended_skills"],
                 "output": output_ref,
             },

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -225,6 +225,7 @@ def build_task_packet(
         task_class=task_class,
         domain=decision.domain,
         candidate_paths=normalized_paths,
+        requested_agents=normalized_requested_agents,
     )
     context_pack = collect_context_pack(
         normalized_paths,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -30,10 +30,16 @@ from scripts.orchestration.agent_consistency_loader import (
 )
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import load_routing_graph
+from scripts.orchestration.requested_agents import normalize_requested_agents
 from scripts.orchestration.skill_router import route_skills
 
 SCHEMA_VERSION = "2.0"
 TASK_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "task_packets"
+REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN = "rejected_unknown_agent"
+REQUESTED_AGENT_STATUS_HONORED_PRIMARY = "honored_primary"
+REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE = "advisory_non_routable"
+REQUESTED_AGENT_STATUS_PROMOTED = "promoted_requested_agent"
+REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH = "advisory_domain_mismatch"
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -46,20 +52,6 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _normalize_requested_agents(requested_agents: list[str] | tuple[str, ...]) -> list[str]:
-    """Normalize requested agent slugs while preserving order and uniqueness."""
-
-    normalized: list[str] = []
-    seen: set[str] = set()
-    for raw_agent in requested_agents:
-        agent = raw_agent.strip().lower()
-        if not agent or agent in seen:
-            continue
-        seen.add(agent)
-        normalized.append(agent)
-    return normalized
-
-
 def _select_independent_reviewer(
     *,
     primary_agent: str,
@@ -69,14 +61,21 @@ def _select_independent_reviewer(
 ) -> str:
     """Keep reviewer independent after requested-agent promotion."""
 
-    for candidate in (
-        canonical_reviewer,
-        canonical_secondary,
-        previous_primary,
-        "agent-coordinator",
-    ):
-        if candidate and candidate != primary_agent:
-            return candidate
+    reviewer_candidate = next(
+        (
+            candidate
+            for candidate in (
+                canonical_reviewer,
+                canonical_secondary,
+                previous_primary,
+                "agent-coordinator",
+            )
+            if candidate and candidate != primary_agent
+        ),
+        None,
+    )
+    if reviewer_candidate is not None:
+        return reviewer_candidate
     return "qa-engineer-agent"
 
 
@@ -100,24 +99,29 @@ def _apply_requested_agent_overrides(
     dispositions: list[dict[str, str]] = []
     advisory_agents: list[str] = []
 
+    def _disposition(agent: str, status: str, reason: str) -> dict[str, str]:
+        """Build a deterministic disposition payload for requested-agent handling."""
+
+        return {"agent": agent, "status": status, "reason": reason}
+
     for agent in requested_agents:
         if agent not in inventory:
             dispositions.append(
-                {
-                    "agent": agent,
-                    "status": "rejected_unknown_agent",
-                    "reason": "Agent is not registered in the canonical inventory.",
-                }
+                _disposition(
+                    agent,
+                    REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN,
+                    "Agent is not registered in the canonical inventory.",
+                )
             )
             continue
 
         if agent == resolved_primary:
             dispositions.append(
-                {
-                    "agent": agent,
-                    "status": "honored_primary",
-                    "reason": "Requested agent already matches the routed primary.",
-                }
+                _disposition(
+                    agent,
+                    REQUESTED_AGENT_STATUS_HONORED_PRIMARY,
+                    "Requested agent already matches the routed primary.",
+                )
             )
             continue
 
@@ -125,11 +129,11 @@ def _apply_requested_agent_overrides(
             if agent not in advisory_agents:
                 advisory_agents.append(agent)
             dispositions.append(
-                {
-                    "agent": agent,
-                    "status": "advisory_non_routable",
-                    "reason": "Agent is canonical but non-routable; kept as an advisory collaborator.",
-                }
+                _disposition(
+                    agent,
+                    REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
+                    "Agent is canonical but non-routable; kept as an advisory collaborator.",
+                )
             )
             continue
 
@@ -157,22 +161,22 @@ def _apply_requested_agent_overrides(
                 previous_primary=previous_primary,
             )
             dispositions.append(
-                {
-                    "agent": agent,
-                    "status": "promoted_requested_agent",
-                    "reason": "Requested agent is compatible with the routed domain and was promoted.",
-                }
+                _disposition(
+                    agent,
+                    REQUESTED_AGENT_STATUS_PROMOTED,
+                    "Requested agent is compatible with the routed domain and was promoted.",
+                )
             )
             continue
 
         if agent not in advisory_agents:
             advisory_agents.append(agent)
         dispositions.append(
-            {
-                "agent": agent,
-                "status": "advisory_domain_mismatch",
-                "reason": "Requested agent stays advisory because it is outside the routed domain slot set.",
-            }
+            _disposition(
+                agent,
+                REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
+                "Requested agent stays advisory because it is outside the routed domain slot set.",
+            )
         )
 
     ordered_secondary_agents: list[str] = []
@@ -203,7 +207,7 @@ def build_task_packet(
     """Build a deterministic task packet for orchestration tooling."""
 
     normalized_paths = repo_relative_paths(candidate_paths)
-    normalized_requested_agents = _normalize_requested_agents(requested_agents)
+    normalized_requested_agents = normalize_requested_agents(requested_agents)
     domain = resolve_domain(
         task_class=task_class,
         candidate_paths=normalized_paths,

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -97,6 +97,36 @@ def test_route_skills_echoes_normalized_requested_agents() -> None:
     assert decision["requested_agents"] == ["frontend-engineer", "backend-engineer"]
 
 
+def test_requested_agent_duplicates_do_not_stack_bundle_boosts() -> None:
+    """Duplicate requested agents should not apply extra bundle boosts."""
+
+    single_requested = route_skills(
+        goal="Open PR for the frontend settings page review",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+        requested_agents=["frontend-engineer"],
+    )
+    duplicate_requested = route_skills(
+        goal="Open PR for the frontend settings page review",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+        requested_agents=["frontend-engineer", "Frontend-Engineer", " frontend-engineer "],
+    )
+
+    single_skill = next(
+        item for item in single_requested["recommended"] if item["skill"] == "pulseplate-gates"
+    )
+    duplicate_skill = next(
+        item for item in duplicate_requested["recommended"] if item["skill"] == "pulseplate-gates"
+    )
+
+    assert duplicate_requested["requested_agents"] == ["frontend-engineer"]
+    assert duplicate_skill["score"] == single_skill["score"]
+    assert duplicate_skill["reasons"].count("requested-agent:frontend-engineer(+2)") == 1
+
+
 def test_skill_router_selects_backend_contract_skills() -> None:
     """Backend contract changes should pull endpoint and OpenAPI skills."""
 

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -29,6 +29,22 @@ def test_skill_router_prefers_orchestration_docs_skills() -> None:
     assert "pulseplate-guards" in skills
 
 
+def test_skill_router_applies_requested_agent_default_bundle() -> None:
+    """Requested agents should boost their documented default helper bundles."""
+
+    skills = select_recommended_skills(
+        goal="Refine frontend settings page",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+        requested_agents=["frontend-engineer"],
+    )
+
+    assert "pulseplate-frontend-ui" in skills
+    assert "pulseplate-gates" in skills
+    assert "vercel-react-best-practices" in skills
+
+
 def test_skill_router_selects_backend_contract_skills() -> None:
     """Backend contract changes should pull endpoint and OpenAPI skills."""
 
@@ -45,6 +61,19 @@ def test_skill_router_selects_backend_contract_skills() -> None:
     assert "pulseplate-backend-endpoints" in skills
     assert "pulseplate-openapi-sync" in skills
     assert "pulseplate-gates" in skills
+
+
+def test_skill_router_selects_openai_docs_for_backend_ai_contracts() -> None:
+    """Backend AI/runtime work should be able to reach OpenAI docs guidance."""
+
+    skills = select_recommended_skills(
+        goal="Update OpenAI assistant contract for backend LLM endpoint",
+        task_class="Backend API",
+        candidate_paths=["app/routers/insight.py"],
+        domain="backend",
+    )
+
+    assert "openai-docs" in skills
 
 
 def test_skill_router_matches_punctuated_keywords_after_normalization() -> None:
@@ -162,6 +191,19 @@ def test_skill_router_selects_ci_fix_for_explicit_ci_failure() -> None:
     assert "ci-fix" in skills
 
 
+def test_skill_router_selects_github_comment_skill_for_review_threads() -> None:
+    """Review-thread remediation should select the dedicated GitHub comments skill."""
+
+    skills = select_recommended_skills(
+        goal="Address review comments and resolve GitHub review thread mappings",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+    )
+
+    assert "gh-address-comments" in skills
+
+
 def test_skill_router_selects_threat_model_for_explicit_security_intent() -> None:
     """Threat-model requests should cross the explicit security threshold."""
 
@@ -173,6 +215,23 @@ def test_skill_router_selects_threat_model_for_explicit_security_intent() -> Non
     )
 
     assert "security-threat-model" in skills
+
+
+def test_skill_router_boosts_security_skills_for_privileged_surfaces() -> None:
+    """Privilege-sensitive workflow and release paths should trigger security helpers."""
+
+    skills = select_recommended_skills(
+        goal="Tighten App Store workflow session handling",
+        task_class="Release",
+        candidate_paths=[
+            ".github/workflows/ios-appstore-assets.yml",
+            "ios/fastlane/Fastfile",
+        ],
+        domain="release",
+    )
+
+    assert "security-best-practices" in skills
+    assert "pulseplate-guards" in skills
 
 
 def test_skill_router_prefix_match_is_boundary_aware() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -286,6 +286,19 @@ def test_skill_router_boosts_security_skills_for_privileged_surfaces() -> None:
     assert "pulseplate-guards" in skills
 
 
+def test_skill_router_treats_review_mapping_docs_as_privileged_surfaces() -> None:
+    """Review-mapping docs should also trigger the privileged-surface security skill."""
+
+    skills = select_recommended_skills(
+        goal="Refresh merge-readiness review mapping guidance",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+    )
+
+    assert "security-best-practices" in skills
+
+
 def test_skill_router_prefix_match_is_boundary_aware() -> None:
     """Filename prefixes must not match unrelated longer filenames."""
 

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -45,6 +45,58 @@ def test_skill_router_applies_requested_agent_default_bundle() -> None:
     assert "vercel-react-best-practices" in skills
 
 
+def test_requested_agent_bundle_boosts_existing_skill_without_duplication() -> None:
+    """Requested bundles should boost existing skills without duplicating entries."""
+
+    baseline = route_skills(
+        goal="Open PR for the frontend settings page review",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+    )
+    with_requested = route_skills(
+        goal="Open PR for the frontend settings page review",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+        requested_agents=["frontend-engineer"],
+    )
+
+    baseline_skill = next(
+        item for item in baseline["recommended"] if item["skill"] == "pulseplate-gates"
+    )
+    requested_skill = next(
+        item for item in with_requested["recommended"] if item["skill"] == "pulseplate-gates"
+    )
+
+    assert (
+        len([item for item in with_requested["recommended"] if item["skill"] == "pulseplate-gates"])
+        == 1
+    )
+    assert requested_skill["score"] == baseline_skill["score"] + 2
+    assert "requested-agent:frontend-engineer(+2)" in requested_skill["reasons"]
+
+
+def test_route_skills_echoes_normalized_requested_agents() -> None:
+    """Router output should echo requested agents in normalized deduplicated form."""
+
+    decision = route_skills(
+        goal="Refine frontend settings page",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Settings.tsx"],
+        domain="frontend",
+        requested_agents=[
+            "frontend-engineer",
+            "Frontend-Engineer",
+            "   FRONTEND-ENGINEER  ",
+            "backend-engineer",
+            "BACKEND-ENGINEER",
+        ],
+    )
+
+    assert decision["requested_agents"] == ["frontend-engineer", "backend-engineer"]
+
+
 def test_skill_router_selects_backend_contract_skills() -> None:
     """Backend contract changes should pull endpoint and OpenAPI skills."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -124,6 +124,24 @@ def test_task_bootstrap_keeps_non_routable_requested_agent_as_advisory() -> None
     ]
 
 
+def test_task_bootstrap_requested_agents_change_packet_id() -> None:
+    """Requested agents should contribute to the deterministic packet identity."""
+
+    baseline = build_task_packet(
+        goal="Implement backend entitlement routing",
+        task_class="Backend API",
+        candidate_paths=["app/middleware/api_tiers.py"],
+    )
+    with_requested = build_task_packet(
+        goal="Implement backend entitlement routing",
+        task_class="Backend API",
+        candidate_paths=["app/middleware/api_tiers.py"],
+        requested_agents=["backend-engineer"],
+    )
+
+    assert baseline["task_packet_id"] != with_requested["task_packet_id"]
+
+
 def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
     """Security acronyms must not trigger the CV routing domain."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -142,6 +142,24 @@ def test_task_bootstrap_requested_agents_change_packet_id() -> None:
     assert baseline["task_packet_id"] != with_requested["task_packet_id"]
 
 
+def test_task_bootstrap_keeps_security_auditor_in_privileged_review_path() -> None:
+    """Privileged orchestration paths must retain security review after overrides."""
+
+    packet = build_task_packet(
+        goal="Update privileged orchestration workflow",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["agent-coordinator"],
+    )
+
+    review_path = {
+        packet["primary_agent"],
+        packet["reviewer"],
+        *packet["secondary_agents"],
+    }
+    assert "security-auditor" in review_path
+
+
 def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
     """Security acronyms must not trigger the CV routing domain."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -160,6 +160,32 @@ def test_task_bootstrap_keeps_security_auditor_in_privileged_review_path() -> No
     assert "security-auditor" in review_path
 
 
+def test_task_bootstrap_updates_honored_primary_after_later_promotion() -> None:
+    """Earlier honored-primary dispositions must stay aligned with final routing."""
+
+    packet = build_task_packet(
+        goal="Update privileged orchestration workflow",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["agent-coordinator", "architecture-specialist"],
+    )
+
+    assert packet["primary_agent"] == "architecture-specialist"
+    assert "agent-coordinator" in packet["secondary_agents"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "agent-coordinator",
+            "status": "honored_secondary",
+            "reason": "Requested agent stayed honored but moved to secondary after a later promotion.",
+        },
+        {
+            "agent": "architecture-specialist",
+            "status": "promoted_requested_agent",
+            "reason": "Requested agent is compatible with the routed domain and was promoted.",
+        },
+    ]
+
+
 def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
     """Security acronyms must not trigger the CV routing domain."""
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -79,6 +79,51 @@ def test_task_bootstrap_routes_cv_tasks_to_cv_domain() -> None:
     assert "pulseplate-gates" in packet["recommended_skills"]
 
 
+def test_task_bootstrap_promotes_requested_routable_agent() -> None:
+    """Requested agents already present in the routed slot set may become primary."""
+
+    packet = build_task_packet(
+        goal="Implement backend entitlement routing",
+        task_class="Backend API",
+        candidate_paths=["app/middleware/api_tiers.py"],
+        requested_agents=["backend-engineer"],
+    )
+
+    assert packet["domain"] == "backend"
+    assert packet["primary_agent"] == "backend-engineer"
+    assert "architecture-specialist" in packet["secondary_agents"]
+    assert packet["requested_agents"] == ["backend-engineer"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "backend-engineer",
+            "status": "honored_primary",
+            "reason": "Requested agent already matches the routed primary.",
+        }
+    ]
+
+
+def test_task_bootstrap_keeps_non_routable_requested_agent_as_advisory() -> None:
+    """Non-routable specialists should be preserved as advisory collaborators."""
+
+    packet = build_task_packet(
+        goal="Design AI reliability experiment packet",
+        task_class="AI / ML",
+        candidate_paths=["docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md"],
+        requested_agents=["ml-engineer-agent"],
+    )
+
+    assert packet["domain"] == "ml"
+    assert packet["primary_agent"] == "ai-innovation-specialist"
+    assert "ml-engineer-agent" in packet["secondary_agents"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "ml-engineer-agent",
+            "status": "advisory_non_routable",
+            "reason": "Agent is canonical but non-routable; kept as an advisory collaborator.",
+        }
+    ]
+
+
 def test_task_bootstrap_does_not_treat_cve_or_cvss_as_cv_domain() -> None:
     """Security acronyms must not trigger the CV routing domain."""
 
@@ -199,11 +244,14 @@ def test_main_writes_relative_output_inside_repo(tmp_path, monkeypatch, capsys) 
         "primary_agent": "agent-coordinator",
         "secondary_agents": [],
         "reviewer": "architecture-specialist",
+        "requested_agents": [],
+        "requested_agent_disposition": [],
         "required_context": ["AGENTS.md"],
         "recommended_skills": ["pulseplate-workflow"],
         "skill_routing": {
             "policy_version": "2026-03-08",
             "selection_mode": "deterministic-weighted",
+            "requested_agents": [],
             "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
             "blocked": [],
         },
@@ -254,11 +302,14 @@ def test_main_writes_repo_root_output_as_relative_path(monkeypatch, capsys) -> N
         "primary_agent": "agent-coordinator",
         "secondary_agents": [],
         "reviewer": "architecture-specialist",
+        "requested_agents": [],
+        "requested_agent_disposition": [],
         "required_context": ["AGENTS.md"],
         "recommended_skills": ["pulseplate-workflow"],
         "skill_routing": {
             "policy_version": "2026-03-08",
             "selection_mode": "deterministic-weighted",
+            "requested_agents": [],
             "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
             "blocked": [],
         },
@@ -287,3 +338,62 @@ def test_main_writes_repo_root_output_as_relative_path(monkeypatch, capsys) -> N
     finally:
         if repo_output.exists():
             repo_output.unlink()
+
+
+def test_main_passes_requested_agent_flags(monkeypatch, capsys) -> None:
+    """CLI should propagate repeated --requested-agent values into the packet builder."""
+
+    observed: dict[str, object] = {}
+
+    def _fake_build_task_packet(**kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        return {
+            "schema_version": "2.0",
+            "task_packet_id": "req-agent-packet",
+            "goal": "Use requested agents",
+            "task_class": "Orchestration",
+            "domain": "orchestration",
+            "cluster": "ops",
+            "candidate_paths": ["scripts/orchestration/task_bootstrap.py"],
+            "primary_agent": "agent-coordinator",
+            "secondary_agents": ["security-auditor"],
+            "reviewer": "architecture-specialist",
+            "requested_agents": ["agent-coordinator", "security-auditor"],
+            "requested_agent_disposition": [],
+            "required_context": ["AGENTS.md"],
+            "recommended_skills": ["pulseplate-workflow"],
+            "skill_routing": {
+                "policy_version": "2026-03-08",
+                "selection_mode": "deterministic-weighted",
+                "requested_agents": ["agent-coordinator", "security-auditor"],
+                "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
+                "blocked": [],
+            },
+            "routing_rationale": {"source": "canonical_only"},
+        }
+
+    monkeypatch.setattr(
+        "scripts.orchestration.task_bootstrap.build_task_packet",
+        _fake_build_task_packet,
+    )
+
+    exit_code = main(
+        [
+            "--goal",
+            "Use explicit requested agents",
+            "--task-class",
+            "Orchestration",
+            "--requested-agent",
+            "agent-coordinator",
+            "--requested-agent",
+            "security-auditor",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert observed["requested_agents"] == ["agent-coordinator", "security-auditor"]
+    assert json.loads(captured.out)["requested_agents"] == [
+        "agent-coordinator",
+        "security-auditor",
+    ]


### PR DESCRIPTION
## Summary
- preserve explicit requested-agent slugs through coordinator bootstrap and skill routing so task packets stay deterministic
- add default requested-agent skill bundles and privileged-surface security review rules across orchestration docs, coordinator guidance, and tests
- align orchestration docs and regression tests with the new requested-agent override contract

## Scope
IN: orchestration routing docs, coordinator contract, task bootstrap + skill router logic, orchestration regression tests.
OUT: backlog ledger normalization, readiness blocker fixes, merge-readiness gate consolidation, logic/philosophy replay experiment.

## Test plan
- [x] `pytest -q tests/test_task_bootstrap.py tests/test_skill_router.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`
- [x] `git push -u origin HEAD` pre-push hooks

## Rollback plan
Revert this PR to restore the previous requested-agent routing behavior and coordinator guidance.

## Deferred / Follow-ups
- Ledger normalization and cross-lane backlog updates remain in the planned follow-up PR cycles.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [x] Local hard gate passed (`make verify`)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed

## Summary by Sourcery

Усилена обработка `requested-agent` в оркестрации за счёт детерминированного роутинга, сквозного сохранения явных запросов агентов и обновления документации и тестов в соответствии с новым контрактом переопределения и требованиями к security-review.

New Features:
- Разрешить передавать явные слаги `requested-agent` через CLI в процесс bootstrap задачи и сохранять их в пакетах задач.
- Поддержать детерминированную логику переопределения `requested-agent`, которая может повышать совместимых агентов до основных ролей или оставлять их в роли консультативных коллабораторов с зафиксированным статусом.
- Ввести наборы навыков по умолчанию, ассоциированные со слагами запрошенных агентов, чтобы смещать роутинг навыков в сторону релевантных вспомогательных навыков.

Enhancements:
- Расширить правила роутинга навыков дополнительными эвристиками, связанными с безопасностью, backend, frontend и GitHub-review, включая триггеры привилегированных поверхностей и покрытие OpenAI-docs для backend‑AI задач.
- Обновить каноничный граф роутинга агентов, рекомендации координатора и чек-лист workflow оркестрации, чтобы зафиксировать поведение переопределения `requested-agent` и требования к security review для привилегированных поверхностей.

Documentation:
- Задокументировать наборы по умолчанию для `requested-agent`, контракты переопределения для неспособных к роутингу специалистов и триггеры security для привилегированных поверхностей в политике оркестрации и документации по роутингу.
- Добавить пункт в чек-лист review, чтобы гарантировать корректное отображение запрошенных агентов и путей security review в пакетах задач.

Tests:
- Добавить регрессионные тесты для поведения повышения/консультативной роли `requested-agent` в bootstrap задач и для наборов, управляемых `requested-agent`, а также новых навыков security/GitHub-comment в маршрутизаторе навыков.
- Обновить существующие тесты оркестрации, чтобы они покрывали расширенный payload роутинга (запрошенные агенты, статусы) и оставались синхронизированными с обновлённым графом роутинга.

Chores:
- Добавить документ сопоставления review с фиксацией «fixed-in-commit» для PR 1166.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden requested-agent handling in orchestration by making routing deterministic, preserving explicit agent requests end-to-end, and updating docs and tests to reflect the new override and security-review contracts.

New Features:
- Allow explicit requested-agent slugs to be passed via CLI into task bootstrap and preserved in task packets.
- Support deterministic requested-agent override logic that can promote compatible agents into primary roles or retain them as advisory collaborators with recorded disposition.
- Introduce default skill bundles keyed by requested agent slugs to bias skill routing toward appropriate helper skills.

Enhancements:
- Extend skill routing rules with additional security, backend, frontend, and GitHub-review-related heuristics, including privileged-surface triggers and OpenAI-docs coverage for backend AI work.
- Update the canonical agent routing graph, coordinator guidance, and orchestration workflow checklist to encode requested-agent override behavior and privileged-surface security review requirements.

Documentation:
- Document requested-agent default bundles, non-routable specialist override contracts, and privileged-surface security triggers in orchestration policy and routing docs.
- Add a review checklist entry to ensure requested agents and security review paths are correctly reflected in task packets.

Tests:
- Add regression tests for requested-agent promotion/advisory behavior in task bootstrap and for requested-agent-driven bundles and new security/GitHub-comment skills in the skill router.
- Update existing orchestration tests to cover the extended routing payload (requested agents, dispositions) and to keep them aligned with the refreshed routing graph.

Chores:
- Add a fixed-in-commit review mapping document for PR 1166.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve explicit requested agents in task packets (recorded with disposition); honor compatible requests and apply helper skill bundles after canonical routing. CLI accepts repeated requested-agent flags and packets include requested_agents.

* **Documentation**
  * Updated routing policies, specialist allowlists, routing graph, and workflow checklists to reflect requested-agent semantics and privileged-surface security review rules.

* **Tests**
  * Extensive tests added for routing, requested-agent promotions/advisory behavior, security review triggers, and deterministic packet IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->