### PR TITLE
feat(ai): extract bounded AI runtime ownership into canonical core/ai seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,9 +1033,11 @@ Detailed procedures stay in runbooks, ADRs, and scoped `AGENTS.md` files.
 ### AI bounded context
 
 - AI/insight/provider runtime boundary: `docs/architecture/providers_implementation.md`
+- Canonical bounded-context entry seam: `core/ai/*` for AI runtime preparation, provider loading, and transparency ownership that sits between thin legacy adapters and deeper runtime internals.
+- Shared app-layer insight execution adapter: `app/services/insight_application_service.py` and `app/services/insight_runtime.py` keep HTTP/tracing concerns out of `core/`.
 - LLM rate-limit and monthly quota rules: see `AGENTS.md` sections `Rate Limiting Policy` and `LLM Monthly Quota Policy`.
 - Privacy and PII handling for AI-adjacent endpoints: `core/pii_redaction.py`, `docs/security/SECURITY_POSTURE.md`
-- Target-state extraction of AI runtime into a dedicated bounded context is tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ai-bounded-context-extraction` and governed by `docs/architecture/ADR_AI_RUNTIME_BOUNDED_CONTEXT_SEAM_2026-03-09.md` (the ADR now carries `file:line` evidence for current boundary claims; retire the seam only when canonical AI package boundaries and ownership are documented without transitional wording).
+- Remaining consolidation and seam-retirement work stays tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ai-bounded-context-extraction` and governed by `docs/architecture/ADR_AI_RUNTIME_BOUNDED_CONTEXT_SEAM_2026-03-09.md` (retire the seam only when provider/safety/eval ownership no longer needs transitional wording outside the canonical AI boundary).
 
 ### Creative research lane
 

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -10,6 +10,8 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from fastapi import HTTPException, status
+
 from app.services.insight_runtime import generate_traced_insight
 from app.utils.feature_flags import (
     is_philosophy_linguistic_enabled,
@@ -27,9 +29,14 @@ INSIGHT_TEXT_MAX_LENGTH = 2000
 
 
 def _ensure_insight_text_length(prompt_text: str) -> str:
-    """Return prompt text trimmed to the canonical insight limit."""
+    """Return prompt text when within limits; reject oversized prompts."""
 
-    return prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
+    if len(prompt_text) > INSIGHT_TEXT_MAX_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="Prompt too long",
+        )
+    return prompt_text
 
 
 async def execute_insight_request(

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -1,0 +1,99 @@
+"""Application service for insight execution.
+
+RU: Application service для /insight execution path.
+EN: Application service for the /insight execution path.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+from app.services.insight_runtime import generate_traced_insight
+from app.utils.feature_flags import (
+    is_philosophy_linguistic_enabled,
+    is_philosophy_phase12_enabled,
+    is_philosophy_pragmatic_enabled,
+    is_philosophy_router_enabled,
+    is_philosophy_validation_enabled,
+    is_recursive_rag_enabled,
+)
+from core.ai import prepare_insight_runtime
+
+INSIGHT_TEXT_MAX_LENGTH = 2000
+
+
+def _ensure_insight_text_length(prompt_text: str) -> str:
+    """Return prompt text trimmed to the canonical insight limit."""
+
+    return prompt_text[:INSIGHT_TEXT_MAX_LENGTH]
+
+
+async def execute_insight_request(
+    req: Any,
+    *,
+    route_path: str,
+    user_tier: str,
+    subject_id: int | None = None,
+    input_guard: Callable[[str], object],
+    provider_loader: Callable[[], Any],
+    transparency_loader: Callable[[], tuple[str, str]],
+    response_factory: Callable[..., Any],
+    source_item_factory: Callable[..., Any],
+) -> Any:
+    """Execute the shared insight runtime path behind legacy adapters."""
+
+    input_guard(req.text)
+    prompt_input = _ensure_insight_text_length(req.text)
+    use_rag = str(os.getenv("FEATURE_RAG", "")).strip().lower() in {"1", "true", "on", "yes"}
+
+    philosophy_router_enabled = is_philosophy_router_enabled()
+    philosophy_linguistic_enabled = is_philosophy_linguistic_enabled()
+    prepared_runtime = prepare_insight_runtime(
+        text=prompt_input,
+        use_rag=use_rag,
+        philosophy_router_enabled=philosophy_router_enabled,
+        philosophy_linguistic_enabled=philosophy_linguistic_enabled,
+        provider_loader=provider_loader,
+        transparency_loader=transparency_loader,
+    )
+
+    runtime_result = await generate_traced_insight(
+        runtime=prepared_runtime.runtime,
+        text=prompt_input,
+        lang=None,
+        provider=prepared_runtime.provider,
+        use_rag=use_rag,
+        philo_validation_enabled=is_philosophy_validation_enabled(),
+        recursive_rag_enabled=is_recursive_rag_enabled(),
+        subject_id=subject_id,
+        philosophy_router_enabled=philosophy_router_enabled,
+        philosophy_phase12_enabled=is_philosophy_phase12_enabled(),
+        philosophy_linguistic_enabled=philosophy_linguistic_enabled,
+        philosophy_pragmatic_enabled=is_philosophy_pragmatic_enabled(),
+        route_path=route_path,
+        route_type=prepared_runtime.decision.route_type.value,
+        user_tier=user_tier,
+    )
+    insight_text = runtime_result.insight[:INSIGHT_TEXT_MAX_LENGTH]
+    source_items = [source_item_factory(**item) for item in runtime_result.source_dicts]
+    return response_factory(
+        provider=runtime_result.provider_name,
+        insight=insight_text,
+        sources=source_items,
+        confidence=runtime_result.confidence,
+        rag_used=runtime_result.rag_used,
+        hops=runtime_result.hops,
+        latency_ms=runtime_result.latency_ms,
+        route_type=runtime_result.metadata.route_type,
+        depth_used=runtime_result.metadata.depth_used,
+        verification_rate=runtime_result.metadata.verification_rate,
+        falsifiability_rate=runtime_result.metadata.falsifiability_rate,
+        contradiction_count=runtime_result.metadata.contradiction_count,
+        reason_codes=runtime_result.metadata.reason_codes,
+        optimization_applied=runtime_result.metadata.optimization_applied,
+        automated_analysis=True,
+        transparency_notice_id=prepared_runtime.transparency_notice.surface_id,
+        wellness_boundary=prepared_runtime.transparency_notice.wellness_boundary,
+    )

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -19,6 +19,8 @@ from app.utils.feature_flags import (
     is_philosophy_validation_enabled,
     is_recursive_rag_enabled,
 )
+from core.ai.insight_runtime import InsightTransparencyNotice
+from core.insight.llm_provider_loader import LLMProvider
 from core.ai import prepare_insight_runtime
 
 INSIGHT_TEXT_MAX_LENGTH = 2000
@@ -37,8 +39,9 @@ async def execute_insight_request(
     user_tier: str,
     subject_id: int | None = None,
     input_guard: Callable[[str], object],
-    provider_loader: Callable[[], Any],
-    transparency_loader: Callable[[], tuple[str, str]],
+    provider_loader: Callable[[], LLMProvider | None],
+    transparency_loader: Callable[[], tuple[str, str] | InsightTransparencyNotice],
+    direct_provider_factory: Callable[[], LLMProvider] | None = None,
     response_factory: Callable[..., Any],
     source_item_factory: Callable[..., Any],
 ) -> Any:
@@ -57,6 +60,7 @@ async def execute_insight_request(
         philosophy_linguistic_enabled=philosophy_linguistic_enabled,
         provider_loader=provider_loader,
         transparency_loader=transparency_loader,
+        direct_provider_factory=direct_provider_factory,
     )
 
     runtime_result = await generate_traced_insight(

--- a/core/ai/__init__.py
+++ b/core/ai/__init__.py
@@ -1,0 +1,27 @@
+"""Canonical AI bounded-context facade.
+
+RU: Канонический facade для AI bounded context.
+EN: Canonical facade for the AI bounded context.
+"""
+
+from core.ai.insight_runtime import (
+    DirectInsightProviderStub,
+    InsightProviderLoadError,
+    InsightTransparencyNotice,
+    InsightTransparencyUnavailableError,
+    PreparedInsightRuntime,
+    load_insight_provider,
+    prepare_insight_runtime,
+    require_ai_generated_insight_notice,
+)
+
+__all__ = [
+    "DirectInsightProviderStub",
+    "InsightProviderLoadError",
+    "InsightTransparencyNotice",
+    "InsightTransparencyUnavailableError",
+    "PreparedInsightRuntime",
+    "load_insight_provider",
+    "prepare_insight_runtime",
+    "require_ai_generated_insight_notice",
+]

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -10,9 +10,13 @@ AI runtime preparation behind a stable bounded-context package.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from typing import Callable, Mapping
 
-from core.insight.llm_provider_loader import load_llm_get_provider
+from core.insight.llm_provider_loader import (
+    LLMProvider,
+    LLMProviderFactory,
+    load_llm_get_provider,
+)
 from core.insight.philosophical_runtime import PhilosophicalRuntime, RouteDecision
 
 
@@ -38,14 +42,14 @@ class PreparedInsightRuntime:
 
     runtime: PhilosophicalRuntime
     decision: RouteDecision
-    provider: Any
+    provider: LLMProvider
     transparency_notice: InsightTransparencyNotice
 
 
 class DirectInsightProviderStub:
     """Provider stub used when the runtime can answer locally without an LLM call."""
 
-    name = "philosophical_runtime"
+    name: str = "philosophical_runtime"
 
     async def generate(self, text: str) -> str:
         raise RuntimeError("Direct runtime route must not call provider.generate")
@@ -53,8 +57,8 @@ class DirectInsightProviderStub:
 
 def load_insight_provider(
     *,
-    provider_factory_loader: Callable[[], Callable[[], Any | None]] | None = None,
-) -> Any:
+    provider_factory_loader: Callable[[], LLMProviderFactory] | None = None,
+) -> LLMProvider:
     """Load configured LLM provider while preserving lazy import behavior."""
 
     if provider_factory_loader is None:
@@ -65,7 +69,10 @@ def load_insight_provider(
     except Exception as exc:  # pragma: no cover - covered via legacy/service tests
         raise InsightProviderLoadError("LLM module is not available") from exc
 
-    provider = get_provider()
+    try:
+        provider = get_provider()
+    except Exception as exc:  # pragma: no cover - covered via legacy/service tests
+        raise InsightProviderLoadError("LLM provider initialization failed") from exc
     if provider is None:
         raise InsightProviderLoadError("No LLM provider configured")
     return provider
@@ -105,16 +112,42 @@ def require_ai_generated_insight_notice(
     )
 
 
+def _coerce_transparency_notice(
+    loaded_notice: tuple[str, str] | InsightTransparencyNotice,
+) -> InsightTransparencyNotice:
+    """Normalize custom transparency-loader output into the canonical notice."""
+
+    if isinstance(loaded_notice, InsightTransparencyNotice):
+        return loaded_notice
+
+    try:
+        surface_id, boundary = loaded_notice
+    except Exception as exc:
+        raise InsightTransparencyUnavailableError("transparency_registry_unavailable") from exc
+
+    if (
+        not isinstance(surface_id, str)
+        or not surface_id
+        or not isinstance(boundary, str)
+        or not boundary
+    ):
+        raise InsightTransparencyUnavailableError("transparency_registry_unavailable")
+
+    return InsightTransparencyNotice(
+        surface_id=surface_id,
+        wellness_boundary=boundary,
+    )
+
+
 def prepare_insight_runtime(
     *,
     text: str,
     use_rag: bool,
     philosophy_router_enabled: bool,
     philosophy_linguistic_enabled: bool,
-    provider_loader: Callable[[], Any] | None = None,
-    transparency_loader: (
-        Callable[[], tuple[str, str]] | Callable[[], InsightTransparencyNotice] | None
-    ) = None,
+    provider_loader: Callable[[], LLMProvider | None] | None = None,
+    transparency_loader: Callable[[], tuple[str, str] | InsightTransparencyNotice] | None = None,
+    direct_provider_factory: Callable[[], LLMProvider] | None = None,
 ) -> PreparedInsightRuntime:
     """Prepare runtime, route decision, provider, and transparency metadata.
 
@@ -134,20 +167,15 @@ def prepare_insight_runtime(
     if transparency_loader is None:
         transparency_notice = require_ai_generated_insight_notice()
     else:
-        loaded_notice = transparency_loader()
-        if isinstance(loaded_notice, InsightTransparencyNotice):
-            transparency_notice = loaded_notice
-        else:
-            surface_id, boundary = loaded_notice
-            transparency_notice = InsightTransparencyNotice(
-                surface_id=surface_id,
-                wellness_boundary=boundary,
-            )
+        transparency_notice = _coerce_transparency_notice(transparency_loader())
 
     if decision.needs_generation:
         provider = load_insight_provider() if provider_loader is None else provider_loader()
+        if provider is None:
+            raise InsightProviderLoadError("No LLM provider configured")
     else:
-        provider = DirectInsightProviderStub()
+        provider_factory = direct_provider_factory or DirectInsightProviderStub
+        provider = provider_factory()
 
     return PreparedInsightRuntime(
         runtime=runtime,

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -1,0 +1,157 @@
+"""Core AI facade for insight runtime ownership.
+
+RU: Канонический core/ai facade для ownership insight runtime.
+EN: Canonical core/ai facade for insight runtime ownership.
+
+The goal is to keep FastAPI/HTTP concerns out of ``core/`` while consolidating
+AI runtime preparation behind a stable bounded-context package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from core.insight.llm_provider_loader import load_llm_get_provider
+from core.insight.philosophical_runtime import PhilosophicalRuntime, RouteDecision
+
+
+class InsightProviderLoadError(RuntimeError):
+    """Raised when provider resolution fails inside the bounded context."""
+
+
+class InsightTransparencyUnavailableError(RuntimeError):
+    """Raised when required transparency metadata is unavailable or malformed."""
+
+
+@dataclass(frozen=True)
+class InsightTransparencyNotice:
+    """Required transparency metadata for AI-generated insight output."""
+
+    surface_id: str
+    wellness_boundary: str
+
+
+@dataclass(frozen=True)
+class PreparedInsightRuntime:
+    """Prepared insight runtime state before app-layer execution."""
+
+    runtime: PhilosophicalRuntime
+    decision: RouteDecision
+    provider: Any
+    transparency_notice: InsightTransparencyNotice
+
+
+class DirectInsightProviderStub:
+    """Provider stub used when the runtime can answer locally without an LLM call."""
+
+    name = "philosophical_runtime"
+
+    async def generate(self, text: str) -> str:
+        raise RuntimeError("Direct runtime route must not call provider.generate")
+
+
+def load_insight_provider(
+    *,
+    provider_factory_loader: Callable[[], Callable[[], Any | None]] | None = None,
+) -> Any:
+    """Load configured LLM provider while preserving lazy import behavior."""
+
+    if provider_factory_loader is None:
+        provider_factory_loader = load_llm_get_provider
+
+    try:
+        get_provider = provider_factory_loader()
+    except Exception as exc:  # pragma: no cover - covered via legacy/service tests
+        raise InsightProviderLoadError("LLM module is not available") from exc
+
+    provider = get_provider()
+    if provider is None:
+        raise InsightProviderLoadError("No LLM provider configured")
+    return provider
+
+
+def require_ai_generated_insight_notice(
+    *,
+    registry_loader: Callable[[], Mapping[str, object]] | None = None,
+) -> InsightTransparencyNotice:
+    """Return the required transparency notice or fail closed."""
+
+    if registry_loader is None:
+        from core.compliance import get_transparency_registry
+
+        registry_loader = get_transparency_registry
+
+    try:
+        transparency_notice = registry_loader().get("ai_generated_insight")
+    except Exception as exc:  # pragma: no cover - covered via legacy/service tests
+        raise InsightTransparencyUnavailableError("transparency_registry_unavailable") from exc
+    if not isinstance(transparency_notice, dict):
+        raise InsightTransparencyUnavailableError("transparency_registry_unavailable")
+
+    surface_id = transparency_notice.get("surface_id")
+    boundary = transparency_notice.get("boundary")
+    if (
+        not isinstance(surface_id, str)
+        or not surface_id
+        or not isinstance(boundary, str)
+        or not boundary
+    ):
+        raise InsightTransparencyUnavailableError("transparency_registry_unavailable")
+
+    return InsightTransparencyNotice(
+        surface_id=surface_id,
+        wellness_boundary=boundary,
+    )
+
+
+def prepare_insight_runtime(
+    *,
+    text: str,
+    use_rag: bool,
+    philosophy_router_enabled: bool,
+    philosophy_linguistic_enabled: bool,
+    provider_loader: Callable[[], Any] | None = None,
+    transparency_loader: (
+        Callable[[], tuple[str, str]] | Callable[[], InsightTransparencyNotice] | None
+    ) = None,
+) -> PreparedInsightRuntime:
+    """Prepare runtime, route decision, provider, and transparency metadata.
+
+    RU: Подготовить runtime/route/provider/transparency без HTTP-зависимостей.
+    EN: Prepare runtime/route/provider/transparency without HTTP dependencies.
+    """
+
+    runtime = PhilosophicalRuntime()
+    router_enabled = philosophy_router_enabled or philosophy_linguistic_enabled
+    decision = runtime.preview_route(
+        text=text,
+        lang=None,
+        router_enabled=router_enabled,
+        use_rag=use_rag,
+    )
+
+    if transparency_loader is None:
+        transparency_notice = require_ai_generated_insight_notice()
+    else:
+        loaded_notice = transparency_loader()
+        if isinstance(loaded_notice, InsightTransparencyNotice):
+            transparency_notice = loaded_notice
+        else:
+            surface_id, boundary = loaded_notice
+            transparency_notice = InsightTransparencyNotice(
+                surface_id=surface_id,
+                wellness_boundary=boundary,
+            )
+
+    if decision.needs_generation:
+        provider = load_insight_provider() if provider_loader is None else provider_loader()
+    else:
+        provider = DirectInsightProviderStub()
+
+    return PreparedInsightRuntime(
+        runtime=runtime,
+        decision=decision,
+        provider=provider,
+        transparency_notice=transparency_notice,
+    )

--- a/docs/architecture/ADR_AI_RUNTIME_BOUNDED_CONTEXT_SEAM_2026-03-09.md
+++ b/docs/architecture/ADR_AI_RUNTIME_BOUNDED_CONTEXT_SEAM_2026-03-09.md
@@ -6,9 +6,10 @@
 
 ## Context
 
-AI provider integration, safety controls, and insight/runtime behavior are
-documented across several runtime areas. The target architecture is a clearer
-bounded context, but the canonical package boundary is not implemented yet.
+AI provider integration, safety controls, and insight/runtime behavior were
+documented across several runtime areas. A canonical bounded-context entry seam
+now exists in `core/ai/*`, but broader provider/safety/eval ownership is still
+distributed enough that the seam-retirement ledger item remains open.
 
 ## Evidence
 
@@ -18,9 +19,9 @@ bounded context, but the canonical package boundary is not implemented yet.
 - Import-safe compat and router-registration seams still live in
   `legacy_app.py:170`-`legacy_app.py:175` and
   `app/routers/pro_registration.py:26`-`app/routers/pro_registration.py:45`.
-- Provider loading, transparency gating, and runtime orchestration for insights
-  still flow through the legacy compatibility layer in
-  `legacy_app.py:2225`-`legacy_app.py:2344`.
+- Provider loading, transparency preparation, and runtime preparation for
+  insights now enter through `core/ai/*`, while HTTP mapping and route wrappers
+  remain in the legacy compatibility layer.
 - Hard quota enforcement remains in `app/security/llm_monthly_quota.py:52`-`app/security/llm_monthly_quota.py:77`
   and `app/security/llm_monthly_quota.py:117`-`app/security/llm_monthly_quota.py:152`.
 - Rate-limit guardrails remain in `app/security/rate_limit.py:48`-`app/security/rate_limit.py:76`
@@ -30,8 +31,9 @@ bounded context, but the canonical package boundary is not implemented yet.
 
 ## Decision
 
-Keep the current runtime structure, but document AI bounded-context extraction
-as an explicit temporary seam with a linked ledger item and removal criteria.
+Keep the canonical `core/ai/*` entry seam, but retain the ledger item until the
+remaining provider/safety/eval ownership is fully consolidated and the
+architecture no longer needs transitional wording.
 
 The bounded-context lane may use packet-only architecture PRs to freeze
 ownership boundaries, implementation decomposition, and non-goals before the
@@ -55,4 +57,4 @@ Retire this seam only when all are true:
 - Positive: contributors get an auditable explanation for the current wording.
 - Positive: the architecture target is explicit without pretending it already
   exists.
-- Negative: AI runtime ownership remains distributed until the follow-up PR.
+- Negative: some AI runtime ownership remains distributed until follow-up consolidation lands.

--- a/docs/architecture/providers_implementation.md
+++ b/docs/architecture/providers_implementation.md
@@ -1,7 +1,7 @@
 # Providers Implementation — Detailed Analysis
 
 **Originally drafted:** 2026-01-12
-**Purpose:** Document how `providers/` is implemented and how it is wired into runtime (via `llm.py` + `legacy_app.py` insight endpoints).
+**Purpose:** Document how `providers/` is implemented and how it is wired into runtime through the canonical AI bounded-context seam (`core/ai/*`) and the legacy insight adapters.
 
 ---
 
@@ -182,30 +182,36 @@ def get_provider():
 
 ---
 
-## ✅ Current Runtime Usage: WIRED (via `legacy_app.py` insight endpoints)
+## ✅ Current Runtime Usage: WIRED (via `core/ai/*` + legacy insight adapters)
 
-### Evidence: Providers are used via `legacy_app.py → llm.py → providers/*`
+### Evidence: Providers are used via `legacy_app.py → app/services/insight_application_service.py → core/ai/* → llm.py → providers/*`
 
-**1. Insight endpoints live in `legacy_app.py` (not in `app/routers/`)**
+**1. Insight endpoints remain compatibility adapters in `legacy_app.py`**
 
 - Evidence:
   - `legacy_app.py:2168-2187` defines HTTP routes:
     - `POST /api/v1/insight` (API key gated)
     - `POST /insight` (legacy path)
 
-**2. `legacy_app.py` loads `llm.get_provider` lazily and calls `provider.generate()`**
+**2. The shared application service owns endpoint orchestration, not `legacy_app.py`**
 
 - Evidence:
-  - `legacy_app.py:2066-2076` — `_load_llm_get_provider()` imports `llm.get_provider`
-  - `legacy_app.py:2098-2117` — `provider = get_provider()` and `await provider.generate(prompt_text)`
+  - `app/services/insight_application_service.py` executes shared `/insight` orchestration
+  - `app/services/insight_runtime.py` owns traced `provider.generate(...)` execution
 
-**3. `llm.py` imports `providers/*` and selects provider by env var**
+**3. `core/ai/*` is the canonical provider/runtime preparation seam**
+
+- Evidence:
+  - `core/ai/insight_runtime.py` prepares `PhilosophicalRuntime`, route decision, transparency notice, and provider selection
+  - `legacy_app.py` keeps HTTPException mapping and route wrappers as thin adapters for compatibility/tests
+
+**4. `llm.py` imports `providers/*` and selects provider by env var**
 
 - Evidence:
   - `llm.py:57-79` — optional imports of `providers.grok`, `providers.ollama`, `providers.pico`
   - `llm.py:91-153` — `get_provider()` selects provider based on `LLM_PROVIDER`
 
-**Conclusion:** `providers/` is wired into runtime through the insight endpoints in `legacy_app.py`, with `llm.get_provider()` acting as the factory/adapter layer.
+**Conclusion:** `providers/` is wired into runtime through the canonical `core/ai/*` seam, with `llm.get_provider()` acting as the low-level factory/adapter layer and legacy routes remaining thin HTTP compatibility wrappers.
 
 ---
 
@@ -230,7 +236,9 @@ def get_provider():
 - ✅ Tests (unit tests for each provider)
 
 **Runtime wiring (current):**
-- ✅ Insight endpoints in `legacy_app.py` call `llm.get_provider()` and then `provider.generate()`
+- ✅ Insight endpoints stay in `legacy_app.py` as thin wrappers
+- ✅ Shared app service and tracing adapters live in `app/services/*`
+- ✅ Canonical provider/runtime preparation now enters through `core/ai/*`
 
 **Historical note (superseded):**
 - Earlier versions of this doc claimed providers were “not wired into runtime” because `app/routers/` did not import them.
@@ -310,7 +318,7 @@ def get_provider():
 
 Evidence pointers (runtime truth):
 
-- `legacy_app.py:2168-2187` — insight HTTP endpoints exist (`/api/v1/insight`, `/insight`)
+- `legacy_app.py` — insight HTTP endpoints exist (`/api/v1/insight`, `/insight`) as compatibility adapters
 - `legacy_app.py:2066-2076` — lazy loader imports `llm.get_provider`
 - `legacy_app.py:2098-2117` — calls `provider.generate(...)`
 - `llm.py:57-79` + `91-153` — imports/selects `providers/*` via `LLM_PROVIDER`
@@ -347,7 +355,7 @@ Evidence pointers (runtime truth):
 
 **Current status:**
 - ✅ Implemented (code exists)
-- ✅ Wired into runtime via `legacy_app.py` insight endpoints and `llm.get_provider()`
+- ✅ Wired into runtime via `core/ai/*`, shared app insight services, and `llm.get_provider()`
 - ✅ Tested (unit tests exist)
 
 **Why they exist:**

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -97,6 +97,10 @@ Historical ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (superse
   - LLM/exports endpoints must be rate-limited and have deterministic 429 tests; rate limiting is proxy-aware and privacy-friendly.
 - **AI bounded-context entry seam**
   - `/api/v1/insight` and `/insight` remain legacy compatibility endpoints, but runtime preparation/provider selection now enters through `core/ai/*` while traced execution stays in `app/services/*`.
+  - Evidence:
+    - `legacy_app.py:2251-2275`
+    - `core/ai/insight_runtime.py:142-187`
+    - `app/services/insight_application_service.py:35-94`
 
 ## Maintenance rule
 

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -16,6 +16,7 @@
 - **Backend**
   - `app/` (FastAPI adapters): routers, schemas, middleware, bootstrap
   - `core/` (domain): BMI engine, nutrition logic, i18n, business rules
+  - `core/ai/` (canonical AI bounded-context entry seam): runtime preparation, provider loading, transparency ownership
   - `providers/` (LLM providers): Grok/Ollama/Pico/Stub (env-selected via `llm.py`)
 - **Infra**
   - DB: PostgreSQL (prod canonical), SQLite (dev/test fallback)
@@ -41,11 +42,12 @@ flowchart LR
 
   subgraph Backend
     ENTRY[app/main.py (canonical entrypoint)]
-    LEG[legacy_app.py (FastAPI app instance)]
-    API[app/ (routers + bootstrap)]
-    CORE[core/ (domain engine)]
-    LLM[llm.py (provider factory)]
-    PROV[providers/ (LLM adapters)]
+  LEG[legacy_app.py (compat app instance)]
+  API[app/ (routers + bootstrap)]
+  CORE[core/ (domain engine)]
+  AI[core/ai/ (AI bounded-context seam)]
+  LLM[llm.py (provider factory)]
+  PROV[providers/ (LLM adapters)]
   end
 
   DB[(DB)]
@@ -58,7 +60,8 @@ flowchart LR
   LEG -->|include_router / route handlers| API
 
   API -->|delegates business rules| CORE
-  API -->|/insight uses factory| LLM
+  LEG -->|/insight thin adapters| AI
+  AI -->|lazy provider loading| LLM
   LLM --> PROV
 
   CORE --> DB
@@ -92,6 +95,8 @@ Historical ADR: `docs/architecture/ADR-002-openapi-schema-only-mode.md` (superse
       - Evidence: `tests/test_openapi_determinism.py:17` (hash comparison)
 - **Rate limiting for expensive endpoints**
   - LLM/exports endpoints must be rate-limited and have deterministic 429 tests; rate limiting is proxy-aware and privacy-friendly.
+- **AI bounded-context entry seam**
+  - `/api/v1/insight` and `/insight` remain legacy compatibility endpoints, but runtime preparation/provider selection now enters through `core/ai/*` while traced execution stays in `app/services/*`.
 
 ## Maintenance rule
 

--- a/docs/review/PR_1203_FIXED_MAPPING.md
+++ b/docs/review/PR_1203_FIXED_MAPPING.md
@@ -47,6 +47,11 @@ Evidence: app/services/insight_application_service.py:31-39; app/services/insigh
 Reason: The review-shell URL only summarizes the inline CodeRabbit finding above and does not introduce an additional unresolved action once the mapped thread is dispositioned.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3985580981
 
+Disposition: NOT-A-BUG
+Evidence: app/services/insight_application_service.py:57-64; app/security/agent_input_guard.py:267-276; legacy_app.py:2269-2277
+Reason: The shared insight service treats `input_guard` as a fail-closed validation seam, not a sanitizer. The production guard `require_safe_ai_agent_input()` returns the original text unchanged or raises a stable 400, so consuming a return value would not change runtime behavior and is not required to preserve the current legacy length contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3985624764
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads

--- a/docs/review/PR_1203_FIXED_MAPPING.md
+++ b/docs/review/PR_1203_FIXED_MAPPING.md
@@ -6,7 +6,7 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
-Commit: pending-local-commit
+Commit: 1377cd91
 Evidence: core/ai/insight_runtime.py:49-78; core/ai/insight_runtime.py:115-185; app/services/insight_application_service.py:35-64; legacy_app.py:2251-2275; tests/test_core_ai_insight_runtime.py:76-263; tests/test_insight_application_service.py:17-137
 Reason: The bounded-context seam now uses explicit `LLMProvider` typing, preserves the legacy direct-provider patchpoint via an injectable direct factory, normalizes provider loader failures into canonical bounded-context errors, rejects invalid transparency tuples fail-closed, and adds deterministic regression tests for direct-notice and missing-provider branches.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968166358
@@ -17,6 +17,15 @@ Reason: The bounded-context seam now uses explicit `LLMProvider` typing, preserv
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198529
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198533
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198535
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968166358 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968182664 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198519 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198522 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198527 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198529 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198533 -> 1377cd91
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198535 -> 1377cd91
 
 Disposition: NOT-A-BUG
 Evidence: core/ai/insight_runtime.py:49-78; core/ai/insight_runtime.py:115-185; app/services/insight_application_service.py:35-64; legacy_app.py:2251-2275; docs/roadmap/BACKLOG_LEDGER.md:1208-1215; docs/architecture/system_overview.md:98-103

--- a/docs/review/PR_1203_FIXED_MAPPING.md
+++ b/docs/review/PR_1203_FIXED_MAPPING.md
@@ -34,6 +34,19 @@ Reason: The review-summary URLs aggregate the inline bot findings dispositioned 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3984313392
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3984329399
 
+Disposition: FIXED
+Commit: dfbeae5d
+Evidence: app/services/insight_application_service.py:31-39; app/services/insight_application_service.py:57-64; tests/test_insight_application_service.py:145-192
+Reason: The shared insight service now rejects oversized prompt input with HTTP 413 before runtime preparation, preserving the legacy fail-closed contract and keeping truncation only on response text.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2969109594
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2969109594 -> dfbeae5d
+
+Disposition: NOT-A-BUG
+Evidence: app/services/insight_application_service.py:31-39; app/services/insight_application_service.py:57-64; tests/test_insight_application_service.py:145-192
+Reason: The review-shell URL only summarizes the inline CodeRabbit finding above and does not introduce an additional unresolved action once the mapped thread is dispositioned.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3985580981
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads

--- a/docs/review/PR_1203_FIXED_MAPPING.md
+++ b/docs/review/PR_1203_FIXED_MAPPING.md
@@ -1,0 +1,32 @@
+# PR 1203 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: pending-local-commit
+Evidence: core/ai/insight_runtime.py:49-78; core/ai/insight_runtime.py:115-185; app/services/insight_application_service.py:35-64; legacy_app.py:2251-2275; tests/test_core_ai_insight_runtime.py:76-263; tests/test_insight_application_service.py:17-137
+Reason: The bounded-context seam now uses explicit `LLMProvider` typing, preserves the legacy direct-provider patchpoint via an injectable direct factory, normalizes provider loader failures into canonical bounded-context errors, rejects invalid transparency tuples fail-closed, and adds deterministic regression tests for direct-notice and missing-provider branches.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968166358
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968182664
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198519
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198522
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198527
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198529
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198533
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#discussion_r2968198535
+
+Disposition: NOT-A-BUG
+Evidence: core/ai/insight_runtime.py:49-78; core/ai/insight_runtime.py:115-185; app/services/insight_application_service.py:35-64; legacy_app.py:2251-2275; docs/roadmap/BACKLOG_LEDGER.md:1208-1215; docs/architecture/system_overview.md:98-103
+Reason: The review-summary URLs aggregate the inline bot findings dispositioned above and do not add independent unresolved actions once those mapped threads are closed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3984297653
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3984313392
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1203#pullrequestreview-3984329399
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1209,10 +1209,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Extract AI runtime into a dedicated bounded context
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: #1203
+  - Target PR: PR `#1203`
   - Area: backend / AI runtime / architecture
   - Finding Type: bounded-context hardening
-  - Reason: AI logic, provider seams, and safety-related behavior were historically distributed across runtime areas. The canonical `core/ai/*` seam now exists, but the remaining consolidation still needs to remove transitional ownership outside that boundary.
+  - Reason: AI logic, provider seams, and safety-related behavior were historically distributed across runtime areas. The canonical `core/ai/*` seam now exists, but the remaining consolidation still needs to remove transitional ownership outside that boundary. Follow-up tracking remains anchored here: `docs/roadmap/BACKLOG_LEDGER.md:1208`. Closure criteria: move the remaining provider/runtime ownership into `core/ai/*`, keep legacy/app layers as thin adapters, and verify ownership through canonical `file:line` evidence plus passing `make verify`.
   - Links:
     - `docs/architecture/providers_implementation.md`
     - `AGENTS.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1209,10 +1209,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Extract AI runtime into a dedicated bounded context
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-AI-BOUNDED-CONTEXT
+  - Target PR: feat(ai): extract bounded AI runtime ownership into canonical core/ai seam
   - Area: backend / AI runtime / architecture
   - Finding Type: bounded-context hardening
-  - Reason: AI logic, provider seams, and safety-related behavior are currently documented across runtime areas, but there is no canonical `core/ai/*` bounded context yet. This increases the risk of router/business-logic drift and makes AI safety ownership harder to enforce.
+  - Reason: AI logic, provider seams, and safety-related behavior were historically distributed across runtime areas. The canonical `core/ai/*` seam now exists, but the remaining consolidation still needs to remove transitional ownership outside that boundary.
   - Links:
     - `docs/architecture/providers_implementation.md`
     - `AGENTS.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1209,7 +1209,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Extract AI runtime into a dedicated bounded context
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: feat(ai): extract bounded AI runtime ownership into canonical core/ai seam
+  - Target PR: #1203
   - Area: backend / AI runtime / architecture
   - Finding Type: bounded-context hardening
   - Reason: AI logic, provider seams, and safety-related behavior were historically distributed across runtime areas. The canonical `core/ai/*` seam now exists, but the remaining consolidation still needs to remove transitional ownership outside that boundary.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -2269,6 +2269,7 @@ async def _execute_insight_request(
             input_guard=require_safe_ai_agent_input,
             provider_loader=_load_insight_provider,
             transparency_loader=_require_ai_generated_insight_notice,
+            direct_provider_factory=_DirectInsightProviderStub,
             response_factory=InsightResponse,
             source_item_factory=RAGSourceItem,
         ),

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -129,7 +129,6 @@ from app.middleware.api_tiers import derive_subject_id_from_api_key, require_vip
 from app.security.llm_monthly_quota import (
     attempt_consume_vip_llm_monthly_quota,
 )
-from app.services.insight_runtime import generate_traced_insight
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
     _calculate_all_tdee_wrapper,
@@ -2204,8 +2203,18 @@ INSIGHT_TEMP_UNAVAILABLE_CODE = "INSIGHT_TEMPORARILY_UNAVAILABLE"
 INSIGHT_TEMP_UNAVAILABLE_MESSAGE = "Insight is temporarily unavailable. Please try again later."
 
 
+from core.ai import (  # noqa: E402
+    DirectInsightProviderStub,
+    InsightProviderLoadError,
+    InsightTransparencyUnavailableError,
+    load_insight_provider as _core_load_insight_provider,
+    require_ai_generated_insight_notice as _core_require_ai_generated_insight_notice,
+)
 from core.insight.llm_provider_loader import (  # noqa: E402
     load_llm_get_provider as _load_llm_get_provider,
+)
+from app.services.insight_application_service import (  # noqa: E402
+    execute_insight_request as _execute_insight_request_via_service,
 )
 from app.security.agent_input_guard import (  # noqa: E402
     require_safe_ai_agent_input,
@@ -2222,54 +2231,24 @@ def _build_rag_source_items(chunks: list[Any]) -> list[RAGSourceItem]:
 def _load_insight_provider() -> Any:
     """Load configured LLM provider with legacy error contract preserved."""
     try:
-        get_provider = _load_llm_get_provider()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail="LLM module is not available") from e
-
-    provider = get_provider()
-    if provider is None:
-        raise HTTPException(status_code=503, detail="No LLM provider configured")
-    return provider
+        return _core_load_insight_provider(provider_factory_loader=_load_llm_get_provider)
+    except InsightProviderLoadError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 def _require_ai_generated_insight_notice() -> tuple[str, str]:
     """Return the required transparency notice id and boundary or fail closed."""
-    from core.compliance import get_transparency_registry
-
     try:
-        transparency_notice = get_transparency_registry().get("ai_generated_insight")
-    except Exception as exc:
+        notice = _core_require_ai_generated_insight_notice()
+    except InsightTransparencyUnavailableError as exc:
         raise HTTPException(
             status_code=fastapi_status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
+            detail=str(exc),
         ) from exc
-    if not isinstance(transparency_notice, dict):
-        raise HTTPException(
-            status_code=fastapi_status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    surface_id = transparency_notice.get("surface_id")
-    boundary = transparency_notice.get("boundary")
-    if (
-        not isinstance(surface_id, str)
-        or not surface_id
-        or not isinstance(boundary, str)
-        or not boundary
-    ):
-        raise HTTPException(
-            status_code=fastapi_status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="transparency_registry_unavailable",
-        )
-    return surface_id, boundary
+    return notice.surface_id, notice.wellness_boundary
 
 
-class _DirectInsightProviderStub:
-    """Provider stub used when the runtime can answer locally without an LLM call."""
-
-    name = "philosophical_runtime"
-
-    async def generate(self, text: str) -> str:
-        raise RuntimeError("Direct runtime route must not call provider.generate")
+_DirectInsightProviderStub = DirectInsightProviderStub
 
 
 async def _execute_insight_request(
@@ -2280,70 +2259,19 @@ async def _execute_insight_request(
     subject_id: int | None = None,
 ) -> InsightResponse:
     """Shared /insight execution path with philosophical runtime support."""
-    require_safe_ai_agent_input(req.text)
-    prompt_input = _ensure_insight_text_length(req.text)
-
-    use_rag = str(os.getenv("FEATURE_RAG", "")).strip().lower() in {"1", "true", "on", "yes"}
-    from app.utils.feature_flags import (
-        is_philosophy_linguistic_enabled,
-        is_philosophy_phase12_enabled,
-        is_philosophy_pragmatic_enabled,
-        is_philosophy_router_enabled,
-        is_philosophy_validation_enabled,
-        is_recursive_rag_enabled,
-    )
-    from core.insight.philosophical_runtime import PhilosophicalRuntime
-
-    runtime = PhilosophicalRuntime()
-    philosophy_router_enabled = is_philosophy_router_enabled()
-    philosophy_linguistic_enabled = is_philosophy_linguistic_enabled()
-    decision = runtime.preview_route(
-        text=prompt_input,
-        lang=None,
-        router_enabled=philosophy_router_enabled or philosophy_linguistic_enabled,
-        use_rag=use_rag,
-    )
-    transparency_notice_id, wellness_boundary = _require_ai_generated_insight_notice()
-    provider = (
-        _load_insight_provider() if decision.needs_generation else _DirectInsightProviderStub()
-    )
-    runtime_result = await generate_traced_insight(
-        runtime=runtime,
-        text=prompt_input,
-        lang=None,
-        provider=provider,
-        use_rag=use_rag,
-        philo_validation_enabled=is_philosophy_validation_enabled(),
-        recursive_rag_enabled=is_recursive_rag_enabled(),
-        subject_id=subject_id,
-        philosophy_router_enabled=philosophy_router_enabled,
-        philosophy_phase12_enabled=is_philosophy_phase12_enabled(),
-        philosophy_linguistic_enabled=philosophy_linguistic_enabled,
-        philosophy_pragmatic_enabled=is_philosophy_pragmatic_enabled(),
-        route_path=route_path,
-        route_type=decision.route_type.value,
-        user_tier=user_tier,
-    )
-    insight_text = runtime_result.insight[:INSIGHT_TEXT_MAX_LENGTH]
-    source_items = [RAGSourceItem(**item) for item in runtime_result.source_dicts]
-    return InsightResponse(
-        provider=runtime_result.provider_name,
-        insight=insight_text,
-        sources=source_items,
-        confidence=runtime_result.confidence,
-        rag_used=runtime_result.rag_used,
-        hops=runtime_result.hops,
-        latency_ms=runtime_result.latency_ms,
-        route_type=runtime_result.metadata.route_type,
-        depth_used=runtime_result.metadata.depth_used,
-        verification_rate=runtime_result.metadata.verification_rate,
-        falsifiability_rate=runtime_result.metadata.falsifiability_rate,
-        contradiction_count=runtime_result.metadata.contradiction_count,
-        reason_codes=runtime_result.metadata.reason_codes,
-        optimization_applied=runtime_result.metadata.optimization_applied,
-        automated_analysis=True,
-        transparency_notice_id=transparency_notice_id,
-        wellness_boundary=wellness_boundary,
+    return cast(
+        InsightResponse,
+        await _execute_insight_request_via_service(
+            req,
+            route_path=route_path,
+            user_tier=user_tier,
+            subject_id=subject_id,
+            input_guard=require_safe_ai_agent_input,
+            provider_loader=_load_insight_provider,
+            transparency_loader=_require_ai_generated_insight_notice,
+            response_factory=InsightResponse,
+            source_item_factory=RAGSourceItem,
+        ),
     )
 
 

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Any, Callable
 
 import pytest
 
@@ -19,7 +20,10 @@ from core.ai.insight_runtime import (
 
 
 class _FakeProvider:
-    name = "fake-provider"
+    name: str = "fake-provider"
+
+    async def generate(self, text: str) -> str:
+        return text
 
 
 def test_load_insight_provider_uses_lazy_loader(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -69,6 +73,24 @@ def test_load_insight_provider_raises_when_provider_missing(
         load_insight_provider()
 
 
+def test_load_insight_provider_raises_when_provider_factory_call_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider factory invocation must map to the bounded-context error contract."""
+
+    def _raise_provider_init_failure() -> _FakeProvider:
+        raise RuntimeError("provider init boom")
+
+    monkeypatch.setattr(
+        "core.ai.insight_runtime.load_llm_get_provider",
+        lambda: _raise_provider_init_failure,
+        raising=True,
+    )
+
+    with pytest.raises(InsightProviderLoadError, match="LLM provider initialization failed"):
+        load_insight_provider()
+
+
 def test_require_ai_generated_insight_notice_returns_notice() -> None:
     """Valid transparency metadata must become the canonical notice object."""
 
@@ -95,7 +117,7 @@ def test_require_ai_generated_insight_notice_returns_notice() -> None:
     ],
 )
 def test_require_ai_generated_insight_notice_fails_closed(
-    registry_loader,
+    registry_loader: Callable[[], dict[str, Any]],
 ) -> None:
     """Malformed transparency metadata must fail closed."""
 
@@ -114,7 +136,7 @@ def test_prepare_insight_runtime_uses_direct_stub_for_local_answer(
     class _FakeRuntime:
         def preview_route(
             self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
-        ):
+        ) -> SimpleNamespace:
             del text, lang, router_enabled, use_rag
             return SimpleNamespace(
                 needs_generation=False, route_type=SimpleNamespace(value="direct")
@@ -129,6 +151,7 @@ def test_prepare_insight_runtime_uses_direct_stub_for_local_answer(
         philosophy_linguistic_enabled=False,
         provider_loader=lambda: pytest.fail("provider loader must not run"),
         transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        direct_provider_factory=DirectInsightProviderStub,
     )
 
     assert isinstance(prepared.provider, DirectInsightProviderStub)
@@ -148,7 +171,7 @@ def test_prepare_insight_runtime_uses_provider_loader_for_generation(
     class _FakeRuntime:
         def preview_route(
             self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
-        ):
+        ) -> _FakeDecision:
             assert text == "hello"
             assert lang is None
             assert router_enabled is True
@@ -173,3 +196,98 @@ def test_prepare_insight_runtime_uses_provider_loader_for_generation(
     assert prepared.provider is provider
     assert prepared.decision.route_type.value == "deep_reasoning"
     assert prepared.transparency_notice.wellness_boundary == "Wellness only."
+
+
+def test_prepare_insight_runtime_uses_direct_transparency_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct notice payloads must stay valid without tuple coercion."""
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> SimpleNamespace:
+            del text, lang, router_enabled, use_rag
+            return SimpleNamespace(
+                needs_generation=False, route_type=SimpleNamespace(value="direct")
+            )
+
+    notice = InsightTransparencyNotice(
+        surface_id="ai_generated_insight",
+        wellness_boundary="Wellness only.",
+    )
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=False,
+        philosophy_router_enabled=False,
+        philosophy_linguistic_enabled=False,
+        transparency_loader=lambda: notice,
+        direct_provider_factory=DirectInsightProviderStub,
+    )
+
+    assert prepared.transparency_notice is notice
+
+
+def test_prepare_insight_runtime_rejects_invalid_custom_transparency_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom tuple-based transparency loaders must fail closed on invalid payloads."""
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> SimpleNamespace:
+            del text, lang, router_enabled, use_rag
+            return SimpleNamespace(
+                needs_generation=False, route_type=SimpleNamespace(value="direct")
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    with pytest.raises(
+        InsightTransparencyUnavailableError,
+        match="transparency_registry_unavailable",
+    ):
+        prepare_insight_runtime(
+            text="hello",
+            use_rag=False,
+            philosophy_router_enabled=False,
+            philosophy_linguistic_enabled=False,
+            transparency_loader=lambda: ("", "Wellness only."),
+            direct_provider_factory=DirectInsightProviderStub,
+        )
+
+
+def test_prepare_insight_runtime_raises_when_custom_provider_loader_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom generation provider loaders must not leak `None` downstream."""
+
+    @dataclass
+    class _FakeDecision:
+        needs_generation: bool
+        route_type: object
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> _FakeDecision:
+            del text, lang, router_enabled, use_rag
+            return _FakeDecision(
+                needs_generation=True,
+                route_type=SimpleNamespace(value="deep_reasoning"),
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    with pytest.raises(InsightProviderLoadError, match="No LLM provider configured"):
+        prepare_insight_runtime(
+            text="hello",
+            use_rag=False,
+            philosophy_router_enabled=False,
+            philosophy_linguistic_enabled=False,
+            provider_loader=lambda: None,
+            transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        )

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -1,0 +1,175 @@
+"""Unit tests for the canonical core.ai insight runtime facade."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from core.ai.insight_runtime import (
+    DirectInsightProviderStub,
+    InsightProviderLoadError,
+    InsightTransparencyNotice,
+    InsightTransparencyUnavailableError,
+    load_insight_provider,
+    prepare_insight_runtime,
+    require_ai_generated_insight_notice,
+)
+
+
+class _FakeProvider:
+    name = "fake-provider"
+
+
+def test_load_insight_provider_uses_lazy_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Facade must stay lazy and return the resolved provider instance."""
+
+    monkeypatch.setattr(
+        "core.ai.insight_runtime.load_llm_get_provider",
+        lambda: (lambda: _FakeProvider()),
+        raising=True,
+    )
+
+    provider = load_insight_provider()
+
+    assert provider.name == "fake-provider"
+
+
+def test_load_insight_provider_raises_on_import_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Import failures must map to the bounded-context provider error."""
+
+    def _raise_import_failure() -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "core.ai.insight_runtime.load_llm_get_provider",
+        _raise_import_failure,
+        raising=True,
+    )
+
+    with pytest.raises(InsightProviderLoadError, match="LLM module is not available"):
+        load_insight_provider()
+
+
+def test_load_insight_provider_raises_when_provider_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing provider must stay a deterministic bounded-context failure."""
+
+    monkeypatch.setattr(
+        "core.ai.insight_runtime.load_llm_get_provider",
+        lambda: (lambda: None),
+        raising=True,
+    )
+
+    with pytest.raises(InsightProviderLoadError, match="No LLM provider configured"):
+        load_insight_provider()
+
+
+def test_require_ai_generated_insight_notice_returns_notice() -> None:
+    """Valid transparency metadata must become the canonical notice object."""
+
+    notice = require_ai_generated_insight_notice(
+        registry_loader=lambda: {
+            "ai_generated_insight": {
+                "surface_id": "ai_generated_insight",
+                "boundary": "Wellness only.",
+            }
+        }
+    )
+
+    assert notice == InsightTransparencyNotice(
+        surface_id="ai_generated_insight",
+        wellness_boundary="Wellness only.",
+    )
+
+
+@pytest.mark.parametrize(
+    "registry_loader",
+    [
+        lambda: {},
+        lambda: {"ai_generated_insight": {"surface_id": None, "boundary": ""}},
+    ],
+)
+def test_require_ai_generated_insight_notice_fails_closed(
+    registry_loader,
+) -> None:
+    """Malformed transparency metadata must fail closed."""
+
+    with pytest.raises(
+        InsightTransparencyUnavailableError,
+        match="transparency_registry_unavailable",
+    ):
+        require_ai_generated_insight_notice(registry_loader=registry_loader)
+
+
+def test_prepare_insight_runtime_uses_direct_stub_for_local_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local-direct routes must not touch provider loading."""
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ):
+            del text, lang, router_enabled, use_rag
+            return SimpleNamespace(
+                needs_generation=False, route_type=SimpleNamespace(value="direct")
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=False,
+        philosophy_router_enabled=False,
+        philosophy_linguistic_enabled=False,
+        provider_loader=lambda: pytest.fail("provider loader must not run"),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert isinstance(prepared.provider, DirectInsightProviderStub)
+    assert prepared.transparency_notice.surface_id == "ai_generated_insight"
+
+
+def test_prepare_insight_runtime_uses_provider_loader_for_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generation routes must resolve provider and keep the preview decision."""
+
+    @dataclass
+    class _FakeDecision:
+        needs_generation: bool
+        route_type: object
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ):
+            assert text == "hello"
+            assert lang is None
+            assert router_enabled is True
+            assert use_rag is True
+            return _FakeDecision(
+                needs_generation=True,
+                route_type=SimpleNamespace(value="deep_reasoning"),
+            )
+
+    provider = _FakeProvider()
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=True,
+        philosophy_router_enabled=True,
+        philosophy_linguistic_enabled=False,
+        provider_loader=lambda: provider,
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert prepared.provider is provider
+    assert prepared.decision.route_type.value == "deep_reasoning"
+    assert prepared.transparency_notice.wellness_boundary == "Wellness only."

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -1,0 +1,115 @@
+"""Unit tests for the shared insight application service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.insight_application_service import execute_insight_request
+from core.ai.insight_runtime import InsightTransparencyNotice
+
+
+@pytest.mark.asyncio
+async def test_execute_insight_request_uses_injected_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service must preserve injected patch-points and response mapping."""
+
+    observed: dict[str, object] = {}
+
+    @dataclass
+    class _Request:
+        text: str
+
+    def _input_guard(text: str) -> None:
+        observed["guard_text"] = text
+
+    def _provider_loader() -> object:
+        observed["provider_loader_called"] = True
+        return object()
+
+    def _transparency_loader() -> tuple[str, str]:
+        observed["transparency_loader_called"] = True
+        return ("ai_generated_insight", "Wellness only.")
+
+    def _response_factory(**payload: object) -> dict[str, object]:
+        observed["response_payload"] = payload
+        return dict(payload)
+
+    def _source_item_factory(**payload: object) -> dict[str, object]:
+        return dict(payload)
+
+    prepared_runtime = SimpleNamespace(
+        runtime=object(),
+        provider=object(),
+        decision=SimpleNamespace(route_type=SimpleNamespace(value="deep_reasoning")),
+        transparency_notice=InsightTransparencyNotice(
+            surface_id="ai_generated_insight",
+            wellness_boundary="Wellness only.",
+        ),
+    )
+
+    async def _fake_generate_traced_insight(**kwargs: object) -> object:
+        observed["generate_kwargs"] = kwargs
+        return SimpleNamespace(
+            insight="generated insight",
+            provider_name="fake-provider",
+            source_dicts=[{"chunk_id": "c1", "file": "doc.md", "score": 0.9, "hop": 1}],
+            confidence=0.9,
+            rag_used=True,
+            hops=1,
+            latency_ms=12,
+            metadata=SimpleNamespace(
+                route_type="deep_reasoning",
+                depth_used=2,
+                verification_rate=0.8,
+                falsifiability_rate=0.7,
+                contradiction_count=0,
+                reason_codes=["legacy_path"],
+                optimization_applied=False,
+            ),
+        )
+
+    def _fake_prepare_insight_runtime(**kwargs: object) -> object:
+        observed["prepare_kwargs"] = kwargs
+        return prepared_runtime
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        _fake_prepare_insight_runtime,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.generate_traced_insight",
+        _fake_generate_traced_insight,
+        raising=True,
+    )
+
+    response = await execute_insight_request(
+        _Request(text="hello"),
+        route_path="/api/v1/insight",
+        user_tier="VIP",
+        subject_id=123,
+        input_guard=_input_guard,
+        provider_loader=_provider_loader,
+        transparency_loader=_transparency_loader,
+        response_factory=_response_factory,
+        source_item_factory=_source_item_factory,
+    )
+
+    assert observed["guard_text"] == "hello"
+    assert observed["prepare_kwargs"] == {
+        "text": "hello",
+        "use_rag": False,
+        "philosophy_router_enabled": False,
+        "philosophy_linguistic_enabled": False,
+        "provider_loader": _provider_loader,
+        "transparency_loader": _transparency_loader,
+    }
+    assert observed["generate_kwargs"]["subject_id"] == 123
+    assert observed["generate_kwargs"]["route_path"] == "/api/v1/insight"
+    assert response["provider"] == "fake-provider"
+    assert response["transparency_notice_id"] == "ai_generated_insight"
+    assert response["sources"][0]["chunk_id"] == "c1"

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -8,8 +8,12 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from fastapi import HTTPException, status
 
-from app.services.insight_application_service import execute_insight_request
+from app.services.insight_application_service import (
+    INSIGHT_TEXT_MAX_LENGTH,
+    execute_insight_request,
+)
 from core.ai.insight_runtime import InsightTransparencyNotice
 from core.insight.llm_provider_loader import LLMProvider
 
@@ -135,3 +139,54 @@ async def test_execute_insight_request_uses_injected_dependencies(
     assert response["provider"] == "fake-provider"
     assert response["transparency_notice_id"] == "ai_generated_insight"
     assert response["sources"][0]["chunk_id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_execute_insight_request_rejects_oversized_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized prompt text must fail fast with 413 instead of silent truncation."""
+
+    observed: dict[str, Any] = {}
+
+    @dataclass
+    class _Request:
+        text: str
+
+    def _input_guard(text: str) -> None:
+        observed["guard_text"] = text
+
+    def _provider_loader() -> LLMProvider:
+        raise AssertionError("provider loader must not run for oversized prompts")
+
+    def _transparency_loader() -> tuple[str, str]:
+        raise AssertionError("transparency loader must not run for oversized prompts")
+
+    def _response_factory(**payload: object) -> dict[str, object]:
+        return dict(payload)
+
+    def _source_item_factory(**payload: object) -> dict[str, object]:
+        return dict(payload)
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        lambda **kwargs: observed.setdefault("prepare_kwargs", kwargs),
+        raising=True,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await execute_insight_request(
+            _Request(text="x" * (INSIGHT_TEXT_MAX_LENGTH + 1)),
+            route_path="/api/v1/insight",
+            user_tier="VIP",
+            input_guard=_input_guard,
+            provider_loader=_provider_loader,
+            transparency_loader=_transparency_loader,
+            response_factory=_response_factory,
+            source_item_factory=_source_item_factory,
+        )
+
+    assert observed["guard_text"] == "x" * (INSIGHT_TEXT_MAX_LENGTH + 1)
+    assert "prepare_kwargs" not in observed
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == "Prompt too long"

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from app.services.insight_application_service import execute_insight_request
 from core.ai.insight_runtime import InsightTransparencyNotice
+from core.insight.llm_provider_loader import LLMProvider
+
+
+class _FakeProvider:
+    """Minimal provider stub matching the insight runtime protocol.
+
+    RU: Минимальный provider stub для типобезопасного тестового seams.
+    EN: Minimal provider stub for type-safe testing seams.
+    """
+
+    name: str = "fake-provider"
+
+    def generate(self, prompt: str) -> Awaitable[str]:
+        raise RuntimeError(f"Unexpected provider.generate call for prompt={prompt!r}")
 
 
 @pytest.mark.asyncio
@@ -17,7 +33,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
 ) -> None:
     """Service must preserve injected patch-points and response mapping."""
 
-    observed: dict[str, object] = {}
+    observed: dict[str, Any] = {}
 
     @dataclass
     class _Request:
@@ -26,13 +42,17 @@ async def test_execute_insight_request_uses_injected_dependencies(
     def _input_guard(text: str) -> None:
         observed["guard_text"] = text
 
-    def _provider_loader() -> object:
+    def _provider_loader() -> LLMProvider:
         observed["provider_loader_called"] = True
-        return object()
+        return _FakeProvider()
 
     def _transparency_loader() -> tuple[str, str]:
         observed["transparency_loader_called"] = True
         return ("ai_generated_insight", "Wellness only.")
+
+    def _direct_provider_factory() -> LLMProvider:
+        observed["direct_provider_factory_called"] = True
+        return _FakeProvider()
 
     def _response_factory(**payload: object) -> dict[str, object]:
         observed["response_payload"] = payload
@@ -95,6 +115,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
         input_guard=_input_guard,
         provider_loader=_provider_loader,
         transparency_loader=_transparency_loader,
+        direct_provider_factory=_direct_provider_factory,
         response_factory=_response_factory,
         source_item_factory=_source_item_factory,
     )
@@ -107,6 +128,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
         "philosophy_linguistic_enabled": False,
         "provider_loader": _provider_loader,
         "transparency_loader": _transparency_loader,
+        "direct_provider_factory": _direct_provider_factory,
     }
     assert observed["generate_kwargs"]["subject_id"] == 123
     assert observed["generate_kwargs"]["route_path"] == "/api/v1/insight"


### PR DESCRIPTION
## Summary
- introduce a canonical `core/ai/*` bounded-context entry seam for insight runtime preparation
- move shared `/api/v1/insight` and `/insight` execution orchestration behind `app/services/insight_application_service.py`
- keep `legacy_app.py` as thin compatibility adapters while preserving existing patch-points and HTTP contracts
- sync architecture and AGENTS docs to reflect the new canonical seam

## What Changed
- added `core/ai/insight_runtime.py` and `core/ai/__init__.py`
- added `app/services/insight_application_service.py`
- rewired `legacy_app.py` helpers to delegate into the new seam
- kept provider execution/tracing in `app/services/insight_runtime.py`
- preserved VIP gate, rate-limit, transparency, and quota ordering on route wrappers
- added focused tests for the new core/app seams

## Non-Goals
- no OpenAPI wire-shape changes
- no new public endpoints
- no FitChef / GTM / branding changes
- no broad legacy/runtime cleanup outside the insight seam

## Validation
- `pre-commit run --all-files`
- `make verify`
- `pytest -q tests/test_core_ai_insight_runtime.py tests/test_insight_application_service.py`
- `pytest -q tests/test_insight_error_hygiene.py tests/test_insight_vip_guard_api.py tests/test_rag_vector_feature_flag_guard.py`
- `pytest -q tests/test_genai_tracing.py tests/test_philosophy_validation_integration.py tests/test_insight_rag_response_fields.py`

## Review Notes
- `#1201` was merged first as the packet-only architecture freeze PR
- this PR is the runtime follow-up implementation slice from fresh `main`
- legacy compatibility patch-points were intentionally preserved because the regression suite still depends on them

## Summary by Sourcery

Ввести канонический шов рантайма инсайтов core/ai и сервис оркестрации маршрутов, сохранив устаревшие endpoints инсайтов как тонкие адаптеры совместимости.

Новые возможности:
- Добавить фасад ограниченного контекста core AI в `core/ai` для подготовки рантайма инсайтов, загрузки провайдеров и метаданных прозрачности.
- Добавить прикладной сервис выполнения инсайтов для централизованной оркестрации общих `/insight` за устаревшими HTTP endpoints.

Улучшения:
- Рефакторинг устаревших endpoints инсайтов так, чтобы они делегировали загрузку провайдеров, разрешение прозрачности и выполнение рантайма новому шву core/ai и прикладному сервису, при этом сохранив существующие HTTP-контракты ошибок и точки патчинга.
- Уточнить архитектуру, ADR, документацию по агентам и бэклогу, чтобы отразить новый канонический AI-шов и оставшийся объем работ по консолидации.

Документация:
- Обновить архитектуру, ADR и документацию AGENTS, чтобы описать входной шов ограниченного контекста `core/ai` и его отношение к устаревшим адаптерам и провайдерам.

Тесты:
- Добавить целевые модульные тесты для фасада рантайма инсайтов в `core/ai` и общего прикладного сервиса инсайтов для проверки поведения и инъекции точек патчинга.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a canonical core/ai insight runtime seam and route orchestration service while keeping legacy insight endpoints as thin compatibility adapters.

New Features:
- Add a core AI bounded-context facade in core/ai for insight runtime preparation, provider loading, and transparency metadata.
- Add an application-level insight execution service to centralize shared /insight orchestration behind legacy HTTP endpoints.

Enhancements:
- Refactor legacy insight endpoints to delegate provider loading, transparency resolution, and runtime execution to the new core/ai seam and application service while preserving existing HTTP error contracts and patch points.
- Clarify architecture, ADR, agents, and backlog documentation to reflect the new canonical AI seam and remaining consolidation work.

Documentation:
- Update architecture, ADR, and AGENTS documentation to describe the core/ai bounded-context entry seam and its relationship to legacy adapters and providers.

Tests:
- Add focused unit tests for the core/ai insight runtime facade and the shared insight application service to validate behavior and patch-point injection.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the insight runtime behind a canonical `core/ai/*` seam and introduced `app/services/insight_application_service.py` for shared `/insight` orchestration. Legacy `/api/v1/insight` and `/insight` now delegate to this service and the `core/ai` facade with stricter provider/transparency handling and prompt-size checks.

- **Refactors**
  - Added `core/ai/insight_runtime.py` and `core/ai/__init__.py` for runtime prep, lazy provider loading, transparency notices, and an injectable direct‑provider stub.
  - Introduced `app/services/insight_application_service.py`; `legacy_app.py` now calls it and uses `core.ai` loaders while preserving existing HTTP behavior and patch points.
  - Updated docs (AGENTS, providers implementation, system overview, ADR) and finalized `docs/review/PR_1203_FIXED_MAPPING.md`; backlog now links `#1203`.

- **Bug Fixes**
  - Normalized provider/transparency failures into canonical errors (`InsightProviderLoadError`, `InsightTransparencyUnavailableError`) mapped to 503 in legacy adapters; invalid transparency tuples fail closed.
  - Rejected oversized insight prompts with HTTP 413 (response text still capped at 2000 chars). Added focused tests for `core/ai` and the application service covering direct routes, missing provider, invalid transparency, prompt size, and response mapping.

<sup>Written for commit 7be070ba8bc5475e20ce1d99c942e911bd357e07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * /insight now validates/caps prompt input (2000 chars), returns HTTP 413 for oversized prompts, and returns structured insight payloads including source items, provider name, confidence/RAG/hops/latency, route and verification metrics, and a transparency notice (surface ID + wellness boundary).

* **Bug Fixes**
  * More deterministic provider resolution and consistent 503 behavior when provider or transparency metadata are unavailable.

* **Documentation**
  * Architecture, ADRs, roadmap, and implementation docs updated to reflect a canonical AI bounded-context seam.

* **Tests**
  * New unit tests covering runtime preparation, provider loading, transparency handling, and the insight service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical SoT: `docs/review/PR_1203_FIXED_MAPPING.md`
