### PR TITLE
docs(security): sync dompurify/jspdf CVE truth to merged dependency state

### DIFF
--- a/docs/review/PR_1191_FIXED_MAPPING.md
+++ b/docs/review/PR_1191_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+# PR 1191 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: cfa08e46
+Evidence: `docs/security/CVE-2026-0540-dompurify.md:9`, `docs/security/CVE-2026-0540-dompurify.md:22`, `docs/security/CVE-2026-0540-dompurify.md:51`
+Reason: Replaced brittle line-number evidence anchors with path/key-based dependency truth and clarified that `dompurify` is resolved transitively via `jspdf` with no direct `frontend/src` import.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974789912 -> cfa08e46
+
+## Merge Readiness
+
+- Status: actionables addressed in docs; waiting for current-head CI and the next bot/review wave
+- Local validation:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `pre-commit run --files docs/security/CVE-2026-0540-dompurify.md`
+  - `cd frontend && npm ls jspdf dompurify`

--- a/docs/review/PR_1191_FIXED_MAPPING.md
+++ b/docs/review/PR_1191_FIXED_MAPPING.md
@@ -14,9 +14,16 @@ Reason: Replaced brittle line-number evidence anchors with path/key-based depend
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974789912 -> cfa08e46
 
+Disposition: FIXED
+Commit: eec9151b
+Evidence: `docs/security/CVE-2026-0540-dompurify.md:78`, `docs/security/CVE-2026-0540-dompurify.md:79`, `docs/security/CVE-2026-0540-dompurify.md:80`
+Reason: Clarified that the repo still keeps an active `overrides.dompurify = 3.3.2` safeguard in `frontend/package.json`, so the document no longer implies a pure upstream-resolution path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959777481 -> eec9151b
+
 ## Merge Readiness
 
-- Status: actionables addressed in docs; waiting for current-head CI and the next bot/review wave
+- Status: actionables addressed in docs; waiting for current-head CI, thread resolution sync, and the next bot/review wave
 - Local validation:
   - `python3 scripts/orchestration/check_preflight.py`
   - `pre-commit run --files docs/security/CVE-2026-0540-dompurify.md`

--- a/docs/review/PR_1191_FIXED_MAPPING.md
+++ b/docs/review/PR_1191_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ Reason: Clarified that the repo still keeps an active `overrides.dompurify = 3.3
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959777481 -> eec9151b
 
 Disposition: FIXED
-Commit: see mapping entries below
+Commit: 50fc3a7e
 Evidence: `docs/security/CVE-2026-0540-dompurify.md:56`, `docs/security/CVE-2026-0540-dompurify.md:57`, `docs/security/CVE-2026-0540-dompurify.md:58`
 Reason: Corrected the evidence anchors to point at the actual `package-lock.json` version lines and the `optionalDependencies.dompurify` path, matching the current resolved dependency tree.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974906249 -> 50fc3a7e

--- a/docs/review/PR_1191_FIXED_MAPPING.md
+++ b/docs/review/PR_1191_FIXED_MAPPING.md
@@ -11,15 +11,24 @@ Disposition: FIXED
 Commit: cfa08e46
 Evidence: `docs/security/CVE-2026-0540-dompurify.md:9`, `docs/security/CVE-2026-0540-dompurify.md:22`, `docs/security/CVE-2026-0540-dompurify.md:51`
 Reason: Replaced brittle line-number evidence anchors with path/key-based dependency truth and clarified that `dompurify` is resolved transitively via `jspdf` with no direct `frontend/src` import.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974789912 -> cfa08e46
 
 Disposition: FIXED
 Commit: eec9151b
 Evidence: `docs/security/CVE-2026-0540-dompurify.md:78`, `docs/security/CVE-2026-0540-dompurify.md:79`, `docs/security/CVE-2026-0540-dompurify.md:80`
 Reason: Clarified that the repo still keeps an active `overrides.dompurify = 3.3.2` safeguard in `frontend/package.json`, so the document no longer implies a pure upstream-resolution path.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959777481 -> eec9151b
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `docs/security/CVE-2026-0540-dompurify.md:56`, `docs/security/CVE-2026-0540-dompurify.md:57`, `docs/security/CVE-2026-0540-dompurify.md:58`
+Reason: Corrected the evidence anchors to point at the actual `package-lock.json` version lines and the `optionalDependencies.dompurify` path, matching the current resolved dependency tree.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974906249 -> 50fc3a7e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959855353 -> 50fc3a7e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#pullrequestreview-3974911784 -> 50fc3a7e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959861000 -> 50fc3a7e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959861008 -> 50fc3a7e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1191#discussion_r2959861012 -> 50fc3a7e
 
 ## Merge Readiness
 

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -75,6 +75,9 @@ npm run test:ci
 
 - The earlier git-commit override was an intermediate mitigation stage, not the
   final steady-state dependency truth.
+- The repo still keeps an active `overrides.dompurify = 3.3.2` safeguard in
+  `frontend/package.json` while the resolved dependency tree stays on published
+  npm versions (`jspdf@4.2.1` -> `dompurify@3.3.2`).
 - This document should not imply any additional dependency bump, lockfile
   change, runtime fix, or suppression wave for CVE-2026-0540.
 - If a future alert returns on this lane, treat it as a new security batch with

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -1,37 +1,67 @@
-# CVE-2026-0540 — dompurify (transitive via jspdf) — Dependabot #47 remediation
+# CVE-2026-0540 — dompurify (transitive via jspdf) — merged truth sync
 
 ## Summary
 
 - **CVE**: CVE-2026-0540
 - **GHSA**: GHSA-v2wj-7wpq-c8vv
 - **Package**: `dompurify`
-- **Alert type**: GitHub Dependabot alert
-- **Scope**: Transitive dependency via `jspdf@4.2.0`
+- **Alert type**: GitHub Dependabot alert `#47`
+- **Current repo scope**: transitive / optional dependency via `jspdf@4.2.1`
+- **Current state**: fixed in the merged dependency tree; no new dependency remediation PR is required for this lane
 
-Dependabot reported XSS vulnerability in DOMPurify. Affected versions: 2.5.3–2.5.8 and 3.1.3–3.3.1. Root cause: five missing rawtext elements (noscript, xmp, noembed, noframes, iframe) in SAFE_FOR_XML regex.
+Dependabot originally reported an XSS vulnerability in DOMPurify affecting
+versions `2.5.3`–`2.5.8` and `3.1.3`–`3.3.1`. The repo is now on the merged
+steady-state path with published npm packages:
 
-## Remediation strategy
+- `jspdf@4.2.1`
+- `dompurify@3.3.2`
 
-- Add npm `overrides` in `frontend/package.json` to force `dompurify` to the patched commit `729097f` from DOMPurify main (fix not yet published to npm; verified on 2026-03-04 UTC).
-- When upstream releases a patched version (e.g. 3.3.2), replace override with version pin and remove this doc's "override" note.
+This document records the final merged security truth after the remediation lane
+was completed. It is a docs/evidence sync artifact, not a remediation plan.
 
-## Evidence anchors
+## Historical remediation path
 
-- `frontend/package.json:82` — `overrides.dompurify` git resolution
-- `frontend/package-lock.json:5219` — resolved dompurify from git
+The lane closed in three merged steps:
+
+1. `PR #977` introduced the temporary override-based mitigation while upstream
+   packaged the fix.
+2. `PR #987` closed Dependabot alert `#47`.
+3. `PR #1186` moved the repo to `jspdf@4.2.1`, with the current dependency tree
+   resolving `dompurify@3.3.2`.
+
+GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
+`fixed`, including Dependabot alert `#47`.
+
+## Current evidence anchors
+
+- `frontend/package.json:36` — `jspdf` pinned to `^4.2.1`
+- `frontend/package.json:86` — `overrides` block starts
+- `frontend/package.json:87` — `dompurify` override is `3.3.2`
+- `frontend/package-lock.json:21` — root dependency on `jspdf`
+- `frontend/package-lock.json:5896` — resolved `node_modules/dompurify`
+- `frontend/package-lock.json:5897` — `dompurify` version `3.3.2`
+- `frontend/package-lock.json:7841` — resolved `node_modules/jspdf`
+- `frontend/package-lock.json:7842` — `jspdf` version `4.2.1`
 
 ## Validation
 
 ```bash
 cd frontend
-npm ls dompurify
-# Expect: dompurify overridden (git+...729097f...)
+npm ls jspdf dompurify
+# Expect:
+# - jspdf@4.2.1 in the resolved tree
+# - dompurify@3.3.2 in the resolved tree
+
 npm run build
 npm run test:ci
 ```
 
 ## Notes
 
-- Upstream fix: [commit 729097f](https://github.com/cure53/DOMPurify/commit/729097f63a78e3e0e9f771e648f462bee100e78f)
-- `npm audit` may still report the vulnerability; it does not recognize git-override as patched. Manual verification via commit hash is authoritative.
-- Monitor: [DOMPurify releases](https://github.com/cure53/DOMPurify/releases) for official patched release.
+- The earlier git-commit override was an intermediate mitigation stage, not the
+  final steady-state dependency truth.
+- This document should not imply any additional dependency bump, lockfile
+  change, runtime fix, or suppression wave for CVE-2026-0540.
+- If a future alert returns on this lane, treat it as a new security batch with
+  fresh evidence rather than reusing the closed remediation history recorded
+  here.

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -6,7 +6,7 @@
 - **GHSA**: GHSA-v2wj-7wpq-c8vv
 - **Package**: `dompurify`
 - **Alert type**: GitHub Dependabot alert `#47`
-- **Current repo scope**: transitive / optional dependency via `jspdf@4.2.1`
+- **Current repo scope**: transitive dependency resolved via `jspdf@4.2.1`
 - **Current state**: fixed in the merged dependency tree; no new dependency remediation PR is required for this lane
 
 Dependabot originally reported an XSS vulnerability in DOMPurify affecting
@@ -18,6 +18,22 @@ steady-state path with published npm packages:
 
 This document records the final merged security truth after the remediation lane
 was completed. It is a docs/evidence sync artifact, not a remediation plan.
+
+## Practical repo exposure
+
+The current repo resolves `dompurify` through `jspdf` in the frontend dependency
+tree. It is not declared as a standalone application dependency outside the
+package-manager override path, and there are no direct `dompurify` imports under
+`frontend/src` in the current tree.
+
+This means the security scope for this lane is:
+
+- resolved dependency-tree truth for `jspdf -> dompurify`
+- current package-manager evidence that the fixed `dompurify@3.3.2` version is
+  what the repo resolves
+
+This document does not claim a separate application-level runtime integration of
+`dompurify` beyond that transitive `jspdf` path.
 
 ## Historical remediation path
 
@@ -34,14 +50,13 @@ GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
 
 ## Current evidence anchors
 
-- `frontend/package.json:36` — `jspdf` pinned to `^4.2.1`
-- `frontend/package.json:86` — `overrides` block starts
-- `frontend/package.json:87` — `dompurify` override is `3.3.2`
-- `frontend/package-lock.json:21` — root dependency on `jspdf`
-- `frontend/package-lock.json:5896` — resolved `node_modules/dompurify`
-- `frontend/package-lock.json:5897` — `dompurify` version `3.3.2`
-- `frontend/package-lock.json:7841` — resolved `node_modules/jspdf`
-- `frontend/package-lock.json:7842` — `jspdf` version `4.2.1`
+- `frontend/package.json` — `dependencies.jspdf = ^4.2.1`
+- `frontend/package.json` — `overrides.dompurify = 3.3.2`
+- `frontend/package-lock.json` — root package dependency on `jspdf`
+- `frontend/package-lock.json` — `packages["node_modules/jspdf"].version = 4.2.1`
+- `frontend/package-lock.json` — `packages["node_modules/jspdf"].dependencies.dompurify = ^3.3.1`
+- `frontend/package-lock.json` — `packages["node_modules/dompurify"].version = 3.3.2`
+- `frontend/src` — no direct `dompurify` import in application source (`rg -n 'dompurify' frontend/src`)
 
 ## Validation
 

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -50,12 +50,12 @@ GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
 
 ## Current evidence anchors
 
-- `frontend/package.json` — `dependencies.jspdf = ^4.2.1`
-- `frontend/package.json` — `overrides.dompurify = 3.3.2`
-- `frontend/package-lock.json` — root package dependency on `jspdf`
-- `frontend/package-lock.json` — `packages["node_modules/jspdf"].version = 4.2.1`
-- `frontend/package-lock.json` — `packages["node_modules/jspdf"].dependencies.dompurify = ^3.3.1`
-- `frontend/package-lock.json` — `packages["node_modules/dompurify"].version = 3.3.2`
+- `frontend/package.json:36` — `dependencies.jspdf = ^4.2.1` (key: `dependencies.jspdf`)
+- `frontend/package.json:87` — `overrides.dompurify = 3.3.2` (key: `overrides.dompurify`)
+- `frontend/package-lock.json:21` — root package dependency on `jspdf`
+- `frontend/package-lock.json:7841` — `packages["node_modules/jspdf"].version = 4.2.1`
+- `frontend/package-lock.json:7854` — `packages["node_modules/jspdf"].dependencies.dompurify = ^3.3.1`
+- `frontend/package-lock.json:5896` — `packages["node_modules/dompurify"].version = 3.3.2`
 - `frontend/src` — no direct `dompurify` import in application source (`rg -n 'dompurify' frontend/src`)
 
 ## Validation

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -53,9 +53,9 @@ GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
 - `frontend/package.json:36` — `dependencies.jspdf = ^4.2.1` (key: `dependencies.jspdf`)
 - `frontend/package.json:87` — `overrides.dompurify = 3.3.2` (key: `overrides.dompurify`)
 - `frontend/package-lock.json:21` — root package dependency on `jspdf`
-- `frontend/package-lock.json:7841` — `packages["node_modules/jspdf"].version = 4.2.1`
-- `frontend/package-lock.json:7854` — `packages["node_modules/jspdf"].dependencies.dompurify = ^3.3.1`
-- `frontend/package-lock.json:5896` — `packages["node_modules/dompurify"].version = 3.3.2`
+- `frontend/package-lock.json:7842` — `packages["node_modules/jspdf"].version = 4.2.1`
+- `frontend/package-lock.json:7854` — `packages["node_modules/jspdf"].optionalDependencies.dompurify = ^3.3.1`
+- `frontend/package-lock.json:5897` — `packages["node_modules/dompurify"].version = 3.3.2`
 - `frontend/src` — no direct `dompurify` import in application source (`rg -n 'dompurify' frontend/src`)
 
 ## Validation


### PR DESCRIPTION
## Summary

Sync `docs/security/CVE-2026-0540-dompurify.md` to the current merged dependency truth.

This PR is docs-only. It does not change dependency versions, runtime behavior,
frontend code, lockfiles, package manifests, suppressions, or Batch B trackers.

## Scope

- update `docs/security/CVE-2026-0540-dompurify.md`
- remove stale temporary-remediation wording
- record the final merged/fixed dependency truth for the `dompurify` / `jspdf` lane
- keep the lane framed as docs/evidence sync, not a new remediation wave

## Current canonical truth

- current repo dependency path is `jspdf@4.2.1` with `dompurify@3.3.2`
- the earlier git-commit override was an intermediate mitigation stage, not the final steady-state
- relevant GitHub alerts are already fixed
- no new dependency remediation PR is required for this lane

## Non-goals

- no `package.json` changes
- no `package-lock.json` changes
- no dependency bumps
- no runtime/frontend changes
- no new suppressions or security policy changes
- no reopening of Batch B or payments lanes

## Touched files

- `docs/security/CVE-2026-0540-dompurify.md`

## Validation

Passed locally:
- `python3 scripts/orchestration/check_preflight.py`
- `pytest -q tests/test_repo_policy_guards.py`
- `pre-commit run --all-files`

Sanity grep on stale wording is clean.

## DoD

- security doc reflects merged/fixed dependency truth
- stale pending-remediation narrative is removed
- docs-only diff remains narrow
- local repo policy and pre-commit checks pass

## Security Notes

This PR does not change runtime behavior or dependency state.
It only aligns the security documentation with the already merged/fixed repo truth.

## Follow-up

If future `dompurify` / `jspdf` alerts reappear, treat that as a new security batch
with fresh evidence rather than reusing this closed remediation history.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1191_FIXED_MAPPING.md`

## Summary by Sourcery

Привести документацию по безопасности dompurify для CVE-2026-0540 в соответствие с текущим объединённым состоянием зависимостей для ветки dompurify/jspdf, отражая, что уязвимость исправлена без введения нового кода или изменений зависимостей.

Документация:
- Обновить документ по безопасности dompurify для CVE-2026-0540, чтобы описать окончательные версии объединённых зависимостей (jspdf@4.2.1, dompurify@3.3.2) и отметить ветку как исправленную, а не находящуюся в ожидании ремедиации.
- Переработать описание ремедиации, чтобы задокументировать историческую меру смягчения на основе override и последующие PR, одновременно прояснив, что дополнительная ремедиация зависимостей не требуется.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the CVE-2026-0540 dompurify security documentation with the current merged dependency state for the dompurify/jspdf lane, reflecting that the vulnerability is fixed without introducing new code or dependency changes.

Documentation:
- Update the CVE-2026-0540 dompurify security doc to describe the final merged dependency versions (jspdf@4.2.1, dompurify@3.3.2) and mark the lane as fixed rather than pending remediation.
- Revise the remediation narrative to document the historical override-based mitigation and subsequent PRs while clarifying that no further dependency remediation is required.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified security write-up to reflect current resolved dependency state, confirmed safeguarding and that no new remediation PR is required for this lane.
  * Reframed the CVE narrative to focus on repository exposure, the historical remediation path, and removed prior temporary remediation instructions.
  * Added a review record documenting fix verification, evidence-anchoring corrections, and preflight/validation steps for dependency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
