### PR TITLE
feat(ios): add thin SubscriptionManager and receipt-send flow

### DIFF
--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1207 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review threads are recorded on current head yet.
+- No actionable review comments
 
 ## Merge Readiness
 - Status: draft / not ready to merge.

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -6,32 +6,37 @@
 
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969286594 -> 415c3562
-  Disposition: FIXED
-  Commit: 415c3562
-  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
-  Reason: sanitized persisted activation pointers before refresh fetch and added regression coverage proving blank stored IDs are cleared without backend fetch.
+Disposition: FIXED
+Commit: 415c3562
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
+Reason: sanitized persisted activation pointers before refresh fetch and added regression coverage proving blank stored IDs are cleared without backend fetch.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> 415c3562
-  Disposition: FIXED
-  Commit: 415c3562
-  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
-  Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
+Disposition: FIXED
+Commit: 415c3562
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
+Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> 415c3562
-  Disposition: FIXED
-  Commit: 415c3562
-  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
-  Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.
+Disposition: FIXED
+Commit: 415c3562
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
+Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768
-  Disposition: NOT-A-BUG
-  Evidence: `ios/AGENTS.md:86`, `ios/AGENTS.md:88`, `ios/AGENTS.md:92`
-  Reason: activation-ID normalization stays in `SubscriptionManager` by design because this seam is orchestration-only and backend-owned; moving validation into transport DTOs would broaden scope and weaken the thin-client boundary without a current second caller.
+Disposition: NOT-A-BUG
+Evidence: `ios/AGENTS.md:86`, `ios/AGENTS.md:88`, `ios/AGENTS.md:92`
+Reason: activation-ID normalization stays in `SubscriptionManager` by design because this seam is orchestration-only and backend-owned; moving validation into transport DTOs would broaden scope and weaken the thin-client boundary without a current second caller.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765863
-  Disposition: NOT-A-BUG
-  Evidence: `AGENTS.md:3`, `AGENTS.md:8`, `RUNBOOK_AGENT.md:113`
-  Reason: CodeRabbit's docstring coverage warning is advisory and not part of this repo's blocking merge gates; the required local bundle is `pre-commit run --all-files` plus `make verify`, both green on this lane.
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:3`, `AGENTS.md:8`, `RUNBOOK_AGENT.md:113`
+Reason: CodeRabbit's docstring coverage warning is advisory and not part of this repo's blocking merge gates; the required local bundle is `pre-commit run --all-files` plus `make verify`, both green on this lane.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765990
-  Disposition: NOT-A-BUG
-  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/AGENTS.md:88`
-  Reason: the Sourcery review-guide comment duplicates the actionable review above and adds no independent unresolved item after the FIXED and NOT-A-BUG dispositions recorded here.
+Disposition: NOT-A-BUG
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/AGENTS.md:88`
+Reason: the Sourcery review-guide comment duplicates the actionable review above and adds no independent unresolved item after the FIXED and NOT-A-BUG dispositions recorded here.
 
 ## Merge Readiness
 - Status: in progress; draft removed, local gates green, waiting for pushed head + current-head CI/governance re-check.

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -1,0 +1,28 @@
+# PR 1207 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review threads are recorded on current head yet.
+
+## Merge Readiness
+- Status: draft / not ready to merge.
+- Current fix commits:
+  - `2f98dea7` — `docs(roadmap): close B3 in local tracker`
+  - `d4c9a38f` — `feat(ios): harden thin subscription activation flow`
+- Current scope discipline:
+  - repo-local SoT alignment after B3 closure in PR #1189
+  - iOS thin `SubscriptionManager` activation hardening
+  - fail-closed regression tests and scoped `ios/AGENTS.md` policy sync
+- Local validation executed on this lane:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - targeted `make ios-test` for `SubscriptionManager` / billing runtime tests
+  - `pre-commit run --all-files`
+  - `make verify`
+- Required before merge:
+  - record every actionable review disposition in this artifact
+  - resolve threads only after disposition evidence exists
+  - confirm current-head required checks are green with no pending required jobs
+  - confirm no actionable bot comments remain

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -5,6 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969286594 -> 415c3562
+  Disposition: FIXED
+  Commit: 415c3562
+  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
+  Reason: sanitized persisted activation pointers before refresh fetch and added regression coverage proving blank stored IDs are cleared without backend fetch.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> 415c3562
   Disposition: FIXED
   Commit: 415c3562

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -32,15 +32,15 @@ Disposition: NOT-A-BUG
 Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/AGENTS.md:88`
 Reason: the Sourcery review-guide comment duplicates the actionable review above and adds no independent unresolved item after the FIXED and NOT-A-BUG dispositions recorded here.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985798146 -> 9938ce65
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985798146 -> 81ea1995
 Disposition: FIXED
-Commit: 9938ce65
+Commit: 81ea1995
 Evidence: `docs/review/PR_1207_FIXED_MAPPING.md:20`, `docs/review/PR_1207_FIXED_MAPPING.md:31`
 Reason: cubic identified an ambiguous double-disposition on the same review URL; this artifact now assigns a single disposition to the Sourcery review and keeps each review URL unique.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969317746 -> 9938ce65
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969317746 -> 81ea1995
 Disposition: FIXED
-Commit: 9938ce65
+Commit: 81ea1995
 Evidence: `docs/review/PR_1207_FIXED_MAPPING.md:20`, `docs/review/PR_1207_FIXED_MAPPING.md:31`
 Reason: fixed the exact mapping ambiguity called out by cubic on the review thread by removing the duplicate disposition for the same review URL.
 

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -5,13 +5,33 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> `415c3562`
+  Disposition: FIXED
+  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
+  Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> `415c3562`
+  Disposition: FIXED
+  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
+  Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768
+  Disposition: NOT-A-BUG
+  Evidence: `ios/AGENTS.md:86`, `ios/AGENTS.md:88`, `ios/AGENTS.md:92`
+  Reason: activation-ID normalization stays in `SubscriptionManager` by design because this seam is orchestration-only and backend-owned; moving validation into transport DTOs would broaden scope and weaken the thin-client boundary without a current second caller.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765863
+  Disposition: NOT-A-BUG
+  Evidence: `AGENTS.md:3`, `AGENTS.md:8`, `RUNBOOK_AGENT.md:113`
+  Reason: CodeRabbit's docstring coverage warning is advisory and not part of this repo's blocking merge gates; the required local bundle is `pre-commit run --all-files` plus `make verify`, both green on this lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765990
+  Disposition: NOT-A-BUG
+  Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/AGENTS.md:88`
+  Reason: the Sourcery review-guide comment duplicates the actionable review above and adds no independent unresolved item after the FIXED and NOT-A-BUG dispositions recorded here.
 
 ## Merge Readiness
-- Status: draft / not ready to merge.
+- Status: in progress; draft removed, local gates green, waiting for pushed head + current-head CI/governance re-check.
 - Current fix commits:
   - `2f98dea7` — `docs(roadmap): close B3 in local tracker`
   - `d4c9a38f` — `feat(ios): harden thin subscription activation flow`
+  - `415c3562` — `fix(ios): harden activation id refresh flow`
 - Current scope discipline:
   - repo-local SoT alignment after B3 closure in PR #1189
   - iOS thin `SubscriptionManager` activation hardening
@@ -19,10 +39,16 @@
 - Local validation executed on this lane:
   - `python3 scripts/orchestration/check_preflight.py`
   - targeted `make ios-test` for `SubscriptionManager` / billing runtime tests
+  - `pytest -q tests/test_repo_policy_guards.py`
+  - `bug-hunter` review pass (no findings in current diff; residual risk limited to missing higher-level relaunch integration coverage)
   - `pre-commit run --all-files`
   - `make verify`
+- Bot status snapshot before push:
+  - CodeRabbit: actionable review addressed in `415c3562`; summary docstring warning classified as advisory / NOT-A-BUG.
+  - Sourcery: logging feedback addressed in `415c3562`; DTO-centralization suggestion classified as NOT-A-BUG for current thin-client boundary.
+  - cubic identified no issues in `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774235`.
 - Required before merge:
-  - record every actionable review disposition in this artifact
-  - resolve threads only after disposition evidence exists
+  - push `415c3562` plus this artifact update and refresh PR body mirror
+  - resolve threads only after disposition evidence exists on pushed commits
   - confirm current-head required checks are green with no pending required jobs
   - confirm no actionable bot comments remain

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -5,11 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> `415c3562`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> 415c3562
   Disposition: FIXED
   Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
   Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> `415c3562`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> 415c3562
   Disposition: FIXED
   Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
   Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -17,16 +17,10 @@ Commit: 415c3562
 Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
 Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> 415c3562
-Disposition: FIXED
-Commit: 415c3562
-Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
-Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768
 Disposition: NOT-A-BUG
-Evidence: `ios/AGENTS.md:86`, `ios/AGENTS.md:88`, `ios/AGENTS.md:92`
-Reason: activation-ID normalization stays in `SubscriptionManager` by design because this seam is orchestration-only and backend-owned; moving validation into transport DTOs would broaden scope and weaken the thin-client boundary without a current second caller.
+Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`, `ios/AGENTS.md:86`, `ios/AGENTS.md:88`, `ios/AGENTS.md:92`
+Reason: the review bundles two high-level suggestions into one review URL; for governance this review is classified as NOT-A-BUG because runtime logging for invalid activation identifiers is already present and DTO-level normalization remains intentionally out of scope for the thin-client boundary.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765863
 Disposition: NOT-A-BUG
@@ -37,6 +31,18 @@ Reason: CodeRabbit's docstring coverage warning is advisory and not part of this
 Disposition: NOT-A-BUG
 Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/AGENTS.md:88`
 Reason: the Sourcery review-guide comment duplicates the actionable review above and adds no independent unresolved item after the FIXED and NOT-A-BUG dispositions recorded here.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985798146 -> 9938ce65
+Disposition: FIXED
+Commit: 9938ce65
+Evidence: `docs/review/PR_1207_FIXED_MAPPING.md:20`, `docs/review/PR_1207_FIXED_MAPPING.md:31`
+Reason: cubic identified an ambiguous double-disposition on the same review URL; this artifact now assigns a single disposition to the Sourcery review and keeps each review URL unique.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969317746 -> 9938ce65
+Disposition: FIXED
+Commit: 9938ce65
+Evidence: `docs/review/PR_1207_FIXED_MAPPING.md:20`, `docs/review/PR_1207_FIXED_MAPPING.md:31`
+Reason: fixed the exact mapping ambiguity called out by cubic on the review thread by removing the duplicate disposition for the same review URL.
 
 ## Merge Readiness
 - Status: in progress; draft removed, local gates green, waiting for pushed head + current-head CI/governance re-check.

--- a/docs/review/PR_1207_FIXED_MAPPING.md
+++ b/docs/review/PR_1207_FIXED_MAPPING.md
@@ -7,10 +7,12 @@
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> 415c3562
   Disposition: FIXED
+  Commit: 415c3562
   Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:252`, `ios/PulsePlate/Services/SubscriptionManager.swift:260`, `ios/PulsePlate/Services/SubscriptionManager.swift:276`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:236`, `ios/PulsePlateTests/Services/SubscriptionManagerTests.swift:390`
   Reason: normalized stored activation pointers before refresh fetch, short-circuited blank stored IDs locally, and added restore/refresh regression coverage for blank activation identifiers.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768 -> 415c3562
   Disposition: FIXED
+  Commit: 415c3562
   Evidence: `ios/PulsePlate/Services/SubscriptionManager.swift:93`, `ios/PulsePlate/Services/SubscriptionManager.swift:360`
   Reason: added explicit runtime logging for blank or whitespace-only activation identifiers.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1015,11 +1015,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Follow the canonical DoD recorded under `ledger-p1-ios-subscription-manager`
 
 <a id="ledger-p1-ios-storekit-products"></a>
-- [ ] P1: iOS StoreKit products contract and setup baseline
+- [x] P1: iOS StoreKit products contract and setup baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1172 (contract baseline landed) -> PR #1189 (operational/setup close-out)
-  - Status: 🟡 Contract baseline is merged; PR #1189 carries the operational/setup close-out and this item remains open until that PR merges
+  - Status: ✅ Contract baseline merged in PR #1172; operational/setup close-out merged in PR #1189 and future setup work must use the canonical checklist
   - Area: ios / release / billing operations
   - Finding Type: store configuration readiness
   - Reason (EN): PR #1172 already versioned the canonical StoreKit product IDs and setup baseline in-repo. The remaining B3 work was to consolidate the surviving operational release/setup residue into one canonical checklist and make all Batch B follow-through docs point back to that contract instead of drifting into parallel setup notes after PR #1185 / PR #1187.

--- a/docs/roadmap/PulsePlate_Master_Index_A-E.md
+++ b/docs/roadmap/PulsePlate_Master_Index_A-E.md
@@ -1,14 +1,14 @@
 # PulsePlate — Unified Execution Tracker
 Batches A–E in one operational view: what is archived, what executes next, what stays queued and what must wait.
 
-**Date:** 19 March 2026
-**Last sync:** B3 operational setup consolidation is staged in PR #1189 after the StoreKit contract baseline in PR #1172 and B2 activation normalization in PR #1185.
+**Date:** 21 March 2026
+**Last sync:** B3 operational setup consolidation merged in PR #1189 after the StoreKit contract baseline in PR #1172 and B2 activation normalization in PR #1185.
 
 ## Current truth
 
 | Current truth | What is next | What stays out of scope for now |
 |---------------|--------------|----------------------------------|
-| Batch A is archived after PR-6.<br/>Batch B monetization foundations already merged on `main` are:<br/>- B1 baseline runtime in PR #1182<br/>- StoreKit contract baseline in PR #1172<br/>- Thin SubscriptionManager groundwork in PR #1171<br/>- Apple verify -> activation normalization in PR #1185<br/>B3 operational/setup close-out is staged in PR #1189 and is still pending merge. | The next Batch B work is follow-through, not first-pass baseline creation: backend-driven SubscriptionManager hardening and the remaining runtime cleanup around the merged billing truth. | Do not reopen baseline contract work, and do not mix unrelated AI/GTM or dependency-remediation scope into this lane. |
+| Batch A is archived after PR-6.<br/>Batch B monetization foundations already merged on `main` are:<br/>- B1 baseline runtime in PR #1182<br/>- StoreKit contract baseline in PR #1172<br/>- Thin SubscriptionManager groundwork in PR #1171<br/>- Apple verify -> activation normalization in PR #1185<br/>B3 operational/setup close-out merged in PR #1189. | The next Batch B work is follow-through, not first-pass baseline creation: backend-driven SubscriptionManager hardening and the remaining runtime cleanup around the merged billing truth. | Do not reopen baseline contract work, and do not mix unrelated AI/GTM or dependency-remediation scope into this lane. |
 
 ## Batch B — Item-level execution tracker
 
@@ -16,7 +16,7 @@ Batches A–E in one operational view: what is archived, what executes next, wha
 |----|-------------|----------|---------------|------------------|----------------------|
 | B1 | Payments RU/BY + iOS Baseline Runtime W1 | P0/P1 | **✅ Completed** | — | PR #1182 merged. |
 | B2 | Apple Receipt Verification Backend (full activation) | P0/P1 | **✅ Completed** | — | PR #1185 merged. |
-| B3 | StoreKit Product Contract and Operational Setup | P0/P1 | **Docs/ops close-out is in PR #1189; merge pending** | — | Merge PR #1189; after merge, future TestFlight / App Store setup work must use the canonical checklist in `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`. |
+| B3 | StoreKit Product Contract and Operational Setup | P0/P1 | **✅ Completed** | — | PR #1189 merged; future TestFlight / App Store setup work must use the canonical checklist in `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`. |
 | B4 | iOS SubscriptionManager Thin-Client Integration | P0/P1 | **Runtime client follow-through still pending** | After backend activation and StoreKit contract baseline are merged | Complete the thin-client activation handoff so iOS forwards backend activation contract data without rebuilding billing truth on-device. |
 
 **Batch rule:** PR-6 and Batch A governance work closed; do not mix with AI/GTM.

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -83,6 +83,14 @@
 - FREE-tier iOS surfaces may show bounded/static FitChef guidance, but must not expose open-ended coach runtime.
 - Mascot or App Store asset changes must land through dedicated asset-focused PRs; docs/policy PRs must not mix in binary asset promotion.
 
+## iOS billing runtime thin-client policy
+
+- `SubscriptionManager` is orchestration-only; entitlement truth remains backend-owned.
+- StoreKit purchase success must not unlock paid UI until backend verification, activation, and refresh confirm entitlement.
+- Missing, stale, or malformed activation payload or activation context must keep UI locked (fail-closed).
+- All billing-runtime calls must go through `APIClient` / `HTTPClient`; direct `URLSession` networking is forbidden on this seam.
+- App relaunch or foreground refresh with stored activation context must re-check entitlement with the backend instead of inferring tier locally.
+
 ## Enforced CI Rules (Anti-Duplication)
 
 **Guard test:** `ThinClientGuardsTests` in `PulsePlateTests/Guards/`

--- a/ios/PulsePlate/Services/SubscriptionManager.swift
+++ b/ios/PulsePlate/Services/SubscriptionManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import OSLog
 
 struct SubscriptionErrorState: Equatable, Sendable {
     let message: String
@@ -89,6 +90,10 @@ final class SubscriptionManager: ObservableObject {
 
         return [fractionalFormatter, basicFormatter]
     }()
+    private static let logger = Logger(
+        subsystem: "PulsePlate",
+        category: "SubscriptionManager"
+    )
 
     @Published private(set) var products: [SubscriptionProduct] = []
     @Published private(set) var catalogState: ProductCatalogState = .idle
@@ -244,7 +249,19 @@ final class SubscriptionManager: ObservableObject {
             return
         }
 
-        guard let activationID = activationPointerStore.loadActivationID(), activationID.isEmpty == false else {
+        guard let rawActivationID = activationPointerStore.loadActivationID() else {
+            finishOperation(operation, token: token)
+            clearErrorState()
+            entitlement = nil
+            flowState = .idle
+            return
+        }
+
+        let storedActivationID: String
+        do {
+            storedActivationID = try validatedActivationID(rawActivationID)
+        } catch {
+            activationPointerStore.clearActivationID()
             finishOperation(operation, token: token)
             clearErrorState()
             entitlement = nil
@@ -257,7 +274,7 @@ final class SubscriptionManager: ObservableObject {
             clearErrorState()
             flowState = .refreshingEntitlement
             let activation = try await billingService.fetchActivationStatus(
-                activationID: activationID,
+                activationID: storedActivationID,
                 apiKey: apiKey
             )
 
@@ -343,6 +360,7 @@ final class SubscriptionManager: ObservableObject {
     private func validatedActivationID(_ rawValue: String) throws -> String {
         let normalizedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard normalizedValue.isEmpty == false else {
+            Self.logger.error("Subscription activation id validation failed: blank or whitespace-only value.")
             throw SubscriptionManagerError.missingActivationID
         }
         return normalizedValue

--- a/ios/PulsePlate/Services/SubscriptionManager.swift
+++ b/ios/PulsePlate/Services/SubscriptionManager.swift
@@ -176,7 +176,7 @@ final class SubscriptionManager: ObservableObject {
                 finishOperation(.purchase, token: token)
                 flowState = .pendingApproval
                 return
-            case .success(let transaction):
+            case .success:
                 let receiptData = try await storeKitManager.currentReceiptData()
                 flowState = .sendingReceipt
                 let verification = try await billingService.verifyReceipt(
@@ -191,7 +191,8 @@ final class SubscriptionManager: ObservableObject {
                     request: activationRequest,
                     apiKey: apiKey
                 )
-                activationPointerStore.saveActivationID(activation.activationID)
+                let activationID = try validatedActivationID(activation.activationID)
+                activationPointerStore.saveActivationID(activationID)
                 finishOperation(.purchase, token: token)
                 await refreshEntitlement(trigger: .postPurchase)
             }
@@ -228,7 +229,8 @@ final class SubscriptionManager: ObservableObject {
                 request: activationRequest,
                 apiKey: apiKey
             )
-            activationPointerStore.saveActivationID(activation.activationID)
+            let activationID = try validatedActivationID(activation.activationID)
+            activationPointerStore.saveActivationID(activationID)
             finishOperation(.restore, token: token)
             await refreshEntitlement(trigger: .postRestore)
         } catch {
@@ -268,7 +270,11 @@ final class SubscriptionManager: ObservableObject {
                 return
             }
 
-            let snapshot = makeEntitlementSnapshot(from: activation)
+            let activationID = try validatedActivationID(activation.activationID)
+            let snapshot = makeEntitlementSnapshot(
+                from: activation,
+                activationID: activationID
+            )
             entitlement = snapshot
             activationPointerStore.saveActivationID(snapshot.activationID)
             finishOperation(operation, token: token)
@@ -322,15 +328,24 @@ final class SubscriptionManager: ObservableObject {
     }
 
     private func makeEntitlementSnapshot(
-        from response: SubscriptionActivationResponseDTO
+        from response: SubscriptionActivationResponseDTO,
+        activationID: String
     ) -> EntitlementSnapshot {
         EntitlementSnapshot(
-            activationID: response.activationID,
+            activationID: activationID,
             tier: (response.tier ?? response.subscriptionTier ?? "").lowercased(),
             status: response.status.lowercased(),
             expiresAt: parseISO8601(response.expiresAt),
             productID: response.productID
         )
+    }
+
+    private func validatedActivationID(_ rawValue: String) throws -> String {
+        let normalizedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedValue.isEmpty == false else {
+            throw SubscriptionManagerError.missingActivationID
+        }
+        return normalizedValue
     }
 
 

--- a/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
+++ b/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
@@ -102,6 +102,35 @@ final class SubscriptionManagerTests: XCTestCase {
         }
     }
 
+    func test_purchaseBlankActivationIDFailsClosed() async {
+        let storeKit = MockStoreKitManager()
+        let billing = MockSubscriptionBillingService()
+        let pointerStore = InMemoryActivationPointerStore()
+        let manager = makeManager(
+            storeKit: storeKit,
+            billing: billing,
+            pointerStore: pointerStore
+        )
+
+        storeKit.purchaseResult = .success(.fixture())
+        storeKit.receiptData = "receipt-123"
+        billing.verifyResult = .activeVerify()
+        billing.activateResult = .activeActivation(id: "   ")
+
+        await manager.purchase(productID: "com.pulseplate.premium.monthly")
+
+        XCTAssertNil(pointerStore.activationID)
+        XCTAssertNil(manager.entitlement)
+        XCTAssertEqual(billing.verifyCallCount, 1)
+        XCTAssertEqual(billing.activateCallCount, 1)
+        XCTAssertEqual(billing.fetchCallCount, 0)
+        if case .failed(let message) = manager.flowState {
+            XCTAssertTrue(message.contains("activation id"))
+        } else {
+            XCTFail("Expected failed state")
+        }
+    }
+
     func test_purchaseForwardsBackendActivationPayloadUnchanged() async {
         let storeKit = MockStoreKitManager()
         let billing = MockSubscriptionBillingService()
@@ -307,6 +336,27 @@ final class SubscriptionManagerTests: XCTestCase {
         XCTAssertNil(manager.entitlement)
         XCTAssertEqual(manager.flowState, .idle)
         XCTAssertNil(manager.lastError)
+    }
+
+    func test_refreshWithBlankActivationIDResponseFailsClosed() async {
+        let billing = MockSubscriptionBillingService()
+        let pointerStore = InMemoryActivationPointerStore(activationID: "act-existing")
+        let manager = makeManager(
+            billing: billing,
+            pointerStore: pointerStore
+        )
+
+        billing.fetchResult = .activeActivation(id: "")
+
+        await manager.refreshEntitlement(trigger: .manualRetry)
+
+        XCTAssertEqual(pointerStore.activationID, "act-existing")
+        XCTAssertNil(manager.entitlement)
+        if case .failed(let message) = manager.flowState {
+            XCTAssertTrue(message.contains("activation id"))
+        } else {
+            XCTFail("Expected failed state")
+        }
     }
 
     func test_foregroundRefreshWhilePurchaseInFlightDoesNotStartSecondFlow() async {

--- a/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
+++ b/ios/PulsePlateTests/Services/SubscriptionManagerTests.swift
@@ -233,6 +233,34 @@ final class SubscriptionManagerTests: XCTestCase {
         XCTAssertEqual(pointerStore.activationID, "act-restore")
     }
 
+    func test_restoreBlankActivationIDFailsClosed() async {
+        let storeKit = MockStoreKitManager()
+        let billing = MockSubscriptionBillingService()
+        let pointerStore = InMemoryActivationPointerStore(activationID: "act-existing")
+        let manager = makeManager(
+            storeKit: storeKit,
+            billing: billing,
+            pointerStore: pointerStore
+        )
+
+        storeKit.latestVerifiedTransaction = .fixture()
+        storeKit.receiptData = "receipt-restore"
+        billing.verifyResult = .restoredVerify()
+        billing.activateResult = .activeActivation(id: "   ")
+
+        await manager.restore()
+
+        XCTAssertEqual(pointerStore.activationID, "act-existing")
+        XCTAssertNil(manager.entitlement)
+        XCTAssertEqual(billing.activateCallCount, 1)
+        XCTAssertEqual(billing.fetchCallCount, 0)
+        if case .failed(let message) = manager.flowState {
+            XCTAssertTrue(message.contains("activation id"))
+        } else {
+            XCTFail("Expected failed state")
+        }
+    }
+
     func test_appRelaunchWithActivationIDRefreshesEntitlement() async {
         let storeKit = MockStoreKitManager()
         let billing = MockSubscriptionBillingService()
@@ -357,6 +385,23 @@ final class SubscriptionManagerTests: XCTestCase {
         } else {
             XCTFail("Expected failed state")
         }
+    }
+
+    func test_refreshWithStoredBlankActivationIDClearsPointerWithoutFetch() async {
+        let billing = MockSubscriptionBillingService()
+        let pointerStore = InMemoryActivationPointerStore(activationID: "   ")
+        let manager = makeManager(
+            billing: billing,
+            pointerStore: pointerStore
+        )
+
+        await manager.refreshEntitlement(trigger: .manualRetry)
+
+        XCTAssertNil(pointerStore.activationID)
+        XCTAssertNil(manager.entitlement)
+        XCTAssertEqual(billing.fetchCallCount, 0)
+        XCTAssertEqual(manager.flowState, .idle)
+        XCTAssertNil(manager.lastError)
     }
 
     func test_foregroundRefreshWhilePurchaseInFlightDoesNotStartSecondFlow() async {


### PR DESCRIPTION
## Summary
- close the local B3 tracker blocker after PR #1189 so B4 can proceed from repo-local SoT
- harden the iOS thin `SubscriptionManager` path to fail closed on blank backend activation identifiers
- address post-ready bot feedback from CodeRabbit and Sourcery with runtime validation, logging, and regression coverage

## Why
B4 is only legal after B3 closure is explicit in the local canonical tracker. Once that gate is satisfied, this PR keeps the iOS subscription flow thin-client only: StoreKit success does not unlock paid UI unless backend verification, activation, and refresh complete with valid activation state.

## How to validate
- run `python3 scripts/orchestration/check_preflight.py`
- run targeted iOS billing tests, for example `make ios-test IOS_DESTINATION='platform=iOS Simulator,id=<UDID>' IOS_ONLY_TESTING='PulsePlateTests/SubscriptionManagerTests,PulsePlateTests/SubscriptionBillingServiceTests,PulsePlateTests/StoreKitProductCatalogTests,PulsePlateTests/StoreKitManagerCatalogTests,PulsePlateTests/ThinClientGuardsTests'`
- run `pytest -q tests/test_repo_policy_guards.py`
- run `pre-commit run --all-files`
- run `make verify`

## Screenshots / GIF
- none; no visual changes

## Risk / rollout notes
- scope stays intentionally narrow: local SoT alignment, `SubscriptionManager` hardening, tests, scoped `ios/AGENTS.md` policy sync, and review-governance artifact updates
- no backend API contract changes
- no direct `URLSession` billing networking introduced
- entitlement truth remains backend-owned and fail-closed

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1207_FIXED_MAPPING.md`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985774046 -> 415c3562`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985772768` — NOT-A-BUG
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765863` — NOT-A-BUG
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#issuecomment-4102765990` — NOT-A-BUG
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#pullrequestreview-3985798146 -> 81ea1995`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1207#discussion_r2969317746 -> 81ea1995`

## Merge Readiness
- local blocking bundle is green: `pre-commit run --all-files`, targeted iOS billing tests, `pytest -q tests/test_repo_policy_guards.py`, `make verify`
- `bug-hunter` pass completed with no findings in the current diff; residual risk limited to missing higher-level relaunch integration coverage outside this PR scope
- CodeRabbit actionable items are addressed in `415c3562`; its docstring coverage warning is advisory only for this repo
- Sourcery logging feedback is addressed in `415c3562`; DTO-centralization suggestion is classified NOT-A-BUG for the current thin-client boundary
- cubic mapping ambiguity was fixed in `81ea1995` and mirrored on the current head
- remaining before merge:
  - wait for current-head required checks to pass with no pending required jobs
  - resolve review threads only after pushed evidence is live
  - perform one final merge-readiness pass after the latest bot/review activity wait-window


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a merge-readiness review document recording discussion dispositions, mappings to fix commits, evidence notes, and a pre-merge checklist
  * Updated backlog and roadmap to mark iOS StoreKit setup as completed and advanced timeline
  * Added iOS billing runtime policy requiring backend-verified entitlements and fail-closed UI behavior

* **Bug Fixes**
  * Subscription flows now validate and reject blank/whitespace activation IDs and fail closed

* **Tests**
  * Added tests covering blank activation ID behavior across purchase, restore, and refresh flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
