### PR TITLE
feat(ai): migrate LLM provider from Grok to Perplexity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,10 @@
 # === LLM Provider Settings ===
-LLM_PROVIDER=ollama
-XAI_API_KEY=__replace_me__
+LLM_PROVIDER=perplexity
 
-# === Grok API ===
-GROK_MODEL=grok-4-latest
-GROK_ENDPOINT=https://api.x.ai/v1
-GROK_RPS=1
-GROK_RPM=60
-GROK_MAX_RETRIES=3
-GROK_BACKOFF_MS=300
+# === Perplexity API ===
+PERPLEXITY_API_KEY=__replace_me__
+PERPLEXITY_MODEL=sonar
+PERPLEXITY_ENDPOINT=https://api.perplexity.ai/v1
 
 # === Ollama Local ===
 # Local native run: localhost. Docker Compose: host.docker.internal or ollama service name.

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ LLM_PROVIDER=perplexity
 # === Perplexity API ===
 PERPLEXITY_API_KEY=__replace_me__
 PERPLEXITY_MODEL=sonar
-PERPLEXITY_ENDPOINT=https://api.perplexity.ai/v1
+PERPLEXITY_ENDPOINT=https://api.perplexity.ai
 
 # === Ollama Local ===
 # Local native run: localhost. Docker Compose: host.docker.internal or ollama service name.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,7 +146,7 @@
         "filename": ".env.example",
         "hashed_secret": "e476c2231e0e3e5e6b28c3eda61f30fc606ea57c",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 22
       }
     ],
     ".github/workflows/accessibility.yml": [
@@ -473,22 +473,6 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 22
-      }
-    ],
-    "tests/disabled_hypothesis/test_llm_import_coverage.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/disabled_hypothesis/test_llm_import_coverage.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/disabled_hypothesis/test_llm_import_coverage.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 176
       }
     ],
     "tests/disabled_hypothesis/test_plate_targets_micros_hypothesis.py": [
@@ -1092,7 +1076,7 @@
         "filename": "tests/test_llm_comprehensive.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 226
+        "line_number": 228
       }
     ],
     "tests/test_llm_import_coverage.py": [
@@ -1101,7 +1085,7 @@
         "filename": "tests/test_llm_import_coverage.py",
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 68
       }
     ],
     "tests/test_llm_simple_96.py": [
@@ -1536,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-22T21:21:45Z"
+  "generated_at": "2026-03-24T13:31:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1076,7 +1076,7 @@
         "filename": "tests/test_llm_comprehensive.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 227
       }
     ],
     "tests/test_llm_import_coverage.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T13:31:19Z"
+  "generated_at": "2026-03-24T13:49:12Z"
 }

--- a/app/telemetry/genai.py
+++ b/app/telemetry/genai.py
@@ -153,7 +153,7 @@ def _estimate_token_count(text: str) -> int:
 def _resolve_model_name(provider_name: str) -> str:
     normalized = provider_name.strip().lower()
     env_mapping = {
-        "grok": ("GROK_MODEL", "grok-4-latest"),
+        "perplexity": ("PERPLEXITY_MODEL", "sonar"),
         "ollama": ("OLLAMA_MODEL", "llama3.1:8b"),
         "stub": ("LLM_STUB_MODEL", "stub"),
         "pico": ("PICO_MODEL", "pico"),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,10 @@ services:
       - ALLOW_PROMPT_EVENTS=${ALLOW_PROMPT_EVENTS:-false}
       - CBT_AGENT_EXECUTION_MODE=${CBT_AGENT_EXECUTION_MODE:-auto-safe}
       - AGENT_CONTROL_AUDIT_LOG_PATH=${AGENT_CONTROL_AUDIT_LOG_PATH:-/app/logs/agent_control_audit.jsonl}
+      - LLM_PROVIDER=${LLM_PROVIDER:-perplexity}
+      - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY:-__replace_me__}
+      - PERPLEXITY_ENDPOINT=${PERPLEXITY_ENDPOINT:-https://api.perplexity.ai}
+      - PERPLEXITY_MODEL=${PERPLEXITY_MODEL:-sonar}
     volumes:
       - ./data:/app/data:ro
       - artifacts-volume:/app/artifacts:rw
@@ -78,6 +82,10 @@ services:
       - ALLOW_PROMPT_EVENTS=${ALLOW_PROMPT_EVENTS:-false}
       - CBT_AGENT_EXECUTION_MODE=${CBT_AGENT_EXECUTION_MODE:-auto-safe}
       - AGENT_CONTROL_AUDIT_LOG_PATH=${AGENT_CONTROL_AUDIT_LOG_PATH:-/app/logs/agent_control_audit.jsonl}
+      - LLM_PROVIDER=${LLM_PROVIDER:-perplexity}
+      - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY:-__replace_me__}
+      - PERPLEXITY_ENDPOINT=${PERPLEXITY_ENDPOINT:-https://api.perplexity.ai}
+      - PERPLEXITY_MODEL=${PERPLEXITY_MODEL:-sonar}
     volumes:
       - .:/app:rw
       - /app/__pycache__

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -25,6 +25,14 @@ Disposition: FIXED
 Commit: 64244290
 Evidence: `tests/test_llm.py` (switch env mutation to `monkeypatch` for deterministic isolation)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733319
+Disposition: FIXED
+Commit: PENDING_PUSH
+Evidence: `tests/test_llm_extras.py` (`test_get_provider_ollama_typeerror_posargs_fallback` now asserts constructor path via type and env-bound fields)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825324
+Disposition: FIXED
+Commit: PENDING_PUSH
+Evidence: `tests/test_llm.py` (add `pytest.MonkeyPatch` annotations and `-> None` return types for modified test functions)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825340
 Disposition: NOT-A-BUG
 Evidence: `tests/test_llm_comprehensive.py` (`TestPerplexityLiteProvider.test_grok_lite_provider_through_exception`) intentionally validates provider-unavailable fallback path by setting `PerplexityProvider=None`; this is distinct from API-key guard coverage, which is already covered in `tests/test_llm_extras.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723500
@@ -37,6 +45,8 @@ Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` entries above map all actionabl
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999279826
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999355816
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999367140
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999432091
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999471188
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -6,47 +6,65 @@
 Disposition: FIXED
 Commit: 81b79450
 Evidence: `llm.py`, `.env.example`, `tests/test_llm_comprehensive.py`, `tests/test_llm_extras.py`
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981662350
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981696506
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723514
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981662350 -> 81b79450
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981696506 -> 81b79450
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723514 -> 81b79450
+
 Disposition: FIXED
 Commit: 64244290
 Evidence: `scripts/validate-ci-environment.sh` (supported provider messages aligned with runtime)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723508
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723508 -> 64244290
+
 Disposition: FIXED
 Commit: 64244290
 Evidence: `tests/test_llm_extras.py` (`_PerplexityProvider` keyword-only init + strict instance/field assertions)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733299
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733299 -> 64244290
+
 Disposition: FIXED
 Commit: 64244290
 Evidence: `tests/test_llm.py` (remove ImportError-swallow fallback; import `get_provider` directly)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733314
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733314 -> 64244290
+
 Disposition: FIXED
 Commit: 64244290
 Evidence: `tests/test_llm.py` (switch env mutation to `monkeypatch` for deterministic isolation)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733319
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733319 -> 64244290
+
 Disposition: FIXED
 Commit: 307adf04
 Evidence: `tests/test_llm_extras.py` (`test_get_provider_ollama_typeerror_posargs_fallback` now asserts constructor path via type and env-bound fields)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825324
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825324 -> 307adf04
+
 Disposition: FIXED
 Commit: 307adf04
 Evidence: `tests/test_llm.py` (add `pytest.MonkeyPatch` annotations and `-> None` return types for modified test functions)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825340
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825340 -> 307adf04
+
 Disposition: NOT-A-BUG
 Evidence: `tests/test_llm_comprehensive.py` (`TestPerplexityLiteProvider.test_grok_lite_provider_through_exception`) intentionally validates provider-unavailable fallback path by setting `PerplexityProvider=None`; this is distinct from API-key guard coverage, which is already covered in `tests/test_llm_extras.py`.
+Reason: The comment proposes changing test intent, but this test explicitly covers a different contract branch (provider-unavailable fallback), while API-key guard behavior is already verified in dedicated tests.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723500
+
 Disposition: FIXED
 Commit: 06fcd766
 Evidence: `docker-compose.yaml` (`pulseplate` + `pulseplate-dev` now export `LLM_PROVIDER`, `PERPLEXITY_API_KEY`, `PERPLEXITY_ENDPOINT`, `PERPLEXITY_MODEL`)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733280
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733280 -> 06fcd766
+
 Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` entries above map all actionable inline comments; review-summary comments from bots are informational wrappers over already mapped items.
+Reason: Review-level bot summaries duplicate inline actionables that are already dispositioned with evidence/commit mapping in this artifact.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999279826
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999355816
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999367140
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999432091
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999471188
+
+Disposition: FIXED
+Commit: PENDING_PUSH
+Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` (blank-line separators between disposition blocks, explicit `Reason:` fields for `NOT-A-BUG`, and `thread_url -> commit_sha` syntax for `FIXED` entries)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841185 -> PENDING_PUSH
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841191 -> PENDING_PUSH
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841192 -> PENDING_PUSH
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: 81b79450
+Evidence: `llm.py`, `.env.example`, `tests/test_llm_comprehensive.py`, `tests/test_llm_extras.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981662350
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981696506
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (resolve on GitHub after push)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -26,11 +26,11 @@ Commit: 64244290
 Evidence: `tests/test_llm.py` (switch env mutation to `monkeypatch` for deterministic isolation)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733319
 Disposition: FIXED
-Commit: PENDING_PUSH
+Commit: 307adf04
 Evidence: `tests/test_llm_extras.py` (`test_get_provider_ollama_typeerror_posargs_fallback` now asserts constructor path via type and env-bound fields)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825324
 Disposition: FIXED
-Commit: PENDING_PUSH
+Commit: 307adf04
 Evidence: `tests/test_llm.py` (add `pytest.MonkeyPatch` annotations and `-> None` return types for modified test functions)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981825340
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -58,6 +58,7 @@ Reason: Review-level bot summaries duplicate inline actionables that are already
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999367140
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999432091
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999471188
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999489152
 
 Disposition: FIXED
 Commit: a22f6514
@@ -68,6 +69,6 @@ Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` (blank-line separators between 
 
 ## Merge Readiness
 - [ ] All required checks pass
-- [ ] No unresolved review threads (resolve on GitHub after push)
+- [x] No unresolved review threads (resolved via GitHub review thread API; re-check before merge)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] Pre-commit green

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -60,11 +60,11 @@ Reason: Review-level bot summaries duplicate inline actionables that are already
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999471188
 
 Disposition: FIXED
-Commit: PENDING_PUSH
+Commit: a22f6514
 Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` (blank-line separators between disposition blocks, explicit `Reason:` fields for `NOT-A-BUG`, and `thread_url -> commit_sha` syntax for `FIXED` entries)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841185 -> PENDING_PUSH
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841191 -> PENDING_PUSH
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841192 -> PENDING_PUSH
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841185 -> a22f6514
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841191 -> a22f6514
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981841192 -> a22f6514
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -8,6 +8,25 @@ Commit: 81b79450
 Evidence: `llm.py`, `.env.example`, `tests/test_llm_comprehensive.py`, `tests/test_llm_extras.py`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981662350
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981696506
+Disposition: FIXED
+Commit: 64244290
+Evidence: `scripts/validate-ci-environment.sh` (supported provider messages aligned with runtime)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723508
+Disposition: FIXED
+Commit: 64244290
+Evidence: `tests/test_llm_extras.py` (`_PerplexityProvider` keyword-only init + strict instance/field assertions)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733299
+Disposition: FIXED
+Commit: 64244290
+Evidence: `tests/test_llm.py` (remove ImportError-swallow fallback; import `get_provider` directly)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733314
+Disposition: FIXED
+Commit: 64244290
+Evidence: `tests/test_llm.py` (switch env mutation to `monkeypatch` for deterministic isolation)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733319
+Disposition: NOT-A-BUG
+Evidence: `tests/test_llm_comprehensive.py` (`TestPerplexityLiteProvider.test_grok_lite_provider_through_exception`) intentionally validates provider-unavailable fallback path by setting `PerplexityProvider=None`; this is distinct from API-key guard coverage, which is already covered in `tests/test_llm_extras.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723500
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -8,6 +8,7 @@ Commit: 81b79450
 Evidence: `llm.py`, `.env.example`, `tests/test_llm_comprehensive.py`, `tests/test_llm_extras.py`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981662350
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981696506
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723514
 Disposition: FIXED
 Commit: 64244290
 Evidence: `scripts/validate-ci-environment.sh` (supported provider messages aligned with runtime)
@@ -27,6 +28,15 @@ Evidence: `tests/test_llm.py` (switch env mutation to `monkeypatch` for determin
 Disposition: NOT-A-BUG
 Evidence: `tests/test_llm_comprehensive.py` (`TestPerplexityLiteProvider.test_grok_lite_provider_through_exception`) intentionally validates provider-unavailable fallback path by setting `PerplexityProvider=None`; this is distinct from API-key guard coverage, which is already covered in `tests/test_llm_extras.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723500
+Disposition: FIXED
+Commit: PENDING_PUSH
+Evidence: `docker-compose.yaml` (`pulseplate` + `pulseplate-dev` now export `LLM_PROVIDER`, `PERPLEXITY_API_KEY`, `PERPLEXITY_ENDPOINT`, `PERPLEXITY_MODEL`)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733280
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1231_FIXED_MAPPING.md` entries above map all actionable inline comments; review-summary comments from bots are informational wrappers over already mapped items.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999279826
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999355816
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999367140
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -29,7 +29,7 @@ Disposition: NOT-A-BUG
 Evidence: `tests/test_llm_comprehensive.py` (`TestPerplexityLiteProvider.test_grok_lite_provider_through_exception`) intentionally validates provider-unavailable fallback path by setting `PerplexityProvider=None`; this is distinct from API-key guard coverage, which is already covered in `tests/test_llm_extras.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981723500
 Disposition: FIXED
-Commit: PENDING_PUSH
+Commit: 06fcd766
 Evidence: `docker-compose.yaml` (`pulseplate` + `pulseplate-dev` now export `LLM_PROVIDER`, `PERPLEXITY_API_KEY`, `PERPLEXITY_ENDPOINT`, `PERPLEXITY_MODEL`)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#discussion_r2981733280
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1231_FIXED_MAPPING.md
+++ b/docs/review/PR_1231_FIXED_MAPPING.md
@@ -59,6 +59,7 @@ Reason: Review-level bot summaries duplicate inline actionables that are already
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999432091
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999471188
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999489152
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1231#pullrequestreview-3999568538
 
 Disposition: FIXED
 Commit: a22f6514

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -4533,8 +4533,8 @@ async def debug_env() -> JSONResponse:
     data = {
         "FEATURE_INSIGHT": os.getenv("FEATURE_INSIGHT", ""),
         "LLM_PROVIDER": os.getenv("LLM_PROVIDER", ""),
-        "GROK_MODEL": os.getenv("GROK_MODEL", ""),
-        "GROK_ENDPOINT": os.getenv("GROK_ENDPOINT", ""),
+        "PERPLEXITY_MODEL": os.getenv("PERPLEXITY_MODEL", ""),
+        "PERPLEXITY_ENDPOINT": os.getenv("PERPLEXITY_ENDPOINT", ""),
     }
     flag = str(os.getenv("FEATURE_INSIGHT", "")).strip().lower()
     data["insight_enabled"] = str(flag in {"1", "true", "yes", "on"})

--- a/llm.py
+++ b/llm.py
@@ -13,6 +13,12 @@ from core.time_utils import isoformat_utc
 from providers import ProviderBase
 
 logger = logging.getLogger(__name__)
+_PLACEHOLDER_API_KEYS = {
+    "__replace_me__",
+    "paste_your_real_key_here",
+    "changeme",
+    "your_api_key_here",
+}
 
 
 def _load_optional_provider(module_name: str, class_name: str) -> type[ProviderBase] | None:
@@ -116,13 +122,19 @@ def get_provider():
         if PerplexityProvider is not None:
             api_key = os.getenv("PERPLEXITY_API_KEY", "")
             model = os.getenv("PERPLEXITY_MODEL", "sonar")
-            endpoint = os.getenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai/v1")
+            endpoint = os.getenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai")
 
-            if not api_key.strip():
+            normalized_api_key = api_key.strip()
+            if not normalized_api_key or normalized_api_key.lower() in _PLACEHOLDER_API_KEYS:
                 return PerplexityLiteProvider()
 
             try:
-                return PerplexityProvider(endpoint=endpoint, api_key=api_key, model=model)
+                # Perplexity uses OpenAI-compatible init signature; we keep a single
+                # constructor path (no positional retry) to avoid silently masking
+                # schema/auth mistakes and to fail-closed into lite fallback.
+                return PerplexityProvider(
+                    endpoint=endpoint, api_key=normalized_api_key, model=model
+                )
             except Exception:
                 return PerplexityLiteProvider()
         else:

--- a/llm.py
+++ b/llm.py
@@ -26,24 +26,6 @@ def _load_optional_provider(module_name: str, class_name: str) -> type[ProviderB
         return None
 
 
-class GrokLiteProvider(ProviderBase):  # lightweight fallback that never uses network
-    name = "grok"
-
-    def __init__(
-        self,
-        endpoint: str = "",
-        model: str = "",
-        api_key: str = "",
-        timeout: Optional[float] = None,
-    ) -> None:
-        # RU: Параметры игнорируются, так как это легковесный fallback без сети
-        # EN: Parameters are ignored as this is a lightweight fallback without network
-        pass
-
-    async def generate(self, text: str) -> str:
-        return f"[grok-lite] {text}"
-
-
 class OllamaLiteProvider(ProviderBase):
     """Lightweight fallback implementation that never uses the network.
 
@@ -66,9 +48,18 @@ class OllamaLiteProvider(ProviderBase):
         return f"[ollama-lite] {text}"
 
 
+class PerplexityLiteProvider(ProviderBase):
+    """Lightweight fallback implementation that never uses the network."""
+
+    name = "perplexity"
+
+    async def generate(self, text: str) -> str:
+        return f"[perplexity-lite] {text}"
+
+
 # Опциональные импорты — модуль должен грузиться даже без внешних либ
-GrokProvider = _load_optional_provider("providers.grok", "GrokProvider")  # xAI
 OllamaProvider = _load_optional_provider("providers.ollama", "OllamaProvider")
+PerplexityProvider = _load_optional_provider("providers.perplexity", "PerplexityProvider")
 PicoProvider = _load_optional_provider("providers.pico", "PicoProvider")
 
 
@@ -95,28 +86,6 @@ def get_provider():
     if val == "stub":
         return StubProvider()
 
-    if val == "grok":
-        if GrokProvider is not None:
-            # пример: можно пробросить ключ и модель через env
-            api_key = os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or ""
-            model = os.getenv("GROK_MODEL", "grok-4-latest")
-            endpoint = os.getenv("GROK_ENDPOINT", "https://api.x.ai/v1")
-            # If no API key is provided, prefer lightweight fallback to avoid network use
-            if not api_key.strip():
-                return GrokLiteProvider()
-            try:
-                return GrokProvider(endpoint=endpoint, api_key=api_key, model=model)
-            except Exception:
-                # Fallback to positional args if keyword args fail
-                try:
-                    return GrokProvider(endpoint, model, api_key)
-                except Exception:
-                    # If both fail, return lite provider
-                    return GrokLiteProvider()
-        else:
-            # Fallback when real provider unavailable
-            return GrokLiteProvider()
-
     if val == "ollama":
         if OllamaProvider is not None:
             endpoint = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
@@ -142,6 +111,22 @@ def get_provider():
         else:
             # Fallback when real provider unavailable
             return OllamaLiteProvider()
+
+    if val == "perplexity":
+        if PerplexityProvider is not None:
+            api_key = os.getenv("PERPLEXITY_API_KEY", "")
+            model = os.getenv("PERPLEXITY_MODEL", "sonar")
+            endpoint = os.getenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai/v1")
+
+            if not api_key.strip():
+                return PerplexityLiteProvider()
+
+            try:
+                return PerplexityProvider(endpoint=endpoint, api_key=api_key, model=model)
+            except Exception:
+                return PerplexityLiteProvider()
+        else:
+            return PerplexityLiteProvider()
 
     # неизвестное значение — считаем, что провайдера нет
     return None

--- a/providers/AGENTS.md
+++ b/providers/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Scope and layout
 - This AGENTS.md applies to: `providers/` and below.
-- Key files: `grok.py`, `ollama.py`, `pico.py`, `stub.py`.
+- Key files: `perplexity.py`, `ollama.py`, `pico.py`, `stub.py`.
 
 ## Conventions
 - Keep provider interfaces stable; avoid leaking network calls into core logic.

--- a/providers/perplexity.py
+++ b/providers/perplexity.py
@@ -33,6 +33,11 @@ class PerplexityProvider:
                 timeout=self.timeout,
             )
             content = resp.choices[0].message.content
-            return content.strip() if content else ""
+            if isinstance(content, str):
+                return content.strip()
+            if content is None:
+                return ""
+            # Keep a stable string output for non-string SDK payload variants.
+            return str(content).strip()
         except Exception as e:
             raise RuntimeError(f"Perplexity error: {type(e).__name__}: {e}")

--- a/providers/perplexity.py
+++ b/providers/perplexity.py
@@ -4,20 +4,18 @@ from openai import AsyncOpenAI
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 
-class GrokProvider:
+class PerplexityProvider:
     """
-    Минималистичный провайдер к x.ai (Grok) через совместимый OpenAI SDK.
-    Совместим с вызовом из llm.py:
-        GrokProvider(endpoint=..., model=..., api_key=...)
+    RU: Минималистичный провайдер к Perplexity через OpenAI-совместимый SDK.
+    EN: Minimal Perplexity provider via OpenAI-compatible SDK.
     """
 
-    name = "grok"
+    name = "perplexity"
 
     def __init__(self, endpoint: str, model: str, api_key: str, timeout: Optional[float] = 30.0):
         self.endpoint = endpoint.rstrip("/")
         self.model = model
         self.api_key = api_key
-        # создаём асинхронного клиента (OpenAI совместимый эндпоинт у x.ai)
         self.client = AsyncOpenAI(base_url=self.endpoint, api_key=self.api_key)
         self.timeout = timeout
 
@@ -37,5 +35,4 @@ class GrokProvider:
             content = resp.choices[0].message.content
             return content.strip() if content else ""
         except Exception as e:
-            # Пробрасываем понятную ошибку наверх
-            raise RuntimeError(f"Grok error: {type(e).__name__}: {e}")
+            raise RuntimeError(f"Perplexity error: {type(e).__name__}: {e}")

--- a/scripts/validate-ci-environment.sh
+++ b/scripts/validate-ci-environment.sh
@@ -112,24 +112,27 @@ if [ "$LLM_ENABLED_NORMALIZED" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
         ollama)
             validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
             ;;
+        perplexity)
+            validate_required_secret "PERPLEXITY_API_KEY" "production" "$ENVIRONMENT"
+            ;;
         "")
             # LLM enabled but provider not specified - fail with clear configuration error
             if [ "$LLM_ENABLED_NORMALIZED" = "true" ]; then
-                err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai' or 'ollama' (or disable LLM_ENABLED)."
+                err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai', 'ollama', or 'perplexity' (or disable LLM_ENABLED)."
                 echo "::error::$err_msg"
                 ERRORS+=("$err_msg")
             fi
             ;;
         *)
             # LLM_PROVIDER set but not recognized
-            err_msg="Unsupported LLM_PROVIDER='${LLM_PROVIDER}'. Supported values: openai, ollama."
+            err_msg="Unsupported LLM_PROVIDER='${LLM_PROVIDER}'. Supported values: openai, ollama, perplexity."
             echo "::error::$err_msg"
             ERRORS+=("$err_msg")
             ;;
     esac
 else
     echo "ℹ️  LLM secrets not required (LLM_ENABLED is not true and LLM_PROVIDER not set)."
-    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true and LLM_PROVIDER=openai|ollama."
+    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true and LLM_PROVIDER=openai|ollama|perplexity."
 fi
 
 # Check SSH secrets (required for both staging and production when deploying)

--- a/scripts/validate-ci-environment.sh
+++ b/scripts/validate-ci-environment.sh
@@ -106,9 +106,6 @@ fi
 if [ "$LLM_ENABLED_NORMALIZED" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
     # Require secrets based on configured provider
     case "${LLM_PROVIDER:-}" in
-        openai)
-            validate_required_secret "PULSEPLATE_OPENAI" "production" "$ENVIRONMENT"
-            ;;
         ollama)
             validate_required_secret "OLLAMA_API_KEY" "production" "$ENVIRONMENT"
             ;;
@@ -118,21 +115,21 @@ if [ "$LLM_ENABLED_NORMALIZED" = "true" ] || [ -n "${LLM_PROVIDER:-}" ]; then
         "")
             # LLM enabled but provider not specified - fail with clear configuration error
             if [ "$LLM_ENABLED_NORMALIZED" = "true" ]; then
-                err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'openai', 'ollama', or 'perplexity' (or disable LLM_ENABLED)."
+                err_msg="LLM_ENABLED=true but LLM_PROVIDER is not set. Set LLM_PROVIDER to 'ollama' or 'perplexity' (or disable LLM_ENABLED)."
                 echo "::error::$err_msg"
                 ERRORS+=("$err_msg")
             fi
             ;;
         *)
             # LLM_PROVIDER set but not recognized
-            err_msg="Unsupported LLM_PROVIDER='${LLM_PROVIDER}'. Supported values: openai, ollama, perplexity."
+            err_msg="Unsupported LLM_PROVIDER='${LLM_PROVIDER}'. Supported values: ollama, perplexity."
             echo "::error::$err_msg"
             ERRORS+=("$err_msg")
             ;;
     esac
 else
     echo "ℹ️  LLM secrets not required (LLM_ENABLED is not true and LLM_PROVIDER not set)."
-    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true and LLM_PROVIDER=openai|ollama|perplexity."
+    echo "ℹ️  To enable LLM features, set LLM_ENABLED=true and LLM_PROVIDER=ollama|perplexity."
 fi
 
 # Check SSH secrets (required for both staging and production when deploying)

--- a/tests/disabled_hypothesis/test_llm_import_coverage.py
+++ b/tests/disabled_hypothesis/test_llm_import_coverage.py
@@ -1,10 +1,9 @@
-"""
-Тесты для покрытия исключений при импорте в llm.py
-Цель: достичь 100% покрытия кода включая fallback провайдеры
-"""
+"""Targeted coverage tests for llm provider selector (disabled_hypothesis copy)."""
 
+from __future__ import annotations
+
+import importlib
 import os
-import sys
 from importlib import reload
 from unittest.mock import Mock, patch
 
@@ -14,198 +13,85 @@ import llm
 
 
 @pytest.fixture(autouse=True)
-def setup_test_environment():
-    """Setup test environment for all tests in this module"""
-    os.environ["API_KEY"] = "test_key"
-    os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
+def _llm_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
 
 
 class TestImportFallbacks:
-    """Тесты fallback поведения при недоступности внешних провайдеров"""
+    def test_perplexity_import_exception_coverage(self) -> None:
+        original_import_module = importlib.import_module
+        with patch("importlib.import_module") as mock_import:
 
-    def test_grok_import_exception_coverage(self):
-        """Тест покрытия GrokLiteProvider при ошибке импорта providers.grok"""
-        # Сохраняем оригинальные модули
-        original_modules = sys.modules.copy()
+            def import_side_effect(name: str, package: str | None = None):
+                if name == "providers.perplexity":
+                    raise ImportError("No module named providers.perplexity")
+                return original_import_module(name, package)
 
-        try:
-            # Удаляем модули провайдеров если они загружены
-            modules_to_remove = [
-                name for name in sys.modules.keys() if name.startswith("providers")
-            ]
-            for mod_name in modules_to_remove:
-                del sys.modules[mod_name]
-
-            # Мокаем импорт providers.grok чтобы вызвать исключение
-            import builtins
-
-            real_import = builtins.__import__
-
-            def side_effect(name, globals=None, locals=None, fromlist=(), level=0):
-                if isinstance(name, str) and "providers.grok" in name:
-                    raise ImportError("No module named providers.grok")
-                return real_import(name, globals, locals, fromlist, level)
-
-            # Remove module instead of setting to None (prevents sys.modules None poisoning)
-            module_to_restore = None
-            if "providers.grok" in sys.modules:
-                module_to_restore = sys.modules["providers.grok"]
-                del sys.modules["providers.grok"]
-
-            try:
-                with patch("builtins.__import__", side_effect=side_effect):
-                    # Перезагружаем модуль llm чтобы активировать except блок
-                    if "llm" in sys.modules:
-                        reload(llm)
-
-                    # Теперь GrokLiteProvider должен быть доступен
-                    assert hasattr(llm, "GrokLiteProvider")
-            finally:
-                # Restore module
-                if module_to_restore is not None:
-                    sys.modules["providers.grok"] = module_to_restore
-
-                    # Тестируем создание и использование GrokLiteProvider
-                    provider = llm.GrokLiteProvider()
-                    assert provider.name == "grok"
-
-        finally:
-            # Восстанавливаем оригинальные модули
-            sys.modules.clear()
-            sys.modules.update(original_modules)
-            # Перезагружаем llm в оригинальном состоянии
+            mock_import.side_effect = import_side_effect
             reload(llm)
+            assert llm.PerplexityProvider is None
+            assert hasattr(llm, "PerplexityLiteProvider")
+
+        reload(llm)
 
     @pytest.mark.asyncio
-    async def test_grok_lite_provider_generate_coverage(self):
-        """Тест метода generate класса GrokLiteProvider"""
-        # Используем реальный GrokLiteProvider из llm модуля
-        provider = llm.GrokLiteProvider()
+    async def test_perplexity_lite_provider_generate_coverage(self) -> None:
+        provider = llm.PerplexityLiteProvider()
+        assert provider.name == "perplexity"
         result = await provider.generate("test input")
-
-        # Проверяем поведение реального провайдера
-        assert result == "[grok-lite] test input"
-        assert "grok-lite" in result
-        assert provider.name == "grok"
-
-    def test_ollama_import_exception_coverage(self):
-        """Тест покрытия исключения при импорте OllamaProvider"""
-        # Мокаем ошибку импорта OllamaProvider
-        import builtins
-
-        real_import = builtins.__import__
-
-        with patch("builtins.__import__") as mock_import:
-
-            def import_side_effect(name, globals=None, locals=None, fromlist=(), level=0):
-                if isinstance(name, str) and "providers.ollama" in name:
-                    raise ImportError("No module named 'providers.ollama'")
-                return real_import(name, globals, locals, fromlist, level)
-
-            mock_import.side_effect = import_side_effect
-
-            # Перезагружаем модуль для активации except блока
-            reload(llm)
-
-            # OllamaProvider должен быть None
-            assert llm.OllamaProvider is None
-
-        # Восстанавливаем нормальное состояние
-        reload(llm)
-
-    def test_pico_import_exception_coverage(self):
-        """Тест покрытия исключения при импорте PicoProvider"""
-        # Мокаем ошибку импорта PicoProvider
-        import builtins
-
-        real_import = builtins.__import__
-
-        with patch("builtins.__import__") as mock_import:
-
-            def import_side_effect(name, globals=None, locals=None, fromlist=(), level=0):
-                if isinstance(name, str) and "providers.pico" in name:
-                    raise ImportError("No module named 'providers.pico'")
-                return real_import(name, globals, locals, fromlist, level)
-
-            mock_import.side_effect = import_side_effect
-
-            # Перезагружаем модуль для активации except блока
-            reload(llm)
-
-            # PicoProvider должен быть None
-            assert llm.PicoProvider is None
-
-        # Восстанавливаем нормальное состояние
-        reload(llm)
+        assert result.startswith("[perplexity-lite] ")
+        assert result.endswith("test input")
 
 
 class TestGetProviderEdgeCases:
-    """Тесты граничных случаев функции get_provider()"""
-
-    def test_get_provider_with_pico(self):
-        """Тест несуществующего провайдера pico"""
+    def test_get_provider_with_pico(self) -> None:
         with patch.dict(os.environ, {"LLM_PROVIDER": "pico"}, clear=False):
-            provider = llm.get_provider()
-            # Должен вернуться None так как pico не обрабатывается в get_provider
-            assert provider is None
+            assert llm.get_provider() is None
 
-    def test_get_provider_ollama_with_exception_coverage(self):
-        """Тест покрытия всех путей исключений в Ollama"""
+    def test_get_provider_ollama_with_exception_coverage(self) -> None:
         with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
             with patch.object(llm, "OllamaProvider") as mock_ollama:
-                # Тест TypeError в первом try/except блоке
                 mock_ollama.side_effect = [TypeError("keyword error"), Exception("creation failed")]
-
                 provider = llm.get_provider()
-                # По контракту llm.get_provider(): при ошибках создания OllamaProvider
-                # возвращаем безопасный offline fallback (OllamaLiteProvider), а не None.
                 assert provider is not None
-                assert getattr(provider, "name", None) == "ollama"
+                assert provider.name == "ollama"
                 assert mock_ollama.call_count == 2
 
-    @patch("llm.GrokProvider")
-    def test_grok_provider_positional_args_fallback(self, mock_grok_class):
-        """Тест fallback на позиционные аргументы для GrokProvider"""
-        # Первый вызов с keyword args падает, второй с positional успешен
-        mock_instance = Mock()
-        mock_grok_class.side_effect = [TypeError("unexpected keyword"), mock_instance]
-
-        # Включаем ветку реального провайдера: если нет API ключа,
-        # llm.get_provider() возвращает GrokLiteProvider и GrokProvider не вызывается.
+    @patch("llm.PerplexityProvider")
+    def test_perplexity_provider_keyword_exception_fallback(
+        self, mock_perplexity_class: Mock
+    ) -> None:
+        mock_perplexity_class.side_effect = TypeError("unexpected keyword")
         with patch.dict(
-            os.environ, {"LLM_PROVIDER": "grok", "GROK_API_KEY": "test-key"}, clear=False
+            os.environ,
+            {
+                "LLM_PROVIDER": "perplexity",
+                "PERPLEXITY_API_KEY": "dummy",  # pragma: allowlist secret
+            },  # pragma: allowlist secret
+            clear=False,
         ):
             provider = llm.get_provider()
+            assert provider is not None
+            assert provider.name == "perplexity"
+            assert mock_perplexity_class.call_count == 1
 
-            # Должно быть два вызова: kwargs и positional
-            assert mock_grok_class.call_count == 2
-            assert provider == mock_instance
-
-    def test_get_provider_grok_without_real_provider(self):
-        """Тест get_provider с grok когда GrokProvider недоступен"""
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
-            with patch.object(llm, "GrokProvider", None):
+    def test_get_provider_perplexity_without_real_provider(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
+            with patch.object(llm, "PerplexityProvider", None):
                 provider = llm.get_provider()
-                # Если у нас нет GrokLiteProvider, должен вернуться None
-                # В реальном модуле возвращается GrokLiteProvider только если GrokProvider=None
-                assert provider is not None or provider is None  # Допускаем оба варианта
+                assert provider is not None
+                assert provider.name == "perplexity"
 
 
 class TestEnvironmentVariableEdgeCases:
-    """Тесты граничных случаев обработки переменных окружения"""
-
-    def test_empty_string_values(self):
-        """Тест различных форм пустых строк"""
+    def test_empty_string_values(self) -> None:
         empty_values = ["", " ", "\t", "\n", "\r\n", "  \t\n  "]
-
         for empty_val in empty_values:
             with patch.dict(os.environ, {"LLM_PROVIDER": empty_val}, clear=False):
-                provider = llm.get_provider()
-                assert provider is None, f"Failed for empty value: '{repr(empty_val)}'"
+                assert llm.get_provider() is None
 
-    def test_case_variations(self):
-        """Тест различных вариантов регистра"""
-        # Тест для stub
+    def test_case_variations(self) -> None:
         stub_variations = ["stub", "STUB", "Stub", "StUb", "sTuB"]
         for variation in stub_variations:
             with patch.dict(os.environ, {"LLM_PROVIDER": variation}, clear=False):
@@ -213,19 +99,15 @@ class TestEnvironmentVariableEdgeCases:
                 assert provider is not None
                 assert provider.name == "stub"
 
-        # Тест для grok
-        grok_variations = ["grok", "GROK", "Grok", "GrOk", "gRoK"]
-        for variation in grok_variations:
+        perplexity_variations = ["perplexity", "PERPLEXITY", "Perplexity", "PeRpLeXiTy"]
+        for variation in perplexity_variations:
             with patch.dict(os.environ, {"LLM_PROVIDER": variation}, clear=False):
                 provider = llm.get_provider()
                 assert provider is not None
-                assert provider.name == "grok"
+                assert provider.name == "perplexity"
 
-    def test_special_none_values(self):
-        """Тест специальных значений, означающих None"""
+    def test_special_none_values(self) -> None:
         none_values = ["none", "NONE", "None", "no", "NO", "No"]
-
         for none_val in none_values:
             with patch.dict(os.environ, {"LLM_PROVIDER": none_val}, clear=False):
-                provider = llm.get_provider()
-                assert provider is None, f"Should be None for: '{none_val}'"
+                assert llm.get_provider() is None

--- a/tests/quick/test_llm_quick_check.py
+++ b/tests/quick/test_llm_quick_check.py
@@ -35,15 +35,13 @@ async def test_llm_provider_stub(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_llm_provider_grok_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When LLM_PROVIDER=grok but real provider isn't available, use grok-lite."""
-    monkeypatch.setenv("LLM_PROVIDER", "grok")
-    # Ensure no external provider is available by clearing env that might enable it
-    monkeypatch.delenv("GROK_API_KEY", raising=False)
-    monkeypatch.delenv("XAI_API_KEY", raising=False)
+async def test_llm_provider_perplexity_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When LLM_PROVIDER=perplexity without key, use perplexity-lite."""
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
     llm = _reload_llm()
     provider = llm.get_provider()
     assert provider is not None
     out = await provider.generate("ping")
-    assert out.startswith("[grok-lite] ")
+    assert out.startswith("[perplexity-lite] ")
     assert "ping" in out

--- a/tests/test_app_coverage_unit_combined.py
+++ b/tests/test_app_coverage_unit_combined.py
@@ -56,7 +56,7 @@ class TestAppCoverage:
         ), f"Missing required environment keys: {missing_keys}. Available keys: {list(data.keys())}"
 
         # Check for optional but expected keys
-        optional_keys = ["GROK_MODEL", "GROK_ENDPOINT"]
+        optional_keys = ["PERPLEXITY_MODEL", "PERPLEXITY_ENDPOINT"]
         found_optional = [key for key in optional_keys if key in data]
         assert (
             found_optional

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -602,8 +602,8 @@ class TestDebugEndpoint:
             {
                 "FEATURE_INSIGHT": "true",
                 "LLM_PROVIDER": "test",
-                "GROK_MODEL": "test_model",
-                "GROK_ENDPOINT": "http://test.com",
+                "PERPLEXITY_MODEL": "test_model",
+                "PERPLEXITY_ENDPOINT": "http://test.com",
             },
         ):
             response = self.client.get("/debug_env")

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -45,17 +45,17 @@ class TestComprehensiveCoverage:
         """Test debug_env endpoint with deterministic response."""
         # Mock environment variables to ensure consistent response
         monkeypatch.setenv("FEATURE_INSIGHT", "true")
-        monkeypatch.setenv("LLM_PROVIDER", "grok")
-        monkeypatch.setenv("GROK_MODEL", "grok-1")
-        monkeypatch.setenv("GROK_ENDPOINT", "https://api.x.ai/v1/chat/completions")
+        monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+        monkeypatch.setenv("PERPLEXITY_MODEL", "sonar")
+        monkeypatch.setenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai/v1")
 
         response = self.client.get("/debug_env")
         assert response.status_code == 200
         data = response.json()
         assert "FEATURE_INSIGHT" in data
         assert "LLM_PROVIDER" in data
-        assert "GROK_MODEL" in data
-        assert "GROK_ENDPOINT" in data
+        assert "PERPLEXITY_MODEL" in data
+        assert "PERPLEXITY_ENDPOINT" in data
         assert "insight_enabled" in data
 
     def test_database_status_endpoint_success(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_insight_error_hygiene.py
+++ b/tests/test_insight_error_hygiene.py
@@ -13,7 +13,7 @@ def test_insight_legacy_does_not_leak_provider_exception(
         name = "test_provider"
 
         async def generate(self, text: str) -> str:
-            raise RuntimeError("SENSITIVE: model=grok-4-latest path=/tmp/internal secret=abc")
+            raise RuntimeError("SENSITIVE: model=sonar path=/tmp/internal secret=abc")
 
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
     monkeypatch.setattr(llm, "get_provider", lambda: FailingProvider(), raising=True)
@@ -37,7 +37,7 @@ def test_insight_v1_does_not_leak_provider_exception(
         name = "test_provider"
 
         async def generate(self, text: str) -> str:
-            raise RuntimeError("SENSITIVE: model=grok-4-latest path=/tmp/internal secret=abc")
+            raise RuntimeError("SENSITIVE: model=sonar path=/tmp/internal secret=abc")
 
     monkeypatch.setenv("FEATURE_INSIGHT", "true")
     monkeypatch.setattr(llm, "get_provider", lambda: FailingProvider(), raising=True)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,114 +1,40 @@
 # -*- coding: utf-8 -*-
 """Тесты для llm.py с полным покрытием."""
 
-try:
-    from llm import get_provider
-except ImportError:
-
-    def get_provider():
-        return None
+from llm import get_provider
 
 
-def test_get_provider_stub():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    os.environ["LLM_PROVIDER"] = "stub"
-    try:
-        provider = get_provider()
-        assert provider is not None
-        assert hasattr(provider, "generate")
-        assert provider.name == "stub"
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-        else:
-            del os.environ["LLM_PROVIDER"]
+def test_get_provider_stub(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "stub")
+    provider = get_provider()
+    assert provider is not None
+    assert hasattr(provider, "generate")
+    assert provider.name == "stub"
 
 
-def test_get_provider_ollama():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    os.environ["LLM_PROVIDER"] = "ollama"
-    try:
-        provider = get_provider()
-        assert provider is not None
-        assert hasattr(provider, "generate")
-        assert provider.name == "ollama"
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-        else:
-            del os.environ["LLM_PROVIDER"]
+def test_get_provider_ollama(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    provider = get_provider()
+    assert provider is not None
+    assert hasattr(provider, "generate")
+    assert provider.name == "ollama"
 
 
-def test_get_provider_perplexity():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    os.environ["LLM_PROVIDER"] = "perplexity"
-    try:
-        provider = get_provider()
-        assert provider is not None
-        assert hasattr(provider, "generate")
-        assert provider.name == "perplexity"
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-        else:
-            del os.environ["LLM_PROVIDER"]
+def test_get_provider_perplexity(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    provider = get_provider()
+    assert provider is not None
+    assert hasattr(provider, "generate")
+    assert provider.name == "perplexity"
 
 
-def test_get_provider_invalid():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    os.environ["LLM_PROVIDER"] = "invalid"
-    try:
-        provider = get_provider()
-        assert provider is None
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-        else:
-            del os.environ["LLM_PROVIDER"]
+def test_get_provider_invalid(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "invalid")
+    provider = get_provider()
+    assert provider is None
 
 
-def test_get_provider_no_env():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    if "LLM_PROVIDER" in os.environ:
-        del os.environ["LLM_PROVIDER"]
-    try:
-        provider = get_provider()
-        assert provider is None
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-
-
-# Тесты для провайдеров, если они импортируются
-try:
-    from llm.providers.stub import StubProvider
-
-    def test_stub_provider_generate():
-        provider = StubProvider()
-        result = provider.generate("test")
-        assert isinstance(result, str)
-        assert "stub" in result.lower()
-
-except ImportError:
-    pass
-
-try:
-    from llm.providers.ollama import OllamaProvider
-
-    def test_ollama_provider_generate():
-        provider = OllamaProvider()
-        result = provider.generate("test")
-        assert isinstance(result, str)
-
-except ImportError:
-    pass
+def test_get_provider_no_env(monkeypatch):
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    provider = get_provider()
+    assert provider is None

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Тесты для llm.py с полным покрытием."""
 
+import pytest
+
 from llm import get_provider
 
 
-def test_get_provider_stub(monkeypatch):
+def test_get_provider_stub(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "stub")
     provider = get_provider()
     assert provider is not None
@@ -12,7 +14,7 @@ def test_get_provider_stub(monkeypatch):
     assert provider.name == "stub"
 
 
-def test_get_provider_ollama(monkeypatch):
+def test_get_provider_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     provider = get_provider()
     assert provider is not None
@@ -20,7 +22,7 @@ def test_get_provider_ollama(monkeypatch):
     assert provider.name == "ollama"
 
 
-def test_get_provider_perplexity(monkeypatch):
+def test_get_provider_perplexity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "perplexity")
     provider = get_provider()
     assert provider is not None
@@ -28,13 +30,13 @@ def test_get_provider_perplexity(monkeypatch):
     assert provider.name == "perplexity"
 
 
-def test_get_provider_invalid(monkeypatch):
+def test_get_provider_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "invalid")
     provider = get_provider()
     assert provider is None
 
 
-def test_get_provider_no_env(monkeypatch):
+def test_get_provider_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     provider = get_provider()
     assert provider is None

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,7 +4,9 @@
 try:
     from llm import get_provider
 except ImportError:
-    get_provider = None
+
+    def get_provider():
+        return None
 
 
 def test_get_provider_stub():
@@ -24,23 +26,6 @@ def test_get_provider_stub():
             del os.environ["LLM_PROVIDER"]
 
 
-def test_get_provider_grok():
-    import os
-
-    original = os.environ.get("LLM_PROVIDER")
-    os.environ["LLM_PROVIDER"] = "grok"
-    try:
-        provider = get_provider()
-        assert provider is not None
-        assert hasattr(provider, "generate")
-        assert provider.name == "grok"
-    finally:
-        if original is not None:
-            os.environ["LLM_PROVIDER"] = original
-        else:
-            del os.environ["LLM_PROVIDER"]
-
-
 def test_get_provider_ollama():
     import os
 
@@ -51,6 +36,23 @@ def test_get_provider_ollama():
         assert provider is not None
         assert hasattr(provider, "generate")
         assert provider.name == "ollama"
+    finally:
+        if original is not None:
+            os.environ["LLM_PROVIDER"] = original
+        else:
+            del os.environ["LLM_PROVIDER"]
+
+
+def test_get_provider_perplexity():
+    import os
+
+    original = os.environ.get("LLM_PROVIDER")
+    os.environ["LLM_PROVIDER"] = "perplexity"
+    try:
+        provider = get_provider()
+        assert provider is not None
+        assert hasattr(provider, "generate")
+        assert provider.name == "perplexity"
     finally:
         if original is not None:
             os.environ["LLM_PROVIDER"] = original
@@ -96,17 +98,6 @@ try:
         result = provider.generate("test")
         assert isinstance(result, str)
         assert "stub" in result.lower()
-
-except ImportError:
-    pass
-
-try:
-    from llm.providers.grok import GrokProvider
-
-    def test_grok_provider_generate():
-        provider = GrokProvider()
-        result = provider.generate("test")
-        assert isinstance(result, str)
 
 except ImportError:
     pass

--- a/tests/test_llm_comprehensive.py
+++ b/tests/test_llm_comprehensive.py
@@ -44,62 +44,62 @@ class TestStubProvider:
         assert "[stub @" in result
 
 
-class TestGrokLiteProvider:
-    """Тесты для GrokLiteProvider fallback'а"""
+class TestPerplexityLiteProvider:
+    """Тесты для PerplexityLiteProvider fallback'а"""
 
     def test_grok_lite_provider_through_exception(self):
-        """Тест GrokLiteProvider через симуляцию отсутствия providers.grok"""
-        # Тестируем GrokLiteProvider симулируя отсутствие настоящего провайдера
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
-            # Мокаем GrokProvider на уровне модуля как None
-            with patch.object(llm, "GrokProvider", None):
-                # Нам нужно создать класс GrokLiteProvider для теста
-                original_grok_lite = getattr(llm, "GrokLiteProvider", None)
+        """Тест PerplexityLiteProvider через симуляцию отсутствия providers.perplexity"""
+        # Тестируем PerplexityLiteProvider симулируя отсутствие настоящего провайдера
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
+            # Мокаем PerplexityProvider на уровне модуля как None
+            with patch.object(llm, "PerplexityProvider", None):
+                # Нам нужно создать класс PerplexityLiteProvider для теста
+                original_grok_lite = getattr(llm, "PerplexityLiteProvider", None)
 
-                # Если GrokLiteProvider не существует, создаем его
+                # Если PerplexityLiteProvider не существует, создаем его
                 if not original_grok_lite:
 
-                    class MockGrokLiteProvider:
-                        name = "grok"
+                    class MockPerplexityLiteProvider:
+                        name = "perplexity"
 
                         def __init__(self, *args, **kwargs):
                             pass
 
                         async def generate(self, text: str) -> str:
-                            return f"[grok-lite] {text}"
+                            return f"[perplexity-lite] {text}"
 
                     # Патчим get_provider чтобы возвращал наш мок
                     with patch.object(llm, "get_provider") as mock_get:
-                        mock_provider = MockGrokLiteProvider()
+                        mock_provider = MockPerplexityLiteProvider()
                         mock_get.return_value = mock_provider
 
                         provider = llm.get_provider()
                         assert provider is not None
-                        assert provider.name == "grok"
+                        assert provider.name == "perplexity"
                 else:
                     provider = llm.get_provider()
                     assert provider is not None
 
     @pytest.mark.asyncio
     async def test_grok_lite_provider_generate(self):
-        """Тест генерации текста через GrokLiteProvider"""
+        """Тест генерации текста через PerplexityLiteProvider"""
 
         # Создаем мок провайдер для теста генерации
         # Создаем мок провайдер для теста генерации
-        class MockGrokLiteProvider:
-            name = "grok"
+        class MockPerplexityLiteProvider:
+            name = "perplexity"
 
             def __init__(self, *args, **kwargs):
                 pass
 
             async def generate(self, text: str) -> str:
-                return f"[grok-lite] {text}"
+                return f"[perplexity-lite] {text}"
 
-        provider = MockGrokLiteProvider()
+        provider = MockPerplexityLiteProvider()
         result = await provider.generate("nutrition question")
 
-        assert result == "[grok-lite] nutrition question"
-        assert "grok-lite" in result
+        assert result == "[perplexity-lite] nutrition question"
+        assert "perplexity-lite" in result
 
 
 class TestGetProvider:
@@ -143,106 +143,109 @@ class TestGetProvider:
 
 
 class TestGetProviderGrok:
-    """Тесты для Grok провайдера"""
+    """Тесты для Perplexity провайдера"""
 
     def test_get_provider_grok_fallback_when_none(self):
-        """Тест fallback на GrokLiteProvider когда GrokProvider недоступен"""
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
-            # Мокаем недоступность настоящего GrokProvider
-            with patch.object(llm, "GrokProvider", None):
+        """Тест fallback на PerplexityLiteProvider когда PerplexityProvider недоступен"""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
+            # Мокаем недоступность настоящего PerplexityProvider
+            with patch.object(llm, "PerplexityProvider", None):
                 provider = llm.get_provider()
                 assert provider is not None
-                assert provider.name == "grok"
+                assert provider.name == "perplexity"
 
-    @patch("llm.GrokProvider")
+    @patch("llm.PerplexityProvider")
     def test_get_provider_grok_with_env_vars(self, mock_grok_class):
-        """Тест создания GrokProvider с переменными окружения"""
+        """Тест создания PerplexityProvider с переменными окружения"""
         mock_instance = Mock()
         mock_grok_class.return_value = mock_instance
 
         env_vars = {
-            "LLM_PROVIDER": "grok",
-            "GROK_API_KEY": "test-key-123",
-            "GROK_MODEL": "grok-beta",
-            "GROK_ENDPOINT": "https://test.api.com",
+            "LLM_PROVIDER": "perplexity",
+            "PERPLEXITY_API_KEY": "test-key-123",
+            "PERPLEXITY_MODEL": "sonar-pro",
+            "PERPLEXITY_ENDPOINT": "https://test.api.com",
         }
 
         with patch.dict(os.environ, env_vars, clear=False):
             provider = llm.get_provider()
 
-            # Проверяем что GrokProvider был вызван с правильными параметрами
+            # Проверяем что PerplexityProvider был вызван с правильными параметрами
             mock_grok_class.assert_called_once_with(
-                endpoint="https://test.api.com", api_key="test-key-123", model="grok-beta"
+                endpoint="https://test.api.com", api_key="test-key-123", model="sonar-pro"
             )
             assert provider == mock_instance
 
-    @patch("llm.GrokProvider")
-    def test_get_provider_grok_with_xai_key(self, mock_grok_class):
-        """Тест использования XAI_API_KEY как fallback"""
+    @patch("llm.PerplexityProvider")
+    def test_get_provider_perplexity_with_api_key(self, mock_grok_class):
+        """Тест использования PERPLEXITY_API_KEY."""
         mock_instance = Mock()
         mock_grok_class.return_value = mock_instance
 
         env_vars = {
-            "LLM_PROVIDER": "grok",
-            "XAI_API_KEY": "xai-key-456",  # Альтернативное имя ключа
+            "LLM_PROVIDER": "perplexity",
+            "PERPLEXITY_API_KEY": "xai-key-456",  # Альтернативное имя ключа
         }
 
         with patch.dict(os.environ, env_vars, clear=False):
-            # Убираем GROK_API_KEY если есть
-            if "GROK_API_KEY" in os.environ:
-                del os.environ["GROK_API_KEY"]
-
             provider = llm.get_provider()
             assert provider is not None
 
             mock_grok_class.assert_called_once_with(
-                endpoint="https://api.x.ai/v1",  # дефолтный endpoint
+                endpoint="https://api.perplexity.ai/v1",  # дефолтный endpoint
                 api_key="xai-key-456",
-                model="grok-4-latest",  # дефолтная модель
+                model="sonar",  # дефолтная модель
             )
 
     def test_get_provider_grok_defaults(self):
-        """Тест дефолтных значений для Grok провайдера (fallback to GrokLiteProvider when no API key)"""
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
+        """Тест дефолтных значений для Perplexity провайдера (fallback to PerplexityLiteProvider when no API key)"""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
             # Очищаем все Grok-related env vars
-            grok_vars = ["GROK_API_KEY", "XAI_API_KEY", "GROK_MODEL", "GROK_ENDPOINT"]
+            grok_vars = [
+                "PERPLEXITY_API_KEY",
+                "PERPLEXITY_API_KEY",
+                "PERPLEXITY_MODEL",
+                "PERPLEXITY_ENDPOINT",
+            ]
             for var in grok_vars:
                 if var in os.environ:
                     del os.environ[var]
 
             provider = llm.get_provider()
             assert provider is not None
-            # Когда нет API ключа, должен вернуть GrokLiteProvider
-            assert provider.__class__.__name__ == "GrokLiteProvider"
-            assert provider.name == "grok"
+            # Когда нет API ключа, должен вернуть PerplexityLiteProvider
+            assert provider.__class__.__name__ == "PerplexityLiteProvider"
+            assert provider.name == "perplexity"
 
-    @patch("llm.GrokProvider")
+    @patch("llm.PerplexityProvider")
     def test_get_provider_grok_keyword_exception_fallback(self, mock_grok_class):
         """Тест fallback при ошибке keyword arguments"""
         # Мокаем TypeError при вызове с keyword args
         mock_grok_class.side_effect = [TypeError("unexpected keyword"), Mock()]
 
         with patch.dict(
-            os.environ, {"LLM_PROVIDER": "grok", "GROK_API_KEY": "test-key"}, clear=False
+            os.environ,
+            {"LLM_PROVIDER": "perplexity", "PERPLEXITY_API_KEY": "test-key"},
+            clear=False,
         ):
             provider = llm.get_provider()
             assert provider is not None
 
-            # Должно быть два вызова: первый с kwargs, второй с positional args
-            assert mock_grok_class.call_count == 2
+            # Perplexity path uses one constructor attempt and falls back to lite on error.
+            assert mock_grok_class.call_count == 1
 
-    @patch("llm.GrokProvider")
+    @patch("llm.PerplexityProvider")
     def test_get_provider_grok_all_exceptions_fallback(self, mock_grok_class):
-        """Тест fallback на GrokLiteProvider при всех ошибках"""
+        """Тест fallback на PerplexityLiteProvider при всех ошибках"""
         # Мокаем ошибки для всех попыток создания
         mock_grok_class.side_effect = Exception("Connection failed")
 
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
             provider = llm.get_provider()
 
-            # Должен вернуться GrokLiteProvider
+            # Должен вернуться PerplexityLiteProvider
             assert provider is not None
-            assert provider.name == "grok"
+            assert provider.name == "perplexity"
 
 
 class TestGetProviderOllama:
@@ -253,7 +256,7 @@ class TestGetProviderOllama:
         with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
             with patch.object(llm, "OllamaProvider", None):
                 provider = llm.get_provider()
-                # When OllamaProvider is None, should fallback to OllamaLiteProvider (like GrokProvider)
+                # When OllamaProvider is None, should fallback to OllamaLiteProvider (like PerplexityProvider)
                 assert provider is not None
                 assert provider.name == "ollama"
 
@@ -307,7 +310,7 @@ class TestGetProviderOllama:
         with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
             provider = llm.get_provider()
 
-            # При ошибках должен вернуться OllamaLiteProvider (консистентно с GrokProvider)
+            # При ошибках должен вернуться OllamaLiteProvider (консистентно с PerplexityProvider)
             assert provider is not None
             assert provider.name == "ollama"
             assert mock_ollama_class.call_count == 2
@@ -351,10 +354,10 @@ class TestModuleImports:
         # Это проверяется в runtime при импорте модуля
 
         # Тестируем что fallback провайдеры работают через get_provider
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
-            with patch.object(llm, "GrokProvider", None):
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
+            with patch.object(llm, "PerplexityProvider", None):
                 grok_lite = llm.get_provider()
-                assert grok_lite.name == "grok"
+                assert grok_lite.name == "perplexity"
 
         stub = llm.StubProvider()
         assert stub.name == "stub"

--- a/tests/test_llm_comprehensive.py
+++ b/tests/test_llm_comprehensive.py
@@ -192,7 +192,7 @@ class TestGetProviderGrok:
             assert provider is not None
 
             mock_grok_class.assert_called_once_with(
-                endpoint="https://api.perplexity.ai/v1",  # дефолтный endpoint
+                endpoint="https://api.perplexity.ai",  # дефолтный endpoint
                 api_key="xai-key-456",
                 model="sonar",  # дефолтная модель
             )
@@ -200,14 +200,13 @@ class TestGetProviderGrok:
     def test_get_provider_grok_defaults(self):
         """Тест дефолтных значений для Perplexity провайдера (fallback to PerplexityLiteProvider when no API key)"""
         with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
-            # Очищаем все Grok-related env vars
-            grok_vars = [
-                "PERPLEXITY_API_KEY",
+            # Очищаем все Perplexity-related env vars
+            perplexity_vars = [
                 "PERPLEXITY_API_KEY",
                 "PERPLEXITY_MODEL",
                 "PERPLEXITY_ENDPOINT",
             ]
-            for var in grok_vars:
+            for var in perplexity_vars:
                 if var in os.environ:
                     del os.environ[var]
 

--- a/tests/test_llm_extras.py
+++ b/tests/test_llm_extras.py
@@ -21,7 +21,7 @@ def test__with_name_handles_attribute_error() -> None:
         __slots__ = ()
 
     obj = NoAttrs()
-    res = llm._with_name(obj, "any")  # type: ignore[attr-defined]
+    res = llm._with_name(obj, "any")
     assert res is obj
 
 
@@ -32,29 +32,6 @@ def test_get_provider_stub_branch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert provider is not None
     assert getattr(provider, "name", "") == "stub"
-
-
-def test_get_provider_grok_env_block_executes(monkeypatch: pytest.MonkeyPatch) -> None:
-    class GrokProvider:
-        name = "grok"
-
-        def __init__(self, endpoint: str, model: str, api_key: str, /) -> None:
-            self.endpoint = endpoint
-            self.model = model
-            self.api_key = api_key
-
-        async def generate(self, text: str) -> str:
-            return text
-
-    monkeypatch.setattr(llm, "GrokProvider", GrokProvider)
-    monkeypatch.setenv("GROK_API_KEY", "dummy")
-    monkeypatch.delenv("XAI_API_KEY", raising=False)
-    monkeypatch.setenv("LLM_PROVIDER", "grok")
-
-    provider = llm.get_provider()
-
-    assert provider is not None
-    assert getattr(provider, "name", "") == "grok"
 
 
 def test_get_provider_ollama_typeerror_posargs_fallback(
@@ -92,23 +69,39 @@ def test_get_provider_ollama_import_error_fallback(
     assert getattr(provider, "name", "") == "ollama"
 
 
-def test_get_provider_grok_missing_api_key_triggers_branch(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class GrokProvider:
-        name = "grok"
+def test_get_provider_perplexity_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _PerplexityProvider:
+        name = "perplexity"
 
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            self.args = args
-            self.kwargs = kwargs
+        def __init__(self, endpoint: str, model: str, api_key: str, /) -> None:
+            self.endpoint = endpoint
+            self.model = model
+            self.api_key = api_key
 
-    monkeypatch.setattr(llm, "GrokProvider", GrokProvider)
-    monkeypatch.delenv("GROK_API_KEY", raising=False)
-    monkeypatch.delenv("XAI_API_KEY", raising=False)
-    monkeypatch.setenv("LLM_PROVIDER", "grok")
+        async def generate(self, text: str) -> str:
+            return text
+
+    monkeypatch.setattr(llm, "PerplexityProvider", _PerplexityProvider)
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-key")
+    monkeypatch.setenv("PERPLEXITY_MODEL", "sonar-pro")
+    monkeypatch.setenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai")
 
     provider = llm.get_provider()
 
     assert provider is not None
-    assert isinstance(provider, llm.GrokLiteProvider)
-    assert getattr(provider, "name", "") == "grok"
+    assert getattr(provider, "name", "") == "perplexity"
+
+
+def test_get_provider_perplexity_without_api_key_uses_lite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.setattr(llm, "PerplexityProvider", None)
+
+    provider = llm.get_provider()
+
+    assert provider is not None
+    assert isinstance(provider, llm.PerplexityLiteProvider)
+    assert getattr(provider, "name", "") == "perplexity"

--- a/tests/test_llm_extras.py
+++ b/tests/test_llm_extras.py
@@ -105,3 +105,28 @@ def test_get_provider_perplexity_without_api_key_uses_lite(
     assert provider is not None
     assert isinstance(provider, llm.PerplexityLiteProvider)
     assert getattr(provider, "name", "") == "perplexity"
+
+
+def test_get_provider_perplexity_placeholder_key_uses_lite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PerplexityProvider:
+        name = "perplexity"
+
+        def __init__(self, endpoint: str, model: str, api_key: str, /) -> None:
+            self.endpoint = endpoint
+            self.model = model
+            self.api_key = api_key
+
+        async def generate(self, text: str) -> str:
+            return text
+
+    monkeypatch.setattr(llm, "PerplexityProvider", _PerplexityProvider)
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "__replace_me__")
+
+    provider = llm.get_provider()
+
+    assert provider is not None
+    assert isinstance(provider, llm.PerplexityLiteProvider)
+    assert getattr(provider, "name", "") == "perplexity"

--- a/tests/test_llm_extras.py
+++ b/tests/test_llm_extras.py
@@ -73,7 +73,7 @@ def test_get_provider_perplexity_with_api_key(monkeypatch: pytest.MonkeyPatch) -
     class _PerplexityProvider:
         name = "perplexity"
 
-        def __init__(self, endpoint: str, model: str, api_key: str, /) -> None:
+        def __init__(self, *, endpoint: str, model: str, api_key: str) -> None:
             self.endpoint = endpoint
             self.model = model
             self.api_key = api_key
@@ -83,22 +83,37 @@ def test_get_provider_perplexity_with_api_key(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(llm, "PerplexityProvider", _PerplexityProvider)
     monkeypatch.setenv("LLM_PROVIDER", "perplexity")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-key")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-key")  # pragma: allowlist secret
     monkeypatch.setenv("PERPLEXITY_MODEL", "sonar-pro")
     monkeypatch.setenv("PERPLEXITY_ENDPOINT", "https://api.perplexity.ai")
 
     provider = llm.get_provider()
 
     assert provider is not None
+    assert isinstance(provider, _PerplexityProvider)
+    assert provider.endpoint == "https://api.perplexity.ai"
+    assert provider.model == "sonar-pro"
+    assert provider.api_key == "pplx-key"  # pragma: allowlist secret
     assert getattr(provider, "name", "") == "perplexity"
 
 
 def test_get_provider_perplexity_without_api_key_uses_lite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    class _PerplexityProvider:
+        name = "perplexity"
+
+        def __init__(self, *, endpoint: str, model: str, api_key: str) -> None:
+            self.endpoint = endpoint
+            self.model = model
+            self.api_key = api_key
+
+        async def generate(self, text: str) -> str:
+            return text
+
     monkeypatch.setenv("LLM_PROVIDER", "perplexity")
     monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
-    monkeypatch.setattr(llm, "PerplexityProvider", None)
+    monkeypatch.setattr(llm, "PerplexityProvider", _PerplexityProvider)
 
     provider = llm.get_provider()
 
@@ -113,7 +128,7 @@ def test_get_provider_perplexity_placeholder_key_uses_lite(
     class _PerplexityProvider:
         name = "perplexity"
 
-        def __init__(self, endpoint: str, model: str, api_key: str, /) -> None:
+        def __init__(self, *, endpoint: str, model: str, api_key: str) -> None:
             self.endpoint = endpoint
             self.model = model
             self.api_key = api_key

--- a/tests/test_llm_extras.py
+++ b/tests/test_llm_extras.py
@@ -49,10 +49,15 @@ def test_get_provider_ollama_typeerror_posargs_fallback(
 
     monkeypatch.setattr(llm, "OllamaProvider", OllamaProvider)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("OLLAMA_ENDPOINT", "http://ollama.local:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3.1:8b")
 
     provider = llm.get_provider()
 
     assert provider is not None
+    assert isinstance(provider, OllamaProvider)
+    assert provider.endpoint == "http://ollama.local:11434"
+    assert provider.model == "llama3.1:8b"
     assert getattr(provider, "name", "") == "ollama"
 
 

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -1,11 +1,9 @@
-"""
-Тесты для покрытия исключений при импорте в llm.py
-Цель: достичь 100% покрытия кода включая fallback провайдеры
-"""
+"""Targeted coverage tests for llm provider selector."""
+
+from __future__ import annotations
 
 import importlib
 import os
-import sys
 from importlib import reload
 from unittest.mock import Mock, patch
 
@@ -16,178 +14,81 @@ import llm
 
 @pytest.fixture(autouse=True)
 def _llm_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Isolate llm env defaults per test."""
     monkeypatch.setenv("API_KEY", "test_key")
     monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
 
 
 class TestImportFallbacks:
-    """Тесты fallback поведения при недоступности внешних провайдеров"""
-
-    def test_grok_import_exception_coverage(self, monkeypatch):
-        """Тест покрытия GrokLiteProvider при ошибке импорта providers.grok"""
-        # IMPORTANT: do not mutate sys.modules directly; use monkeypatch so pytest
-        # automatically restores state after the test (repo rule after #406).
-        provider_modules = [
-            name for name in list(sys.modules.keys()) if name.startswith("providers")
-        ]
-        for name in provider_modules:
-            monkeypatch.delitem(sys.modules, name, raising=False)
-
+    def test_perplexity_import_exception_coverage(self) -> None:
         original_import_module = importlib.import_module
+        with patch("importlib.import_module") as mock_import:
 
-        def side_effect(name, *args, **kwargs):
-            if name == "providers.grok":
-                raise ImportError("No module named providers.grok")
-            return original_import_module(name, *args, **kwargs)
+            def import_side_effect(name: str, package: str | None = None):
+                if name == "providers.perplexity":
+                    raise ImportError("No module named providers.perplexity")
+                return original_import_module(name, package)
 
-        with patch("importlib.import_module", side_effect=side_effect):
-            # Перезагружаем модуль llm чтобы активировать except блок
+            mock_import.side_effect = import_side_effect
             reload(llm)
+            assert llm.PerplexityProvider is None
+            assert hasattr(llm, "PerplexityLiteProvider")
 
-            # Ошибка импорта должна оставить реальный провайдер недоступным.
-            # EN: Import failure must leave the real provider unavailable.
-            assert llm.GrokProvider is None
-            # Теперь GrokLiteProvider должен быть доступен
-            assert hasattr(llm, "GrokLiteProvider")
-
-            # Тестируем создание и использование GrokLiteProvider
-            provider = llm.GrokLiteProvider()
-            assert provider.name == "grok"
-
-        # Восстанавливаем "стабильную" версию llm после теста.
-        # sys.modules будет восстановлен pytest monkeypatch автоматически.
         reload(llm)
 
     @pytest.mark.asyncio
-    async def test_grok_lite_provider_generate_coverage(self):
-        """Тест метода generate класса GrokLiteProvider"""
-        # Убеждаемся, что в модуле доступен реальный GrokLiteProvider
-        assert hasattr(llm, "GrokLiteProvider"), "GrokLiteProvider должен существовать в llm"
-
-        provider = llm.GrokLiteProvider()
-        assert getattr(provider, "name", None) == "grok"
-
+    async def test_perplexity_lite_provider_generate_coverage(self) -> None:
+        provider = llm.PerplexityLiteProvider()
+        assert provider.name == "perplexity"
         result = await provider.generate("test input")
-
-        # Поведение задокументировано в llm.GrokLiteProvider.generate
-        # Ожидаем маркер grok-lite и возврат исходного текста
-        assert result.startswith("[grok-lite] ")
+        assert result.startswith("[perplexity-lite] ")
         assert result.endswith("test input")
-        assert "grok-lite" in result
-
-    def test_ollama_import_exception_coverage(self):
-        """Тест покрытия исключения при импорте OllamaProvider"""
-        # Мокаем ошибку импорта OllamaProvider
-        original_import_module = importlib.import_module
-        with patch("importlib.import_module") as mock_import:
-
-            def import_side_effect(name, *args, **kwargs):
-                if name == "providers.ollama":
-                    raise ImportError("No module named 'providers.ollama'")
-                return original_import_module(name, *args, **kwargs)
-
-            mock_import.side_effect = import_side_effect
-
-            # Перезагружаем модуль для активации except блока
-            reload(llm)
-
-            # OllamaProvider должен быть None
-            assert llm.OllamaProvider is None
-
-        # Восстанавливаем нормальное состояние
-        reload(llm)
-
-    def test_pico_import_exception_coverage(self):
-        """Тест покрытия исключения при импорте PicoProvider"""
-        # Мокаем ошибку импорта PicoProvider
-        original_import_module = importlib.import_module
-        with patch("importlib.import_module") as mock_import:
-
-            def import_side_effect(name, *args, **kwargs):
-                if name == "providers.pico":
-                    raise ImportError("No module named 'providers.pico'")
-                return original_import_module(name, *args, **kwargs)
-
-            mock_import.side_effect = import_side_effect
-
-            # Перезагружаем модуль для активации except блока
-            reload(llm)
-
-            # PicoProvider должен быть None
-            assert llm.PicoProvider is None
-
-        # Восстанавливаем нормальное состояние
-        reload(llm)
 
 
 class TestGetProviderEdgeCases:
-    """Тесты граничных случаев функции get_provider()"""
-
-    def test_get_provider_with_pico(self):
-        """Тест несуществующего провайдера pico"""
+    def test_get_provider_with_pico(self) -> None:
         with patch.dict(os.environ, {"LLM_PROVIDER": "pico"}, clear=False):
-            provider = llm.get_provider()
-            # Должен вернуться None так как pico не обрабатывается в get_provider
-            assert provider is None
+            assert llm.get_provider() is None
 
-    def test_get_provider_ollama_with_exception_coverage(self):
-        """Тест покрытия всех путей исключений в Ollama"""
+    def test_get_provider_ollama_with_exception_coverage(self) -> None:
         with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
             with patch.object(llm, "OllamaProvider") as mock_ollama:
-                # Тест TypeError в первом try/except блоке
                 mock_ollama.side_effect = [TypeError("keyword error"), Exception("creation failed")]
-
                 provider = llm.get_provider()
-                # При ошибках должен вернуться OllamaLiteProvider (консистентно с GrokProvider)
                 assert provider is not None
                 assert provider.name == "ollama"
                 assert mock_ollama.call_count == 2
 
-    @patch("llm.GrokProvider")
-    def test_grok_provider_positional_args_fallback(self, mock_grok_class):
-        """Тест fallback на позиционные аргументы для GrokProvider"""
-        # Первый вызов с keyword args падает, второй с positional успешен
-        mock_instance = Mock()
-        mock_grok_class.side_effect = [TypeError("unexpected keyword"), mock_instance]
-
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok", "GROK_API_KEY": "dummy"}, clear=False):
+    @patch("llm.PerplexityProvider")
+    def test_perplexity_provider_keyword_exception_fallback(
+        self, mock_perplexity_class: Mock
+    ) -> None:
+        mock_perplexity_class.side_effect = TypeError("unexpected keyword")
+        with patch.dict(
+            os.environ,
+            {"LLM_PROVIDER": "perplexity", "PERPLEXITY_API_KEY": "dummy"},
+            clear=False,
+        ):
             provider = llm.get_provider()
+            assert provider is not None
+            assert provider.name == "perplexity"
+            assert mock_perplexity_class.call_count == 1
 
-            # Должно быть два вызова: kwargs и positional
-            assert mock_grok_class.call_count == 2
-            assert provider == mock_instance
-
-    def test_get_provider_grok_without_real_provider(self):
-        """Тест get_provider с grok когда GrokProvider недоступен"""
-        with patch.dict(os.environ, {"LLM_PROVIDER": "grok"}, clear=False):
-            with patch.object(llm, "GrokProvider", None):
+    def test_get_provider_perplexity_without_real_provider(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}, clear=False):
+            with patch.object(llm, "PerplexityProvider", None):
                 provider = llm.get_provider()
-                # Если у нас нет GrokLiteProvider, должен вернуться None
-                # В реальном модуле возвращается GrokLiteProvider только если GrokProvider=None
-                # When GrokProvider is None, should fallback to GrokLiteProvider
-                if hasattr(llm, "GrokLiteProvider"):
-                    assert provider is not None
-                    assert provider.name == "grok"
-                else:
-                    assert provider is None
+                assert provider is not None
+                assert provider.name == "perplexity"
 
 
 class TestEnvironmentVariableEdgeCases:
-    """Тесты граничных случаев обработки переменных окружения"""
-
-    def test_empty_string_values(self):
-        """Тест различных форм пустых строк"""
+    def test_empty_string_values(self) -> None:
         empty_values = ["", " ", "\t", "\n", "\r\n", "  \t\n  "]
-
         for empty_val in empty_values:
             with patch.dict(os.environ, {"LLM_PROVIDER": empty_val}, clear=False):
-                provider = llm.get_provider()
-                assert provider is None, f"Failed for empty value: '{repr(empty_val)}'"
+                assert llm.get_provider() is None
 
-    def test_case_variations(self):
-        """Тест различных вариантов регистра"""
-        # Тест для stub
+    def test_case_variations(self) -> None:
         stub_variations = ["stub", "STUB", "Stub", "StUb", "sTuB"]
         for variation in stub_variations:
             with patch.dict(os.environ, {"LLM_PROVIDER": variation}, clear=False):
@@ -195,19 +96,15 @@ class TestEnvironmentVariableEdgeCases:
                 assert provider is not None
                 assert provider.name == "stub"
 
-        # Тест для grok
-        grok_variations = ["grok", "GROK", "Grok", "GrOk", "gRoK"]
-        for variation in grok_variations:
+        perplexity_variations = ["perplexity", "PERPLEXITY", "Perplexity", "PeRpLeXiTy"]
+        for variation in perplexity_variations:
             with patch.dict(os.environ, {"LLM_PROVIDER": variation}, clear=False):
                 provider = llm.get_provider()
                 assert provider is not None
-                assert provider.name == "grok"
+                assert provider.name == "perplexity"
 
-    def test_special_none_values(self):
-        """Тест специальных значений, означающих None"""
+    def test_special_none_values(self) -> None:
         none_values = ["none", "NONE", "None", "no", "NO", "No"]
-
         for none_val in none_values:
             with patch.dict(os.environ, {"LLM_PROVIDER": none_val}, clear=False):
-                provider = llm.get_provider()
-                assert provider is None, f"Should be None for: '{none_val}'"
+                assert llm.get_provider() is None

--- a/tests/test_llm_lite_providers.py
+++ b/tests/test_llm_lite_providers.py
@@ -6,42 +6,42 @@ import llm
 @pytest.mark.asyncio
 async def test_lite_providers_generate_text() -> None:
     """Validate that lite providers generate expected text output and integration behavior."""
-    grok = llm.GrokLiteProvider()
+    perplexity = llm.PerplexityLiteProvider()
     ollama = llm.OllamaLiteProvider()
 
-    assert await grok.generate("hello") == "[grok-lite] hello"
+    assert await perplexity.generate("hello") == "[perplexity-lite] hello"
     assert await ollama.generate("hello") == "[ollama-lite] hello"
 
 
 @pytest.mark.asyncio
 async def test_lite_providers_empty_string() -> None:
     """Test that empty string input is handled correctly."""
-    grok = llm.GrokLiteProvider()
+    perplexity = llm.PerplexityLiteProvider()
     ollama = llm.OllamaLiteProvider()
 
-    assert await grok.generate("") == "[grok-lite] "
+    assert await perplexity.generate("") == "[perplexity-lite] "
     assert await ollama.generate("") == "[ollama-lite] "
 
 
 @pytest.mark.asyncio
 async def test_lite_providers_invalid_input_types() -> None:
     """Test that invalid input types are handled gracefully."""
-    grok = llm.GrokLiteProvider()
+    perplexity = llm.PerplexityLiteProvider()
     ollama = llm.OllamaLiteProvider()
 
     # Lite providers accept any input and return formatted string
     # They don't raise TypeError, they convert to string
-    result_grok_none = await grok.generate(None)  # type: ignore[arg-type]
-    assert isinstance(result_grok_none, str)
-    assert "[grok-lite]" in result_grok_none
+    result_perplexity_none = await perplexity.generate(None)  # type: ignore[arg-type]
+    assert isinstance(result_perplexity_none, str)
+    assert "[perplexity-lite]" in result_perplexity_none
 
     result_ollama_none = await ollama.generate(None)  # type: ignore[arg-type]
     assert isinstance(result_ollama_none, str)
     assert "[ollama-lite]" in result_ollama_none
 
-    result_grok_int = await grok.generate(123)  # type: ignore[arg-type]
-    assert isinstance(result_grok_int, str)
-    assert "123" in result_grok_int
+    result_perplexity_int = await perplexity.generate(123)  # type: ignore[arg-type]
+    assert isinstance(result_perplexity_int, str)
+    assert "123" in result_perplexity_int
 
     result_ollama_int = await ollama.generate(123)  # type: ignore[arg-type]
     assert isinstance(result_ollama_int, str)
@@ -51,30 +51,30 @@ async def test_lite_providers_invalid_input_types() -> None:
 @pytest.mark.asyncio
 async def test_lite_providers_special_characters_and_long_string() -> None:
     """Test that special characters and very long strings are handled correctly."""
-    grok = llm.GrokLiteProvider()
+    perplexity = llm.PerplexityLiteProvider()
     ollama = llm.OllamaLiteProvider()
 
     # Test special characters
     special_input = "Hello! @#$%^&*()[]{}|\\:;\"'<>?/~`"
-    assert await grok.generate(special_input) == f"[grok-lite] {special_input}"
+    assert await perplexity.generate(special_input) == f"[perplexity-lite] {special_input}"
     assert await ollama.generate(special_input) == f"[ollama-lite] {special_input}"
 
     # Test very long string
     long_input = "a" * 10000
-    assert await grok.generate(long_input) == f"[grok-lite] {long_input}"
+    assert await perplexity.generate(long_input) == f"[perplexity-lite] {long_input}"
     assert await ollama.generate(long_input) == f"[ollama-lite] {long_input}"
 
 
 @pytest.mark.asyncio
 async def test_get_provider_factory(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the get_provider() factory function returns correct provider instances."""
-    # Test grok provider
-    monkeypatch.setenv("LLM_PROVIDER", "grok")
-    grok_provider = llm.get_provider()
-    assert grok_provider is not None
-    # Provider could be GrokLiteProvider or GrokProvider depending on availability
-    assert hasattr(grok_provider, "generate")
-    result = await grok_provider.generate("test")
+    # Test perplexity provider
+    monkeypatch.setenv("LLM_PROVIDER", "perplexity")
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    perplexity_provider = llm.get_provider()
+    assert perplexity_provider is not None
+    assert hasattr(perplexity_provider, "generate")
+    result = await perplexity_provider.generate("test")
     assert isinstance(result, str)
     assert "test" in result
 

--- a/tests/test_llm_simple_96.py
+++ b/tests/test_llm_simple_96.py
@@ -12,17 +12,17 @@ class TestLlmSimple96:
     """Simple tests to cover missing lines in llm.py for 96%+ coverage."""
 
     def test_get_provider_grok_keyword_args_fail(self):
-        """Test get_provider with GrokProvider keyword args failure - line 71-77."""
+        """Test get_provider with PerplexityProvider keyword args failure - line 71-77."""
         with (
-            patch("llm.GrokProvider") as mock_grok_provider,
-            patch("llm.GrokLiteProvider") as mock_grok_lite,
+            patch("llm.PerplexityProvider") as mock_grok_provider,
+            patch("llm.PerplexityLiteProvider") as mock_grok_lite,
             patch.dict(
                 os.environ,
                 {
-                    "LLM_PROVIDER": "grok",
-                    "GROK_ENDPOINT": "http://test",
-                    "GROK_API_KEY": "test_key",
-                    "GROK_MODEL": "test_model",
+                    "LLM_PROVIDER": "perplexity",
+                    "PERPLEXITY_ENDPOINT": "http://test",
+                    "PERPLEXITY_API_KEY": "test_key",
+                    "PERPLEXITY_MODEL": "test_model",
                 },
             ),
         ):
@@ -36,22 +36,22 @@ class TestLlmSimple96:
 
             result = get_provider()
 
-            # Should try keyword args first, then positional args
-            assert mock_grok_provider.call_count == 2
+            # Perplexity path currently performs a single constructor attempt.
+            assert mock_grok_provider.call_count == 1
             assert result is not None
 
     def test_get_provider_grok_both_fail(self):
-        """Test get_provider with GrokProvider both calls fail - line 75-77."""
+        """Test get_provider with PerplexityProvider both calls fail - line 75-77."""
         with (
-            patch("llm.GrokProvider") as mock_grok_provider,
-            patch("llm.GrokLiteProvider") as mock_grok_lite,
+            patch("llm.PerplexityProvider") as mock_grok_provider,
+            patch("llm.PerplexityLiteProvider") as mock_grok_lite,
             patch.dict(
                 os.environ,
                 {
-                    "LLM_PROVIDER": "grok",
-                    "GROK_ENDPOINT": "http://test",
-                    "GROK_API_KEY": "test_key",
-                    "GROK_MODEL": "test_model",
+                    "LLM_PROVIDER": "perplexity",
+                    "PERPLEXITY_ENDPOINT": "http://test",
+                    "PERPLEXITY_API_KEY": "test_key",
+                    "PERPLEXITY_MODEL": "test_model",
                 },
             ),
         ):
@@ -119,7 +119,7 @@ class TestLlmSimple96:
 
             result = get_provider()
 
-            # Should fallback to OllamaLiteProvider when both fail (консистентно с GrokProvider)
+            # Should fallback to OllamaLiteProvider when both fail (консистентно с PerplexityProvider)
             assert result is not None
             assert result.name == "ollama"
 
@@ -216,18 +216,18 @@ class TestLlmSimple96:
             assert result == mock_provider
 
     def test_get_provider_grok_fallback_when_unavailable(self):
-        """Test get_provider with GrokProvider fallback when unavailable - line 78-79."""
+        """Test get_provider with PerplexityProvider fallback when unavailable - line 78-79."""
         with (
-            patch("llm.GrokProvider", None),
-            patch("llm.GrokLiteProvider") as mock_grok_lite,
-            patch.dict(os.environ, {"LLM_PROVIDER": "grok"}),
+            patch("llm.PerplexityProvider", None),
+            patch("llm.PerplexityLiteProvider") as mock_grok_lite,
+            patch.dict(os.environ, {"LLM_PROVIDER": "perplexity"}),
         ):
             mock_lite_provider = Mock()
             mock_grok_lite.return_value = mock_lite_provider
 
             result = get_provider()
 
-            # Should fallback to lite provider when GrokProvider is None
+            # Should fallback to lite provider when PerplexityProvider is None
             mock_grok_lite.assert_called_once()
             assert result == mock_lite_provider
 
@@ -236,7 +236,7 @@ class TestLlmSimple96:
         with patch("llm.OllamaProvider", None), patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}):
             result = get_provider()
 
-            # Should fallback to OllamaLiteProvider when OllamaProvider is None (consistent with GrokProvider)
+            # Should fallback to OllamaLiteProvider when OllamaProvider is None (consistent with PerplexityProvider)
             assert result is not None
             assert result.name == "ollama"
 

--- a/tests/test_providers_unit.py
+++ b/tests/test_providers_unit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Изолированные юнит‑тесты для провайдеров: stub, grok, ollama, pico.
+"""Изолированные юнит‑тесты для провайдеров: stub, perplexity, ollama, pico.
 Все сетевые вызовы замещаются фейковыми клиентами; ретраи не ждут времени,
 т.к. мы обращаемся к __wrapped__ при необходимости.
 """
@@ -48,10 +48,10 @@ def test_stub_provider_text_truncation():
     assert "a" * 121 not in result
 
 
-# ---------------- GrokProvider -----------------
+# ---------------- PerplexityProvider -----------------
 
 
-def test_grok_generate_success(monkeypatch):
+def test_perplexity_generate_success(monkeypatch):
     class _Msg:
         def __init__(self, content: str):
             self.content = content
@@ -75,13 +75,13 @@ def test_grok_generate_success(monkeypatch):
     openai_fake = types.ModuleType("openai")
     openai_fake.AsyncOpenAI = _FakeClient  # pyright: ignore[reportAttributeAccessIssue]
     monkeypatch.setitem(sys.modules, "openai", openai_fake)
-    # гарантируем, что модуль grok увидит наш openai
-    if "providers.grok" in sys.modules:
-        grok_mod = importlib.reload(sys.modules["providers.grok"])  # type: ignore[arg-type]
+    # гарантируем, что модуль perplexity увидит наш openai
+    if "providers.perplexity" in sys.modules:
+        perplexity_mod = importlib.reload(sys.modules["providers.perplexity"])
     else:
-        from providers import grok as grok_mod  # type: ignore
+        from providers import perplexity as perplexity_mod
 
-    p = grok_mod.GrokProvider(endpoint="http://x", model="m", api_key="k")
+    p = perplexity_mod.PerplexityProvider(endpoint="http://x", model="m", api_key="k")
     loop = asyncio.new_event_loop()
     try:
         out = loop.run_until_complete(p.generate("test"))
@@ -90,7 +90,7 @@ def test_grok_generate_success(monkeypatch):
     assert out == "hello"  # content.strip()
 
 
-def test_grok_generate_error_wrapped(monkeypatch):
+def test_perplexity_generate_error_wrapped(monkeypatch):
     class _FakeChat:
         async def create(self, *a, **kw):
             raise RuntimeError("boom")
@@ -102,20 +102,20 @@ def test_grok_generate_error_wrapped(monkeypatch):
     openai_fake = types.ModuleType("openai")
     openai_fake.AsyncOpenAI = _FakeClient  # pyright: ignore[reportAttributeAccessIssue]
     monkeypatch.setitem(sys.modules, "openai", openai_fake)
-    if "providers.grok" in sys.modules:
-        grok_mod = importlib.reload(sys.modules["providers.grok"])  # type: ignore[arg-type]
+    if "providers.perplexity" in sys.modules:
+        perplexity_mod = importlib.reload(sys.modules["providers.perplexity"])
     else:
-        from providers import grok as grok_mod  # type: ignore
+        from providers import perplexity as perplexity_mod
 
-    p = grok_mod.GrokProvider(endpoint="http://x", model="m", api_key="k")
+    p = perplexity_mod.PerplexityProvider(endpoint="http://x", model="m", api_key="k")
     with pytest.raises(RuntimeError) as ei:
         # обходим декоратор retry
         loop = asyncio.new_event_loop()
         try:
-            loop.run_until_complete(p.generate.__wrapped__(p, "oops"))  # type: ignore[attr-defined]
+            loop.run_until_complete(p.generate.__wrapped__(p, "oops"))
         finally:
             loop.close()
-    assert "Grok error:" in str(ei.value)
+    assert "Perplexity error:" in str(ei.value)
 
 
 # ---------------- OllamaProvider -----------------
@@ -199,7 +199,7 @@ def test_ollama_unavailable_wrapped(monkeypatch):
         # обойти retries
         loop = asyncio.new_event_loop()
         try:
-            loop.run_until_complete(p.generate.__wrapped__(p, "text"))  # type: ignore[attr-defined]
+            loop.run_until_complete(p.generate.__wrapped__(p, "text"))
         finally:
             loop.close()
 
@@ -223,7 +223,7 @@ def test_ollama_request_error_wrapped(monkeypatch):
     with pytest.raises(RuntimeError) as ei:
         loop = asyncio.new_event_loop()
         try:
-            loop.run_until_complete(p.generate.__wrapped__(p, "text"))  # type: ignore[attr-defined]
+            loop.run_until_complete(p.generate.__wrapped__(p, "text"))
         finally:
             loop.close()
     assert "ollama_unavailable" in str(ei.value)
@@ -357,9 +357,9 @@ def test_pico_generate_choices_and_response_and_else(monkeypatch):
     p = pico_mod.PicoProvider(endpoint="http://x")
     out = _await_or_value(p.generate("t"))
     assert out == "A"
-    p.client.data = {"response": " B "}  # type: ignore[attr-defined]
+    p.client.data = {"response": " B "}
     out = _await_or_value(p.generate("t"))
     assert out == "B"
-    p.client.data = {"unknown": 1}  # type: ignore[attr-defined]
+    p.client.data = {"unknown": 1}
     out = _await_or_value(p.generate("t"))
     assert out == "{'unknown': 1}"


### PR DESCRIPTION
## Summary
- migrate runtime provider selection to Perplexity-first flow and remove Grok wiring (`providers/grok.py` -> `providers/perplexity.py`, `llm.py`, env defaults, CI env validation)
- align telemetry/debug surfaces and provider-focused tests with `PERPLEXITY_*` contracts, including lite fallback behavior and import-coverage suites
- harden placeholder-key behavior and CI/provider messaging based on bot review feedback

## Test plan
- [x] `pytest -q tests/test_llm.py tests/test_llm_extras.py tests/test_llm_lite_providers.py tests/quick/test_llm_quick_check.py tests/test_llm_simple_96.py tests/test_llm_import_coverage.py tests/test_llm_comprehensive.py tests/test_providers_unit.py tests/test_comprehensive_coverage.py tests/test_app_extended_coverage.py tests/test_app_coverage_unit_combined.py tests/test_insight_error_hygiene.py`
- [x] `make test-fast`
- [x] `pre-commit run --all-files` (hooks pass on commit/push path)
- [x] pre-push hooks (`mypy`, `pip-audit`, changed-file pytest, bandit full repo, docker build test)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1231_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [x] No actionable bot comments remain unmapped in canonical artifact
- [x] Pre-commit green

## Deferred / Follow-ups
- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Perplexity as a supported LLM provider with a local “lite” fallback when the real API is unavailable.

* **Chores**
  * Switched default LLM provider to Perplexity and removed prior provider-specific environment keys.
  * Added Perplexity environment variables and updated Docker Compose defaults.
  * Updated debug output and telemetry to reflect Perplexity model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->