### PR TITLE
Feat/c3 recursive ai optimization followthrough

### DIFF
--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -42,6 +42,8 @@ class OptimizationStats(TypedDict):
     enabled: bool
     refinement_cache_hits: int
     cache_hits: int
+    hop_vector_cache_hits: int
+    hop_vector_retrieve_calls: int
     verification_calls: int
     stop_reason: OptimizationStopReason
     early_stop_no_query_change: bool

--- a/core/rag/rag_constants.py
+++ b/core/rag/rag_constants.py
@@ -14,6 +14,9 @@ MAX_REFINEMENT_PASSES: int = 2
 MAX_VERIFICATION_QUERIES: int = 2
 MIN_CONFIDENCE_GAIN_PER_HOP: float = 0.02
 
+# Request-scoped hop vector memo (C3 follow-through; optimization path only)
+MAX_HOP_VECTOR_CACHE_ENTRIES: int = 32
+
 # Vector retrieval constants (P2)
 EMBEDDING_MODEL_NAME: str = "all-mpnet-base-v2"
 EMBEDDING_DIMENSIONS: int = 768

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -23,6 +23,8 @@ from core.rag.rag_constants import (
     RAG_PIPELINE_TIMEOUT_SEC,
 )
 
+import core.rag.vector_rag as vector_rag
+
 logger = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"[\w\-]+", re.UNICODE)
@@ -279,10 +281,8 @@ def _retrieve_vector_for_recursive_hop(
     optimization_stats: OptimizationStats | None,
 ) -> RAGContext:
     """Vector retrieve with optional request-scoped hop memo (optimization path only)."""
-    from core.rag.vector_rag import retrieve_context_structured
-
     if hop_vector_cache is None:
-        return retrieve_context_structured(
+        return vector_rag.retrieve_context_structured(
             current_query,
             max_chunks=limit,
             agent_id=agent_id,
@@ -295,7 +295,7 @@ def _retrieve_vector_for_recursive_hop(
         if optimization_stats is not None:
             _increment_stat(optimization_stats, "hop_vector_cache_hits")
         return cached
-    ctx = retrieve_context_structured(
+    ctx = vector_rag.retrieve_context_structured(
         current_query,
         max_chunks=limit,
         agent_id=agent_id,

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -23,8 +23,6 @@ from core.rag.rag_constants import (
     RAG_PIPELINE_TIMEOUT_SEC,
 )
 
-import core.rag.vector_rag as vector_rag
-
 logger = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"[\w\-]+", re.UNICODE)
@@ -219,6 +217,33 @@ def _hop_vector_cache_key(
     )
 
 
+def _retrieve_context_structured(
+    query: str,
+    *,
+    max_chunks: int,
+    agent_id: str | None,
+    user_tier: str | None,
+    subject_id: int | None,
+) -> RAGContext:
+    """Lazy import of vector RAG so import-time failures stay outside this module.
+
+    RU: Ошибки импорта `vector_rag` не должны ломать загрузку `recursive_retrieval`.
+    EN: Keeps recursive retrieval importable when the vector stack is optional or broken.
+    """
+    import core.rag.vector_rag as vector_rag_mod
+
+    return cast(
+        RAGContext,
+        vector_rag_mod.retrieve_context_structured(
+            query,
+            max_chunks=max_chunks,
+            agent_id=agent_id,
+            user_tier=user_tier,
+            subject_id=subject_id,
+        ),
+    )
+
+
 def _copy_rag_context_snapshot(ctx: RAGContext) -> RAGContext:
     """Return an isolated copy so hop wrapping cannot mutate cached vector rows."""
     return RAGContext(
@@ -258,16 +283,18 @@ class _FifoBoundedHopVectorCache:
             return None
         return _copy_rag_context_snapshot(self._data[key])
 
-    def put(self, key: tuple[str, int, str, str, int | None], ctx: RAGContext) -> None:
+    def put(self, key: tuple[str, int, str, str, int | None], ctx: RAGContext) -> RAGContext:
+        """Store an isolated snapshot and return it (avoid second snapshot from raw ctx)."""
         snap = _copy_rag_context_snapshot(ctx)
         if key in self._data:
             self._data[key] = snap
-            return
+            return snap
         if len(self._order) >= self._max_entries:
             oldest = self._order.pop(0)
             self._data.pop(oldest, None)
         self._order.append(key)
         self._data[key] = snap
+        return snap
 
 
 def _retrieve_vector_for_recursive_hop(
@@ -282,15 +309,12 @@ def _retrieve_vector_for_recursive_hop(
 ) -> RAGContext:
     """Vector retrieve with optional request-scoped hop memo (optimization path only)."""
     if hop_vector_cache is None:
-        return cast(
-            RAGContext,
-            vector_rag.retrieve_context_structured(
-                current_query,
-                max_chunks=limit,
-                agent_id=agent_id,
-                user_tier=user_tier,
-                subject_id=subject_id,
-            ),
+        return _retrieve_context_structured(
+            current_query,
+            max_chunks=limit,
+            agent_id=agent_id,
+            user_tier=user_tier,
+            subject_id=subject_id,
         )
     key = _hop_vector_cache_key(current_query, limit, agent_id, user_tier, subject_id)
     cached = hop_vector_cache.get_copy(key)
@@ -298,20 +322,17 @@ def _retrieve_vector_for_recursive_hop(
         if optimization_stats is not None:
             _increment_stat(optimization_stats, "hop_vector_cache_hits")
         return cached
-    ctx = cast(
-        RAGContext,
-        vector_rag.retrieve_context_structured(
-            current_query,
-            max_chunks=limit,
-            agent_id=agent_id,
-            user_tier=user_tier,
-            subject_id=subject_id,
-        ),
+    ctx = _retrieve_context_structured(
+        current_query,
+        max_chunks=limit,
+        agent_id=agent_id,
+        user_tier=user_tier,
+        subject_id=subject_id,
     )
     if optimization_stats is not None:
         _increment_stat(optimization_stats, "hop_vector_retrieve_calls")
-    hop_vector_cache.put(key, ctx)
-    return _copy_rag_context_snapshot(ctx)
+    stored_snap = hop_vector_cache.put(key, ctx)
+    return _copy_rag_context_snapshot(stored_snap)
 
 
 def retrieve_recursive_context_structured(

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -282,12 +282,15 @@ def _retrieve_vector_for_recursive_hop(
 ) -> RAGContext:
     """Vector retrieve with optional request-scoped hop memo (optimization path only)."""
     if hop_vector_cache is None:
-        return vector_rag.retrieve_context_structured(
-            current_query,
-            max_chunks=limit,
-            agent_id=agent_id,
-            user_tier=user_tier,
-            subject_id=subject_id,
+        return cast(
+            RAGContext,
+            vector_rag.retrieve_context_structured(
+                current_query,
+                max_chunks=limit,
+                agent_id=agent_id,
+                user_tier=user_tier,
+                subject_id=subject_id,
+            ),
         )
     key = _hop_vector_cache_key(current_query, limit, agent_id, user_tier, subject_id)
     cached = hop_vector_cache.get_copy(key)
@@ -295,12 +298,15 @@ def _retrieve_vector_for_recursive_hop(
         if optimization_stats is not None:
             _increment_stat(optimization_stats, "hop_vector_cache_hits")
         return cached
-    ctx = vector_rag.retrieve_context_structured(
-        current_query,
-        max_chunks=limit,
-        agent_id=agent_id,
-        user_tier=user_tier,
-        subject_id=subject_id,
+    ctx = cast(
+        RAGContext,
+        vector_rag.retrieve_context_structured(
+            current_query,
+            max_chunks=limit,
+            agent_id=agent_id,
+            user_tier=user_tier,
+            subject_id=subject_id,
+        ),
     )
     if optimization_stats is not None:
         _increment_stat(optimization_stats, "hop_vector_retrieve_calls")

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -1,4 +1,4 @@
-"""Deterministic recursive RAG retrieval (W1 core-only).
+"""Deterministic recursive RAG retrieval (C3 bounded follow-through).
 
 Performs multi-hop retrieval with deterministic query refinement and
 bounded verification passes. No LLM calls are made in the loop.
@@ -14,6 +14,7 @@ from typing import Dict, Iterable, List, cast
 from core.data_sanitizer import sanitize_rag_markdown
 from core.rag.contracts import OptimizationStats, OptimizationStopReason, RAGChunk, RAGContext
 from core.rag.rag_constants import (
+    MAX_HOP_VECTOR_CACHE_ENTRIES,
     MAX_RAG_HOPS,
     MAX_REFINEMENT_PASSES,
     MAX_SOURCES_IN_RESPONSE,
@@ -79,6 +80,8 @@ def _make_optimization_stats() -> OptimizationStats:
         "enabled": True,
         "refinement_cache_hits": 0,
         "cache_hits": 0,
+        "hop_vector_cache_hits": 0,
+        "hop_vector_retrieve_calls": 0,
         "verification_calls": 0,
         "stop_reason": OptimizationStopReason.COMPLETED,
         "early_stop_no_query_change": False,
@@ -192,6 +195,119 @@ def _apply_verification(
     return filtered
 
 
+def _normalize_hop_vector_cache_query(query: str) -> str:
+    """Deterministic normalization for hop-level vector memo keys."""
+    return " ".join(query.split()).strip().lower()
+
+
+def _hop_vector_cache_key(
+    query: str,
+    limit: int,
+    agent_id: str | None,
+    user_tier: str | None,
+    subject_id: int | None,
+) -> tuple[str, int, str, str, int | None]:
+    """Cache key dimensions must match ``retrieve_context_structured`` call semantics."""
+    return (
+        _normalize_hop_vector_cache_query(query),
+        limit,
+        agent_id or "",
+        user_tier or "",
+        subject_id,
+    )
+
+
+def _copy_rag_context_snapshot(ctx: RAGContext) -> RAGContext:
+    """Return an isolated copy so hop wrapping cannot mutate cached vector rows."""
+    return RAGContext(
+        query=ctx.query,
+        refined_queries=list(ctx.refined_queries),
+        chunks=[
+            RAGChunk(
+                chunk_id=c.chunk_id,
+                file=c.file,
+                content=c.content,
+                score=c.score,
+                hop=c.hop,
+            )
+            for c in ctx.chunks
+        ],
+        confidence=ctx.confidence,
+        hops=ctx.hops,
+        latency_ms=ctx.latency_ms,
+        agent_id=ctx.agent_id,
+        user_tier=ctx.user_tier,
+        optimization_stats=None,
+    )
+
+
+class _FifoBoundedHopVectorCache:
+    """FIFO-bounded request-scoped cache for vector ``RAGContext`` snapshots."""
+
+    __slots__ = ("_data", "_max_entries", "_order")
+
+    def __init__(self, max_entries: int) -> None:
+        self._max_entries = max(1, max_entries)
+        self._order: list[tuple[str, int, str, str, int | None]] = []
+        self._data: dict[tuple[str, int, str, str, int | None], RAGContext] = {}
+
+    def get_copy(self, key: tuple[str, int, str, str, int | None]) -> RAGContext | None:
+        if key not in self._data:
+            return None
+        return _copy_rag_context_snapshot(self._data[key])
+
+    def put(self, key: tuple[str, int, str, str, int | None], ctx: RAGContext) -> None:
+        snap = _copy_rag_context_snapshot(ctx)
+        if key in self._data:
+            self._data[key] = snap
+            return
+        if len(self._order) >= self._max_entries:
+            oldest = self._order.pop(0)
+            self._data.pop(oldest, None)
+        self._order.append(key)
+        self._data[key] = snap
+
+
+def _retrieve_vector_for_recursive_hop(
+    *,
+    current_query: str,
+    limit: int,
+    agent_id: str | None,
+    user_tier: str | None,
+    subject_id: int | None,
+    hop_vector_cache: _FifoBoundedHopVectorCache | None,
+    optimization_stats: OptimizationStats | None,
+) -> RAGContext:
+    """Vector retrieve with optional request-scoped hop memo (optimization path only)."""
+    from core.rag.vector_rag import retrieve_context_structured
+
+    if hop_vector_cache is None:
+        return retrieve_context_structured(
+            current_query,
+            max_chunks=limit,
+            agent_id=agent_id,
+            user_tier=user_tier,
+            subject_id=subject_id,
+        )
+    key = _hop_vector_cache_key(current_query, limit, agent_id, user_tier, subject_id)
+    cached = hop_vector_cache.get_copy(key)
+    if cached is not None:
+        if optimization_stats is not None:
+            _increment_stat(optimization_stats, "hop_vector_cache_hits")
+        return cached
+    ctx = retrieve_context_structured(
+        current_query,
+        max_chunks=limit,
+        agent_id=agent_id,
+        user_tier=user_tier,
+        subject_id=subject_id,
+    )
+    if optimization_stats is not None:
+        _increment_stat(optimization_stats, "hop_vector_retrieve_calls")
+    hop_vector_cache.put(key, ctx)
+    return _copy_rag_context_snapshot(ctx)
+
+
 def retrieve_recursive_context_structured(
     query: str,
     max_chunks: int = 3,
@@ -223,10 +339,11 @@ def retrieve_recursive_context_structured(
     refinement_token_cache: dict[tuple[str, str], list[str]] | None = (
         {} if optimization_enabled else None
     )
+    hop_vector_cache: _FifoBoundedHopVectorCache | None = (
+        _FifoBoundedHopVectorCache(MAX_HOP_VECTOR_CACHE_ENTRIES) if optimization_enabled else None
+    )
 
     try:
-        from core.rag.vector_rag import retrieve_context_structured
-
         for hop in range(1, MAX_RAG_HOPS + 1):
             elapsed_sec = time.perf_counter() - start_ts
             if elapsed_sec >= RAG_PIPELINE_TIMEOUT_SEC:
@@ -243,12 +360,14 @@ def retrieve_recursive_context_structured(
                 break
 
             hops_done = hop
-            hop_ctx = retrieve_context_structured(
-                current_query,
-                max_chunks=limit,
+            hop_ctx = _retrieve_vector_for_recursive_hop(
+                current_query=current_query,
+                limit=limit,
                 agent_id=agent_id,
                 user_tier=user_tier,
                 subject_id=subject_id,
+                hop_vector_cache=hop_vector_cache,
+                optimization_stats=optimization_stats,
             )
             if not hop_ctx.chunks:
                 if hop > 1:

--- a/docs/review/PR_1233_FIXED_MAPPING.md
+++ b/docs/review/PR_1233_FIXED_MAPPING.md
@@ -16,6 +16,12 @@ Evidence: `tests/test_recursive_rag.py` (`test_hop_vector_cache_hits_on_revisite
 Reason: Request-scoped hop memo is an intentional C3 optimization: bounded FIFO dedup when a normalized key repeats within a request (tests drive revisits via `_refine_query`); typical single-path refinement rarely collides, but the feature is covered and overhead is capped.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983870123
 
+Disposition: FIXED
+Commit: 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
+Evidence: `scripts/benchmark_recursive_rag_hop_cache.py` (fail-fast when `TESTING` is preset to a non-`true` value; `stop_reason` JSON uses `Enum.value`)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983896088 -> 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983896101 -> 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
+
 ## Merge Readiness
 
 - [ ] All required checks pass

--- a/docs/review/PR_1233_FIXED_MAPPING.md
+++ b/docs/review/PR_1233_FIXED_MAPPING.md
@@ -22,6 +22,16 @@ Evidence: `scripts/benchmark_recursive_rag_hop_cache.py` (fail-fast when `TESTIN
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983896088 -> 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983896101 -> 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
 
+Disposition: FIXED
+Commit: d0808ee6f77de72638003bfbd0d92b0682ec8717
+Evidence: `core/rag/recursive_retrieval.py`; Sourcery bot submitted-review rollup (same scope as inline threads mapped above)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#pullrequestreview-4001819503 -> d0808ee6f77de72638003bfbd0d92b0682ec8717
+
+Disposition: FIXED
+Commit: 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
+Evidence: `scripts/benchmark_recursive_rag_hop_cache.py`; CodeRabbit bot submitted-review rollup (same scope as inline threads mapped above)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#pullrequestreview-4001862271 -> 6b53b5f604ec217fdff39e141b1b6ddaf8de798d
+
 ## Merge Readiness
 
 - [ ] All required checks pass

--- a/docs/review/PR_1233_FIXED_MAPPING.md
+++ b/docs/review/PR_1233_FIXED_MAPPING.md
@@ -1,0 +1,24 @@
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: d0808ee6f77de72638003bfbd0d92b0682ec8717
+Evidence: `core/rag/recursive_retrieval.py` (`_retrieve_context_structured` lazy-import; `_FifoBoundedHopVectorCache.put` returns stored snapshot; miss path returns `_copy_rag_context_snapshot(stored_snap)`)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983856222 -> d0808ee6f77de72638003bfbd0d92b0682ec8717
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983870118 -> d0808ee6f77de72638003bfbd0d92b0682ec8717
+
+Disposition: NOT-A-BUG
+Evidence: `tests/test_recursive_rag.py` (`test_hop_vector_cache_hits_on_revisited_query_across_hops`, FIFO and flag-off parity tests); `scripts/benchmark_recursive_rag_hop_cache.py`
+Reason: Request-scoped hop memo is an intentional C3 optimization: bounded FIFO dedup when a normalized key repeats within a request (tests drive revisits via `_refine_query`); typical single-path refinement rarely collides, but the feature is covered and overhead is capped.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1233#discussion_r2983870123
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,13 @@ exclude = '''
 module = ["app.security.rate_limit"]
 warn_unused_ignores = false
 
+[[tool.mypy.overrides]]
+# ``cast(RAGContext, vector_rag.retrieve_context_structured(...))`` is required for pre-push mypy
+# (--follow-imports=skip treats ``vector_rag`` as partially unknown). Full mypy resolves imports and
+# would flag redundant-cast without this override.
+module = ["core.rag.recursive_retrieval"]
+disable_error_code = ["redundant-cast"]
+
 [tool.black]
 line-length = 100
 target-version = ["py313"]

--- a/scripts/benchmark_recursive_rag_hop_cache.py
+++ b/scripts/benchmark_recursive_rag_hop_cache.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 import time
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -24,8 +25,15 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-# Tests set this before importing app; keep parity for imports that read env.
-os.environ.setdefault("TESTING", "true")
+# Deterministic harness: this script requires TESTING=true (fail fast if preset otherwise).
+_testing = os.environ.get("TESTING")
+if _testing is None:
+    os.environ["TESTING"] = "true"
+elif _testing.lower() != "true":
+    raise RuntimeError(
+        "benchmark_recursive_rag_hop_cache requires TESTING=true; "
+        f"got TESTING={_testing!r}. Unset TESTING or set it to 'true'."
+    )
 
 
 def _ctx(query: str, chunks: list[Any], confidence: float = 0.7) -> Any:
@@ -115,7 +123,11 @@ def _run_harness(*, optimization_enabled: bool) -> dict[str, Any]:
     if stats is not None:
         out["hop_vector_cache_hits"] = stats.get("hop_vector_cache_hits")
         out["hop_vector_retrieve_calls"] = stats.get("hop_vector_retrieve_calls")
-        out["stop_reason"] = str(stats.get("stop_reason"))
+        stop_reason = stats.get("stop_reason")
+        if isinstance(stop_reason, Enum):
+            out["stop_reason"] = stop_reason.value
+        else:
+            out["stop_reason"] = None if stop_reason is None else str(stop_reason)
     return out
 
 

--- a/scripts/benchmark_recursive_rag_hop_cache.py
+++ b/scripts/benchmark_recursive_rag_hop_cache.py
@@ -83,8 +83,8 @@ def _run_harness(*, optimization_enabled: bool) -> dict[str, Any]:
             return "first"
         return current
 
-    vector_rag.retrieve_context_structured = _fake_retrieve  # type: ignore[assignment]
-    recursive._refine_query = _fake_refine  # type: ignore[assignment]
+    setattr(vector_rag, "retrieve_context_structured", _fake_retrieve)
+    setattr(recursive, "_refine_query", _fake_refine)
 
     t0 = time.perf_counter()
     try:
@@ -97,8 +97,8 @@ def _run_harness(*, optimization_enabled: bool) -> dict[str, Any]:
         setattr(recursive, "MAX_REFINEMENT_PASSES", prev_ref)
         setattr(recursive, "MAX_VERIFICATION_QUERIES", prev_ver)
         setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", prev_gain)
-        vector_rag.retrieve_context_structured = prev_retrieve  # type: ignore[assignment]
-        recursive._refine_query = prev_refine  # type: ignore[assignment]
+        setattr(vector_rag, "retrieve_context_structured", prev_retrieve)
+        setattr(recursive, "_refine_query", prev_refine)
 
     elapsed_ms = int((time.perf_counter() - t0) * 1000)
 
@@ -130,7 +130,7 @@ def _run_fail_safe() -> dict[str, Any]:
         raise RuntimeError("benchmark boom")
 
     prev = vector_rag.retrieve_context_structured
-    vector_rag.retrieve_context_structured = _boom  # type: ignore[assignment]
+    setattr(vector_rag, "retrieve_context_structured", _boom)
     try:
         # Silence exc_info logging from the intentional failure path (stderr noise).
         with patch.object(recursive.logger, "warning"):
@@ -142,7 +142,7 @@ def _run_fail_safe() -> dict[str, Any]:
             "optimization_stats_present": result.optimization_stats is not None,
         }
     finally:
-        vector_rag.retrieve_context_structured = prev  # type: ignore[assignment]
+        setattr(vector_rag, "retrieve_context_structured", prev)
 
 
 def main() -> int:

--- a/scripts/benchmark_recursive_rag_hop_cache.py
+++ b/scripts/benchmark_recursive_rag_hop_cache.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Bounded local benchmark artifact: C3 hop-level vector memo (recursive path).
+
+RU: Локальное воспроизводимое доказательство без внешнего кэша и без новых API.
+EN: Reproducible evidence for PR review — no Redis, no new endpoints, no response fields.
+
+Run from repo root::
+
+    python3 scripts/benchmark_recursive_rag_hop_cache.py
+
+Exit code 0 prints JSON lines with counters and wall-clock for the patched harness only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Tests set this before importing app; keep parity for imports that read env.
+os.environ.setdefault("TESTING", "true")
+
+
+def _ctx(query: str, chunks: list[Any], confidence: float = 0.7) -> Any:
+    from core.rag.contracts import RAGContext
+
+    return RAGContext(
+        query=query,
+        refined_queries=[query],
+        chunks=chunks,
+        confidence=confidence,
+        hops=1,
+        latency_ms=1,
+    )
+
+
+def _run_harness(*, optimization_enabled: bool) -> dict[str, Any]:
+    import core.rag.recursive_retrieval as recursive
+    import core.rag.vector_rag as vector_rag
+    from core.rag.contracts import RAGChunk
+
+    # Match tests/test_recursive_rag.py hop-cache scenario (three hops, revisit query).
+    prev_hops = recursive.MAX_RAG_HOPS
+    prev_ref = recursive.MAX_REFINEMENT_PASSES
+    prev_ver = recursive.MAX_VERIFICATION_QUERIES
+    prev_gain = recursive.MIN_CONFIDENCE_GAIN_PER_HOP
+    prev_retrieve = vector_rag.retrieve_context_structured
+    prev_refine = recursive._refine_query
+
+    setattr(recursive, "MAX_RAG_HOPS", 3)
+    setattr(recursive, "MAX_REFINEMENT_PASSES", 5)
+    setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+    setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+    calls = {"n": 0}
+
+    def _fake_retrieve(query: str, **_: Any) -> Any:
+        calls["n"] += 1
+        return _ctx(
+            query,
+            [
+                RAGChunk(
+                    chunk_id=f"doc-{len(query)}",
+                    file="doc.md",
+                    content=f"fiber vegetables nutrition guidance token{len(query)}",
+                    score=0.7,
+                )
+            ],
+            confidence=0.7,
+        )
+
+    def _fake_refine(current: str, *_args: Any, **_kwargs: Any) -> str:
+        if current == "first":
+            return "second"
+        if current == "second":
+            return "first"
+        return current
+
+    vector_rag.retrieve_context_structured = _fake_retrieve  # type: ignore[assignment]
+    recursive._refine_query = _fake_refine  # type: ignore[assignment]
+
+    t0 = time.perf_counter()
+    try:
+        result = recursive.retrieve_recursive_context_structured(
+            "first",
+            optimization_enabled=optimization_enabled,
+        )
+    finally:
+        setattr(recursive, "MAX_RAG_HOPS", prev_hops)
+        setattr(recursive, "MAX_REFINEMENT_PASSES", prev_ref)
+        setattr(recursive, "MAX_VERIFICATION_QUERIES", prev_ver)
+        setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", prev_gain)
+        vector_rag.retrieve_context_structured = prev_retrieve  # type: ignore[assignment]
+        recursive._refine_query = prev_refine  # type: ignore[assignment]
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+
+    stats = result.optimization_stats
+    out: dict[str, Any] = {
+        "optimization_enabled": optimization_enabled,
+        "elapsed_ms": elapsed_ms,
+        "vector_retrieve_calls": calls["n"],
+        "hop_vector_cache_hits": None,
+        "hop_vector_retrieve_calls": None,
+        "stop_reason": None,
+        "chunks": len(result.chunks),
+    }
+    if stats is not None:
+        out["hop_vector_cache_hits"] = stats.get("hop_vector_cache_hits")
+        out["hop_vector_retrieve_calls"] = stats.get("hop_vector_retrieve_calls")
+        out["stop_reason"] = str(stats.get("stop_reason"))
+    return out
+
+
+def _run_fail_safe() -> dict[str, Any]:
+    from unittest.mock import patch
+
+    import core.rag.recursive_retrieval as recursive
+    import core.rag.vector_rag as vector_rag
+    from core.rag.recursive_retrieval import retrieve_recursive_context_structured
+
+    def _boom(*_: Any, **__: Any) -> Any:
+        raise RuntimeError("benchmark boom")
+
+    prev = vector_rag.retrieve_context_structured
+    vector_rag.retrieve_context_structured = _boom  # type: ignore[assignment]
+    try:
+        # Silence exc_info logging from the intentional failure path (stderr noise).
+        with patch.object(recursive.logger, "warning"):
+            result = retrieve_recursive_context_structured("x", optimization_enabled=True)
+        return {
+            "scenario": "fail_safe",
+            "chunks": len(result.chunks),
+            "confidence": result.confidence,
+            "optimization_stats_present": result.optimization_stats is not None,
+        }
+    finally:
+        vector_rag.retrieve_context_structured = prev  # type: ignore[assignment]
+
+
+def main() -> int:
+    rows = [
+        {"scenario": "flag_off_parity", **_run_harness(optimization_enabled=False)},
+        {"scenario": "flag_on_memo", **_run_harness(optimization_enabled=True)},
+    ]
+    rows.append(_run_fail_safe())
+    for row in rows:
+        print(json.dumps(row, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_recursive_rag.py
+++ b/tests/test_recursive_rag.py
@@ -788,3 +788,167 @@ def test_optimized_recursive_preserves_partial_context_when_helper_raises(
     assert result.refined_queries == ["base query"]
     assert result.optimization_stats is not None
     assert result.optimization_stats["enabled"] is True
+
+
+def test_fifo_hop_vector_cache_evicts_oldest_when_full() -> None:
+    """Bounded FIFO must drop the oldest entry when capacity is exceeded."""
+    import core.rag.recursive_retrieval as recursive
+    from core.rag.contracts import RAGChunk, RAGContext
+
+    cache = recursive._FifoBoundedHopVectorCache(2)
+    key_a = ("a", 3, "", "", None)
+    key_b = ("b", 3, "", "", None)
+    key_c = ("c", 3, "", "", None)
+
+    def _ctx_for(label: str) -> RAGContext:
+        return RAGContext(
+            query=label,
+            refined_queries=[label],
+            chunks=[RAGChunk(chunk_id=label, file="d.md", content="ok", score=0.5)],
+            confidence=0.5,
+            hops=1,
+            latency_ms=1,
+        )
+
+    cache.put(key_a, _ctx_for("a"))
+    cache.put(key_b, _ctx_for("b"))
+    cache.put(key_c, _ctx_for("c"))
+
+    assert cache.get_copy(key_a) is None
+    assert cache.get_copy(key_b) is not None
+    assert cache.get_copy(key_c) is not None
+
+
+def test_fifo_hop_vector_cache_put_updates_existing_key_in_place() -> None:
+    """Replacing an existing key must refresh the snapshot without duplicate order slots."""
+    import core.rag.recursive_retrieval as recursive
+    from core.rag.contracts import RAGChunk, RAGContext
+
+    cache = recursive._FifoBoundedHopVectorCache(4)
+    key = ("same", 3, "", "", None)
+    first = RAGContext(
+        query="same",
+        refined_queries=["same"],
+        chunks=[RAGChunk(chunk_id="v1", file="d.md", content="one", score=0.4)],
+        confidence=0.4,
+        hops=1,
+        latency_ms=1,
+    )
+    second = RAGContext(
+        query="same",
+        refined_queries=["same"],
+        chunks=[RAGChunk(chunk_id="v2", file="d.md", content="two", score=0.9)],
+        confidence=0.9,
+        hops=1,
+        latency_ms=1,
+    )
+    cache.put(key, first)
+    cache.put(key, second)
+    out = cache.get_copy(key)
+    assert out is not None
+    assert out.chunks[0].chunk_id == "v2"
+
+
+def test_hop_vector_cache_key_normalizes_whitespace_and_splits_subject() -> None:
+    """Hop memo keys must be stable on whitespace and tenant-scoped."""
+    import core.rag.recursive_retrieval as recursive
+
+    k1 = recursive._hop_vector_cache_key("  a  b  ", 3, None, None, None)
+    k2 = recursive._hop_vector_cache_key("a b", 3, None, None, None)
+    assert k1 == k2
+
+    k3 = recursive._hop_vector_cache_key("a b", 3, None, None, 1)
+    k4 = recursive._hop_vector_cache_key("a b", 3, None, None, 2)
+    assert k3 != k4
+
+
+def test_hop_vector_cache_hits_on_revisited_query_across_hops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a later hop repeats an earlier query, vector retrieve must be memoized."""
+    import core.rag.recursive_retrieval as recursive
+
+    monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 3)
+    monkeypatch.setattr(recursive, "MAX_REFINEMENT_PASSES", 5)
+    monkeypatch.setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+    monkeypatch.setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+    calls = {"n": 0}
+
+    def _fake_retrieve(query: str, **_: Any) -> RAGContext:
+        calls["n"] += 1
+        return _ctx(
+            query,
+            [
+                RAGChunk(
+                    chunk_id=f"doc-{len(query)}",
+                    file="doc.md",
+                    content=f"fiber vegetables nutrition guidance token{len(query)}",
+                    score=0.7,
+                )
+            ],
+            confidence=0.7,
+        )
+
+    monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _fake_retrieve)
+
+    def _fake_refine(current: str, *_args: Any, **_kwargs: Any) -> str:
+        if current == "first":
+            return "second"
+        if current == "second":
+            return "first"
+        return current
+
+    monkeypatch.setattr(recursive, "_refine_query", _fake_refine)
+
+    result = retrieve_recursive_context_structured("first", optimization_enabled=True)
+
+    assert result.optimization_stats is not None
+    assert result.optimization_stats["hop_vector_cache_hits"] >= 1
+    assert result.optimization_stats["hop_vector_retrieve_calls"] == 2
+    assert calls["n"] == 2
+
+
+def test_hop_vector_cache_disabled_when_optimization_flag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag-off path must call vector retrieve once per hop (no memo layer)."""
+    import core.rag.recursive_retrieval as recursive
+
+    monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 3)
+    monkeypatch.setattr(recursive, "MAX_REFINEMENT_PASSES", 5)
+    monkeypatch.setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+    monkeypatch.setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+    calls = {"n": 0}
+
+    def _fake_retrieve(query: str, **_: Any) -> RAGContext:
+        calls["n"] += 1
+        return _ctx(
+            query,
+            [
+                RAGChunk(
+                    chunk_id=f"doc-{len(query)}",
+                    file="doc.md",
+                    content=f"fiber vegetables nutrition guidance token{len(query)}",
+                    score=0.7,
+                )
+            ],
+            confidence=0.7,
+        )
+
+    monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _fake_retrieve)
+
+    def _fake_refine(current: str, *_args: Any, **_kwargs: Any) -> str:
+        if current == "first":
+            return "second"
+        if current == "second":
+            return "first"
+        return current
+
+    monkeypatch.setattr(recursive, "_refine_query", _fake_refine)
+
+    result = retrieve_recursive_context_structured("first", optimization_enabled=False)
+
+    assert result.optimization_stats is None
+    assert calls["n"] == 3


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `<review-comment-url>` -> `<commit-sha>`
- No actionable review comments

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

<!-- markdownlint-enable MD013 MD033 -->

## Summary by Sourcery

Ввести кэш выборки векторов на уровне переходов с областью видимости в пределах запроса в рекурсивный конвейер RAG и отразить его поведение в статистике оптимизации.

Новые возможности:
- Добавить ограниченный по размеру FIFO‑кэш векторов на уровне перехода для структурированной выборки векторов внутри рекурсивного RAG, индексируемый нормализованным запросом и контекстом арендатора (tenant context).
- Отслеживать количество попаданий в кэш векторов на уровне перехода и количество базовых вызовов выборки векторов в статистике оптимизации для рекурсивного RAG.

Улучшения:
- Уточнить логику выборки в рекурсивном RAG, чтобы направлять обращения к вектору перехода через отдельный вспомогательный метод, который при необходимости использует кэш на уровне запроса, при этом сохраняя текущее поведение, когда оптимизация выключена.
- Добавить настраиваемую константу для ограничения размера кэша векторов на уровне перехода и нормализовать ключи кэша векторов перехода для детерминированного мемоизирования.
- Предоставить изолированный вспомогательный метод для получения snapshot в `RAGContext`, чтобы предотвратить последующие изменения закэшированных результатов выборки векторов.

Сборка:
- Ослабить проверку mypy на redundant-cast для модуля рекурсивной выборки, чтобы учесть приведения типов, необходимые при частичном анализе импортов.

Тесты:
- Расширить тесты для рекурсивного RAG, чтобы покрыть вытеснение по FIFO, обновление кэша на месте, нормализацию и область видимости ключей кэша, поведение мемоизации между переходами и соответствие поведения при выключенном флаге (кэш отключен).

Прочее:
- Добавить автономный скрипт бенчмарка для измерения и демонстрации влияния и безопасного поведения кэша векторов на уровне перехода в рекурсивном пути RAG.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a request-scoped hop-level vector retrieval cache to the recursive RAG pipeline and expose its behavior via optimization stats.

New Features:
- Add a bounded FIFO hop-level vector cache for structured vector retrieval within recursive RAG, keyed by normalized query and tenant context.
- Track hop-level vector cache hit and underlying vector retrieval call counts in optimization statistics for recursive RAG.

Enhancements:
- Refine recursive RAG retrieval to route hop vector lookups through a dedicated helper that optionally uses the per-request cache while preserving existing behavior when optimization is disabled.
- Add a tunable constant to bound hop-level vector cache size and normalize hop vector cache keys for deterministic memoization.
- Provide an isolated snapshot helper for RAGContext to prevent downstream mutation of cached vector retrieval results.

Build:
- Relax mypy redundant-cast checking for the recursive retrieval module to accommodate casts needed under partial import analysis.

Tests:
- Extend recursive RAG tests to cover FIFO eviction, in-place cache updates, cache key normalization and scoping, memoization behavior across hops, and flag-off parity with cache disabled.

Chores:
- Add a standalone benchmark script to measure and demonstrate the impact and fail-safe behavior of the hop-level vector cache in the recursive RAG path.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded, request-scoped hop-level vector cache to recursive RAG when optimization is enabled to avoid duplicate vector lookups across hops. No public API changes; flag-off behavior is unchanged.

- **New Features**
  - FIFO hop vector memo keyed by normalized query + chunk limit + tenant context; size via `MAX_HOP_VECTOR_CACHE_ENTRIES`.
  - Optimization stats now include `hop_vector_cache_hits` and `hop_vector_retrieve_calls`.
  - Adds `scripts/benchmark_recursive_rag_hop_cache.py` and tests for cache hits, FIFO eviction, key normalization, and flag-off parity.

- **Refactors**
  - Route vector retrieval through a helper with lazy import; return isolated snapshots to prevent mutation and keep `recursive_retrieval` import-safe if the vector stack fails.
  - Scoped mypy override (`redundant-cast`) for `core.rag.recursive_retrieval`; no behavior changes.

<sup>Written for commit 5575c1bf5491ae9c7741265d8b1ff3fd6865a9a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-scoped caching for vector retrieval in recursive flows to avoid redundant lookups across hops.

* **Improvements**
  * Expanded optimization diagnostics with two new metrics tracking cache hits and retrieval calls.

* **Testing & Tooling**
  * Added a benchmark script to measure recursive retrieval performance with and without the cache.
  * Added unit/integration tests covering cache behavior and memoization correctness.

* **Documentation**
  * New review notes documenting the change and review disposition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
