### PR TITLE
fix(cd): stabilize gha cache for staging and production

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,10 +68,21 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
+          # Single-arch for cache/push stability. Restore linux/arm64 when
+          # buildx + GHA cache/provenance path is stable again.
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:staging-latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Omit cache-from to avoid 404 BlobNotFound when the GHA cache entry
+          # is missing or evicted mid-build. mode=min keeps export bounded.
+          # ignore-error=true prevents CD failure on transient cache backend
+          # issues while still allowing image publication.
+          cache-to: type=gha,mode=min,ignore-error=true
+          # Disable provenance to avoid buildx/GHA cache export failures
+          # ("cache entry no longer exists" / BlobNotFound). Trade-off: SLSA
+          # attestations are disabled, so cosign verify-attestation will fail
+          # for this image until the cache/provenance stack is stable.
+          provenance: false
           # Use dedicated staging target which extends production but allows
           # staging-specific customizations (e.g., debug logging, extended health checks)
           target: staging
@@ -245,11 +256,22 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
+          # Single-arch for cache/push stability. Restore linux/arm64 when
+          # buildx + GHA cache/provenance path is stable again.
+          platforms: linux/amd64
           push: true
           # Source of truth for production deployments: prod-${tag} (never `latest`).
           tags: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:prod-${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Omit cache-from to avoid 404 BlobNotFound when the GHA cache entry
+          # is missing or evicted mid-build. mode=min keeps export bounded.
+          # ignore-error=true prevents CD failure on transient cache backend
+          # issues while still allowing image publication.
+          cache-to: type=gha,mode=min,ignore-error=true
+          # Disable provenance to avoid buildx/GHA cache export failures
+          # ("cache entry no longer exists" / BlobNotFound). Trade-off: SLSA
+          # attestations are disabled, so cosign verify-attestation will fail
+          # for this image until the cache/provenance stack is stable.
+          provenance: false
           target: production
 
   deploy-production:

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -46,10 +46,10 @@ to `.github/workflows/cd.yml`:
   `linux/amd64`, uses `cache-to: ...mode=min,ignore-error=true`, and sets
   `provenance: false` for publish.
 - `.github/workflows/cd.yml:73`, `.github/workflows/cd.yml:80`,
-  `.github/workflows/cd.yml:84` align the staging CD image build with the same
+  `.github/workflows/cd.yml:85` align the staging CD image build with the same
   cache/provenance workaround profile.
-- `.github/workflows/cd.yml:260`, `.github/workflows/cd.yml:268`,
-  `.github/workflows/cd.yml:272` align the production CD image build with the
+- `.github/workflows/cd.yml:261`, `.github/workflows/cd.yml:269`,
+  `.github/workflows/cd.yml:274` align the production CD image build with the
   same cache/provenance workaround profile.
 
 ## Exit Criteria / Definition of Done

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -6,35 +6,62 @@ Accepted (temporary seam)
 ## Context
 Docker image push to GHCR was failing with `failed to push ... cache entry no longer exists` when using `cache-from: type=gha` and default provenance. This is a known class of issues with buildx + GHA cache backend where cache blobs can become unavailable during export/push.
 
-To unblock main and stabilize CI, we apply two workarounds in `.github/workflows/build.yml`:
+To unblock main and stabilize CI/CD, we keep the existing workaround profile in
+`.github/workflows/build.yml` and extend the same provenance/single-arch policy
+to `.github/workflows/cd.yml`:
 1. **provenance: false** — disables SLSA build provenance attestations so buildx does not generate attestations that can interact badly with the cache export path.
 2. **Single-arch (linux/amd64)** in publish step — reduces surface for cache/export issues; multi-arch can be restored when cache/provenance stack is stable.
+3. **No `cache-from: type=gha` on CD image builds** — avoids `BlobNotFound` /
+   missing cache entry failures when the GitHub Actions cache backend evicts or
+   cannot resolve a referenced blob during multi-stage COPY.
 
 ## Decision
-- Set `provenance: false` in the publish job's `docker/build-push-action` step.
-- Keep single platform `linux/amd64` for the publish step; document intent to restore `linux/arm64` when GHA cache/provenance is stable.
+- Keep `provenance: false` in the existing `build.yml` publish step and set it
+  in the corresponding `cd.yml` image-build steps.
+- Keep single platform `linux/amd64` for the affected publish/deploy/CD steps;
+  document intent to restore `linux/arm64` when GHA cache/provenance is
+  stable.
+- Keep `build.yml` publish on its current bounded cache profile, and omit
+  `cache-from: type=gha` for the affected `cd.yml` image-build steps while
+  using `cache-to: type=gha,mode=min,ignore-error=true` as the fail-safe export
+  profile.
 - Inline comments in the workflow document the trade-off (SLSA attestations disabled; `cosign verify-attestation` will fail for consumers) and re-enable intent.
 - This ADR documents the temporary seam and exit criteria.
 
 ## Rationale
-- Restores green CI and reliable image pushes to GHCR.
+- Restores green CI/CD and reliable image pushes to GHCR.
 - Trade-off is explicit: we lose attestations until upstream/buildx or GHA cache behavior is fixed.
 - Single-arch reduces variables while cache/provenance tooling is unstable.
+- Removing `cache-from` on CD image builds favors reliability over cache hit
+  rate for the release path.
 
 ## Consequences
 - Image consumers cannot verify SLSA provenance via cosign for images built by this workflow until the workaround is removed.
 - Arm64 image builds are deferred until we re-enable multi-platform.
 
 ## Evidence Anchors (file:line)
-- `provenance: false` and comment: `.github/workflows/build.yml` (publish step, ~179–183).
-- Platforms comment and single-arch: `.github/workflows/build.yml` (publish step, ~175–176).
-- Build job omits `cache-from` to avoid 404: `.github/workflows/build.yml` (build step, ~32–42).
+- `.github/workflows/build.yml:42` omits `cache-from` in the local build job to
+  avoid `BlobNotFound`.
+- `.github/workflows/build.yml:181`-`.github/workflows/build.yml:193` pins
+  `linux/amd64`, uses `cache-to: ...mode=min,ignore-error=true`, and sets
+  `provenance: false` for publish.
+- `.github/workflows/cd.yml:73`, `.github/workflows/cd.yml:80`,
+  `.github/workflows/cd.yml:84` align the staging CD image build with the same
+  cache/provenance workaround profile.
+- `.github/workflows/cd.yml:260`, `.github/workflows/cd.yml:268`,
+  `.github/workflows/cd.yml:272` align the production CD image build with the
+  same cache/provenance workaround profile.
 
 ## Exit Criteria / Definition of Done
 - [ ] Upstream fix or documented stable approach: buildx and/or GHA cache backend no longer produces "cache entry no longer exists" (or equivalent) when using `cache-from: type=gha` and provenance enabled.
-- [ ] Remove `provenance: false` and restore default or `provenance: mode=max` in `.github/workflows/build.yml` publish step.
-- [ ] Optionally restore `platforms: linux/amd64,linux/arm64` when cache/provenance is stable.
+- [ ] Remove `provenance: false` and restore default or `provenance: mode=max`
+  in the affected publish/deploy workflow steps.
+- [ ] Re-evaluate whether `cache-from: type=gha` can be safely restored on the
+  affected `cd.yml` image-build steps.
+- [ ] Optionally restore `platforms: linux/amd64,linux/arm64` when
+  cache/provenance is stable.
 - [ ] Update this ADR status to Superseded with a pointer to the removal PR when workaround is removed.
 
 ## Links
 - Workflow: `.github/workflows/build.yml`.
+- Workflow: `.github/workflows/cd.yml`.

--- a/docs/review/PR_1204_FIXED_MAPPING.md
+++ b/docs/review/PR_1204_FIXED_MAPPING.md
@@ -1,0 +1,28 @@
+# PR 1204 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments at PR open.
+
+## Merge Readiness
+- Status: ready for review / not ready to merge.
+- Current fix commit:
+  - `f739223f` — `fix(cd): stabilize gha cache for staging and production`
+- Current scope discipline:
+  - workflow-only CD cache/provenance stabilization
+  - ADR sync for the temporary workaround scope
+  - no Dockerfile runtime changes
+- Local validation executed on this lane:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `pre-commit run --all-files`
+  - `make verify`
+  - `docker --context=default buildx build --builder default --load --progress=plain --target staging -t pulseplate:staging-smoke .`
+  - `docker --context=default buildx build --builder default --load --progress=plain --target production -t pulseplate:production-smoke .`
+- Required before merge:
+  - record every actionable review disposition in this artifact
+  - resolve threads only after disposition evidence exists
+  - confirm current-head required checks are green with no pending required jobs
+  - confirm no actionable bot comments remain

--- a/docs/review/PR_1204_FIXED_MAPPING.md
+++ b/docs/review/PR_1204_FIXED_MAPPING.md
@@ -5,12 +5,22 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments at PR open.
+
+Disposition: FIXED
+Commit: dc0f2d50
+Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:48`, `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:51`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1204#discussion_r2968185814 -> dc0f2d50
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1204_FIXED_MAPPING.md:9`, `docs/review/PR_1204_FIXED_MAPPING.md:12`
+Reason: The review summary URL only aggregates the single inline CodeRabbit finding that is dispositioned separately in this artifact and does not add independent unresolved work on current head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1204#pullrequestreview-3984316347
 
 ## Merge Readiness
 - Status: ready for review / not ready to merge.
 - Current fix commit:
   - `f739223f` — `fix(cd): stabilize gha cache for staging and production`
+  - `dc0f2d50` — `docs(architecture): correct cd evidence anchors`
 - Current scope discipline:
   - workflow-only CD cache/provenance stabilization
   - ADR sync for the temporary workaround scope


### PR DESCRIPTION
## Summary
- fix the CD regression behind failing run 23363183360 by aligning `.github/workflows/cd.yml` image-build steps with the stabilized cache/provenance profile already used as the project canon
- remove `cache-from: type=gha` from staging and production CD image builds
- switch CD cache export to `type=gha,mode=min,ignore-error=true`, pin `platforms: linux/amd64`, and set `provenance: false`
- extend `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` so the workaround scope explicitly includes `cd.yml`

## Root Cause
The failing job hit a GitHub Actions cache backend 404 / `BlobNotFound` during the multi-stage copy path:
- failing run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23363183360/job/67971216089
- failure class: `failed to copy` on `COPY --from=builder /opt/venv /opt/venv`
- classification: workflow/buildx GHA cache regression, not a Dockerfile layer bug

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files`
- `make verify`
- `docker --context=default buildx build --builder default --load --progress=plain --target staging -t pulseplate:staging-smoke .`
- `docker --context=default buildx build --builder default --load --progress=plain --target production -t pulseplate:production-smoke .`

## Bug-hunter
- no blocking findings in `.github/workflows/cd.yml`
- both CD image-build steps now use the anti-BlobNotFound profile: no `cache-from`, `platforms: linux/amd64`, `cache-to: type=gha,mode=min,ignore-error=true`, `provenance: false`
- residual drift remains in `.github/workflows/build.yml:186`, which still keeps `cache-from: type=gha`; this PR fixes the CD lane specifically, not the entire repo build/publish surface

## Evidence Anchors
- `.github/workflows/cd.yml:73`
- `.github/workflows/cd.yml:80`
- `.github/workflows/cd.yml:84`
- `.github/workflows/cd.yml:260`
- `.github/workflows/cd.yml:268`
- `.github/workflows/cd.yml:272`
- `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:9`
- `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:42`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CD Docker builds for staging and production to prevent GHA cache/provenance flakes and ensure reliable pushes to GHCR. Aligns `cd.yml` with the CI workaround and updates docs.

- **Bug Fixes**
  - Remove `cache-from: type=gha` from both CD image builds.
  - Set `platforms: linux/amd64`, use `cache-to: type=gha,mode=min,ignore-error=true`, and `provenance: false`.
  - Update ADR to include `cd.yml` and correct evidence anchors; add `docs/review/PR_1204_FIXED_MAPPING.md` to record review dispositions.

<sup>Written for commit 6a5bad7f7142f42139fc81fb79ec72ebf87d071d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized image build behavior for staging and production: set a single target platform, adjusted caching strategy, and disabled provenance generation to stabilize builds and deployments.

* **Documentation**
  * Updated architecture decision record to reflect coordinated build/CD approach and rollback criteria.
  * Added a review/merge-readiness record documenting validation steps and pre-merge requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1204_FIXED_MAPPING.md`
