### PR TITLE
docs(agents): codify stage-4 short-anchor policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,13 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 - Allowlist: `tests/guards/wellness_language_allowlist.txt`; in-file marker: `pulseplate-allow:blocker-example`
 - LLM outputs used in product copy/coaching must pass `philosophy_validator` (BLOCKER = rewrite). See `core.insight.philosophy_validator.validate_llm_output`.
 
+**Stage-4 short-anchor contradiction policy (Hard rule):**
+
+- Short specific query anchors such as `BMI`, `BP`, and `B12` are valid contradiction anchors.
+- Do not apply blanket anchor-specificity tightening without negative tests that keep short-anchor cases valid.
+- If query binding is ambiguous, suppress contradiction rather than escalate it.
+- Bot suggestions that materially change contradiction heuristics default to a separate backlog-backed PR unless they are a proven bugfix with tests.
+
 **FitChef initiative policy (Hard rule):**
 
 - The current live FitChef public canon remains `/api/v1/insight/fitchef*`; do not rename, migrate, or deprecate these routes in foundation or visual-lane PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,7 +581,8 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 
 - Acronym-style short query anchors such as `BMI`, `BP`, and `B12` remain valid contradiction anchors.
 - Do not apply blanket anchor-specificity tightening unless negative tests preserve these short-anchor acronym cases.
-- If local query binding leaves multiple plausible referents or otherwise fails to produce one tested anchor match, do not emit a contradiction.
+- This policy is limited to tested short-anchor cases; broad lexical anchors such as `vitamin` or `protein` remain part of the deferred Stage-4 anchor-specificity follow-up.
+- If a short-anchor query still leaves multiple plausible referents in local context and no single tested anchor match is isolated, do not emit a contradiction.
 - Bot suggestions that materially change contradiction heuristics should go to a separate backlog-backed PR unless the change is a proven bugfix with tests.
 
 **FitChef initiative policy (Hard rule):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,9 +579,9 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 
 **Stage-4 short-anchor contradiction policy (Hard rule):**
 
-- Short specific query anchors such as `BMI`, `BP`, and `B12` remain valid contradiction anchors.
-- Do not apply blanket anchor-specificity tightening unless negative tests preserve these short-anchor cases.
-- If query binding is ambiguous, do not emit a contradiction.
+- Acronym-style short query anchors such as `BMI`, `BP`, and `B12` remain valid contradiction anchors.
+- Do not apply blanket anchor-specificity tightening unless negative tests preserve these short-anchor acronym cases.
+- If local query binding leaves multiple plausible referents or otherwise fails to produce one tested anchor match, do not emit a contradiction.
 - Bot suggestions that materially change contradiction heuristics should go to a separate backlog-backed PR unless the change is a proven bugfix with tests.
 
 **FitChef initiative policy (Hard rule):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,10 +579,10 @@ A repository-wide guard that runs early in CI to prevent PR bloat and mixed conc
 
 **Stage-4 short-anchor contradiction policy (Hard rule):**
 
-- Short specific query anchors such as `BMI`, `BP`, and `B12` are valid contradiction anchors.
-- Do not apply blanket anchor-specificity tightening without negative tests that keep short-anchor cases valid.
-- If query binding is ambiguous, suppress contradiction rather than escalate it.
-- Bot suggestions that materially change contradiction heuristics default to a separate backlog-backed PR unless they are a proven bugfix with tests.
+- Short specific query anchors such as `BMI`, `BP`, and `B12` remain valid contradiction anchors.
+- Do not apply blanket anchor-specificity tightening unless negative tests preserve these short-anchor cases.
+- If query binding is ambiguous, do not emit a contradiction.
+- Bot suggestions that materially change contradiction heuristics should go to a separate backlog-backed PR unless the change is a proven bugfix with tests.
 
 **FitChef initiative policy (Hard rule):**
 

--- a/docs/review/PR_1196_FIXED_MAPPING.md
+++ b/docs/review/PR_1196_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1196 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/docs/review/PR_1196_FIXED_MAPPING.md
+++ b/docs/review/PR_1196_FIXED_MAPPING.md
@@ -8,8 +8,14 @@
 
 Disposition: FIXED
 Commit: a8510cd9
-Evidence: `AGENTS.md:582-584` now defines short anchors as acronym-style examples and makes ambiguity suppression concrete through multiple plausible referents or no single tested anchor match.
+Evidence: `AGENTS.md:582-583` now defines short anchors as acronym-style examples and preserves them explicitly through negative-test language.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1196#issuecomment-4098342621 -> a8510cd9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1196#pullrequestreview-3981882870 -> a8510cd9
+
+Disposition: FIXED
+Commit: 515247ab
+Evidence: `AGENTS.md:584-585` now limits the rule to tested short-anchor cases and keeps broad lexical anchors such as `vitamin` and `protein` in the deferred Stage-4 anchor-specificity follow-up.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1196#discussion_r2966093086 -> 515247ab
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1196_FIXED_MAPPING.md
+++ b/docs/review/PR_1196_FIXED_MAPPING.md
@@ -5,7 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+
+Disposition: FIXED
+Commit: a8510cd9
+Evidence: `AGENTS.md:582-584` now defines short anchors as acronym-style examples and makes ambiguity suppression concrete through multiple plausible referents or no single tested anchor match.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1196#issuecomment-4098342621 -> a8510cd9
 
 ## Merge Readiness
 - [ ] All required checks pass


### PR DESCRIPTION
## Summary
- codify the Stage-4 short-anchor contradiction policy in root `AGENTS.md`
- keep acronym-style anchors such as `BMI`, `BP`, and `B12` explicitly valid
- require separate backlog-backed PRs for contradiction-heuristic tightening unless a proven bugfix ships with tests

## Scope
- docs-only change in `AGENTS.md`
- docs-only governance artifact in `docs/review/PR_1196_FIXED_MAPPING.md`
- no runtime, tests, or backlog edits

## Validation
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1196_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green

## Deferred / Follow-ups
- runtime refinement remains separate in backlog item `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-rag-stage4-anchor-specificity`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Stage‑4 short‑anchor contradiction policy within the wellness language blocker: preserves acronym anchors (e.g., BMI, BP, B12), limits blanket anchor tightening unless negative tests preserve those cases, suppresses contradiction output when local context is ambiguous, and routes heuristic‑changing suggestions to backlog PRs unless proven bugfixes with tests.
  * Added a review/mapping document with fixed‑in‑commit mappings and a merge‑readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->