### PR TITLE
fix(ci): align nightly node parity

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -176,8 +176,8 @@ jobs:
         run: |
           TAG_COMMIT=$(git rev-parse "${GITHUB_REF#refs/tags/}")
 
-          LAST_NIGHTLY_CONCLUSION=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
-          LAST_NIGHTLY_COMMIT=$(gh run list --workflow=nightly.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
+          LAST_NIGHTLY_CONCLUSION=$(gh run list --workflow=nightly-tests.yml --branch=main --limit=1 --json conclusion --jq '.[0].conclusion // "null"')
+          LAST_NIGHTLY_COMMIT=$(gh run list --workflow=nightly-tests.yml --branch=main --limit=1 --json headSha --jq '.[0].headSha // "null"')
 
           if [ "$LAST_NIGHTLY_CONCLUSION" != "success" ] || [ "$LAST_NIGHTLY_CONCLUSION" = "null" ]; then
             echo "❌ Last nightly test did not pass or is missing: $LAST_NIGHTLY_CONCLUSION"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Nightly Full Tests
 
+env:
+  FRONTEND_NODE_VERSION_FILE: ".nvmrc"
+
 on:
   schedule:
     - cron: '0 2 * * *'
@@ -26,6 +29,13 @@ jobs:
         with:
           python-version: '3.13.6'
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ${{ env.FRONTEND_NODE_VERSION_FILE }}
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
       - name: Cache pip
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -39,6 +49,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
+
+      - name: Install frontend dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          working-directory: frontend
 
       - name: Run full test suite with coverage (include slow/MC)
         env:

--- a/docs/ci/triage_nightly_2026-03-22.md
+++ b/docs/ci/triage_nightly_2026-03-22.md
@@ -1,0 +1,47 @@
+# Nightly Full Tests Triage — March 22, 2026
+
+## Symptom
+- Workflow: `Nightly Full Tests`
+- Run: `23395469933`
+- Job: `tests` (`68057604027`)
+- Result: failed at `2026-03-22 04:21:31 UTC`
+- Duration: `6m16s`
+
+## Failure Signature
+- Coverage completed successfully: `97.86%`
+- Single failing test:
+  - `tests/test_openapi_determinism.py::test_openapi_and_schema_ts_are_deterministic`
+- Failing stderr tail from the run:
+  - `Frontend commands require Node 22.22.1 or newer major runtime; current runtime is 20.20.1.`
+  - `make: *** [Makefile:433: frontend-install] Error 1`
+
+## Root Cause
+- PR `#1209` (`96502f42`, `fix(ci): align frontend openapi sync with node 22`) raised the repo frontend/OpenAPI runtime contract to Node `22.22.1` via [.nvmrc](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.nvmrc), [frontend/package.json](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/frontend/package.json), and [scripts/frontend_npm.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/scripts/frontend_npm.sh).
+- `Nightly Full Tests` did not get the same Node bootstrap as the working OpenAPI sync lane in CI, so `make openapi` inside [tests/test_openapi_determinism.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/tests/test_openapi_determinism.py) executed against the runner default Node `20.20.1`.
+- A second drift was found in [cd.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/cd.yml): production gating still queried `nightly.yml` (`Nightly Tests`) instead of `nightly-tests.yml` (`Nightly Full Tests`).
+
+## Chosen Fix
+- Add Node `22.22.1` setup and frontend dependency bootstrap to [nightly-tests.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/nightly-tests.yml) before pytest.
+- Point the production nightly gate in [cd.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/cd.yml) at `nightly-tests.yml`.
+- Keep legacy `nightly.yml` intact for now; this triage only removes it from release gating.
+
+## Repro Commands
+```bash
+python3 scripts/orchestration/check_preflight.py
+make openapi
+pytest -q tests/test_openapi_determinism.py
+gh run view 23395469933 --job 68057604027 --log-failed
+```
+
+## Verification Plan
+```bash
+pre-commit run --all-files
+make verify
+gh workflow run "Nightly Full Tests" --ref fix/nightly-full-tests-node22-parity
+```
+
+## Links
+- Failed run: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23395469933>
+- Failed job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23395469933/job/68057604027>
+- Last green nightly full run before failure: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23371563160>
+- Regression introducer PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1209>

--- a/docs/ci/triage_nightly_2026-03-22.md
+++ b/docs/ci/triage_nightly_2026-03-22.md
@@ -16,13 +16,13 @@
   - `make: *** [Makefile:433: frontend-install] Error 1`
 
 ## Root Cause
-- PR `#1209` (`96502f42`, `fix(ci): align frontend openapi sync with node 22`) raised the repo frontend/OpenAPI runtime contract to Node `22.22.1` via [.nvmrc](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.nvmrc), [frontend/package.json](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/frontend/package.json), and [scripts/frontend_npm.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/scripts/frontend_npm.sh).
-- `Nightly Full Tests` did not get the same Node bootstrap as the working OpenAPI sync lane in CI, so `make openapi` inside [tests/test_openapi_determinism.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/tests/test_openapi_determinism.py) executed against the runner default Node `20.20.1`.
-- A second drift was found in [cd.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/cd.yml): production gating still queried `nightly.yml` (`Nightly Tests`) instead of `nightly-tests.yml` (`Nightly Full Tests`).
+- PR `#1209` (`96502f42`, `fix(ci): align frontend openapi sync with node 22`) raised the repo frontend/OpenAPI runtime contract to Node `22.22.1` via [`.nvmrc`](../../.nvmrc), [`frontend/package.json`](../../frontend/package.json), and [`scripts/frontend_npm.sh`](../../scripts/frontend_npm.sh).
+- `Nightly Full Tests` did not get the same Node bootstrap as the working OpenAPI sync lane in CI, so `make openapi` inside [`tests/test_openapi_determinism.py`](../../tests/test_openapi_determinism.py) executed against the runner default Node `20.20.1`.
+- A second drift was found in [`cd.yml`](../../.github/workflows/cd.yml): production gating still queried `nightly.yml` (`Nightly Tests`) instead of `nightly-tests.yml` (`Nightly Full Tests`).
 
 ## Chosen Fix
-- Add Node `22.22.1` setup and frontend dependency bootstrap to [nightly-tests.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/nightly-tests.yml) before pytest.
-- Point the production nightly gate in [cd.yml](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/nightly_full_tests_node22_fix/.github/workflows/cd.yml) at `nightly-tests.yml`.
+- Add Node `22.22.1` setup and frontend dependency bootstrap to [`nightly-tests.yml`](../../.github/workflows/nightly-tests.yml) before pytest.
+- Point the production nightly gate in [`cd.yml`](../../.github/workflows/cd.yml) at `nightly-tests.yml`.
 - Keep legacy `nightly.yml` intact for now; this triage only removes it from release gating.
 
 ## Repro Commands

--- a/docs/ci/triage_nightly_2026-03-22.md
+++ b/docs/ci/triage_nightly_2026-03-22.md
@@ -38,6 +38,7 @@ gh run view 23395469933 --job 68057604027 --log-failed
 pre-commit run --all-files
 make verify
 gh workflow run "Nightly Full Tests" --ref fix/nightly-full-tests-node22-parity
+gh run watch "$(gh run list --workflow "Nightly Full Tests" --branch fix/nightly-full-tests-node22-parity --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
 ```
 
 ## Links

--- a/docs/review/PR_1226_FIXED_MAPPING.md
+++ b/docs/review/PR_1226_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: fd2b1152
-Evidence: `docs/ci/triage_nightly_2026-03-22.md:19`, `docs/ci/triage_nightly_2026-03-22.md:20`, `docs/ci/triage_nightly_2026-03-22.md:21`, `docs/roadmap/BACKLOG_LEDGER.md:7493`
+Evidence: `docs/ci/triage_nightly_2026-03-22.md:19`, `docs/ci/triage_nightly_2026-03-22.md:20`, `docs/ci/triage_nightly_2026-03-22.md:21`, `docs/roadmap/BACKLOG_LEDGER.md:7491`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988162984 -> fd2b1152
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#discussion_r2971557036 -> fd2b1152
@@ -19,6 +19,12 @@ Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-nightly-full-tests-node22-par
 Reason: The shared Node/frontend bootstrap extraction identified by Sourcery is valid hardening work, but it is intentionally deferred to keep this PR limited to the confirmed parity regression and the release-gate selector drift.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988161712
+
+Disposition: FIXED
+Commit: dec1ab9c
+Evidence: `docs/ci/triage_nightly_2026-03-22.md:40`, `docs/ci/triage_nightly_2026-03-22.md:41`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988195239 -> dec1ab9c
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1226_FIXED_MAPPING.md
+++ b/docs/review/PR_1226_FIXED_MAPPING.md
@@ -1,0 +1,18 @@
+# PR 1226 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No actionable review threads are mapped yet.
+
+Initial implementation commit:
+- `f996cc0a` — workflow parity fix, release-gate selector alignment, triage note, and backlog entry
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/docs/review/PR_1226_FIXED_MAPPING.md
+++ b/docs/review/PR_1226_FIXED_MAPPING.md
@@ -1,15 +1,24 @@
 # PR 1226 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: fd2b1152
+Evidence: `docs/ci/triage_nightly_2026-03-22.md:19`, `docs/ci/triage_nightly_2026-03-22.md:20`, `docs/ci/triage_nightly_2026-03-22.md:21`, `docs/roadmap/BACKLOG_LEDGER.md:7493`
 
-No actionable review threads are mapped yet.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988162984 -> fd2b1152
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#discussion_r2971557036 -> fd2b1152
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988164164 -> fd2b1152
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#discussion_r2971558579 -> fd2b1152
 
-Initial implementation commit:
-- `f996cc0a` — workflow parity fix, release-gate selector alignment, triage note, and backlog entry
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-nightly-full-tests-node22-parity`
+Reason: The shared Node/frontend bootstrap extraction identified by Sourcery is valid hardening work, but it is intentionally deferred to keep this PR limited to the confirmed parity regression and the release-gate selector drift.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1226#pullrequestreview-3988161712
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7484,6 +7484,34 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Local gates pass: `make verify` and `pre-commit run --all-files`
 
 
-**Last updated:** 2026-03-21 (PR #1208 merged; PR-B closeout lane in progress)
+<a id="ledger-p1-nightly-full-tests-node22-parity"></a>
+- [ ] P1: Nightly Full Tests Node 22 parity and release-gate selector alignment
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (CI stability / release safety)
+  - Target PR: PR-TBD (`fix/nightly-full-tests-node22-parity`)
+  - Status: In progress as of March 22, 2026
+  - Reason: `Nightly Full Tests` failed on `main` after PR `#1209` moved OpenAPI/frontend flows to Node `22.22.1`, because `.github/workflows/nightly-tests.yml` still relied on the runner default Node `20.20.1`. Production release gating in `.github/workflows/cd.yml` also drifted to the legacy `nightly.yml` selector instead of the canonical `Nightly Full Tests` workflow.
+  - Links:
+    - `docs/ci/triage_nightly_2026-03-22.md`
+    - `.github/workflows/nightly-tests.yml`
+    - `.github/workflows/cd.yml`
+    - `.nvmrc`
+    - `frontend/package.json`
+    - `scripts/frontend_npm.sh`
+    - `tests/test_openapi_determinism.py`
+    - Failed run: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23395469933>
+    - Failed job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23395469933/job/68057604027>
+    - Regression introducer: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1209>
+  - DoD:
+    - `Nightly Full Tests` provisions Node from `.nvmrc` and installs frontend dependencies before pytest
+    - `pytest -q tests/test_openapi_determinism.py` passes under the nightly workflow contract
+    - `cd.yml` production gate queries `nightly-tests.yml` / `Nightly Full Tests`
+    - `make verify` and `pre-commit run --all-files` pass on the fix branch
+    - Manual `Nightly Full Tests` dispatch on `main` passes after merge and before the next release tag
+  - Deferred hardening follow-up:
+    - Evaluate `npm ci --ignore-scripts` or split frontend bootstrap into a
+      narrower least-privileged nightly job once the parity fix is shipped.
+
+**Last updated:** 2026-03-22 (nightly full tests Node 22 parity lane opened)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7488,7 +7488,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Nightly Full Tests Node 22 parity and release-gate selector alignment
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (CI stability / release safety)
-  - Target PR: PR-TBD (`fix/nightly-full-tests-node22-parity`)
+  - Target PR: PR #1226 (`fix/nightly-full-tests-node22-parity`)
   - Status: In progress as of March 22, 2026
   - Reason: `Nightly Full Tests` failed on `main` after PR `#1209` moved OpenAPI/frontend flows to Node `22.22.1`, because `.github/workflows/nightly-tests.yml` still relied on the runner default Node `20.20.1`. Production release gating in `.github/workflows/cd.yml` also drifted to the legacy `nightly.yml` selector instead of the canonical `Nightly Full Tests` workflow.
   - Links:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7488,7 +7488,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Nightly Full Tests Node 22 parity and release-gate selector alignment
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (CI stability / release safety)
-  - Target PR: PR #1226 (`fix/nightly-full-tests-node22-parity`)
+  - Target PR: PR `#1226` (`fix/nightly-full-tests-node22-parity`)
   - Status: In progress as of March 22, 2026
   - Reason: `Nightly Full Tests` failed on `main` after PR `#1209` moved OpenAPI/frontend flows to Node `22.22.1`, because `.github/workflows/nightly-tests.yml` still relied on the runner default Node `20.20.1`. Production release gating in `.github/workflows/cd.yml` also drifted to the legacy `nightly.yml` selector instead of the canonical `Nightly Full Tests` workflow.
   - Links:
@@ -7511,6 +7511,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Deferred hardening follow-up:
     - Evaluate `npm ci --ignore-scripts` or split frontend bootstrap into a
       narrower least-privileged nightly job once the parity fix is shipped.
+    - Evaluate extracting the Node/frontend bootstrap into a shared workflow or
+      composite action so `ci.yml` and `nightly-tests.yml` do not drift again.
 
 **Last updated:** 2026-03-22 (nightly full tests Node 22 parity lane opened)
 **Maintainer:** @katsiaryna_kavaleuskaya


### PR DESCRIPTION
## Summary
- add Node 22 setup and frontend dependency bootstrap to `Nightly Full Tests`
- point the release gate in `cd.yml` at `nightly-tests.yml` instead of legacy `nightly.yml`
- document the incident, verification flow, and follow-up in the CI triage note, backlog ledger, and canonical review mapping artifact

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `make openapi`
- `pytest -q tests/test_openapi_determinism.py`
- `pre-commit run --all-files`
- `make verify`

## Notes
- Local Node parity verification used `v22.22.1` from the repo baseline.
- Manual `Nightly Full Tests` dispatch on commit `fd2b1152` succeeded in run `23404681122`.
- Governance-only follow-up commits on this branch update the triage doc and review mapping; after push, rerun manual `Nightly Full Tests` on the current head before merge.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1226_FIXED_MAPPING.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `Nightly Full Tests` with Node 22 to restore OpenAPI determinism. CD now gates on the canonical `nightly-tests.yml` job.

- **Bug Fixes**
  - Provision Node 22 from `.nvmrc` in `nightly-tests.yml` via `actions/setup-node` with `npm` cache, and install `frontend` deps via `./.github/actions/npm-ci-with-retry` before `pytest`.
  - Update `cd.yml` to query `nightly-tests.yml` (drop legacy `nightly.yml` from gating).
  - Add CI triage note, backlog ledger entry, and finalize the PR review mapping doc.

<sup>Written for commit 2b38ca4f675af50d8f8c181c1d54bc33f9acb4bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure CI boots the repo Node version, adds Node setup with npm caching, and installs frontend dependencies before tests.
  * Update release gating to query the correct nightly test lane.
* **Documentation**
  * Add nightly failure triage, a backlog entry for nightly parity work, and a review/merge-readiness note for tracking and follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
