### PR TITLE
feat(business): add collateral builders and specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,16 @@ jobs:
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20.11.1"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install root Node dependencies
+        run: npm ci
+
       - name: Clean Python cache
         uses: ./.github/actions/clean-python-cache
 
@@ -485,6 +495,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20.11.1"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install root Node dependencies
+        run: npm ci
 
       - name: Clean Python cache
         uses: ./.github/actions/clean-python-cache
@@ -592,6 +612,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20.11.1"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install root Node dependencies
+        run: npm ci
 
       - name: Clean Python cache
         uses: ./.github/actions/clean-python-cache

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -137,6 +137,16 @@ jobs:
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20.11.1"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install root Node dependencies
+        run: npm ci
+
       # Diagnostics enabled in PR jobs only to reduce CI noise and verify nh3 availability
       # after runtime import fix (see core/data_sanitizer.py _require_nh3)
       - name: Diagnostics - Python, pip, and nh3 installation

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 411
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1536,5 +1536,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-17T12:33:03Z"
+  "generated_at": "2026-03-21T15:35:17Z"
 }

--- a/docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md
+++ b/docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md
@@ -1,0 +1,95 @@
+<!-- markdownlint-disable MD013 MD022 MD032 MD024 MD029 MD031 MD060 -->
+
+# PulsePlate B2B Partnership Proposal Spec
+
+Version: 2026-03-21 (`America/New_York`)
+Change note: Added canonical proposal source for automated DOCX generation.
+Decision reference: `docs/orchestration/BUSINESS_WAVE_PR_SERIES_RUNBOOK.md`
+
+## Proposal Title
+
+PulsePlate partnership proposal for wellness and nutrition workflows
+
+## Intended Audience
+
+- Corporate wellness programs
+- Digital fitness products
+- Wellness coaches and operational partners
+- API and embedded-experience partners
+
+## Executive Summary
+
+PulsePlate is a wellness-first platform that turns body and nutrition-related metrics
+into actionable daily guidance. The B2B opportunity is not another dashboard; it is
+an action layer that partners can use to reduce drop-off after measurement,
+accelerate onboarding clarity, and package repeatable habit workflows.
+
+## Problem Framing
+
+- Many wellness experiences stop at showing numbers or isolated recommendations.
+- Users often lose momentum after the first check-in because the next action is unclear.
+- Partners need a wellness-safe system that can connect insight, plan, and daily continuity.
+
+## Product Fit
+
+- Shared backend for web and iOS clients
+- Tiered product structure with `FREE`, `PRO`, and `VIP` value ladders
+- Wellness-safe positioning and quality-gated engineering process
+- Ability to package action-oriented nutrition and planning workflows
+
+## Partnership Offer
+
+- Pilot scope: one use case, one primary KPI, one guardrail KPI
+- Delivery mode: lightweight pilot or API/embedded integration path
+- Review cadence: weekly checkpoint with explicit decision rule
+- Success framing: prove action-layer value before scale
+
+## Candidate Use Cases
+
+- Post-check-in action layer for fitness and wellness apps
+- Daily nutrition workflow for coaching businesses
+- Guided shopping-list and meal-planning continuity for habit programs
+- B2B API pilot for partner-owned frontends
+
+## Operating Model
+
+- Week 1: align target user flow, KPI, and owner map
+- Week 2: launch the narrow pilot scenario
+- Weekly: review KPI trend, qualitative friction, and expansion readiness
+- End of pilot: continue, expand, or stop based on decision rule
+
+## KPI Framework
+
+- Primary KPI: `[VERIFY_VALUE:B2B_PRIMARY_KPI]`
+- Guardrail KPI: `[VERIFY_VALUE:B2B_GUARDRAIL_KPI]`
+- Success threshold: `[VERIFY_VALUE:B2B_SUCCESS_THRESHOLD]`
+- Decision owner: `[VERIFY_VALUE:B2B_DECISION_OWNER]`
+
+## Commercial Structure
+
+- Pilot pricing model: `[VERIFY_VALUE:B2B_PILOT_PRICING_MODEL]`
+- Expansion trigger: `[VERIFY_VALUE:B2B_EXPANSION_TRIGGER]`
+- Packaging options:
+  - services-assisted pilot
+  - embedded product partnership
+  - API-based integration
+
+## Why PulsePlate
+
+- Wellness-first product framing
+- Repo-governed operational discipline
+- Action-oriented narrative instead of metrics-only positioning
+- Ability to convert existing product truth into partner-ready materials quickly
+
+## Risks And Boundaries
+
+- No medical claims or diagnostic positioning
+- No invented ROI or outcome numbers
+- Pilot economics must stay explicit and reviewable
+- Expansion requires validated signal, not presentation quality alone
+
+## Call To Action
+
+- Confirm one pilot scenario
+- Confirm one KPI pair
+- Confirm one decision date

--- a/docs/audience_pack/B2B_PITCH_DECK_SPEC.md
+++ b/docs/audience_pack/B2B_PITCH_DECK_SPEC.md
@@ -1,0 +1,93 @@
+<!-- markdownlint-disable MD013 MD022 MD032 MD024 MD029 MD031 MD060 -->
+
+# PulsePlate B2B Pitch Deck Spec
+
+Version: 2026-03-21 (`America/New_York`)
+Change note: Added canonical slide-by-slide source for automated PPTX generation.
+Decision reference: `docs/orchestration/BUSINESS_WAVE_PR_SERIES_RUNBOOK.md`
+
+## Slide 01 - PulsePlate for B2B Wellness Workflows
+
+From metrics to daily action for wellness and nutrition journeys
+
+- Wellness-first platform
+- Shared backend for web and iOS delivery
+- Partner-ready action layer for pilots and embedded use cases
+
+## Slide 02 - The Gap We See
+
+Users often receive numbers, but not a clear next action
+
+- Check-ins create data
+- Data without action creates drop-off
+- Partners need continuity, not another static dashboard
+
+## Slide 03 - What PulsePlate Changes
+
+PulsePlate links insight, interpretation, and execution
+
+- Interpret metrics in a wellness-safe frame
+- Turn interpretation into a daily plan
+- Support continuity with shopping-list and routine-oriented flows
+
+## Slide 04 - Why This Matters for Partners
+
+This is a packaging problem and an engagement problem
+
+- Reduce ambiguity after the first user interaction
+- Create a repeatable daily contour
+- Test narrow pilots before committing to scale
+
+## Slide 05 - Product Foundation Already Exists
+
+The repo already contains the operational product substrate
+
+- FastAPI backend and tiered product model
+- Web and iOS client surfaces
+- Quality gates and policy-driven release discipline
+- Audience-pack documentation as external narrative SoT
+
+## Slide 06 - Partnership Shapes
+
+PulsePlate can support multiple low-friction partner motions
+
+- Wellness or fitness pilot
+- Coach-enablement workflow
+- Embedded action layer
+- API-first partner experiment
+
+## Slide 07 - Pilot Design
+
+Keep the first motion narrow and measurable
+
+- One use case
+- One primary KPI
+- One guardrail KPI
+- One decision date
+
+## Slide 08 - KPI And Decision Framework
+
+Business decisions should be explicit before the pilot starts
+
+- Primary KPI: `[VERIFY_VALUE:B2B_PRIMARY_KPI]`
+- Guardrail KPI: `[VERIFY_VALUE:B2B_GUARDRAIL_KPI]`
+- Success threshold: `[VERIFY_VALUE:B2B_SUCCESS_THRESHOLD]`
+- Expansion trigger: `[VERIFY_VALUE:B2B_EXPANSION_TRIGGER]`
+
+## Slide 09 - Why PulsePlate vs Generic Alternatives
+
+The advantage is not more dashboards; it is operational clarity
+
+- Action-layer framing over metrics-only presentation
+- Repo-governed truth and execution discipline
+- Wellness-safe language boundaries
+- Faster collateral and pilot packaging through automation
+
+## Slide 10 - Next Step
+
+Choose one pilot path and one decision owner
+
+- Confirm scenario
+- Confirm KPI pair
+- Confirm timeline
+- Generate partner-ready proposal and launch packet

--- a/docs/audience_pack/BUSINESS_COLLATERAL_AUTOMATION.md
+++ b/docs/audience_pack/BUSINESS_COLLATERAL_AUTOMATION.md
@@ -1,0 +1,64 @@
+<!-- markdownlint-disable MD013 MD022 MD032 MD024 MD029 MD031 MD060 -->
+
+# Business Collateral Automation
+
+Version: 2026-03-21 (`America/New_York`)
+Change note: Added markdown-first collateral generation contract for B2B proposal and pitch deck outputs.
+Decision reference: `docs/executive/PR_PORTFOLIO_BRIEF_DIRECTORS_2026-03.md`
+
+## Purpose
+
+This document defines how PulsePlate generates partner-facing business collateral
+without creating a second business source of truth.
+
+## Canonical Inputs
+
+- `docs/audience_pack/FACTS_CANONICAL.md`
+- `docs/audience_pack/INVESTOR_PUBLIC_OVERVIEW.md`
+- `docs/audience_pack/MARKETING_DESIGN_OVERVIEW.md`
+- `docs/audience_pack/PROOF_PACK.md`
+- `docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md`
+- `docs/audience_pack/B2B_PITCH_DECK_SPEC.md`
+
+## Derived Outputs
+
+- `.docx` proposal files
+- `.pptx` pitch decks
+
+Derived outputs are local-only artifacts and must not be committed.
+
+## Builder Commands
+
+- `npm run build:b2b-proposal`
+- `npm run build:b2b-pitch-deck`
+- `npm run build:business-collateral`
+
+## Output Policy
+
+- Default output root: `tmp/business_collateral/`
+- Generated files may be reviewed locally or attached externally after human review.
+- Generated files must not be treated as canonical truth; the markdown specs remain authoritative.
+
+## Placeholder Hygiene
+
+- Verified repo facts may appear directly.
+- Unknown or unverified numbers must remain as `[VERIFY_*]` placeholders inside specs until an owner validates them.
+- Builders must not inject invented values or hidden defaults for missing business data.
+
+## Review Rules
+
+1. Review the markdown spec first.
+2. Generate the collateral locally.
+3. Verify the generated material still uses wellness-safe language.
+4. Remove or replace unresolved placeholders before external distribution when evidence is available.
+
+## Security Notes
+
+- No medical claims.
+- No PII in generated materials.
+- No unsourced metrics should be silently converted into factual-looking statements.
+
+## Marketing & GTM
+
+- The system is optimized for fast pilot outreach, partner packaging, and founder-led sales support.
+- The goal is repeatable conversion-ready collateral, not decorative slideware.

--- a/docs/audience_pack/LIVING_DOCUMENT_PROTOCOL.md
+++ b/docs/audience_pack/LIVING_DOCUMENT_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 # Living Document Protocol
 
-Версия: 2026-02-20 (TZ: America/New_York)
+Версия: 2026-03-21 (TZ: America/New_York)
 
 ## Purpose
 
@@ -29,6 +29,9 @@
 | PROOF_PACK | Growth Ops | Founder | Bi-weekly |
 | ROADMAP_KILL_CRITERIA | Product Architect | Founder | Monthly |
 | NARRATIVE_AND_TEAM | Founder | Marketing Lead | Monthly |
+| B2B_PARTNERSHIP_PROPOSAL_SPEC | Strategy Lead | Founder | Weekly |
+| B2B_PITCH_DECK_SPEC | Strategy Lead | Founder | Weekly |
+| BUSINESS_COLLATERAL_AUTOMATION | Product Ops | Strategy Lead | Bi-weekly |
 
 ## Review Gates
 
@@ -58,6 +61,11 @@ Stale doc action:
 - in-file date,
 - short change note,
 - decision reference (`DECISION_LOG.md`).
+
+## 2026-03-21 Change Note
+
+- Added business collateral ownership for markdown-first partner proposal and pitch-deck specs.
+- Added automation layer governance so generated `.docx` / `.pptx` stay derived, not canonical.
 
 ## Cross-Team Workflow
 

--- a/docs/audience_pack/README.md
+++ b/docs/audience_pack/README.md
@@ -33,6 +33,13 @@
 - `docs/audience_pack/NARRATIVE_AND_TEAM.md` — story arc, credibility, anti-portfolio.
 - `docs/audience_pack/LIVING_DOCUMENT_PROTOCOL.md` — owner/cadence/review/expiry protocol.
 
+## Layer 3: Business Collateral Pack
+
+- `docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md` — canonical proposal source for partner-facing DOCX outputs.
+- `docs/audience_pack/B2B_PITCH_DECK_SPEC.md` — canonical slide-by-slide source for partner/investor PPTX outputs.
+- `docs/audience_pack/BUSINESS_COLLATERAL_AUTOMATION.md` — builder contract, output policy, and placeholder hygiene.
+- `docs/executive/PR_PORTFOLIO_BRIEF_DIRECTORS_2026-03.md` — thin executive brief linked back to audience-pack fact/narrative SoT.
+
 ## Deferred Layer (Set C)
 
 Пункты Set C зафиксированы в `docs/roadmap/BACKLOG_LEDGER.md`.
@@ -63,6 +70,7 @@
 - `ROADMAP_KILL_CRITERIA.md`,
 - `RISK_REGISTER.md`.
 4. Для обновляемости пакета следовать `LIVING_DOCUMENT_PROTOCOL.md`.
+5. Для partner-ready collateral использовать markdown specs above and generate binaries locally rather than editing `.docx` / `.pptx` by hand.
 
 ## Security Notes
 

--- a/docs/review/PR_1218_FIXED_MAPPING.md
+++ b/docs/review/PR_1218_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1218 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@goplus/agentguard": "^1.0.4"
+        "@goplus/agentguard": "^1.0.4",
+        "docx": "^9.6.1",
+        "pptxgenjs": "^4.0.1"
       },
       "devDependencies": {
         "@cspell/dict-data-science": "^2.0.9",
@@ -728,6 +730,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1056,7 +1067,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1306,6 +1316,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -1836,6 +1863,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1877,6 +1914,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1892,6 +1935,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -1993,6 +2057,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2034,6 +2104,27 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -2096,6 +2187,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2125,6 +2222,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -2182,6 +2297,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "2.0.0",
@@ -2262,6 +2383,39 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2296,6 +2450,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2318,6 +2481,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/repeat-string": {
@@ -2365,11 +2543,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -2428,6 +2621,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2560,6 +2759,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -2698,6 +2906,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2706,6 +2920,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -2853,6 +3073,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:b2b-proposal": "node scripts/business_collateral/build_b2b_proposal.js",
+    "build:b2b-pitch-deck": "node scripts/business_collateral/build_b2b_pitch_deck.js",
+    "build:business-collateral": "npm run build:b2b-proposal && npm run build:b2b-pitch-deck"
   },
   "repository": {
     "type": "git",
@@ -22,7 +25,9 @@
   },
   "homepage": "https://github.com/Katsiarynakavaleuskaya/PulsePlate#readme",
   "dependencies": {
-    "@goplus/agentguard": "^1.0.4"
+    "@goplus/agentguard": "^1.0.4",
+    "docx": "^9.6.1",
+    "pptxgenjs": "^4.0.1"
   },
   "devDependencies": {
     "@cspell/dict-data-science": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "[![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/branch/main/graph/badge.svg)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)",
   "main": "worker.js",
+  "type": "module",
   "directories": {
     "doc": "docs",
     "test": "tests"

--- a/scripts/business_collateral/README.md
+++ b/scripts/business_collateral/README.md
@@ -1,0 +1,27 @@
+# Business Collateral Builders
+
+## Purpose
+
+Generate local-only business collateral from repo-managed markdown specs.
+
+## Canonical inputs
+
+- `docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md`
+- `docs/audience_pack/B2B_PITCH_DECK_SPEC.md`
+- `docs/audience_pack/BUSINESS_COLLATERAL_AUTOMATION.md`
+
+## Commands
+
+- `npm run build:b2b-proposal`
+- `npm run build:b2b-pitch-deck`
+- `npm run build:business-collateral`
+
+## Output location
+
+- Default output root: `tmp/business_collateral/`
+
+## Rules
+
+- Builders must not invent missing business values.
+- Generated files remain untracked.
+- Markdown remains the source of truth.

--- a/scripts/business_collateral/build_b2b_pitch_deck.js
+++ b/scripts/business_collateral/build_b2b_pitch_deck.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const PptxGenJS = require("pptxgenjs");
+const { parseDeckSpec, resolveRepoPath } = require("./content_loader");
+
+function resolveOutputPath() {
+  const outputFlagIndex = process.argv.indexOf("--output");
+  if (outputFlagIndex >= 0 && process.argv[outputFlagIndex + 1]) {
+    return path.resolve(process.argv[outputFlagIndex + 1]);
+  }
+
+  return resolveRepoPath(
+    "tmp",
+    "business_collateral",
+    "deck",
+    "PulsePlate_B2B_Pitch_Deck.pptx",
+  );
+}
+
+async function main() {
+  const outputPath = resolveOutputPath();
+  const outputDir = path.dirname(outputPath);
+  const deck = parseDeckSpec();
+  const presentation = new PptxGenJS();
+
+  presentation.layout = "LAYOUT_WIDE";
+  presentation.author = "Codex";
+  presentation.company = "PulsePlate";
+  presentation.subject = deck.title;
+  presentation.title = deck.title;
+  presentation.lang = "en-US";
+
+  for (const [index, slideSpec] of deck.slides.entries()) {
+    const slide = presentation.addSlide();
+    slide.background = { color: "F6F3EC" };
+    slide.addShape(presentation.ShapeType.rect, {
+      x: 0,
+      y: 0,
+      w: 13.333,
+      h: 0.35,
+      fill: { color: "2E5E4E" },
+      line: { color: "2E5E4E" },
+    });
+
+    slide.addText(slideSpec.title, {
+      x: 0.7,
+      y: 0.6,
+      w: 11.5,
+      h: 0.6,
+      fontFace: "Aptos Display",
+      fontSize: 24,
+      bold: true,
+      color: "21332B",
+    });
+
+    if (slideSpec.paragraphs.length) {
+      slide.addText(slideSpec.paragraphs[0], {
+        x: 0.7,
+        y: 1.35,
+        w: 11.3,
+        h: 0.7,
+        fontFace: "Aptos",
+        fontSize: 14,
+        color: "42574E",
+      });
+    }
+
+    let bulletY = slideSpec.paragraphs.length ? 2.2 : 1.6;
+    for (const bullet of slideSpec.bullets) {
+      slide.addText(`• ${bullet}`, {
+        x: 0.95,
+        y: bulletY,
+        w: 11.0,
+        h: 0.42,
+        fontFace: "Aptos",
+        fontSize: 18,
+        color: "21332B",
+      });
+      bulletY += 0.5;
+    }
+
+    slide.addText(`PulsePlate B2B Deck | ${String(index + 1).padStart(2, "0")}`, {
+      x: 9.9,
+      y: 7.05,
+      w: 2.3,
+      h: 0.2,
+      fontFace: "Aptos",
+      fontSize: 9,
+      color: "6D7C75",
+      align: "right",
+    });
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  await presentation.writeFile({ fileName: outputPath });
+  process.stdout.write(`${outputPath}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exit(1);
+});

--- a/scripts/business_collateral/build_b2b_proposal.js
+++ b/scripts/business_collateral/build_b2b_proposal.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { Document, HeadingLevel, Packer, Paragraph } = require("docx");
+const { parseProposalSpec, resolveRepoPath } = require("./content_loader");
+
+function resolveOutputPath() {
+  const outputFlagIndex = process.argv.indexOf("--output");
+  if (outputFlagIndex >= 0 && process.argv[outputFlagIndex + 1]) {
+    return path.resolve(process.argv[outputFlagIndex + 1]);
+  }
+
+  return resolveRepoPath(
+    "tmp",
+    "business_collateral",
+    "proposal",
+    "PulsePlate_B2B_Partnership_Proposal.docx",
+  );
+}
+
+function blockToParagraph(block) {
+  if (block.type === "heading1") {
+    return new Paragraph({
+      heading: HeadingLevel.HEADING_1,
+      text: block.text,
+    });
+  }
+
+  if (block.type === "heading2") {
+    return new Paragraph({
+      heading: HeadingLevel.HEADING_2,
+      text: block.text,
+    });
+  }
+
+  if (block.type === "bullet") {
+    return new Paragraph({
+      bullet: { level: 0 },
+      text: block.text,
+    });
+  }
+
+  return new Paragraph({ text: block.text });
+}
+
+async function main() {
+  const outputPath = resolveOutputPath();
+  const outputDir = path.dirname(outputPath);
+  const proposal = parseProposalSpec();
+
+  // RU: Сохраняем генерацию производной и предсказуемой. EN: Keep generation derived and predictable.
+  const children = [
+    new Paragraph({
+      heading: HeadingLevel.TITLE,
+      text: proposal.title,
+    }),
+    ...proposal.blocks.map(blockToParagraph),
+  ];
+
+  const document = new Document({
+    creator: "Codex",
+    description: `Derived from ${proposal.sourcePath}`,
+    title: proposal.title,
+    sections: [{ children }],
+  });
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  const buffer = await Packer.toBuffer(document);
+  fs.writeFileSync(outputPath, buffer);
+  process.stdout.write(`${outputPath}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exit(1);
+});

--- a/scripts/business_collateral/content_loader.js
+++ b/scripts/business_collateral/content_loader.js
@@ -1,0 +1,139 @@
+const fs = require("fs");
+const path = require("path");
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function resolveRepoPath(...segments) {
+  return path.resolve(__dirname, "..", "..", ...segments);
+}
+
+function flushParagraph(paragraphBuffer, blocks) {
+  if (!paragraphBuffer.length) {
+    return;
+  }
+
+  blocks.push({
+    type: "paragraph",
+    text: paragraphBuffer.join(" ").trim(),
+  });
+  paragraphBuffer.length = 0;
+}
+
+function parseMarkdownBlocks(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const blocks = [];
+  const paragraphBuffer = [];
+  let title = "Untitled";
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (!line) {
+      flushParagraph(paragraphBuffer, blocks);
+      continue;
+    }
+
+    if (line.startsWith("# ")) {
+      flushParagraph(paragraphBuffer, blocks);
+      title = line.replace(/^#\s+/, "").trim();
+      continue;
+    }
+
+    if (line.startsWith("## ")) {
+      flushParagraph(paragraphBuffer, blocks);
+      blocks.push({
+        type: "heading1",
+        text: line.replace(/^##\s+/, "").trim(),
+      });
+      continue;
+    }
+
+    if (line.startsWith("### ")) {
+      flushParagraph(paragraphBuffer, blocks);
+      blocks.push({
+        type: "heading2",
+        text: line.replace(/^###\s+/, "").trim(),
+      });
+      continue;
+    }
+
+    if (line.startsWith("- ")) {
+      flushParagraph(paragraphBuffer, blocks);
+      blocks.push({
+        type: "bullet",
+        text: line.replace(/^-+\s+/, "").trim(),
+      });
+      continue;
+    }
+
+    paragraphBuffer.push(line);
+  }
+
+  flushParagraph(paragraphBuffer, blocks);
+  return { title, blocks };
+}
+
+function parseProposalSpec() {
+  const sourcePath = resolveRepoPath(
+    "docs",
+    "audience_pack",
+    "B2B_PARTNERSHIP_PROPOSAL_SPEC.md",
+  );
+  return {
+    sourcePath,
+    ...parseMarkdownBlocks(readUtf8(sourcePath)),
+  };
+}
+
+function parseDeckSpec() {
+  const sourcePath = resolveRepoPath(
+    "docs",
+    "audience_pack",
+    "B2B_PITCH_DECK_SPEC.md",
+  );
+  const { title, blocks } = parseMarkdownBlocks(readUtf8(sourcePath));
+  const slides = [];
+  let currentSlide = null;
+
+  for (const block of blocks) {
+    if (block.type === "heading1" && /^Slide\s+\d+/i.test(block.text)) {
+      if (currentSlide) {
+        slides.push(currentSlide);
+      }
+
+      currentSlide = {
+        title: block.text.replace(/^Slide\s+\d+\s*-\s*/i, "").trim(),
+        paragraphs: [],
+        bullets: [],
+      };
+      continue;
+    }
+
+    if (!currentSlide) {
+      continue;
+    }
+
+    if (block.type === "bullet") {
+      currentSlide.bullets.push(block.text);
+      continue;
+    }
+
+    if (block.type === "paragraph" || block.type === "heading2") {
+      currentSlide.paragraphs.push(block.text);
+    }
+  }
+
+  if (currentSlide) {
+    slides.push(currentSlide);
+  }
+
+  return { sourcePath, title, slides };
+}
+
+module.exports = {
+  parseDeckSpec,
+  parseProposalSpec,
+  resolveRepoPath,
+};

--- a/scripts/business_collateral/package.json
+++ b/scripts/business_collateral/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/test_business_collateral_builders.py
+++ b/tests/test_business_collateral_builders.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_builder(script_relative_path: str, output_path: Path) -> subprocess.CompletedProcess[str]:
+    script_path = REPO_ROOT / script_relative_path
+    return subprocess.run(
+        ["node", str(script_path), "--output", str(output_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_b2b_proposal_builder_creates_docx(tmp_path: Path) -> None:
+    output_path = tmp_path / "proposal.docx"
+    result = _run_builder("scripts/business_collateral/build_b2b_proposal.js", output_path)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    assert str(output_path) in result.stdout
+
+    with zipfile.ZipFile(output_path) as archive:
+        assert "word/document.xml" in archive.namelist()
+
+
+def test_b2b_pitch_deck_builder_creates_pptx(tmp_path: Path) -> None:
+    output_path = tmp_path / "deck.pptx"
+    result = _run_builder("scripts/business_collateral/build_b2b_pitch_deck.js", output_path)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    assert str(output_path) in result.stdout
+
+    with zipfile.ZipFile(output_path) as archive:
+        assert "ppt/presentation.xml" in archive.namelist()


### PR DESCRIPTION
## Summary
- add canonical markdown specs for a B2B partnership proposal and pitch deck
- add business collateral automation guidance under audience-pack docs
- add deterministic JS builders for `.docx` and `.pptx` generation
- add smoke tests that verify the generated archives exist and contain the expected internal structures

## Why
This is PR-3 of the business-line wave. It turns the repo’s business canon into repeatable partner-facing collateral without committing generated binaries.

## Stack
- base: #1217

## Validation
- npm run build:b2b-proposal
- npm run build:b2b-pitch-deck
- pytest -q tests/test_business_collateral_builders.py
- pre-commit run --all-files
- make verify

## Summary by Sourcery

Добавлены спецификации бизнес-материалов с приоритетом на markdown и автоматизированные билдеры для генерации партнерских предложений и питч-деков.

New Features:
- Введены канонические markdown-спецификации для B2B-партнерского предложения и B2B pitch deck в составе audience pack.
- Добавлены Node-билдеры для генерации DOCX-предложений и PPTX-pitch deck’ов из markdown-спецификаций, а также npm-скрипты для их запуска.

Enhancements:
- Задокументирован контракт по автоматизации бизнес-материалов, включая канонические входные данные, политику формирования выходных файлов и правила работы с плейсхолдерами.
- Обновлено управление живыми документами и документация по audience-pack, чтобы охватить владение бизнес-материалами и использование сгенерированных бинарных файлов.
- Добавлен README для билдеров бизнес-материалов с описанием входных данных, команд и правил.

Build:
- Расширены скрипты и зависимости в package.json для поддержки команд сборки бизнес-материалов с использованием docx и pptxgenjs.

Tests:
- Добавлены smoke-тесты, которые запускают билдеры предложения и pitch deck’а, проверяют успешное завершение и удостоверяются, что сгенерированные DOCX/PPTX-архивы содержат ожидаемую внутреннюю структуру.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add markdown-first business collateral specs and automated builders for generating partner-facing proposal and pitch deck files.

New Features:
- Introduce canonical markdown specs for the B2B partnership proposal and B2B pitch deck under the audience pack.
- Add Node-based builders to generate DOCX proposals and PPTX pitch decks from the markdown specs, with npm scripts to run them.

Enhancements:
- Document the business collateral automation contract, including canonical inputs, output policy, and placeholder hygiene.
- Update living document governance and audience-pack documentation to cover business collateral ownership and usage of generated binaries.
- Add a README for the business collateral builders describing inputs, commands, and rules.

Build:
- Extend package.json scripts and dependencies to support business collateral build commands using docx and pptxgenjs.

Tests:
- Add smoke tests that run the proposal and pitch deck builders, assert successful completion, and verify the generated DOCX/PPTX archives contain expected internal structures.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds markdown-first specs and Node builders to generate partner-ready B2B proposal (.docx) and pitch deck (.pptx). Also marks the edge worker as ESM and updates CI to install Node and run `npm ci` so builders run in tests.

- **New Features**
  - Canonical specs: `docs/audience_pack/B2B_PARTNERSHIP_PROPOSAL_SPEC.md`, `B2B_PITCH_DECK_SPEC.md`.
  - Builders using `docx` and `pptxgenjs` with npm scripts (`build:b2b-proposal`, `build:b2b-pitch-deck`, `build:business-collateral`); outputs to `tmp/business_collateral/`.
  - Automation and ownership docs added; updates to living doc protocol and audience-pack README.
  - Smoke tests verify `.docx`/`.pptx` internals; CI sets up Node v20 and runs `npm ci` in `ci.yml` and `pr-tests.yml`.

- **Bug Fixes**
  - Marked edge worker as ESM by setting `"type": "module"` in root `package.json`; scoped builders to CommonJS via `scripts/business_collateral/package.json` to keep `require` working.

<sup>Written for commit 8e90594c083ae099f093f6508a60c61de0efc240. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1218_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
