### PR TITLE
fix(ci): install root node deps in nightly

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           node-version-file: ${{ env.FRONTEND_NODE_VERSION_FILE }}
           cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
 
       - name: Cache pip
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -49,6 +51,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -c constraints.txt
           python -m pip install -r requirements-dev.txt -c constraints.txt
+
+      - name: Install root Node dependencies
+        uses: ./.github/actions/npm-ci-with-retry
 
       - name: Install frontend dependencies
         uses: ./.github/actions/npm-ci-with-retry

--- a/docs/review/PR_1227_FIXED_MAPPING.md
+++ b/docs/review/PR_1227_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1227 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: `No actionable review comments were present when this hotfix PR was opened; mapping will be expanded if human or bot review adds actionable threads.`
+
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/docs/review/PR_1227_FIXED_MAPPING.md
+++ b/docs/review/PR_1227_FIXED_MAPPING.md
@@ -6,9 +6,10 @@
 
 ## Fixed in Commit Mapping
 Disposition: NOT-A-BUG
-Evidence: `No actionable review comments were present when this hotfix PR was opened; mapping will be expanded if human or bot review adds actionable threads.`
+Evidence: `.github/workflows/nightly-tests.yml:55`, `.github/workflows/nightly-tests.yml:58`, `package.json:13`, `package.json:14`, `package.json:28`, `package.json:31`
+Reason: The root Node package is required by repo-level business collateral scripts, so the root cache entry and root `npm-ci` step are intentionally unconditional. The frontend step keeps an explicit `working-directory` because it is the non-default path, while the root install intentionally uses the action's default repository root.
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1227#pullrequestreview-3988288594
 
 ## Merge Readiness
 - [ ] All required checks pass


### PR DESCRIPTION
## Summary
- install root npm dependencies in nightly full-tests workflow
- cache both root and frontend lockfiles for Node setup
- unblock business collateral builder tests that require root JS packages

## Why
Post-merge nightly run `23406507878` on `main` failed in `tests/test_business_collateral_builders.py` because nightly installed only frontend dependencies, while the builders executed root scripts requiring root Node modules already declared in `package.json`.

## Test Plan
- `pytest -q tests/test_business_collateral_builders.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1227_FIXED_MAPPING.md`
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1227#pullrequestreview-3988288594` — `NOT-A-BUG` (`.github/workflows/nightly-tests.yml:55`, `.github/workflows/nightly-tests.yml:58`, `package.json:13`, `package.json:14`, `package.json:28`, `package.json:31`)

## Merge Readiness (Mandatory)
- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups
- [x] Ledger item(s): None
- [x] GitHub issue(s): None
