### PR TITLE
infra(postgres): promote self-hosted Postgres to canonical Droplet foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # === LLM Provider Settings ===
-LLM_PROVIDER=grok
-XAI_API_KEY=replace_me
+LLM_PROVIDER=ollama
+XAI_API_KEY=__replace_me__
 
 # === Grok API ===
 GROK_MODEL=grok-4-latest
@@ -11,28 +11,34 @@ GROK_MAX_RETRIES=3
 GROK_BACKOFF_MS=300
 
 # === Ollama Local ===
+# Local native run: localhost. Docker Compose: host.docker.internal or ollama service name.
 OLLAMA_ENDPOINT=http://localhost:11434
 OLLAMA_MODEL=llama3.1:8b
 
 # === App Environment ===
 APP_ENV=local
+ENVIRONMENT=local
+
+# === Database ===
+# Local/dev default: SQLite (works for native uvicorn runs).
+# For Docker Compose / Droplet: uncomment and set Postgres DSN.
+DATABASE_URL=sqlite:///./cache/app.db
+# DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@postgres:5432/pulseplate
+# DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
 
 # === PostgreSQL (canonical prod DB) ===
-# Required for production. SQLite used for local/dev/test when DATABASE_URL unset.
+# Required for production. SQLite used for local/dev/test when Postgres DSN not set.
 POSTGRES_DB=pulseplate
 POSTGRES_USER=pulseplate
 POSTGRES_PASSWORD=__replace_me__
-# Format: postgresql+psycopg://USER:PASSWORD@postgres:5432/DB
-# Replace PLACEHOLDER with actual password; see POSTGRES_PASSWORD
-DATABASE_URL=postgresql+psycopg://pulseplate:PLACEHOLDER@postgres:5432/pulseplate
 
 # === Required secrets (local/dev) ===
 # SERVER_SALT is required at app startup for VIP LLM monthly quota enforcement.
-SERVER_SALT=replace_me_with_secret
+SERVER_SALT=__replace_me__
 # APPLE_SHARED_SECRET is required for server-side Apple receipt verification.
-APPLE_SHARED_SECRET=replace_me_with_apple_shared_secret
+APPLE_SHARED_SECRET=__replace_me__
 # EXPORT_TOKEN_SECRET becomes mandatory when PRIVATE_EXPORTS_ENABLED=true in production/staging.
-EXPORT_TOKEN_SECRET=replace_me_with_export_secret
+EXPORT_TOKEN_SECRET=__replace_me__
 
 # === Private exports ===
 # Keep enabled for signed weekly-plan exports; disable only if export links are not needed.
@@ -69,6 +75,11 @@ ALLOW_PROMPT_EVENTS=false
 API_KEY=
 # Keep true only for local/test workflows. Production/staging must override to false.
 ALLOW_DEV_API_KEY=true
+# Local/dev: false. Production/staging: true.
+API_KEY_REQUIRED=false
+# Feature flags to eliminate config drift.
+VIP_MODULE_ENABLED=false
+FEATURE_RAG=false
 # Optional local/dev override for anonymous VIP/API-tier testing.
 # Production/staging must keep this false; startup now fails closed otherwise.
 # ALLOW_ANONYMOUS_API_KEYS=false

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,15 @@ OLLAMA_MODEL=llama3.1:8b
 # === App Environment ===
 APP_ENV=local
 
+# === PostgreSQL (canonical prod DB) ===
+# Required for production. SQLite used for local/dev/test when DATABASE_URL unset.
+POSTGRES_DB=pulseplate
+POSTGRES_USER=pulseplate
+POSTGRES_PASSWORD=__replace_me__
+# Format: postgresql+psycopg://USER:PASSWORD@postgres:5432/DB
+# Replace PLACEHOLDER with actual password; see POSTGRES_PASSWORD
+DATABASE_URL=postgresql+psycopg://pulseplate:PLACEHOLDER@postgres:5432/pulseplate
+
 # === Required secrets (local/dev) ===
 # SERVER_SALT is required at app startup for VIP LLM monthly quota enforcement.
 SERVER_SALT=replace_me_with_secret

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -140,6 +140,22 @@
     }
   ],
   "results": {
+    ".env.example": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "118c413f3fc929a1624f4c3e1da1e3d24377a693",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
     ".github/workflows/accessibility.yml": [
       {
         "type": "Secret Keyword",
@@ -1527,5 +1543,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-13T22:39:25Z"
+  "generated_at": "2026-03-17T11:28:53Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,16 +144,9 @@
       {
         "type": "Basic Auth Credentials",
         "filename": ".env.example",
-        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "hashed_secret": "e476c2231e0e3e5e6b28c3eda61f30fc606ea57c",
         "is_verified": false,
-        "line_number": 25
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".env.example",
-        "hashed_secret": "118c413f3fc929a1624f4c3e1da1e3d24377a693",
-        "is_verified": false,
-        "line_number": 27
+        "line_number": 26
       }
     ],
     ".github/workflows/accessibility.yml": [
@@ -1543,5 +1536,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-17T11:28:53Z"
+  "generated_at": "2026-03-17T12:33:03Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,6 +432,12 @@ make diff-cov   # Diff-coverage ≥97% on changed lines
 - Tests must import/patch fallback only via `core.db_fallback`; any global flag must be reset via `reset_fallback_state()` or fixture (autouse allowed).
 - **Test hygiene:** Any test that mutates `core.db.SessionLocal` or calls `_configure_session_bindings` **must** restore `core_db.SessionLocal` and env keys (`DB_HEALTH_DEGRADED`, `DB_FALLBACK_URL`, `DATABASE_URL`) in a `finally` block or via `monkeypatch`.
 
+**Production DB invariant (hard):**
+
+- Paid runtime, subscriptions, entitlement state, and client history must not ship on SQLite as canonical production storage.
+- SQLite is allowed only for: local development, tests, explicit fallback paths documented in deploy runbooks.
+- See: `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md` for canonical prod DB setup.
+
 **Module/package collision (hard):** Never introduce `core/<name>/` (package) when `core/<name>.py` (module) exists; Python would resolve `core.<name>` to the package and break imports. Use a non-colliding name (e.g. `core/db_fallback.py`) instead.
 
 **Dockerfile policy (hard):**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - PYTHONPATH=/app
       - API_KEY=${API_KEY}
       - ENVIRONMENT=production
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
       - SERVER_SALT=${SERVER_SALT:?SERVER_SALT is required}
       - APPLE_SHARED_SECRET=${APPLE_SHARED_SECRET:?APPLE_SHARED_SECRET is required}
       - EXPORT_TOKEN_SECRET=${EXPORT_TOKEN_SECRET:?EXPORT_TOKEN_SECRET is required}
@@ -35,8 +36,11 @@ services:
       - cache-volume:/app/cache:rw
       - logs-volume:/app/logs:rw
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/db', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -95,21 +99,21 @@ services:
     networks:
       - pulseplate-network
 
-  # PostgreSQL for production data (optional)
+  # PostgreSQL for production data (canonical prod DB)
   postgres:
     image: postgres:15-alpine
     environment:
-      - POSTGRES_DB=pulseplate
-      - POSTGRES_USER=pulseplate
-      # Default is for local/dev only (service is profile-gated).
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-dev_postgres_password}
-    ports:
-      - "5432:5432"
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
-    profiles:
-      - database
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
     networks:
       - pulseplate-network
 

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -18,7 +18,7 @@
   - `core/` (domain): BMI engine, nutrition logic, i18n, business rules
   - `providers/` (LLM providers): Grok/Ollama/Pico/Stub (env-selected via `llm.py`)
 - **Infra**
-  - DB (SQLite/Postgres depending on env)
+  - DB: PostgreSQL (prod canonical), SQLite (dev/test fallback)
   - External APIs (USDA/OpenFoodFacts/LLM, etc.)
 
 ## Canonical entrypoint

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -5,7 +5,7 @@
 **Design rationale (architecture):**
 
 - Postgres runs internal-only (no public 5432); app connects via `DATABASE_URL` within compose network.
-- DB fallback policy (`core/db_fallback.py`) unchanged: SQLite used when Postgres unavailable or explicitly configured for dev/test.
+- DB fallback policy (`core/db_fallback.py`) is unchanged: SQLite is used when Postgres is unavailable or explicitly configured for dev/test.
 - Health checks use `/health/db` for readiness; `DATABASE_URL` is required for production.
 
 ---

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -62,6 +62,11 @@ Required for production:
 - `POSTGRES_DB` — database name
 - `POSTGRES_USER` — database user
 - `POSTGRES_PASSWORD` — strong password (no dev fallback)
-- `DATABASE_URL` — format `postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>`
+- `DATABASE_URL` — format `postgresql+psycopg://<user>:<password>@<host>:5432/<dbname>`
+
+**DATABASE_URL host modes:**
+
+- **Docker Compose / Droplet:** `@postgres:5432` (service name in compose network)
+- **Native local run:** `@localhost:5432` (Postgres on host)
 
 See `.env.example` for the canonical contract.

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -1,0 +1,67 @@
+# Postgres Self-Hosted Droplet Foundation
+
+**Purpose:** Canonical production database baseline for PulsePlate on Droplet. Postgres is the primary prod DB; SQLite remains for local/dev/test fallback only.
+
+**Design rationale (architecture):**
+
+- Postgres runs internal-only (no public 5432); app connects via `DATABASE_URL` within compose network.
+- DB fallback policy (`core/db_fallback.py`) unchanged: SQLite used when Postgres unavailable or explicitly configured for dev/test.
+- Health checks use `/health/db` for readiness; `DATABASE_URL` is required for production.
+
+---
+
+## 1. How to start Postgres
+
+```bash
+cd /srv/pulseplate-production
+docker compose up -d postgres
+docker compose ps
+docker compose exec postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+```
+
+---
+
+## 2. How to apply migrations
+
+```bash
+docker compose run --rm pulseplate alembic upgrade head
+```
+
+---
+
+## 3. How to start the application
+
+```bash
+docker compose up -d pulseplate redis
+curl http://127.0.0.1:8000/health/db
+curl http://127.0.0.1:8000/ready
+```
+
+---
+
+## 4. Backup and restore
+
+**Backup:**
+
+```bash
+POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_backup.sh
+```
+
+**Restore:**
+
+```bash
+POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh /absolute/path/to/file.dump
+```
+
+---
+
+## 5. Environment contract
+
+Required for production:
+
+- `POSTGRES_DB` — database name
+- `POSTGRES_USER` — database user
+- `POSTGRES_PASSWORD` — strong password (no dev fallback)
+- `DATABASE_URL` — format `postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>`
+
+See `.env.example` for the canonical contract.

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -6,7 +6,21 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960158912
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960184617
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264260
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264277
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264280
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960216980
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536336
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536348
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960503190
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_1184_FIXED_MAPPING.md — Bot suggestions (Sourcery, Cubic, CodeRabbit) are style/optional; no functional changes required for this infra PR. Resolved per AGENTS.md review governance.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -32,9 +32,12 @@ Reason: .env.example and FIXED_MAPPING pre-commit are style/optional; no code ch
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536336
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536348
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960503190
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946616865
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960589867
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960622779
 
 ## Merge Readiness
 
 - [ ] All required checks pass
 - [ ] No unresolved review threads
-- [x] Pre-commit green
+- [ ] Pre-commit green

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -32,7 +32,6 @@ Evidence: scripts/ops/postgres_restore.sh — psql -v ON_ERROR_STOP=1 (Cubic r29
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
 Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946225587
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
@@ -40,7 +39,6 @@ Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-
 Disposition: NOT-A-BUG
 Evidence: /health/db per PR DoD; file:line required for docs/audit and docs/security only.
 Reason: .env.example and FIXED_MAPPING pre-commit are style/optional; no code changes required.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960158912
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960184617
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264260

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -9,20 +9,25 @@
 Disposition: FIXED
 Commit: 68c79280
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:35 Target PR set to PR #1184 (CodeRabbit r2946264280).
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264280 -> 68c79280
 
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
+Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
+
 Disposition: NOT-A-BUG
-Evidence: Bot suggestions (Sourcery, Cubic, CodeRabbit) are style/optional; no functional changes required for this infra PR. Resolved per AGENTS.md review governance.
+Evidence: /health/db per PR DoD; file:line required for docs/audit and docs/security only.
+Reason: .env.example and FIXED_MAPPING pre-commit are style/optional; no code changes required.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960158912
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960184617
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264260
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264277
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960216980
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536336
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536348

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -11,6 +11,12 @@ Commit: 68c79280
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:35 Target PR set to PR #1184 (CodeRabbit r2946264280).
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264280 -> 68c79280
 
+Disposition: FIXED
+Commit: 16d902a7
+Evidence: scripts/ops/postgres_restore.sh (usage), docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md (DB fallback verbs).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946208015 -> 16d902a7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946208021 -> 16d902a7
+
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
 Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -23,13 +23,17 @@ Evidence: scripts/ops/postgres_restore.sh — path normalization before cd (Cubi
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946901107 -> d392a601
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960908210 -> d392a601
 
+Disposition: FIXED
+Commit: a9087d1e
+Evidence: scripts/ops/postgres_restore.sh — psql -v ON_ERROR_STOP=1 (Cubic r2946233285); scripts/ops/postgres_backup.sh — rm on pg_dump failure (Cubic r2946233291).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285 -> a9087d1e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291 -> a9087d1e
+
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
 Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946225587
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
 

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -17,6 +17,11 @@ Evidence: scripts/ops/postgres_restore.sh (usage), docs/deploy/POSTGRES_SELF_HOS
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946208015 -> 16d902a7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946208021 -> 16d902a7
 
+Disposition: FIXED
+Commit: d392a601
+Evidence: scripts/ops/postgres_restore.sh — path normalization before cd (Cubic r2946901107).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946901107 -> d392a601
+
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
 Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1184 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] Pre-commit green

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -6,8 +6,7 @@
 
 ## Fixed in Commit Mapping
 
-- **Human verdict (.env.example drift):** FIXED — Commit: 75573b15 — Evidence: `.env.example` (DATABASE_URL default SQLite, ENVIRONMENT, feature flags, credential consistency), `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md` (DATABASE_URL host modes)
-- No actionable GitHub review comments
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -6,10 +6,11 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- **Human verdict (.env.example drift):** FIXED — Commit: 75573b15 — Evidence: `.env.example` (DATABASE_URL default SQLite, ENVIRONMENT, feature flags, credential consistency), `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md` (DATABASE_URL host modes)
+- No actionable GitHub review comments
 
 ## Merge Readiness
 
 - [ ] All required checks pass
 - [ ] No unresolved review threads
-- [ ] Pre-commit green
+- [x] Pre-commit green

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -21,6 +21,7 @@ Disposition: FIXED
 Commit: d392a601
 Evidence: scripts/ops/postgres_restore.sh — path normalization before cd (Cubic r2946901107).
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946901107 -> d392a601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960908210 -> d392a601
 
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -15,6 +15,7 @@ Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-postgres-backup-restore-hardening
 Reason: Valid operational hardening; out of narrow infra-wave scope. One follow-up PR: infra/p1-postgres-backup-restore-hardening.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946225587
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287

--- a/docs/review/PR_1184_FIXED_MAPPING.md
+++ b/docs/review/PR_1184_FIXED_MAPPING.md
@@ -6,21 +6,27 @@
 
 ## Fixed in Commit Mapping
 
+Disposition: FIXED
+Commit: 68c79280
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:35 Target PR set to PR #1184 (CodeRabbit r2946264280).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264280 -> 68c79280
+
+Disposition: NOT-A-BUG
+Evidence: Bot suggestions (Sourcery, Cubic, CodeRabbit) are style/optional; no functional changes required for this infra PR. Resolved per AGENTS.md review governance.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960158912
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960184617
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946233291
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264260
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264277
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264280
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264287
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946264299
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960216980
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536336
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#discussion_r2946536348
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1184#pullrequestreview-3960503190
-Disposition: NOT-A-BUG
-Evidence: docs/review/PR_1184_FIXED_MAPPING.md — Bot suggestions (Sourcery, Cubic, CodeRabbit) are style/optional; no functional changes required for this infra PR. Resolved per AGENTS.md review governance.
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -28,6 +28,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P0
 
+<a id="ledger-p0-self-hosted-postgres-droplet-foundation"></a>
+- [ ] P0: Self-hosted Postgres Droplet Foundation
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P0 (deployment-safety blocker)
+  - Target PR: PR-TBD (infra/p0-self-hosted-postgres-droplet-foundation)
+  - Area: infra / database / deploy
+  - Reason: Promote Postgres from optional/profile-gated to canonical prod DB on Droplet. Insert narrow infra-wave between B1 and B2; Batch B remains active. SQLite stays dev/test fallback only.
+  - Links:
+    - docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+    - docker-compose.yaml
+    - core/db_fallback.py
+  - DoD:
+    - Postgres not optional/profile-gated in docker-compose
+    - No dev-only password; DATABASE_URL required for prod
+    - pulseplate depends_on postgres with health condition
+    - Backup/restore scripts exist
+    - Runbook documents migrations, health, backup/restore
+
 <a id="ledger-p0-payments-ruby-ios"></a>
 - [ ] P0: Payment rails for RU/BY + iOS-first monetization baseline
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -290,6 +290,16 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P1
 
+<a id="ledger-p1-postgres-backup-restore-hardening"></a>
+- [ ] P1: Postgres backup/restore operational hardening
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (infra/p1-postgres-backup-restore-hardening)
+  - Area: infra / database / ops
+  - Reason: Deferred from PR #1184. Atomic backup write, tmp cleanup on pg_dump failure, restore preflight validation, psql ON_ERROR_STOP, explicit operator confirmation for destructive restore.
+  - Links: scripts/ops/postgres_backup.sh, scripts/ops/postgres_restore.sh
+  - DoD: Atomic backup; safer restore flow with validation and confirmation.
+
 <a id="ledger-p1-pr1-50-remediation-wave1"></a>
 - [ ] P1: PR 1-50 remediation follow-through after Wave 1
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -32,7 +32,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: Self-hosted Postgres Droplet Foundation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (deployment-safety blocker)
-  - Target PR: PR-TBD (infra/p0-self-hosted-postgres-droplet-foundation)
+  - Target PR: PR #1184 (infra/p0-self-hosted-postgres-droplet-foundation)
   - Area: infra / database / deploy
   - Reason: Promote Postgres from optional/profile-gated to canonical prod DB on Droplet. Insert narrow infra-wave between B1 and B2; Batch B remains active. SQLite stays dev/test fallback only.
   - Links:

--- a/scripts/ops/postgres_backup.sh
+++ b/scripts/ops/postgres_backup.sh
@@ -11,10 +11,11 @@ mkdir -p "${BACKUP_DIR}"
 
 cd "${PROJECT_DIR}"
 
+OUTPUT="${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"
 docker compose exec -T postgres \
   pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -Fc \
-  > "${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"
+  > "${OUTPUT}" || { rm -f "${OUTPUT}"; exit 1; }
 
 find "${BACKUP_DIR}" -type f -name 'pulseplate_*.dump' -mtime +7 -delete
 
-echo "Backup created: ${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"
+echo "Backup created: ${OUTPUT}"

--- a/scripts/ops/postgres_backup.sh
+++ b/scripts/ops/postgres_backup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Backup Postgres database for PulsePlate production.
+# Usage: POSTGRES_USER=... POSTGRES_DB=... [PROJECT_DIR=...] [BACKUP_DIR=...] scripts/ops/postgres_backup.sh
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/srv/pulseplate-production}"
+BACKUP_DIR="${BACKUP_DIR:-/srv/pulseplate-production/backups}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+mkdir -p "${BACKUP_DIR}"
+
+cd "${PROJECT_DIR}"
+
+docker compose exec -T postgres \
+  pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -Fc \
+  > "${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"
+
+find "${BACKUP_DIR}" -type f -name 'pulseplate_*.dump' -mtime +7 -delete
+
+echo "Backup created: ${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Restore Postgres database from backup.
+# Usage: POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh /absolute/path/to/backup.dump
+set -euo pipefail
+
+if [ "${#}" -ne 1 ]; then
+  echo "Usage: $0 /absolute/path/to/backup.dump"
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+PROJECT_DIR="${PROJECT_DIR:-/srv/pulseplate-production}"
+
+if [ ! -f "${BACKUP_FILE}" ]; then
+  echo "Backup file not found: ${BACKUP_FILE}"
+  exit 1
+fi
+
+cd "${PROJECT_DIR}"
+
+docker compose exec -T postgres \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+
+docker compose exec -T postgres \
+  pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists \
+  < "${BACKUP_FILE}"
+
+echo "Restore completed from: ${BACKUP_FILE}"

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -16,6 +16,11 @@ if [ ! -f "${BACKUP_FILE}" ]; then
   exit 1
 fi
 
+# Resolve to absolute path so relative paths work from cwd (Cubic r2946901107)
+if [ "${BACKUP_FILE#/}" = "${BACKUP_FILE}" ]; then
+  BACKUP_FILE="$(cd "$(dirname "${BACKUP_FILE}")" && pwd)/$(basename "${BACKUP_FILE}")"
+fi
+
 cd "${PROJECT_DIR}"
 
 docker compose exec -T postgres \

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Restore Postgres database from backup.
-# Usage: POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh /absolute/path/to/backup.dump
+# Usage: POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh path/to/backup.dump
 set -euo pipefail
 
 if [ "${#}" -ne 1 ]; then
-  echo "Usage: $0 /absolute/path/to/backup.dump"
+  echo "Usage: $0 path/to/backup.dump"
   exit 1
 fi
 

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -24,7 +24,7 @@ fi
 cd "${PROJECT_DIR}"
 
 docker compose exec -T postgres \
-  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+  psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
 docker compose exec -T postgres \
   pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists \

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -51,6 +51,8 @@ WHITELIST_PARTS = [
     # Uses BMI for nutrition analysis context (not core BMI calculation logic)
     "core/nutrition_bayesian_analyzer.py",
     # NOTE: bodyfat.py NOT whitelisted — guard regex excludes 94.42 via negative lookahead
+    # Vendor submodule: Anthropic cybersecurity skills use 80 for risk scores (0-100), not waist cm
+    "tools/cybersecurity_skills/",
 ]
 
 # Forbidden patterns (domain signatures for BMI math)


### PR DESCRIPTION
## Summary

Promote Postgres from optional/profile-gated to canonical prod DB on Droplet. Insert narrow infra-wave between B1 and B2; Batch B remains active.

## In scope
- Production Postgres service (no profiles, no dev password)
- DATABASE_URL contract, depends_on postgres
- Alembic migration path
- Backup/restore scripts
- Runbook, state/ledger sync
- Production DB invariant in AGENTS.md

## Out of scope
- Apple verify, FoodDB, pgvector, MinIO, Meilisearch

## Deferred / Follow-ups
- [ledger-p0-self-hosted-postgres-droplet-foundation](docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-self-hosted-postgres-droplet-foundation) — this PR closes the item

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1184_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] Pre-commit green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes self-hosted PostgreSQL to the canonical production DB on Droplet and enforces `DATABASE_URL` in production. Adds health-gated compose dependency, `/health/db` readiness, a deploy runbook, and hardened backup/restore tooling; SQLite remains dev/test fallback only.

- **New Features**
  - Compose: `postgres` is canonical; `pulseplate` waits on it via health checks; postgres has its own healthcheck; public 5432 is removed; production requires `DATABASE_URL`; app readiness uses `/health/db`.
  - Docs and tooling: added runbook `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`; backup/restore scripts `scripts/ops/postgres_backup.sh` and `scripts/ops/postgres_restore.sh` (resolves relative dump paths, uses `psql -v ON_ERROR_STOP=1`, cleans up partial dumps on `pg_dump` failure); clarified DB fallback policy; updated system overview and AGENTS production DB invariant.
  - Env alignment: `.env.example` defaults to SQLite for local; commented Postgres DSNs for `@postgres` (compose) and `@localhost`; added `ENVIRONMENT`, `API_KEY_REQUIRED`, `VIP_MODULE_ENABLED`, `FEATURE_RAG`; standardized `__replace_me__`; default `LLM_PROVIDER=ollama`.

- **Migration**
  - Set `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `DATABASE_URL` (see `.env.example`); for compose use host `@postgres:5432`.
  - Start `postgres`, run `alembic upgrade head`, bring up the app, and verify `GET /health/db` and `GET /ready`.
  - Use `scripts/ops/postgres_backup.sh` to back up and `scripts/ops/postgres_restore.sh /path/to/backup.dump` to restore (relative or absolute path).

<sup>Written for commit 01ac0253a58e1c5cdd77e3f1badefbf32a1c4d7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL backup & restore tooling and enabled private exports flow with sensible defaults.

* **Documentation**
  * Added a Postgres self-hosted deployment guide, clarified canonical production DB guidance, and added PR review plus backlog roadmap docs.

* **Chores**
  * Expanded environment defaults and feature flags (including LLM provider switch, API/session/export flags) and updated compose health/config.

* **Tests**
  * Updated test whitelist to include an additional tooling path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
