### PR TITLE
chore(deps): add thesvg for image generation

### DIFF
--- a/docs/review/PR_1230_FIXED_MAPPING.md
+++ b/docs/review/PR_1230_FIXED_MAPPING.md
@@ -1,0 +1,9 @@
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: `package.json`, `package-lock.json`
+Reason: `thesvg` is intentionally added as a runtime dependency for image-generation workflows; lockfile shows only JS package dependencies with Node engine constraints and no native addon requirements.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1230#pullrequestreview-3990224194

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@goplus/agentguard": "^1.0.4",
         "docx": "^9.6.1",
-        "pptxgenjs": "^4.0.1"
+        "pptxgenjs": "^4.0.1",
+        "thesvg": "^2.0.1"
       },
       "devDependencies": {
         "@cspell/dict-data-science": "^2.0.9",
@@ -728,6 +729,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@thesvg/icons": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@thesvg/icons/-/icons-2.0.1.tgz",
+      "integrity": "sha512-Z/OAk6V/lHbaeA5NnxCke7y/lTrc1KpQPZpQb2tRnNze2HE5EHIpauxGDHnaqiDDVd8N/msBZQGnilFRjonmWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -2864,6 +2874,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thesvg": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/thesvg/-/thesvg-2.0.1.tgz",
+      "integrity": "sha512-DnEdATTs5LoS3P9nnhsSY8UuYFY4d14ykSXNAkwcJju3m3gW3MlXs6xfIMOTU39BbV+pEBxGxbF4N56NCIozvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@thesvg/icons": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "@goplus/agentguard": "^1.0.4",
     "docx": "^9.6.1",
-    "pptxgenjs": "^4.0.1"
+    "pptxgenjs": "^4.0.1",
+    "thesvg": "^2.0.1"
   },
   "devDependencies": {
     "@cspell/dict-data-science": "^2.0.9",


### PR DESCRIPTION
## Summary
- add `thesvg` runtime dependency to support image-generation workflows
- include lockfile updates for deterministic installs

## Test plan
- [x] pre-push hooks pass locally
- [x] no backend/frontend runtime code changes

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1230#pullrequestreview-3990224194

## Merge Readiness
- [x] Required checks are green on current PR head
- [x] Actionable review items have recorded disposition in `docs/review/PR_1230_FIXED_MAPPING.md`
- [x] No unresolved blocking review threads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the thesvg runtime dependency to support image-generation features.
* **Documentation**
  * Added a review checklist documenting a discussion-thread pass, commit-to-fix mapping, and a NOT-A-BUG disposition explaining the intentional dependency addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->