### PR TITLE
feat(rag): make stage-4 contradiction checks query-aware

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,8 @@
     "ms-python.debugpy",
     "charliermarsh.ruff",
     "Webnative.webnative",
-    "ms-azuretools.vscode-docker"
+    "ms-azuretools.vscode-docker",
+    "openai.chatgpt"
   ],
   "unwantedRecommendations": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,8 +8,7 @@
     "ms-python.debugpy",
     "charliermarsh.ruff",
     "Webnative.webnative",
-    "ms-azuretools.vscode-docker",
-    "openai.chatgpt"
+    "ms-azuretools.vscode-docker"
   ],
   "unwantedRecommendations": []
 }

--- a/core/rag/philosophy_pipeline.py
+++ b/core/rag/philosophy_pipeline.py
@@ -103,7 +103,7 @@ _SPECULATION_RE = re.compile(
 _NUMERIC_RANGE_RE = re.compile(
     r"(\d+\.?\d*)\s*[-\u2013]\s*(\d+\.?\d*)",
 )
-_TOKEN_RE = re.compile(r"\b[^\W\d_]{2,}\b", re.UNICODE)
+_TOKEN_RE = re.compile(r"\b[^\W\d_][\w-]*\b", re.UNICODE)
 
 _QUERY_STOPWORDS = frozenset(
     {
@@ -438,12 +438,13 @@ def _stage4_logical_consistency(
     # Check 2: Contradictory numeric ranges
     chunk_ranges: list[tuple[str, tuple[float, float], set[str]]] = []
     for chunk in chunks:
+        anchors = _extract_query_anchors(chunk.content, query_terms)
         for r in _extract_numeric_ranges(chunk.content):
             chunk_ranges.append(
                 (
                     chunk.chunk_id,
                     r,
-                    _extract_query_anchors(chunk.content, query_terms),
+                    anchors,
                 )
             )
 

--- a/core/rag/philosophy_pipeline.py
+++ b/core/rag/philosophy_pipeline.py
@@ -103,6 +103,57 @@ _SPECULATION_RE = re.compile(
 _NUMERIC_RANGE_RE = re.compile(
     r"(\d+\.?\d*)\s*[-\u2013]\s*(\d+\.?\d*)",
 )
+_TOKEN_RE = re.compile(r"\b[^\W\d_]{2,}\b", re.UNICODE)
+
+_QUERY_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "adult",
+        "adults",
+        "be",
+        "best",
+        "child",
+        "children",
+        "daily",
+        "female",
+        "for",
+        "good",
+        "healthy",
+        "how",
+        "ideal",
+        "in",
+        "is",
+        "level",
+        "levels",
+        "many",
+        "male",
+        "meal",
+        "meals",
+        "men",
+        "normal",
+        "of",
+        "per",
+        "people",
+        "person",
+        "practical",
+        "range",
+        "ranges",
+        "recommended",
+        "should",
+        "target",
+        "targets",
+        "the",
+        "to",
+        "value",
+        "values",
+        "what",
+        "with",
+        "women",
+    }
+)
 
 # Stage 3: Alignment thresholds
 # These thresholds detect score-vs-content quality mismatches.
@@ -339,9 +390,27 @@ def _ranges_contradict(a: tuple[float, float], b: tuple[float, float]) -> bool:
     return a[1] < b[0] or b[1] < a[0]
 
 
+def _extract_query_terms(query: str) -> set[str]:
+    """Return significant query anchors for query-aware contradiction checks."""
+    return {
+        token.lower()
+        for token in _TOKEN_RE.findall(query)
+        if len(token) >= 2 and token.lower() not in _QUERY_STOPWORDS
+    }
+
+
+def _extract_query_anchors(text: str, query_terms: set[str]) -> set[str]:
+    """Return query terms that are explicitly present in chunk-local text."""
+    if not query_terms:
+        return set()
+
+    text_terms = {token.lower() for token in _TOKEN_RE.findall(text)}
+    return text_terms & query_terms
+
+
 def _stage4_logical_consistency(
     chunks: list[RAGChunk],
-    query: str,  # noqa: ARG001 - reserved for future semantic contradiction detection
+    query: str,
 ) -> StageResult:
     """Detect contradictory numeric claims and single-source echo.
 
@@ -350,13 +419,12 @@ def _stage4_logical_consistency(
     chunks:
         Filtered chunks to check for consistency.
     query:
-        Original user query (reserved for future query-aware contradiction
-        detection, e.g. flagging when query asks about X but chunks contradict on X).
+        Original user query used to anchor contradiction checks to the active topic.
     """
-    _ = query  # Silence unused-variable linters; see docstring for rationale
     start = time.perf_counter()
     warnings: list[str] = []
     metadata: dict[str, Any] = {}
+    query_terms = _extract_query_terms(query)
 
     # Check 1: Single-source echo
     if len(chunks) > 1:
@@ -368,15 +436,22 @@ def _stage4_logical_consistency(
             )
 
     # Check 2: Contradictory numeric ranges
-    chunk_ranges: list[tuple[str, tuple[float, float]]] = []
+    chunk_ranges: list[tuple[str, tuple[float, float], set[str]]] = []
     for chunk in chunks:
         for r in _extract_numeric_ranges(chunk.content):
-            chunk_ranges.append((chunk.chunk_id, r))
+            chunk_ranges.append(
+                (
+                    chunk.chunk_id,
+                    r,
+                    _extract_query_anchors(chunk.content, query_terms),
+                )
+            )
 
     contradictions: list[str] = []
-    for i, (id_a, range_a) in enumerate(chunk_ranges):
-        for id_b, range_b in chunk_ranges[i + 1 :]:
-            if id_a != id_b and _ranges_contradict(range_a, range_b):
+    for i, (id_a, range_a, anchors_a) in enumerate(chunk_ranges):
+        for id_b, range_b, anchors_b in chunk_ranges[i + 1 :]:
+            shared_query_anchors = anchors_a & anchors_b
+            if id_a != id_b and shared_query_anchors and _ranges_contradict(range_a, range_b):
                 contradictions.append(
                     f"{id_a}({range_a[0]}-{range_a[1]}) vs {id_b}({range_b[0]}-{range_b[1]})"
                 )

--- a/core/rag/philosophy_pipeline.py
+++ b/core/rag/philosophy_pipeline.py
@@ -105,6 +105,8 @@ _NUMERIC_RANGE_RE = re.compile(
 )
 _TOKEN_RE = re.compile(r"\b[^\W\d_][\w-]*\b", re.UNICODE)
 
+# Audience/cadence words stay non-binding on purpose: they tend to create
+# false contradictions across different metrics that happen to share a cohort.
 _QUERY_STOPWORDS = frozenset(
     {
         "a",
@@ -154,6 +156,8 @@ _QUERY_STOPWORDS = frozenset(
         "women",
     }
 )
+_RANGE_ANCHOR_PREFIX_CHARS = 24
+_RANGE_ANCHOR_SUFFIX_CHARS = 12
 
 # Stage 3: Alignment thresholds
 # These thresholds detect score-vs-content quality mismatches.
@@ -408,6 +412,39 @@ def _extract_query_anchors(text: str, query_terms: set[str]) -> set[str]:
     return text_terms & query_terms
 
 
+def _extract_anchored_numeric_ranges(
+    text: str,
+    query_terms: set[str],
+) -> list[tuple[tuple[float, float], set[str]]]:
+    """Extract numeric ranges together with query anchors near each range.
+
+    Using range-local context prevents one topic inside a mixed chunk from
+    lending its anchor to unrelated numeric ranges later in the paragraph.
+    """
+    anchored_ranges: list[tuple[tuple[float, float], set[str]]] = []
+    for match in _NUMERIC_RANGE_RE.finditer(text):
+        try:
+            low = float(match.group(1))
+            high = float(match.group(2))
+        except ValueError:  # pragma: no cover - defensive; regex ensures valid floats
+            continue
+
+        if low >= high:
+            continue
+
+        context_start = max(0, match.start() - _RANGE_ANCHOR_PREFIX_CHARS)
+        context_end = min(len(text), match.end() + _RANGE_ANCHOR_SUFFIX_CHARS)
+        context = text[context_start:context_end]
+        anchored_ranges.append(
+            (
+                (low, high),
+                _extract_query_anchors(context, query_terms),
+            )
+        )
+
+    return anchored_ranges
+
+
 def _stage4_logical_consistency(
     chunks: list[RAGChunk],
     query: str,
@@ -438,8 +475,7 @@ def _stage4_logical_consistency(
     # Check 2: Contradictory numeric ranges
     chunk_ranges: list[tuple[str, tuple[float, float], set[str]]] = []
     for chunk in chunks:
-        anchors = _extract_query_anchors(chunk.content, query_terms)
-        for r in _extract_numeric_ranges(chunk.content):
+        for r, anchors in _extract_anchored_numeric_ranges(chunk.content, query_terms):
             chunk_ranges.append(
                 (
                     chunk.chunk_id,

--- a/docs/review/PR_1195_FIXED_MAPPING.md
+++ b/docs/review/PR_1195_FIXED_MAPPING.md
@@ -11,6 +11,7 @@ Evidence: Aggregate bot review records are roll-up comments only; their actionab
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981300665
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981313064
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981327585
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981358403
 
 Disposition: FIXED
 Commit: 6d0b35cd

--- a/docs/review/PR_1195_FIXED_MAPPING.md
+++ b/docs/review/PR_1195_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1195 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No actionable review threads or bot comments are mapped yet.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/docs/review/PR_1195_FIXED_MAPPING.md
+++ b/docs/review/PR_1195_FIXED_MAPPING.md
@@ -1,15 +1,40 @@
 # PR 1195 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-## Fixed in Commit Mapping
+### Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: Aggregate bot review records are roll-up comments only; their actionable items are dispositioned individually below in this artifact.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981300665
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981313064
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981327585
 
 Disposition: FIXED
 Commit: 6d0b35cd
-Evidence: `core/rag/philosophy_pipeline.py` now preserves Unicode and mixed health tokens such as `A1C` and `LDL-C` in query anchors, reuses per-chunk anchors instead of recomputing them per numeric range, and `tests/test_philosophy_pipeline.py` adds a regression that asserts alphanumeric medical token extraction.
+Evidence: `core/rag/philosophy_pipeline.py:106-160` preserves Unicode and mixed health tokens such as `A1C` and `LDL-C`, and `tests/test_philosophy_pipeline.py:297-301` asserts alphanumeric medical token extraction.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#issuecomment-4097730775 -> 6d0b35cd
+
+Disposition: FIXED
+Commit: 7db0cd50
+Evidence: `core/rag/philosophy_pipeline.py:415-445` now extracts anchors per numeric range using range-local context, `core/rag/philosophy_pipeline.py:475-491` compares contradictions with those range-local anchors, and `tests/test_philosophy_pipeline.py:322-330,420-442` cover multi-topic chunk suppression and `B12` contradiction detection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965562418 -> 7db0cd50
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573190 -> 7db0cd50
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573907 -> 7db0cd50
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573913 -> 7db0cd50
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965587728 -> 7db0cd50
+
+Disposition: NOT-A-BUG
+Evidence: `core/rag/philosophy_pipeline.py:108-160` intentionally keeps audience/cadence terms non-binding, and `tests/test_philosophy_pipeline.py:397-432` proves cohort-only overlap would reintroduce false contradictions across different metrics.
+Reason: C2 ambiguity policy prefers suppressing contradiction when only demographic or cadence language overlaps.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965587721
+
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md:2866
+Reason: Long-form to acronym normalization (for example `body mass index` -> `BMI`) needs an explicit synonym/alias layer and is outside narrow C2 follow-through.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573196
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1195_FIXED_MAPPING.md
+++ b/docs/review/PR_1195_FIXED_MAPPING.md
@@ -6,7 +6,10 @@
 
 ## Fixed in Commit Mapping
 
-No actionable review threads or bot comments are mapped yet.
+Disposition: FIXED
+Commit: 6d0b35cd
+Evidence: `core/rag/philosophy_pipeline.py` now preserves Unicode and mixed health tokens such as `A1C` and `LDL-C` in query anchors, reuses per-chunk anchors instead of recomputing them per numeric range, and `tests/test_philosophy_pipeline.py` adds a regression that asserts alphanumeric medical token extraction.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#issuecomment-4097730775 -> 6d0b35cd
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1195_FIXED_MAPPING.md
+++ b/docs/review/PR_1195_FIXED_MAPPING.md
@@ -37,6 +37,12 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md:2866
 Reason: Long-form to acronym normalization (for example `body mass index` -> `BMI`) needs an explicit synonym/alias layer and is outside narrow C2 follow-through.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573196
 
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-rag-stage4-anchor-specificity
+Reason: Topic-binding specificity for broad anchors such as `vitamin` or `protein` is a follow-up refinement. The current C2 implementation intentionally preserves valid single-anchor contradictions for narrow queries such as `BMI`, `BP`, and `B12`, so tightening the overlap rule needs a separate design pass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965794257
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981560445
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2881,6 +2881,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Reliability fields (`verification_state`, `confidence`) remain backward-compatible
 
 
+<a id="ledger-p2-rag-stage4-anchor-specificity"></a>
+- [ ] P2: Stage-4 anchor specificity for broad medical tokens
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (quality refinement)
+  - Target PR: PR-TBD-RAG-STAGE4-ANCHOR-SPECIFICITY
+  - Status: 📋 Planned
+  - Reason: Current Stage-4 contradiction binding treats any shared query anchor as sufficient. That is intentional for narrow acronym-style queries (`BMI`, `BP`, `B12`) but may still be too permissive for broad lexical anchors such as `vitamin` or `protein`, especially when cohort qualifiers are intentionally non-binding. The next refinement should separate specific-topic anchors from broad-topic anchors without regressing valid single-anchor contradiction detection.
+  - Links:
+    - `core/rag/philosophy_pipeline.py`
+    - `tests/test_philosophy_pipeline.py`
+    - `docs/contracts/RAG_CONTRACT.md`
+    - `docs/insights/PHILOSOPHICAL_LOGIC_LLM_RELIABILITY.md`
+  - DoD:
+    - Stage-4 distinguishes broad-topic anchors from specific-topic anchors deterministically
+    - Regression tests cover `vitamin D` vs `vitamin B12` and cohort-specific `protein` cases
+    - Existing valid single-anchor contradiction cases (`BMI`, `BP`, `B12`) remain green
+
+
 <a id="ledger-p2-wellness-explainers-learning-cycles"></a>
 - [ ] P2: Wellness Explainers + Learning Cycles MVP (rules-first, trust-first)
   - Owner: @katsiaryna_kavaleuskaya

--- a/tests/test_philosophy_pipeline.py
+++ b/tests/test_philosophy_pipeline.py
@@ -293,6 +293,12 @@ class TestQueryAwareAnchors:
 
         assert "bp" in query_terms
 
+    def test_extract_query_terms_keeps_alphanumeric_medical_tokens(self) -> None:
+        query_terms = _extract_query_terms("A1C and LDL-C targets")
+
+        assert "a1c" in query_terms
+        assert "ldl-c" in query_terms
+
     def test_extract_query_terms_supports_unicode_letters(self) -> None:
         query_terms = _extract_query_terms("Índice BMI y presión")
 

--- a/tests/test_philosophy_pipeline.py
+++ b/tests/test_philosophy_pipeline.py
@@ -19,6 +19,7 @@ from core.rag.philosophy_pipeline import (
     ClaimType,
     PipelineResult,
     _alignment_score,
+    _extract_anchored_numeric_ranges,
     _extract_numeric_ranges,
     _extract_query_anchors,
     _extract_query_terms,
@@ -299,6 +300,11 @@ class TestQueryAwareAnchors:
         assert "a1c" in query_terms
         assert "ldl-c" in query_terms
 
+    def test_extract_query_terms_keeps_alphanumeric_nutrition_tokens(self) -> None:
+        query_terms = _extract_query_terms("What B12 range is normal?")
+
+        assert "b12" in query_terms
+
     def test_extract_query_terms_supports_unicode_letters(self) -> None:
         query_terms = _extract_query_terms("Índice BMI y presión")
 
@@ -312,6 +318,23 @@ class TestQueryAwareAnchors:
 
         assert "bmi" in anchors
         assert "range" not in anchors
+
+    def test_extract_anchored_numeric_ranges_binds_anchors_per_range(self) -> None:
+        query_terms = _extract_query_terms("What is the BMI range?")
+        anchored_ranges = _extract_anchored_numeric_ranges(
+            "Healthy BMI is 18.5-24.9 and protein intake is 30-40 grams per meal.",
+            query_terms,
+        )
+
+        assert anchored_ranges[0] == ((18.5, 24.9), {"bmi"})
+        assert anchored_ranges[1] == ((30.0, 40.0), set())
+
+    def test_extract_anchored_numeric_ranges_skips_reversed_ranges(self) -> None:
+        query_terms = _extract_query_terms("What BMI range is normal?")
+
+        anchored_ranges = _extract_anchored_numeric_ranges("BMI 30-10 is invalid.", query_terms)
+
+        assert anchored_ranges == []
 
 
 class TestStage4LogicalConsistency:
@@ -400,6 +423,30 @@ class TestStage4LogicalConsistency:
 
         assert not any("numeric_contradiction" in w for w in result.warnings)
         assert "contradictions" not in result.metadata
+
+    def test_contradiction_suppressed_for_irrelevant_range_inside_multi_topic_chunk(self) -> None:
+        chunks = [
+            _chunk(
+                "c1",
+                "Healthy BMI is 18.5-24.9 and protein intake is 30-40 grams per meal.",
+                0.9,
+            ),
+            _chunk("c2", "Normal BMI range is 20-22 for adults.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "What is the BMI range for adults?")
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+        assert "contradictions" not in result.metadata
+
+    def test_contradictory_numeric_ranges_detected_for_b12_query(self) -> None:
+        chunks = [
+            _chunk("c1", "Normal B12 range is 200-900 for adults.", 0.9),
+            _chunk("c2", "Normal B12 range is 1000-1400 for adults.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "What B12 range is normal?")
+
+        assert any("numeric_contradiction" in w for w in result.warnings)
+        assert len(result.metadata["contradictions"]) >= 1
 
     def test_no_contradictions_consistent_ranges(self) -> None:
         chunks = [

--- a/tests/test_philosophy_pipeline.py
+++ b/tests/test_philosophy_pipeline.py
@@ -20,6 +20,8 @@ from core.rag.philosophy_pipeline import (
     PipelineResult,
     _alignment_score,
     _extract_numeric_ranges,
+    _extract_query_anchors,
+    _extract_query_terms,
     _ranges_contradict,
     _stage1_rule_validation,
     _stage2_claim_classification,
@@ -278,6 +280,34 @@ class TestNumericRangeExtraction:
         assert _ranges_contradict((10.0, 20.0), (20.0, 30.0)) is False
 
 
+class TestQueryAwareAnchors:
+    """Stage 4 query anchors suppress ambiguity before contradiction warnings."""
+
+    def test_extract_query_terms_drops_generic_tokens(self) -> None:
+        query_terms = _extract_query_terms("What is a healthy normal range?")
+
+        assert query_terms == set()
+
+    def test_extract_query_terms_keeps_two_letter_domain_acronyms(self) -> None:
+        query_terms = _extract_query_terms("What BP range is normal?")
+
+        assert "bp" in query_terms
+
+    def test_extract_query_terms_supports_unicode_letters(self) -> None:
+        query_terms = _extract_query_terms("Índice BMI y presión")
+
+        assert "índice" in query_terms
+        assert "presión" in query_terms
+
+    def test_extract_query_anchors_returns_topic_specific_terms(self) -> None:
+        query_terms = _extract_query_terms("What is the BMI range for adults?")
+
+        anchors = _extract_query_anchors("Healthy BMI is 18.5-24.9 for adults.", query_terms)
+
+        assert "bmi" in anchors
+        assert "range" not in anchors
+
+
 class TestStage4LogicalConsistency:
     """Stage 4 detects contradictions and single-source echo."""
 
@@ -311,6 +341,59 @@ class TestStage4LogicalConsistency:
 
         assert any("numeric_contradiction" in w for w in result.warnings)
         assert len(result.metadata["contradictions"]) >= 1
+
+    def test_contradictory_numeric_ranges_detected_for_two_letter_acronym_query(self) -> None:
+        chunks = [
+            _chunk("c1", "Normal BP range is 90-120 for adults.", 0.9),
+            _chunk("c2", "Normal BP range is 140-180 for adults.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "What BP range is normal?")
+
+        assert any("numeric_contradiction" in w for w in result.warnings)
+        assert len(result.metadata["contradictions"]) >= 1
+
+    def test_contradiction_suppressed_when_query_targets_other_topic(self) -> None:
+        chunks = [
+            _chunk("c1", "Healthy BMI is 18.5-24.9 for adults.", 0.9),
+            _chunk("c2", "Normal BMI range is 30-40 in this system.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "protein intake query")
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+        assert "contradictions" not in result.metadata
+
+    def test_contradiction_suppressed_when_query_binding_is_ambiguous(self) -> None:
+        chunks = [
+            _chunk("c1", "Healthy BMI is 18.5-24.9 for adults.", 0.9),
+            _chunk("c2", "Normal BMI range is 30-40 in this system.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "What is a normal healthy range?")
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+        assert "contradictions" not in result.metadata
+
+    def test_contradiction_suppressed_for_mixed_topic_query(self) -> None:
+        chunks = [
+            _chunk("c1", "Healthy BMI is 18.5-24.9 for adults.", 0.9),
+            _chunk("c2", "Normal blood pressure range is 140-180 for adults.", 0.8),
+        ]
+        result = _stage4_logical_consistency(
+            chunks,
+            "What BMI and blood pressure ranges are normal for adults?",
+        )
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+        assert "contradictions" not in result.metadata
+
+    def test_contradiction_suppressed_for_same_audience_different_metric(self) -> None:
+        chunks = [
+            _chunk("c1", "Healthy BMI is 18.5-24.9 for adults.", 0.9),
+            _chunk("c2", "Protein intake is 30-40 grams per meal for adults.", 0.8),
+        ]
+        result = _stage4_logical_consistency(chunks, "What is the BMI range for adults?")
+
+        assert not any("numeric_contradiction" in w for w in result.warnings)
+        assert "contradictions" not in result.metadata
 
     def test_no_contradictions_consistent_ranges(self) -> None:
         chunks = [

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -583,6 +583,41 @@ class TestRetrieveAndValidateRag:
         assert "claim_speculation" in result.warnings[1]
 
     @pytest.mark.asyncio
+    async def test_ambiguity_suppression_keeps_output_chunks_and_confidence(self) -> None:
+        """Ambiguous Stage-4 contradiction checks must not alter output chunk confidence."""
+        chunks = [
+            _make_chunk("c1", content="Healthy BMI is 18.5-24.9 for adults.", score=0.9),
+            _make_chunk("c2", content="Normal BMI range is 30-40 in this system.", score=0.8),
+        ]
+        rag_ctx = _make_rag_context(chunks=chunks, confidence=0.42)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1\nChunk2",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1\nChunk2",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "What is a normal healthy range?",
+                philo_validation_enabled=True,
+            )
+
+        assert result.rag_actually_used is True
+        assert len(result.chunks) == 2
+        assert result.confidence == 0.85
+        assert not any("numeric_contradiction" in warning for warning in result.warnings)
+
+    @pytest.mark.asyncio
     async def test_failsafe_on_exception_returns_empty(self) -> None:
         """On any exception, returns empty result (fail-safe)."""
         with patch(


### PR DESCRIPTION
## Summary
- make Stage 4 contradiction detection query-aware in `core/rag/philosophy_pipeline.py`
- suppress contradictions when query binding is ambiguous instead of falling back to a global scan
- bind query anchors to each numeric range so mixed-topic chunks do not leak anchors across unrelated ranges
- preserve advisory-only `single_source_echo` semantics and downstream confidence/response compatibility

## Validation
- `pytest -q tests/test_philosophy_pipeline.py tests/test_philosophy_validation_integration.py tests/test_rag_orchestration.py tests/test_insight_rag_response_fields.py`
- `pre-commit run --all-files`
- `make verify`

## Scope
- narrow C2 follow-through in `core/rag/*` only
- no public API expansion
- no `validation.py` rewrite

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1195_FIXED_MAPPING.md`

Disposition: NOT-A-BUG
Evidence: Aggregate bot review records are roll-up comments only; their actionable items are dispositioned individually in the canonical artifact.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981300665
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981313064
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981327585
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981358403

Disposition: FIXED
Commit: `6d0b35cd`
Evidence: `core/rag/philosophy_pipeline.py:106-160` preserves Unicode and mixed health tokens such as `A1C` and `LDL-C`, and `tests/test_philosophy_pipeline.py:297-301` asserts alphanumeric medical token extraction.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#issuecomment-4097730775 -> `6d0b35cd`

Disposition: FIXED
Commit: `7db0cd50`
Evidence: `core/rag/philosophy_pipeline.py:415-445` now extracts anchors per numeric range using range-local context, `core/rag/philosophy_pipeline.py:475-491` compares contradictions with those range-local anchors, and `tests/test_philosophy_pipeline.py:322-330,420-442` cover multi-topic chunk suppression and `B12` contradiction detection.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965562418 -> `7db0cd50`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573190 -> `7db0cd50`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573907 -> `7db0cd50`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573913 -> `7db0cd50`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965587728 -> `7db0cd50`

Disposition: NOT-A-BUG
Evidence: `core/rag/philosophy_pipeline.py:108-160` intentionally keeps audience/cadence terms non-binding, and `tests/test_philosophy_pipeline.py:397-432` proves cohort-only overlap would reintroduce false contradictions across different metrics.
Reason: C2 ambiguity policy prefers suppressing contradiction when only demographic or cadence language overlaps.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965587721

Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md:2866`
Reason: Long-form to acronym normalization (for example `body mass index` -> `BMI`) needs an explicit synonym/alias layer and is outside narrow C2 follow-through.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965573196

Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-rag-stage4-anchor-specificity`
Reason: Topic-binding specificity for broad anchors such as `vitamin` or `protein` is a follow-up refinement. The current C2 implementation intentionally preserves valid single-anchor contradictions for narrow queries such as `BMI`, `BP`, and `B12`, so tightening the overlap rule needs a separate design pass.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#discussion_r2965794257
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1195#pullrequestreview-3981560445

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contradiction detection is now query-aware: numeric contradictions are only reported when ranges share query-relevant anchors, reducing false alarms and improving topic sensitivity.
  * Ambiguity handling preserves relevant chunks and reported confidence while suppressing inappropriate contradiction warnings.

* **Tests**
  * Added coverage for query-term/anchor extraction, anchored numeric-range binding, orchestration ambiguity suppression, and varied contradiction scenarios.

* **Documentation**
  * Added a review artifact documenting fixes and a backlog ledger entry for future Stage‑4 refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

