### PR TITLE
feat(ios): centralize -only-testing list in scripts/ios_test_targets.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1460,6 +1460,8 @@ jobs:
 
           # Step 2: Run unit tests (only when UI smoke passes)
           echo "=== Running tests (timeout: 15 minutes) ==="
+          ONLY_TESTING="$(../scripts/ios_test_targets.sh)"
+          export ONLY_TESTING
           python3 - << 'PY'
           import subprocess
           import sys
@@ -1470,25 +1472,15 @@ jobs:
               print("::error::DESTINATION is empty", file=sys.stderr)
               sys.exit(1)
 
+          tests = [t.strip() for t in os.environ.get("ONLY_TESTING", "").split(",") if t.strip()]
+          only_flags = [f"-only-testing:{t}" for t in tests]
+
           cmd = [
               "xcodebuild", "test-without-building",
               "-project", "PulsePlate.xcodeproj",
               "-scheme", "PulsePlate",
               "-skip-testing:PulsePlateUITests",
-              "-only-testing:PulsePlateTests/ThinClientGuardsTests",
-              "-only-testing:PulsePlateTests/ProKeyProviderTests",
-              "-only-testing:PulsePlateTests/KeychainStoreTests",
-              "-only-testing:PulsePlateTests/BMIServiceTests",
-              "-only-testing:PulsePlateTests/BMIResponseDecodingTests",
-              "-only-testing:PulsePlateTests/BMIRequestEncodingTests",
-              "-only-testing:PulsePlateTests/LocaleParsingTests",
-              "-only-testing:PulsePlateTests/HTTPClientTests",
-              "-only-testing:PulsePlateTests/APIClientTests",
-              "-only-testing:PulsePlateTests/BMIServiceThinAdapterTests",
-              "-only-testing:PulsePlateTests/SubscriptionBillingServiceTests",
-              "-only-testing:PulsePlateTests/SubscriptionManagerTests",
-              "-only-testing:PulsePlateTests/StoreKitProductCatalogTests",
-              "-only-testing:PulsePlateTests/StoreKitManagerCatalogTests",
+          ] + only_flags + [
               "-destination", destination,
               "-derivedDataPath", ".derivedData",
               "-clonedSourcePackagesDirPath", ".derivedData/SourcePackages",

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		DESTINATION="$${IOS_DESTINATION:-$(IOS_DESTINATION)}"; \
 		if [ -z "$$DESTINATION" ]; then DESTINATION="platform=iOS Simulator,name=$$SIM_NAME,OS=$$SIM_OS"; fi; \
 		echo "Using destination: $$DESTINATION"; \
-		ONLY_ITEMS="$${IOS_ONLY_TESTING:-$(IOS_ONLY_TESTING)}"; \
+		ONLY_ITEMS="$${IOS_ONLY_TESTING:-$(shell ./scripts/ios_test_targets.sh)}"; \
 		SKIP_ITEMS="$${IOS_SKIP_TESTING:-$(IOS_SKIP_TESTING)}"; \
 		SKIP_PROVIDED=""; \
 		if [ -n "$${IOS_SKIP_TESTING+x}" ]; then SKIP_PROVIDED="1"; fi; \
@@ -456,8 +456,6 @@ ios-test: ## Run iOS unit tests (recommended before pushing iOS PR)
 		SKIP_FLAGS=""; \
 		if [ -n "$$ONLY_ITEMS" ]; then \
 			IFS=','; for t in $$ONLY_ITEMS; do t=$${t# }; t=$${t% }; [ -n "$$t" ] && ONLY_FLAGS="$$ONLY_FLAGS -only-testing:$$t"; done; unset IFS; \
-		else \
-			ONLY_FLAGS="-only-testing:PulsePlateTests/ThinClientGuardsTests -only-testing:PulsePlateTests/ProKeyProviderTests -only-testing:PulsePlateTests/KeychainStoreTests -only-testing:PulsePlateTests/BMIServiceTests -only-testing:PulsePlateTests/BMIResponseDecodingTests -only-testing:PulsePlateTests/BMIRequestEncodingTests -only-testing:PulsePlateTests/LocaleParsingTests -only-testing:PulsePlateTests/HTTPClientTests -only-testing:PulsePlateTests/APIClientTests -only-testing:PulsePlateTests/BMIServiceThinAdapterTests -only-testing:PulsePlateTests/SubscriptionBillingServiceTests -only-testing:PulsePlateTests/SubscriptionManagerTests -only-testing:PulsePlateTests/StoreKitProductCatalogTests -only-testing:PulsePlateTests/StoreKitManagerCatalogTests"; \
 		fi; \
 		if [ -z "$$ONLY_ITEMS" ] && [ -z "$$SKIP_PROVIDED" ]; then \
 			SKIP_FLAGS="-skip-testing:PulsePlateUITests"; \

--- a/docs/pr/PR-6b_HANDOFF.md
+++ b/docs/pr/PR-6b_HANDOFF.md
@@ -1,0 +1,55 @@
+# PR-6b HANDOFF — iOS -only-testing Centralize (Sourcery Follow-up)
+
+**Topic:** Centralize `-only-testing` xcodebuild list (ledger-p2-ios-agents-only-testing-centralize)
+**Date:** 2026-03-16
+**Status:** Ready for implementation
+
+---
+
+## Backlog
+
+- [P2: iOS agents-only-testing centralize](../roadmap/BACKLOG_LEDGER.md#ledger-p2-ios-agents-only-testing-centralize)
+
+---
+
+## Scope
+
+- Single source of truth for iOS unit test `-only-testing` list
+- Future test-set changes require one edit (`scripts/ios_test_targets.sh`), not three (Makefile, ci.yml, ios/AGENTS.md)
+
+---
+
+## Non-goals
+
+- Changing which tests run (same 14 tests as before)
+- iOS test logic or coverage changes
+
+---
+
+## Files
+
+- **New:** `scripts/ios_test_targets.sh` — canonical comma-separated list
+- **Edit:** `Makefile` — use `$(shell ./scripts/ios_test_targets.sh)` for default ONLY_ITEMS
+- **Edit:** `.github/workflows/ci.yml` — call script, pass output to Python xcodebuild step
+- **Edit:** `ios/AGENTS.md` — remove 3 duplicated blocks; add canonical reference
+- **Edit:** `docs/roadmap/BACKLOG_LEDGER.md` — update ledger-p2 when merged
+
+---
+
+## DoD
+
+- [x] `scripts/ios_test_targets.sh` outputs 14-test comma-separated list
+- [x] Makefile `ios-test` uses script when `IOS_ONLY_TESTING` unset
+- [x] ci.yml ios-tests job uses script output
+- [x] ios/AGENTS.md references script; no duplicated inline lists
+- [ ] `make ios-test` passes
+- [ ] `pre-commit run --all-files` passes
+- [ ] `make verify` passes
+
+---
+
+## Merge gates (required)
+
+- [ ] `python3 scripts/orchestration/check_preflight.py` — PASS
+- [ ] `pre-commit run --all-files` — PASS
+- [ ] `make verify` — PASS

--- a/docs/review/PR_1181_FIXED_MAPPING.md
+++ b/docs/review/PR_1181_FIXED_MAPPING.md
@@ -6,4 +6,18 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: b583f940
+Evidence: ios/AGENTS.md:174
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#pullrequestreview-3954009795 -> b583f940
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#discussion_r2940543579 -> b583f940
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#pullrequestreview-3954048925 -> b583f940
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#pullrequestreview-3954053006 -> b583f940
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#discussion_r2940547328 -> b583f940
+
+Disposition: NOT-A-BUG
+Evidence: .github/workflows/ci.yml:1468; .cursor/plans/pr-1179_backlog_closure_and_sourcery_follow-up_340d2e3b.plan.md §3.4
+Reason: ci.yml Python block has `import os` at line 1468. Plan §3.4 explicitly requires 14-test list (Makefile/ci.yml set); script is canonical source.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1181#discussion_r2940543589

--- a/docs/review/PR_1181_FIXED_MAPPING.md
+++ b/docs/review/PR_1181_FIXED_MAPPING.md
@@ -1,0 +1,9 @@
+# PR 1181 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -171,7 +171,7 @@
   ```
 - **Step 2: Run tests** (timeout: 15 minutes):
   ```bash
-  # Canonical test list: scripts/ios_test_targets.sh (run from repo root)
+  # Canonical test list: scripts/ios_test_targets.sh (run from ios/)
   xcodebuild test-without-building \
     -project PulsePlate.xcodeproj \
     -scheme PulsePlate \

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -171,22 +171,18 @@
   ```
 - **Step 2: Run tests** (timeout: 15 minutes):
   ```bash
+  # Canonical test list: scripts/ios_test_targets.sh (run from repo root)
   xcodebuild test-without-building \
     -project PulsePlate.xcodeproj \
     -scheme PulsePlate \
     -skip-testing:PulsePlateUITests \
-    -only-testing:PulsePlateTests/ThinClientGuardsTests \
-    -only-testing:PulsePlateTests/ProKeyProviderTests \
-    -only-testing:PulsePlateTests/KeychainStoreTests \
-    -only-testing:PulsePlateTests/BMIServiceTests \
-    -only-testing:PulsePlateTests/BMIResponseDecodingTests \
-    -only-testing:PulsePlateTests/BMIRequestEncodingTests \
-    -only-testing:PulsePlateTests/LocaleParsingTests \
+    $(../scripts/ios_test_targets.sh | tr ',' '\n' | while read t; do [ -n "$t" ] && echo "-only-testing:$t"; done) \
     -destination "$DESTINATION" \
     -derivedDataPath ../.derivedData \
     -enableCodeCoverage NO \
     -parallel-testing-enabled NO
   ```
+- **Canonical test list:** `scripts/ios_test_targets.sh` (single source for Makefile, ci.yml, AGENTS.md)
 - **Do not use `-workspace` for tests unless scheme has explicit TestAction** (confirmed via separate PR)
 - Workspace (`PulsePlate.xcworkspace`) is used for building/running app (SPM dependencies), but tests run via project
 - Project-based approach avoids exit code 66 when app scheme lacks TestAction in workspace context
@@ -340,17 +336,12 @@
   ```
 - **Step 2: Run tests** (timeout: 15 minutes):
   ```bash
+  # Canonical list: scripts/ios_test_targets.sh (run from ios/)
   xcodebuild test-without-building \
     -project PulsePlate.xcodeproj \
     -scheme PulsePlate \
     -skip-testing:PulsePlateUITests \
-    -only-testing:PulsePlateTests/ThinClientGuardsTests \
-    -only-testing:PulsePlateTests/ProKeyProviderTests \
-    -only-testing:PulsePlateTests/KeychainStoreTests \
-    -only-testing:PulsePlateTests/BMIServiceTests \
-    -only-testing:PulsePlateTests/BMIResponseDecodingTests \
-    -only-testing:PulsePlateTests/BMIRequestEncodingTests \
-    -only-testing:PulsePlateTests/LocaleParsingTests \
+    $(../scripts/ios_test_targets.sh | tr ',' '\n' | while read t; do [ -n "$t" ] && echo "-only-testing:$t"; done) \
     -destination "$DESTINATION" \
     -derivedDataPath ../.derivedData \
     -enableCodeCoverage NO \
@@ -399,19 +390,14 @@ xcrun simctl list devices
 
 # Run CI test suite (locally can use name, but UDID preferred)
 # Run `xcrun simctl list devices` to find a valid simulator name (e.g., "iPhone 14").
+# Canonical test list: scripts/ios_test_targets.sh
 xcodebuild test \
   -project PulsePlate.xcodeproj \
   -scheme PulsePlate \
   -destination "platform=iOS Simulator,name=<SIMULATOR_NAME>" \
   -configuration Debug \
   -skip-testing:PulsePlateUITests \
-  -only-testing:PulsePlateTests/ThinClientGuardsTests \
-  -only-testing:PulsePlateTests/ProKeyProviderTests \
-  -only-testing:PulsePlateTests/KeychainStoreTests \
-  -only-testing:PulsePlateTests/BMIServiceTests \
-  -only-testing:PulsePlateTests/BMIResponseDecodingTests \
-  -only-testing:PulsePlateTests/BMIRequestEncodingTests \
-  -only-testing:PulsePlateTests/LocaleParsingTests
+  $(../scripts/ios_test_targets.sh | tr ',' '\n' | while read t; do [ -n "$t" ] && echo "-only-testing:$t"; done)
 ```
 
 ### Simulator troubleshooting (runtime state issues)

--- a/scripts/ios_test_targets.sh
+++ b/scripts/ios_test_targets.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Canonical -only-testing list for iOS unit tests (AGENTS.md, Makefile, ci.yml)
+# Output: comma-separated PulsePlateTests/ClassName entries
+# Usage: ./scripts/ios_test_targets.sh
+# Consumers: Makefile (ios-test), .github/workflows/ci.yml (ios-tests job)
+set -euo pipefail
+
+TESTS=(
+  "PulsePlateTests/ThinClientGuardsTests"
+  "PulsePlateTests/ProKeyProviderTests"
+  "PulsePlateTests/KeychainStoreTests"
+  "PulsePlateTests/BMIServiceTests"
+  "PulsePlateTests/BMIResponseDecodingTests"
+  "PulsePlateTests/BMIRequestEncodingTests"
+  "PulsePlateTests/LocaleParsingTests"
+  "PulsePlateTests/HTTPClientTests"
+  "PulsePlateTests/APIClientTests"
+  "PulsePlateTests/BMIServiceThinAdapterTests"
+  "PulsePlateTests/SubscriptionBillingServiceTests"
+  "PulsePlateTests/SubscriptionManagerTests"
+  "PulsePlateTests/StoreKitProductCatalogTests"
+  "PulsePlateTests/StoreKitManagerCatalogTests"
+)
+
+# Output comma-separated for Makefile IOS_ONLY_TESTING parsing (no trailing newline)
+IFS=','; printf '%s' "${TESTS[*]}"; unset IFS


### PR DESCRIPTION
## Summary
Sourcery follow-up: single source of truth for iOS unit test `-only-testing` list (ledger-p2-ios-agents-only-testing-centralize).

## Scope
- **New:** `scripts/ios_test_targets.sh` — canonical comma-separated list (14 tests)
- **Makefile:** use script output for default `IOS_ONLY_TESTING` when env unset
- **ci.yml:** call script, pass output to Python xcodebuild step
- **ios/AGENTS.md:** remove 3 duplicated blocks; add canonical reference
- **docs/pr/PR-6b_HANDOFF.md:** handoff artifact

## DoD
- [x] `make ios-test` passes
- [x] `pre-commit run --all-files` passes
- [x] `make verify` passes
- [x] Preflight check passes

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1181_FIXED_MAPPING.md`

## Verification
`make ios-test` — uses script output for -only-testing flags
`./scripts/ios_test_targets.sh` — outputs 14 comma-separated test names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated iOS unit test targets into a single canonical source and removed hard-coded test lists; CI and build tooling now derive test subsets dynamically for more consistent test selection.
* **Documentation**
  * Added handoff and review guidance documenting the new centralized test-target approach and related acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->