### PR TITLE
feat(ios): forward backend activation payload unchanged

### DIFF
--- a/docs/IOS_API_INTEGRATION.md
+++ b/docs/IOS_API_INTEGRATION.md
@@ -115,12 +115,12 @@ Contract source:
 Thin-client boundary (current merged state):
 - **What iOS sends:** Receipt verification requests, activation handoff to `POST /api/v1/pro/payments/activate`, manual intent payload, and reconcile requests. Transport-only; no entitlement or billing decision logic.
 - **What backend decides:** Activation, tier assignment, reconciliation status, signature validation. Billing truth is server-authoritative only.
-- **Merged in B2 / PR #1185:** Apple verify now normalizes into the backend activation contract. The surviving B4 gap is still client-side follow-through: the shipped iOS flow calls `POST /api/v1/pro/payments/activate`, but it still reconstructs `payload.verification_result` locally instead of forwarding the backend-returned `activation_payload` unchanged. StoreKit/App Store operational setup truth is now centralized in `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`; remaining post-B3 follow-through is backend-driven SubscriptionManager contract adoption plus the later App Store Server API migration.
+- **Merged in B2 / PR #1185:** Apple verify now normalizes into the backend activation contract.
+- **B4 runtime truth:** iOS decodes the full backend `activation_payload` from verify-response and forwards it as `payload.verification_result` unchanged when calling `POST /api/v1/pro/payments/activate`. StoreKit/App Store operational setup truth remains centralized in `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`; the later App Store Server API migration is still out of scope for this lane.
 
 ### Remaining follow-through (separate lanes)
 
 - Future StoreKit / App Store submission work must use the operational checklist in `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md` instead of creating a parallel setup source.
-- SubscriptionManager contract follow-through so the client forwards the backend activation handoff without rebuilding billing truth on-device.
 - Apple receipt verification migration to App Store Server API.
 
 Thin-client rules for payments:
@@ -132,7 +132,7 @@ Thin-client rules for payments:
 
 Current transport surfaces (B1 implemented):
 - `POST /api/v1/billing/apple/verify-receipt` (implemented additive billing seam for verify-only receipt validation)
-- `POST /api/v1/pro/payments/activate` (current iOS purchase flow handoff after receipt verification; B4 remains open until the client forwards backend `activation_payload` without local reconstruction)
+- `POST /api/v1/pro/payments/activate` (current iOS purchase flow handoff after receipt verification; client now forwards backend `activation_payload` as `payload.verification_result` without local reconstruction)
 - `POST /api/v1/pro/payments/ru-by/manual-intent` (current runtime transport during the transition window)
 - `POST /api/v1/pro/payments/ru-by/reconcile` (current runtime transport during the transition window)
 - `GET /api/v1/pro/payments/ru-by/reconcile/{intent_id}` (current runtime transport during the transition window)

--- a/docs/review/PR_1190_FIXED_MAPPING.md
+++ b/docs/review/PR_1190_FIXED_MAPPING.md
@@ -13,9 +13,15 @@ Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:186`, `ios/PulsePla
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1190#pullrequestreview-3973435214 -> ac657e87
 
+Disposition: FIXED
+Commit: 90149308
+Evidence: `ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift:53`, `ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift:160`, `ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift:120`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1190#pullrequestreview-3973474094 -> 90149308
+
 ## Merge Readiness
 
-- Status: ready for review; waiting for current-head CI completion and CodeRabbit final verdict
+- Status: ready for review; waiting for current-head CI completion and next review wave to confirm no new actionables
 - Local validation:
   - `pre-commit run --all-files`
   - `make verify`

--- a/docs/review/PR_1190_FIXED_MAPPING.md
+++ b/docs/review/PR_1190_FIXED_MAPPING.md
@@ -7,11 +7,15 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: ac657e87
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:186`, `ios/PulsePlate/Services/SubscriptionManager.swift:223`, `ios/PulsePlate/Services/SubscriptionManager.swift:301`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1190#pullrequestreview-3973435214 -> ac657e87
 
 ## Merge Readiness
 
-- Status: draft; review wave has only non-actionable bot status/guide comments so far
+- Status: ready for review; waiting for current-head CI completion and CodeRabbit final verdict
 - Local validation:
   - `pre-commit run --all-files`
   - `make verify`

--- a/docs/review/PR_1190_FIXED_MAPPING.md
+++ b/docs/review/PR_1190_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1190 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- Status: draft; review wave has only non-actionable bot status/guide comments so far
+- Local validation:
+  - `pre-commit run --all-files`
+  - `make verify`
+  - targeted `xcodebuild` subset for `SubscriptionBillingServiceTests` and `SubscriptionManagerTests`
+- Current scope rule: runtime-only iOS thin-client handoff with minimal docs sync

--- a/ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift
+++ b/ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift
@@ -26,11 +26,6 @@ enum BillingPlatform: String, Codable, Sendable {
     case ios
 }
 
-struct AppleActivationHintDTO: Decodable, Equatable, Sendable {
-    let tier: BillingSubscriptionTier
-    let platform: String
-}
-
 struct AppleProviderErrorDTO: Decodable, Equatable, Sendable {
     let code: String
     let message: String
@@ -47,7 +42,7 @@ struct AppleReceiptVerificationResponseDTO: Decodable, Equatable, Sendable {
     let environment: String?
     let productID: String?
     let expiresAt: String?
-    let activationPayload: AppleActivationHintDTO?
+    let activationPayload: IOSVerifiedActivationResultDTO?
     let error: AppleProviderErrorDTO?
 
     private enum CodingKeys: String, CodingKey {
@@ -62,7 +57,7 @@ struct AppleReceiptVerificationResponseDTO: Decodable, Equatable, Sendable {
     }
 }
 
-struct IOSVerifiedActivationResultDTO: Encodable, Equatable, Sendable {
+struct IOSVerifiedActivationResultDTO: Codable, Equatable, Sendable {
     let transactionID: String
     let originalTransactionID: String?
     let productID: String
@@ -70,6 +65,74 @@ struct IOSVerifiedActivationResultDTO: Encodable, Equatable, Sendable {
     let status: BillingVerificationStatus
     let expiresAt: String?
     let platform: BillingPlatform
+
+    // RU: Декодирование идёт через HTTPClient с `.convertFromSnakeCase`, поэтому ключи
+    // здесь должны совпадать с уже преобразованными именами (`transactionId`).
+    // Кодирование для activate-request остаётся канонически snake_case, поэтому для
+    // encode используется отдельный набор ключей ниже.
+    // EN: Decoding goes through HTTPClient with `.convertFromSnakeCase`, so these keys
+    // must match the already-transformed names (`transactionId`).
+    // Encoding for the activate request must stay canonical snake_case, so encode uses
+    // a separate key set below.
+    private enum DecodingKeys: String, CodingKey {
+        case transactionID = "transactionId"
+        case originalTransactionID = "originalTransactionId"
+        case productID = "productId"
+        case subscriptionTier
+        case status
+        case expiresAt
+        case platform
+    }
+
+    private enum EncodingKeys: String, CodingKey {
+        case transactionID = "transaction_id"
+        case originalTransactionID = "original_transaction_id"
+        case productID = "product_id"
+        case subscriptionTier = "subscription_tier"
+        case status
+        case expiresAt = "expires_at"
+        case platform
+    }
+
+    init(
+        transactionID: String,
+        originalTransactionID: String?,
+        productID: String,
+        subscriptionTier: BillingSubscriptionTier,
+        status: BillingVerificationStatus,
+        expiresAt: String?,
+        platform: BillingPlatform
+    ) {
+        self.transactionID = transactionID
+        self.originalTransactionID = originalTransactionID
+        self.productID = productID
+        self.subscriptionTier = subscriptionTier
+        self.status = status
+        self.expiresAt = expiresAt
+        self.platform = platform
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DecodingKeys.self)
+        self.transactionID = try container.decode(String.self, forKey: .transactionID)
+        self.originalTransactionID = try container.decodeIfPresent(String.self, forKey: .originalTransactionID)
+        self.productID = try container.decode(String.self, forKey: .productID)
+        self.subscriptionTier = try container.decode(BillingSubscriptionTier.self, forKey: .subscriptionTier)
+        self.status = try container.decode(BillingVerificationStatus.self, forKey: .status)
+        self.expiresAt = try container.decodeIfPresent(String.self, forKey: .expiresAt)
+        self.platform = try container.decode(BillingPlatform.self, forKey: .platform)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: EncodingKeys.self)
+        try container.encode(transactionID, forKey: .transactionID)
+        try container.encodeIfPresent(originalTransactionID, forKey: .originalTransactionID)
+        try container.encode(productID, forKey: .productID)
+        try container.encode(subscriptionTier, forKey: .subscriptionTier)
+        try container.encode(status, forKey: .status)
+        try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
+        try container.encode(platform, forKey: .platform)
+    }
 }
 
 struct IOSAppStoreActivationPayloadDTO: Encodable, Equatable, Sendable {

--- a/ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift
+++ b/ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift
@@ -50,7 +50,7 @@ struct AppleReceiptVerificationResponseDTO: Decodable, Equatable, Sendable {
         case verified
         case verificationState
         case environment
-        case productID
+        case productID = "productId"
         case expiresAt
         case activationPayload
         case error
@@ -157,10 +157,10 @@ struct SubscriptionActivationResponseDTO: Decodable, Equatable, Sendable {
     let paymentSource: String?
 
     private enum CodingKeys: String, CodingKey {
-        case activationID
+        case activationID = "activationId"
         case tier
         case status
-        case productID
+        case productID = "productId"
         case expiresAt
         case activatedAt
         case subscriptionTier

--- a/ios/PulsePlate/Services/SubscriptionManager.swift
+++ b/ios/PulsePlate/Services/SubscriptionManager.swift
@@ -184,7 +184,6 @@ final class SubscriptionManager: ObservableObject {
                     apiKey: apiKey
                 )
                 let activationRequest = try makeActivationRequest(
-                    from: transaction,
                     receiptData: receiptData,
                     verification: verification
                 )
@@ -222,7 +221,6 @@ final class SubscriptionManager: ObservableObject {
                 apiKey: apiKey
             )
             let activationRequest = try makeActivationRequest(
-                from: transaction,
                 receiptData: receiptData,
                 verification: verification
             )
@@ -301,7 +299,6 @@ final class SubscriptionManager: ObservableObject {
     }
 
     private func makeActivationRequest(
-        from _: StoreEntitlementTransaction,
         receiptData: String,
         verification: AppleReceiptVerificationResponseDTO
     ) throws -> ActivateSubscriptionRequestDTO {
@@ -309,6 +306,12 @@ final class SubscriptionManager: ObservableObject {
             throw SubscriptionManagerError.missingActivationPayload
         }
 
+        // RU: `activationPayload` — это канонический backend handoff для activate-запроса.
+        // `verificationState` остаётся envelope-метаданными verify-ответа и намеренно не
+        // ремапится здесь, чтобы клиент не реконструировал billing truth локально.
+        // EN: `activationPayload` is the canonical backend handoff for the activate request.
+        // `verificationState` stays verify-response envelope metadata and is intentionally
+        // not remapped here so the client does not reconstruct billing truth locally.
         return ActivateSubscriptionRequestDTO(
             source: .iosAppStore,
             payload: IOSAppStoreActivationPayloadDTO(

--- a/ios/PulsePlate/Services/SubscriptionManager.swift
+++ b/ios/PulsePlate/Services/SubscriptionManager.swift
@@ -59,8 +59,7 @@ struct EntitlementSnapshot: Equatable, Sendable {
 enum SubscriptionManagerError: Error, Equatable, Sendable {
     case missingAPIKey
     case missingActivationID
-    case missingTierHint
-    case missingProductID
+    case missingActivationPayload
     case restoreTransactionMissing
 }
 
@@ -71,10 +70,8 @@ extension SubscriptionManagerError: LocalizedError {
             return "Subscription flow requires a configured API key."
         case .missingActivationID:
             return "Subscription activation id is unavailable."
-        case .missingTierHint:
-            return "Backend verification did not return a subscription tier hint."
-        case .missingProductID:
-            return "Backend verification did not return a product identifier."
+        case .missingActivationPayload:
+            return "Backend verification did not return an activation payload."
         case .restoreTransactionMissing:
             return "Restore did not produce a verified entitlement transaction."
         }
@@ -304,28 +301,13 @@ final class SubscriptionManager: ObservableObject {
     }
 
     private func makeActivationRequest(
-        from transaction: StoreEntitlementTransaction,
+        from _: StoreEntitlementTransaction,
         receiptData: String,
         verification: AppleReceiptVerificationResponseDTO
     ) throws -> ActivateSubscriptionRequestDTO {
-        guard let productID = verification.productID?.nilIfEmpty ?? transaction.productID.nilIfEmpty else {
-            throw SubscriptionManagerError.missingProductID
+        guard let verificationResult = verification.activationPayload else {
+            throw SubscriptionManagerError.missingActivationPayload
         }
-
-        guard let subscriptionTier = verification.activationPayload?.tier else {
-            throw SubscriptionManagerError.missingTierHint
-        }
-
-        let verificationStatus = normalizeVerificationStatus(verification.verificationState)
-        let verificationResult = IOSVerifiedActivationResultDTO(
-            transactionID: transaction.transactionID,
-            originalTransactionID: transaction.originalTransactionID,
-            productID: productID,
-            subscriptionTier: subscriptionTier,
-            status: verificationStatus,
-            expiresAt: verification.expiresAt,
-            platform: .ios
-        )
 
         return ActivateSubscriptionRequestDTO(
             source: .iosAppStore,
@@ -334,19 +316,6 @@ final class SubscriptionManager: ObservableObject {
                 receiptData: receiptData
             )
         )
-    }
-
-    private func normalizeVerificationStatus(
-        _ verificationState: BillingVerificationState
-    ) -> BillingVerificationStatus {
-        switch verificationState {
-        case .active, .restored:
-            return .active
-        case .expired:
-            return .expired
-        case .invalid:
-            return .rejected
-        }
     }
 
     private func makeEntitlementSnapshot(

--- a/ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift
+++ b/ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift
@@ -109,11 +109,37 @@ final class SubscriptionBillingServiceTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let response = try decoder.decode(AppleReceiptVerificationResponseDTO.self, from: json)
 
+        XCTAssertEqual(response.productID, "com.pulseplate.premium.monthly")
         XCTAssertEqual(response.activationPayload?.transactionID, "txn-backend")
         XCTAssertEqual(response.activationPayload?.productID, "com.pulseplate.premium.yearly")
         XCTAssertEqual(response.activationPayload?.subscriptionTier, .vip)
         XCTAssertEqual(response.activationPayload?.status, .expired)
         XCTAssertEqual(response.activationPayload?.platform, .ios)
+    }
+
+    func test_activationResponse_decodesOuterAcronymKeys() throws {
+        let json = """
+        {
+          "activation_id": "act-backend-001",
+          "tier": "pro",
+          "status": "active",
+          "product_id": "com.pulseplate.premium.monthly",
+          "expires_at": "2026-04-01T00:00:00Z",
+          "activated_at": "2026-03-10T00:00:00Z",
+          "subscription_tier": "pro",
+          "source": "ios_app_store",
+          "payment_source": "ios_app_store"
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(SubscriptionActivationResponseDTO.self, from: json)
+
+        XCTAssertEqual(response.activationID, "act-backend-001")
+        XCTAssertEqual(response.productID, "com.pulseplate.premium.monthly")
+        XCTAssertEqual(response.subscriptionTier, "pro")
+        XCTAssertEqual(response.paymentSource, "ios_app_store")
     }
 
     func test_fetchActivationStatus_sendsCanonicalPathAndHeader() async throws {

--- a/ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift
+++ b/ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift
@@ -13,7 +13,15 @@ final class SubscriptionBillingServiceTests: XCTestCase {
                 environment: "production",
                 productID: "com.pulseplate.premium.monthly",
                 expiresAt: "2026-04-01T00:00:00Z",
-                activationPayload: AppleActivationHintDTO(tier: .pro, platform: "ios"),
+                activationPayload: IOSVerifiedActivationResultDTO(
+                    transactionID: "txn-001",
+                    originalTransactionID: "orig-001",
+                    productID: "com.pulseplate.premium.monthly",
+                    subscriptionTier: .pro,
+                    status: .active,
+                    expiresAt: "2026-04-01T00:00:00Z",
+                    platform: .ios
+                ),
                 error: nil
             )
         )
@@ -74,6 +82,38 @@ final class SubscriptionBillingServiceTests: XCTestCase {
         XCTAssertEqual(verificationResult["transaction_id"] as? String, "txn-001")
         XCTAssertEqual(verificationResult["subscription_tier"] as? String, "pro")
         XCTAssertEqual(payload["receipt_data"] as? String, "receipt-123")
+    }
+
+    func test_verifyReceiptResponse_decodesFullActivationPayload() throws {
+        let json = """
+        {
+          "provider": "apple",
+          "verified": true,
+          "verification_state": "active",
+          "environment": "production",
+          "product_id": "com.pulseplate.premium.monthly",
+          "expires_at": "2026-04-01T00:00:00Z",
+          "activation_payload": {
+            "transaction_id": "txn-backend",
+            "original_transaction_id": "orig-backend",
+            "product_id": "com.pulseplate.premium.yearly",
+            "subscription_tier": "vip",
+            "status": "expired",
+            "expires_at": "2026-06-01T00:00:00Z",
+            "platform": "ios"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(AppleReceiptVerificationResponseDTO.self, from: json)
+
+        XCTAssertEqual(response.activationPayload?.transactionID, "txn-backend")
+        XCTAssertEqual(response.activationPayload?.productID, "com.pulseplate.premium.yearly")
+        XCTAssertEqual(response.activationPayload?.subscriptionTier, .vip)
+        XCTAssertEqual(response.activationPayload?.status, .expired)
+        XCTAssertEqual(response.activationPayload?.platform, .ios)
     }
 
     func test_fetchActivationStatus_sendsCanonicalPathAndHeader() async throws {

--- a/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
+++ b/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
@@ -102,21 +102,35 @@ final class SubscriptionManagerTests: XCTestCase {
         }
     }
 
-    func test_purchaseFallsBackToTransactionProductIDWhenVerificationProductIDBlank() async {
+    func test_purchaseForwardsBackendActivationPayloadUnchanged() async {
         let storeKit = MockStoreKitManager()
         let billing = MockSubscriptionBillingService()
         let manager = makeManager(storeKit: storeKit, billing: billing)
 
-        storeKit.purchaseResult = .success(.fixture())
+        storeKit.purchaseResult = .success(
+            StoreEntitlementTransaction(
+                transactionID: "txn-local",
+                originalTransactionID: "orig-local",
+                productID: "com.pulseplate.premium.monthly"
+            )
+        )
         storeKit.receiptData = "receipt-blank-product-id"
         billing.verifyResult = AppleReceiptVerificationResponseDTO(
             provider: "apple",
             verified: true,
             verificationState: .active,
             environment: "production",
-            productID: "   ",
+            productID: "com.pulseplate.premium.monthly",
             expiresAt: "2026-04-01T00:00:00Z",
-            activationPayload: AppleActivationHintDTO(tier: .pro, platform: "ios"),
+            activationPayload: IOSVerifiedActivationResultDTO(
+                transactionID: "txn-backend",
+                originalTransactionID: "orig-backend",
+                productID: "com.pulseplate.premium.yearly",
+                subscriptionTier: .vip,
+                status: .expired,
+                expiresAt: "2026-06-01T00:00:00Z",
+                platform: .ios
+            ),
             error: nil
         )
         billing.activateResult = .activeActivation(id: "act-fallback")
@@ -125,10 +139,46 @@ final class SubscriptionManagerTests: XCTestCase {
         await manager.purchase(productID: "com.pulseplate.premium.monthly")
 
         XCTAssertEqual(
-            billing.lastActivateRequest?.payload.verificationResult.productID,
-            "com.pulseplate.premium.monthly"
+            billing.lastActivateRequest?.payload.verificationResult,
+            billing.verifyResult.activationPayload
         )
         XCTAssertEqual(manager.flowState, .unlocked)
+    }
+
+    func test_purchaseMissingActivationPayloadFailsClosed() async {
+        let storeKit = MockStoreKitManager()
+        let billing = MockSubscriptionBillingService()
+        let pointerStore = InMemoryActivationPointerStore()
+        let manager = makeManager(
+            storeKit: storeKit,
+            billing: billing,
+            pointerStore: pointerStore
+        )
+
+        storeKit.purchaseResult = .success(.fixture())
+        storeKit.receiptData = "receipt-missing-activation-payload"
+        billing.verifyResult = AppleReceiptVerificationResponseDTO(
+            provider: "apple",
+            verified: true,
+            verificationState: .active,
+            environment: "production",
+            productID: "com.pulseplate.premium.monthly",
+            expiresAt: "2026-04-01T00:00:00Z",
+            activationPayload: nil,
+            error: nil
+        )
+
+        await manager.purchase(productID: "com.pulseplate.premium.monthly")
+
+        XCTAssertNil(pointerStore.activationID)
+        XCTAssertNil(manager.entitlement)
+        XCTAssertEqual(billing.activateCallCount, 0)
+        XCTAssertEqual(billing.fetchCallCount, 0)
+        if case .failed(let message) = manager.flowState {
+            XCTAssertTrue(message.contains("activation payload"))
+        } else {
+            XCTFail("Expected failed state")
+        }
     }
 
     func test_restoreHappyPathUnlocksAfterRefresh() async {
@@ -469,7 +519,15 @@ private extension AppleReceiptVerificationResponseDTO {
             environment: "production",
             productID: "com.pulseplate.premium.monthly",
             expiresAt: "2026-04-01T00:00:00Z",
-            activationPayload: AppleActivationHintDTO(tier: .pro, platform: "ios"),
+            activationPayload: IOSVerifiedActivationResultDTO(
+                transactionID: "txn-001",
+                originalTransactionID: "orig-001",
+                productID: "com.pulseplate.premium.monthly",
+                subscriptionTier: .pro,
+                status: .active,
+                expiresAt: "2026-04-01T00:00:00Z",
+                platform: .ios
+            ),
             error: nil
         )
     }
@@ -482,7 +540,15 @@ private extension AppleReceiptVerificationResponseDTO {
             environment: "production",
             productID: "com.pulseplate.premium.monthly",
             expiresAt: "2026-04-01T00:00:00Z",
-            activationPayload: AppleActivationHintDTO(tier: .pro, platform: "ios"),
+            activationPayload: IOSVerifiedActivationResultDTO(
+                transactionID: "txn-restore",
+                originalTransactionID: "orig-restore",
+                productID: "com.pulseplate.premium.monthly",
+                subscriptionTier: .pro,
+                status: .active,
+                expiresAt: "2026-04-01T00:00:00Z",
+                platform: .ios
+            ),
             error: nil
         )
     }


### PR DESCRIPTION
# feat(iOS): forward backend activation payload unchanged

## Summary
- Stop rebuilding `payload.verification_result` on-device in the StoreKit purchase/restore flow.
- Decode the full backend `activation_payload` from verify-response and forward it unchanged to `POST /api/v1/pro/payments/activate`.
- Keep the request envelope stable: `source=ios_app_store`, `payload.verification_result`, `payload.receipt_data`.

## Scope
- `ios/PulsePlate/Models/Payments/SubscriptionBillingDTOs.swift`
- `ios/PulsePlate/Services/SubscriptionManager.swift`
- `ios/PulsePlateTests/Services/SubscriptionBillingServiceTests.swift`
- `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift`
- minimal runtime wording sync in `docs/IOS_API_INTEGRATION.md`

Out of scope:
- backend billing redesign
- App Store Server API migration
- UI / paywall / marketing work
- StoreKit baseline / B3 operational docs lane

## Acceptance Criteria
- verify-response DTO decodes the full backend activation payload
- `SubscriptionManager` forwards backend `activation_payload` unchanged as `payload.verification_result`
- local reconstruction of `IOSVerifiedActivationResultDTO` is removed
- missing activation payload fails closed deterministically
- purchase and restore happy paths remain green

## Tests
- [x] Xcode build / targeted iOS test subset
- [x] Unit tests
- [ ] UI / integration (not in scope)
- [ ] Manual simulator/device checks (not run)

```bash
pre-commit run --all-files
make verify
cd ios && xcodebuild test \
  -project PulsePlate.xcodeproj \
  -scheme PulsePlate \
  -destination "platform=iOS Simulator,id=<UDID>" \
  -only-testing:PulsePlateTests/SubscriptionBillingServiceTests \
  -only-testing:PulsePlateTests/SubscriptionManagerTests \
  -skip-testing:PulsePlateUITests \
  -parallel-testing-enabled NO
```

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1190_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1190#pullrequestreview-3973435214 -> ac657e87
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1190#pullrequestreview-3973474094 -> 90149308

## Deferred / Follow-ups
- [ ] Ledger item(s): None
- [ ] GitHub issue(s): None

## Merge Readiness (Mandatory)
- Status: ready for review; waiting for current-head CI completion and next review wave to confirm no new actionables
- Local validation:
  - `pre-commit run --all-files`
  - `make verify`
  - targeted `xcodebuild` subset for `SubscriptionBillingServiceTests` and `SubscriptionManagerTests`
- Current scope rule: runtime-only with minimal docs sync

## Summary by Sourcery

Пробросить предоставляемый бэкендом активационный payload через iOS‑флоу покупки/восстановления и скорректировать модели, логику, тесты и документацию так, чтобы бэкенд рассматривался как единственный источник истины для данных об активации.

New Features:
- Поддержать декодирование и проброс полного `IOSVerifiedActivationResultDTO` от бэкенда в качестве активационного payload в ответах проверки Apple‑квитанций и запросах активации.

Bug Fixes:
- Гарантировать, что активация подписки завершается в закрытом (fail‑closed) состоянии, когда в ответе бэкенда на проверку отсутствует активационный payload, чтобы избежать неконсистентного локального состояния прав (entitlements).

Enhancements:
- Удалить локальную реконструкцию результатов проверки в `SubscriptionManager` в пользу проброса активационного payload бэкенда без изменений.
- Сделать `IOSVerifiedActivationResultDTO` полностью `Codable` с явной snake_case‑кодировкой и camelCase‑декодированием, чтобы соответствовать контрактам бэкенда и поведению HTTP‑клиента.

Documentation:
- Обновить документацию по интеграции iOS API, указав, что клиент теперь пробрасывает бэкендовый `activation_payload` без изменений как `payload.verification_result`, и отметить актуальный источник истины во время выполнения.
- Добавить документ обзора сопоставления, исправленного этим PR, описывающий статус валидации и охват изменений.

Tests:
- Обновить тесты `SubscriptionManager` и `SubscriptionBillingService`, чтобы покрыть проброс активационного payload бэкенда, поведение fail‑closed при его отсутствии и декодирование полного активационного payload из ответов `verify`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Forward the backend-provided activation payload through the iOS purchase/restore flow and adjust models, logic, tests, and docs to treat the backend as the single source of truth for activation data.

New Features:
- Support decoding and passing through the full backend IOSVerifiedActivationResultDTO as the activation payload in Apple receipt verification responses and activation requests.

Bug Fixes:
- Ensure subscription activation fails closed when the backend verification response omits an activation payload, avoiding inconsistent local entitlement state.

Enhancements:
- Remove local reconstruction of verification results in SubscriptionManager in favor of forwarding the backend activation payload unchanged.
- Make IOSVerifiedActivationResultDTO fully Codable with explicit snake_case encoding and camelCase decoding to match backend contracts and HTTP client behavior.

Documentation:
- Update iOS API integration docs to state that the client now forwards backend activation_payload unchanged as payload.verification_result and note the current runtime truth.
- Add a PR-fixed mapping review document describing validation status and scope for this change.

Tests:
- Update SubscriptionManager and SubscriptionBillingService tests to cover pass-through of backend activation payload, closed-fail behavior when it is missing, and decoding of the full activation payload from verify responses.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Пробросить предоставляемый бэкендом активационный payload через iOS‑флоу покупки/восстановления и скорректировать модели, логику, тесты и документацию так, чтобы бэкенд рассматривался как единственный источник истины для данных об активации.

New Features:
- Поддержать декодирование и проброс полного `IOSVerifiedActivationResultDTO` от бэкенда в качестве активационного payload в ответах проверки Apple‑квитанций и запросах активации.

Bug Fixes:
- Гарантировать, что активация подписки завершается в закрытом (fail‑closed) состоянии, когда в ответе бэкенда на проверку отсутствует активационный payload, чтобы избежать неконсистентного локального состояния прав (entitlements).

Enhancements:
- Удалить локальную реконструкцию результатов проверки в `SubscriptionManager` в пользу проброса активационного payload бэкенда без изменений.
- Сделать `IOSVerifiedActivationResultDTO` полностью `Codable` с явной snake_case‑кодировкой и camelCase‑декодированием, чтобы соответствовать контрактам бэкенда и поведению HTTP‑клиента.

Documentation:
- Обновить документацию по интеграции iOS API, указав, что клиент теперь пробрасывает бэкендовый `activation_payload` без изменений как `payload.verification_result`, и отметить актуальный источник истины во время выполнения.
- Добавить документ обзора сопоставления, исправленного этим PR, описывающий статус валидации и охват изменений.

Tests:
- Обновить тесты `SubscriptionManager` и `SubscriptionBillingService`, чтобы покрыть проброс активационного payload бэкенда, поведение fail‑closed при его отсутствии и декодирование полного активационного payload из ответов `verify`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Forward the backend-provided activation payload through the iOS purchase/restore flow and adjust models, logic, tests, and docs to treat the backend as the single source of truth for activation data.

New Features:
- Support decoding and passing through the full backend IOSVerifiedActivationResultDTO as the activation payload in Apple receipt verification responses and activation requests.

Bug Fixes:
- Ensure subscription activation fails closed when the backend verification response omits an activation payload, avoiding inconsistent local entitlement state.

Enhancements:
- Remove local reconstruction of verification results in SubscriptionManager in favor of forwarding the backend activation payload unchanged.
- Make IOSVerifiedActivationResultDTO fully Codable with explicit snake_case encoding and camelCase decoding to match backend contracts and HTTP client behavior.

Documentation:
- Update iOS API integration docs to state that the client now forwards backend activation_payload unchanged as payload.verification_result and note the current runtime truth.
- Add a PR-fixed mapping review document describing validation status and scope for this change.

Tests:
- Update SubscriptionManager and SubscriptionBillingService tests to cover pass-through of backend activation payload, closed-fail behavior when it is missing, and decoding of the full activation payload from verify responses.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
iOS now forwards the backend `activation_payload` unchanged as `payload.verification_result` for purchase and restore. It also fixes DTO key mapping so outer `productId` and `activationId` decode correctly, and fails closed when the payload is missing.

- **New Features**
  - Decode and forward the full backend `activation_payload` (`IOSVerifiedActivationResultDTO`) to `POST /api/v1/pro/payments/activate` without local reconstruction or `verification_state` remapping.
  - Keep the request envelope stable (`source=ios_app_store`, `receipt_data`) and fail closed with a clear error if `activation_payload` is absent.
  - Make `IOSVerifiedActivationResultDTO` fully `Codable` with snake_case encoding, remove `AppleActivationHintDTO`, update tests and iOS API docs (B4 runtime truth), and add `docs/review/PR_1190_FIXED_MAPPING.md`.

- **Bug Fixes**
  - Map outer billing DTO acronym keys for correct decoding (`productId`, `activationId`) and add tests to cover the path.

<sup>Written for commit 20b58816ec0c982da07c7c6eec41237aa122fde5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS now forwards backend payment verification payloads unchanged during activation and fails safely when the activation payload is missing.

* **Documentation**
  * Clarified iOS payment-activation behavior and tightened contract language; added a review/traceability page recording the fixed mapping and merge-readiness notes.

* **Tests**
  * Added and updated tests to validate full verification-payload decoding, forwarding behavior, and missing-payload failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

