### PR TITLE
feat(api): direct uvicorn GET / JSON probe + legacy BMI HTML path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22.22.1"
+          node-version-file: ${{ env.FRONTEND_NODE_VERSION_FILE }}
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1516,7 +1516,7 @@
         "filename": "tests/test_web_interface_spanish.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       }
     ],
     "tests/test_weekly_planning_blocks_97.py": [
@@ -1536,5 +1536,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-22T13:03:15Z"
+  "generated_at": "2026-03-22T21:21:45Z"
 }

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ make lint
   - Comprehensive test suite with 97%+ coverage (enforced in CI)
   - Docker support with optimized production builds
   - CI/CD with GitHub Actions and automated security scans
-  - Simple web UI at root path for easy BMI calculation
+  - Legacy BMI HTML UI at `GET /legacy/bmi-calculator` (apex `/` is SPA or direct-API probe; see `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`)
   - Structured logging and request monitoring
   - **Pre-commit hooks** for code quality (Black, Ruff, MyPy, Bandit)
   - **Automatic cache cleanup** in CI and pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ The merged food database follows a standardized schema:
 
 ### Web UI
 
-- `GET /` - Simple web interface for BMI calculation
+- `GET /` - Direct-API JSON probe when hitting FastAPI without Caddy (operators / scanners); apex browsers get the SPA from static hosting
+- `GET /legacy/bmi-calculator` - Legacy standalone HTML form for BMI (same UI historically served at `/`)
 
 ### Body Fat Estimation
 

--- a/app/bootstrap/direct_api_root.py
+++ b/app/bootstrap/direct_api_root.py
@@ -1,0 +1,21 @@
+"""Direct ``GET /`` policy when clients reach FastAPI without Caddy/static apex."""
+
+from __future__ import annotations
+
+from app.schemas.direct_api_root import DirectApiRootLinks, DirectApiRootProbe
+
+LEGACY_BMI_WEB_ROUTE: str = "/legacy/bmi-calculator"
+
+_DIRECT_ROOT_MESSAGE: str = (
+    "Direct access hits the API process only. With Caddy in front, the browser SPA is "
+    "served at site apex; use /health, /docs, or the legacy HTML UI link in `links`."
+)
+
+
+def build_direct_api_root_probe() -> DirectApiRootProbe:
+    """Return the stable JSON probe for ``GET /`` (uvicorn / internal scanners)."""
+    probe: DirectApiRootProbe = DirectApiRootProbe(
+        message=_DIRECT_ROOT_MESSAGE,
+        links=DirectApiRootLinks(),
+    )
+    return probe

--- a/app/bootstrap/direct_api_root.py
+++ b/app/bootstrap/direct_api_root.py
@@ -10,7 +10,7 @@ from app.schemas.direct_api_root import DirectApiRootLinks, DirectApiRootProbe
 
 LEGACY_BMI_WEB_ROUTE: str = "/legacy/bmi-calculator"
 
-_DIRECT_ROOT_MESSAGE: str = (
+DIRECT_API_ROOT_PROBE_MESSAGE: str = (
     "Direct access hits the API process only. With Caddy in front, the browser SPA is "
     "served at site apex; use /health, /docs, or the legacy HTML UI link in `links`."
 )
@@ -19,7 +19,7 @@ _DIRECT_ROOT_MESSAGE: str = (
 def build_direct_api_root_probe() -> DirectApiRootProbe:
     """Return the stable JSON probe for ``GET /`` (uvicorn / internal scanners)."""
     probe: DirectApiRootProbe = DirectApiRootProbe(
-        message=_DIRECT_ROOT_MESSAGE,
+        message=DIRECT_API_ROOT_PROBE_MESSAGE,
         links=DirectApiRootLinks(),
     )
     return probe

--- a/app/bootstrap/direct_api_root.py
+++ b/app/bootstrap/direct_api_root.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+from app.bootstrap.legacy_bmi_web_html import render_legacy_bmi_calculator_page
 from app.schemas.direct_api_root import DirectApiRootLinks, DirectApiRootProbe
 
 LEGACY_BMI_WEB_ROUTE: str = "/legacy/bmi-calculator"
@@ -19,3 +23,13 @@ def build_direct_api_root_probe() -> DirectApiRootProbe:
         links=DirectApiRootLinks(),
     )
     return probe
+
+
+async def serve_direct_api_root_probe() -> DirectApiRootProbe:
+    """ASGI handler for ``GET /`` JSON probe (registered from ``app.main`` bootstrap)."""
+    return build_direct_api_root_probe()
+
+
+async def serve_legacy_bmi_calculator_web(request: Request) -> HTMLResponse:
+    """ASGI handler for embedded legacy BMI HTML (registered from ``app.main`` bootstrap)."""
+    return render_legacy_bmi_calculator_page(request)

--- a/app/bootstrap/legacy_bmi_web_html.py
+++ b/app/bootstrap/legacy_bmi_web_html.py
@@ -79,6 +79,10 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
             const translations = {
                 en: {
                     title: "BMI Calculator",
+                    result_bmi: "BMI",
+                    result_category: "Category",
+                    result_note: "Note",
+                    result_error: "Error calculating BMI",
                     label_weight: "Weight (kg):",
                     label_height: "Height (m):",
                     label_age: "Age:",
@@ -96,6 +100,10 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                 },
                 ru: {
                     title: "Калькулятор ИМТ",
+                    result_bmi: "ИМТ",
+                    result_category: "Категория",
+                    result_note: "Примечание",
+                    result_error: "Ошибка расчёта ИМТ",
                     label_weight: "Вес (кг):",
                     label_height: "Рост (м):",
                     label_age: "Возраст:",
@@ -113,6 +121,10 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                 },
                 es: {
                     title: "Calculadora de IMC",
+                    result_bmi: "IMC",
+                    result_category: "Categoría",
+                    result_note: "Nota",
+                    result_error: "Error al calcular el IMC",
                     label_weight: "Peso (kg):",
                     label_height: "Altura (m):",
                     label_age: "Edad:",
@@ -130,28 +142,33 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                 }
             };
 
+            const ALLOWED_LANGS = new Set(['en', 'ru', 'es']);
+
+            /** Allowlist URL/cookie lang to prevent cookie injection / odd payloads. */
+            function normalizeLang(raw) {
+                const code = String(raw || '').trim().toLowerCase();
+                return ALLOWED_LANGS.has(code) ? code : 'en';
+            }
+
             // Set language from cookie or URL parameter
             function getLanguage() {
-                // Check URL parameter first
                 const urlParams = new URLSearchParams(window.location.search);
                 if (urlParams.has('lang')) {
-                    return urlParams.get('lang');
+                    return normalizeLang(urlParams.get('lang'));
                 }
-                // Check cookie
                 const cookies = document.cookie.split(';');
                 for (let cookie of cookies) {
                     const [name, value] = cookie.trim().split('=');
                     if (name === 'lang') {
-                        return value;
+                        return normalizeLang(value);
                     }
                 }
-                // Default to English
                 return 'en';
             }
 
             // Update UI based on selected language
             function updateUILanguage(lang) {
-                const langCode = translations[lang] ? lang : 'en';
+                const langCode = normalizeLang(lang);
                 const t = translations[langCode];
 
                 // Update text elements
@@ -181,7 +198,7 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
 
             // Change language function
             function changeLanguage() {
-                const lang = document.getElementById('language').value;
+                const lang = normalizeLang(document.getElementById('language').value);
                 // Set cookie
                 // Security: add SameSite and conditionally Secure under HTTPS.
                 // RU: HttpOnly нельзя выставить из JS — это должен делать сервер.
@@ -190,6 +207,32 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                 document.cookie = `lang=${lang}${cookieAttrs}`;
                 // Update UI
                 updateUILanguage(lang);
+            }
+
+            function showBmiResult(result) {
+                const langCode = normalizeLang(getLanguage());
+                const t = translations[langCode];
+                const box = document.getElementById('result');
+                box.replaceChildren();
+                box.style.display = 'block';
+                const h2 = document.createElement('h2');
+                h2.textContent = `${t.result_bmi}: ${result.bmi}`;
+                const pCat = document.createElement('p');
+                pCat.textContent = `${t.result_category}: ${result.category ?? ''}`;
+                const pNote = document.createElement('p');
+                pNote.textContent = `${t.result_note}: ${result.note ?? ''}`;
+                box.append(h2, pCat, pNote);
+            }
+
+            function showBmiError() {
+                const langCode = normalizeLang(getLanguage());
+                const t = translations[langCode];
+                const box = document.getElementById('result');
+                box.replaceChildren();
+                const p = document.createElement('p');
+                p.textContent = t.result_error;
+                box.append(p);
+                box.style.display = 'block';
             }
 
             document.getElementById('bmiForm').addEventListener('submit', async (e) => {
@@ -214,15 +257,9 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                         body: JSON.stringify(data)
                     });
                     const result = await response.json();
-                    document.getElementById('result').innerHTML = `
-                        <h2>BMI: ${result.bmi}</h2>
-                        <p>Category: ${result.category}</p>
-                        <p>Note: ${result.note}</p>
-                    `;
-                    document.getElementById('result').style.display = 'block';
+                    showBmiResult(result);
                 } catch (error) {
-                    document.getElementById('result').innerHTML = '<p>Error calculating BMI</p>';
-                    document.getElementById('result').style.display = 'block';
+                    showBmiError();
                 }
             });
         </script>

--- a/app/bootstrap/legacy_bmi_web_html.py
+++ b/app/bootstrap/legacy_bmi_web_html.py
@@ -1,0 +1,233 @@
+"""Legacy embedded BMI calculator HTML (historically served at ``GET /``)."""
+
+from __future__ import annotations
+
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+
+def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
+    """Serve the standalone HTML BMI form with CSP nonce slots when middleware sets them."""
+    nonce = getattr(request.state, "csp_nonce", "")
+    nonce_attr = f' nonce="{nonce}"' if nonce else ""
+
+    html_template = """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>BMI Calculator 2025</title>
+        <style{nonce_attr}>
+            body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;
+                   padding: 20px; }
+            form { margin-bottom: 20px; }
+            input, button, select { display: block; margin: 10px 0; padding: 10px; width: 100%; }
+            .result { margin-top: 20px; padding: 10px; border: 1px solid #ccc; }
+            .language-selector { position: absolute; top: 20px; right: 20px; }
+        </style>
+    </head>
+    <body>
+        <div class="language-selector">
+            <label for="language">Language:</label>
+            <select id="language" onchange="changeLanguage()">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+                <option value="es">Español</option>
+            </select>
+        </div>
+
+        <h1 id="title">BMI Calculator</h1>
+        <form id="bmiForm">
+            <label for="weight" id="label_weight">Weight (kg):</label>
+            <input type="number" id="weight" step="0.1" required>
+
+            <label for="height" id="label_height">Height (m):</label>
+            <input type="number" id="height" step="0.01" required>
+
+            <label for="age" id="label_age">Age:</label>
+            <input type="number" id="age" required>
+
+            <label for="gender" id="label_gender">Gender:</label>
+            <select id="gender" required>
+                <option value="male" id="option_male">Male</option>
+                <option value="female" id="option_female">Female</option>
+            </select>
+
+            <label for="pregnant" id="label_pregnant">Pregnant:</label>
+            <select id="pregnant">
+                <option value="no" id="option_pregnant_no">No</option>
+                <option value="yes" id="option_pregnant_yes">Yes</option>
+            </select>
+
+            <label for="athlete" id="label_athlete">Athlete:</label>
+            <select id="athlete">
+                <option value="no" id="option_athlete_no">No</option>
+                <option value="yes" id="option_athlete_yes">Yes</option>
+            </select>
+
+            <label for="waist" id="label_waist">Waist (cm, optional):</label>
+            <input type="number" id="waist" step="0.1">
+
+            <button type="submit" id="button_calculate">Calculate BMI</button>
+        </form>
+
+        <div id="result" class="result" style="display:none;"></div>
+
+        <script{nonce_attr}>
+            // Language translations
+            const translations = {
+                en: {
+                    title: "BMI Calculator",
+                    label_weight: "Weight (kg):",
+                    label_height: "Height (m):",
+                    label_age: "Age:",
+                    label_gender: "Gender:",
+                    option_male: "Male",
+                    option_female: "Female",
+                    label_pregnant: "Pregnant:",
+                    option_pregnant_no: "No",
+                    option_pregnant_yes: "Yes",
+                    label_athlete: "Athlete:",
+                    option_athlete_no: "No",
+                    option_athlete_yes: "Yes",
+                    label_waist: "Waist (cm, optional):",
+                    button_calculate: "Calculate BMI"
+                },
+                ru: {
+                    title: "Калькулятор ИМТ",
+                    label_weight: "Вес (кг):",
+                    label_height: "Рост (м):",
+                    label_age: "Возраст:",
+                    label_gender: "Пол:",
+                    option_male: "Мужской",
+                    option_female: "Женский",
+                    label_pregnant: "Беременность:",
+                    option_pregnant_no: "Нет",
+                    option_pregnant_yes: "Да",
+                    label_athlete: "Спортсмен:",
+                    option_athlete_no: "Нет",
+                    option_athlete_yes: "Да",
+                    label_waist: "Талия (см, опционально):",
+                    button_calculate: "Рассчитать ИМТ"
+                },
+                es: {
+                    title: "Calculadora de IMC",
+                    label_weight: "Peso (kg):",
+                    label_height: "Altura (m):",
+                    label_age: "Edad:",
+                    label_gender: "Género:",
+                    option_male: "Masculino",
+                    option_female: "Femenino",
+                    label_pregnant: "Embarazada:",
+                    option_pregnant_no: "No",
+                    option_pregnant_yes: "Sí",
+                    label_athlete: "Atleta:",
+                    option_athlete_no: "No",
+                    option_athlete_yes: "Sí",
+                    label_waist: "Cintura (cm, opcional):",
+                    button_calculate: "Calcular IMC"
+                }
+            };
+
+            // Set language from cookie or URL parameter
+            function getLanguage() {
+                // Check URL parameter first
+                const urlParams = new URLSearchParams(window.location.search);
+                if (urlParams.has('lang')) {
+                    return urlParams.get('lang');
+                }
+                // Check cookie
+                const cookies = document.cookie.split(';');
+                for (let cookie of cookies) {
+                    const [name, value] = cookie.trim().split('=');
+                    if (name === 'lang') {
+                        return value;
+                    }
+                }
+                // Default to English
+                return 'en';
+            }
+
+            // Update UI based on selected language
+            function updateUILanguage(lang) {
+                const langCode = translations[lang] ? lang : 'en';
+                const t = translations[langCode];
+
+                // Update text elements
+                document.getElementById('title').textContent = t.title;
+                document.getElementById('label_weight').textContent = t.label_weight;
+                document.getElementById('label_height').textContent = t.label_height;
+                document.getElementById('label_age').textContent = t.label_age;
+                document.getElementById('label_gender').textContent = t.label_gender;
+                document.getElementById('option_male').textContent = t.option_male;
+                document.getElementById('option_female').textContent = t.option_female;
+                document.getElementById('label_pregnant').textContent = t.label_pregnant;
+                document.getElementById('option_pregnant_no').textContent = t.option_pregnant_no;
+                document.getElementById('option_pregnant_yes').textContent = t.option_pregnant_yes;
+                document.getElementById('label_athlete').textContent = t.label_athlete;
+                document.getElementById('option_athlete_no').textContent = t.option_athlete_no;
+                document.getElementById('option_athlete_yes').textContent = t.option_athlete_yes;
+                document.getElementById('label_waist').textContent = t.label_waist;
+                document.getElementById('button_calculate').textContent = t.button_calculate;
+
+                // Set language selector
+                document.getElementById('language').value = langCode;
+            }
+
+            // Set language selector based on current language
+            const currentLang = getLanguage();
+            updateUILanguage(currentLang);
+
+            // Change language function
+            function changeLanguage() {
+                const lang = document.getElementById('language').value;
+                // Set cookie
+                // Security: add SameSite and conditionally Secure under HTTPS.
+                // RU: HttpOnly нельзя выставить из JS — это должен делать сервер.
+                // EN: HttpOnly cannot be set from client-side JS; server must set it.
+                const cookieAttrs = `; path=/; SameSite=Lax${window.location.protocol === 'https:' ? '; Secure' : ''}`;
+                document.cookie = `lang=${lang}${cookieAttrs}`;
+                // Update UI
+                updateUILanguage(lang);
+            }
+
+            document.getElementById('bmiForm').addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const lang = getLanguage();
+                const data = {
+                    weight_kg: parseFloat(document.getElementById('weight').value),
+                    height_m: parseFloat(document.getElementById('height').value),
+                    age: parseInt(document.getElementById('age').value),
+                    gender: document.getElementById('gender').value,
+                    pregnant: document.getElementById('pregnant').value,
+                    athlete: document.getElementById('athlete').value,
+                    waist_cm: document.getElementById('waist').value ?
+                              parseFloat(document.getElementById('waist').value) : null,
+                    lang: lang
+                };
+
+                try {
+                    const response = await fetch('/bmi', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(data)
+                    });
+                    const result = await response.json();
+                    document.getElementById('result').innerHTML = `
+                        <h2>BMI: ${result.bmi}</h2>
+                        <p>Category: ${result.category}</p>
+                        <p>Note: ${result.note}</p>
+                    `;
+                    document.getElementById('result').style.display = 'block';
+                } catch (error) {
+                    document.getElementById('result').innerHTML = '<p>Error calculating BMI</p>';
+                    document.getElementById('result').style.display = 'block';
+                }
+            });
+        </script>
+    </body>
+    </html>
+    """
+    html_content = html_template.replace("{nonce_attr}", nonce_attr)
+    return HTMLResponse(content=html_content)

--- a/app/bootstrap/legacy_bmi_web_html.py
+++ b/app/bootstrap/legacy_bmi_web_html.py
@@ -17,7 +17,7 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>BMI Calculator 2025</title>
+        <title>BMI Calculator</title>
         <style{nonce_attr}>
             body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;
                    padding: 20px; }
@@ -30,7 +30,7 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
     <body>
         <div class="language-selector">
             <label for="language">Language:</label>
-            <select id="language" onchange="changeLanguage()">
+            <select id="language">
                 <option value="en">English</option>
                 <option value="ru">Русский</option>
                 <option value="es">Español</option>
@@ -195,6 +195,7 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
             // Set language selector based on current language
             const currentLang = getLanguage();
             updateUILanguage(currentLang);
+            document.getElementById('language').addEventListener('change', changeLanguage);
 
             // Change language function
             function changeLanguage() {
@@ -256,6 +257,9 @@ def render_legacy_bmi_calculator_page(request: Request) -> HTMLResponse:
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify(data)
                     });
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}`);
+                    }
                     const result = await response.json();
                     showBmiResult(result);
                 } catch (error) {

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ Keep imports deterministic: do NOT use importlib exec_module, do NOT mutate sys.
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 
 from legacy_app import (
     _install_openapi_builder,
@@ -15,6 +16,11 @@ from legacy_app import (
 
 # Register observability infrastructure (middleware + /metrics endpoint)
 # This must be done here, not in legacy_app.py, to keep legacy as a thin proxy
+from app.bootstrap.direct_api_root import (
+    LEGACY_BMI_WEB_ROUTE,
+    serve_direct_api_root_probe,
+    serve_legacy_bmi_calculator_web,
+)
 from app.bootstrap.food_search import register_food_search_backend
 from app.bootstrap.metrics import register_metrics
 from app.bootstrap.pro_contracts import register_pro_contract_routes
@@ -27,6 +33,7 @@ from app.routers.cbt_insight import router as cbt_insight_router
 from app.routers.feedback import router as feedback_router
 from app.routers.fitchef_structured import router as fitchef_structured_router
 from app.routers.legal import router as legal_router
+from app.schemas.direct_api_root import DirectApiRootProbe
 
 app: FastAPI = _legacy_app
 
@@ -114,6 +121,23 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     app = target_app
     _internalize_users_openapi_surface(app)
     _install_openapi_builder(app)
+
+    if not _has_route(target_app, "/", "GET"):
+        target_app.add_api_route(
+            "/",
+            serve_direct_api_root_probe,
+            methods=["GET"],
+            include_in_schema=False,
+            response_model=DirectApiRootProbe,
+        )
+    if not _has_route(target_app, LEGACY_BMI_WEB_ROUTE, "GET"):
+        target_app.add_api_route(
+            LEGACY_BMI_WEB_ROUTE,
+            serve_legacy_bmi_calculator_web,
+            methods=["GET"],
+            include_in_schema=False,
+            response_class=HTMLResponse,
+        )
     register_food_search_backend(app)
     register_metrics(app)
     register_request_telemetry(app)

--- a/app/main.py
+++ b/app/main.py
@@ -65,6 +65,29 @@ def _has_route(
     return False
 
 
+def _route_has_endpoint(
+    target_app: FastAPI,
+    path: str,
+    method: str,
+    endpoint: object,
+) -> bool:
+    """True when ``path``+``method`` is already bound to the expected callable.
+
+    RU: Не считаем «маршрут есть», если на пути висит чужой handler (контракт другой).
+    EN: Path/method alone is insufficient — wrong handler means wrong contract.
+    """
+    method_name = method.upper()
+    for route in target_app.routes:
+        if getattr(route, "path", None) != path:
+            continue
+        methods = getattr(route, "methods", None) or set()
+        if method_name not in methods:
+            continue
+        if getattr(route, "endpoint", None) is endpoint:
+            return True
+    return False
+
+
 def _assert_no_duplicate_ws_route(target_app: FastAPI | None = None) -> None:
     """Fail fast when WS paths are already occupied before canonical registration.
 
@@ -122,7 +145,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _internalize_users_openapi_surface(app)
     _install_openapi_builder(app)
 
-    if not _has_route(target_app, "/", "GET"):
+    if not _route_has_endpoint(target_app, "/", "GET", serve_direct_api_root_probe):
         target_app.add_api_route(
             "/",
             serve_direct_api_root_probe,
@@ -130,7 +153,9 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
             include_in_schema=False,
             response_model=DirectApiRootProbe,
         )
-    if not _has_route(target_app, LEGACY_BMI_WEB_ROUTE, "GET"):
+    if not _route_has_endpoint(
+        target_app, LEGACY_BMI_WEB_ROUTE, "GET", serve_legacy_bmi_calculator_web
+    ):
         target_app.add_api_route(
             LEGACY_BMI_WEB_ROUTE,
             serve_legacy_bmi_calculator_web,

--- a/app/schemas/direct_api_root.py
+++ b/app/schemas/direct_api_root.py
@@ -1,0 +1,33 @@
+"""Pydantic contract for direct FastAPI ``GET /`` probe (bypassing Caddy)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DirectApiRootLinks(BaseModel):
+    """Stable relative links for operators hitting uvicorn directly."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    health: str = Field(default="/health", description="Liveness JSON probe")
+    docs: str = Field(default="/docs", description="Swagger UI")
+    openapi: str = Field(default="/openapi.json", description="OpenAPI document")
+    legacy_bmi_web_ui: str = Field(
+        default="/legacy/bmi-calculator",
+        description="Embedded legacy HTML BMI form (moved from /)",
+    )
+
+
+class DirectApiRootProbe(BaseModel):
+    """JSON body for ``GET /`` when traffic reaches FastAPI without SPA static host."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str = Field(default="pulseplate-api")
+    surface: str = Field(default="api")
+    message: str = Field(
+        ...,
+        description="Explains apex SPA vs direct API access for operators.",
+    )
+    links: DirectApiRootLinks

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Production Caddy + SPA (apex)
 
-- **Contract:** [`docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`](../docs/deploy/SPA_APEX_ROUTING_CONTRACT.md) — path/method split (legacy POST/OPTIONS/GET vs SPA GET on `/bmi`), proxy prefixes, default `VITE_API_BASE=/api/v1` (same-origin).
+- **Contract:** [`docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`](../docs/deploy/SPA_APEX_ROUTING_CONTRACT.md) — path/method split (legacy POST/OPTIONS/GET vs SPA GET on `/bmi`), proxy prefixes, default `VITE_API_BASE=/api/v1` (same-origin). FastAPI legacy HTML surfaces under `/legacy*` are proxied via the `@api` matcher (`deploy/Caddyfile.production:42`) so they are not swallowed by SPA `try_files`.
 - **Build Caddy image** (from repo root; compose uses `frontend/` as build context so root `.dockerignore` stays backend-focused):
 
 ```bash

--- a/deploy/Caddyfile.production
+++ b/deploy/Caddyfile.production
@@ -39,7 +39,7 @@ www.{$PRODUCTION_DOMAIN} {
 
     # RU: Всё API и операционные пути — на FastAPI (без коллизий с GET SPA выше).
     # EN: API and ops paths → FastAPI (no GET collision with SPA for legacy POST paths).
-    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env /legacy*
     handle @api {
         reverse_proxy app:8000
     }
@@ -105,7 +105,7 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
         reverse_proxy app:8000
     }
 
-    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env /legacy*
     handle @api {
         reverse_proxy app:8000
     }

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -37,8 +37,15 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 | `/ws*` | WebSocket foundation |
 | `/docs*`, `/redoc*`, `/openapi.json` | OpenAPI / docs |
 | `/admin*` | Admin |
-| `/privacy`, `/terms` | Legacy HTML (no client route today) |
+| `/privacy`, `/terms` | Legal JSON endpoints (no SPA route today) |
+| `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: `legacy_app.py:1494`) |
 | `/debug_env` | Debug (gate in prod env) |
+
+**Caddy matcher evidence:** `/legacy*` is included in the `@api` path list in [`deploy/Caddyfile.production:42`](../../deploy/Caddyfile.production).
+
+## Direct uvicorn / bypass Caddy
+
+When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; handler `legacy_app.py:1486`, payload builder `app/bootstrap/direct_api_root.py:18`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (`legacy_app.py:1494`, template `app/bootstrap/legacy_bmi_web_html.py:9`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.
 
 ## Static (Caddy `file_server`)
 
@@ -56,7 +63,8 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 
 ## QA smoke checklist (after deploy)
 
-- **MIME:** `GET /` returns `text/html`; `GET /health` returns JSON (via proxy).
+- **MIME (through Caddy):** `GET /` returns SPA `text/html` from static `file_server`; `GET /health` returns JSON (via proxy).
+- **Direct API:** `GET /` on uvicorn returns JSON probe (`app/bootstrap/direct_api_root.py:18`); legacy HTML UI: `GET /legacy/bmi-calculator` (proxied via `/legacy*` in `deploy/Caddyfile.production:42`).
 - **Deep link:** `GET /bmi` serves SPA `index.html` (not API); `GET /plan` (no SPA route) is proxied to the app.
 - **Legacy POST:** `POST /bmi` (and peers) reaches FastAPI (not static 405 from `file_server`).
 - **OpenAPI:** `GET /openapi.json` proxied (200, JSON).

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -38,14 +38,16 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 | `/docs*`, `/redoc*`, `/openapi.json` | OpenAPI / docs |
 | `/admin*` | Admin |
 | `/privacy`, `/terms` | Legal JSON endpoints (no SPA route today) |
-| `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: `legacy_app.py:1494`) |
+| `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: `legacy_app.py:1493`) |
 | `/debug_env` | Debug (gate in prod env) |
 
 **Caddy matcher evidence:** `/legacy*` is included in the `@api` path list in [`deploy/Caddyfile.production:42`](../../deploy/Caddyfile.production).
 
 ## Direct uvicorn / bypass Caddy
 
-When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; handler `legacy_app.py:1486`, payload builder `app/bootstrap/direct_api_root.py:18`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (`legacy_app.py:1494`, template `app/bootstrap/legacy_bmi_web_html.py:9`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.
+When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; handler `legacy_app.py:1487`, payload builder `app/bootstrap/direct_api_root.py:18`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (`legacy_app.py:1493`, template `app/bootstrap/legacy_bmi_web_html.py:9`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.
+
+**Operator trap:** `curl https://<your-apex-domain>/` **through Caddy** returns the SPA shell (`text/html`), **not** the JSON probe. Use direct uvicorn/port `8000`, or call **`GET /health`**, to verify the API behind the edge.
 
 ## Static (Caddy `file_server`)
 

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -38,14 +38,14 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 | `/docs*`, `/redoc*`, `/openapi.json` | OpenAPI / docs |
 | `/admin*` | Admin |
 | `/privacy`, `/terms` | Legal JSON endpoints (no SPA route today) |
-| `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: `legacy_app.py:1493`) |
+| `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: registered in `app/main.py`, template `app/bootstrap/legacy_bmi_web_html.py`) |
 | `/debug_env` | Debug (gate in prod env) |
 
 **Caddy matcher evidence:** `/legacy*` is included in the `@api` path list in [`deploy/Caddyfile.production:42`](../../deploy/Caddyfile.production).
 
-## Direct uvicorn / bypass Caddy
+## Direct Uvicorn / bypass Caddy
 
-When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; handler `legacy_app.py:1487`, payload builder `app/bootstrap/direct_api_root.py:18`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (`legacy_app.py:1493`, template `app/bootstrap/legacy_bmi_web_html.py:9`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.
+When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; registration `app/main.py` → `serve_direct_api_root_probe`, payload builder `app/bootstrap/direct_api_root.py`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (same bootstrap, handler `serve_legacy_bmi_calculator_web`, template `app/bootstrap/legacy_bmi_web_html.py`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.
 
 **Operator trap:** `curl https://<your-apex-domain>/` **through Caddy** returns the SPA shell (`text/html`), **not** the JSON probe. Use direct uvicorn/port `8000`, or call **`GET /health`**, to verify the API behind the edge.
 

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -6,25 +6,33 @@
 
 ## Fixed in Commit Mapping
 
-### Batch A — direct root probe + Codex P1 relocation
+### Batch A — direct root probe, Spanish smoke path constant, Uvicorn heading
 Disposition: FIXED
 Commit: d0e43d20
-Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_direct_api_root_probe.py:21`, `tests/test_spanish_end_to_end_smoke.py:103`, `tests/test_app_basic_combined.py:88`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:46`
+Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_direct_api_root_probe.py:21`, `tests/test_spanish_end_to_end_smoke.py:13`, `tests/test_spanish_end_to_end_smoke.py:103`, `tests/test_app_basic_combined.py:88`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:46`
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124555
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124557
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124559
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972129621
 
-### Batch B — route endpoint identity, legacy HTML CSP/fetch, test contract, ledger
+### Batch B — Codex P1 bootstrap + route endpoint identity, legacy HTML CSP/fetch, guards, ledger
 Disposition: FIXED
 Commit: de54e75f
 Evidence: `app/main.py:68`, `app/main.py:148`, `app/bootstrap/legacy_bmi_web_html.py:20`, `app/bootstrap/legacy_bmi_web_html.py:198`, `app/bootstrap/legacy_bmi_web_html.py:260`, `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py`, `docs/roadmap/BACKLOG_LEDGER.md`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972129621
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135430
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140766
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140768
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972145442
+
+### Batch C — coverage test comment + .nvmrc parse hardening
+Disposition: FIXED
+Commit: a769d1d2
+Evidence: `tests/test_coverage_improvement.py:42`, `tests/test_openapi_determinism.py:38`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135433
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135434
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -37,7 +37,7 @@ Commit: de54e75f
 Evidence: `app/bootstrap/legacy_bmi_web_html.py:20` (page title without stale year)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135425
 Disposition: FIXED
-Commit: 81c71e64793e4ebcc22266ec668496a3bf008aaf
+Commit: 4ec3dd82
 Evidence: `README.md` (Development & Operations bullet: BMI UI path vs apex `/` contract)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135431
 Disposition: FIXED

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -5,32 +5,23 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-
-### Batch A — direct root probe, Spanish smoke path constant, Uvicorn heading
 Disposition: FIXED
 Commit: d0e43d20
 Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_direct_api_root_probe.py:21`, `tests/test_spanish_end_to_end_smoke.py:13`, `tests/test_spanish_end_to_end_smoke.py:103`, `tests/test_app_basic_combined.py:88`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:46`
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124555
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124557
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124559
-
-### Batch B — Codex P1 bootstrap + route endpoint identity, legacy HTML CSP/fetch, guards, ledger
 Disposition: FIXED
 Commit: de54e75f
 Evidence: `app/main.py:68`, `app/main.py:148`, `app/bootstrap/legacy_bmi_web_html.py:20`, `app/bootstrap/legacy_bmi_web_html.py:198`, `app/bootstrap/legacy_bmi_web_html.py:260`, `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py`, `docs/roadmap/BACKLOG_LEDGER.md`
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972129621
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135430
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140766
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140768
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972145442
-
-### Batch C — coverage test comment + .nvmrc parse hardening
 Disposition: FIXED
 Commit: a769d1d2
 Evidence: `tests/test_coverage_improvement.py:42`, `tests/test_openapi_determinism.py:38`
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135433
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135434
 

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR 1229 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: d0e43d20
+Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_direct_api_root_probe.py:21`, `tests/test_spanish_end_to_end_smoke.py:103`, `tests/test_app_basic_combined.py:88`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:46`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124555
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124557
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124559
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972129621
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (resolve on GitHub after push)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -24,6 +24,11 @@ Commit: a769d1d2
 Evidence: `tests/test_coverage_improvement.py:42`, `tests/test_openapi_determinism.py:38`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135433
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135434
+Disposition: FIXED
+Commit: 5252261e
+Evidence: `app/bootstrap/direct_api_root.py` (`DIRECT_API_ROOT_PROBE_MESSAGE`), `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972159157
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972159163
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -5,6 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+
+### Batch A — direct root probe + Codex P1 relocation
 Disposition: FIXED
 Commit: d0e43d20
 Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_direct_api_root_probe.py:21`, `tests/test_spanish_end_to_end_smoke.py:103`, `tests/test_app_basic_combined.py:88`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md:46`
@@ -13,6 +15,16 @@ Evidence: `app/main.py:125`, `app/bootstrap/direct_api_root.py:28`, `tests/test_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124557
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972124559
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972129621
+
+### Batch B — route endpoint identity, legacy HTML CSP/fetch, test contract, ledger
+Disposition: FIXED
+Commit: de54e75f
+Evidence: `app/main.py:68`, `app/main.py:148`, `app/bootstrap/legacy_bmi_web_html.py:20`, `app/bootstrap/legacy_bmi_web_html.py:198`, `app/bootstrap/legacy_bmi_web_html.py:260`, `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py`, `docs/roadmap/BACKLOG_LEDGER.md`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135430
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140766
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972140768
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972145442
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1229_FIXED_MAPPING.md
+++ b/docs/review/PR_1229_FIXED_MAPPING.md
@@ -29,6 +29,34 @@ Commit: 5252261e
 Evidence: `app/bootstrap/direct_api_root.py` (`DIRECT_API_ROOT_PROBE_MESSAGE`), `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972159157
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972159163
+Disposition: NOT-A-BUG
+Evidence: `app/bootstrap/direct_api_root.py`, `app/bootstrap/legacy_bmi_web_html.py`, `tests/test_openapi_determinism.py` — Sourcery summary overlaps threads mapped below; bootstrap route constants and Node/.nvmrc CI gate are intentionally scoped as implemented.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#pullrequestreview-3988632955
+Disposition: FIXED
+Commit: de54e75f
+Evidence: `app/bootstrap/legacy_bmi_web_html.py:20` (page title without stale year)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135425
+Disposition: FIXED
+Commit: 81c71e64793e4ebcc22266ec668496a3bf008aaf
+Evidence: `README.md` (Development & Operations bullet: BMI UI path vs apex `/` contract)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135431
+Disposition: FIXED
+Commit: a769d1d2
+Evidence: `tests/test_openapi_determinism.py` (CI fail-closed when Node major < `.nvmrc`)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#discussion_r2972135438
+Disposition: FIXED
+Commit: de54e75f
+Evidence: `app/main.py`, `app/bootstrap/legacy_bmi_web_html.py`, routing/docs batch (CodeRabbit review cycle 1)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#pullrequestreview-3988641521
+Disposition: FIXED
+Commit: a126a079
+Evidence: `app/bootstrap/direct_api_root.py`, `tests/test_direct_api_root_probe.py`, `tests/test_legacy_bmi_web_html_guard.py` (CodeRabbit review cycles 2–3)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#pullrequestreview-3988645373
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#pullrequestreview-3988648467
+Disposition: FIXED
+Commit: 5252261e
+Evidence: `app/bootstrap/direct_api_root.py` (`DIRECT_API_ROOT_PROBE_MESSAGE`), guard tests (Cubic P2 review)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1229#pullrequestreview-3988659006
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2112,7 +2112,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (deploy ergonomics / operator clarity)
-  - Target PR: (set at merge time — opened as direct-root JSON probe + `/legacy/bmi-calculator`)
+  - Target PR: #1229
   - Area: backend / deploy / legacy surface
   - Reason (EN): With SPA served at apex via Caddy, operators or health tools may still hit uvicorn directly. `legacy_app.py` behavior for `GET /` should be explicit: redirect to public origin, `404`, JSON probe, or documented “Caddy-only” with no code change — pick one and test if behavior changes.
   - Links:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2109,16 +2109,17 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 ### P2
 
 <a id="ledger-p2-legacy-app-direct-root-get-policy"></a>
-- [x] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
+- [ ] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (deploy ergonomics / operator clarity)
   - Target PR: #1229
   - Area: backend / deploy / legacy surface
   - Reason (EN): With SPA served at apex via Caddy, operators or health tools may still hit uvicorn directly. `legacy_app.py` behavior for `GET /` should be explicit: redirect to public origin, `404`, JSON probe, or documented “Caddy-only” with no code change — pick one and test if behavior changes.
+  - Note (EN): Keep **open** until PR #1229 is merged; close via **docs-only** follow-up that sets `[x]` with merge evidence (ledger closure rule — do not pre-close in the implementation PR).
   - Links:
     - `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`
     - `deploy/Caddyfile.production`
-    - `legacy_app.py`
+    - `app/main.py` (canonical bootstrap registers direct-root probe + legacy HTML route)
   - DoD:
     - Documented policy in contract or runbook with `file:line` evidence
     - If code changes: deterministic tests for chosen status/body

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2109,10 +2109,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 ### P2
 
 <a id="ledger-p2-legacy-app-direct-root-get-policy"></a>
-- [ ] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
+- [x] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (deploy ergonomics / operator clarity)
-  - Target PR: PR-TBD-LEGACY-ROOT-GET-POLICY
+  - Target PR: (set at merge time — opened as direct-root JSON probe + `/legacy/bmi-calculator`)
   - Area: backend / deploy / legacy surface
   - Reason (EN): With SPA served at apex via Caddy, operators or health tools may still hit uvicorn directly. `legacy_app.py` behavior for `GET /` should be explicit: redirect to public origin, `404`, JSON probe, or documented “Caddy-only” with no code change — pick one and test if behavior changes.
   - Links:

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -30,7 +30,7 @@ from typing import (
 
 import dotenv
 from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import JSONResponse, Response
 from pydantic import (
     BaseModel,
     ConfigDict,

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -46,6 +46,8 @@ from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from settings import get_runtime_env_name, is_explicit_developer_env, is_production_like_env
 
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE, build_direct_api_root_probe
+from app.bootstrap.legacy_bmi_web_html import render_legacy_bmi_calculator_page
 from app.bootstrap.startup_guards import run_startup_guards
 from app.dependencies import validate_template_dir
 from app.http_error_details import (
@@ -72,6 +74,7 @@ from app.routers.shopping_list_pro import router as shopping_list_pro_router
 from app.routers.shoplist_export import router as shoplist_router
 from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
+from app.schemas.direct_api_root import DirectApiRootProbe
 from app.schemas.premium_contracts import (
     Activity,
     DietFlag,
@@ -1480,233 +1483,17 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 # ---------- Misc routes ----------
 
 
-@app.get("/")
-async def root(request: Request) -> HTMLResponse:
-    # Get nonce from middleware
-    nonce = getattr(request.state, "csp_nonce", "")
-    nonce_attr = f' nonce="{nonce}"' if nonce else ""
+@app.get("/", include_in_schema=False, response_model=DirectApiRootProbe)
+async def root() -> DirectApiRootProbe:
+    """JSON probe for direct uvicorn access; apex SPA is served by Caddy when configured."""
+    result: DirectApiRootProbe = build_direct_api_root_probe()
+    return result
 
-    # Build HTML with nonce injection - use string replacement to avoid f-string issues
-    html_template = """
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>BMI Calculator 2025</title>
-        <style{nonce_attr}>
-            body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;
-                   padding: 20px; }
-            form { margin-bottom: 20px; }
-            input, button, select { display: block; margin: 10px 0; padding: 10px; width: 100%; }
-            .result { margin-top: 20px; padding: 10px; border: 1px solid #ccc; }
-            .language-selector { position: absolute; top: 20px; right: 20px; }
-        </style>
-    </head>
-    <body>
-        <div class="language-selector">
-            <label for="language">Language:</label>
-            <select id="language" onchange="changeLanguage()">
-                <option value="en">English</option>
-                <option value="ru">Русский</option>
-                <option value="es">Español</option>
-            </select>
-        </div>
 
-        <h1 id="title">BMI Calculator</h1>
-        <form id="bmiForm">
-            <label for="weight" id="label_weight">Weight (kg):</label>
-            <input type="number" id="weight" step="0.1" required>
-
-            <label for="height" id="label_height">Height (m):</label>
-            <input type="number" id="height" step="0.01" required>
-
-            <label for="age" id="label_age">Age:</label>
-            <input type="number" id="age" required>
-
-            <label for="gender" id="label_gender">Gender:</label>
-            <select id="gender" required>
-                <option value="male" id="option_male">Male</option>
-                <option value="female" id="option_female">Female</option>
-            </select>
-
-            <label for="pregnant" id="label_pregnant">Pregnant:</label>
-            <select id="pregnant">
-                <option value="no" id="option_pregnant_no">No</option>
-                <option value="yes" id="option_pregnant_yes">Yes</option>
-            </select>
-
-            <label for="athlete" id="label_athlete">Athlete:</label>
-            <select id="athlete">
-                <option value="no" id="option_athlete_no">No</option>
-                <option value="yes" id="option_athlete_yes">Yes</option>
-            </select>
-
-            <label for="waist" id="label_waist">Waist (cm, optional):</label>
-            <input type="number" id="waist" step="0.1">
-
-            <button type="submit" id="button_calculate">Calculate BMI</button>
-        </form>
-
-        <div id="result" class="result" style="display:none;"></div>
-
-        <script{nonce_attr}>
-            // Language translations
-            const translations = {
-                en: {
-                    title: "BMI Calculator",
-                    label_weight: "Weight (kg):",
-                    label_height: "Height (m):",
-                    label_age: "Age:",
-                    label_gender: "Gender:",
-                    option_male: "Male",
-                    option_female: "Female",
-                    label_pregnant: "Pregnant:",
-                    option_pregnant_no: "No",
-                    option_pregnant_yes: "Yes",
-                    label_athlete: "Athlete:",
-                    option_athlete_no: "No",
-                    option_athlete_yes: "Yes",
-                    label_waist: "Waist (cm, optional):",
-                    button_calculate: "Calculate BMI"
-                },
-                ru: {
-                    title: "Калькулятор ИМТ",
-                    label_weight: "Вес (кг):",
-                    label_height: "Рост (м):",
-                    label_age: "Возраст:",
-                    label_gender: "Пол:",
-                    option_male: "Мужской",
-                    option_female: "Женский",
-                    label_pregnant: "Беременность:",
-                    option_pregnant_no: "Нет",
-                    option_pregnant_yes: "Да",
-                    label_athlete: "Спортсмен:",
-                    option_athlete_no: "Нет",
-                    option_athlete_yes: "Да",
-                    label_waist: "Талия (см, опционально):",
-                    button_calculate: "Рассчитать ИМТ"
-                },
-                es: {
-                    title: "Calculadora de IMC",
-                    label_weight: "Peso (kg):",
-                    label_height: "Altura (m):",
-                    label_age: "Edad:",
-                    label_gender: "Género:",
-                    option_male: "Masculino",
-                    option_female: "Femenino",
-                    label_pregnant: "Embarazada:",
-                    option_pregnant_no: "No",
-                    option_pregnant_yes: "Sí",
-                    label_athlete: "Atleta:",
-                    option_athlete_no: "No",
-                    option_athlete_yes: "Sí",
-                    label_waist: "Cintura (cm, opcional):",
-                    button_calculate: "Calcular IMC"
-                }
-            };
-
-            // Set language from cookie or URL parameter
-            function getLanguage() {
-                // Check URL parameter first
-                const urlParams = new URLSearchParams(window.location.search);
-                if (urlParams.has('lang')) {
-                    return urlParams.get('lang');
-                }
-                // Check cookie
-                const cookies = document.cookie.split(';');
-                for (let cookie of cookies) {
-                    const [name, value] = cookie.trim().split('=');
-                    if (name === 'lang') {
-                        return value;
-                    }
-                }
-                // Default to English
-                return 'en';
-            }
-
-            // Update UI based on selected language
-            function updateUILanguage(lang) {
-                const langCode = translations[lang] ? lang : 'en';
-                const t = translations[langCode];
-
-                // Update text elements
-                document.getElementById('title').textContent = t.title;
-                document.getElementById('label_weight').textContent = t.label_weight;
-                document.getElementById('label_height').textContent = t.label_height;
-                document.getElementById('label_age').textContent = t.label_age;
-                document.getElementById('label_gender').textContent = t.label_gender;
-                document.getElementById('option_male').textContent = t.option_male;
-                document.getElementById('option_female').textContent = t.option_female;
-                document.getElementById('label_pregnant').textContent = t.label_pregnant;
-                document.getElementById('option_pregnant_no').textContent = t.option_pregnant_no;
-                document.getElementById('option_pregnant_yes').textContent = t.option_pregnant_yes;
-                document.getElementById('label_athlete').textContent = t.label_athlete;
-                document.getElementById('option_athlete_no').textContent = t.option_athlete_no;
-                document.getElementById('option_athlete_yes').textContent = t.option_athlete_yes;
-                document.getElementById('label_waist').textContent = t.label_waist;
-                document.getElementById('button_calculate').textContent = t.button_calculate;
-
-                // Set language selector
-                document.getElementById('language').value = langCode;
-            }
-
-            // Set language selector based on current language
-            const currentLang = getLanguage();
-            updateUILanguage(currentLang);
-
-            // Change language function
-            function changeLanguage() {
-                const lang = document.getElementById('language').value;
-                // Set cookie
-                // Security: add SameSite and conditionally Secure under HTTPS.
-                // RU: HttpOnly нельзя выставить из JS — это должен делать сервер.
-                // EN: HttpOnly cannot be set from client-side JS; server must set it.
-                const cookieAttrs = `; path=/; SameSite=Lax${window.location.protocol === 'https:' ? '; Secure' : ''}`;
-                document.cookie = `lang=${lang}${cookieAttrs}`;
-                // Update UI
-                updateUILanguage(lang);
-            }
-
-            document.getElementById('bmiForm').addEventListener('submit', async (e) => {
-                e.preventDefault();
-                const lang = getLanguage();
-                const data = {
-                    weight_kg: parseFloat(document.getElementById('weight').value),
-                    height_m: parseFloat(document.getElementById('height').value),
-                    age: parseInt(document.getElementById('age').value),
-                    gender: document.getElementById('gender').value,
-                    pregnant: document.getElementById('pregnant').value,
-                    athlete: document.getElementById('athlete').value,
-                    waist_cm: document.getElementById('waist').value ?
-                              parseFloat(document.getElementById('waist').value) : null,
-                    lang: lang
-                };
-
-                try {
-                    const response = await fetch('/bmi', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(data)
-                    });
-                    const result = await response.json();
-                    document.getElementById('result').innerHTML = `
-                        <h2>BMI: ${result.bmi}</h2>
-                        <p>Category: ${result.category}</p>
-                        <p>Note: ${result.note}</p>
-                    `;
-                    document.getElementById('result').style.display = 'block';
-                } catch (error) {
-                    document.getElementById('result').innerHTML = '<p>Error calculating BMI</p>';
-                    document.getElementById('result').style.display = 'block';
-                }
-            });
-        </script>
-    </body>
-    </html>
-    """
-    html_content = html_template.replace("{nonce_attr}", nonce_attr)
-    return HTMLResponse(content=html_content)
+@app.get(LEGACY_BMI_WEB_ROUTE, include_in_schema=False, response_class=HTMLResponse)
+async def legacy_bmi_calculator_web(request: Request) -> HTMLResponse:
+    """Embedded legacy HTML BMI form (moved from ``GET /`` for operator clarity)."""
+    return render_legacy_bmi_calculator_page(request)
 
 
 @app.get("/favicon.ico")

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -46,8 +46,6 @@ from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from settings import get_runtime_env_name, is_explicit_developer_env, is_production_like_env
 
-from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE, build_direct_api_root_probe
-from app.bootstrap.legacy_bmi_web_html import render_legacy_bmi_calculator_page
 from app.bootstrap.startup_guards import run_startup_guards
 from app.dependencies import validate_template_dir
 from app.http_error_details import (
@@ -74,7 +72,6 @@ from app.routers.shopping_list_pro import router as shopping_list_pro_router
 from app.routers.shoplist_export import router as shoplist_router
 from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
-from app.schemas.direct_api_root import DirectApiRootProbe
 from app.schemas.premium_contracts import (
     Activity,
     DietFlag,
@@ -1481,19 +1478,6 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 
 
 # ---------- Misc routes ----------
-
-
-@app.get("/", include_in_schema=False, response_model=DirectApiRootProbe)
-async def root() -> DirectApiRootProbe:
-    """JSON probe for direct uvicorn access; apex SPA is served by Caddy when configured."""
-    result: DirectApiRootProbe = build_direct_api_root_probe()
-    return result
-
-
-@app.get(LEGACY_BMI_WEB_ROUTE, include_in_schema=False, response_class=HTMLResponse)
-async def legacy_bmi_calculator_web(request: Request) -> HTMLResponse:
-    """Embedded legacy HTML BMI form (moved from ``GET /`` for operator clarity)."""
-    return render_legacy_bmi_calculator_page(request)
 
 
 @app.get("/favicon.ico")

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 import app
 import pytest
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
 from tests.helpers.module_resolve import resolve_module
 
 
@@ -85,6 +86,8 @@ class TestAppImport:
         assert "/api/v1/feedback/rag" in route_paths
         assert "/api/v1/pro/cbt/insight" in route_paths
         assert "/ws" in route_paths
+        assert "/" in route_paths
+        assert LEGACY_BMI_WEB_ROUTE in route_paths
 
 
 class TestAppVIPIntegration:

--- a/tests/test_app_branching_and_errors.py
+++ b/tests/test_app_branching_and_errors.py
@@ -209,7 +209,9 @@ def test_no_premium_week_router(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_root_endpoint(client: TestClient) -> None:
     response = client.get("/")
     assert response.status_code == 200
-    assert "PulsePlate" in response.text or "ok" in response.text
+    assert response.headers["content-type"].startswith("application/json")
+    probe = response.json()
+    assert probe.get("service") == "pulseplate-api"
 
 
 def test_invalid_route(client: TestClient) -> None:

--- a/tests/test_app_coverage_missing_lines.py
+++ b/tests/test_app_coverage_missing_lines.py
@@ -218,7 +218,7 @@ class TestAppMissingLinesCoverage:
         """Test the root endpoint."""
         client = client
 
-        response = client.get("/")
+        response = client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         assert "BMI Calculator" in response.text
 

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -52,9 +52,17 @@ class TestHealthAndMonitoringEndpoints:
             or "Prometheus client not available" in content
         )
 
-    def test_root_page_renders(self, client: TestClient) -> None:
-        """Test root / endpoint renders HTML BMI calculator"""
+    def test_root_returns_direct_api_probe(self, client: TestClient) -> None:
+        """Test GET / returns JSON when hitting FastAPI directly (Caddy serves SPA at apex)."""
         response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        data = response.json()
+        assert data["surface"] == "api"
+
+    def test_legacy_bmi_page_renders(self, client: TestClient) -> None:
+        """Legacy HTML BMI calculator remains on /legacy/bmi-calculator."""
+        response = client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         content = response.text
         assert "<title" in content

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -122,8 +122,10 @@ class TestAPIEndpoints:
         """Test root endpoint returns proper HTML."""
         response = self.client.get("/")
         assert response.status_code == 200
-        assert "text/html" in response.headers["content-type"]
-        assert "BMI Calculator" in response.text
+        assert response.headers["content-type"].startswith("application/json")
+        payload = response.json()
+        assert payload["service"] == "pulseplate-api"
+        assert payload["links"]["legacy_bmi_web_ui"] == "/legacy/bmi-calculator"
 
     def test_favicon_endpoint(self):
         """Test favicon endpoint."""

--- a/tests/test_app_missing_coverage_96.py
+++ b/tests/test_app_missing_coverage_96.py
@@ -341,7 +341,7 @@ class TestAppMissingCoverage96:
 
     def test_root_endpoint(self):
         """Test root endpoint returns HTML."""
-        response = self.client.get("/")
+        response = self.client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         # Should return HTML content
         assert "text/html" in response.headers.get("content-type", "")

--- a/tests/test_app_production_coverage.py
+++ b/tests/test_app_production_coverage.py
@@ -218,7 +218,6 @@ class TestAppProductionCoverage:
         # Проверяем, что root endpoint работает в production режиме
         response = client.get("/")
         assert response.status_code == 200
-
-        # Root endpoint может возвращать HTML, а не JSON
-        # root_data = response.json()
-        # assert "message" in root_data
+        assert response.headers["content-type"].startswith("application/json")
+        root_data = response.json()
+        assert root_data.get("service") == "pulseplate-api"

--- a/tests/test_app_specific_coverage_96.py
+++ b/tests/test_app_specific_coverage_96.py
@@ -396,9 +396,9 @@ class TestAppSpecificCoverage96:
     # permissive to avoid brittle failures and can be tightened once the API
     # surface stabilizes.
 
-    def test_root_endpoint_html_content(self) -> None:
-        """Test root endpoint returns proper HTML content."""
-        response = self.client.get("/")
+    def test_legacy_bmi_web_ui_returns_html(self) -> None:
+        """Legacy embedded BMI page lives under /legacy/bmi-calculator (not GET /)."""
+        response = self.client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         assert "text/html" in response.headers.get("content-type", "")
         html_content = response.text

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -40,7 +40,7 @@ class TestCoverageImprovement:
             pass
 
         # Test the root endpoint more thoroughly
-        response = self.client.get("/")
+        response = self.client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         assert "BMI Calculator" in response.text
 

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -39,7 +39,7 @@ class TestCoverageImprovement:
             # This line is covered by the environment setup
             pass
 
-        # Test the root endpoint more thoroughly
+        # Legacy embedded BMI calculator HTML (canonical path; GET / is JSON probe)
         response = self.client.get("/legacy/bmi-calculator")
         assert response.status_code == 200
         assert "BMI Calculator" in response.text

--- a/tests/test_direct_api_root_probe.py
+++ b/tests/test_direct_api_root_probe.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app import app
-from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE, build_direct_api_root_probe
+from app.bootstrap.direct_api_root import (
+    DIRECT_API_ROOT_PROBE_MESSAGE,
+    LEGACY_BMI_WEB_ROUTE,
+)
 
 
 def test_get_slash_returns_json_probe() -> None:
@@ -18,7 +21,7 @@ def test_get_slash_returns_json_probe() -> None:
     assert data["service"] == "pulseplate-api"
     assert data["surface"] == "api"
     assert "message" in data
-    assert data["message"] == build_direct_api_root_probe().message
+    assert data["message"] == DIRECT_API_ROOT_PROBE_MESSAGE
     links = data["links"]
     assert links["health"] == "/health"
     assert links["docs"] == "/docs"

--- a/tests/test_direct_api_root_probe.py
+++ b/tests/test_direct_api_root_probe.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app import app
-from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE, build_direct_api_root_probe
 
 
 def test_get_slash_returns_json_probe() -> None:
@@ -18,7 +18,7 @@ def test_get_slash_returns_json_probe() -> None:
     assert data["service"] == "pulseplate-api"
     assert data["surface"] == "api"
     assert "message" in data
-    assert "SPA" in data["message"]
+    assert data["message"] == build_direct_api_root_probe().message
     links = data["links"]
     assert links["health"] == "/health"
     assert links["docs"] == "/docs"

--- a/tests/test_direct_api_root_probe.py
+++ b/tests/test_direct_api_root_probe.py
@@ -1,0 +1,34 @@
+"""Contract tests for direct FastAPI ``GET /`` (bypassing Caddy / static apex)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import app
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
+
+
+def test_get_slash_returns_json_probe() -> None:
+    """Direct ``GET /`` must return a stable JSON envelope for operators."""
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    data = response.json()
+    assert data["service"] == "pulseplate-api"
+    assert data["surface"] == "api"
+    assert "message" in data
+    links = data["links"]
+    assert links["health"] == "/health"
+    assert links["docs"] == "/docs"
+    assert links["openapi"] == "/openapi.json"
+    assert links["legacy_bmi_web_ui"] == LEGACY_BMI_WEB_ROUTE
+
+
+def test_legacy_bmi_web_route_serves_html() -> None:
+    """Embedded legacy calculator remains available for manual smoke tests."""
+    client = TestClient(app)
+    response = client.get(LEGACY_BMI_WEB_ROUTE)
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "BMI Calculator" in response.text

--- a/tests/test_direct_api_root_probe.py
+++ b/tests/test_direct_api_root_probe.py
@@ -18,6 +18,7 @@ def test_get_slash_returns_json_probe() -> None:
     assert data["service"] == "pulseplate-api"
     assert data["surface"] == "api"
     assert "message" in data
+    assert "SPA" in data["message"]
     links = data["links"]
     assert links["health"] == "/health"
     assert links["docs"] == "/docs"

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -23,7 +23,7 @@ import legacy_app
 def test_language_cookie_has_samesite_and_secure_guard() -> None:
     """Security: language cookie must include SameSite and Secure-on-HTTPS guard."""
     client = TestClient(legacy_app.app)
-    resp = client.get("/")
+    resp = client.get("/legacy/bmi-calculator")
     assert resp.status_code == 200
     assert "SameSite=Lax" in resp.text
     assert "window.location.protocol === 'https:'" in resp.text

--- a/tests/test_legacy_bmi_web_html_guard.py
+++ b/tests/test_legacy_bmi_web_html_guard.py
@@ -13,3 +13,7 @@ def test_legacy_bmi_calculator_template_avoids_innerhtml_for_results() -> None:
     assert (
         "innerHTML" not in text
     ), "legacy BMI HTML must use DOM textContent for user-visible API fields, not innerHTML"
+    assert (
+        "onchange=" not in text
+    ), "legacy BMI HTML must bind events from the nonce'd script (CSP), not inline handlers"
+    assert "response.ok" in text, "legacy BMI fetch must branch on HTTP ok before parsing JSON"

--- a/tests/test_legacy_bmi_web_html_guard.py
+++ b/tests/test_legacy_bmi_web_html_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -13,7 +14,8 @@ def test_legacy_bmi_calculator_template_avoids_innerhtml_for_results() -> None:
     assert (
         "innerHTML" not in text
     ), "legacy BMI HTML must use DOM textContent for user-visible API fields, not innerHTML"
+    normalized = re.sub(r"\s+", "", text.lower())
     assert (
-        "onchange=" not in text
+        "onchange=" not in normalized
     ), "legacy BMI HTML must bind events from the nonce'd script (CSP), not inline handlers"
     assert "response.ok" in text, "legacy BMI fetch must branch on HTTP ok before parsing JSON"

--- a/tests/test_legacy_bmi_web_html_guard.py
+++ b/tests/test_legacy_bmi_web_html_guard.py
@@ -1,0 +1,15 @@
+"""Guard: legacy embedded BMI page must not inject API fields via innerHTML (XSS)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_legacy_bmi_calculator_template_avoids_innerhtml_for_results() -> None:
+    """Regression for bug-hunter P1: /bmi JSON fields must reach DOM via textContent only."""
+    root = Path(__file__).resolve().parents[1]
+    path = root / "app" / "bootstrap" / "legacy_bmi_web_html.py"
+    text = path.read_text(encoding="utf-8")
+    assert (
+        "innerHTML" not in text
+    ), "legacy BMI HTML must use DOM textContent for user-visible API fields, not innerHTML"

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -28,8 +29,8 @@ def _node_major_meets_nvmrc(repo_root: Path) -> bool:
     """
     Match scripts/frontend_npm.sh: `make openapi` fails when Node major < .nvmrc major.
 
-    RU: Локально без Node 22 полный пайплайн не запускаем — скип вместо ложного FAIL.
-    EN: Skip determinism test when toolchain cannot run the real OpenAPI pipeline.
+    RU: Локально без нужного Node major — скип; в CI (CI=true) — fail-closed, без «тихого» skip.
+    EN: Skip locally when Node is too old; in CI, callers must not skip silently.
     """
     nvmrc = repo_root / ".nvmrc"
     if not nvmrc.is_file():
@@ -108,6 +109,12 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
         pytest.skip("OpenAPI determinism test requires node/npm/make toolchain")
 
     if not _node_major_meets_nvmrc(repo_root):
+        if os.environ.get("CI") == "true":
+            pytest.fail(
+                "OpenAPI determinism must run in CI with Node major >= .nvmrc "
+                "(use node-version-file: env.FRONTEND_NODE_VERSION_FILE; "
+                "see scripts/frontend_npm.sh)."
+            )
         pytest.skip(
             "OpenAPI determinism test requires Node major >= .nvmrc "
             "(same gate as scripts/frontend_npm.sh / make openapi)"

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -24,6 +24,33 @@ def _tail_log(log_text: str) -> str:
     return "\n".join(lines[-_SUBPROCESS_LOG_TAIL_LINES:])
 
 
+def _node_major_meets_nvmrc(repo_root: Path) -> bool:
+    """
+    Match scripts/frontend_npm.sh: `make openapi` fails when Node major < .nvmrc major.
+
+    RU: Локально без Node 22 полный пайплайн не запускаем — скип вместо ложного FAIL.
+    EN: Skip determinism test when toolchain cannot run the real OpenAPI pipeline.
+    """
+    nvmrc = repo_root / ".nvmrc"
+    if not nvmrc.is_file():
+        return True
+    expected_major = int(nvmrc.read_text(encoding="utf-8").strip().split(".")[0])
+    proc = subprocess.run(
+        ["node", "-p", "parseInt(process.versions.node.split('.')[0], 10)"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return False
+    try:
+        current_major = int((proc.stdout or "").strip())
+    except ValueError:
+        return False
+    return current_major >= expected_major
+
+
 def _run_openapi_pipeline(repo_root: Path) -> None:
     """
     Run `make openapi` with bounded retry and actionable failure diagnostics.
@@ -74,11 +101,17 @@ def test_openapi_and_schema_ts_are_deterministic() -> None:
     - No drift occurs in openapi.json or schema.ts
     - Full pipeline (make openapi) is deterministic for CI and local development
     """
+    repo_root = Path(__file__).resolve().parents[1]
+
     # This test is meant for the dedicated CI job that has Node/npm installed.
     if not (shutil.which("node") and shutil.which("npm") and shutil.which("make")):
         pytest.skip("OpenAPI determinism test requires node/npm/make toolchain")
 
-    repo_root = Path(__file__).resolve().parents[1]
+    if not _node_major_meets_nvmrc(repo_root):
+        pytest.skip(
+            "OpenAPI determinism test requires Node major >= .nvmrc "
+            "(same gate as scripts/frontend_npm.sh / make openapi)"
+        )
     openapi_path = repo_root / "frontend" / "src" / "api" / "openapi.json"
     schema_path = repo_root / "frontend" / "src" / "api" / "schema.ts"
 

--- a/tests/test_openapi_determinism.py
+++ b/tests/test_openapi_determinism.py
@@ -35,7 +35,11 @@ def _node_major_meets_nvmrc(repo_root: Path) -> bool:
     nvmrc = repo_root / ".nvmrc"
     if not nvmrc.is_file():
         return True
-    expected_major = int(nvmrc.read_text(encoding="utf-8").strip().split(".")[0])
+    first_segment = nvmrc.read_text(encoding="utf-8").strip().split(".")[0].lstrip("v")
+    try:
+        expected_major = int(first_segment)
+    except ValueError:
+        return False
     proc = subprocess.run(
         ["node", "-p", "parseInt(process.versions.node.split('.')[0], 10)"],
         cwd=repo_root,

--- a/tests/test_spanish_end_to_end_smoke.py
+++ b/tests/test_spanish_end_to_end_smoke.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
+
 
 @pytest.mark.slow
 class TestSpanishEndToEndSmoke:
@@ -98,7 +100,7 @@ class TestSpanishEndToEndSmoke:
         assert isinstance(bmi_pro_result.get("notes"), list)
 
         # 4. Legacy embedded BMI web UI (Spanish) — canonical path (GET / is JSON probe)
-        web_response = self.client.get("/legacy/bmi-calculator?lang=es")
+        web_response = self.client.get(f"{LEGACY_BMI_WEB_ROUTE}?lang=es")
         assert web_response.status_code == 200
         assert "text/html" in web_response.headers["content-type"]
 

--- a/tests/test_spanish_end_to_end_smoke.py
+++ b/tests/test_spanish_end_to_end_smoke.py
@@ -97,8 +97,8 @@ class TestSpanishEndToEndSmoke:
         # Verify Spanish language is processed (notes should be localized)
         assert isinstance(bmi_pro_result.get("notes"), list)
 
-        # 4. Test web interface with Spanish language parameter
-        web_response = self.client.get("/?lang=es")
+        # 4. Legacy embedded BMI web UI (Spanish) — canonical path (GET / is JSON probe)
+        web_response = self.client.get("/legacy/bmi-calculator?lang=es")
         assert web_response.status_code == 200
         assert "text/html" in web_response.headers["content-type"]
 

--- a/tests/test_targeted_coverage_improvement.py
+++ b/tests/test_targeted_coverage_improvement.py
@@ -177,7 +177,7 @@ class TestTargetedCoverageImprovement:
         """Test root endpoint."""
         response = self.client.get("/")
         assert response.status_code == 200
-        assert "text/html" in response.headers["content-type"]
+        assert response.headers["content-type"].startswith("application/json")
 
     def test_favicon_endpoint(self):
         """Test favicon endpoint."""

--- a/tests/test_web_interface_spanish.py
+++ b/tests/test_web_interface_spanish.py
@@ -10,6 +10,7 @@ import sys
 from fastapi.testclient import TestClient
 
 from app import app
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
 
 
 class TestWebInterfaceSpanish:
@@ -28,7 +29,7 @@ class TestWebInterfaceSpanish:
     def test_web_interface_contains_spanish_option(self) -> None:
         """Test that the web interface contains Spanish language option."""
         # Test that the root endpoint returns HTML with Spanish option
-        response = self.client.get("/")
+        response = self.client.get(LEGACY_BMI_WEB_ROUTE)
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
 
@@ -41,7 +42,7 @@ class TestWebInterfaceSpanish:
     def test_web_interface_form_labels_spanish(self) -> None:
         """Test that form labels are correctly translated to Spanish."""
         # Get the web interface with Spanish language
-        response = self.client.get("/?lang=es")
+        response = self.client.get(f"{LEGACY_BMI_WEB_ROUTE}?lang=es")
         assert response.status_code == 200
 
         html_content = response.text
@@ -59,7 +60,7 @@ class TestWebInterfaceSpanish:
     def test_web_interface_translations_loaded(self) -> None:
         """Test that translation script is loaded in the web interface."""
         # Get the web interface
-        response = self.client.get("/")
+        response = self.client.get(LEGACY_BMI_WEB_ROUTE)
         assert response.status_code == 200
 
         html_content = response.text


### PR DESCRIPTION
## Summary
Implements backlog `ledger-p2-legacy-app-direct-root-get-policy`: explicit behavior when FastAPI is hit directly (bypassing Caddy).

## Behavior
- **GET /** → stable `application/json` probe (`service`, `surface`, `message`, `links`) — `include_in_schema=False`.
- **GET /legacy/bmi-calculator** → embedded legacy HTML BMI calculator (moved out of root).
- **Caddy**: `/legacy*` proxied via `@api` so SPA `try_files` does not swallow the HTML route.

## Docs
- `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`, `README.md`, `deploy/AGENTS.md`, `BACKLOG_LEDGER` (item closed).

## Tests
- `tests/test_direct_api_root_probe.py`; retargeted HTML expectations; Spanish E2E uses `/legacy/bmi-calculator?lang=es`.
- `tests/test_openapi_determinism.py`: skip when Node major &lt; `.nvmrc` (aligns with `scripts/frontend_npm.sh`).

## Local verification
```bash
make verify
```

## Deferred / Follow-ups
- None.

## Carrying detect-secrets baseline
`.secrets.baseline` refreshed by pre-commit (line drift).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Определить явный JSON‑пробник для прямого доступа FastAPI по маршруту GET /, одновременно перенесши устаревший HTML‑интерфейс BMI на выделенный маршрут /legacy/bmi-calculator и согласовав документацию, роутинг и тесты с новым поведением.

New Features:
- Открыть поддерживаемый схемой JSON‑пробник на GET / для прямого доступа через uvicorn, предоставляющий метаданные сервиса и ключевые ссылки для операторов.
- Обслуживать устаревший встроенный HTML‑калькулятор BMI с стабильной конечной точки /legacy/bmi-calculator вне корневого пути.

Enhancements:
- Рефакторить устаревшую HTML‑страницу BMI в переиспользуемый вспомогательный модуль и подключить её к приложению FastAPI под префиксом /legacy.
- Прояснить SPA‑роутинг на апексе и поведение прямого API в документации по деплою и агентам, включая контракт сопоставления Caddy для путей /legacy*.
- Скорректировать покрытие различных конечных точек и испанские UI‑тесты так, чтобы они нацеливались на новый устаревший маршрут BMI и проверяли JSON‑семантику на GET /, включая новый специализированный набор тестов контракта пробника.
- Ограничить тест детерминированности OpenAPI условием, что установленная мажорная версия Node соответствует .nvmrc, чтобы избежать ложных срабатываний на недостаточно специфицированных тулчейнах.

Tests:
- Добавить выделенные тесты, проверяющие контракт JSON‑пробника корня прямого API и поведение веб‑маршрута устаревшего BMI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define an explicit JSON probe for direct FastAPI GET / access while relocating the legacy BMI HTML UI to a dedicated /legacy/bmi-calculator route and aligning docs, routing, and tests with the new behavior.

New Features:
- Expose a schema-backed JSON probe at GET / for direct uvicorn access, advertising service metadata and key operator links.
- Serve the legacy embedded BMI calculator HTML from a stable /legacy/bmi-calculator endpoint outside the root path.

Enhancements:
- Refactor the legacy BMI HTML page into a reusable helper module and wire it into the FastAPI app under the /legacy prefix.
- Clarify SPA apex routing and direct-API behavior in deployment and agent documentation, including the Caddy matcher contract for /legacy* paths.
- Adjust assorted endpoint coverage and Spanish UI tests to target the new legacy BMI route and to assert JSON semantics on GET /, including a new focused probe contract test suite.
- Gate the OpenAPI determinism test on the installed Node major version matching .nvmrc to avoid false negatives on underspecified toolchains.

Tests:
- Add dedicated tests validating the direct API root JSON probe contract and the legacy BMI web route behavior.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable JSON probe on direct `GET /` for `FastAPI`/`uvicorn`, and moves the legacy BMI HTML to `/legacy/bmi-calculator`. Keeps the SPA at apex via Caddy, hardens the legacy UI, and tightens OpenAPI CI. Implements backlog item: ledger-p2-legacy-app-direct-root-get-policy.

- **New Features**
  - `GET /` now returns `application/json` with `service`, `surface`, `message`, and `links` (not in OpenAPI); routes are registered in `app.main` with endpoint-identity guards.
  - Legacy BMI UI lives at `/legacy/bmi-calculator`; Caddy proxies `/legacy*` via `@api` so SPA `try_files` doesn’t swallow it; docs/README call out the apex “operator trap.”
  - Security/CI: legacy page uses DOM `textContent`, allowlists `lang` (`en|ru|es`), removes inline handlers, and checks `response.ok`. OpenAPI determinism gates on `.nvmrc` major (skip local if too old, fail-closed in CI); CI reads Node from a node-version file.

- **Migration**
  - Update probes/scripts expecting HTML at `/` to expect JSON when hitting `uvicorn`; use `/legacy/bmi-calculator` for the HTML UI.
  - Ensure the production `Caddyfile` includes `/legacy*` in the `@api` matcher.

<sup>Written for commit 025bb059427e142bfb3a6751400c1468e19f7953. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legacy standalone BMI calculator page added and a direct-API JSON probe exposed at the service root for direct (bypass-proxy) access.

* **Documentation**
  * Clarified routing/proxy contract and GET / behavior (proxy vs direct), documented the legacy route and updated QA smoke checks.

* **Chores**
  * Reverse-proxy routing extended to include legacy paths, CI Node version now read from file, secrets baseline timestamp/metadata refreshed.

* **Tests**
  * Added and updated tests covering the direct JSON probe, legacy BMI HTML, and an HTML-safety guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1229_FIXED_MAPPING.md`
