### PR TITLE
feat(orchestration): bridge repo agents to native subagents

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -73,6 +73,7 @@ When coordinating multi-agent work, use these canonical protocols:
 - Dialogue Template: `docs/orchestration/AGENT_DIALOGUE_TEMPLATE.md`
 - Parallel Work Protocol: `docs/orchestration/PARALLEL_WORK_PROTOCOL.md`
 - Message envelopes (multi-model robustness): `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`
+- Native runtime bridge (repo-agent slug -> transport-only native executor): `docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md`
 - Research track (web/OSS intake): `docs/orchestration/RESEARCH_TRACK_PROTOCOL.md`
 - Experimentation protocol (bounded optimization/eval loops): `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
 - Reflection / KPP promotion: `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md`

--- a/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+++ b/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
@@ -1,0 +1,133 @@
+# Native Subagent Bridge Protocol
+
+**Purpose:** Preserve PulsePlate repo-agent orchestration when the execution
+runtime exposes its own native subagents (for example transport labels such as
+`worker`, `explorer`, or `default`).
+
+**Status:** Canonical for the runtime adapter layer. This protocol does not
+replace `AGENT_ROUTING_GRAPH.md`; it adapts that routing into a newer
+subagent-capable runtime.
+
+---
+
+## 1. Why this exists
+
+PulsePlate has two layers now:
+
+1. **Canonical orchestration layer**
+   - repo agent slugs from `.cursor/agents/*.md`
+   - coordinator-first routing
+   - SoT docs in `docs/orchestration/*`
+2. **Runtime transport layer**
+   - native executor types exposed by the host runtime
+   - examples: `default`, `worker`, `explorer`
+
+Hard rule:
+
+- PulsePlate repo-agent slugs stay canonical.
+- Native executor names are **transport-only** and must not replace repo-agent
+  identity in packets, logs, or user-facing updates.
+
+---
+
+## 2. Canonical invariants
+
+1. Routing still resolves through `docs/orchestration/AGENT_ROUTING_GRAPH.md`.
+2. The coordinator still decides `primary_agent`, `secondary_agents`, and
+   `reviewer`.
+3. Native runtime subagents may be spawned only through coordinator-mediated
+   dispatch.
+4. Every spawned native subagent must carry the corresponding repo-agent
+   instruction file from `.cursor/agents/<slug>.md`.
+5. User-facing updates must identify the repo agent slug, not only the native
+   executor type.
+
+---
+
+## 3. Task packet contract
+
+`scripts/orchestration/task_bootstrap.py` must emit a
+`native_subagent_bridge` object with:
+
+- `protocol_version`
+- `transport`
+- `dispatch_policy`
+- `primary`
+- `secondary`
+- `reviewer`
+
+Each role binding includes:
+
+- `repo_agent_slug`
+- `display_name`
+- `native_agent_type`
+- `execution_mode`
+- `instruction_path`
+- `transport_rationale`
+- `dispatch_contract`
+
+This makes the adapter explicit and testable without changing the canonical
+repo-agent routing contract.
+
+---
+
+## 4. Dispatch rules
+
+When a runtime supports native subagents:
+
+1. Read the task packet first.
+2. Use `primary_agent` / `secondary_agents` / `reviewer` as the canonical role
+   identities.
+3. Read `native_subagent_bridge` only to choose the host runtime transport type.
+4. Load the instruction path listed in the bridge entry.
+5. Load `required_context` and `recommended_skills` from the same task packet.
+6. In updates, describe the work using the repo-agent slug.
+
+Example:
+
+- Canonical role: `bug-hunter`
+- Native transport: `worker`
+- Correct user-facing update: `bug-hunter is triaging the regression`
+- Incorrect update: `worker is running`
+
+---
+
+## 5. Scope boundary
+
+This protocol is an adapter only.
+
+It must not:
+
+- rewrite the routing graph,
+- invent runtime-only agent names as canonical roles,
+- bypass coordinator-first policy,
+- bypass scoped `AGENTS.md` or quality gates.
+
+---
+
+## 6. Implementation reference
+
+- Bridge module: `scripts/orchestration/native_subagent_bridge.py`
+- Packet builder: `scripts/orchestration/task_bootstrap.py`
+- Coordinator SoT: `.cursor/agents/agent-coordinator.md`
+- Workflow SoT: `docs/orchestration/workflow.md`
+
+---
+
+## 7. Security Notes
+
+- Native subagents must inherit the same repo constraints as the canonical
+  agent role.
+- The bridge must not create hidden autonomous routing outside coordinator
+  control.
+- Runtime executor labels must not be treated as permission grants.
+
+---
+
+## 8. Marketing & GTM
+
+- This change protects PulsePlate operator ergonomics during platform updates:
+  your team keeps the same agent language and SoT instead of retraining around
+  runtime-internal labels.
+- Clear repo-agent naming improves onboarding, debugging, and reviewability,
+  which reduces execution friction for future AI-assisted releases.

--- a/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+++ b/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
@@ -1,7 +1,7 @@
 # Native Subagent Bridge Protocol
 
 **Purpose:** Preserve PulsePlate repo-agent orchestration when the execution
-runtime exposes its own native subagents (for example transport labels such as
+runtime exposes its own native subagents (for example, transport labels such as
 `worker`, `explorer`, or `default`).
 
 **Status:** Canonical for the runtime adapter layer. This protocol does not
@@ -54,6 +54,7 @@ Hard rule:
 - `dispatch_policy`
 - `primary`
 - `secondary`
+- `advisory`
 - `reviewer`
 
 Each role binding includes:
@@ -65,6 +66,10 @@ Each role binding includes:
 - `instruction_path`
 - `transport_rationale`
 - `dispatch_contract`
+
+Advisory collaborators are visible in the packet for transparency, but they are
+**not runnable native subagents** unless a later contract explicitly promotes
+them.
 
 This makes the adapter explicit and testable without changing the canonical
 repo-agent routing contract.
@@ -79,9 +84,12 @@ When a runtime supports native subagents:
 2. Use `primary_agent` / `secondary_agents` / `reviewer` as the canonical role
    identities.
 3. Read `native_subagent_bridge` only to choose the host runtime transport type.
-4. Load the instruction path listed in the bridge entry.
-5. Load `required_context` and `recommended_skills` from the same task packet.
-6. In updates, describe the work using the repo-agent slug.
+4. Spawn only `primary`, executable `secondary`, and `reviewer` bindings.
+5. Keep `advisory` bindings non-runnable unless a future promoted contract says
+   otherwise.
+6. Load the instruction path listed in the bridge entry.
+7. Load `required_context` and `recommended_skills` from the same task packet.
+8. In updates, describe the work using the repo-agent slug.
 
 Example:
 
@@ -89,6 +97,11 @@ Example:
 - Native transport: `worker`
 - Correct user-facing update: `bug-hunter is triaging the regression`
 - Incorrect update: `worker is running`
+
+Reviewer rule:
+
+- reviewer bindings must use a read-only transport (`explorer`) even when the
+  base repo role is normally implemented via a write-capable transport.
 
 ---
 

--- a/docs/orchestration/workflow.md
+++ b/docs/orchestration/workflow.md
@@ -16,6 +16,7 @@
 - **Orchestration protocols:** see `docs/orchestration/AGENT_*.md` (context, capability, handoff, dialogue, parallel)
 - **Design rationale (multi-model + research tracks):** `docs/audit/AGENT_ORCHESTRATION_MULTI_MODEL_AND_RESEARCH_AUDIT_2026-02-10.md`
 - **Message envelopes (multi-model robustness):** `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`
+- **Native runtime bridge (repo-agent slug -> transport-only native executor):** `docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md`
 - **Research track (web/OSS intake):** `docs/orchestration/RESEARCH_TRACK_PROTOCOL.md`
 - **Research brainstorming (brainstorm → research → decision → promotion):** `docs/orchestration/RESEARCH_BRAINSTORMING_PROTOCOL.md`
 - **Experimentation loops (bounded optimization / eval):** `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
@@ -90,6 +91,8 @@ Task
 - [ ] Назначены secondary agents (если multi-domain)
 - [ ] Проставлены зависимости / handoff / sync points (если multi-agent)
 - [ ] Определён `recommended_skills` packet по `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+- [ ] Если runtime использует native subagents, task packet содержит `native_subagent_bridge`,
+  а repo-agent slug остаётся канонической идентичностью роли
 - [ ] Явно запрошенные пользователем agent slugs сохранены в task packet и либо honor/advisory,
   либо отклонены с явной причиной
 - [ ] Для privilege-sensitive surfaces (`.github/workflows/**`, `ios/fastlane/**`,

--- a/docs/review/PR_1188_FIXED_MAPPING.md
+++ b/docs/review/PR_1188_FIXED_MAPPING.md
@@ -20,6 +20,11 @@ Evidence: [tests/test_task_bootstrap.py](../../tests/test_task_bootstrap.py#L182
 Reason: The review self-corrects in the body and confirms the test already declares `-> None`; no code or test logic change is required.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971468596
 
+Disposition: FIXED
+Commit: b0a2648df06099ba27f6738d2165395f9773185f
+Evidence: [docs/review/PR_1188_FIXED_MAPPING.md](PR_1188_FIXED_MAPPING.md#L11)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956825543 -> b0a2648df06099ba27f6738d2165395f9773185f
+
 ## Merge Readiness
 
 - [ ] All required checks pass

--- a/docs/review/PR_1188_FIXED_MAPPING.md
+++ b/docs/review/PR_1188_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 
 Disposition: FIXED
 Commit: e8a5fba41b7f5245b8ff03f0422ef4897038696e
-Evidence: [docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md#L3), [scripts/orchestration/native_subagent_bridge.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/scripts/orchestration/native_subagent_bridge.py#L177), [scripts/orchestration/task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/scripts/orchestration/task_bootstrap.py#L101), [tests/test_native_subagent_bridge.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_native_subagent_bridge.py#L59), [tests/test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_task_bootstrap.py#L101)
+Evidence: [docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md](../orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md#L3), [scripts/orchestration/native_subagent_bridge.py](../../scripts/orchestration/native_subagent_bridge.py#L177), [scripts/orchestration/task_bootstrap.py](../../scripts/orchestration/task_bootstrap.py#L101), [tests/test_native_subagent_bridge.py](../../tests/test_native_subagent_bridge.py#L59), [tests/test_task_bootstrap.py](../../tests/test_task_bootstrap.py#L101)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956653776 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661486 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661490 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
@@ -16,12 +16,12 @@ Evidence: [docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md](/Users/katsiar
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971308229 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 
 Disposition: NOT-A-BUG
-Evidence: [tests/test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_task_bootstrap.py#L182)
+Evidence: [tests/test_task_bootstrap.py](../../tests/test_task_bootstrap.py#L182)
 Reason: The review self-corrects in the body and confirms the test already declares `-> None`; no code or test logic change is required.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971468596
 
 ## Merge Readiness
 
 - [ ] All required checks pass
-- [x] No unresolved review threads
+- [ ] No unresolved review threads
 - [x] Pre-commit green

--- a/docs/review/PR_1188_FIXED_MAPPING.md
+++ b/docs/review/PR_1188_FIXED_MAPPING.md
@@ -8,15 +8,20 @@
 
 Disposition: FIXED
 Commit: e8a5fba41b7f5245b8ff03f0422ef4897038696e
-Evidence: scripts/orchestration/native_subagent_bridge.py, scripts/orchestration/task_bootstrap.py, tests/test_native_subagent_bridge.py, tests/test_task_bootstrap.py, docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+Evidence: [docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md#L3), [scripts/orchestration/native_subagent_bridge.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/scripts/orchestration/native_subagent_bridge.py#L177), [scripts/orchestration/task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/scripts/orchestration/task_bootstrap.py#L101), [tests/test_native_subagent_bridge.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_native_subagent_bridge.py#L59), [tests/test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_task_bootstrap.py#L101)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956653776 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661486 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661490 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971298391 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971308229 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
 
+Disposition: NOT-A-BUG
+Evidence: [tests/test_task_bootstrap.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tests/test_task_bootstrap.py#L182)
+Reason: The review self-corrects in the body and confirms the test already declares `-> None`; no code or test logic change is required.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971468596
+
 ## Merge Readiness
 
 - [ ] All required checks pass
-- [ ] No unresolved review threads
-- [ ] Pre-commit green
+- [x] No unresolved review threads
+- [x] Pre-commit green

--- a/docs/review/PR_1188_FIXED_MAPPING.md
+++ b/docs/review/PR_1188_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR 1188 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: e8a5fba41b7f5245b8ff03f0422ef4897038696e
+Evidence: scripts/orchestration/native_subagent_bridge.py, scripts/orchestration/task_bootstrap.py, tests/test_native_subagent_bridge.py, tests/test_task_bootstrap.py, docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956653776 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661486 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956661490 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971298391 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971308229 -> e8a5fba41b7f5245b8ff03f0422ef4897038696e
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] Pre-commit green

--- a/docs/review/PR_1188_FIXED_MAPPING.md
+++ b/docs/review/PR_1188_FIXED_MAPPING.md
@@ -21,9 +21,10 @@ Reason: The review self-corrects in the body and confirms the test already decla
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971468596
 
 Disposition: FIXED
-Commit: b0a2648df06099ba27f6738d2165395f9773185f
+Commit: b0a2648d492420c400f9aec3b453a47b4efefdcb
 Evidence: [docs/review/PR_1188_FIXED_MAPPING.md](PR_1188_FIXED_MAPPING.md#L11)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956825543 -> b0a2648df06099ba27f6738d2165395f9773185f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#discussion_r2956825543 -> b0a2648d492420c400f9aec3b453a47b4efefdcb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1188#pullrequestreview-3971520545 -> b0a2648d492420c400f9aec3b453a47b4efefdcb
 
 ## Merge Readiness
 

--- a/scripts/orchestration/native_subagent_bridge.py
+++ b/scripts/orchestration/native_subagent_bridge.py
@@ -180,7 +180,7 @@ def build_native_subagent_bridge(
     for agent_slug in normalized_advisory_agents:
         advisory_binding = build_native_subagent_binding(
             agent_slug=agent_slug,
-            role="secondary",
+            role="advisory",
         )
         advisory_bindings.append(
             {

--- a/scripts/orchestration/native_subagent_bridge.py
+++ b/scripts/orchestration/native_subagent_bridge.py
@@ -104,6 +104,20 @@ def _instruction_path(agent_slug: str) -> str:
     return (AGENTS_DIR / f"{agent_slug}.md").relative_to(REPO_ROOT).as_posix()
 
 
+def _resolve_native_agent_type(*, profile: NativeExecutorProfile, role: str) -> str:
+    """Choose the runtime transport type without changing canonical repo identity.
+
+    RU: Reviewer всегда получает read-only transport even if the base role is
+    normally write-capable.
+    EN: Reviewer always gets a read-only transport even if the base role is
+    normally write-capable.
+    """
+
+    if role == "reviewer":
+        return "explorer"
+    return profile.native_agent_type
+
+
 def validate_native_subagent_bridge_profiles() -> None:
     """Ensure every canonical inventory agent has a transport profile."""
 
@@ -131,7 +145,7 @@ def build_native_subagent_binding(*, agent_slug: str, role: str) -> dict[str, An
         "role": role,
         "repo_agent_slug": agent_slug,
         "display_name": agent_slug,
-        "native_agent_type": profile.native_agent_type,
+        "native_agent_type": _resolve_native_agent_type(profile=profile, role=role),
         "execution_mode": execution_mode,
         "instruction_path": _instruction_path(agent_slug),
         "transport_rationale": profile.rationale,
@@ -150,6 +164,7 @@ def build_native_subagent_bridge(
     primary_agent: str,
     secondary_agents: list[str],
     reviewer: str,
+    advisory_agents: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build transport metadata for runtimes that expose native subagents.
 
@@ -160,6 +175,24 @@ def build_native_subagent_bridge(
     """
 
     validate_native_subagent_bridge_profiles()
+    normalized_advisory_agents = advisory_agents or []
+    advisory_bindings: list[dict[str, Any]] = []
+    for agent_slug in normalized_advisory_agents:
+        advisory_binding = build_native_subagent_binding(
+            agent_slug=agent_slug,
+            role="secondary",
+        )
+        advisory_bindings.append(
+            {
+                **advisory_binding,
+                "execution_mode": "advisory_no_spawn",
+                "dispatch_contract": {
+                    **advisory_binding["dispatch_contract"],
+                    "spawn_with_native_subagent": False,
+                    "advisory_only": True,
+                },
+            }
+        )
     return {
         "protocol_version": BRIDGE_PROTOCOL_VERSION,
         "transport": BRIDGE_TRANSPORT,
@@ -178,6 +211,7 @@ def build_native_subagent_bridge(
             build_native_subagent_binding(agent_slug=agent_slug, role="secondary")
             for agent_slug in secondary_agents
         ],
+        "advisory": advisory_bindings,
         "reviewer": build_native_subagent_binding(
             agent_slug=reviewer,
             role="reviewer",

--- a/scripts/orchestration/native_subagent_bridge.py
+++ b/scripts/orchestration/native_subagent_bridge.py
@@ -1,0 +1,185 @@
+"""Deterministic bridge between repo agents and native subagent runtimes.
+
+RU: Сохраняет repo-agent slug как каноническую роль и добавляет transport-only
+mapping на native subagent runtime для новых Codex/ChatGPT execution flows.
+EN: Keeps the repo-agent slug as the canonical role while adding a
+transport-only mapping to native subagent runtimes for newer Codex/ChatGPT
+execution flows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.orchestration.agent_consistency_loader import load_inventory_agents
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_DIR = REPO_ROOT / ".cursor" / "agents"
+BRIDGE_PROTOCOL_VERSION = "1.0"
+BRIDGE_TRANSPORT = "codex-native-subagents"
+
+
+@dataclass(frozen=True)
+class NativeExecutorProfile:
+    """Canonical execution profile for one repo agent.
+
+    RU: Профиль определяет transport-only executor type и режим исполнения.
+    EN: The profile defines the transport-only executor type and execution mode.
+    """
+
+    native_agent_type: str
+    execution_mode: str
+    rationale: str
+
+
+ANALYSIS_PROFILE = NativeExecutorProfile(
+    native_agent_type="default",
+    execution_mode="advisory",
+    rationale=(
+        "Analysis-first role; keep native executor generic while canonical "
+        "identity stays the repo-agent slug."
+    ),
+)
+
+CODEBASE_EXPLORER_PROFILE = NativeExecutorProfile(
+    native_agent_type="explorer",
+    execution_mode="read_only_analysis",
+    rationale=(
+        "Read-mostly codebase analysis role; use explorer transport for "
+        "inspection-heavy tasks before implementation."
+    ),
+)
+
+IMPLEMENTATION_PROFILE = NativeExecutorProfile(
+    native_agent_type="worker",
+    execution_mode="read_write",
+    rationale=(
+        "Implementation-heavy role expected to edit files, run checks, or "
+        "prepare merge-ready artifacts."
+    ),
+)
+
+
+REPO_AGENT_EXECUTOR_PROFILES: dict[str, NativeExecutorProfile] = {
+    "agent-coordinator": ANALYSIS_PROFILE,
+    "backend-engineer": IMPLEMENTATION_PROFILE,
+    "frontend-engineer": IMPLEMENTATION_PROFILE,
+    "bug-hunter": IMPLEMENTATION_PROFILE,
+    "dev-operator": IMPLEMENTATION_PROFILE,
+    "qa-engineer-agent": IMPLEMENTATION_PROFILE,
+    "architecture-specialist": CODEBASE_EXPLORER_PROFILE,
+    "security-auditor": IMPLEMENTATION_PROFILE,
+    "ai-app-architect": ANALYSIS_PROFILE,
+    "ai-innovation-specialist": ANALYSIS_PROFILE,
+    "rag-systems-agent": ANALYSIS_PROFILE,
+    "web-research-agent": ANALYSIS_PROFILE,
+    "data-scientist-agent": ANALYSIS_PROFILE,
+    "ml-engineer-agent": IMPLEMENTATION_PROFILE,
+    "bayesian-uq-agent": ANALYSIS_PROFILE,
+    "cv-agent": ANALYSIS_PROFILE,
+    "philosophy-agent": ANALYSIS_PROFILE,
+    "logic-agent": ANALYSIS_PROFILE,
+    "nutritionist-agent": ANALYSIS_PROFILE,
+    "cbt-psychologist-agent": ANALYSIS_PROFILE,
+    "epistemology-discovery-agent": ANALYSIS_PROFILE,
+    "physics-sensor-agent": ANALYSIS_PROFILE,
+    "creative-designer": ANALYSIS_PROFILE,
+    "designer-artist-agent": ANALYSIS_PROFILE,
+    "sora-prompt-engineer": ANALYSIS_PROFILE,
+    "app-store-release-agent": IMPLEMENTATION_PROFILE,
+    "marketing-strategist": ANALYSIS_PROFILE,
+    "wellness-analyst-agent": ANALYSIS_PROFILE,
+    "business-strategist-agent": ANALYSIS_PROFILE,
+    "ai-trend-reporter": ANALYSIS_PROFILE,
+    "cursor-specialist-agent": CODEBASE_EXPLORER_PROFILE,
+    "tutor-mentor-agent": ANALYSIS_PROFILE,
+}
+
+
+def _instruction_path(agent_slug: str) -> str:
+    """Return the repo-relative instruction file for a canonical repo agent."""
+
+    return (AGENTS_DIR / f"{agent_slug}.md").relative_to(REPO_ROOT).as_posix()
+
+
+def validate_native_subagent_bridge_profiles() -> None:
+    """Ensure every canonical inventory agent has a transport profile."""
+
+    inventory_agents = load_inventory_agents()
+    missing = sorted(inventory_agents - REPO_AGENT_EXECUTOR_PROFILES.keys())
+    if missing:
+        raise ValueError(
+            "Native subagent bridge missing executor profile(s) for: " f"{', '.join(missing)}"
+        )
+
+
+def build_native_subagent_binding(*, agent_slug: str, role: str) -> dict[str, Any]:
+    """Build one deterministic runtime binding for a canonical repo agent."""
+
+    if agent_slug not in REPO_AGENT_EXECUTOR_PROFILES:
+        raise ValueError(f"Unknown native subagent bridge profile for agent: {agent_slug}")
+
+    profile = REPO_AGENT_EXECUTOR_PROFILES[agent_slug]
+    if role == "reviewer":
+        execution_mode = "review_read_only"
+    else:
+        execution_mode = profile.execution_mode
+
+    return {
+        "role": role,
+        "repo_agent_slug": agent_slug,
+        "display_name": agent_slug,
+        "native_agent_type": profile.native_agent_type,
+        "execution_mode": execution_mode,
+        "instruction_path": _instruction_path(agent_slug),
+        "transport_rationale": profile.rationale,
+        "dispatch_contract": {
+            "canonical_identity": "repo_agent_slug",
+            "native_executor_name_transport_only": True,
+            "load_required_context_from_task_packet": True,
+            "load_recommended_skills_from_task_packet": True,
+            "announce_identity_as_repo_agent_slug": True,
+        },
+    }
+
+
+def build_native_subagent_bridge(
+    *,
+    primary_agent: str,
+    secondary_agents: list[str],
+    reviewer: str,
+) -> dict[str, Any]:
+    """Build transport metadata for runtimes that expose native subagents.
+
+    RU: Канон роли остаётся repo-agent slug; native type нужен только как
+    transport hint для нового runtime.
+    EN: The canonical role remains the repo-agent slug; the native type is only
+    a transport hint for the newer runtime.
+    """
+
+    validate_native_subagent_bridge_profiles()
+    return {
+        "protocol_version": BRIDGE_PROTOCOL_VERSION,
+        "transport": BRIDGE_TRANSPORT,
+        "dispatch_policy": {
+            "canonical_agent_identity": "repo_agent_slug",
+            "native_executor_identity": "transport_only",
+            "spawn_via_coordinator_only": True,
+            "display_repo_agent_slug_in_user_updates": True,
+            "instruction_source_of_truth": ".cursor/agents/*.md",
+        },
+        "primary": build_native_subagent_binding(
+            agent_slug=primary_agent,
+            role="primary",
+        ),
+        "secondary": [
+            build_native_subagent_binding(agent_slug=agent_slug, role="secondary")
+            for agent_slug in secondary_agents
+        ],
+        "reviewer": build_native_subagent_binding(
+            agent_slug=reviewer,
+            role="reviewer",
+        ),
+    }

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -28,6 +28,7 @@ from scripts.orchestration.agent_consistency_loader import (
     load_inventory_agents,
     load_non_routable_agents,
 )
+from scripts.orchestration.native_subagent_bridge import build_native_subagent_bridge
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import load_routing_graph
 from scripts.orchestration.requested_agents import normalize_requested_agents
@@ -283,6 +284,11 @@ def build_task_packet(
         domain=decision.domain,
         requested_agents=normalized_requested_agents,
     )
+    native_subagent_bridge = build_native_subagent_bridge(
+        primary_agent=requested_agent_resolution["primary_agent"],
+        secondary_agents=requested_agent_resolution["secondary_agents"],
+        reviewer=requested_agent_resolution["reviewer"],
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -300,6 +306,7 @@ def build_task_packet(
         "required_context": context_pack,
         "recommended_skills": [item["skill"] for item in skill_routing["recommended"]],
         "skill_routing": skill_routing,
+        "native_subagent_bridge": native_subagent_bridge,
         "routing_rationale": decision.rationale,
     }
 
@@ -379,6 +386,12 @@ def main(argv: list[str] | None = None) -> int:
                 "reviewer": packet["reviewer"],
                 "requested_agents": packet["requested_agents"],
                 "recommended_skills": packet["recommended_skills"],
+                "primary_native_agent_type": packet["native_subagent_bridge"]["primary"][
+                    "native_agent_type"
+                ],
+                "reviewer_native_agent_type": packet["native_subagent_bridge"]["reviewer"][
+                    "native_agent_type"
+                ],
                 "output": output_ref,
             },
             ensure_ascii=False,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -98,6 +98,38 @@ def _requires_security_review(candidate_paths: list[str] | tuple[str, ...]) -> b
     )
 
 
+def _partition_native_secondaries(
+    *,
+    secondary_agents: list[str],
+    requested_agent_disposition: list[dict[str, str]],
+) -> tuple[list[str], list[str]]:
+    """Split executable secondaries from advisory-only collaborators.
+
+    RU: advisory specialists stay in the task packet but must not be promoted to
+    runnable native subagents.
+    EN: advisory specialists remain in the task packet but must not be promoted
+    into runnable native subagents.
+    """
+
+    advisory_statuses = {
+        REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
+        REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
+    }
+    advisory_agents = {
+        disposition["agent"]
+        for disposition in requested_agent_disposition
+        if disposition["status"] in advisory_statuses
+    }
+    executable_secondaries: list[str] = []
+    advisory_collaborators: list[str] = []
+    for agent_slug in secondary_agents:
+        if agent_slug in advisory_agents:
+            advisory_collaborators.append(agent_slug)
+        else:
+            executable_secondaries.append(agent_slug)
+    return executable_secondaries, advisory_collaborators
+
+
 def _apply_requested_agent_overrides(
     *,
     domain: str,
@@ -284,10 +316,15 @@ def build_task_packet(
         domain=decision.domain,
         requested_agents=normalized_requested_agents,
     )
+    executable_secondaries, advisory_agents = _partition_native_secondaries(
+        secondary_agents=requested_agent_resolution["secondary_agents"],
+        requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
+    )
     native_subagent_bridge = build_native_subagent_bridge(
         primary_agent=requested_agent_resolution["primary_agent"],
-        secondary_agents=requested_agent_resolution["secondary_agents"],
+        secondary_agents=executable_secondaries,
         reviewer=requested_agent_resolution["reviewer"],
+        advisory_agents=advisory_agents,
     )
 
     return {

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -102,6 +102,7 @@ def _partition_native_secondaries(
     *,
     secondary_agents: list[str],
     requested_agent_disposition: list[dict[str, str]],
+    forced_executable_agents: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Split executable secondaries from advisory-only collaborators.
 
@@ -115,6 +116,7 @@ def _partition_native_secondaries(
         REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
         REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
     }
+    normalized_forced_executable_agents = forced_executable_agents or set()
     advisory_agents = {
         disposition["agent"]
         for disposition in requested_agent_disposition
@@ -123,11 +125,40 @@ def _partition_native_secondaries(
     executable_secondaries: list[str] = []
     advisory_collaborators: list[str] = []
     for agent_slug in secondary_agents:
-        if agent_slug in advisory_agents:
+        if agent_slug in advisory_agents and agent_slug not in normalized_forced_executable_agents:
             advisory_collaborators.append(agent_slug)
         else:
             executable_secondaries.append(agent_slug)
     return executable_secondaries, advisory_collaborators
+
+
+def _promote_forced_secondary_dispositions(
+    *,
+    requested_agent_disposition: list[dict[str, str]],
+    forced_executable_agents: set[str],
+) -> None:
+    """Keep dispositions aligned with forced executable secondaries.
+
+    RU: Если привилегированный review-path требует агента, он не должен
+    оставаться advisory only в packet-disposition metadata.
+    EN: If the privileged review path requires an agent, it must not remain
+    advisory-only in packet disposition metadata.
+    """
+
+    advisory_statuses = {
+        REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
+        REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
+    }
+    for disposition in requested_agent_disposition:
+        if disposition["agent"] not in forced_executable_agents:
+            continue
+        if disposition["status"] not in advisory_statuses:
+            continue
+        disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
+        disposition["reason"] = (
+            "Requested agent is required for the privileged review path and stays "
+            "executable in secondary."
+        )
 
 
 def _apply_requested_agent_overrides(
@@ -299,7 +330,8 @@ def build_task_packet(
         requested_agents=normalized_requested_agents,
         routing=routing,
     )
-    if _requires_security_review(normalized_paths):
+    security_review_required = _requires_security_review(normalized_paths)
+    if security_review_required:
         secondary_agents = list(requested_agent_resolution["secondary_agents"])
         security_in_review_path = "security-auditor" in {
             requested_agent_resolution["primary_agent"],
@@ -316,9 +348,16 @@ def build_task_packet(
         domain=decision.domain,
         requested_agents=normalized_requested_agents,
     )
+    forced_executable_agents = {"security-auditor"} if security_review_required else set()
+    if forced_executable_agents:
+        _promote_forced_secondary_dispositions(
+            requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
+            forced_executable_agents=forced_executable_agents,
+        )
     executable_secondaries, advisory_agents = _partition_native_secondaries(
         secondary_agents=requested_agent_resolution["secondary_agents"],
         requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
+        forced_executable_agents=forced_executable_agents,
     )
     native_subagent_bridge = build_native_subagent_bridge(
         primary_agent=requested_agent_resolution["primary_agent"],

--- a/tests/test_native_subagent_bridge.py
+++ b/tests/test_native_subagent_bridge.py
@@ -72,5 +72,6 @@ def test_build_native_subagent_bridge_keeps_advisory_collaborators_non_runnable(
 
     assert [binding["repo_agent_slug"] for binding in bridge["secondary"]] == ["rag-systems-agent"]
     assert [binding["repo_agent_slug"] for binding in bridge["advisory"]] == ["ml-engineer-agent"]
+    assert bridge["advisory"][0]["role"] == "advisory"
     assert bridge["advisory"][0]["execution_mode"] == "advisory_no_spawn"
     assert bridge["advisory"][0]["dispatch_contract"]["spawn_with_native_subagent"] is False

--- a/tests/test_native_subagent_bridge.py
+++ b/tests/test_native_subagent_bridge.py
@@ -56,4 +56,21 @@ def test_build_native_subagent_bridge_shapes_primary_secondary_and_reviewer() ->
     assert bridge["secondary"][1]["repo_agent_slug"] == "security-auditor"
     assert bridge["secondary"][1]["native_agent_type"] == "worker"
     assert bridge["reviewer"]["repo_agent_slug"] == "architecture-specialist"
+    assert bridge["reviewer"]["native_agent_type"] == "explorer"
     assert bridge["reviewer"]["execution_mode"] == "review_read_only"
+
+
+def test_build_native_subagent_bridge_keeps_advisory_collaborators_non_runnable() -> None:
+    """Advisory specialists must stay visible but not spawnable."""
+
+    bridge = build_native_subagent_bridge(
+        primary_agent="ai-innovation-specialist",
+        secondary_agents=["rag-systems-agent"],
+        reviewer="architecture-specialist",
+        advisory_agents=["ml-engineer-agent"],
+    )
+
+    assert [binding["repo_agent_slug"] for binding in bridge["secondary"]] == ["rag-systems-agent"]
+    assert [binding["repo_agent_slug"] for binding in bridge["advisory"]] == ["ml-engineer-agent"]
+    assert bridge["advisory"][0]["execution_mode"] == "advisory_no_spawn"
+    assert bridge["advisory"][0]["dispatch_contract"]["spawn_with_native_subagent"] is False

--- a/tests/test_native_subagent_bridge.py
+++ b/tests/test_native_subagent_bridge.py
@@ -1,0 +1,59 @@
+"""Tests for the deterministic native subagent bridge contract."""
+
+from __future__ import annotations
+
+from scripts.orchestration.agent_consistency_loader import load_inventory_agents
+from scripts.orchestration.native_subagent_bridge import (
+    BRIDGE_PROTOCOL_VERSION,
+    BRIDGE_TRANSPORT,
+    REPO_AGENT_EXECUTOR_PROFILES,
+    build_native_subagent_binding,
+    build_native_subagent_bridge,
+    validate_native_subagent_bridge_profiles,
+)
+
+
+def test_native_subagent_bridge_covers_inventory_agents() -> None:
+    """Every canonical inventory agent must have a native transport profile."""
+
+    inventory_agents = load_inventory_agents()
+    assert inventory_agents <= REPO_AGENT_EXECUTOR_PROFILES.keys()
+    validate_native_subagent_bridge_profiles()
+
+
+def test_build_native_subagent_binding_keeps_repo_agent_slug_canonical() -> None:
+    """Native executor names are transport-only; repo slug stays canonical."""
+
+    binding = build_native_subagent_binding(
+        agent_slug="bug-hunter",
+        role="primary",
+    )
+
+    assert binding["repo_agent_slug"] == "bug-hunter"
+    assert binding["display_name"] == "bug-hunter"
+    assert binding["native_agent_type"] == "worker"
+    assert binding["instruction_path"] == ".cursor/agents/bug-hunter.md"
+    assert binding["dispatch_contract"]["canonical_identity"] == "repo_agent_slug"
+    assert binding["dispatch_contract"]["native_executor_name_transport_only"] is True
+
+
+def test_build_native_subagent_bridge_shapes_primary_secondary_and_reviewer() -> None:
+    """Bridge payload must be deterministic for all routed roles."""
+
+    bridge = build_native_subagent_bridge(
+        primary_agent="agent-coordinator",
+        secondary_agents=["cursor-specialist-agent", "security-auditor"],
+        reviewer="architecture-specialist",
+    )
+
+    assert bridge["protocol_version"] == BRIDGE_PROTOCOL_VERSION
+    assert bridge["transport"] == BRIDGE_TRANSPORT
+    assert bridge["dispatch_policy"]["spawn_via_coordinator_only"] is True
+    assert bridge["primary"]["repo_agent_slug"] == "agent-coordinator"
+    assert bridge["primary"]["native_agent_type"] == "default"
+    assert bridge["secondary"][0]["repo_agent_slug"] == "cursor-specialist-agent"
+    assert bridge["secondary"][0]["native_agent_type"] == "explorer"
+    assert bridge["secondary"][1]["repo_agent_slug"] == "security-auditor"
+    assert bridge["secondary"][1]["native_agent_type"] == "worker"
+    assert bridge["reviewer"]["repo_agent_slug"] == "architecture-specialist"
+    assert bridge["reviewer"]["execution_mode"] == "review_read_only"

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -36,6 +36,10 @@ def test_task_bootstrap_resolves_orchestration_domain() -> None:
     assert "pulseplate-workflow" in packet["recommended_skills"]
     assert "docs-sync" in packet["recommended_skills"]
     assert "agents-md" in packet["recommended_skills"]
+    assert packet["native_subagent_bridge"]["primary"]["repo_agent_slug"] == "agent-coordinator"
+    assert packet["native_subagent_bridge"]["reviewer"]["repo_agent_slug"] == (
+        "architecture-specialist"
+    )
 
 
 def test_task_bootstrap_includes_scoped_agents_only_once() -> None:
@@ -77,6 +81,8 @@ def test_task_bootstrap_routes_cv_tasks_to_cv_domain() -> None:
     assert packet["reviewer"] == "security-auditor"
     assert "docs-sync" in packet["recommended_skills"]
     assert "pulseplate-gates" in packet["recommended_skills"]
+    assert packet["native_subagent_bridge"]["primary"]["native_agent_type"] == "default"
+    assert packet["native_subagent_bridge"]["reviewer"]["native_agent_type"] == "worker"
 
 
 def test_task_bootstrap_promotes_requested_routable_agent() -> None:
@@ -317,6 +323,13 @@ def test_main_writes_relative_output_inside_repo(tmp_path, monkeypatch, capsys) 
             "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
             "blocked": [],
         },
+        "native_subagent_bridge": {
+            "protocol_version": "1.0",
+            "transport": "codex-native-subagents",
+            "primary": {"native_agent_type": "default"},
+            "secondary": [],
+            "reviewer": {"native_agent_type": "explorer"},
+        },
         "routing_rationale": {"source": "canonical_only"},
     }
     monkeypatch.setattr(
@@ -340,6 +353,7 @@ def test_main_writes_relative_output_inside_repo(tmp_path, monkeypatch, capsys) 
         written = json.loads(repo_output.read_text(encoding="utf-8"))
         assert written["task_packet_id"] == "abc123def456"
         assert json.loads(captured.out)["output"] == relative_output.as_posix()
+        assert json.loads(captured.out)["primary_native_agent_type"] == "default"
     finally:
         if repo_output.exists():
             repo_output.unlink()
@@ -375,6 +389,13 @@ def test_main_writes_repo_root_output_as_relative_path(monkeypatch, capsys) -> N
             "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
             "blocked": [],
         },
+        "native_subagent_bridge": {
+            "protocol_version": "1.0",
+            "transport": "codex-native-subagents",
+            "primary": {"native_agent_type": "default"},
+            "secondary": [],
+            "reviewer": {"native_agent_type": "explorer"},
+        },
         "routing_rationale": {"source": "canonical_only"},
     }
     monkeypatch.setattr(
@@ -397,6 +418,7 @@ def test_main_writes_repo_root_output_as_relative_path(monkeypatch, capsys) -> N
         assert exit_code == 0
         assert repo_output.exists()
         assert json.loads(captured.out)["output"] == relative_output.as_posix()
+        assert json.loads(captured.out)["reviewer_native_agent_type"] == "explorer"
     finally:
         if repo_output.exists():
             repo_output.unlink()
@@ -431,6 +453,13 @@ def test_main_passes_requested_agent_flags(monkeypatch, capsys) -> None:
                 "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
                 "blocked": [],
             },
+            "native_subagent_bridge": {
+                "protocol_version": "1.0",
+                "transport": "codex-native-subagents",
+                "primary": {"native_agent_type": "default"},
+                "secondary": [{"native_agent_type": "worker"}],
+                "reviewer": {"native_agent_type": "explorer"},
+            },
             "routing_rationale": {"source": "canonical_only"},
         }
 
@@ -459,3 +488,4 @@ def test_main_passes_requested_agent_flags(monkeypatch, capsys) -> None:
         "agent-coordinator",
         "security-auditor",
     ]
+    assert json.loads(captured.out)["primary_native_agent_type"] == "default"

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -82,7 +82,7 @@ def test_task_bootstrap_routes_cv_tasks_to_cv_domain() -> None:
     assert "docs-sync" in packet["recommended_skills"]
     assert "pulseplate-gates" in packet["recommended_skills"]
     assert packet["native_subagent_bridge"]["primary"]["native_agent_type"] == "default"
-    assert packet["native_subagent_bridge"]["reviewer"]["native_agent_type"] == "worker"
+    assert packet["native_subagent_bridge"]["reviewer"]["native_agent_type"] == "explorer"
 
 
 def test_task_bootstrap_promotes_requested_routable_agent() -> None:
@@ -121,6 +121,12 @@ def test_task_bootstrap_keeps_non_routable_requested_agent_as_advisory() -> None
     assert packet["domain"] == "ml"
     assert packet["primary_agent"] == "ai-innovation-specialist"
     assert "ml-engineer-agent" in packet["secondary_agents"]
+    assert [
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
+    ] == ["rag-systems-agent"]
+    assert [
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
+    ] == ["ml-engineer-agent"]
     assert packet["requested_agent_disposition"] == [
         {
             "agent": "ml-engineer-agent",

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -170,6 +170,42 @@ def test_task_bootstrap_keeps_security_auditor_in_privileged_review_path() -> No
         *packet["secondary_agents"],
     }
     assert "security-auditor" in review_path
+    assert "security-auditor" in {
+        packet["native_subagent_bridge"]["reviewer"]["repo_agent_slug"],
+        *[binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]],
+    }
+    assert "security-auditor" not in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
+    }
+
+
+def test_task_bootstrap_forces_requested_security_auditor_into_executable_bridge() -> None:
+    """Privileged review must keep an explicitly requested security auditor runnable."""
+
+    packet = build_task_packet(
+        goal="Audit privileged orchestration workflow",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["security-auditor"],
+    )
+
+    assert "security-auditor" in packet["secondary_agents"]
+    assert "security-auditor" in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
+    }
+    assert "security-auditor" not in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
+    }
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "security-auditor",
+            "status": "honored_secondary",
+            "reason": (
+                "Requested agent is required for the privileged review path and stays "
+                "executable in secondary."
+            ),
+        }
+    ]
 
 
 def test_task_bootstrap_updates_honored_primary_after_later_promotion() -> None:


### PR DESCRIPTION
## Summary
- add a deterministic native-subagent bridge so PulsePlate repo-agent slugs stay canonical under newer Codex/ChatGPT runtimes
- attach `native_subagent_bridge` transport metadata to coordinator task packets instead of letting platform executor names replace repo roles
- document the adapter contract and wire coordinator/workflow docs to the new protocol

## Why
Recent native subagent runtimes expose transport labels such as `worker` / `explorer` / `default`, but PulsePlate orchestration is built around `.cursor/agents/*.md` and coordinator-first routing. This PR keeps repo-agent identity as the source of truth while making the runtime adapter explicit and testable.

## Changes
- add `scripts/orchestration/native_subagent_bridge.py`
- emit `native_subagent_bridge` from `scripts/orchestration/task_bootstrap.py`
- add `docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md`
- link the bridge from coordinator/workflow docs
- add deterministic tests for bridge coverage and task-packet shape

## Validation
- `pytest -q tests/test_native_subagent_bridge.py tests/test_task_bootstrap.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `make verify`
- `pre-commit run --all-files`
- pre-push hooks during `git push -u origin orchestration/native-subagent-bridge`

## Notes
- canonical routing remains in `docs/orchestration/AGENT_ROUTING_GRAPH.md`
- native executor names remain transport-only and must not replace repo-agent slugs in user-facing updates

## Summary by Sourcery

Ввести детерминированный мост к нативным субагентам, чтобы пакеты задач явно отображали канонические роли репозитория-агента на нативные субагенты рантайма без изменения существующей семантики маршрутизации.

Новые возможности:
- Добавить модуль моста нативных субагентов, который определяет профили исполнения и детерминированные привязки от слагов repo-agent к типам нативных исполнителей для ролей primary, secondary и reviewer.
- Эмитировать метаданные `native_subagent_bridge` в пакетах задач и отображать нативные типы агентов primary/reviewer в выводе CLI команды `task_bootstrap`.

Документация:
- Задокументировать протокол Native Subagent Bridge и сослаться на него из документации по оркестрационным workflow и координатору-агенту, чтобы прояснить, как маршрутизация repo-agent сопоставляется с нативными рантаймами.

Тесты:
- Добавить отдельные тесты для контракта моста нативных субагентов и расширить тесты `task_bootstrap`, чтобы проверять наличие и структуру данных `native_subagent_bridge` в пакетах задач и выводе CLI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a deterministic native subagent bridge so task packets explicitly map canonical repo-agent roles to runtime-native subagents without changing existing routing semantics.

New Features:
- Add a native subagent bridge module that defines execution profiles and deterministic bindings from repo-agent slugs to native executor types for primary, secondary, and reviewer roles.
- Emit native_subagent_bridge metadata in task packets and surface primary/reviewer native agent types in task_bootstrap CLI output.

Documentation:
- Document the Native Subagent Bridge protocol and link it from orchestration workflow and coordinator agent docs to clarify how repo-agent routing maps onto native runtimes.

Tests:
- Add dedicated tests for the native subagent bridge contract and extend task_bootstrap tests to validate presence and shape of native_subagent_bridge data in task packets and CLI output.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridges canonical repo-agent slugs to runtime-native subagents without changing routing. Task packets now include `native_subagent_bridge`; security review stays enforced and advisory collaborators remain non-spawnable.

- **New Features**
  - Added `scripts/orchestration/native_subagent_bridge.py`; `scripts/orchestration/task_bootstrap.py` now emits `native_subagent_bridge` (primary/secondary/reviewer/advisory). CLI prints `primary_native_agent_type` and `reviewer_native_agent_type`.
  - Added `docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md` and linked it from coordinator/workflow docs.
  - Added `docs/review/PR_1188_FIXED_MAPPING.md` to map review threads to fixed commits.

- **Bug Fixes**
  - Preserve privileged security review: keep `security-auditor` executable in the bridge and promote to `honored_secondary` when explicitly requested.
  - Keep advisory collaborators visible but non-spawnable (`advisory_no_spawn`); `task_bootstrap` separates executable vs advisory secondaries.
  - Fixed and corrected portable evidence links in `docs/review/PR_1188_FIXED_MAPPING.md` for stable cross-references.

<sup>Written for commit 1b31249436bafd3bd83d13a31231283d7945a1cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task packets now include a native_subagent_bridge and top-level primary/reviewer native agent type fields for native subagent orchestration.

* **Documentation**
  * Added a Native Subagent Bridge protocol doc and updated orchestration workflow and pre-flight checklist with native subagent routing and requirements.

* **Tests**
  * Added validations and coverage for bridge profiles, bindings, task-packet serialization, and CLI output showing native subagent metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1188_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [x] Pre-commit green

