### PR TITLE
fix(orchestration): clarify merge readiness bundles

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -106,6 +106,25 @@ Rule: RUNBOOK does not duplicate checklists; it only links to the canonical sour
 
 **This is the authoritative procedural checklist.** Thresholds/policy live in `AGENTS.md`.
 
+### Merge-Ready Bundle (Blocking vs Advisory)
+
+Use this bundle when you need a strict merge claim:
+
+1. Local blocking bundle:
+   - `pre-commit run --all-files`
+   - `make verify`
+2. PR governance blocking bundle:
+   - `python scripts/orchestration/check_merge_ready.py --pr-number <N> --repo <owner/name> --require-auth`
+3. Advisory / external signals:
+   - Non-required CI jobs
+   - Third-party review bots unless branch protection marks them required
+4. Release-ops blocking bundle:
+   - Fastlane / App Store validation and upload lanes are blocking for publish claims, not automatically for ordinary PR merge claims unless the PR itself changes release surfaces
+
+Canonical SoT for the lane matrix:
+- `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md` (`CI Check Classification`)
+- `scripts/orchestration/check_merge_ready.py`
+
 ## Guard Coverage Step (EVMbench-inspired)
 
 **Purpose:** Ensure comprehensive coverage — address *all* related violations, not just one.

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -164,9 +164,23 @@ Evidence:
 | Soft gate | advisory quality signal   | no                          |
 | External  | third-party review signal | only if explicitly required |
 
+Canonical lane matrix:
+
+| Lane        | Command / Surface | Class | Blocking Rule |
+| ----------- | ----------------- | ----- | ------------- |
+| Local       | `pre-commit run --all-files` | Hard gate | Must pass before push; hook modifications must be committed |
+| Local       | `make verify` | Hard gate | Canonical code-quality bundle for merge claims |
+| Local / CI  | `python scripts/orchestration/check_merge_ready.py ...` | Hard gate | Wrapper must pass Phase 2 + review governance + current-head required checks + disposition proof |
+| PR CI       | GitHub branch-protection required checks on current HEAD | Hard gate | Pending/failed current-head required jobs block merge |
+| PR CI       | Non-required jobs / informational workflows | Soft gate | Visible signal only; fix or ledger if risk is real |
+| Release ops | App Store / Fastlane validation lanes | Hard gate for release, not PR merge by default | Must pass before upload/publish claims; may be out-of-scope for code-only PR merge |
+| External    | CodeRabbit / Sourcery / Cubic / similar bots | External | Advisory unless GitHub explicitly marks them required |
+
 Evidence:
 - `scripts/ci/check_pr_merge_readiness.py:349`
 - `scripts/ci/check_pr_merge_readiness.py:400`
+- `scripts/ci/check_current_head_pr_checks.py:406`
+- `scripts/orchestration/check_merge_ready.py:1`
 - `scripts/ci/check_pr_body_phase2_gates.py:162`
 - `scripts/ci/check_pr_body_phase2_gates.py:182`
 

--- a/docs/review/PR_1169_FIXED_MAPPING.md
+++ b/docs/review/PR_1169_FIXED_MAPPING.md
@@ -29,7 +29,7 @@ Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:8` now points to `scripts/orches
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935302846 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
 
 ## Merge Readiness
-- [x] Local hard gate passed (`make verify`)
+- [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1169_FIXED_MAPPING.md
+++ b/docs/review/PR_1169_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1169 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+Disposition: FIXED
+Commit: 7b6ef2da5e5149bb63793f203a0a6512c952a356
+Evidence: `scripts/orchestration/check_merge_ready.py:56` defines a stable `BLOCKING_MERGE_READY_GATES` order, while `scripts/orchestration/check_merge_ready.py:253` now derives `blocking=yes/no` from `policy.blocking` instead of hardcoding the label; `tests/test_orchestration_merge_ready.py:225` locks the contract with a regression test that proves a non-blocking policy prints `blocking=no`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948850887 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935290995 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1169_FIXED_MAPPING.md
+++ b/docs/review/PR_1169_FIXED_MAPPING.md
@@ -33,6 +33,11 @@ Commit: c64a656cfe4252bca97f58c2d1dfac20228ff3c5
 Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:32` now keeps `Local hard gate passed (\`make verify\`)` unchecked so the merge-readiness checklist remains forward-looking until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935307686 -> c64a656cfe4252bca97f58c2d1dfac20228ff3c5
 
+Disposition: NOT-A-BUG
+Evidence: The review-level CodeRabbit summary at `pullrequestreview-3948864094` only restates the single inline checkbox finding already fixed and mapped above at `discussion_r2935307686`; `docs/review/PR_1169_FIXED_MAPPING.md:37` shows no additional action item beyond that resolved thread.
+Reason: This review object does not introduce a second independent merge-readiness issue, so it is dispositioned as a summary-only wrapper around the already fixed inline comment.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948864094
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1169_FIXED_MAPPING.md
+++ b/docs/review/PR_1169_FIXED_MAPPING.md
@@ -28,6 +28,11 @@ Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:8` now points to `scripts/orches
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948859818 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935302846 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
 
+Disposition: FIXED
+Commit: c64a656cfe4252bca97f58c2d1dfac20228ff3c5
+Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:32` now keeps `Local hard gate passed (\`make verify\`)` unchecked so the merge-readiness checklist remains forward-looking until the final merge cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935307686 -> c64a656cfe4252bca97f58c2d1dfac20228ff3c5
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1169_FIXED_MAPPING.md
+++ b/docs/review/PR_1169_FIXED_MAPPING.md
@@ -7,12 +7,29 @@
 ### Fixed in Commit Mapping
 Disposition: FIXED
 Commit: 7b6ef2da5e5149bb63793f203a0a6512c952a356
-Evidence: `scripts/orchestration/check_merge_ready.py:56` defines a stable `BLOCKING_MERGE_READY_GATES` order, while `scripts/orchestration/check_merge_ready.py:253` now derives `blocking=yes/no` from `policy.blocking` instead of hardcoding the label; `tests/test_orchestration_merge_ready.py:225` locks the contract with a regression test that proves a non-blocking policy prints `blocking=no`.
+Evidence: `scripts/orchestration/check_merge_ready.py:56` defines a stable `BLOCKING_MERGE_READY_GATES` order, while `scripts/orchestration/check_merge_ready.py:266` now derives `blocking=yes/no` from `policy.blocking` instead of hardcoding the label; `tests/test_orchestration_merge_ready.py:225` locks the contract with a regression test that proves a non-blocking policy prints `blocking=no`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948850887 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935290995 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
 
+Disposition: FIXED
+Commit: 7b6ef2da5e5149bb63793f203a0a6512c952a356
+Evidence: `scripts/orchestration/check_merge_ready.py:56` defines the canonical blocking gate order, and `scripts/orchestration/check_merge_ready.py:266` now prints `blocking=yes/no` from `policy.blocking`; this satisfies the duplicate cubic finding about hardcoded bundle output, with the regression expectation anchored in `tests/test_orchestration_merge_ready.py:225`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948852341 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935292982 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/check_merge_ready.py:310` constructs `gate_results` only from the four canonical hard gates, and `scripts/orchestration/check_merge_ready.py:325` therefore intentionally treats every non-zero return in that fixed bundle as blocking. The advisory fallback policy is currently output metadata for unknown names, not an executed lane inside this wrapper contract.
+Reason: CodeRabbit identified a hypothetical future mismatch if non-blocking gates are ever added to `gate_results`, but the current wrapper executes only the fixed blocking bundle, so the present merge verdict logic remains consistent with the implemented contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948859273
+
+Disposition: FIXED
+Commit: cc39111f5d6d98b0f879ae2319139d68412b00b4
+Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:8` now points to `scripts/orchestration/check_merge_ready.py:266`, the actual line where `blocking_value` is derived, so the artifact proof matches the code that implements the fix.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948859818 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935302846 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
+
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
+- [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -1,4 +1,9 @@
-"""Merge-readiness CI gate: fail when non-draft PR has unresolved threads or unmapped bot comments."""
+"""Review-governance merge gate for unresolved threads and bot-comment mapping.
+
+This script does not classify current-head required checks; the canonical
+required-check truth lives in `check_current_head_pr_checks.py` and the
+`check_merge_ready.py` wrapper bundles both hard gates.
+"""
 
 from __future__ import annotations
 
@@ -392,12 +397,12 @@ def main() -> int:
                 print(f"UNMAPPED: {item.author} [{item.kind}] {item.url} ({item.created_at})")
 
     if errors:
-        print("ERROR: merge-readiness gate failed:")
+        print("ERROR: review-governance merge gate failed:")
         for line in errors:
             print(f"- {line}")
         return 1
 
-    print("merge-readiness-gate: passed.")
+    print("merge-readiness-gate: passed (review governance only).")
     print(
         "Zero comments: 0 unresolved threads, all actionable bot comments mapped in canonical artifact."
     )

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -34,6 +34,23 @@ class GateResult:
     stderr: str
 
 
+@dataclass(frozen=True)
+class GatePolicy:
+    """Static gate classification used by the wrapper output."""
+
+    gate_class: str
+    lane: str
+    blocking: bool
+
+
+GATE_POLICIES: dict[str, GatePolicy] = {
+    "phase2-pr-body-gates": GatePolicy(gate_class="hard", lane="pr-governance", blocking=True),
+    "merge-readiness-gate": GatePolicy(gate_class="hard", lane="review-governance", blocking=True),
+    "current-head-checks": GatePolicy(gate_class="hard", lane="required-checks", blocking=True),
+    "review-threads-disposition": GatePolicy(gate_class="hard", lane="review-proof", blocking=True),
+}
+
+
 def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     """Enforce CI vs local mode contract for the wrapper CLI."""
 
@@ -215,12 +232,29 @@ def _disposition_gate_skipped(result: GateResult) -> bool:
 def _print_gate_output(result: GateResult) -> None:
     """Render one gate block for deterministic local/CI diagnostics."""
 
+    policy = GATE_POLICIES.get(
+        result.name,
+        GatePolicy(gate_class="advisory", lane="unclassified", blocking=False),
+    )
     status = "PASS" if result.returncode == 0 else "FAIL"
-    print(f"[{status}] {result.name}")
+    blocking_label = "blocking" if policy.blocking else "advisory"
+    print(
+        f"[{status}] {result.name} " f"({policy.gate_class}; lane={policy.lane}; {blocking_label})"
+    )
     if result.stdout:
         print(result.stdout)
     if result.stderr:
         print(result.stderr)
+
+
+def _print_merge_ready_bundle() -> None:
+    """Render the canonical blocking bundle before gate execution output."""
+
+    print("Blocking merge-ready bundle:")
+    for gate_name, policy in GATE_POLICIES.items():
+        print(f"- {gate_name}: class={policy.gate_class}, lane={policy.lane}, blocking=yes")
+    print("Advisory / external signals:")
+    print("- third-party review bots remain advisory unless GitHub branch protection promotes them")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -277,6 +311,7 @@ def main(argv: list[str] | None = None) -> int:
     disposition_skipped = any(_disposition_gate_skipped(result) for result in gate_results)
     if disposition_skipped:
         failed.append("review-threads-disposition")
+    _print_merge_ready_bundle()
     for result in gate_results:
         _print_gate_output(result)
 

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -11,6 +11,7 @@ import subprocess  # nosec B404: wrapper executes fixed repo scripts only (remov
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -38,8 +39,10 @@ class GateResult:
 class GatePolicy:
     """Static gate classification used by the wrapper output."""
 
-    gate_class: str
-    lane: str
+    gate_class: Literal["hard", "soft", "external", "advisory"]
+    lane: Literal[
+        "pr-governance", "review-governance", "required-checks", "review-proof", "unclassified"
+    ]
     blocking: bool
 
 
@@ -49,6 +52,13 @@ GATE_POLICIES: dict[str, GatePolicy] = {
     "current-head-checks": GatePolicy(gate_class="hard", lane="required-checks", blocking=True),
     "review-threads-disposition": GatePolicy(gate_class="hard", lane="review-proof", blocking=True),
 }
+
+BLOCKING_MERGE_READY_GATES: tuple[str, ...] = (
+    "phase2-pr-body-gates",
+    "merge-readiness-gate",
+    "current-head-checks",
+    "review-threads-disposition",
+)
 
 
 def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
@@ -251,8 +261,13 @@ def _print_merge_ready_bundle() -> None:
     """Render the canonical blocking bundle before gate execution output."""
 
     print("Blocking merge-ready bundle:")
-    for gate_name, policy in GATE_POLICIES.items():
-        print(f"- {gate_name}: class={policy.gate_class}, lane={policy.lane}, blocking=yes")
+    for gate_name in BLOCKING_MERGE_READY_GATES:
+        policy = GATE_POLICIES[gate_name]
+        blocking_value = "yes" if policy.blocking else "no"
+        print(
+            f"- {gate_name}: class={policy.gate_class}, "
+            f"lane={policy.lane}, blocking={blocking_value}"
+        )
     print("Advisory / external signals:")
     print("- third-party review bots remain advisory unless GitHub branch protection promotes them")
 

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -215,6 +215,8 @@ def test_wrapper_surfaces_failing_gate_names(
 
     captured = capsys.readouterr()
     assert exit_code == 1
+    assert "Blocking merge-ready bundle:" in captured.out
+    assert "[FAIL] merge-readiness-gate (hard; lane=review-governance; blocking)" in captured.out
     assert "ERROR: orchestration merge-check failed." in captured.out
     assert "Failing gates: merge-readiness-gate" in captured.out
     assert "ERROR: unresolved review threads" in captured.out

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -222,6 +222,45 @@ def test_wrapper_surfaces_failing_gate_names(
     assert "ERROR: unresolved review threads" in captured.out
 
 
+def test_merge_ready_bundle_uses_declared_blocking_policy(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        merge_ready,
+        "GATE_POLICIES",
+        {
+            "phase2-pr-body-gates": merge_ready.GatePolicy(
+                gate_class="hard", lane="pr-governance", blocking=True
+            ),
+            "merge-readiness-gate": merge_ready.GatePolicy(
+                gate_class="hard", lane="review-governance", blocking=False
+            ),
+            "current-head-checks": merge_ready.GatePolicy(
+                gate_class="hard", lane="required-checks", blocking=True
+            ),
+            "review-threads-disposition": merge_ready.GatePolicy(
+                gate_class="hard", lane="review-proof", blocking=True
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        merge_ready,
+        "BLOCKING_MERGE_READY_GATES",
+        (
+            "phase2-pr-body-gates",
+            "merge-readiness-gate",
+            "current-head-checks",
+            "review-threads-disposition",
+        ),
+    )
+
+    merge_ready._print_merge_ready_bundle()
+
+    captured = capsys.readouterr()
+    assert "phase2-pr-body-gates: class=hard, lane=pr-governance, blocking=yes" in captured.out
+    assert "merge-readiness-gate: class=hard, lane=review-governance, blocking=no" in captured.out
+
+
 def test_wrapper_fails_when_disposition_gate_skips_in_advisory_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- make the merge-readiness wrapper print the canonical blocking bundle before gate output
- label review-governance output explicitly so operators do not confuse it with current-head required checks
- align the runbook and orchestration contract matrix with the same hard/soft/external lane taxonomy

## Test plan
- [x] `pytest -q tests/test_orchestration_merge_ready.py`
- [x] `pytest -q tests/test_current_head_pr_checks.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: 7b6ef2da5e5149bb63793f203a0a6512c952a356
Evidence: `scripts/orchestration/check_merge_ready.py:56` defines a stable `BLOCKING_MERGE_READY_GATES` order, while `scripts/orchestration/check_merge_ready.py:266` now derives `blocking=yes/no` from `policy.blocking` instead of hardcoding the label; `tests/test_orchestration_merge_ready.py:225` locks the contract with a regression test that proves a non-blocking policy prints `blocking=no`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948850887 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935290995 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356

Disposition: FIXED
Commit: 7b6ef2da5e5149bb63793f203a0a6512c952a356
Evidence: `scripts/orchestration/check_merge_ready.py:56` defines the canonical blocking gate order, and `scripts/orchestration/check_merge_ready.py:266` now prints `blocking=yes/no` from `policy.blocking`; this satisfies the duplicate cubic finding about hardcoded bundle output, with the regression expectation anchored in `tests/test_orchestration_merge_ready.py:225`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948852341 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935292982 -> 7b6ef2da5e5149bb63793f203a0a6512c952a356

Disposition: NOT-A-BUG
Evidence: `scripts/orchestration/check_merge_ready.py:310` constructs `gate_results` only from the four canonical hard gates, and `scripts/orchestration/check_merge_ready.py:325` therefore intentionally treats every non-zero return in that fixed bundle as blocking. The advisory fallback policy is currently output metadata for unknown names, not an executed lane inside this wrapper contract.
Reason: CodeRabbit identified a hypothetical future mismatch if non-blocking gates are ever added to `gate_results`, but the current wrapper executes only the fixed blocking bundle, so the present merge verdict logic remains consistent with the implemented contract.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948859273

Disposition: FIXED
Commit: cc39111f5d6d98b0f879ae2319139d68412b00b4
Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:8` now points to `scripts/orchestration/check_merge_ready.py:266`, the actual line where `blocking_value` is derived, so the artifact proof matches the code that implements the fix.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948859818 -> cc39111f5d6d98b0f879ae2319139d68412b00b4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935302846 -> cc39111f5d6d98b0f879ae2319139d68412b00b4

Disposition: FIXED
Commit: c64a656cfe4252bca97f58c2d1dfac20228ff3c5
Evidence: `docs/review/PR_1169_FIXED_MAPPING.md:32` now keeps `Local hard gate passed (\`make verify\`)` unchecked so the merge-readiness checklist remains forward-looking until the final merge cycle.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#discussion_r2935307686 -> c64a656cfe4252bca97f58c2d1dfac20228ff3c5

Disposition: NOT-A-BUG
Evidence: The review-level CodeRabbit summary at `pullrequestreview-3948864094` only restates the single inline checkbox finding already fixed and mapped above at `discussion_r2935307686`; `docs/review/PR_1169_FIXED_MAPPING.md:37` shows no additional action item beyond that resolved thread.
Reason: This review object does not introduce a second independent merge-readiness issue, so it is dispositioned as a summary-only wrapper around the already fixed inline comment.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1169#pullrequestreview-3948864094

## Merge Readiness
- [ ] Local hard gate passed (`make verify`)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added merge-ready bundle classification guidance documenting gate categories
  * Added canonical lane matrix reference for orchestration processes
  * Added PR verification status and merge readiness checklist documentation

* **New Features**
  * Introduced blocking and advisory gate classification in merge readiness output
  * Added human-readable merge-ready bundle summary with policy details

* **Improvements**
  * Refined merge gate messaging for clarity on governance review scope

<!-- end of auto-generated comment: release notes by coderabbit.ai -->