### PR TITLE
feat(deploy): SPA at apex via Caddy + static image

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Production Caddy + SPA (apex)
 
-- **Contract:** [`docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`](../docs/deploy/SPA_APEX_ROUTING_CONTRACT.md) — path/method split (legacy POST vs SPA GET), proxy prefixes, `VITE_API_BASE`.
+- **Contract:** [`docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`](../docs/deploy/SPA_APEX_ROUTING_CONTRACT.md) — path/method split (legacy POST/OPTIONS/GET vs SPA GET on `/bmi`), proxy prefixes, default `VITE_API_BASE=/api/v1` (same-origin).
 - **Build Caddy image** (from repo root; compose uses `frontend/` as build context so root `.dockerignore` stays backend-focused):
 
 ```bash

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -3,7 +3,33 @@
 ## Scope and layout
 - This AGENTS.md applies to: `deploy/` and below.
 - Key files: `deploy/Caddyfile`, `deploy/Caddyfile.production`, `deploy/docker-compose.staging.yaml`,
+  `deploy/docker-compose.production.yaml`, `frontend/Dockerfile.caddy-spa`,
   root `Dockerfile`, root `docker-compose.yaml`.
+
+## Production Caddy + SPA (apex)
+
+- **Contract:** [`docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`](../docs/deploy/SPA_APEX_ROUTING_CONTRACT.md) — path/method split (legacy POST vs SPA GET), proxy prefixes, `VITE_API_BASE`.
+- **Build Caddy image** (from repo root; compose uses `frontend/` as build context so root `.dockerignore` stays backend-focused):
+
+```bash
+docker compose -f deploy/docker-compose.production.yaml build caddy
+```
+
+- **Override API base at image build time** (staging / alternate host):
+
+```bash
+VITE_API_BASE=https://staging.example.com/api/v1 docker compose -f deploy/docker-compose.production.yaml build caddy
+```
+
+- **`deploy/docker-compose.production.yaml`** references `env_file: .env` for the `app` service (path relative to `deploy/`). Create a local `deploy/.env` (gitignored) before `docker compose config` / up, or Compose will error if the file is missing.
+- **Validate Caddyfile** (requires Docker daemon + placeholder env for `{$PRODUCTION_DOMAIN}`):
+
+```bash
+PRODUCTION_DOMAIN=example.com STAGING_FALLBACK_DOMAIN=staging.example.com \
+  docker run --rm -e PRODUCTION_DOMAIN -e STAGING_FALLBACK_DOMAIN \
+  -v "$PWD/deploy/Caddyfile.production:/etc/caddy/Caddyfile:ro" \
+  caddy:2.10.2 caddy validate --config /etc/caddy/Caddyfile
+```
 
 ## Commands (run from repo root)
 - Build images: `make docker-build`, `make docker-build-dev`

--- a/deploy/Caddyfile.production
+++ b/deploy/Caddyfile.production
@@ -6,7 +6,31 @@ www.{$PRODUCTION_DOMAIN} {
 
 {$PRODUCTION_DOMAIN} {
     encode gzip
-    reverse_proxy app:8000
+
+    # RU: Legacy POST-only маршруты совпадают с GET SPA (см. docs/deploy/SPA_APEX_ROUTING_CONTRACT.md).
+    # EN: Legacy POST-only routes share paths with SPA GET (see SPA_APEX_ROUTING_CONTRACT.md).
+    @legacy_post {
+        method POST
+        path /bmi /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_post {
+        reverse_proxy app:8000
+    }
+
+    # RU: Всё API и операционные пути — на FastAPI (без коллизий с GET SPA выше).
+    # EN: API and ops paths → FastAPI (no GET collision with SPA for legacy POST paths).
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env
+    handle @api {
+        reverse_proxy app:8000
+    }
+
+    # RU: Статика SPA + fallback на index.html.
+    # EN: SPA static files + index.html fallback.
+    handle {
+        root * /srv/frontend
+        try_files {path} /index.html
+        file_server
+    }
 
     # RU: Безопасные заголовки по умолчанию (дополняет Cloudflare)
     # EN: Basic security headers (complements Cloudflare)
@@ -36,7 +60,25 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
 
 {$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
     encode gzip
-    reverse_proxy app:8000
+
+    @legacy_post {
+        method POST
+        path /bmi /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_post {
+        reverse_proxy app:8000
+    }
+
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env
+    handle @api {
+        reverse_proxy app:8000
+    }
+
+    handle {
+        root * /srv/frontend
+        try_files {path} /index.html
+        file_server
+    }
 
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"

--- a/deploy/Caddyfile.production
+++ b/deploy/Caddyfile.production
@@ -17,6 +17,26 @@ www.{$PRODUCTION_DOMAIN} {
         reverse_proxy app:8000
     }
 
+    # RU: CORS preflight для legacy POST — не отдавать из file_server.
+    # EN: CORS preflight for legacy POST must reach FastAPI, not static fallback.
+    @legacy_options {
+        method OPTIONS
+        path /bmi /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_options {
+        reverse_proxy app:8000
+    }
+
+    # RU: GET на путях без SPA-маршрута — в FastAPI (404/405), не пустой shell.
+    # EN: GET on paths with no React route → FastAPI (404/405), not empty SPA shell.
+    @legacy_get {
+        method GET
+        path /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_get {
+        reverse_proxy app:8000
+    }
+
     # RU: Всё API и операционные пути — на FastAPI (без коллизий с GET SPA выше).
     # EN: API and ops paths → FastAPI (no GET collision with SPA for legacy POST paths).
     @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env
@@ -66,6 +86,22 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
         path /bmi /plan /insight /premium_bmr /premium_targets
     }
     handle @legacy_post {
+        reverse_proxy app:8000
+    }
+
+    @legacy_options {
+        method OPTIONS
+        path /bmi /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_options {
+        reverse_proxy app:8000
+    }
+
+    @legacy_get {
+        method GET
+        path /plan /insight /premium_bmr /premium_targets
+    }
+    handle @legacy_get {
         reverse_proxy app:8000
     }
 

--- a/deploy/Caddyfile.production
+++ b/deploy/Caddyfile.production
@@ -11,7 +11,7 @@ www.{$PRODUCTION_DOMAIN} {
     # EN: Legacy POST-only routes share paths with SPA GET (see SPA_APEX_ROUTING_CONTRACT.md).
     @legacy_post {
         method POST
-        path /bmi /plan /insight /premium_bmr /premium_targets
+        path /bmi /bmi/ /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_post {
         reverse_proxy app:8000
@@ -21,7 +21,7 @@ www.{$PRODUCTION_DOMAIN} {
     # EN: CORS preflight for legacy POST must reach FastAPI, not static fallback.
     @legacy_options {
         method OPTIONS
-        path /bmi /plan /insight /premium_bmr /premium_targets
+        path /bmi /bmi/ /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_options {
         reverse_proxy app:8000
@@ -31,7 +31,7 @@ www.{$PRODUCTION_DOMAIN} {
     # EN: GET on paths with no React route → FastAPI (404/405), not empty SPA shell.
     @legacy_get {
         method GET
-        path /plan /insight /premium_bmr /premium_targets
+        path /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_get {
         reverse_proxy app:8000
@@ -83,7 +83,7 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
 
     @legacy_post {
         method POST
-        path /bmi /plan /insight /premium_bmr /premium_targets
+        path /bmi /bmi/ /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_post {
         reverse_proxy app:8000
@@ -91,7 +91,7 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
 
     @legacy_options {
         method OPTIONS
-        path /bmi /plan /insight /premium_bmr /premium_targets
+        path /bmi /bmi/ /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_options {
         reverse_proxy app:8000
@@ -99,7 +99,7 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
 
     @legacy_get {
         method GET
-        path /plan /insight /premium_bmr /premium_targets
+        path /plan /plan/ /insight /insight/ /premium_bmr /premium_bmr/ /premium_targets /premium_targets/
     }
     handle @legacy_get {
         reverse_proxy app:8000

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -141,9 +141,9 @@ ssh root@pulseplate.app
 # Перейти в deploy директорию
 cd /srv/pulseplate-production
 
-# Обновить и перезапустить
-docker-compose -f docker-compose.production.yaml pull
-docker-compose -f docker-compose.production.yaml up -d --force-recreate
+# Обновить и перезапустить (Caddy собирается из репозитория — нужен build, не только pull)
+docker compose -f docker-compose.production.yaml build caddy
+docker compose -f docker-compose.production.yaml up -d --force-recreate
 
 # Проверить
 curl -fsS https://pulseplate.app/health | jq .
@@ -169,7 +169,7 @@ curl -fsS https://pulseplate.app/health | jq .
 | ------------------ | ---------------------------------------------- | --------------------------------------- |
 | **Cursor**         | Код, фиксы, коммиты, PR                       | Правка на сервере                       |
 | **GitHub Actions** | Автоматическая сборка Docker image             | Ручная сборка                           |
-| **DigitalOcean**   | `docker pull` + `docker-compose up`            | Правка кода, git clone, изменение файлов |
+| **DigitalOcean**   | `docker compose build caddy` + `up` (см. `scripts/redeploy_caddy.sh:70`) | Правка кода, git clone, изменение файлов |
 
 ---
 

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -141,7 +141,8 @@ ssh root@pulseplate.app
 # Перейти в deploy директорию
 cd /srv/pulseplate-production
 
-# Обновить и перезапустить (Caddy собирается из репозитория — нужен build, не только pull)
+# Обновить образ app из registry (IMAGE_REF), затем пересобрать Caddy из репозитория и перезапустить стек
+docker compose -f docker-compose.production.yaml pull app
 docker compose -f docker-compose.production.yaml build caddy
 docker compose -f docker-compose.production.yaml up -d --force-recreate
 
@@ -169,7 +170,7 @@ curl -fsS https://pulseplate.app/health | jq .
 | ------------------ | ---------------------------------------------- | --------------------------------------- |
 | **Cursor**         | Код, фиксы, коммиты, PR                       | Правка на сервере                       |
 | **GitHub Actions** | Автоматическая сборка Docker image             | Ручная сборка                           |
-| **DigitalOcean**   | `docker compose build caddy` + `up` (см. `scripts/redeploy_caddy.sh:70`) | Правка кода, git clone, изменение файлов |
+| **DigitalOcean**   | `docker compose pull app` + `build caddy` + `up` (см. `scripts/redeploy_caddy.sh:76`) | Правка кода, git clone, изменение файлов |
 
 ---
 

--- a/deploy/docker-compose.production.yaml
+++ b/deploy/docker-compose.production.yaml
@@ -35,7 +35,11 @@ services:
       start_period: 40s
 
   caddy:
-    image: caddy:2.10.2
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile.caddy-spa
+      args:
+        VITE_API_BASE: ${VITE_API_BASE:-https://pulseplate.app/api/v1}
     restart: unless-stopped
     networks: [web]
     ports:

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -1,6 +1,6 @@
 # SPA at apex — routing contract (Caddy + FastAPI)
 
-**Status:** Contract for production/staging Caddy in [`deploy/Caddyfile.production`](../../deploy/Caddyfile.production) (legacy matchers at `deploy/Caddyfile.production:12`).
+**Status:** Contract for production/staging Caddy in [`deploy/Caddyfile.production`](../../deploy/Caddyfile.production) (legacy matchers at `deploy/Caddyfile.production:14`).
 **Scope:** Edge routing only — no thin-client or OpenAPI changes.
 
 ## Goals
@@ -22,6 +22,8 @@ These paths overlap between **legacy HTTP clients** and the SPA:
 | `/insight` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
 | `/premium_bmr` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
 | `/premium_targets` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
+
+Caddy `path` matching is **exact** (no automatic trailing-slash merge). Legacy matchers list both `/foo` and `/foo/` for POST, OPTIONS, and GET so clients that append a trailing slash still hit FastAPI (`deploy/Caddyfile.production:14`).
 
 Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), then the general API matcher, then SPA `file_server`.
 

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -1,6 +1,6 @@
 # SPA at apex — routing contract (Caddy + FastAPI)
 
-**Status:** Contract for production/staging Caddy in [`deploy/Caddyfile.production`](../../deploy/Caddyfile.production).
+**Status:** Contract for production/staging Caddy in [`deploy/Caddyfile.production`](../../deploy/Caddyfile.production) (legacy matchers at `deploy/Caddyfile.production:12`).
 **Scope:** Edge routing only — no thin-client or OpenAPI changes.
 
 ## Goals
@@ -10,17 +10,20 @@
 
 ## Method split (SPA vs legacy POST)
 
-These paths are **React Router** pages for **GET** (see [`frontend/src/config/routes.ts`](../../frontend/src/config/routes.ts)) but **FastAPI** defines **POST** on the same path for legacy clients:
+These paths overlap between **legacy HTTP clients** and the SPA:
 
-| Path | GET | POST |
-|------|-----|------|
-| `/bmi` | SPA (`file_server` + fallback) | `reverse_proxy` → app |
-| `/plan` | SPA | `reverse_proxy` → app |
-| `/insight` | SPA | `reverse_proxy` → app |
-| `/premium_bmr` | SPA | `reverse_proxy` → app |
-| `/premium_targets` | SPA | `reverse_proxy` → app |
+- **`/bmi`**: **GET** is a React route ([`frontend/src/config/routes.ts:30`](../../frontend/src/config/routes.ts)); **POST** (and **OPTIONS** preflight) go to FastAPI.
+- **`/plan`**, **`/insight`**, **`/premium_bmr`**, **`/premium_targets`**: no SPA routes today — **GET**, **POST**, and **OPTIONS** go to FastAPI so browsers do not receive an empty SPA shell for direct GETs.
 
-Caddy matches **POST** only for this set before the general API matcher.
+| Path | GET | POST | OPTIONS |
+|------|-----|------|---------|
+| `/bmi` | SPA | `reverse_proxy` → app | `reverse_proxy` → app |
+| `/plan` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
+| `/insight` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
+| `/premium_bmr` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
+| `/premium_targets` | `reverse_proxy` → app | `reverse_proxy` → app | `reverse_proxy` → app |
+
+Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), then the general API matcher, then SPA `file_server`.
 
 ## Paths proxied to FastAPI (all methods unless noted)
 
@@ -47,12 +50,12 @@ Caddy matches **POST** only for this set before the general API matcher.
 
 ## Build-time API base
 
-- Docker build ARG `VITE_API_BASE` (default `https://pulseplate.app/api/v1`). Override for staging/other hosts when building the Caddy image.
+- Docker build ARG `VITE_API_BASE` (default same-origin `/api/v1`). Override with an absolute URL for split-origin or Workers-backed API builds ([`frontend/Dockerfile.caddy-spa:17`](../../frontend/Dockerfile.caddy-spa)).
 
 ## QA smoke checklist (after deploy)
 
 - **MIME:** `GET /` returns `text/html`; `GET /health` returns JSON (via proxy).
-- **Deep link:** `GET /bmi` (or another client route) serves SPA `index.html` (not API).
+- **Deep link:** `GET /bmi` serves SPA `index.html` (not API); `GET /plan` (no SPA route) is proxied to the app.
 - **Legacy POST:** `POST /bmi` (and peers) reaches FastAPI (not static 405 from `file_server`).
 - **OpenAPI:** `GET /openapi.json` proxied (200, JSON).
 - **Ops:** `GET /metrics` proxied when enabled; `GET /ready` behavior unchanged.

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -1,0 +1,64 @@
+# SPA at apex — routing contract (Caddy + FastAPI)
+
+**Status:** Contract for production/staging Caddy in [`deploy/Caddyfile.production`](../../deploy/Caddyfile.production).
+**Scope:** Edge routing only — no thin-client or OpenAPI changes.
+
+## Goals
+
+- Browser **GET** `/` and client-side routes are served from **`frontend/dist`** (SPA fallback to `index.html`).
+- All API and operational traffic reaches **FastAPI** (`app:8000`) unchanged.
+
+## Method split (SPA vs legacy POST)
+
+These paths are **React Router** pages for **GET** (see [`frontend/src/config/routes.ts`](../../frontend/src/config/routes.ts)) but **FastAPI** defines **POST** on the same path for legacy clients:
+
+| Path | GET | POST |
+|------|-----|------|
+| `/bmi` | SPA (`file_server` + fallback) | `reverse_proxy` → app |
+| `/plan` | SPA | `reverse_proxy` → app |
+| `/insight` | SPA | `reverse_proxy` → app |
+| `/premium_bmr` | SPA | `reverse_proxy` → app |
+| `/premium_targets` | SPA | `reverse_proxy` → app |
+
+Caddy matches **POST** only for this set before the general API matcher.
+
+## Paths proxied to FastAPI (all methods unless noted)
+
+| Pattern | Notes |
+|---------|--------|
+| `/api*` | REST API |
+| `/health*`, `/ready` | Probes |
+| `/metrics` | Prometheus |
+| `/ws*` | WebSocket foundation |
+| `/docs*`, `/redoc*`, `/openapi.json` | OpenAPI / docs |
+| `/admin*` | Admin |
+| `/privacy`, `/terms` | Legacy HTML (no client route today) |
+| `/debug_env` | Debug (gate in prod env) |
+
+## Static (Caddy `file_server`)
+
+- Built assets under `/srv/frontend` (from [`frontend/Dockerfile.caddy-spa`](../../frontend/Dockerfile.caddy-spa)).
+- **`/favicon.ico`**: prefer `dist` (not proxied to app).
+
+## CSP
+
+- API responses may set CSP via app middleware.
+- Static HTML from Caddy does not automatically get the same headers; avoid duplicating conflicting CSP on static responses unless product/security requires it (follow-up if needed).
+
+## Build-time API base
+
+- Docker build ARG `VITE_API_BASE` (default `https://pulseplate.app/api/v1`). Override for staging/other hosts when building the Caddy image.
+
+## QA smoke checklist (after deploy)
+
+- **MIME:** `GET /` returns `text/html`; `GET /health` returns JSON (via proxy).
+- **Deep link:** `GET /bmi` (or another client route) serves SPA `index.html` (not API).
+- **Legacy POST:** `POST /bmi` (and peers) reaches FastAPI (not static 405 from `file_server`).
+- **OpenAPI:** `GET /openapi.json` proxied (200, JSON).
+- **Ops:** `GET /metrics` proxied when enabled; `GET /ready` behavior unchanged.
+- **WebSocket:** upgrade to `/ws` reaches app when feature flag allows.
+
+## References
+
+- [`deploy/docker-compose.production.yaml`](../../deploy/docker-compose.production.yaml)
+- [`deploy/AGENTS.md`](../../deploy/AGENTS.md)

--- a/docs/review/PR_1228_FIXED_MAPPING.md
+++ b/docs/review/PR_1228_FIXED_MAPPING.md
@@ -20,6 +20,6 @@ Evidence: `deploy/Caddyfile.production:14`, `deploy/Caddyfile.production:100`, `
 
 ## Merge Readiness
 - [ ] All required checks pass
-- [ ] No unresolved review threads (resolve CodeRabbit + Cubic threads after this push once checks are green)
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] No unresolved review threads (GitHub review threads resolved after fixes in `fdf1a191`)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green

--- a/docs/review/PR_1228_FIXED_MAPPING.md
+++ b/docs/review/PR_1228_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1228 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green

--- a/docs/review/PR_1228_FIXED_MAPPING.md
+++ b/docs/review/PR_1228_FIXED_MAPPING.md
@@ -6,6 +6,7 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
+Commit: 04366f44
 Evidence: `deploy/Caddyfile.production:12`, `frontend/src/api/client.ts:107`, `frontend/Dockerfile.caddy-spa:17`, `scripts/redeploy_caddy.sh:70`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:13`, `deploy/WORKFLOW.md:145`, `scripts/DIGITALOCEAN_CONSOLE_ACCESS.md:124`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988553487

--- a/docs/review/PR_1228_FIXED_MAPPING.md
+++ b/docs/review/PR_1228_FIXED_MAPPING.md
@@ -6,16 +6,20 @@
 
 ## Fixed in Commit Mapping
 Disposition: FIXED
-Commit: 04366f44
-Evidence: `deploy/Caddyfile.production:12`, `frontend/src/api/client.ts:107`, `frontend/Dockerfile.caddy-spa:17`, `scripts/redeploy_caddy.sh:70`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:13`, `deploy/WORKFLOW.md:145`, `scripts/DIGITALOCEAN_CONSOLE_ACCESS.md:124`
+Commit: fdf1a191
+Evidence: `deploy/Caddyfile.production:14`, `deploy/Caddyfile.production:100`, `frontend/src/api/client.ts:107`, `frontend/Dockerfile.caddy-spa:17`, `scripts/redeploy_caddy.sh:77`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:26`, `deploy/WORKFLOW.md:145`, `scripts/DIGITALOCEAN_CONSOLE_ACCESS.md:125`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988553487
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972026335
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972027670
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988554483
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972048147
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988570578
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988571108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972048933
 
 ## Merge Readiness
 - [ ] All required checks pass
-- [ ] No unresolved review threads (resolve all 5 threads in GitHub after this push — includes Codex inline threads)
+- [ ] No unresolved review threads (resolve CodeRabbit + Cubic threads after this push once checks are green)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green

--- a/docs/review/PR_1228_FIXED_MAPPING.md
+++ b/docs/review/PR_1228_FIXED_MAPPING.md
@@ -5,10 +5,16 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Evidence: `deploy/Caddyfile.production:12`, `frontend/src/api/client.ts:107`, `frontend/Dockerfile.caddy-spa:17`, `scripts/redeploy_caddy.sh:70`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:13`, `deploy/WORKFLOW.md:145`, `scripts/DIGITALOCEAN_CONSOLE_ACCESS.md:124`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988553487
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972026335
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972027670
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988554483
 
 ## Merge Readiness
 - [ ] All required checks pass
-- [ ] No unresolved review threads
+- [ ] No unresolved review threads (resolve all 5 threads in GitHub after this push — includes Codex inline threads)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2108,6 +2108,22 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P2
 
+<a id="ledger-p2-legacy-app-direct-root-get-policy"></a>
+- [ ] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (deploy ergonomics / operator clarity)
+  - Target PR: PR-TBD-LEGACY-ROOT-GET-POLICY
+  - Area: backend / deploy / legacy surface
+  - Reason (EN): With SPA served at apex via Caddy, operators or health tools may still hit uvicorn directly. `legacy_app.py` behavior for `GET /` should be explicit: redirect to public origin, `404`, JSON probe, or documented “Caddy-only” with no code change — pick one and test if behavior changes.
+  - Links:
+    - `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`
+    - `deploy/Caddyfile.production`
+    - `legacy_app.py`
+  - DoD:
+    - Documented policy in contract or runbook with `file:line` evidence
+    - If code changes: deterministic tests for chosen status/body
+    - No accidental regression for Caddy-served SPA or canonical API paths
+
 <a id="ledger-p2-movement-performance-coaching-wave"></a>
 - [ ] P2: Movement/performance coaching expansion lane
   - Owner: @katsiaryna_kavaleuskaya

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+# Keep Caddy+SPA image build context small and reproducible (see Dockerfile.caddy-spa).
+node_modules
+dist
+coverage
+.husky
+*.log
+.DS_Store
+.env
+.env.*
+!.env.example

--- a/frontend/Dockerfile.caddy-spa
+++ b/frontend/Dockerfile.caddy-spa
@@ -2,7 +2,7 @@
 # Multi-stage image: Vite build → Caddy with static SPA at /srv/frontend.
 # Build from repo root (recommended):
 #   docker compose -f deploy/docker-compose.production.yaml build caddy
-# Or with explicit API base for staging:
+# Or with explicit absolute API base (split-origin / Workers):
 #   docker build -f Dockerfile.caddy-spa --build-arg VITE_API_BASE=https://example.com/api/v1 -t pulseplate-caddy:local .
 
 FROM node:22-bookworm-slim AS frontend-build
@@ -14,8 +14,8 @@ RUN npm ci
 
 COPY . .
 
-# Same-origin production default; override per environment at build time.
-ARG VITE_API_BASE=https://pulseplate.app/api/v1
+# Same-origin default (/api/v1 on current host); override for split-origin builds.
+ARG VITE_API_BASE=/api/v1
 ENV VITE_API_BASE=${VITE_API_BASE}
 
 RUN npm run build

--- a/frontend/Dockerfile.caddy-spa
+++ b/frontend/Dockerfile.caddy-spa
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+# Multi-stage image: Vite build → Caddy with static SPA at /srv/frontend.
+# Build from repo root (recommended):
+#   docker compose -f deploy/docker-compose.production.yaml build caddy
+# Or with explicit API base for staging:
+#   docker build -f Dockerfile.caddy-spa --build-arg VITE_API_BASE=https://example.com/api/v1 -t pulseplate-caddy:local .
+
+FROM node:22-bookworm-slim AS frontend-build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# Same-origin production default; override per environment at build time.
+ARG VITE_API_BASE=https://pulseplate.app/api/v1
+ENV VITE_API_BASE=${VITE_API_BASE}
+
+RUN npm run build
+
+FROM caddy:2.10.2
+
+COPY --from=frontend-build /app/dist /srv/frontend

--- a/frontend/src/api/__tests__/client.normalizeUrl.test.ts
+++ b/frontend/src/api/__tests__/client.normalizeUrl.test.ts
@@ -7,10 +7,28 @@
  * This is a pure function test (no network, no MSW).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { normalizeApiUrl } from '../client';
 
 describe('normalizeApiUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('origin-relative API base (same-host Caddy + SPA)', () => {
+    it('resolves /api/v1 against window.location.origin', () => {
+      vi.stubGlobal('window', { location: { origin: 'https://staging.example' } });
+      expect(normalizeApiUrl('/api/v1', '/api/v1/pro/session')).toBe(
+        'https://staging.example/api/v1/pro/session'
+      );
+    });
+
+    it('deduplicates /api/v1 when base is origin-relative', () => {
+      vi.stubGlobal('window', { location: { origin: 'https://app.example' } });
+      expect(normalizeApiUrl('/api/v1/', '/api/v1/health')).toBe('https://app.example/api/v1/health');
+    });
+  });
+
   describe('deduplication when base contains /api/v1', () => {
     it('should deduplicate /api/v1 when base and path both contain it', () => {
       const base = 'http://localhost:8000/api/v1';

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,18 +100,34 @@ const validateApiBase = () => {
  * - base: "http://localhost:8000/api", path: "/api/x" => "http://localhost:8000/api/x"
  * - base: "https://api.test.com", path: "/api/v1/x" => "https://api.test.com/api/v1/x"
  *
- * @param base - API base URL (may include /api or /api/v1)
+ * @param base - API base URL (may include /api or /api/v1), or origin-relative path e.g. `/api/v1`
  * @param apiPath - API path (must start with /api/...)
  * @returns Normalized URL without duplicate segments
  */
+function resolveApiBaseForNormalization(base: string): string {
+  const trimmed = base.trim();
+  if (!trimmed.startsWith("/")) {
+    return trimmed;
+  }
+  // RU: Сборка на том же хосте, что и SPA (Caddy → тот же origin).
+  // EN: Same-host Caddy+SPA: resolve path-only base against current origin.
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "http://localhost";
+  return new URL(trimmed, `${origin}/`).toString();
+}
+
 export function normalizeApiUrl(base: string, apiPath: string): string {
   // Ensure apiPath starts with /
   const path = apiPath.startsWith('/') ? apiPath : `/${apiPath}`;
 
+  const baseForParse = resolveApiBaseForNormalization(base);
+
   // Parse base URL to get pathname
   let baseUrl: URL;
   try {
-    baseUrl = new URL(base);
+    baseUrl = new URL(baseForParse);
   } catch {
     // If base is not a valid URL, fall back to naive concat
     return `${base}${path}`;

--- a/scripts/DIGITALOCEAN_CONSOLE_ACCESS.md
+++ b/scripts/DIGITALOCEAN_CONSOLE_ACCESS.md
@@ -120,8 +120,8 @@ docker compose -f docker-compose.production.yaml up -d --force-recreate app
 # Использовать скрипт (если скопировали на сервер)
 bash scripts/redeploy_caddy.sh
 
-# Или вручную
-docker compose -f docker-compose.production.yaml pull caddy
+# Или вручную (образ caddy собирается локально из compose — см. deploy/WORKFLOW.md:145)
+docker compose -f docker-compose.production.yaml build caddy
 docker compose -f docker-compose.production.yaml up -d caddy
 docker compose -f docker-compose.production.yaml ps caddy
 docker compose -f docker-compose.production.yaml logs --tail=100 caddy

--- a/scripts/DIGITALOCEAN_CONSOLE_ACCESS.md
+++ b/scripts/DIGITALOCEAN_CONSOLE_ACCESS.md
@@ -120,7 +120,8 @@ docker compose -f docker-compose.production.yaml up -d --force-recreate app
 # Использовать скрипт (если скопировали на сервер)
 bash scripts/redeploy_caddy.sh
 
-# Или вручную (образ caddy собирается локально из compose — см. deploy/WORKFLOW.md:145)
+# Или вручную (см. deploy/WORKFLOW.md:145 — сначала pull app, затем build caddy)
+docker compose -f docker-compose.production.yaml pull app
 docker compose -f docker-compose.production.yaml build caddy
 docker compose -f docker-compose.production.yaml up -d caddy
 docker compose -f docker-compose.production.yaml ps caddy

--- a/scripts/redeploy_caddy.sh
+++ b/scripts/redeploy_caddy.sh
@@ -67,24 +67,31 @@ else
     exit 1
 fi
 
-echo "=== Step 1: Pull latest Caddy image ==="
+echo "=== Step 1: Pull Caddy image (no-op when service uses build:) ==="
 $DC_CMD pull caddy || {
-    echo "⚠️  Warning: Failed to pull Caddy image (may already be up to date)"
+    echo "⚠️  Warning: pull failed or skipped (expected when caddy uses compose build: context)"
 }
 
 echo ""
-echo "=== Step 2: Restart Caddy container ==="
+echo "=== Step 2: Build Caddy image (frontend dist + Caddyfile) ==="
+$DC_CMD build caddy || {
+    echo "❌ Failed to build Caddy image"
+    exit 1
+}
+
+echo ""
+echo "=== Step 3: Restart Caddy container ==="
 $DC_CMD up -d caddy || {
     echo "❌ Failed to start Caddy container"
     exit 1
 }
 
 echo ""
-echo "=== Step 3: Check Caddy container status ==="
+echo "=== Step 4: Check Caddy container status ==="
 $DC_CMD ps caddy
 
 echo ""
-echo "=== Step 4: Show recent Caddy logs ==="
+echo "=== Step 5: Show recent Caddy logs ==="
 $DC_CMD logs --tail=100 caddy
 
 echo ""

--- a/scripts/redeploy_caddy.sh
+++ b/scripts/redeploy_caddy.sh
@@ -73,6 +73,12 @@ $DC_CMD pull caddy || {
 }
 
 echo ""
+echo "=== Step 1b: Pull app image (IMAGE_REF from registry) ==="
+$DC_CMD pull app || {
+    echo "⚠️  Warning: pull app failed — verify registry auth / IMAGE_REF in .env"
+}
+
+echo ""
 echo "=== Step 2: Build Caddy image (frontend dist + Caddyfile) ==="
 $DC_CMD build caddy || {
     echo "❌ Failed to build Caddy image"


### PR DESCRIPTION
## Summary

Production Caddy serves the Vite SPA from a multi-stage image (`frontend/Dockerfile.caddy-spa`); FastAPI paths are proxied with a **POST-only** split for legacy routes that collide with SPA GET (`/bmi`, `/plan`, `/insight`, `/premium_bmr`, `/premium_targets`). Contract: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`.

## Scope (IN)

- `deploy/Caddyfile.production` (prod + staging blocks)
- `deploy/docker-compose.production.yaml` (Caddy build from `frontend/`)
- `frontend/Dockerfile.caddy-spa`, `frontend/.dockerignore`
- Deploy contract + `deploy/AGENTS.md` workflow notes
- Backlog item for direct-uvicorn `GET /` policy

## Scope (OUT)

- `legacy_app.py` `GET /` behavior (follow-up)
- OpenAPI / `schema.ts` regeneration
- iOS / unrelated refactors

## Deferred / Follow-ups

- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-legacy-app-direct-root-get-policy` — explicit policy for `GET /` when bypassing Caddy.

## Validation (local)

- `python3 scripts/orchestration/check_preflight.py` — PASS
- `pre-commit run --all-files` — PASS (on commit)
- `make test-fast` — PASS

Merge readiness: `make verify` + green CI required per `AGENTS.md` (do not merge on green CI alone).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Обслуживать фронтенд SPA с кастомного образа Caddy на апекс-домене и задокументировать контракт роутинга между Caddy и FastAPI для продакшена и стейджинга.

Новые возможности:
- Ввести Docker-образ на базе Caddy, который обслуживает Vite SPA и проксирует API-трафик для продакшен-развертываний.
- Определить формальный контракт роутинга SPA на апекс-домене, описывающий разделение по методам/путям между Caddy и FastAPI.

Улучшения:
- Обновить продакшен-конфигурацию Docker Compose так, чтобы собирать Caddy из контекста фронтенда с настраиваемым базовым URL API.
- Расширить runbook по деплою, добавив заметки по сборке и валидации продакшен-конфигурации Caddy + SPA и необходимых env-файлов.
- Добавить элемент в бэклог для уточнения поведения корневого GET FastAPI при прямом обращении без Caddy.

Документация:
- Добавить документацию по контракту роутинга SPA на апекс-домене, описывающую поведение Caddy/FastAPI, проксируемые пути и QA-проверки для продакшена.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serve the frontend SPA from a custom Caddy image at the apex domain and document the routing contract between Caddy and FastAPI for production and staging.

New Features:
- Introduce a Caddy-built Docker image that serves the Vite SPA and proxies API traffic for production deployments.
- Define a formal SPA apex routing contract covering method/path splits between Caddy and FastAPI.

Enhancements:
- Update production Docker Compose to build Caddy from the frontend context with a configurable API base URL.
- Extend deployment runbook notes to cover building and validating the production Caddy + SPA setup and required env files.
- Add a backlog item to clarify FastAPI root GET behavior when accessed directly without Caddy.

Documentation:
- Add SPA apex routing contract documentation describing Caddy/FastAPI behavior, proxied paths, and QA checks for production.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the SPA at the apex domain using a Caddy-built static image with method- and trailing-slash-aware routing that proxies API, legacy POST/OPTIONS, and selected GETs to FastAPI. This fixes deep links and CORS and sets a clear routing contract for prod and staging.

- **New Features**
  - Static SPA hosting with `index.html` fallback from `/srv/frontend` via `frontend/Dockerfile.caddy-spa`.
  - Method split with `/foo` and `/foo/` coverage: `POST`/`OPTIONS` on `/bmi`, `/plan`, `/insight`, `/premium_bmr`, `/premium_targets` → proxy; `GET` on `/plan`, `/insight`, `/premium_bmr`, `/premium_targets` → proxy; `GET` on `/bmi` → SPA.
  - API/ops paths (`/api*`, `/health*`, `/ready`, `/metrics`, `/ws*`, `/docs*`, `/redoc*`, `/openapi.json`, `/admin*`, `/privacy`, `/terms`, `/debug_env`) proxy to `app:8000`; prod/staging add security headers.
  - Build-time `VITE_API_BASE` defaults to `/api/v1` (same-origin); `docker compose` builds Caddy from `frontend/`; `normalizeApiUrl` resolves origin-relative bases and deduplicates; tests added.
  - Routing contract and QA checklist in `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`.

- **Migration**
  - Redeploy: `docker compose -f deploy/docker-compose.production.yaml pull app && docker compose -f deploy/docker-compose.production.yaml build caddy && docker compose -f deploy/docker-compose.production.yaml up -d --force-recreate`.
  - Override API base if needed: `VITE_API_BASE=https://staging.example.com/api/v1 ... build caddy`; ensure `deploy/.env` exists for the `app` service.
  - Smoke test: `GET /bmi` → SPA; `GET /plan` and `/plan/` → proxy; legacy `POST`/`OPTIONS` reach FastAPI; `/openapi.json` and `/metrics` behave as before.

<sup>Written for commit a5219f3041a79d9fa93e52d90170ff34e98de70e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a production SPA apex routing contract, deployment QA checklist, and a review record.
  * Documented build-time API base configuration, Caddy validation guidance, and updated deploy workflow notes.

* **Chores**
  * Split production routing between API/ops, legacy POST/OPTIONS, and SPA static serving with SPA fallback.
  * Switched to building a SPA-optimized Caddy image with configurable API base and added frontend Docker ignore rules.
  * Updated redeploy sequence to pull the app image, build Caddy, then restart.

* **Tests**
  * Added tests and cleanup for origin-relative API-base handling; improved URL normalization for origin-relative bases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED
Commit: fdf1a191
Evidence: `deploy/Caddyfile.production:14`, `deploy/Caddyfile.production:100`, `frontend/src/api/client.ts:107`, `frontend/Dockerfile.caddy-spa:17`, `scripts/redeploy_caddy.sh:77`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:26`, `deploy/WORKFLOW.md:145`, `scripts/DIGITALOCEAN_CONSOLE_ACCESS.md:125`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988553487
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972026335
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972027670
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988554483
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972048147
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988570578
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#pullrequestreview-3988571108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1228#discussion_r2972048933

## Merge Readiness
- [ ] All required checks pass
- [x] No unresolved review threads (CodeRabbit + Cubic threads resolved; verify on PR)
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping` (canonical: `docs/review/PR_1228_FIXED_MAPPING.md`)
- [x] Pre-commit green

