### PR TITLE
fix(ci): Docker publish — Trivy SARIF upload when file exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,11 @@ jobs:
             --exit-code 0 \
             '${{ steps.image-ref.outputs.ref }}'
 
+      - name: Warn when Trivy image SARIF is missing
+        if: ${{ hashFiles('trivy-image.sarif') == '' }}
+        run: |
+          echo "::warning::Trivy image SARIF not produced; CodeQL upload will be skipped. Check scan logs (registry/auth/DB)."
+
       # upload-sarif fails closed if sarif is missing; Trivy may not write a file on hard errors.
       - name: Upload Trivy image scan results
         if: ${{ hashFiles('trivy-image.sarif') != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
           sudo apt-get install -y trivy
           trivy --version
 
+      # SARIF path must stay relative to GITHUB_WORKSPACE (hashFiles/upload-sarif assume repo root).
       - name: Run Trivy vulnerability scanner (filesystem scan)
         run: |
           trivy fs . \
@@ -126,9 +127,14 @@ jobs:
             --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
             --ignore-unfixed --exit-code 0 --ignorefile .trivyignore
 
+      - name: Warn when Trivy filesystem SARIF is missing
+        if: ${{ hashFiles('trivy-results.sarif') == '' }}
+        run: |
+          echo "::warning::Trivy filesystem SARIF not produced; Security tab upload skipped."
+
       - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ hashFiles('trivy-results.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
-        if: ${{ always() }}
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -208,6 +214,10 @@ jobs:
           sudo apt-get install -y trivy
           trivy --version
 
+      # Image scan: --exit-code 0 makes findings report-only (no fail on vuln count).
+      # continue-on-error: true keeps the publish job moving when Trivy fails before SARIF exists
+      # (DB/network/registry); hashFiles guards upload-sarif. Do not change output path without
+      # updating hashFiles('trivy-image.sarif') and upload/warn steps (paths are workspace-relative).
       - name: Run Trivy vulnerability scanner (image scan, report-only)
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,9 +215,12 @@ jobs:
             --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
             --format sarif --output trivy-image.sarif --severity CRITICAL,HIGH \
             --ignorefile .trivyignore \
+            --exit-code 0 \
             '${{ steps.image-ref.outputs.ref }}'
 
+      # upload-sarif fails closed if sarif is missing; Trivy may not write a file on hard errors.
       - name: Upload Trivy image scan results
+        if: ${{ hashFiles('trivy-image.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
         with:
           sarif_file: 'trivy-image.sarif'

--- a/docs/review/PR_1232_FIXED_MAPPING.md
+++ b/docs/review/PR_1232_FIXED_MAPPING.md
@@ -9,6 +9,12 @@ Evidence: `.github/workflows/build.yml` — `publish` builds and pushes the imag
 Reason: Intentional resilience vs. upload-sarif hard-fail; observability via logs and workflow warning, not job failure after push.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1232#discussion_r2983561400
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1232_FIXED_MAPPING.md:2-3` — required “Discussion Thread Pass” checkboxes are `[x]` on branch head (already in `c3e180e2`). CodeRabbit text assumed `[ ]`; file matches `scripts/orchestration/review_mapping_artifact.py` expectations (`CHECKBOX_DISCUSSION_PASS`, `CHECKBOX_FIXED_MAPPING`).
+Reason: Bot finding does not match repository artifact state; mapping records disposition for merge-readiness URL matching.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1232#discussion_r2983583099
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1232#pullrequestreview-4001491973
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (per disposition evidence)

--- a/docs/review/PR_1232_FIXED_MAPPING.md
+++ b/docs/review/PR_1232_FIXED_MAPPING.md
@@ -1,0 +1,12 @@
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+_Initial open: no review threads yet. Add `Disposition` blocks with evidence and `thread_url -> commit_sha` as bots/humans comment._
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (per disposition evidence)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] `pre-commit run --all-files` green on latest head

--- a/docs/review/PR_1232_FIXED_MAPPING.md
+++ b/docs/review/PR_1232_FIXED_MAPPING.md
@@ -1,9 +1,13 @@
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-_Initial open: no review threads yet. Add `Disposition` blocks with evidence and `thread_url -> commit_sha` as bots/humans comment._
+
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/build.yml` — `publish` builds and pushes the image before `trivy image`; failing late does not roll back GHCR. Unconditional `upload-sarif` failed `main` when SARIF was absent (CodeQL “Path does not exist”). Conditional upload plus `--exit-code 0`, `continue-on-error` on the scan step, and a `::warning::` step when SARIF is missing preserve publish while surfacing outages; filesystem Trivy remains in job `security-scan`.
+Reason: Intentional resilience vs. upload-sarif hard-fail; observability via logs and workflow warning, not job failure after push.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1232#discussion_r2983561400
 
 ## Merge Readiness
 - [ ] All required checks pass


### PR DESCRIPTION
## Summary
Fixes **Docker Build and Push** failing on `main` after publish: CodeQL `upload-sarif` expected `trivy-image.sarif` but the file was missing (run `23505004925`, error: `Path does not exist: trivy-image.sarif`).

## Changes
- Add `--exit-code 0` to image scan (report-only for findings).
- Gate **Upload Trivy image scan results** with `hashFiles('trivy-image.sarif') != ''`.
- Emit `::warning::` when SARIF is missing so scanner outages are visible without failing `upload-sarif`.

## Verification
- `pre-commit` / pre-push — pass on branch.

## Deferred / Follow-ups
- If missing SARIF is frequent, investigate Trivy pull/auth for the pushed `ghcr.io` ref.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1232_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made vulnerability scans in the build pipeline non-blocking: scan results now run in report-only mode, explicit warnings are shown when scan outputs are missing, and uploads are skipped when no scan output is produced.
* **Documentation**
  * Added a review checklist template to track discussion-thread status, map fixes to commits, and define merge-readiness criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->