### PR TITLE
feat(authz): enforce entitlement-backed routing after billing activation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ ENVIRONMENT=local
 DATABASE_URL=sqlite:///./cache/app.db
 # DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@postgres:5432/pulseplate
 # DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
+# Production/staging must set this to true; local/dev/test may keep false until
+# DB-backed entitlement routing is being validated end-to-end.
+SUBSCRIPTION_DB_ENABLED=false
 
 # === PostgreSQL (canonical prod DB) ===
 # Required for production. SQLite used for local/dev/test when Postgres DSN not set.

--- a/.github/workflows/docker-openapi-smoke.yml
+++ b/.github/workflows/docker-openapi-smoke.yml
@@ -58,6 +58,7 @@ jobs:
           export_token_secret_name="EXPORT_TOKEN""_SECRET"
           server_salt_name="SERVER""_SALT"
           apple_shared_secret_name="APPLE_SHARED""_SECRET"
+          subscription_db_enabled_name="SUBSCRIPTION_DB""_ENABLED"
 
           args=(
             -d
@@ -67,6 +68,7 @@ jobs:
             -e "${export_token_secret_name}=ci-smoke-export-secret"
             -e "${server_salt_name}=StrongServerSaltForCI1234567890!"
             -e "${apple_shared_secret_name}=StrongAppleSharedSecretForCI1234567890!"
+            -e "${subscription_db_enabled_name}=true"
             -e APP_ENV=production
             -e ENVIRONMENT=production
             -e "${allow_dev_api_key_name}=false"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -830,6 +830,7 @@ Source of truth:
 - **iOS Apple verify:** iOS must never call Apple `verifyReceipt` directly. Verification is server-side only; app sends receipt to backend.
 - **RU/BY manual rails:** `erip_qr` and `swift_manual` flows are reconcile-based; activation requires backend verification, not client-declared truth.
 - **Billing Truth Invariant:** Client-supplied payment verification payloads must never be used as the source of truth for persisted entitlement or subscription state. For provider-based automated billing flows (e.g. Apple App Store), backend activation must derive subscription tier/status only from server-side provider verification or a server-signed verification artifact. Unsigned client verification payloads may be accepted only as compatibility input, logging context, or mismatch evidence — never as entitlement truth.
+- **Billing Entitlement Routing Invariant:** Protected PRO/VIP routes must derive access only from canonical backend entitlement/subscription state. Client-declared tier, verification hints, activation attempts, or manual billing entry flows must not unlock protected routes. Billing entry routes may remain transport-auth surfaces before entitlement, but they are not entitlement truth and must not be treated as paid-content access.
 - **Canonical contract:** `docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md`, `docs/IOS_API_INTEGRATION.md`.
 
 ## Product tiers and API namespaces (canonical)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -830,7 +830,7 @@ Source of truth:
 - **iOS Apple verify:** iOS must never call Apple `verifyReceipt` directly. Verification is server-side only; app sends receipt to backend.
 - **RU/BY manual rails:** `erip_qr` and `swift_manual` flows are reconcile-based; activation requires backend verification, not client-declared truth.
 - **Billing Truth Invariant:** Client-supplied payment verification payloads must never be used as the source of truth for persisted entitlement or subscription state. For provider-based automated billing flows (e.g. Apple App Store), backend activation must derive subscription tier/status only from server-side provider verification or a server-signed verification artifact. Unsigned client verification payloads may be accepted only as compatibility input, logging context, or mismatch evidence — never as entitlement truth.
-- **Billing Entitlement Routing Invariant:** Protected PRO/VIP routes must derive access only from canonical backend entitlement/subscription state. Client-declared tier, verification hints, activation attempts, or manual billing entry flows must not unlock protected routes. Billing entry routes may remain transport-auth surfaces before entitlement, but they are not entitlement truth and must not be treated as paid-content access.
+- **Billing Entitlement Routing Invariant:** Protected PRO/VIP routes must derive access only from canonical backend entitlement/subscription state. Client-declared tier, verification hints, activation attempts, or manual billing entry flows must not unlock protected routes. Billing entry routes may remain transport-auth surfaces before entitlement, but they are not entitlement truth and must not be treated as paid-content access. Under `SUBSCRIPTION_DB_ENABLED=true`, protected-route auth is currently fail-closed for every non-`HIT` DB lookup result, including `MISS`, `ERROR`, and `INVALID_TIER`. Any future `MISS` migration exception would need an explicit, time-bounded follow-up before it can ship.
 - **Canonical contract:** `docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md`, `docs/IOS_API_INTEGRATION.md`.
 
 ## Product tiers and API namespaces (canonical)
@@ -982,9 +982,10 @@ Source of truth:
 - **Do not use `Header(...)` in tier dependencies** — use `Security(api_key_header)` to ensure OpenAPI models credentials as security scheme (not per-operation header params). This prevents OpenAPI drift and dirty TypeScript types.
 - **Tier guard order**: Tier checks (403) must run before payload validation (422). Principle: "tier wins over payload".
 - **New metrics/features policy**: Any new metrics (e.g., WHR) must be added via tier-specific schemas + endpoints; FREE contract must not be extended without explicit tier policy decision.
-- **DB lookup policy** (when `SUBSCRIPTION_DB_ENABLED=true`): `ERROR` and `INVALID_TIER` are
-  **fail-closed** (no env fallback). `MISS` may fallback **only during migration**; plan a
-  follow-up to make DB authoritative.
+- **DB lookup policy** (when `SUBSCRIPTION_DB_ENABLED=true`): protected-route auth is
+  **fail-closed** for `MISS`, `ERROR`, and `INVALID_TIER` (no env fallback). If a
+  migration-only `MISS` exception is ever proposed, it must be explicit, time-bounded, and
+  tracked for removal before DB-backed entitlement routing can be called complete.
 
 **See:**
 

--- a/app/bootstrap/startup_guards.py
+++ b/app/bootstrap/startup_guards.py
@@ -6,12 +6,39 @@ EN: Centralizes fail-closed startup guards in one bootstrap seam.
 
 from __future__ import annotations
 
+import os
+
 from app.security.llm_monthly_quota import (
     require_pro_llm_monthly_limit,
     require_vip_llm_monthly_limit,
 )
 from app.security.server_salt import require_server_salt
-from settings import validate_api_key_toggle_guard, validate_apple_receipt_verification_config
+from settings import (
+    get_runtime_env_name,
+    is_production_like_env,
+    is_truthy_env_var,
+    validate_api_key_toggle_guard,
+    validate_apple_receipt_verification_config,
+)
+
+
+def _require_subscription_db_in_production_like_env() -> None:
+    """Fail closed when paid entitlement mode lacks DB-backed subscription truth.
+
+    RU: В production/staging платный authz должен опираться на persisted entitlement truth.
+    EN: In production/staging, paid authz must rely on persisted entitlement truth.
+    """
+
+    if not is_production_like_env():
+        return
+    if is_truthy_env_var("SUBSCRIPTION_DB_ENABLED", "false"):
+        return
+
+    runtime_env = get_runtime_env_name()
+    raise RuntimeError(
+        "SUBSCRIPTION_DB_ENABLED must be true in production/staging environments "
+        f"(current env: {runtime_env or os.getenv('APP_ENV', 'unknown')})."
+    )
 
 
 def run_startup_guards() -> None:
@@ -26,3 +53,4 @@ def run_startup_guards() -> None:
     require_vip_llm_monthly_limit()
     validate_apple_receipt_verification_config()
     validate_api_key_toggle_guard()
+    _require_subscription_db_in_production_like_env()

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -121,6 +121,15 @@ def _tier_allows_access(tier: SubscriptionTier, required_tier: SubscriptionTier)
     return True
 
 
+def tier_allows_access(tier: SubscriptionTier, required_tier: SubscriptionTier) -> bool:
+    """Public wrapper for stable tier-compatibility checks.
+
+    RU: Публичная обёртка для проверки совместимости tier access.
+    EN: Public wrapper for tier-compatibility checks.
+    """
+    return _tier_allows_access(tier, required_tier)
+
+
 def _parse_tier_value(raw_tier: str) -> SubscriptionTier | None:
     """Convert DB/env tier string to SubscriptionTier enum safely."""
     normalized = raw_tier.strip().upper()
@@ -282,6 +291,15 @@ def _resolve_tier_from_env(
         return SubscriptionTier.PRO
 
     return None
+
+
+def resolve_tier_from_env(api_key: str, *, allow_test_keys: bool = True) -> SubscriptionTier | None:
+    """Public wrapper for env-backed tier resolution.
+
+    RU: Публичная обёртка для env-backed tier resolution.
+    EN: Public wrapper for env-backed tier resolution.
+    """
+    return _resolve_tier_from_env(api_key, allow_test_keys=allow_test_keys)
 
 
 def _is_production_environment() -> tuple[bool, str]:

--- a/app/middleware/api_tiers.py
+++ b/app/middleware/api_tiers.py
@@ -188,6 +188,10 @@ def _lookup_tier_from_db(api_key: str) -> DBLookupResult:
 
     RU: Пытается определить entitlement из persisted subscriptions и возвращает статус lookup.
     EN: Attempts to resolve entitlement from persisted subscriptions and returns structured status.
+
+    Protected paid routes must derive access only from this persisted backend truth
+    when SUBSCRIPTION_DB_ENABLED=true. Client-declared tier, activation hints, and
+    manual billing entry events are never entitlement authority.
     """
     try:
         from core.db import get_session_factory
@@ -302,6 +306,10 @@ def _resolve_authorized_api_key_tier(
     allow_developer_api_keys = in_developer_env and is_truthy_env_var("ALLOW_DEV_API_KEY", "true")
 
     if _is_subscription_db_enabled():
+        # RU: В DB-backed режиме только persisted entitlement state имеет право
+        # открывать protected paid routes.
+        # EN: In DB-backed mode, only persisted entitlement state may unlock
+        # protected paid routes.
         db_lookup = _lookup_tier_from_db(api_key)
         if db_lookup.status == DBLookupStatus.HIT and db_lookup.tier is not None:
             if _tier_allows_access(db_lookup.tier, required_tier):

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -17,7 +17,11 @@ from fastapi.responses import JSONResponse
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-from app.middleware.api_tiers import SubscriptionTier, _resolve_tier_from_env, _tier_allows_access
+from app.middleware.api_tiers import (
+    SubscriptionTier,
+    resolve_tier_from_env,
+    tier_allows_access,
+)
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,
@@ -249,8 +253,8 @@ def _resolve_manual_transport_key_fallback(api_key: str) -> str | None:
         "ALLOW_DEV_API_KEY",
         "true",
     )
-    resolved_tier = _resolve_tier_from_env(api_key, allow_test_keys=allow_test_keys)
-    if resolved_tier is not None and _tier_allows_access(resolved_tier, SubscriptionTier.PRO):
+    resolved_tier = resolve_tier_from_env(api_key, allow_test_keys=allow_test_keys)
+    if resolved_tier is not None and tier_allows_access(resolved_tier, SubscriptionTier.PRO):
         return api_key
     return None
 

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
 from fastapi.responses import JSONResponse
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+from app.middleware.api_tiers import SubscriptionTier, _resolve_tier_from_env, _tier_allows_access
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,
@@ -34,6 +35,7 @@ from app.schemas.payments import (
     SubscriptionActivationResponse,
 )
 from app.services import payments_activation
+from settings import is_explicit_developer_env, is_truthy_env_var
 
 billing_router = APIRouter(prefix="/api/v1/billing", tags=["billing"])
 router = APIRouter(prefix="/api/v1/pro/payments", tags=["pro", "payments"])
@@ -200,7 +202,7 @@ def _require_manual_billing_transport_key(
     """
     return _validate_billing_transport_key(
         x_api_key,
-        validator_resolver=_get_effective_app_get_api_key,
+        validator_resolver=_get_effective_manual_billing_key_validator,
     )
 
 
@@ -231,6 +233,55 @@ def _get_effective_app_get_api_key():
     if callable(override):
         return override
     return app_get_api_key
+
+
+def _resolve_manual_transport_key_fallback(api_key: str) -> str | None:
+    """Accept issued PRO/VIP transport keys for pre-entitlement manual billing routes.
+
+    RU: Pre-entitlement manual rails принимают валидированный transport key через
+    app-level validator или через выданный PRO/VIP key из env/test surface, но не
+    используют persisted entitlement как источник истины.
+    EN: Pre-entitlement manual rails accept a validated transport key via the
+    app-level validator or an issued PRO/VIP key from the env/test surface, but
+    they do not use persisted entitlement as the source of truth.
+    """
+    allow_test_keys = is_explicit_developer_env() and is_truthy_env_var(
+        "ALLOW_DEV_API_KEY",
+        "true",
+    )
+    resolved_tier = _resolve_tier_from_env(api_key, allow_test_keys=allow_test_keys)
+    if resolved_tier is not None and _tier_allows_access(resolved_tier, SubscriptionTier.PRO):
+        return api_key
+    return None
+
+
+def _get_effective_manual_billing_key_validator() -> Callable[..., str]:
+    """Resolve manual-route validator without reintroducing entitlement-gated auth.
+
+    RU: Manual RU/BY routes должны принимать transport-auth до entitlment, поэтому
+    fallback ограничен issued PRO/VIP keys и не ходит в persisted entitlement lookup.
+    EN: Manual RU/BY routes must accept transport auth before entitlement exists, so
+    the fallback is limited to issued PRO/VIP keys and never consults persisted
+    entitlement lookup.
+    """
+    app_get_api_key = cast(Callable[[str], str] | None, _get_effective_app_get_api_key())
+
+    def _validate_manual_transport_key(api_key: str) -> str:
+        last_http_error: HTTPException | None = None
+        if callable(app_get_api_key):
+            try:
+                return app_get_api_key(api_key)
+            except HTTPException as exc:
+                last_http_error = exc
+
+        fallback_key = _resolve_manual_transport_key_fallback(api_key)
+        if fallback_key is not None:
+            return fallback_key
+        if last_http_error is not None:
+            raise last_http_error
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API Key")
+
+    return _validate_manual_transport_key
 
 
 def _apple_operational_error_response(

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -8,6 +8,7 @@ EN: Canonical billing endpoints for RU/BY + iOS baseline.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
@@ -16,7 +17,6 @@ from fastapi.responses import JSONResponse
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-from app.middleware.api_tiers import require_pro_tier
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,
@@ -119,10 +119,18 @@ def _payment_error_response(
     return JSONResponse(status_code=status_code, content=error.model_dump(mode="json"))
 
 
-def _require_billing_transport_key(
-    x_api_key: Optional[str] = Security(api_key_header),
+def _validate_billing_transport_key(
+    x_api_key: Optional[str],
+    *,
+    validator_resolver: Callable[[], Callable[..., str] | None],
 ) -> str:
-    """Require a validated transport API key without tier or cookie semantics."""
+    """Validate billing transport auth with a strict app-level key validator.
+
+    RU: manual RU/BY routes остаются pre-entitlement, но не принимают произвольный
+    непустой ключ. Transport-auth carveout не ослабляет валидацию ключа.
+    EN: manual RU/BY routes remain pre-entitlement, but they do not accept an
+    arbitrary non-empty key. The transport-auth carveout does not weaken key validation.
+    """
     if x_api_key is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -137,7 +145,7 @@ def _require_billing_transport_key(
             headers={"WWW-Authenticate": "ApiKey"},
         )
 
-    app_get_api_key = _get_app_get_api_key()
+    app_get_api_key = validator_resolver()
     if not callable(app_get_api_key):
         logger.error("Billing transport key validation is unavailable")
         raise HTTPException(
@@ -148,16 +156,12 @@ def _require_billing_transport_key(
     try:
         result = app_get_api_key(normalized_api_key)
     except HTTPException as exc:
-        try:
-            require_pro_tier(x_api_key=normalized_api_key)
-            return normalized_api_key
-        except HTTPException:
-            logger.warning("Billing transport key rejected by app-level validator")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="API key required for billing verification",
-                headers={"WWW-Authenticate": "ApiKey"},
-            ) from exc
+        logger.warning("Billing transport key rejected by app-level validator")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="API key required for billing verification",
+            headers={"WWW-Authenticate": "ApiKey"},
+        ) from exc
     except Exception as exc:  # pragma: no cover - defensive guard
         logger.exception("Billing transport key validation failed")
         raise HTTPException(
@@ -174,14 +178,59 @@ def _require_billing_transport_key(
     return result
 
 
+def _require_billing_transport_key(
+    x_api_key: Optional[str] = Security(api_key_header),
+) -> str:
+    """Require a strict validated transport API key for billing verification."""
+    return _validate_billing_transport_key(
+        x_api_key,
+        validator_resolver=_get_app_get_api_key,
+    )
+
+
+def _require_manual_billing_transport_key(
+    x_api_key: Optional[str] = Security(api_key_header),
+) -> str:
+    """Require transport auth for manual RU/BY routes before entitlement exists.
+
+    RU: это pre-entitlement transport-auth carveout, а не entitlement truth;
+    route не требует entitlement, но всё равно требует валидированный transport key.
+    EN: this is a pre-entitlement transport-auth carveout, not entitlement truth;
+    the route does not require entitlement, but it still requires a validated transport key.
+    """
+    return _validate_billing_transport_key(
+        x_api_key,
+        validator_resolver=_get_effective_app_get_api_key,
+    )
+
+
 def _get_app_get_api_key():
-    """Resolve the app-level API-key validator via a cached module import."""
+    """Resolve the strict app-level API-key validator from the app module."""
     global _APP_MODULE
     if _APP_MODULE is None:
         import app as app_module
 
         _APP_MODULE = app_module
+
     return getattr(_APP_MODULE, "get_api_key", None)
+
+
+def _get_effective_app_get_api_key():
+    """Resolve the effective app-level API-key validator, honoring overrides."""
+    app_get_api_key = _get_app_get_api_key()
+    if not callable(app_get_api_key):
+        return None
+
+    try:
+        from app.main import app as fastapi_app
+    except Exception:  # pragma: no cover - defensive import guard
+        return app_get_api_key
+
+    dependency_overrides = getattr(fastapi_app, "dependency_overrides", None) or {}
+    override = dependency_overrides.get(app_get_api_key)
+    if callable(override):
+        return override
+    return app_get_api_key
 
 
 def _apple_operational_error_response(
@@ -266,9 +315,9 @@ async def verify_apple_receipt(
 )
 def create_manual_payment_intent(
     payload: ManualRailIntentRequest,
-    x_api_key: str = Depends(require_pro_tier),
+    x_api_key: str = Depends(_require_manual_billing_transport_key),
 ) -> SubscriptionActivationResponse | JSONResponse:
-    """Create manual RU/BY payment intent with pending reconciliation lifecycle."""
+    """Create manual RU/BY payment intent on a pre-entitlement transport-auth surface."""
     activation_request = payments_activation.build_manual_intent_request(payload=payload)
     try:
         activation, is_new = payments_activation.activate_subscription(
@@ -312,9 +361,9 @@ def create_manual_payment_intent(
 )
 def reconcile_manual_payment_intent(
     payload: ManualRailReconcileRequest,
-    x_api_key: str = Depends(require_pro_tier),
+    x_api_key: str = Depends(_require_manual_billing_transport_key),
 ) -> SubscriptionActivationResponse | JSONResponse:
-    """Apply reconciliation decision to pending manual payment intent."""
+    """Apply reconciliation decision on a pre-entitlement transport-auth surface."""
     try:
         return payments_activation.reconcile_activation(
             issuer=_issuer_from_api_key(x_api_key),
@@ -368,9 +417,9 @@ def reconcile_manual_payment_intent(
 )
 def get_manual_payment_intent_status(
     intent_id: str,
-    x_api_key: str = Depends(require_pro_tier),
+    x_api_key: str = Depends(_require_manual_billing_transport_key),
 ) -> SubscriptionActivationResponse | JSONResponse:
-    """Fetch current status of manual payment reconciliation intent."""
+    """Fetch manual payment reconciliation status on a pre-entitlement transport-auth surface."""
     issuer = _issuer_from_api_key(x_api_key)
     try:
         activation = payments_activation.get_reconcile_activation_status(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - PYTHONPATH=/app
       - API_KEY=${API_KEY}
       - ENVIRONMENT=production
+      - SUBSCRIPTION_DB_ENABLED=${SUBSCRIPTION_DB_ENABLED:-true}
       - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
       - SERVER_SALT=${SERVER_SALT:?SERVER_SALT is required}
       - APPLE_SHARED_SECRET=${APPLE_SHARED_SECRET:?APPLE_SHARED_SECRET is required}
@@ -62,6 +63,7 @@ services:
       - PYTHONPATH=/app
       - API_KEY=${API_KEY}
       - ENVIRONMENT=development
+      - SUBSCRIPTION_DB_ENABLED=${SUBSCRIPTION_DB_ENABLED:-false}
       - SERVER_SALT=${SERVER_SALT:?SERVER_SALT is required}
       - APPLE_SHARED_SECRET=${APPLE_SHARED_SECRET:-replace_me_with_apple_shared_secret}
       - EXPORT_TOKEN_SECRET=${EXPORT_TOKEN_SECRET:-__set_me__}

--- a/docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
+++ b/docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
@@ -31,6 +31,13 @@ Implemented endpoints (evidence: `app/routers/billing.py`, `app/routers/pro_paym
 
 Legacy behavior remains unchanged; additive surface is non-breaking.
 
+### Manual RU/BY pre-entitlement carveout
+
+- Manual RU/BY routes remain on `/api/v1/pro/payments/ru-by/*` during the current namespace window.
+- These routes are **transport-auth-only** surfaces before entitlement exists and still require a validated transport key.
+- They are not paid-content unlock paths and they are not entitlement truth.
+- Access to canonical `/api/v1/pro/*` and `/api/v1/vip/*` surfaces still derives only from persisted backend subscription state.
+
 ### Apple verify response (B2 activation-contract)
 
 When `POST /api/v1/billing/apple/verify-receipt` returns `verified=true`, the `activation_payload` field carries the full `IOSVerifiedActivationResult` (activation-contract shape):
@@ -150,6 +157,7 @@ Semantic note:
 3. Manual rails have increased fraud risk; require reviewer/audit trace.
 4. Keep Apple digital-goods policy compliance in scope for iOS rails.
 5. RU/BY manual rails are operational fallback, not anonymous bypass path.
+6. RU/BY manual entry, reconcile, and status routes may stay reachable before entitlement exists, but they must still require validated transport auth and must never unlock protected PRO/VIP content routes by themselves.
 
 ## 8. Runtime Test Plan (must be green in runtime PR)
 

--- a/docs/review/PR_1192_FIXED_MAPPING.md
+++ b/docs/review/PR_1192_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1192 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Pending review wave.
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] Pre-commit green

--- a/docs/review/PR_1192_FIXED_MAPPING.md
+++ b/docs/review/PR_1192_FIXED_MAPPING.md
@@ -1,12 +1,12 @@
 # PR 1192 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-Pending review wave.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1192_FIXED_MAPPING.md
+++ b/docs/review/PR_1192_FIXED_MAPPING.md
@@ -6,7 +6,30 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 1fcbf395
+Evidence: `.env.example:28` now ships `SUBSCRIPTION_DB_ENABLED=false` with production guidance, `docker-compose.yaml:18` sets `SUBSCRIPTION_DB_ENABLED` for the production service, and `docker-compose.yaml:65` sets the dev default explicitly so the new startup guard no longer breaks repo-shipped deployment inputs.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#discussion_r2961928851 -> 1fcbf395
+
+Disposition: FIXED
+Commit: 1fcbf395
+Evidence: `app/routers/billing.py:238`-`app/routers/billing.py:286` now accept issued PRO/VIP transport keys for pre-entitlement RU/BY manual rails without consulting persisted entitlement state, and `tests/test_payment_source_contract_api.py:38` proves a production-like DB mode request with `PRO_API_KEYS` still reaches `/api/v1/pro/payments/ru-by/manual-intent` while protected `/api/v1/pro/session` remains blocked at `tests/test_payment_source_contract_api.py:61`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#discussion_r2961928857 -> 1fcbf395
+
+Disposition: FIXED
+Commit: 1fcbf395
+Evidence: `AGENTS.md:833` and `AGENTS.md:985` now describe the current fail-closed runtime contract for `MISS`, `ERROR`, and `INVALID_TIER` under `SUBSCRIPTION_DB_ENABLED=true`, removing the stale migration-fallback wording that contradicted `app/middleware/api_tiers.py:308`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#discussion_r2961953817 -> 1fcbf395
+
+Disposition: FIXED
+Commit: 1fcbf395
+Evidence: `tests/test_payment_source_contract_api.py:13` replaces direct private-helper invocation with a behavioral `TestClient` request that asserts the 401 integration path, and `tests/test_payment_source_contract_api.py:32` replaces the dead-env setup case with a route-level production-like scenario that actually exercises manual-route auth wiring.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#discussion_r2961953827 -> 1fcbf395
+
+Disposition: FIXED
+Commit: 1fcbf395
+Evidence: The review-level CodeRabbit summary is fully covered by the concrete fixes above: deploy templates now ship `SUBSCRIPTION_DB_ENABLED`, the policy text matches the fail-closed DB lookup contract, and `tests/test_payment_source_contract_api.py` now uses behavioral route coverage instead of private helper calls.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#pullrequestreview-3977153010 -> 1fcbf395
 
 ## Merge Readiness
 

--- a/docs/review/PR_1192_FIXED_MAPPING.md
+++ b/docs/review/PR_1192_FIXED_MAPPING.md
@@ -31,6 +31,17 @@ Commit: 1fcbf395
 Evidence: The review-level CodeRabbit summary is fully covered by the concrete fixes above: deploy templates now ship `SUBSCRIPTION_DB_ENABLED`, the policy text matches the fail-closed DB lookup contract, and `tests/test_payment_source_contract_api.py` now uses behavioral route coverage instead of private helper calls.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#pullrequestreview-3977153010 -> 1fcbf395
 
+Disposition: FIXED
+Commit: e80e6f76
+Evidence: `app/middleware/api_tiers.py:124` exposes stable public wrappers `tier_allows_access(...)` and `resolve_tier_from_env(...)`, and `app/routers/billing.py:20` now imports those public helpers instead of coupling the router to underscored middleware internals.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#pullrequestreview-3977334982 -> e80e6f76
+
+Disposition: FIXED
+Commit: e80e6f76
+Evidence: `tests/test_payment_source_contract_api.py:41` now uses an isolated `TestClient(app)` context for the production-like manual-intent auth-isolation scenario, so the test no longer relies on the shared `client` fixture while mutating `dependency_overrides`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#discussion_r2962194720 -> e80e6f76
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1192#pullrequestreview-3977421339 -> e80e6f76
+
 ## Merge Readiness
 
 - [ ] All required checks pass

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -7858,7 +7858,7 @@
     },
     "/api/v1/pro/payments/ru-by/manual-intent": {
       "post": {
-        "description": "Create manual RU/BY payment intent with pending reconciliation lifecycle.",
+        "description": "Create manual RU/BY payment intent on a pre-entitlement transport-auth surface.",
         "operationId": "create_manual_payment_intent_api_v1_pro_payments_ru_by_manual_intent_post",
         "requestBody": {
           "content": {
@@ -7945,7 +7945,7 @@
     },
     "/api/v1/pro/payments/ru-by/reconcile": {
       "post": {
-        "description": "Apply reconciliation decision to pending manual payment intent.",
+        "description": "Apply reconciliation decision on a pre-entitlement transport-auth surface.",
         "operationId": "reconcile_manual_payment_intent_api_v1_pro_payments_ru_by_reconcile_post",
         "requestBody": {
           "content": {
@@ -8049,7 +8049,7 @@
     },
     "/api/v1/pro/payments/ru-by/reconcile/{intent_id}": {
       "get": {
-        "description": "Fetch current status of manual payment reconciliation intent.",
+        "description": "Fetch manual payment reconciliation status on a pre-entitlement transport-auth surface.",
         "operationId": "get_manual_payment_intent_status_api_v1_pro_payments_ru_by_reconcile__intent_id__get",
         "parameters": [
           {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -624,7 +624,7 @@ export interface paths {
         put?: never;
         /**
          * Create Manual Payment Intent
-         * @description Create manual RU/BY payment intent with pending reconciliation lifecycle.
+         * @description Create manual RU/BY payment intent on a pre-entitlement transport-auth surface.
          */
         post: operations["create_manual_payment_intent_api_v1_pro_payments_ru_by_manual_intent_post"];
         delete?: never;
@@ -644,7 +644,7 @@ export interface paths {
         put?: never;
         /**
          * Reconcile Manual Payment Intent
-         * @description Apply reconciliation decision to pending manual payment intent.
+         * @description Apply reconciliation decision on a pre-entitlement transport-auth surface.
          */
         post: operations["reconcile_manual_payment_intent_api_v1_pro_payments_ru_by_reconcile_post"];
         delete?: never;
@@ -662,7 +662,7 @@ export interface paths {
         };
         /**
          * Get Manual Payment Intent Status
-         * @description Fetch current status of manual payment reconciliation intent.
+         * @description Fetch manual payment reconciliation status on a pre-entitlement transport-auth surface.
          */
         get: operations["get_manual_payment_intent_status_api_v1_pro_payments_ru_by_reconcile__intent_id__get"];
         put?: never;

--- a/tests/test_api_tiers_db_lookup.py
+++ b/tests/test_api_tiers_db_lookup.py
@@ -106,6 +106,23 @@ def test_lookup_tier_from_db_returns_free_for_non_active_entitlements() -> None:
     assert result.tier == SubscriptionTier.FREE
 
 
+def test_lookup_tier_from_db_returns_free_for_cancelled_entitlement() -> None:
+    """Cancelled persisted entitlements must not unlock protected paid routes."""
+
+    future = datetime.now(timezone.utc) + timedelta(days=14)
+    _persist_subscription(
+        api_key="cancelled-subscription-key",  # pragma: allowlist secret
+        source="ios_app_store",
+        tier="vip",
+        status="cancelled",
+        expires_at=future,
+    )
+
+    result = api_tiers_mod._lookup_tier_from_db("cancelled-subscription-key")
+    assert result.status == DBLookupStatus.HIT
+    assert result.tier == SubscriptionTier.FREE
+
+
 def test_lookup_tier_from_db_parses_free_tier_and_normalizes_aware_expiry() -> None:
     """Aware datetimes must normalize to UTC and a persisted free tier must stay free."""
 

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -182,6 +182,56 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
     monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
     monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+
+    async with app.lifespan(app.app):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_env", ["production", "staging"])
+async def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_env: str,
+) -> None:
+    """Paid-route entitlement mode must fail closed without DB truth in prod/staging."""
+
+    lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
+    monkeypatch.setenv("ENVIRONMENT", runtime_env)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+    monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
+    monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
+    monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+
+    with pytest.raises(RuntimeError, match="SUBSCRIPTION_DB_ENABLED"):
+        async with app.lifespan(app.app):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_env", ["local", "dev", "development", "test", "testing", "ci"])
+async def test_lifespan_allows_subscription_db_disabled_outside_production_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_env: str,
+) -> None:
+    """Local/dev/test-like environments keep non-fatal startup for DB-backed entitlement mode."""
+
+    lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
+    monkeypatch.setenv("ENVIRONMENT", runtime_env)
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+    monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
+    monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+    monkeypatch.delenv("APPLE_SHARED_SECRET", raising=False)
 
     async with app.lifespan(app.app):
         pass

--- a/tests/test_ios_receipt_verification_api.py
+++ b/tests/test_ios_receipt_verification_api.py
@@ -718,6 +718,18 @@ def test_get_app_get_api_key_imports_and_caches_validator(
     assert billing._APP_MODULE is app_module
 
 
+def test_get_effective_app_get_api_key_returns_none_when_validator_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app as app_module
+    from app.routers import billing
+
+    billing._APP_MODULE = None
+    monkeypatch.setattr(app_module, "get_api_key", None, raising=False)
+
+    assert billing._get_effective_app_get_api_key() is None
+
+
 def test_require_billing_transport_key_returns_normalized_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_paid_route_guards.py
+++ b/tests/test_paid_route_guards.py
@@ -272,6 +272,38 @@ def test_pending_manual_review_does_not_unlock_paid_routes(
     assert client.get("/api/v1/vip/health", headers=pro_headers).status_code == 403
 
 
+def test_manual_ru_by_entry_routes_remain_callable_before_entitlement(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    """Manual RU/BY entry routes stay transport-auth accessible before entitlement exists."""
+
+    create_intent = client.post(
+        "/api/v1/pro/payments/ru-by/manual-intent",
+        headers=pro_headers,
+        json={
+            "source": "erip_qr",
+            "plan": "pro_monthly",
+            "client_event_id": "evt-transport-auth-1",
+            "external_txn_id": "erip-transport-auth-1",
+            "amount_minor": 1999,
+            "currency": "BYN",
+        },
+    )
+    assert create_intent.status_code == 201, create_intent.text
+    intent_id = _json(create_intent)["intent_id"]
+
+    status_response = client.get(
+        f"/api/v1/pro/payments/ru-by/reconcile/{intent_id}",
+        headers=pro_headers,
+    )
+    assert status_response.status_code == 200, status_response.text
+    assert _json(status_response)["reconcile_status"] == "pending"
+
+    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
+    assert client.get("/api/v1/vip/health", headers=pro_headers).status_code == 403
+
+
 def test_cancelled_entitlement_does_not_unlock_paid_routes(
     client: TestClient,
     vip_headers: dict[str, str],

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -10,7 +10,8 @@ from tests.payment_test_utils import json_response_payload as _json
 pytestmark = pytest.mark.usefixtures("reset_payments_state")
 
 
-def test_manual_billing_transport_key_rejects_invalid_key_when_subscription_db_mode_is_enabled(
+def test_manual_intent_rejects_invalid_transport_key_behaviorally(
+    client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from app.routers import billing
@@ -19,35 +20,58 @@ def test_manual_billing_transport_key_rejects_invalid_key_when_subscription_db_m
         raise HTTPException(status_code=401, detail="transport key rejected")
 
     monkeypatch.setattr(billing, "_get_app_get_api_key", lambda: _reject_transport_key)
+    response = client.post(
+        "/api/v1/pro/payments/ru-by/manual-intent",
+        headers={"X-API-Key": "bad-key"},
+        json={
+            "source": "erip_qr",
+            "plan": "pro_monthly",
+            "client_event_id": "evt-invalid-transport-key",
+            "external_txn_id": "invalid-transport-key",
+            "amount_minor": 1999,
+            "currency": "BYN",
+        },
+    )
+
+    assert response.status_code == 401, response.text
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["detail"] == "API key required for billing verification"
+
+
+def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_mode(
+    client: TestClient,
+    pro_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app as app_module
+    from app.main import app as canonical_app
+
+    original_override = canonical_app.dependency_overrides.pop(app_module.get_api_key, None)
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
-
-    with pytest.raises(
-        HTTPException, match="API key required for billing verification"
-    ) as exc_info:
-        billing._require_manual_billing_transport_key("pro-key")
-
-    assert exc_info.value.status_code == 401
-
-
-def test_manual_billing_transport_key_rejects_request_when_subscription_db_mode_is_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from app.routers import billing
-
-    def _reject_transport_key(_: str) -> str:
-        raise HTTPException(status_code=401, detail="transport key rejected")
-
-    monkeypatch.setattr(billing, "_get_app_get_api_key", lambda: _reject_transport_key)
-    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("PRO_API_KEYS", pro_headers["X-API-Key"])
 
-    with pytest.raises(
-        HTTPException, match="API key required for billing verification"
-    ) as exc_info:
-        billing._require_manual_billing_transport_key("free-key")
+    try:
+        response = client.post(
+            "/api/v1/pro/payments/ru-by/manual-intent",
+            headers=pro_headers,
+            json={
+                "source": "erip_qr",
+                "plan": "pro_monthly",
+                "client_event_id": "evt-pre-entitlement-db-mode",
+                "external_txn_id": "pre-entitlement-db-mode",
+                "amount_minor": 1999,
+                "currency": "BYN",
+            },
+        )
+    finally:
+        if original_override is not None:
+            canonical_app.dependency_overrides[app_module.get_api_key] = original_override
 
-    assert exc_info.value.status_code == 401
+    assert response.status_code == 201, response.text
+    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
 
 
 def test_manual_intent_happy_path(

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -10,7 +10,7 @@ from tests.payment_test_utils import json_response_payload as _json
 pytestmark = pytest.mark.usefixtures("reset_payments_state")
 
 
-def test_billing_transport_key_falls_back_to_pro_tier(
+def test_manual_billing_transport_key_rejects_invalid_key_when_subscription_db_mode_is_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from app.routers import billing
@@ -19,29 +19,33 @@ def test_billing_transport_key_falls_back_to_pro_tier(
         raise HTTPException(status_code=401, detail="transport key rejected")
 
     monkeypatch.setattr(billing, "_get_app_get_api_key", lambda: _reject_transport_key)
-    monkeypatch.setattr(billing, "require_pro_tier", lambda x_api_key: x_api_key)
-
-    assert billing._require_billing_transport_key("pro-key") == "pro-key"
-
-
-def test_billing_transport_key_rejects_request_without_pro_tier(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from app.routers import billing
-
-    def _reject_transport_key(_: str) -> str:
-        raise HTTPException(status_code=401, detail="transport key rejected")
-
-    def _reject_pro_tier(*, x_api_key: str) -> str:
-        raise HTTPException(status_code=403, detail=f"{x_api_key} is not PRO")
-
-    monkeypatch.setattr(billing, "_get_app_get_api_key", lambda: _reject_transport_key)
-    monkeypatch.setattr(billing, "require_pro_tier", _reject_pro_tier)
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
 
     with pytest.raises(
         HTTPException, match="API key required for billing verification"
     ) as exc_info:
-        billing._require_billing_transport_key("free-key")
+        billing._require_manual_billing_transport_key("pro-key")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_manual_billing_transport_key_rejects_request_when_subscription_db_mode_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import billing
+
+    def _reject_transport_key(_: str) -> str:
+        raise HTTPException(status_code=401, detail="transport key rejected")
+
+    monkeypatch.setattr(billing, "_get_app_get_api_key", lambda: _reject_transport_key)
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+
+    with pytest.raises(
+        HTTPException, match="API key required for billing verification"
+    ) as exc_info:
+        billing._require_manual_billing_transport_key("free-key")
 
     assert exc_info.value.status_code == 401
 

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 import pytest
@@ -39,14 +39,13 @@ def test_manual_intent_rejects_invalid_transport_key_behaviorally(
 
 
 def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_mode(
-    client: TestClient,
+    app: FastAPI,
     pro_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import app as app_module
-    from app.main import app as canonical_app
 
-    original_override = canonical_app.dependency_overrides.pop(app_module.get_api_key, None)
+    original_override = app.dependency_overrides.pop(app_module.get_api_key, None)
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "false")
@@ -54,24 +53,26 @@ def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_
     monkeypatch.setenv("PRO_API_KEYS", pro_headers["X-API-Key"])
 
     try:
-        response = client.post(
-            "/api/v1/pro/payments/ru-by/manual-intent",
-            headers=pro_headers,
-            json={
-                "source": "erip_qr",
-                "plan": "pro_monthly",
-                "client_event_id": "evt-pre-entitlement-db-mode",
-                "external_txn_id": "pre-entitlement-db-mode",
-                "amount_minor": 1999,
-                "currency": "BYN",
-            },
-        )
+        with TestClient(app) as isolated_client:
+            response = isolated_client.post(
+                "/api/v1/pro/payments/ru-by/manual-intent",
+                headers=pro_headers,
+                json={
+                    "source": "erip_qr",
+                    "plan": "pro_monthly",
+                    "client_event_id": "evt-pre-entitlement-db-mode",
+                    "external_txn_id": "pre-entitlement-db-mode",
+                    "amount_minor": 1999,
+                    "currency": "BYN",
+                },
+            )
+            session_response = isolated_client.get("/api/v1/pro/session", headers=pro_headers)
     finally:
         if original_override is not None:
-            canonical_app.dependency_overrides[app_module.get_api_key] = original_override
+            app.dependency_overrides[app_module.get_api_key] = original_override
 
     assert response.status_code == 201, response.text
-    assert client.get("/api/v1/pro/session", headers=pro_headers).status_code == 403
+    assert session_response.status_code == 403
 
 
 def test_manual_intent_happy_path(

--- a/tests/test_pro_vip_route_dependency_guard.py
+++ b/tests/test_pro_vip_route_dependency_guard.py
@@ -8,6 +8,7 @@ from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute
 
 from app.middleware.api_tiers import require_pro_tier, require_vip_tier
+from app.routers.billing import _require_manual_billing_transport_key
 from app.routers.api_key import api_key_header
 
 CANONICAL_PREFIX_GUARD = {
@@ -20,6 +21,12 @@ LEGACY_HTTP_ALIAS_ALLOWLIST = {
 PRE_ENTITLEMENT_ROUTE_ALLOWLIST = {
     ("POST", "/api/v1/pro/payments/activate"): api_key_header,
     ("GET", "/api/v1/pro/payments/activations/{activation_id}"): api_key_header,
+    ("POST", "/api/v1/pro/payments/ru-by/manual-intent"): _require_manual_billing_transport_key,
+    ("POST", "/api/v1/pro/payments/ru-by/reconcile"): _require_manual_billing_transport_key,
+    (
+        "GET",
+        "/api/v1/pro/payments/ru-by/reconcile/{intent_id}",
+    ): _require_manual_billing_transport_key,
 }
 
 
@@ -56,6 +63,26 @@ def _canonical_pro_vip_routes(routes: list[APIRoute]) -> list[APIRoute]:
     return canonical
 
 
+def _dependency_key(call: Callable[..., Any]) -> tuple[str, str]:
+    module_name = getattr(call, "__module__", type(call).__module__)
+    qualified_name = getattr(
+        call,
+        "__qualname__",
+        getattr(call, "__name__", type(call).__name__),
+    )
+    return module_name, qualified_name
+
+
+def _contains_dependency(
+    flattened_calls: list[Callable[..., Any]],
+    expected_dependency: Callable[..., Any],
+) -> bool:
+    if expected_dependency in flattened_calls:
+        return True
+    expected_key = _dependency_key(expected_dependency)
+    return any(_dependency_key(call) == expected_key for call in flattened_calls)
+
+
 def test_canonical_pro_vip_routes_require_expected_tier_dependency(app: FastAPI) -> None:
     routes = _canonical_pro_vip_routes(_load_routes(app))
     missing_guards: list[str] = []
@@ -75,7 +102,7 @@ def test_canonical_pro_vip_routes_require_expected_tier_dependency(app: FastAPI)
             ]
             if matching_allowlist:
                 expected_dependency = matching_allowlist[0]
-                if expected_dependency not in flattened_calls:
+                if not _contains_dependency(flattened_calls, expected_dependency):
                     methods = ",".join(sorted(route.methods))
                     names = ", ".join(
                         getattr(call, "__name__", type(call).__name__) for call in flattened_calls


### PR DESCRIPTION
## Summary

Implement `ledger-p0-billing-entitlement-routing` as a narrow backend authz lane.

This PR closes the `activation -> entitlement -> routing` gap without reopening
Apple verify, activation design, iOS billing flow, or provider-level work.

## Scope

- protected `/api/v1/pro/*` and `/api/v1/vip/*` continue to derive access only from
  persisted backend entitlement/subscription state
- manual RU/BY billing routes remain on existing `/api/v1/pro/payments/ru-by/*` paths
  but are now explicitly pre-entitlement transport-auth surfaces only
- `production` and `staging` fail closed when `SUBSCRIPTION_DB_ENABLED` is disabled
  or unset
- docs and policy are synced to the tightened routing contract
- generated OpenAPI descriptions are refreshed where route descriptions changed

## Non-goals

- no Apple verify redesign
- no activation payload redesign
- no iOS/runtime client changes
- no StoreKit/App Store catalog changes
- no namespace migration for RU/BY routes
- no App Store Server API migration
- no GTM/UI/paywall work

## Key contract decisions

### Protected paid routes
- `/api/v1/pro/*` and `/api/v1/vip/*` are unlocked only by canonical backend
  entitlement/subscription state
- client-declared tier, verify hints, activation attempts, and manual billing entry
  flows are not entitlement truth

### Manual RU/BY carveout
- manual RU/BY routes stay callable before entitlement exists
- they are transport-auth-only surfaces
- they are not tier-gated
- they do not unlock protected PRO/VIP content surfaces

### Startup fail-closed
- `production` and `staging` require `SUBSCRIPTION_DB_ENABLED=true`
- startup raises before serving traffic if billing entitlement DB mode is disabled
  or blank in production-like environments

## Touched files

### Runtime
- `app/middleware/api_tiers.py`
- `app/bootstrap/startup_guards.py`
- `app/routers/billing.py`

### Tests
- `tests/test_api_tiers_db_lookup.py`
- `tests/test_paid_route_guards.py`
- `tests/test_pro_vip_route_dependency_guard.py`
- `tests/test_app_lifespan_additional.py`
- `tests/test_payment_source_contract_api.py`
- `tests/test_ios_receipt_verification_api.py`

### Docs / policy / generated contract
- `docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md`
- `AGENTS.md`
- `frontend/src/api/openapi.json`
- `frontend/src/api/schema.ts`

## Validation

Passed locally:
- `pytest -q tests/test_api_tiers_db_lookup.py tests/test_paid_route_guards.py tests/test_pro_vip_route_dependency_guard.py tests/test_app_lifespan_additional.py tests/test_payment_source_contract_api.py`
- `pytest -q tests/test_ios_receipt_verification_api.py -k 'invalid_api_key or translates_http_exception_to_401 or get_effective_app_get_api_key_returns_none_when_validator_missing'`
- `pre-commit run --all-files`
- `make verify`

Diff coverage for changed runtime files is 100%.

## DoD

- protected paid routes derive access only from backend entitlement state
- prod/staging fail closed when DB-backed entitlement mode is misconfigured
- manual RU/BY rails remain pre-entitlement but require validated transport auth
- manual billing flows do not unlock PRO/VIP protected surfaces
- docs and policy reflect the tightened contract
- review threads are fully dispositioned before merge

## Security Notes

This PR is access-control hardening.

Most important change:
- the manual RU/BY pre-entitlement carveout no longer permits arbitrary non-empty
  keys in DB-backed mode
- fallback access is limited to validated transport auth for manual RU/BY routes only
- strict auth remains in place for Apple verify and protected paid surfaces

## Summary by Sourcery

Обеспечить использование основанного на БД механизма прав доступа (entitlement) как единственного источника истины для доступа к защищённым PRO/VIP-маршрутам, при этом сохранив ручные биллинговые потоки для RU/BY как пре-entitlement‑поверхности, защищённые только транспортной аутентификацией, и добавить защиту при запуске в продакшене, требующую режим подписки через БД.

Bug Fixes:
- Рассматривать отменённые сохранённые подписки как бесплатный тариф, чтобы они больше не открывали доступ к защищённым платным маршрутам.

Enhancements:
- Ужесточить проверку транспортного ключа биллинга, убрав резервный путь, основанный на тарифе, введя переиспользуемый helper-валидатор и пропустив RU/BY ручные биллинговые маршруты через выделенную зависимость транспортной аутентификации, которая учитывает переопределения зависимостей FastAPI.
- Добавить защиту при старте, которая в продакшен-подобных окружениях приводит к отказу по умолчанию, если режим подписки, основанный на БД, отключён или неправильно сконфигурирован, при этом остаётся нефатальной в локальном/dev/test окружениях.
- Прояснить в логике разрешения прав (entitlement resolution), что при включённом режиме подписки, основанной на БД, только сохранённое состояние подписки может открывать платные маршруты, а ручные биллинговые потоки не могут предоставлять PRO/VIP-доступ.
- Расширить тесты охранных маршрутов (route guards), чтобы проверять, что RU/BY ручные биллинговые маршруты остаются пре-entitlement‑поверхностями с транспортной аутентификацией и что канонические PRO/VIP-маршруты последовательно защищены ожидаемыми зависимостями.

Documentation:
- Задокументировать carveout для RU/BY как пре-entitlement‑поверхности с транспортной аутентификацией и требование, чтобы эти маршруты никогда не открывали PRO/VIP-контент, а также добавить инвариант «Billing Entitlement Routing» в документацию по политикам агентов; обновить OpenAPI-описания для ручных RU/BY биллинговых эндпойнтов.

Tests:
- Добавить тесты для отказа при старте в продакшен-подобных окружениях при отключённом режиме подписки через БД, разрешающего поведения в непроизводственных окружениях, ручного RU/BY-доступа до entitlement без открытия платных маршрутов, строгой обработки отменённых прав (entitlements) и helper-утилиты для проверки поведения API-ключа на уровне приложения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce DB-backed entitlement as the sole authority for accessing protected PRO/VIP routes while keeping RU/BY manual billing paths as pre-entitlement, strictly transport-authenticated surfaces, and add production startup guards to require subscription DB mode.

Bug Fixes:
- Treat cancelled persisted subscriptions as free tier so they no longer unlock protected paid routes.

Enhancements:
- Harden billing transport-key validation by removing tier-based fallback, introducing a reusable validator helper, and wiring RU/BY manual billing routes through a dedicated transport-auth dependency that honors FastAPI dependency overrides.
- Add a startup guard that fails closed in production-like environments when DB-backed subscription mode is disabled or misconfigured, while remaining non-fatal in local/dev/test environments.
- Clarify in entitlement resolution that, when DB-backed subscription mode is enabled, only persisted subscription state may unlock paid routes and manual billing flows cannot grant PRO/VIP access.
- Extend route guard tests to assert that RU/BY manual billing routes remain pre-entitlement transport-auth surfaces and that canonical PRO/VIP routes are consistently protected by the expected dependencies.

Documentation:
- Document the RU/BY pre-entitlement transport-auth carveout and the requirement that these routes never unlock PRO/VIP content, and add a Billing Entitlement Routing invariant to agent policy docs; refresh OpenAPI descriptions for manual RU/BY billing endpoints.

Tests:
- Add tests for production-like startup failure when subscription DB mode is disabled, permissive behavior in non-production environments, RU/BY manual access before entitlement without unlocking paid routes, strict handling of cancelled entitlements, and helpers for validating app-level API key behavior.

</details>

Исправления ошибок:
- Гарантировать, что отменённые сохранённые подписки больше не открывают доступ к защищённым платным маршрутам и рассматриваются как уровень free tier при поиске entitlements в режиме подписок на базе БД.

Улучшения:
- Укрепить проверку транспортных ключей биллинга, убрав запасной вариант с проверкой уровней (tier checks) и введя выделенную зависимость для ручного биллинга по транспортному ключу, которая поддерживает переопределения во время тестирования.
- Добавить проверку при запуске в production/staging, которая быстро завершает процесс при отключённом или неправильно сконфигурированном режиме подписок на базе БД, при этом позволяя нефатальное поведение в локальной/dev/test‑средах.
- Прояснить, что состояние подписки в БД является единственным источником истины для открытия платных маршрутов при включённом режиме подписок в БД и что ручные биллинговые потоки не могут предоставлять доступ уровня PRO/VIP.
- Расширить тесты охранных зависимостей маршрутов (route dependency guard), чтобы обеспечить, что RU/BY‑маршруты ручного биллинга остаются pre-entitlement поверхностями с использованием новой зависимости transport-auth.

Документация:
- Задокументировать RU/BY‑исключение для ручных pre-entitlement‑маршрутов и требование, чтобы эти маршруты использовали валидированную транспортную аутентификацию без открытия PRO/VIP‑контента, а также обновить политику для агентов и сгенерированные описания OpenAPI соответствующим образом.

Тесты:
- Добавить тесты, покрывающие продоподобный отказ при запуске, когда БД подписок отключена; нефатальное поведение в непроизводственных средах; ручной RU/BY‑доступ до выдачи entitlements без открытия платных маршрутов; строгую обработку отменённых entitlements при запросах к БД; а также новые помощники (helpers) для эффективной валидации API‑ключей на уровне приложения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Обеспечить использование основанного на БД механизма прав доступа (entitlement) как единственного источника истины для доступа к защищённым PRO/VIP-маршрутам, при этом сохранив ручные биллинговые потоки для RU/BY как пре-entitlement‑поверхности, защищённые только транспортной аутентификацией, и добавить защиту при запуске в продакшене, требующую режим подписки через БД.

Bug Fixes:
- Рассматривать отменённые сохранённые подписки как бесплатный тариф, чтобы они больше не открывали доступ к защищённым платным маршрутам.

Enhancements:
- Ужесточить проверку транспортного ключа биллинга, убрав резервный путь, основанный на тарифе, введя переиспользуемый helper-валидатор и пропустив RU/BY ручные биллинговые маршруты через выделенную зависимость транспортной аутентификации, которая учитывает переопределения зависимостей FastAPI.
- Добавить защиту при старте, которая в продакшен-подобных окружениях приводит к отказу по умолчанию, если режим подписки, основанный на БД, отключён или неправильно сконфигурирован, при этом остаётся нефатальной в локальном/dev/test окружениях.
- Прояснить в логике разрешения прав (entitlement resolution), что при включённом режиме подписки, основанной на БД, только сохранённое состояние подписки может открывать платные маршруты, а ручные биллинговые потоки не могут предоставлять PRO/VIP-доступ.
- Расширить тесты охранных маршрутов (route guards), чтобы проверять, что RU/BY ручные биллинговые маршруты остаются пре-entitlement‑поверхностями с транспортной аутентификацией и что канонические PRO/VIP-маршруты последовательно защищены ожидаемыми зависимостями.

Documentation:
- Задокументировать carveout для RU/BY как пре-entitlement‑поверхности с транспортной аутентификацией и требование, чтобы эти маршруты никогда не открывали PRO/VIP-контент, а также добавить инвариант «Billing Entitlement Routing» в документацию по политикам агентов; обновить OpenAPI-описания для ручных RU/BY биллинговых эндпойнтов.

Tests:
- Добавить тесты для отказа при старте в продакшен-подобных окружениях при отключённом режиме подписки через БД, разрешающего поведения в непроизводственных окружениях, ручного RU/BY-доступа до entitlement без открытия платных маршрутов, строгой обработки отменённых прав (entitlements) и helper-утилиты для проверки поведения API-ключа на уровне приложения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce DB-backed entitlement as the sole authority for accessing protected PRO/VIP routes while keeping RU/BY manual billing paths as pre-entitlement, strictly transport-authenticated surfaces, and add production startup guards to require subscription DB mode.

Bug Fixes:
- Treat cancelled persisted subscriptions as free tier so they no longer unlock protected paid routes.

Enhancements:
- Harden billing transport-key validation by removing tier-based fallback, introducing a reusable validator helper, and wiring RU/BY manual billing routes through a dedicated transport-auth dependency that honors FastAPI dependency overrides.
- Add a startup guard that fails closed in production-like environments when DB-backed subscription mode is disabled or misconfigured, while remaining non-fatal in local/dev/test environments.
- Clarify in entitlement resolution that, when DB-backed subscription mode is enabled, only persisted subscription state may unlock paid routes and manual billing flows cannot grant PRO/VIP access.
- Extend route guard tests to assert that RU/BY manual billing routes remain pre-entitlement transport-auth surfaces and that canonical PRO/VIP routes are consistently protected by the expected dependencies.

Documentation:
- Document the RU/BY pre-entitlement transport-auth carveout and the requirement that these routes never unlock PRO/VIP content, and add a Billing Entitlement Routing invariant to agent policy docs; refresh OpenAPI descriptions for manual RU/BY billing endpoints.

Tests:
- Add tests for production-like startup failure when subscription DB mode is disabled, permissive behavior in non-production environments, RU/BY manual access before entitlement without unlocking paid routes, strict handling of cancelled entitlements, and helpers for validating app-level API key behavior.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce entitlement-backed auth for all `PRO`/`VIP` routes and keep RU/BY manual billing as pre‑entitlement, strictly transport‑auth paths. Cancelled subscriptions now resolve to FREE and never unlock paid routes.

- **Migration**
  - Set `SUBSCRIPTION_DB_ENABLED=true` in production and staging; startup now fails closed without it (Compose/CI updated to pass this).
  - RU/BY manual routes use a dedicated transport‑auth dependency with a strict app‑level validator that honors FastAPI overrides and never unlocks `PRO`/`VIP` content.

<sup>Written for commit 6d02ed251030067be1f0fd91a97837d8743c33b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1192_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified RU/BY manual payment routes are pre-entitlement transport-auth surfaces and cannot unlock PRO/VIP content.
  * Updated OpenAPI and docs to reflect pre-entitlement behavior and stronger billing entitlement wording.

* **Bug Fixes**
  * DB-backed entitlement mode is fail-closed for MISS/ERROR/INVALID_TIER; protected paid routes rely only on canonical backend subscription state.
  * Startup now fails in production-like environments when DB-backed entitlement mode is required but disabled.

* **Chores**
  * Added SUBSCRIPTION_DB_ENABLED to env examples and compose configs.

* **Tests**
  * Added/updated tests covering DB entitlement lookups, startup guards, and RU/BY manual-route behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->