### PR TITLE
feat: integrate anthropic-cybersecurity-skills (734+ skills)

### DIFF
--- a/.cursor/rules/cybersecurity-skills-index.md
+++ b/.cursor/rules/cybersecurity-skills-index.md
@@ -1,0 +1,36 @@
+---
+description: Index for 734+ cybersecurity skills (agentskills.io). Use when security audit, vulnerability scan, threat model, API security, DevSecOps, or web app security tasks.
+globs:
+alwaysApply: false
+---
+
+# Cybersecurity Skills Index
+
+**Source:** `tools/cybersecurity_skills/` (git submodule from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills))
+
+**When to use:** Security audit, vulnerability scan, threat modeling, API security review, DevSecOps, web application security, container security.
+
+## PulsePlate-relevant subdomains
+
+| Subdomain | Count | Example skills |
+|-----------|-------|----------------|
+| api-security | 28 | testing-api-for-broken-object-level-authorization, testing-oauth2-implementation-flaws |
+| web-application-security | 42 | testing-for-xss-vulnerabilities, testing-for-json-web-token-vulnerabilities |
+| devsecops | 17 | semgrep-custom-sast-rules, secret-scanning-with-gitleaks |
+| container-security | 30 | trivy-image-scanning, falco-runtime-detection |
+| vulnerability-management | 25 | cvss-scoring, patch-management-workflow |
+
+## Full index
+
+- **Location:** `tools/cybersecurity_skills/index.json`
+- **Skills path:** `tools/cybersecurity_skills/skills/{skill-name}/SKILL.md`
+- **Format:** agentskills.io (YAML frontmatter + workflow)
+
+## Codex install
+
+Skills are installed to `$CODEX_HOME/skills/` via `scripts/install_codex_skills.sh`. Run after clone:
+
+```bash
+git submodule update --init --recursive
+scripts/install_codex_skills.sh
+```

--- a/.cursor/rules/cybersecurity-skills-index.md
+++ b/.cursor/rules/cybersecurity-skills-index.md
@@ -1,5 +1,5 @@
 ---
-description: Index for 734+ cybersecurity skills (agentskills.io). Use when security audit, vulnerability scan, threat model, API security, DevSecOps, or web app security tasks.
+description: Index for 734+ cybersecurity skills (approximate; see tools/cybersecurity_skills/index.json) (agentskills.io). Use when security audit, vulnerability scan, threat model, API security, DevSecOps, or web app security tasks.
 globs:
 alwaysApply: false
 ---

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,141 +1,34 @@
-# Frontend (not needed in backend container)
-frontend/
-ios/
+# -----------------------------------------------------------------------------
+# PulsePlate backend image: strict Docker build context
+# Keeps only files that are actually copied by the current Dockerfile.
+# -----------------------------------------------------------------------------
 
-# Tools and skills (not needed in backend container; reduces build context)
-tools/
+# Ignore everything by default
+**
 
-# Git
-.git
-.gitignore
-.gitattributes
+# Docker metadata
+!.dockerignore
+!Dockerfile
 
-# Documentation
-*.md
-docs/
-README.md
-LICENSE
+# Dependency manifests used during build
+!requirements.txt
+!requirements-dev.txt
 
-# CI/CD
-.github/
-.gitlab-ci.yml
-.travis.yml
-.circleci/
+# Runtime application directories copied by Dockerfile
+!app/
+!app/**
+!core/
+!core/**
+!alembic/
+!alembic/**
+!alembic.ini
 
-# Development files
-.vscode/
-.idea/
-.cursor/
-.agents/
-.codex/
-*.swp
-*.swo
-*~
-
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# Virtual environments
-venv/
-env/
-ENV/
-.venv/
-.env/
-
-# Testing
-.pytest_cache/
-.coverage
-htmlcov/
-.tox/
-.nox/
-coverage.xml
-*.cover
-.hypothesis/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# Environments
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# Cache directories (but keep essential food_db files)
-cache/*
-!cache/food_db/
-!cache/food_db/database_versions.json
-!cache/food_db/unified_food_cache.json
-.cache/
-.mypy_cache/
-.ruff_cache/
-
-# Logs
-logs/
-*.log
-
-# OS
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
-
-# Temporary files
-tmp/
-temp/
-*.tmp
-*.temp
-
-# Node.js (if any frontend components)
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# Docker: exclude metadata from build context
-.dockerignore
-
-# Development scripts
-scripts/dev-*
-scripts/test-*
-scripts/debug-*
-
-# Test files
-tests/
-test_*
-*_test.py
-
-# Coverage reports
-coverage/
-.coverage.*
-
-# Local configuration
-local_config.py
-config.local.py
+# Root-level Python modules copied by Dockerfile
+!legacy_app.py
+!main.py
+!settings.py
+!bmi_core.py
+!bmi_visualization.py
+!nutrition_core.py
+!signed_links.py
+!bodyfat.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,9 @@
 frontend/
 ios/
 
+# Tools and skills (not needed in backend container; reduces build context)
+tools/
+
 # Git
 .git
 .gitignore
@@ -22,6 +25,9 @@ LICENSE
 # Development files
 .vscode/
 .idea/
+.cursor/
+.agents/
+.codex/
 *.swp
 *.swo
 *~

--- a/.flake8
+++ b/.flake8
@@ -25,4 +25,5 @@ exclude =
     .mypy_cache,
     .ruff_cache,
     releases/*,
-    node_modules
+    node_modules,
+    tools/cybersecurity_skills

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/cybersecurity_skills"]
+	path = tools/cybersecurity_skills
+	url = https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,8 @@ make diff-cov   # Diff-coverage ≥97% on changed lines
 
 **Dockerfile policy (hard):**
 
+- Runtime-mounted directories (`data/`, `cache/`, `logs/`, `artifacts/`) must not be included in Docker build context.
+- For the backend image, prefer a whitelist `.dockerignore` synchronized with the Dockerfile; when adding new `COPY` paths, add corresponding `!path` entries.
 - Do not pin `pip` to an exact version in the Dockerfile (e.g., `pip==24.2`). Exact pins can fail when the build environment cannot resolve the version from PyPI index (proxy/index/TLS issues).
 - Prefer using base image pip without upgrade, or upgrade without version pin if upgrade is required.
 - If a pip version constraint is required, use a version range and document the reason + CI verification.

--- a/docs/dev/CYBERSECURITY_SKILLS.md
+++ b/docs/dev/CYBERSECURITY_SKILLS.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 -->
 
-734+ cybersecurity skills from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default with PulsePlate Codex skills.
+734+ cybersecurity skills (approximate; see `tools/cybersecurity_skills/index.json`) from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default with PulsePlate Codex skills.
 
 ## Install
 
@@ -36,7 +36,7 @@ scripts/install_codex_skills.sh
 
 ## Routing
 
-- **security-auditor** gets access to all 734 skills when routed (see `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`)
+- **security-auditor** gets access to all ~734 skills (approximate; see index.json) when routed (see `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`)
 - **Cursor:** `.cursor/rules/cybersecurity-skills-index.md` provides index and triggers
 - **Codex:** Skills installed to `$CODEX_HOME/skills/`; available to all agents
 

--- a/docs/dev/CYBERSECURITY_SKILLS.md
+++ b/docs/dev/CYBERSECURITY_SKILLS.md
@@ -1,0 +1,53 @@
+# Cybersecurity Skills for PulsePlate
+
+<!-- markdownlint-disable MD013 -->
+
+734+ cybersecurity skills from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default with PulsePlate Codex skills.
+
+## Install
+
+First-time setup (after clone):
+
+```bash
+git submodule update --init --recursive
+scripts/install_codex_skills.sh
+```
+
+Skills are symlinked to `$CODEX_HOME/skills/` (or `~/.codex/skills/`).
+
+## Update
+
+To pull latest cybersecurity skills:
+
+```bash
+git submodule update --remote tools/cybersecurity_skills
+scripts/install_codex_skills.sh
+```
+
+## PulsePlate-relevant subdomains
+
+| Subdomain | Skills | Use case |
+|-----------|--------|----------|
+| api-security | 28 | API auth, BOLA, OWASP, JWT |
+| web-application-security | 42 | XSS, XXE, injection, OWASP |
+| devsecops | 17 | semgrep, gitleaks, CI pipeline |
+| container-security | 30 | Trivy, Falco, Kubernetes |
+| vulnerability-management | 25 | CVSS, patch workflow |
+
+## Routing
+
+- **security-auditor** gets access to all 734 skills when routed (see `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`)
+- **Cursor:** `.cursor/rules/cybersecurity-skills-index.md` provides index and triggers
+- **Codex:** Skills installed to `$CODEX_HOME/skills/`; available to all agents
+
+## Index
+
+Full skill list: `tools/cybersecurity_skills/index.json`
+
+Skill structure: `tools/cybersecurity_skills/skills/{skill-name}/SKILL.md`
+
+## References
+
+- [tools/codex_skills/README.md](../../tools/codex_skills/README.md) — install overview
+- [AGENT_SKILL_ROUTING_POLICY.md](../orchestration/AGENT_SKILL_ROUTING_POLICY.md) — skill routing
+- [agentskills.io](https://agentskills.io) — skill format standard

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -91,7 +91,7 @@ domain routing first and then apply these **default helper bundles**:
 |-----------------|-----------------------|
 | `agent-coordinator` | `docs-sync`, `agents-md`, `pulseplate-gates` |
 | `bug-hunter` | `bug-triage`, `pulseplate-gates`, `pulseplate-guards` |
-| `security-auditor` | `security-best-practices`, `security-threat-model`, `pulseplate-guards` |
+| `security-auditor` | `security-best-practices`, `security-threat-model`, `pulseplate-guards`, `tools/cybersecurity_skills` (734 skills) |
 | `backend-engineer` | `pulseplate-backend-endpoints`, `pulseplate-openapi-sync`, `pulseplate-gates` |
 | `qa-engineer-agent` | `bug-triage`, `pulseplate-gates`, `code-review-expert` |
 | `frontend-engineer` | `pulseplate-frontend-ui`, `pulseplate-gates`, `vercel-react-best-practices` |
@@ -111,6 +111,7 @@ The coordinator may use installed skills when they improve delivery and align wi
 ### Preferred by default
 
 - Repo-tracked PulsePlate skills in `tools/codex_skills/`
+- Cybersecurity skills in `tools/cybersecurity_skills/skills/` (734 skills, agentskills.io; installed by default via `scripts/install_codex_skills.sh`)
 - `docs-sync`
 - `bug-triage`
 - `code-review-expert`
@@ -149,7 +150,8 @@ The following touched paths must automatically boost security-oriented skills an
 Expected behavior:
 
 - add `security-best-practices` and/or `pulseplate-guards` when the task packet touches these paths;
-- keep `security-auditor` in the review path even if the dominant domain is docs, release, or orchestration.
+- keep `security-auditor` in the review path even if the dominant domain is docs, release, or orchestration;
+- security-auditor may reference `tools/cybersecurity_skills/` (index: `tools/cybersecurity_skills/index.json`) for subdomain-specific procedures (API Security, DevSecOps, Web App Sec, Container Security).
 
 ---
 

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -91,7 +91,7 @@ domain routing first and then apply these **default helper bundles**:
 |-----------------|-----------------------|
 | `agent-coordinator` | `docs-sync`, `agents-md`, `pulseplate-gates` |
 | `bug-hunter` | `bug-triage`, `pulseplate-gates`, `pulseplate-guards` |
-| `security-auditor` | `security-best-practices`, `security-threat-model`, `pulseplate-guards`, `tools/cybersecurity_skills` (734 skills) |
+| `security-auditor` | `security-best-practices`, `security-threat-model`, `pulseplate-guards`, `cybersecurity-skills` (~734 skills, approximate; see `tools/cybersecurity_skills/index.json`) |
 | `backend-engineer` | `pulseplate-backend-endpoints`, `pulseplate-openapi-sync`, `pulseplate-gates` |
 | `qa-engineer-agent` | `bug-triage`, `pulseplate-gates`, `code-review-expert` |
 | `frontend-engineer` | `pulseplate-frontend-ui`, `pulseplate-gates`, `vercel-react-best-practices` |
@@ -111,7 +111,7 @@ The coordinator may use installed skills when they improve delivery and align wi
 ### Preferred by default
 
 - Repo-tracked PulsePlate skills in `tools/codex_skills/`
-- Cybersecurity skills in `tools/cybersecurity_skills/skills/` (734 skills, agentskills.io; installed by default via `scripts/install_codex_skills.sh`)
+- `cybersecurity-skills` bundle (maps to `tools/cybersecurity_skills/skills/` or `$CODEX_HOME/skills` when installed; ~734 skills, approximate; see `tools/cybersecurity_skills/index.json`; agentskills.io; installed by default via `scripts/install_codex_skills.sh`)
 - `docs-sync`
 - `bug-triage`
 - `code-review-expert`
@@ -151,7 +151,7 @@ Expected behavior:
 
 - add `security-best-practices` and/or `pulseplate-guards` when the task packet touches these paths;
 - keep `security-auditor` in the review path even if the dominant domain is docs, release, or orchestration;
-- security-auditor may reference `tools/cybersecurity_skills/` (index: `tools/cybersecurity_skills/index.json`) for subdomain-specific procedures (API Security, DevSecOps, Web App Sec, Container Security).
+- security-auditor may reference `cybersecurity-skills` bundle (repo path: `tools/cybersecurity_skills/`; index: `tools/cybersecurity_skills/index.json`) for subdomain-specific procedures (API Security, DevSecOps, Web App Sec, Container Security).
 
 ---
 

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1183 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+(No review threads yet.)
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] Pre-commit green

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -7,10 +7,10 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: (to be filled after commit)
+Commit: 98b024d6
 Evidence: scripts/install_codex_skills.sh (--no-cybersec/--only-cybersec), AGENT_SKILL_ROUTING_POLICY.md (cybersecurity-skills bundle), docs (approximate skill counts)
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959214960 -> (sha)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959214960 -> 98b024d6
 
 ## Merge Readiness
 

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -17,10 +17,18 @@ Evidence: scripts/install_codex_skills.sh (--no-cybersec/--only-cybersec), AGENT
 Disposition: NOT-A-BUG
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959235254
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959249506
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959430874
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959431113
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379494
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379515
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945392614
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945392629
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945558797
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945558807
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945558814
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945558820
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945559066
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945559080
 Evidence: docs/review/PR_1183_FIXED_MAPPING.md
 Reason: Cubic/CodeRabbit reviews contain no actionable code changes; Sourcery feedback addressed in 98b024d6.
 

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -1,12 +1,16 @@
 # PR 1183 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-(No review threads yet.)
+Disposition: FIXED
+Commit: (to be filled after commit)
+Evidence: scripts/install_codex_skills.sh (--no-cybersec/--only-cybersec), AGENT_SKILL_ROUTING_POLICY.md (cybersecurity-skills bundle), docs (approximate skill counts)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959214960 -> (sha)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -16,6 +16,7 @@ Evidence: scripts/install_codex_skills.sh (--no-cybersec/--only-cybersec), AGENT
 
 Disposition: NOT-A-BUG
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959235254
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959249506
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379494
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379515
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945392614

--- a/docs/review/PR_1183_FIXED_MAPPING.md
+++ b/docs/review/PR_1183_FIXED_MAPPING.md
@@ -11,6 +11,17 @@ Commit: 98b024d6
 Evidence: scripts/install_codex_skills.sh (--no-cybersec/--only-cybersec), AGENT_SKILL_ROUTING_POLICY.md (cybersecurity-skills bundle), docs (approximate skill counts)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959214960 -> 98b024d6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945362089 -> 98b024d6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379211 -> 98b024d6
+
+Disposition: NOT-A-BUG
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#pullrequestreview-3959235254
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379494
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945379515
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945392614
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1183#discussion_r2945392629
+Evidence: docs/review/PR_1183_FIXED_MAPPING.md
+Reason: Cubic/CodeRabbit reviews contain no actionable code changes; Sourcery feedback addressed in 98b024d6.
 
 ## Merge Readiness
 

--- a/scripts/install_codex_skills.sh
+++ b/scripts/install_codex_skills.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Install PulsePlate Codex skills from this repo into a Codex skills directory.
+Install PulsePlate and cybersecurity Codex skills from this repo into a Codex skills directory.
 
 Usage:
   scripts/install_codex_skills.sh [--copy] [--unlink] [--list] [--dest <skills_dir>]
@@ -26,7 +26,11 @@ EOF
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-SKILLS_SRC_ROOT="${REPO_ROOT}/tools/codex_skills"
+# Both sources installed by default (PulsePlate + cybersecurity)
+SKILLS_SRC_ROOTS=(
+  "${REPO_ROOT}/tools/codex_skills"
+  "${REPO_ROOT}/tools/cybersecurity_skills/skills"
+)
 COPY_MARKER_FILE=".pulseplate_codex_skill_source"
 
 CODEX_HOME_DEFAULT="${CODEX_HOME:-${HOME}/.codex}"
@@ -68,23 +72,24 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ ! -d "${SKILLS_SRC_ROOT}" ]]; then
-  echo "Error: source skills directory not found: ${SKILLS_SRC_ROOT}" >&2
-  exit 1
-fi
-
 SKILL_DIRS=()
-while IFS= read -r src_dir; do
-  SKILL_DIRS+=("${src_dir}")
-done < <(find "${SKILLS_SRC_ROOT}" -mindepth 1 -maxdepth 1 -type d | sort)
+for root in "${SKILLS_SRC_ROOTS[@]}"; do
+  if [[ ! -d "${root}" ]]; then
+    echo "Note: skipping missing source ${root} (run: git submodule update --init)" >&2
+    continue
+  fi
+  while IFS= read -r src_dir; do
+    SKILL_DIRS+=("${src_dir}")
+  done < <(find "${root}" -mindepth 1 -maxdepth 1 -type d | sort)
+done
 
 if [[ "${#SKILL_DIRS[@]}" -eq 0 ]]; then
-  echo "Error: no skill directories found under ${SKILLS_SRC_ROOT}" >&2
+  echo "Error: no skill directories found. Check tools/codex_skills and tools/cybersecurity_skills (git submodule update --init)." >&2
   exit 1
 fi
 
 list_skills() {
-  echo "Source: ${SKILLS_SRC_ROOT}"
+  echo "Sources: tools/codex_skills, tools/cybersecurity_skills/skills"
   echo "Destination: ${DEST_ROOT}"
   echo
   printf "%-36s %s\n" "SKILL" "STATUS"

--- a/scripts/install_codex_skills.sh
+++ b/scripts/install_codex_skills.sh
@@ -6,18 +6,22 @@ usage() {
 Install PulsePlate and cybersecurity Codex skills from this repo into a Codex skills directory.
 
 Usage:
-  scripts/install_codex_skills.sh [--copy] [--unlink] [--list] [--dest <skills_dir>]
+  scripts/install_codex_skills.sh [--copy] [--unlink] [--list] [--dest <skills_dir>] [--no-cybersec|--only-cybersec]
 
 Options:
   --copy            Install by copying directories (default is symlink mode).
   --unlink          Remove installed skills from destination.
   --list            Print source skills and destination install status.
   --dest <path>     Destination skills directory (default: $CODEX_HOME/skills or ~/.codex/skills).
+  --no-cybersec     Install only PulsePlate skills (skip cybersecurity skills).
+  --only-cybersec   Install only cybersecurity skills (skip PulsePlate skills).
   -h, --help        Show this help.
 
 Examples:
   scripts/install_codex_skills.sh
   scripts/install_codex_skills.sh --copy
+  scripts/install_codex_skills.sh --no-cybersec --list
+  scripts/install_codex_skills.sh --only-cybersec
   scripts/install_codex_skills.sh --list
   scripts/install_codex_skills.sh --unlink
   scripts/install_codex_skills.sh --dest /tmp/codex-skills
@@ -26,17 +30,13 @@ EOF
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-# Both sources installed by default (PulsePlate + cybersecurity)
-SKILLS_SRC_ROOTS=(
-  "${REPO_ROOT}/tools/codex_skills"
-  "${REPO_ROOT}/tools/cybersecurity_skills/skills"
-)
 COPY_MARKER_FILE=".pulseplate_codex_skill_source"
 
 CODEX_HOME_DEFAULT="${CODEX_HOME:-${HOME}/.codex}"
 DEST_ROOT="${CODEX_HOME_DEFAULT}/skills"
 MODE="link"
 ACTION="install"
+CYBERSEC_MODE="both"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,6 +60,14 @@ while [[ $# -gt 0 ]]; do
       DEST_ROOT="$2"
       shift 2
       ;;
+    --no-cybersec)
+      CYBERSEC_MODE="exclude"
+      shift
+      ;;
+    --only-cybersec)
+      CYBERSEC_MODE="only"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -71,6 +79,27 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Build SKILLS_SRC_ROOTS based on CYBERSEC_MODE
+SKILLS_SRC_ROOTS=()
+case "${CYBERSEC_MODE}" in
+  both)
+    SKILLS_SRC_ROOTS=(
+      "${REPO_ROOT}/tools/codex_skills"
+      "${REPO_ROOT}/tools/cybersecurity_skills/skills"
+    )
+    ;;
+  exclude)
+    SKILLS_SRC_ROOTS=("${REPO_ROOT}/tools/codex_skills")
+    ;;
+  only)
+    SKILLS_SRC_ROOTS=("${REPO_ROOT}/tools/cybersecurity_skills/skills")
+    ;;
+  *)
+    echo "Error: invalid CYBERSEC_MODE ${CYBERSEC_MODE}" >&2
+    exit 1
+    ;;
+esac
 
 SKILL_DIRS=()
 for root in "${SKILLS_SRC_ROOTS[@]}"; do
@@ -89,7 +118,12 @@ if [[ "${#SKILL_DIRS[@]}" -eq 0 ]]; then
 fi
 
 list_skills() {
-  echo "Sources: tools/codex_skills, tools/cybersecurity_skills/skills"
+  local sources_str=""
+  for r in "${SKILLS_SRC_ROOTS[@]}"; do
+    [[ -n "${sources_str}" ]] && sources_str="${sources_str}, "
+    sources_str="${sources_str}${r#${REPO_ROOT}/}"
+  done
+  echo "Sources: ${sources_str}"
   echo "Destination: ${DEST_ROOT}"
   echo
   printf "%-36s %s\n" "SKILL" "STATUS"

--- a/tools/codex_skills/README.md
+++ b/tools/codex_skills/README.md
@@ -2,15 +2,15 @@
 
 <!-- markdownlint-disable MD013 -->
 
-Repo-tracked source for project-specific Codex skills.
+Repo-tracked source for project-specific Codex skills and cybersecurity skills.
 
-- Source of truth: `tools/codex_skills/*`
+- Source of truth: `tools/codex_skills/*`, `tools/cybersecurity_skills/skills/*`
 - Install target: `$CODEX_HOME/skills/*` (or `~/.codex/skills/*`)
 - Installer: `scripts/install_codex_skills.sh`
 
 Default install mode uses symlinks so updates in this repo immediately apply to installed skills.
 
-Current skills:
+## PulsePlate skills
 
 - `pulseplate-workflow`
 - `pulseplate-gates`
@@ -22,3 +22,23 @@ Current skills:
 - `pulseplate-ai-reports`
 - `pulseplate-graphmap`
 - `pulseplate-playwright-e2e`
+
+## Cybersecurity skills (submodule)
+
+734+ skills from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default from `tools/cybersecurity_skills/` (git submodule).
+
+**First-time setup:**
+
+```bash
+git submodule update --init --recursive
+scripts/install_codex_skills.sh
+```
+
+**Update to latest:**
+
+```bash
+git submodule update --remote tools/cybersecurity_skills
+scripts/install_codex_skills.sh
+```
+
+See `docs/dev/CYBERSECURITY_SKILLS.md` for details.

--- a/tools/codex_skills/README.md
+++ b/tools/codex_skills/README.md
@@ -25,7 +25,7 @@ Default install mode uses symlinks so updates in this repo immediately apply to 
 
 ## Cybersecurity skills (submodule)
 
-734+ skills from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default from `tools/cybersecurity_skills/` (git submodule).
+734+ skills (approximate; see `tools/cybersecurity_skills/index.json`) from [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (agentskills.io format). Installed by default from `tools/cybersecurity_skills/` (git submodule).
 
 **First-time setup:**
 


### PR DESCRIPTION
## Summary

Integrate [anthropic-cybersecurity-skills](https://github.com/Katsiarynakavaleuskaya/anthropic-cybersecurity-skills) (734+ agentskills.io skills) into PulsePlate for Cursor and Codex.

## Changes

- Add `tools/cybersecurity_skills` as git submodule
- Extend `scripts/install_codex_skills.sh` to install from both `tools/codex_skills` and `tools/cybersecurity_skills/skills` by default
- Update `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md` for security-auditor bundle
- Add `.cursor/rules/cybersecurity-skills-index.md` for Cursor
- Add `docs/dev/CYBERSECURITY_SKILLS.md`
- Exclude `tools/cybersecurity_skills` from flake8 (external submodule)

## Verification

- `make lint` — pass
- `make test-fast` — pass
- `pre-commit run --all-files` — pass

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

See `docs/review/PR_1183_FIXED_MAPPING.md` for disposition mapping.

## Merge Readiness

- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] Pre-commit green

## Deferred / Follow-ups

- None

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Интеграция сабмодуля с навыками в области кибербезопасности и его подключение к установке Codex, маршрутизации и документации по инструментам.

New Features:
- Добавить `anthropic-cybersecurity-skills` как git-сабмодуль в `tools/cybersecurity_skills`, чтобы предоставить 734+ навыков кибербезопасности в формате agentskills.io.
- Включить навыки кибербезопасности наряду с существующими навыками PulsePlate Codex в установщик `install_codex_skills.sh` и каталог навыков Codex.
- Открыть доступ к навыкам кибербезопасности для Cursor через новое правило `.cursor/rules/cybersecurity-skills-index.md` и для пакета `security-auditor` через обновления политики маршрутизации.

Enhancements:
- Задокументировать установку, процесс обновления, маршрутизацию и расположение индексов для навыков кибербезопасности в новых и существующих документах, включая `AGENT_SKILL_ROUTING_POLICY` и `CYBERSECURITY_SKILLS.md`.
- Уточнить `tools/codex_skills/README.md`, чтобы описать и PulsePlate, и навыки кибербезопасности как источники истины и объяснить, как ими управлять.

Documentation:
- Добавить документацию для разработчиков по установке, обновлению и маршрутизации навыков кибербезопасности, включая разбиение по поддоменам и ссылки на индексы.
- Обновить документацию по политике маршрутизации оркестрации, чтобы отразить использование новым пакетом `security-auditor` навыков кибербезопасности и их предпочтительный статус.
- Добавить документ с правилами Cursor, описывающий, когда и как использовать индекс навыков кибербезопасности.

Chores:
- Исключить внешний сабмодуль `tools/cybersecurity_skills` из проверки flake8.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a cybersecurity skills submodule and wire it into Codex installation, routing, and tooling documentation.

New Features:
- Add anthropic-cybersecurity-skills as a git submodule under tools/cybersecurity_skills to provide 734+ agentskills.io-format cybersecurity skills.
- Include cybersecurity skills alongside existing PulsePlate Codex skills in the install_codex_skills.sh installer and Codex skills directory.
- Expose cybersecurity skills to Cursor via a new .cursor/rules/cybersecurity-skills-index.md rule and to the security-auditor bundle via routing policy updates.

Enhancements:
- Document installation, update workflow, routing, and index locations for the cybersecurity skills in new and existing docs, including AGENT_SKILL_ROUTING_POLICY and CYBERSECURITY_SKILLS.md.
- Clarify tools/codex_skills/README.md to describe both PulsePlate and cybersecurity skills as sources of truth and how to manage them.

Documentation:
- Add developer documentation for installing, updating, and routing cybersecurity skills, including subdomain breakdowns and index references.
- Update orchestration routing policy docs to reflect the security-auditor bundle’s use of the new cybersecurity skills and their preferred status.
- Add a Cursor rules doc describing when and how to use the cybersecurity skills index.

Chores:
- Exclude the external tools/cybersecurity_skills submodule from flake8 linting.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates ~734 `anthropic-cybersecurity-skills` into PulsePlate and Codex with a named `cybersecurity-skills` bundle and installer flags, and hardens the backend image with a strict whitelist `.dockerignore`.

- **New Features**
  - Added `tools/cybersecurity_skills` as a git submodule and excluded it from `flake8`.
  - Extended `scripts/install_codex_skills.sh` to install from `tools/codex_skills` and `tools/cybersecurity_skills/skills`, with `--no-cybersec` and `--only-cybersec`.
  - Updated routing policy with a `cybersecurity-skills` bundle for `security-auditor` (~734 skills; see `tools/cybersecurity_skills/index.json`).
  - Added `.cursor/rules/cybersecurity-skills-index.md`, `docs/dev/CYBERSECURITY_SKILLS.md`, updated `tools/codex_skills/README.md`, and expanded `docs/review/PR_1183_FIXED_MAPPING.md` with additional NOT-A-BUG mappings.
  - Replaced `.dockerignore` with a strict whitelist aligned to the Dockerfile and documented the policy in `AGENTS.md`.

- **Migration**
  - First-time: `git submodule update --init --recursive` then `scripts/install_codex_skills.sh` (defaults install both; flags: `--no-cybersec`, `--only-cybersec`).
  - Updates: `git submodule update --remote tools/cybersecurity_skills` then reinstall.

<sup>Written for commit 7545c2f53deb99857f24ee959aaa815a97237d9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated ~734 cybersecurity skills as a default resource for the security-auditor role and added selectable cybersec install modes (both/exclude/only) for skill installation.

* **Documentation**
  * Added developer, orchestration, routing, index, and review docs describing the cybersecurity skills index, routing policy, setup/install guidance, and review notes.

* **Chores**
  * Added the cybersecurity skills repository as a tracked submodule; updated lint exclusions, install script behavior, README/setup instructions, and Docker build-context ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
