### PR TITLE
feat(experimentation): add logic philosophy replay lane

### DIFF
--- a/docs/analytics/EXPERIMENT_REGISTRY.md
+++ b/docs/analytics/EXPERIMENT_REGISTRY.md
@@ -13,6 +13,7 @@ success criteria explicit.
 
 | Experiment | Hypothesis (falsifiable) | Start date | End date | Owner | Status |
 |-----------|---------------------------|------------|----------|-------|--------|
+| EXP-AIR-001: Logic + philosophy replay | Combined `A3` offline replay answers improve correctness pass rate and first-pass readiness proxy over `A0` without increasing unsupported-claim rate, contradiction rate, or known-good false positives | 2026-03-14 | 2026-03-28 | AI Quality + Orchestration | Planned |
 | EXP-ONB-001: Onboarding copy clarity | Reworded first-run value proposition increases onboarding completion by at least 5% relative | 2026-03-01 | 2026-03-21 | Product + Growth | Planned |
 | EXP-PWL-001: Soft paywall timing | Showing soft paywall after first_success improves trial starts without D7 retention drop >1pp | 2026-03-08 | 2026-03-29 | Growth | Planned |
 | EXP-PWL-002: CTA framing | Changing CTA from generic upgrade to goal-based CTA improves paywall CTR by at least 7% | 2026-03-15 | 2026-04-05 | Growth + Design | Planned |

--- a/docs/analytics/EXPERIMENT_REGISTRY.md
+++ b/docs/analytics/EXPERIMENT_REGISTRY.md
@@ -13,7 +13,7 @@ success criteria explicit.
 
 | Experiment | Hypothesis (falsifiable) | Start date | End date | Owner | Status |
 |-----------|---------------------------|------------|----------|-------|--------|
-| EXP-AIR-001: Logic + philosophy replay | Combined `A3` offline replay answers improve correctness pass rate and first-pass readiness proxy over `A0` without increasing unsupported-claim rate, contradiction rate, or known-good false positives | 2026-03-14 | 2026-03-28 | AI Quality + Orchestration | Planned |
+| EXP-AIR-001: Logic + philosophy replay | Combined `A3` offline replay answers improve correctness pass rate and first-pass readiness proxy over `A0` without increasing unsupported claim rate, contradiction rate, or known-good false positives | 2026-03-14 | 2026-03-28 | AI Quality + Orchestration | Planned |
 | EXP-ONB-001: Onboarding copy clarity | Reworded first-run value proposition increases onboarding completion by at least 5% relative | 2026-03-01 | 2026-03-21 | Product + Growth | Planned |
 | EXP-PWL-001: Soft paywall timing | Showing soft paywall after first_success improves trial starts without D7 retention drop >1pp | 2026-03-08 | 2026-03-29 | Growth | Planned |
 | EXP-PWL-002: CTA framing | Changing CTA from generic upgrade to goal-based CTA improves paywall CTR by at least 7% | 2026-03-15 | 2026-04-05 | Growth + Design | Planned |

--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -254,6 +254,114 @@ Daily
 
 ---
 
+## Correctness pass rate
+
+#### Definition
+
+Percent of replay cases where an answer includes every required fact from the immutable offline oracle.
+
+#### Formula
+
+```text
+correctness_pass_rate =
+  cases_with_all_required_facts / total_replay_cases
+```
+
+#### Owner
+
+AI Quality + Orchestration
+
+#### Update frequency
+
+Per offline replay run
+
+#### Change history
+
+- 2026-03-14: initial definition for the logic + philosophy replay contract
+
+---
+
+## Unsupported claim rate
+
+#### Definition
+
+Share of extracted answer claims that do not match any supported oracle snippet for the replay case.
+
+#### Formula
+
+```text
+unsupported_claim_rate =
+  unsupported_claims / total_extracted_claims
+```
+
+#### Owner
+
+AI Quality + Orchestration
+
+#### Update frequency
+
+Per offline replay run
+
+#### Change history
+
+- 2026-03-14: initial definition for the logic + philosophy replay contract
+
+---
+
+## Contradiction rate
+
+#### Definition
+
+Percent of replay cases whose answer contains at least one deterministic contradiction detected by the offline checker.
+
+#### Formula
+
+```text
+contradiction_rate =
+  replay_cases_with_contradiction / total_replay_cases
+```
+
+#### Owner
+
+AI Quality + Orchestration
+
+#### Update frequency
+
+Per offline replay run
+
+#### Change history
+
+- 2026-03-14: initial definition for the logic + philosophy replay contract
+
+---
+
+## First-pass readiness proxy
+
+#### Definition
+
+Percent of replay cases that pass the full offline readiness bundle on the first scored answer: correctness pass, zero unsupported claims, zero contradictions, and usefulness floor met.
+
+#### Formula
+
+```text
+first_pass_readiness_proxy =
+  replay_cases_ready_on_first_score / total_replay_cases
+```
+
+#### Owner
+
+AI Quality + Orchestration
+
+#### Update frequency
+
+Per offline replay run
+
+#### Change history
+
+- 2026-03-14: initial definition for the logic + philosophy replay contract
+
+---
+
 ## Event taxonomy (growth funnel)
 
 Canonical event families and payload contracts for the growth funnel (onboarding → paywall → conversion → retention). Runtime implementation: `frontend/src/lib/telemetry/eventRegistry.ts`. This section is the doc SoT for semantics; code must stay aligned.

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -333,6 +333,7 @@ An experimentation cycle is complete only when all are true:
 ## Related documents
 
 - `docs/orchestration/AGENT_EXPERIMENT_PACKET_TEMPLATE.md`
+- `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md`
 - `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md`
 - `docs/memory/kpp_knowledge_promotion_pipeline.md`
 - `docs/roadmap/BACKLOG_LEDGER.md`

--- a/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
+++ b/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
@@ -1,0 +1,79 @@
+# Logic + Philosophy Replay Eval Contract
+
+## Summary
+
+This contract defines the first applied `LLM/RAG reliability` experiment lane for PulsePlate as a strictly offline replay + ablation workflow. It evaluates whether deterministic `logic` and `philosophy` layers improve answer quality before any runtime rollout.
+
+The lane is grounded in the existing experimentation umbrella and runtime foundations:
+
+- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
+- `core/insight/philosophical_runtime.py`
+- `core/insight/analytical/__init__.py`
+
+## Scope
+
+- Mode: `offline_replay_ablation`
+- Budget: `network_budget = 0`
+- Mutable runtime surfaces are out of scope for this PR; this lane evaluates immutable replay fixtures only.
+- Promotion target remains evidence-only until the replay summary passes and a later human-reviewed PR chooses to consume it.
+
+## Canonical Arms
+
+- `A0_control`: baseline answer without the added logic/philosophy stack
+- `A1_logic`: logic-only answer
+- `A2_philosophy`: philosophy-only answer
+- `A3_combined`: combined logic + philosophy answer
+
+All replay fixtures must provide outputs for all four arms. Partial arm sets are invalid.
+
+## Immutable Oracle Inputs
+
+- Replay corpus: `tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json`
+- Known-good negative controls: `tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json`
+- Evaluator: `scripts/orchestration/logic_philosophy_replay_eval.py`
+- Contract validation helpers: `scripts/orchestration/logic_philosophy_replay_contract.py`
+
+The replay corpus is immutable during evaluation. The evaluator may score it, but it must not mutate it.
+
+## Primary Metrics
+
+- `correctness_pass_rate`
+- `unsupported_claim_rate`
+- `contradiction_rate`
+- `first_pass_readiness_proxy`
+
+Definitions live in `docs/analytics/METRICS_CATALOG.md`.
+
+## Guardrails
+
+- `known_good_false_positive_rate` must stay at `0.0` for the provided negative controls
+- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves
+- Any non-zero network budget invalidates the lane for wave 1
+- The evaluator must remain deterministic and offline-only
+
+## CLI Contract
+
+Run from repo root:
+
+```bash
+python3 scripts/orchestration/logic_philosophy_replay_eval.py \
+  --cases tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json \
+  --negative-controls tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json
+```
+
+Optional artifact output must stay under:
+
+```text
+artifacts/orchestration/experiments/results/
+```
+
+## Promotion Rule
+
+The replay summary is promotion-ready only when all are true:
+
+- `A3_combined` ranks highest by readiness/correctness
+- `A3_combined` improves over `A0_control` on readiness and correctness
+- `A3_combined` does not regress unsupported-claim rate or contradiction rate vs `A0_control`
+- `known_good_false_positive_rate == 0.0`
+
+Passing this contract authorizes only a later human-reviewed `pr_packet` promotion step. It does not authorize runtime rollout, autonomous merge, or live provider experimentation.

--- a/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
+++ b/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
@@ -47,7 +47,7 @@ Definitions live in `docs/analytics/METRICS_CATALOG.md:266`, `docs/analytics/MET
 ## Guardrails
 
 - `known_good_false_positive_rate` must stay at `0.0` for the provided negative controls (`scripts/orchestration/logic_philosophy_replay_eval.py:167-190`)
-- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:200-207`)
+- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:200-210`)
 - Any non-zero network budget invalidates the lane for wave 1 (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`)
 - The evaluator must remain deterministic and offline-only (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`, `scripts/orchestration/logic_philosophy_replay_eval.py:144-229`)
 
@@ -75,6 +75,6 @@ The replay summary is promotion-ready only when all are true:
 - `A3_combined` improves over `A0_control` on readiness and correctness
 - `A3_combined` does not regress unsupported-claim rate or contradiction rate vs `A0_control`
 - `known_good_false_positive_rate == 0.0`
-- `A3_combined` does not regress `usefulness_floor_rate` vs `A0_control` (`scripts/orchestration/logic_philosophy_replay_eval.py:200-207`)
+- `A3_combined` does not regress `usefulness_floor_rate` vs `A0_control` (`scripts/orchestration/logic_philosophy_replay_eval.py:200-210`)
 
 Passing this contract authorizes only a later human-reviewed `pr_packet` promotion step. It does not authorize runtime rollout, autonomous merge, or live provider experimentation.

--- a/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
+++ b/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
@@ -6,9 +6,9 @@ This contract defines the first applied `LLM/RAG reliability` experiment lane fo
 
 The lane is grounded in the existing experimentation umbrella and runtime foundations:
 
-- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
-- `core/insight/philosophical_runtime.py`
-- `core/insight/analytical/__init__.py`
+- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md:24`
+- `core/insight/philosophical_runtime.py:170`
+- `core/insight/analytical/__init__.py:89`
 
 ## Scope
 
@@ -28,12 +28,12 @@ All replay fixtures must provide outputs for all four arms. Partial arm sets are
 
 ## Immutable Oracle Inputs
 
-- Replay corpus: `tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json`
-- Known-good negative controls: `tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json`
-- Evaluator: `scripts/orchestration/logic_philosophy_replay_eval.py`
-- Contract validation helpers: `scripts/orchestration/logic_philosophy_replay_contract.py`
+- Replay corpus: `tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json:1`
+- Known-good negative controls: `tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json:1`
+- Evaluator: `scripts/orchestration/logic_philosophy_replay_eval.py:50-59` and `scripts/orchestration/logic_philosophy_replay_eval.py:144-192`
+- Contract validation helpers: `scripts/orchestration/logic_philosophy_replay_contract.py:44-88` and `scripts/orchestration/logic_philosophy_replay_contract.py:90-231`
 
-The replay corpus is immutable during evaluation. The evaluator may score it, but it must not mutate it.
+The replay corpus is immutable during evaluation. The evaluator may score it, but it must not mutate it (`scripts/orchestration/logic_philosophy_replay_contract.py:90-231`, `scripts/orchestration/logic_philosophy_replay_eval.py:151-192`).
 
 ## Primary Metrics
 
@@ -42,14 +42,14 @@ The replay corpus is immutable during evaluation. The evaluator may score it, bu
 - `contradiction_rate`
 - `first_pass_readiness_proxy`
 
-Definitions live in `docs/analytics/METRICS_CATALOG.md`.
+Definitions live in `docs/analytics/METRICS_CATALOG.md:266`, `docs/analytics/METRICS_CATALOG.md:293`, `docs/analytics/METRICS_CATALOG.md:320`, and `docs/analytics/METRICS_CATALOG.md:347`.
 
 ## Guardrails
 
-- `known_good_false_positive_rate` must stay at `0.0` for the provided negative controls
-- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves
-- Any non-zero network budget invalidates the lane for wave 1
-- The evaluator must remain deterministic and offline-only
+- `known_good_false_positive_rate` must stay at `0.0` for the provided negative controls (`scripts/orchestration/logic_philosophy_replay_eval.py:167-190`)
+- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:177-188`)
+- Any non-zero network budget invalidates the lane for wave 1 (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`)
+- The evaluator must remain deterministic and offline-only (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`, `scripts/orchestration/logic_philosophy_replay_eval.py:144-229`)
 
 ## CLI Contract
 
@@ -61,7 +61,7 @@ python3 scripts/orchestration/logic_philosophy_replay_eval.py \
   --negative-controls tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json
 ```
 
-Optional artifact output must stay under:
+Optional artifact output must stay under (`scripts/orchestration/logic_philosophy_replay_eval.py:230-240`):
 
 ```text
 artifacts/orchestration/experiments/results/
@@ -75,5 +75,6 @@ The replay summary is promotion-ready only when all are true:
 - `A3_combined` improves over `A0_control` on readiness and correctness
 - `A3_combined` does not regress unsupported-claim rate or contradiction rate vs `A0_control`
 - `known_good_false_positive_rate == 0.0`
+- `A3_combined` does not regress `usefulness_floor_rate` vs `A0_control` (`scripts/orchestration/logic_philosophy_replay_eval.py:177-188`)
 
 Passing this contract authorizes only a later human-reviewed `pr_packet` promotion step. It does not authorize runtime rollout, autonomous merge, or live provider experimentation.

--- a/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
+++ b/docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
@@ -47,7 +47,7 @@ Definitions live in `docs/analytics/METRICS_CATALOG.md:266`, `docs/analytics/MET
 ## Guardrails
 
 - `known_good_false_positive_rate` must stay at `0.0` for the provided negative controls (`scripts/orchestration/logic_philosophy_replay_eval.py:167-190`)
-- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:177-188`)
+- `usefulness_floor_rate` is reported for every arm and must not silently collapse when correctness improves (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:200-207`)
 - Any non-zero network budget invalidates the lane for wave 1 (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`)
 - The evaluator must remain deterministic and offline-only (`scripts/orchestration/logic_philosophy_replay_contract.py:82-88`, `scripts/orchestration/logic_philosophy_replay_eval.py:144-229`)
 
@@ -75,6 +75,6 @@ The replay summary is promotion-ready only when all are true:
 - `A3_combined` improves over `A0_control` on readiness and correctness
 - `A3_combined` does not regress unsupported-claim rate or contradiction rate vs `A0_control`
 - `known_good_false_positive_rate == 0.0`
-- `A3_combined` does not regress `usefulness_floor_rate` vs `A0_control` (`scripts/orchestration/logic_philosophy_replay_eval.py:177-188`)
+- `A3_combined` does not regress `usefulness_floor_rate` vs `A0_control` (`scripts/orchestration/logic_philosophy_replay_eval.py:200-207`)
 
 Passing this contract authorizes only a later human-reviewed `pr_packet` promotion step. It does not authorize runtime rollout, autonomous merge, or live provider experimentation.

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -24,6 +24,12 @@ Evidence: `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935354925 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935359571 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1170_FIXED_MAPPING.md:8-29` already maps each actionable inline comment from these review passes to its commit proof, so the review-level rollup URLs are non-actionable summary wrappers and require no additional code or docs changes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948905012
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948908665
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948912620
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -33,6 +33,9 @@ Evidence: `docs/review/PR_1170_FIXED_MAPPING.md:8-29` already maps each actionab
 Disposition: FIXED
 Commit: 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-62` now checks each normalized snippet occurrence so an earlier negated mention no longer suppresses a later valid match, `tests/test_logic_philosophy_replay_eval.py:119-134` locks that regression, and `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:49-50` plus `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:78` now cite the exact usefulness-floor reporting and promotion-rule lines (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:200-207`).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935378317 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935378319 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935378320 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948928659 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 
 ## Merge Readiness

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -12,6 +12,18 @@ Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:260` and `scrip
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935349289 -> 531d25dd7f1fa6fa309c953e06fbb8274892dd18
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935349294 -> 531d25dd7f1fa6fa309c953e06fbb8274892dd18
 
+Disposition: FIXED
+Commit: af9b9482d562a9955eb6d16fc260aeb95b4c383d
+Evidence: `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:9-11` and `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:31-34` now anchor contract truth claims with explicit `file:line` evidence; `scripts/orchestration/logic_philosophy_replay_contract.py:44-50` and `scripts/orchestration/logic_philosophy_replay_contract.py:82-88` fail closed on non-string snippets and non-integer network budgets; `scripts/orchestration/logic_philosophy_replay_eval.py:35-59`, `scripts/orchestration/logic_philosophy_replay_eval.py:85-105`, and `scripts/orchestration/logic_philosophy_replay_eval.py:177-205` reject empty or negated snippet matches, expose missing required facts, count correctness failures in known-good controls, and enforce the usefulness-floor promotion guardrail; `tests/test_logic_philosophy_replay_eval.py:52-69` and `tests/test_logic_philosophy_replay_eval.py:103-188` lock the strict contract and evaluator regressions.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935351139 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935351289 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935351291 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935354922 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935354923 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935354924 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935354925 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935359571 -> af9b9482d562a9955eb6d16fc260aeb95b4c383d
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 531d25dd7f1fa6fa309c953e06fbb8274892dd18
+Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:260` and `scripts/orchestration/logic_philosophy_replay_eval.py:271` now send replay failures to `stderr`, `tests/test_logic_philosophy_replay_eval.py:153` locks the stderr-only error contract, and `docs/analytics/EXPERIMENT_REGISTRY.md:16` now matches the canonical metric wording with `unsupported claim rate`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948903506 -> 531d25dd7f1fa6fa309c953e06fbb8274892dd18
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935349289 -> 531d25dd7f1fa6fa309c953e06fbb8274892dd18
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935349294 -> 531d25dd7f1fa6fa309c953e06fbb8274892dd18
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -38,6 +38,14 @@ Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-62` now chec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935378320 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948928659 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 
+Disposition: FIXED
+Commit: 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-61` now uses non-word neighbor boundaries so normalized snippets with punctuation like `1.2 to 2.0 g/kg` still match without regressing sentence-final facts, `tests/test_logic_philosophy_replay_eval.py:137-150` locks the punctuation boundary regression, and `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:50` plus `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:78` now point to the exact usefulness-floor enforcement range (`scripts/orchestration/logic_philosophy_replay_eval.py:200-210`).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393423 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393680 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943116 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943305 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -30,6 +30,11 @@ Evidence: `docs/review/PR_1170_FIXED_MAPPING.md:8-29` already maps each actionab
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948908665
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948912620
 
+Disposition: FIXED
+Commit: 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
+Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-62` now checks each normalized snippet occurrence so an earlier negated mention no longer suppresses a later valid match, `tests/test_logic_philosophy_replay_eval.py:119-134` locks that regression, and `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:49-50` plus `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:78` now cite the exact usefulness-floor reporting and promotion-rule lines (`scripts/orchestration/logic_philosophy_replay_eval.py:115-140`, `scripts/orchestration/logic_philosophy_replay_eval.py:200-207`).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948928659 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -39,12 +39,12 @@ Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-62` now chec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948928659 -> 22d0ef0cb95920e2fd3dc456e05a49d4b5eb8405
 
 Disposition: FIXED
-Commit: 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+Commit: 7030ea9f5b896dbdf839b2f6b8a1d981224e7420
 Evidence: `scripts/orchestration/logic_philosophy_replay_eval.py:35-61` now uses non-word neighbor boundaries so normalized snippets with punctuation like `1.2 to 2.0 g/kg` still match without regressing sentence-final facts, `tests/test_logic_philosophy_replay_eval.py:137-150` locks the punctuation boundary regression, and `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:50` plus `docs/orchestration/contracts/LOGIC_PHILOSOPHY_REPLAY_EVAL_CONTRACT.md:78` now point to the exact usefulness-floor enforcement range (`scripts/orchestration/logic_philosophy_replay_eval.py:200-210`).
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393423 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393680 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943116 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943305 -> 7030ea9f2a0532ae1b8d9b5e77cc0f6517480386
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393423 -> 7030ea9f5b896dbdf839b2f6b8a1d981224e7420
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#discussion_r2935393680 -> 7030ea9f5b896dbdf839b2f6b8a1d981224e7420
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943116 -> 7030ea9f5b896dbdf839b2f6b8a1d981224e7420
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1170#pullrequestreview-3948943305 -> 7030ea9f5b896dbdf839b2f6b8a1d981224e7420
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1170_FIXED_MAPPING.md
+++ b/docs/review/PR_1170_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1170 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/scripts/orchestration/logic_philosophy_replay_contract.py
+++ b/scripts/orchestration/logic_philosophy_replay_contract.py
@@ -1,0 +1,231 @@
+"""Offline replay contract for the logic + philosophy reliability lane.
+
+RU: Fail-closed contract helpers for the offline replay + ablation lane.
+EN: Fail-closed contract helpers for the offline replay + ablation lane.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPLAY_SCHEMA_VERSION = "1.0"
+REPLAY_MODE = "offline_replay_ablation"
+REPLAY_ARMS: tuple[str, ...] = (
+    "A0_control",
+    "A1_logic",
+    "A2_philosophy",
+    "A3_combined",
+)
+PRIMARY_METRICS: tuple[str, ...] = (
+    "correctness_pass_rate",
+    "unsupported_claim_rate",
+    "contradiction_rate",
+    "first_pass_readiness_proxy",
+)
+DEFAULT_NETWORK_BUDGET = 0
+
+
+def load_json_document(path: Path, *, label: str) -> dict[str, Any]:
+    """RU: Загружает JSON object. EN: Load a JSON object from disk."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"{label} file does not exist: {path}") from exc
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} must be valid UTF-8 JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return payload
+
+
+def _require_non_empty_string(value: Any, *, label: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{label} must be non-empty.")
+    return normalized
+
+
+def _normalize_snippet_list(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a list.")
+    normalized: list[str] = []
+    for item in value:
+        snippet = _require_non_empty_string(item, label=label)
+        if snippet not in normalized:
+            normalized.append(snippet)
+    if not normalized:
+        raise ValueError(f"{label} must contain at least one non-empty item.")
+    return normalized
+
+
+def _validate_arm_outputs(value: Any, *, label: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object.")
+    missing_arms = [arm for arm in REPLAY_ARMS if arm not in value]
+    if missing_arms:
+        joined = ", ".join(missing_arms)
+        raise ValueError(f"{label} is missing required arms: {joined}")
+    extra_arms = sorted(set(value) - set(REPLAY_ARMS))
+    if extra_arms:
+        joined = ", ".join(extra_arms)
+        raise ValueError(f"{label} contains unsupported arms: {joined}")
+    return {
+        arm: _require_non_empty_string(value[arm], label=f"{label}.{arm}") for arm in REPLAY_ARMS
+    }
+
+
+def _validate_network_budget(value: Any, *, label: str) -> int:
+    try:
+        budget = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be an integer.") from exc
+    if budget != DEFAULT_NETWORK_BUDGET:
+        raise ValueError(f"{label} must equal {DEFAULT_NETWORK_BUDGET} for wave 1 offline replay.")
+    return budget
+
+
+def validate_replay_cases_document(payload: Any) -> dict[str, Any]:
+    """Validate the immutable replay corpus document."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("Replay cases document must be a JSON object.")
+    schema_version = _require_non_empty_string(
+        payload.get("schema_version", ""),
+        label="Replay cases document schema_version",
+    )
+    if schema_version != REPLAY_SCHEMA_VERSION:
+        raise ValueError(
+            "Replay cases document schema_version must equal " f"{REPLAY_SCHEMA_VERSION!r}."
+        )
+    mode = _require_non_empty_string(payload.get("mode", ""), label="Replay cases document mode")
+    if mode != REPLAY_MODE:
+        raise ValueError(f"Replay cases document mode must equal {REPLAY_MODE!r}.")
+    network_budget = _validate_network_budget(
+        payload.get("network_budget", DEFAULT_NETWORK_BUDGET),
+        label="Replay cases document network_budget",
+    )
+    primary_metrics = _normalize_snippet_list(
+        payload.get("primary_metrics", []),
+        label="Replay cases document primary_metrics",
+    )
+    if tuple(primary_metrics) != PRIMARY_METRICS:
+        raise ValueError(
+            "Replay cases document primary_metrics must equal the canonical list: "
+            f"{', '.join(PRIMARY_METRICS)}"
+        )
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError("Replay cases document cases must be a non-empty list.")
+    cases: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, raw_case in enumerate(raw_cases):
+        label = f"Replay case #{index + 1}"
+        if not isinstance(raw_case, dict):
+            raise ValueError(f"{label} must be an object.")
+        case_id = _require_non_empty_string(raw_case.get("case_id", ""), label=f"{label} case_id")
+        if case_id in seen_ids:
+            raise ValueError(f"Replay case ids must be unique; duplicate: {case_id}")
+        seen_ids.add(case_id)
+        required_facts = _normalize_snippet_list(
+            raw_case.get("required_facts", []),
+            label=f"{label} required_facts",
+        )
+        supported_claims = _normalize_snippet_list(
+            raw_case.get("supported_claims", []),
+            label=f"{label} supported_claims",
+        )
+        for fact in required_facts:
+            if fact not in supported_claims:
+                supported_claims.append(fact)
+        cases.append(
+            {
+                "case_id": case_id,
+                "prompt": _require_non_empty_string(
+                    raw_case.get("prompt", ""), label=f"{label} prompt"
+                ),
+                "required_facts": required_facts,
+                "supported_claims": supported_claims,
+                "usefulness_markers": _normalize_snippet_list(
+                    raw_case.get("usefulness_markers", []),
+                    label=f"{label} usefulness_markers",
+                ),
+                "arm_outputs": _validate_arm_outputs(
+                    raw_case.get("arm_outputs", {}),
+                    label=f"{label} arm_outputs",
+                ),
+            }
+        )
+    return {
+        "schema_version": schema_version,
+        "mode": mode,
+        "network_budget": network_budget,
+        "primary_metrics": list(PRIMARY_METRICS),
+        "cases": cases,
+    }
+
+
+def validate_negative_controls_document(payload: Any) -> dict[str, Any]:
+    """Validate the immutable known-good negative-control document."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("Replay negative controls document must be a JSON object.")
+    schema_version = _require_non_empty_string(
+        payload.get("schema_version", ""),
+        label="Replay negative controls document schema_version",
+    )
+    if schema_version != REPLAY_SCHEMA_VERSION:
+        raise ValueError(
+            "Replay negative controls document schema_version must equal "
+            f"{REPLAY_SCHEMA_VERSION!r}."
+        )
+    mode = _require_non_empty_string(
+        payload.get("mode", ""),
+        label="Replay negative controls document mode",
+    )
+    if mode != REPLAY_MODE:
+        raise ValueError(f"Replay negative controls document mode must equal {REPLAY_MODE!r}.")
+    network_budget = _validate_network_budget(
+        payload.get("network_budget", DEFAULT_NETWORK_BUDGET),
+        label="Replay negative controls document network_budget",
+    )
+    raw_controls = payload.get("known_good_controls")
+    if not isinstance(raw_controls, list) or not raw_controls:
+        raise ValueError("Replay negative controls document must include known_good_controls.")
+    controls: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, raw_control in enumerate(raw_controls):
+        label = f"Replay negative control #{index + 1}"
+        if not isinstance(raw_control, dict):
+            raise ValueError(f"{label} must be an object.")
+        control_id = _require_non_empty_string(
+            raw_control.get("control_id", ""),
+            label=f"{label} control_id",
+        )
+        if control_id in seen_ids:
+            raise ValueError(f"Replay negative control ids must be unique; duplicate: {control_id}")
+        seen_ids.add(control_id)
+        controls.append(
+            {
+                "control_id": control_id,
+                "answer": _require_non_empty_string(
+                    raw_control.get("answer", ""), label=f"{label} answer"
+                ),
+                "supported_claims": _normalize_snippet_list(
+                    raw_control.get("supported_claims", []),
+                    label=f"{label} supported_claims",
+                ),
+                "usefulness_markers": _normalize_snippet_list(
+                    raw_control.get("usefulness_markers", []),
+                    label=f"{label} usefulness_markers",
+                ),
+            }
+        )
+    return {
+        "schema_version": schema_version,
+        "mode": mode,
+        "network_budget": network_budget,
+        "known_good_controls": controls,
+    }

--- a/scripts/orchestration/logic_philosophy_replay_contract.py
+++ b/scripts/orchestration/logic_philosophy_replay_contract.py
@@ -42,7 +42,9 @@ def load_json_document(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _require_non_empty_string(value: Any, *, label: str) -> str:
-    normalized = str(value).strip()
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string.")
+    normalized = value.strip()
     if not normalized:
         raise ValueError(f"{label} must be non-empty.")
     return normalized
@@ -78,10 +80,9 @@ def _validate_arm_outputs(value: Any, *, label: str) -> dict[str, str]:
 
 
 def _validate_network_budget(value: Any, *, label: str) -> int:
-    try:
-        budget = int(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{label} must be an integer.") from exc
+    if type(value) is not int:
+        raise ValueError(f"{label} must be an integer.")
+    budget = value
     if budget != DEFAULT_NETWORK_BUDGET:
         raise ValueError(f"{label} must equal {DEFAULT_NETWORK_BUDGET} for wave 1 offline replay.")
     return budget

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -258,7 +258,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         output_path = _resolve_output_path(args.output)
     except ValueError as exc:
-        print(f"FAIL: {exc}")
+        print(f"FAIL: {exc}", file=sys.stderr)
         return 1
 
     if output_path is not None:
@@ -269,7 +269,7 @@ def main(argv: list[str] | None = None) -> int:
                 encoding="utf-8",
             )
         except OSError as exc:
-            print(f"FAIL: unable to write replay result: {exc}")
+            print(f"FAIL: unable to write replay result: {exc}", file=sys.stderr)
             return 1
 
     try:

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -47,7 +47,7 @@ def _contains_supported_snippet(text: str, snippets: list[str]) -> bool:
 def _claim_list(answer: str) -> list[str]:
     claims = extract_claims(answer)
     if claims:
-        return claims
+        return [str(claim) for claim in claims]
     normalized_answer = answer.strip()
     return [normalized_answer] if normalized_answer else []
 

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -32,7 +32,7 @@ from scripts.orchestration.logic_philosophy_replay_contract import (
 
 RESULTS_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "results"
 _WHITESPACE_RE = re.compile(r"\s+")
-_SNIPPET_TEMPLATE = r"\b{snippet}\b"
+_SNIPPET_TEMPLATE = r"(?<!\w){snippet}(?!\w)"
 _NEGATED_PREFIX_RE = re.compile(r"\b(?:no|not|never)(?:\s+\w+){0,2}$")
 
 

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -32,7 +32,8 @@ from scripts.orchestration.logic_philosophy_replay_contract import (
 
 RESULTS_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "results"
 _WHITESPACE_RE = re.compile(r"\s+")
-_NEGATED_SNIPPET_TEMPLATE = r"\b(?:no|not|never)\b(?:\s+\w+){{0,2}}\s+{snippet}\b"
+_SNIPPET_TEMPLATE = r"\b{snippet}\b"
+_NEGATED_PREFIX_RE = re.compile(r"\b(?:no|not|never)(?:\s+\w+){0,2}$")
 
 
 def _normalize_text(value: str) -> str:
@@ -40,11 +41,9 @@ def _normalize_text(value: str) -> str:
     return _WHITESPACE_RE.sub(" ", compact).strip()
 
 
-def _is_negated_match(normalized_text: str, normalized_snippet: str) -> bool:
-    negated_pattern = re.compile(
-        _NEGATED_SNIPPET_TEMPLATE.format(snippet=re.escape(normalized_snippet))
-    )
-    return bool(negated_pattern.search(normalized_text))
+def _is_negated_match(normalized_text: str, start_index: int) -> bool:
+    prefix = normalized_text[:start_index].strip()
+    return bool(_NEGATED_PREFIX_RE.search(prefix))
 
 
 def _contains_supported_snippet(text: str, snippets: list[str]) -> bool:
@@ -53,9 +52,13 @@ def _contains_supported_snippet(text: str, snippets: list[str]) -> bool:
         normalized_snippet = _normalize_text(snippet)
         if not normalized_snippet or normalized_snippet not in normalized_text:
             continue
-        if _is_negated_match(normalized_text, normalized_snippet):
-            continue
-        return True
+        snippet_pattern = re.compile(
+            _SNIPPET_TEMPLATE.format(snippet=re.escape(normalized_snippet))
+        )
+        for match in snippet_pattern.finditer(normalized_text):
+            if _is_negated_match(normalized_text, match.start()):
+                continue
+            return True
     return False
 
 

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -32,16 +32,31 @@ from scripts.orchestration.logic_philosophy_replay_contract import (
 
 RESULTS_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "results"
 _WHITESPACE_RE = re.compile(r"\s+")
+_NEGATED_SNIPPET_TEMPLATE = r"\b(?:no|not|never)\b(?:\s+\w+){{0,2}}\s+{snippet}\b"
 
 
 def _normalize_text(value: str) -> str:
-    compact = re.sub(r"[^\w\s.%/-]", " ", value.casefold())
+    compact = re.sub(r"[^\w\s.%/-]", " ", value.casefold().replace("n't", " not"))
     return _WHITESPACE_RE.sub(" ", compact).strip()
+
+
+def _is_negated_match(normalized_text: str, normalized_snippet: str) -> bool:
+    negated_pattern = re.compile(
+        _NEGATED_SNIPPET_TEMPLATE.format(snippet=re.escape(normalized_snippet))
+    )
+    return bool(negated_pattern.search(normalized_text))
 
 
 def _contains_supported_snippet(text: str, snippets: list[str]) -> bool:
     normalized_text = _normalize_text(text)
-    return any(_normalize_text(snippet) in normalized_text for snippet in snippets)
+    for snippet in snippets:
+        normalized_snippet = _normalize_text(snippet)
+        if not normalized_snippet or normalized_snippet not in normalized_text:
+            continue
+        if _is_negated_match(normalized_text, normalized_snippet):
+            continue
+        return True
+    return False
 
 
 def _claim_list(answer: str) -> list[str]:
@@ -67,6 +82,9 @@ def evaluate_answer(
         claim for claim in claims if not _contains_supported_snippet(claim, supported_claims)
     ]
     contradiction_count = contradiction_checker.count(answer)
+    missing_required_facts = [
+        fact for fact in required_facts if not _contains_supported_snippet(answer, [fact])
+    ]
     correctness_pass = all(_contains_supported_snippet(answer, [fact]) for fact in required_facts)
     usefulness_pass = _contains_supported_snippet(answer, usefulness_markers)
     claim_count = max(1, len(claims))
@@ -81,6 +99,7 @@ def evaluate_answer(
         "unsupported_claims": unsupported_claims,
         "unsupported_claim_rate": round(unsupported_claim_rate, 4),
         "contradiction_count": contradiction_count,
+        "missing_required_facts": missing_required_facts,
         "correctness_pass": correctness_pass,
         "usefulness_pass": usefulness_pass,
         "first_pass_ready": first_pass_ready,
@@ -156,7 +175,9 @@ def evaluate_replay_documents(
             contradiction_checker=checker,
         )
         false_positive = (
-            bool(evaluation["unsupported_claims"])
+            not bool(evaluation["correctness_pass"])
+            or bool(evaluation["missing_required_facts"])
+            or bool(evaluation["unsupported_claims"])
             or int(evaluation["contradiction_count"]) > 0
             or not bool(evaluation["usefulness_pass"])
         )
@@ -183,6 +204,7 @@ def evaluate_replay_documents(
         and combined["correctness_pass_rate"] > baseline["correctness_pass_rate"]
         and combined["unsupported_claim_rate"] <= baseline["unsupported_claim_rate"]
         and combined["contradiction_rate"] <= baseline["contradiction_rate"]
+        and combined["usefulness_floor_rate"] >= baseline["usefulness_floor_rate"]
     )
     return {
         "schema_version": REPLAY_SCHEMA_VERSION,

--- a/scripts/orchestration/logic_philosophy_replay_eval.py
+++ b/scripts/orchestration/logic_philosophy_replay_eval.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Deterministic offline replay evaluator for logic + philosophy reliability.
+
+RU: Оценивает offline replay + ablation без live provider/network calls.
+EN: Scores offline replay + ablation without live provider/network calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.insight.analytical import extract_claims
+from core.insight.aristotelian import NonContradictionChecker
+from scripts.orchestration.logic_philosophy_replay_contract import (
+    PRIMARY_METRICS,
+    REPLAY_ARMS,
+    REPLAY_MODE,
+    REPLAY_SCHEMA_VERSION,
+    load_json_document,
+    validate_negative_controls_document,
+    validate_replay_cases_document,
+)
+
+RESULTS_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "results"
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _normalize_text(value: str) -> str:
+    compact = re.sub(r"[^\w\s.%/-]", " ", value.casefold())
+    return _WHITESPACE_RE.sub(" ", compact).strip()
+
+
+def _contains_supported_snippet(text: str, snippets: list[str]) -> bool:
+    normalized_text = _normalize_text(text)
+    return any(_normalize_text(snippet) in normalized_text for snippet in snippets)
+
+
+def _claim_list(answer: str) -> list[str]:
+    claims = extract_claims(answer)
+    if claims:
+        return claims
+    normalized_answer = answer.strip()
+    return [normalized_answer] if normalized_answer else []
+
+
+def evaluate_answer(
+    *,
+    answer: str,
+    required_facts: list[str],
+    supported_claims: list[str],
+    usefulness_markers: list[str],
+    contradiction_checker: NonContradictionChecker,
+) -> dict[str, Any]:
+    """Evaluate one deterministic answer against the immutable replay oracle."""
+
+    claims = _claim_list(answer)
+    unsupported_claims = [
+        claim for claim in claims if not _contains_supported_snippet(claim, supported_claims)
+    ]
+    contradiction_count = contradiction_checker.count(answer)
+    correctness_pass = all(_contains_supported_snippet(answer, [fact]) for fact in required_facts)
+    usefulness_pass = _contains_supported_snippet(answer, usefulness_markers)
+    claim_count = max(1, len(claims))
+    unsupported_claim_rate = len(unsupported_claims) / claim_count
+    first_pass_ready = (
+        correctness_pass and usefulness_pass and contradiction_count == 0 and not unsupported_claims
+    )
+    return {
+        "answer": answer,
+        "claims": claims,
+        "claim_count": claim_count,
+        "unsupported_claims": unsupported_claims,
+        "unsupported_claim_rate": round(unsupported_claim_rate, 4),
+        "contradiction_count": contradiction_count,
+        "correctness_pass": correctness_pass,
+        "usefulness_pass": usefulness_pass,
+        "first_pass_ready": first_pass_ready,
+    }
+
+
+def _round_rate(numerator: int | float, denominator: int | float) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(float(numerator) / float(denominator), 4)
+
+
+def _summarize_arm(case_results: list[dict[str, Any]]) -> dict[str, Any]:
+    total_cases = len(case_results)
+    total_claims = sum(int(item["claim_count"]) for item in case_results)
+    unsupported_claims = sum(len(item["unsupported_claims"]) for item in case_results)
+    contradiction_cases = sum(int(item["contradiction_count"]) > 0 for item in case_results)
+    correctness_passes = sum(bool(item["correctness_pass"]) for item in case_results)
+    readiness_passes = sum(bool(item["first_pass_ready"]) for item in case_results)
+    usefulness_passes = sum(bool(item["usefulness_pass"]) for item in case_results)
+    return {
+        "case_count": total_cases,
+        "correctness_pass_rate": _round_rate(correctness_passes, total_cases),
+        "unsupported_claim_rate": _round_rate(unsupported_claims, total_claims),
+        "contradiction_rate": _round_rate(contradiction_cases, total_cases),
+        "first_pass_readiness_proxy": _round_rate(readiness_passes, total_cases),
+        "usefulness_floor_rate": _round_rate(usefulness_passes, total_cases),
+        "cases": case_results,
+    }
+
+
+def _arm_rank(summary: dict[str, Any]) -> tuple[float, float, float, float, float]:
+    return (
+        float(summary["first_pass_readiness_proxy"]),
+        float(summary["correctness_pass_rate"]),
+        -float(summary["unsupported_claim_rate"]),
+        -float(summary["contradiction_rate"]),
+        float(summary["usefulness_floor_rate"]),
+    )
+
+
+def evaluate_replay_documents(
+    *,
+    replay_cases: dict[str, Any],
+    negative_controls: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate all replay arms and negative controls against the immutable corpus."""
+
+    validated_cases = validate_replay_cases_document(replay_cases)
+    validated_controls = validate_negative_controls_document(negative_controls)
+    checker = NonContradictionChecker()
+
+    arm_results: dict[str, list[dict[str, Any]]] = {arm: [] for arm in REPLAY_ARMS}
+    for case in validated_cases["cases"]:
+        for arm in REPLAY_ARMS:
+            evaluation = evaluate_answer(
+                answer=case["arm_outputs"][arm],
+                required_facts=case["required_facts"],
+                supported_claims=case["supported_claims"],
+                usefulness_markers=case["usefulness_markers"],
+                contradiction_checker=checker,
+            )
+            arm_results[arm].append({"case_id": case["case_id"], **evaluation})
+
+    known_good_controls: list[dict[str, Any]] = []
+    flagged_controls = 0
+    for control in validated_controls["known_good_controls"]:
+        evaluation = evaluate_answer(
+            answer=control["answer"],
+            required_facts=control["supported_claims"],
+            supported_claims=control["supported_claims"],
+            usefulness_markers=control["usefulness_markers"],
+            contradiction_checker=checker,
+        )
+        false_positive = (
+            bool(evaluation["unsupported_claims"])
+            or int(evaluation["contradiction_count"]) > 0
+            or not bool(evaluation["usefulness_pass"])
+        )
+        if false_positive:
+            flagged_controls += 1
+        known_good_controls.append(
+            {
+                "control_id": control["control_id"],
+                **evaluation,
+                "false_positive": false_positive,
+            }
+        )
+
+    arm_summaries = {arm: _summarize_arm(results) for arm, results in arm_results.items()}
+    sorted_arms = sorted(REPLAY_ARMS, key=lambda arm: _arm_rank(arm_summaries[arm]), reverse=True)
+    winner_arm = sorted_arms[0]
+    baseline = arm_summaries["A0_control"]
+    combined = arm_summaries["A3_combined"]
+    known_good_false_positive_rate = _round_rate(flagged_controls, len(known_good_controls))
+    promotion_ready = (
+        winner_arm == "A3_combined"
+        and known_good_false_positive_rate == 0.0
+        and combined["first_pass_readiness_proxy"] > baseline["first_pass_readiness_proxy"]
+        and combined["correctness_pass_rate"] > baseline["correctness_pass_rate"]
+        and combined["unsupported_claim_rate"] <= baseline["unsupported_claim_rate"]
+        and combined["contradiction_rate"] <= baseline["contradiction_rate"]
+    )
+    return {
+        "schema_version": REPLAY_SCHEMA_VERSION,
+        "mode": REPLAY_MODE,
+        "network_budget": validated_cases["network_budget"],
+        "primary_metrics": list(PRIMARY_METRICS),
+        "winner_arm": winner_arm,
+        "promotion_ready": promotion_ready,
+        "arm_order": sorted_arms,
+        "arms": arm_summaries,
+        "guardrails": {
+            "known_good_false_positive_rate": known_good_false_positive_rate,
+            "flagged_known_good_controls": flagged_controls,
+            "known_good_control_count": len(known_good_controls),
+            "usefulness_floor_rate": {
+                arm: arm_summaries[arm]["usefulness_floor_rate"] for arm in REPLAY_ARMS
+            },
+        },
+        "known_good_controls": known_good_controls,
+    }
+
+
+def _resolve_output_path(raw_output: str | None) -> Path | None:
+    if not raw_output:
+        return None
+    candidate = Path(raw_output)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        resolved = (RESULTS_DIR / candidate).resolve()
+    try:
+        resolved.relative_to(RESULTS_DIR.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            "--output must stay within artifacts/orchestration/experiments/results"
+        ) from exc
+    return resolved
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="logic_philosophy_replay_eval",
+        description="Run deterministic offline replay scoring for logic/philosophy ablation arms.",
+    )
+    parser.add_argument("--cases", required=True, help="Path to replay_cases.json")
+    parser.add_argument(
+        "--negative-controls",
+        required=True,
+        help="Path to replay_negative_controls.json",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Optional JSON output path under artifacts/orchestration/experiments/results/. "
+            "If omitted, the summary is printed to stdout only."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        replay_cases = load_json_document(Path(args.cases), label="Replay cases")
+        negative_controls = load_json_document(
+            Path(args.negative_controls),
+            label="Replay negative controls",
+        )
+        summary = evaluate_replay_documents(
+            replay_cases=replay_cases,
+            negative_controls=negative_controls,
+        )
+        output_path = _resolve_output_path(args.output)
+    except ValueError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    if output_path is not None:
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(f"FAIL: unable to write replay result: {exc}")
+            return 1
+
+    try:
+        output_ref = str(output_path.relative_to(REPO_ROOT)) if output_path is not None else None
+    except ValueError:
+        output_ref = str(output_path)
+    print(
+        json.dumps(
+            {
+                "mode": summary["mode"],
+                "winner_arm": summary["winner_arm"],
+                "promotion_ready": summary["promotion_ready"],
+                "network_budget": summary["network_budget"],
+                "known_good_false_positive_rate": summary["guardrails"][
+                    "known_good_false_positive_rate"
+                ],
+                "output": output_ref,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json
+++ b/tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "1.0",
+  "mode": "offline_replay_ablation",
+  "network_budget": 0,
+  "primary_metrics": [
+    "correctness_pass_rate",
+    "unsupported_claim_rate",
+    "contradiction_rate",
+    "first_pass_readiness_proxy"
+  ],
+  "cases": [
+    {
+      "case_id": "protein_recovery_guidance",
+      "prompt": "How much protein should I eat for recovery?",
+      "required_facts": [
+        "Protein needs vary by body size and activity",
+        "1.2 to 2.0 g/kg",
+        "licensed clinician"
+      ],
+      "supported_claims": [
+        "Protein needs vary by body size and activity",
+        "1.2 to 2.0 g/kg",
+        "general wellness information",
+        "licensed clinician"
+      ],
+      "usefulness_markers": [
+        "body size and activity",
+        "1.2 to 2.0 g/kg"
+      ],
+      "arm_outputs": {
+        "A0_control": "Everyone needs exactly 200 g of protein. This always works.",
+        "A1_logic": "A common recovery range is 1.2 to 2.0 g/kg.",
+        "A2_philosophy": "This is general wellness information, and a licensed clinician should handle symptoms or disease questions.",
+        "A3_combined": "Protein needs vary by body size and activity. A common recovery range is 1.2 to 2.0 g/kg. This is general wellness information, and a licensed clinician should handle symptoms or disease questions."
+      }
+    },
+    {
+      "case_id": "bmi_definition_guardrails",
+      "prompt": "What is BMI?",
+      "required_facts": [
+        "BMI stands for body mass index",
+        "screening metric",
+        "not a diagnosis"
+      ],
+      "supported_claims": [
+        "BMI stands for body mass index",
+        "screening metric",
+        "not a diagnosis"
+      ],
+      "usefulness_markers": [
+        "screening metric"
+      ],
+      "arm_outputs": {
+        "A0_control": "BMI is a perfect diagnosis for everyone.",
+        "A1_logic": "BMI stands for body mass index. It is a screening metric.",
+        "A2_philosophy": "BMI is not a diagnosis.",
+        "A3_combined": "BMI stands for body mass index. It is a screening metric and not a diagnosis."
+      }
+    },
+    {
+      "case_id": "calorie_deficit_readiness",
+      "prompt": "How should I think about a calorie deficit for sustainable fat loss?",
+      "required_facts": [
+        "small calorie deficit",
+        "training quality",
+        "not medical advice"
+      ],
+      "supported_claims": [
+        "small calorie deficit",
+        "training quality",
+        "general wellness information",
+        "not medical advice"
+      ],
+      "usefulness_markers": [
+        "small calorie deficit",
+        "training quality"
+      ],
+      "arm_outputs": {
+        "A0_control": "A 700 to 800 calorie deficit is always best. This plan is balanced. This plan is not balanced.",
+        "A1_logic": "A small calorie deficit can support fat loss while protecting training quality.",
+        "A2_philosophy": "This is general wellness information, not medical advice.",
+        "A3_combined": "A small calorie deficit can support fat loss while protecting training quality. This is general wellness information, not medical advice."
+      }
+    }
+  ]
+}

--- a/tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json
+++ b/tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.0",
+  "mode": "offline_replay_ablation",
+  "network_budget": 0,
+  "known_good_controls": [
+    {
+      "control_id": "good_protein_recovery_guidance",
+      "answer": "Protein needs vary by body size and activity. A common recovery range is 1.2 to 2.0 g/kg. This is general wellness information, and a licensed clinician should handle symptoms or disease questions.",
+      "supported_claims": [
+        "Protein needs vary by body size and activity",
+        "1.2 to 2.0 g/kg",
+        "general wellness information",
+        "licensed clinician"
+      ],
+      "usefulness_markers": [
+        "body size and activity",
+        "1.2 to 2.0 g/kg"
+      ]
+    },
+    {
+      "control_id": "good_bmi_definition",
+      "answer": "BMI stands for body mass index. It is a screening metric and not a diagnosis.",
+      "supported_claims": [
+        "BMI stands for body mass index",
+        "screening metric",
+        "not a diagnosis"
+      ],
+      "usefulness_markers": [
+        "screening metric"
+      ]
+    },
+    {
+      "control_id": "good_calorie_deficit_guidance",
+      "answer": "A small calorie deficit can support fat loss while protecting training quality. This is general wellness information, not medical advice.",
+      "supported_claims": [
+        "small calorie deficit",
+        "training quality",
+        "general wellness information",
+        "not medical advice"
+      ],
+      "usefulness_markers": [
+        "small calorie deficit",
+        "training quality"
+      ]
+    }
+  ]
+}

--- a/tests/test_logic_philosophy_replay_eval.py
+++ b/tests/test_logic_philosophy_replay_eval.py
@@ -148,3 +148,23 @@ def test_main_writes_result_artifact(
     assert payload["winner_arm"] == "A3_combined"
     assert written["promotion_ready"] is True
     assert written["guardrails"]["known_good_false_positive_rate"] == 0.0
+
+
+def test_main_reports_validation_failures_on_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI failures should keep stdout machine-readable by writing errors to stderr."""
+
+    exit_code = main(
+        [
+            "--cases",
+            str(_fixture("missing_cases.json")),
+            "--negative-controls",
+            str(_fixture("replay_negative_controls.json")),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "FAIL: Replay cases file does not exist" in captured.err

--- a/tests/test_logic_philosophy_replay_eval.py
+++ b/tests/test_logic_philosophy_replay_eval.py
@@ -116,6 +116,24 @@ def test_evaluate_answer_rejects_negated_supported_snippets() -> None:
     assert result["first_pass_ready"] is False
 
 
+def test_evaluate_answer_accepts_later_non_negated_match() -> None:
+    """A later positive occurrence should still count after an earlier negated one."""
+
+    result = evaluate_answer(
+        answer=(
+            "BMI is not a screening metric for diagnosis. "
+            "BMI can still be used as a screening metric in wellness triage."
+        ),
+        required_facts=["screening metric"],
+        supported_claims=["screening metric"],
+        usefulness_markers=["screening metric"],
+        contradiction_checker=replay_eval.NonContradictionChecker(),
+    )
+
+    assert result["correctness_pass"] is True
+    assert result["unsupported_claim_rate"] < 1.0
+
+
 def test_evaluate_replay_documents_picks_combined_arm() -> None:
     """The provided offline corpus should rank the combined arm highest."""
 

--- a/tests/test_logic_philosophy_replay_eval.py
+++ b/tests/test_logic_philosophy_replay_eval.py
@@ -134,6 +134,22 @@ def test_evaluate_answer_accepts_later_non_negated_match() -> None:
     assert result["unsupported_claim_rate"] < 1.0
 
 
+def test_evaluate_answer_matches_non_word_boundary_snippets() -> None:
+    """Normalized snippets with punctuation should still match at string boundaries."""
+
+    result = evaluate_answer(
+        answer="A common recovery range is 1.2 to 2.0 g/kg for active adults.",
+        required_facts=["1.2 to 2.0 g/kg"],
+        supported_claims=["1.2 to 2.0 g/kg"],
+        usefulness_markers=["1.2 to 2.0 g/kg"],
+        contradiction_checker=replay_eval.NonContradictionChecker(),
+    )
+
+    assert result["correctness_pass"] is True
+    assert result["unsupported_claim_rate"] == 0.0
+    assert result["first_pass_ready"] is True
+
+
 def test_evaluate_replay_documents_picks_combined_arm() -> None:
     """The provided offline corpus should rank the combined arm highest."""
 

--- a/tests/test_logic_philosophy_replay_eval.py
+++ b/tests/test_logic_philosophy_replay_eval.py
@@ -1,0 +1,150 @@
+"""Tests for the governed logic + philosophy offline replay lane."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.orchestration.logic_philosophy_replay_eval as replay_eval
+from scripts.orchestration.logic_philosophy_replay_contract import (
+    load_json_document,
+    validate_negative_controls_document,
+    validate_replay_cases_document,
+)
+from scripts.orchestration.logic_philosophy_replay_eval import (
+    _resolve_output_path,
+    evaluate_answer,
+    evaluate_replay_documents,
+    main,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parent / "fixtures" / "orchestration" / "logic_philosophy_replay"
+)
+
+
+def _fixture(path_name: str) -> Path:
+    return FIXTURE_DIR / path_name
+
+
+def test_validate_replay_cases_document_requires_all_arms() -> None:
+    """Replay cases must define all four canonical ablation arms."""
+
+    payload = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    payload["cases"][0]["arm_outputs"].pop("A3_combined")
+
+    with pytest.raises(ValueError, match="missing required arms: A3_combined"):
+        validate_replay_cases_document(payload)
+
+
+def test_validate_replay_cases_document_requires_zero_network_budget() -> None:
+    """Wave 1 replay corpus must stay strictly offline."""
+
+    payload = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    payload["network_budget"] = 1
+
+    with pytest.raises(ValueError, match="must equal 0 for wave 1 offline replay"):
+        validate_replay_cases_document(payload)
+
+
+def test_validate_negative_controls_document_accepts_fixture() -> None:
+    """Known-good controls should validate as immutable offline oracles."""
+
+    payload = load_json_document(
+        _fixture("replay_negative_controls.json"),
+        label="Replay negative controls",
+    )
+
+    validated = validate_negative_controls_document(payload)
+
+    assert validated["network_budget"] == 0
+    assert len(validated["known_good_controls"]) == 3
+
+
+def test_evaluate_answer_flags_unsupported_claims_and_contradictions() -> None:
+    """Per-answer scoring should capture unsupported and contradictory claims."""
+
+    result = evaluate_answer(
+        answer="A 700 to 800 calorie deficit is always best. This plan is balanced. This plan is not balanced.",
+        required_facts=["small calorie deficit"],
+        supported_claims=["small calorie deficit"],
+        usefulness_markers=["small calorie deficit"],
+        contradiction_checker=replay_eval.NonContradictionChecker(),
+    )
+
+    assert result["correctness_pass"] is False
+    assert result["unsupported_claim_rate"] > 0
+    assert result["contradiction_count"] > 0
+    assert result["first_pass_ready"] is False
+
+
+def test_evaluate_replay_documents_picks_combined_arm() -> None:
+    """The provided offline corpus should rank the combined arm highest."""
+
+    replay_cases = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    negative_controls = load_json_document(
+        _fixture("replay_negative_controls.json"),
+        label="Replay negative controls",
+    )
+
+    summary = evaluate_replay_documents(
+        replay_cases=replay_cases,
+        negative_controls=negative_controls,
+    )
+
+    assert summary["mode"] == "offline_replay_ablation"
+    assert summary["network_budget"] == 0
+    assert summary["winner_arm"] == "A3_combined"
+    assert summary["promotion_ready"] is True
+    assert summary["guardrails"]["known_good_false_positive_rate"] == 0.0
+    assert summary["arms"]["A3_combined"]["correctness_pass_rate"] == 1.0
+    assert summary["arms"]["A3_combined"]["first_pass_readiness_proxy"] == 1.0
+    assert summary["arms"]["A0_control"]["unsupported_claim_rate"] > 0.0
+    assert summary["arms"]["A0_control"]["contradiction_rate"] > 0.0
+
+
+def test_resolve_output_path_rejects_paths_outside_results_dir(tmp_path: Path) -> None:
+    """Result artifacts must stay under the local experiment results directory."""
+
+    outside = tmp_path / "logic-philosophy-result.json"
+
+    with pytest.raises(
+        ValueError,
+        match="--output must stay within artifacts/orchestration/experiments/results",
+    ):
+        _resolve_output_path(str(outside))
+
+
+def test_main_writes_result_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """CLI should write replay summaries only inside the local results directory."""
+
+    repo_root = tmp_path.resolve()
+    results_dir = (repo_root / "artifacts" / "orchestration" / "experiments" / "results").resolve()
+    monkeypatch.setattr(replay_eval, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(replay_eval, "RESULTS_DIR", results_dir)
+
+    exit_code = main(
+        [
+            "--cases",
+            str(_fixture("replay_cases.json")),
+            "--negative-controls",
+            str(_fixture("replay_negative_controls.json")),
+            "--output",
+            "logic-philosophy/result.json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    output_path = repo_root / payload["output"]
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["winner_arm"] == "A3_combined"
+    assert written["promotion_ready"] is True
+    assert written["guardrails"]["known_good_false_positive_rate"] == 0.0

--- a/tests/test_logic_philosophy_replay_eval.py
+++ b/tests/test_logic_philosophy_replay_eval.py
@@ -49,6 +49,26 @@ def test_validate_replay_cases_document_requires_zero_network_budget() -> None:
         validate_replay_cases_document(payload)
 
 
+def test_validate_replay_cases_document_rejects_coerced_network_budget() -> None:
+    """Network budget must be a real integer, not a coercible string."""
+
+    payload = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    payload["network_budget"] = "0"
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        validate_replay_cases_document(payload)
+
+
+def test_validate_replay_cases_document_rejects_non_string_snippets() -> None:
+    """Snippet lists must fail closed when fixture items are not strings."""
+
+    payload = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    payload["cases"][0]["supported_claims"][0] = 123
+
+    with pytest.raises(ValueError, match="must be a string"):
+        validate_replay_cases_document(payload)
+
+
 def test_validate_negative_controls_document_accepts_fixture() -> None:
     """Known-good controls should validate as immutable offline oracles."""
 
@@ -80,6 +100,22 @@ def test_evaluate_answer_flags_unsupported_claims_and_contradictions() -> None:
     assert result["first_pass_ready"] is False
 
 
+def test_evaluate_answer_rejects_negated_supported_snippets() -> None:
+    """Negated snippets must not count as support for a required fact."""
+
+    result = evaluate_answer(
+        answer="BMI is not a screening metric in this context.",
+        required_facts=["screening metric"],
+        supported_claims=["screening metric"],
+        usefulness_markers=["screening metric"],
+        contradiction_checker=replay_eval.NonContradictionChecker(),
+    )
+
+    assert result["correctness_pass"] is False
+    assert result["unsupported_claim_rate"] == 1.0
+    assert result["first_pass_ready"] is False
+
+
 def test_evaluate_replay_documents_picks_combined_arm() -> None:
     """The provided offline corpus should rank the combined arm highest."""
 
@@ -103,6 +139,53 @@ def test_evaluate_replay_documents_picks_combined_arm() -> None:
     assert summary["arms"]["A3_combined"]["first_pass_readiness_proxy"] == 1.0
     assert summary["arms"]["A0_control"]["unsupported_claim_rate"] > 0.0
     assert summary["arms"]["A0_control"]["contradiction_rate"] > 0.0
+
+
+def test_evaluate_replay_documents_blocks_usefulness_regression() -> None:
+    """Promotion readiness must fail when the combined arm regresses on usefulness floor."""
+
+    replay_cases = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    negative_controls = load_json_document(
+        _fixture("replay_negative_controls.json"),
+        label="Replay negative controls",
+    )
+
+    replay_cases["cases"][0]["usefulness_markers"] = ["always best"]
+    replay_cases["cases"][1]["usefulness_markers"] = ["perfect diagnosis"]
+    replay_cases["cases"][2]["usefulness_markers"] = ["gradual increase"]
+
+    summary = evaluate_replay_documents(
+        replay_cases=replay_cases,
+        negative_controls=negative_controls,
+    )
+
+    assert summary["winner_arm"] == "A3_combined"
+    assert summary["arms"]["A3_combined"]["usefulness_floor_rate"] < (
+        summary["arms"]["A0_control"]["usefulness_floor_rate"]
+    )
+    assert summary["promotion_ready"] is False
+
+
+def test_evaluate_replay_documents_flags_known_good_correctness_failures() -> None:
+    """Known-good controls must fail the guardrail when required facts go missing."""
+
+    replay_cases = load_json_document(_fixture("replay_cases.json"), label="Replay cases")
+    negative_controls = load_json_document(
+        _fixture("replay_negative_controls.json"),
+        label="Replay negative controls",
+    )
+    negative_controls["known_good_controls"][0]["supported_claims"].append("missing oracle fact")
+
+    summary = evaluate_replay_documents(
+        replay_cases=replay_cases,
+        negative_controls=negative_controls,
+    )
+
+    assert summary["guardrails"]["known_good_false_positive_rate"] == pytest.approx(
+        0.3333, rel=1e-6
+    )
+    assert summary["known_good_controls"][0]["false_positive"] is True
+    assert summary["known_good_controls"][0]["correctness_pass"] is False
 
 
 def test_resolve_output_path_rejects_paths_outside_results_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a governed offline replay contract for the logic + philosophy reliability lane
- add deterministic evaluator scripts plus immutable replay fixtures and targeted tests
- register the experiment and metric definitions so the lane stays offline, reproducible, and promotion-gated

## Test plan
- [x] `pytest -q tests/test_logic_philosophy_replay_eval.py`
- [x] `python3 scripts/orchestration/logic_philosophy_replay_eval.py --cases tests/fixtures/orchestration/logic_philosophy_replay/replay_cases.json --negative-controls tests/fixtures/orchestration/logic_philosophy_replay/replay_negative_controls.json`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1170_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Local hard gate passed (`make verify`)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed

## Deferred / Follow-ups
- None.

## Summary by Sourcery

Добавить контролируемый офлайн‑реплей и абляционный «лейн» для эксперимента по надежности в области логики и философии, включая его оценщик, контракт, фикстуры и подключение к документации.

Новые возможности:
- Ввести детерминированный офлайн‑реплей‑оценщик и контракт для «лейна» надежности логики и философии, включая логику ранжирования «рукавов» (arm ranking) и готовности к промоуту.
- Зарегистрировать эксперимент реплея по логике и философии в реестре экспериментов с явно заданными основными метриками и гипотезами.

Документация:
- Задокументировать контракт оценки реплея, конфигурацию эксперимента и добавить записи в каталог метрик для корректности, неподдержанных утверждений, противоречий и прокси‑метрики готовности первого прохода.

Тесты:
- Добавить целевые тесты и неизменяемые JSON‑фикстуры для валидации контракта реплея, поведения оценщика, CLI‑выводов и защитных условий (guardrails) для нового «лейна».

Рутинные задачи:
- Зафиксировать соответствие между обсуждением (discussion thread) и коммитом, в котором внесено исправление, для этого PR в журнале ревью.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a governed offline replay and ablation lane for the logic + philosophy reliability experiment, including its evaluator, contract, fixtures, and documentation wiring.

New Features:
- Introduce a deterministic offline replay evaluator and contract for the logic + philosophy reliability lane, including arm ranking and promotion readiness logic.
- Register the logic + philosophy replay experiment in the experimentation registry with explicit primary metrics and hypotheses.

Documentation:
- Document the replay evaluation contract, experiment setup, and add metric catalog entries for correctness, unsupported claims, contradictions, and first-pass readiness proxy.

Tests:
- Add targeted tests and immutable JSON fixtures to validate the replay contract, evaluator behavior, CLI outputs, and guardrail conditions for the new lane.

Chores:
- Record the discussion-thread and fixed-in-commit mapping for this PR in the review log.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registered Logic + Philosophy replay experiment (EXP-AIR-001) scheduled Mar 14–28, 2026.
  * Added a deterministic offline replay evaluation workflow with a CLI and artifact output.

* **Documentation**
  * Added four metrics: correctness pass rate, unsupported claim rate, contradiction rate, first-pass readiness proxy.
  * Added experiment contract, linked protocol, and PR_1170 review note.

* **Tests**
  * Added comprehensive tests and fixtures validating replay inputs, evaluation outcomes, guardrails, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->