### PR TITLE
fix(tests): stabilize llm importlib.reload after sys.modules eviction

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1085,7 +1085,7 @@
         "filename": "tests/test_llm_import_coverage.py",
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 87
       }
     ],
     "tests/test_llm_simple_96.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T20:31:07Z"
+  "generated_at": "2026-03-24T20:57:37Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1085,7 +1085,7 @@
         "filename": "tests/test_llm_import_coverage.py",
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 85
       }
     ],
     "tests/test_llm_simple_96.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T20:21:13Z"
+  "generated_at": "2026-03-24T20:31:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1085,7 +1085,7 @@
         "filename": "tests/test_llm_import_coverage.py",
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 80
       }
     ],
     "tests/test_llm_simple_96.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T13:49:12Z"
+  "generated_at": "2026-03-24T20:21:13Z"
 }

--- a/docs/review/PR_1235_FIXED_MAPPING.md
+++ b/docs/review/PR_1235_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: b20a85e413c6684e1e9a5b88952e15bcc667167b
+Evidence: `tests/test_llm_import_coverage.py` (`_llm_live() -> types.ModuleType`, `llm_mod` in `test_perplexity_lite_provider_generate_coverage`, `global llm` + rebind after reload for stale alias); `.secrets.baseline` (detect-secrets line metadata)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002076022 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002084274 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002094825 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#discussion_r2984092258 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [x] No unresolved review threads (re-check on current head before merge)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/docs/review/PR_1235_FIXED_MAPPING.md
+++ b/docs/review/PR_1235_FIXED_MAPPING.md
@@ -13,6 +13,10 @@ Evidence: `tests/test_llm_import_coverage.py` (`_llm_live() -> types.ModuleType`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002094825 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#discussion_r2984092258 -> b20a85e413c6684e1e9a5b88952e15bcc667167b
 
+Disposition: NOT-A-BUG
+Evidence: `tests/test_llm_import_coverage.py:13-54` — CodeRabbit nitpick ([review #4002274846](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002274846)): after `reload(importlib.import_module("llm"))`, assigning to the module-level `llm` name updates this test file’s import alias to the refreshed `sys.modules["llm"]` object; dropping the rebind would leave `llm` stale for code paths that use the `import llm` binding. Refactor to fixture-only is optional follow-up, not required for correctness of the reload coverage scenario.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1235#pullrequestreview-4002274846
+
 ## Merge Readiness
 
 - [ ] All required checks pass

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -12,6 +12,17 @@ import pytest
 import llm
 
 
+def _llm_live():
+    """Canonical ``llm`` module (matches ``sys.modules``).
+
+    Some tests delete and re-import ``llm``; a module-level ``import llm`` can
+    become stale so ``importlib.reload`` raises ImportError (wrong object vs
+    ``sys.modules['llm']``).
+    """
+
+    return importlib.import_module("llm")
+
+
 @pytest.fixture(autouse=True)
 def _llm_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_KEY", "test_key")
@@ -20,6 +31,7 @@ def _llm_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestImportFallbacks:
     def test_perplexity_import_exception_coverage(self) -> None:
+        llm_mod = _llm_live()
         original_import_module = importlib.import_module
         with patch("importlib.import_module") as mock_import:
 
@@ -29,15 +41,15 @@ class TestImportFallbacks:
                 return original_import_module(name, package)
 
             mock_import.side_effect = import_side_effect
-            reload(llm)
-            assert llm.PerplexityProvider is None
-            assert hasattr(llm, "PerplexityLiteProvider")
+            reload(llm_mod)
+            assert llm_mod.PerplexityProvider is None
+            assert hasattr(llm_mod, "PerplexityLiteProvider")
 
-        reload(llm)
+        reload(_llm_live())
 
     @pytest.mark.asyncio
     async def test_perplexity_lite_provider_generate_coverage(self) -> None:
-        provider = llm.PerplexityLiteProvider()
+        provider = _llm_live().PerplexityLiteProvider()
         assert provider.name == "perplexity"
         result = await provider.generate("test input")
         assert result.startswith("[perplexity-lite] ")

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -48,8 +48,10 @@ class TestImportFallbacks:
             assert llm_mod.PerplexityProvider is None
             assert hasattr(llm_mod, "PerplexityLiteProvider")
 
-        reload(_llm_live())
-        llm = importlib.import_module("llm")
+        # Use reload(importlib.import_module("llm")) so repo AST policy can resolve the
+        # target (forbid obfuscated reload(call()) patterns); _llm_live() is still the
+        # runtime-safe accessor when tests evict sys.modules["llm"].
+        llm = reload(importlib.import_module("llm"))
 
     @pytest.mark.asyncio
     async def test_perplexity_lite_provider_generate_coverage(self) -> None:

--- a/tests/test_llm_import_coverage.py
+++ b/tests/test_llm_import_coverage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import types
 from importlib import reload
 from unittest.mock import Mock, patch
 
@@ -12,7 +13,7 @@ import pytest
 import llm
 
 
-def _llm_live():
+def _llm_live() -> types.ModuleType:
     """Canonical ``llm`` module (matches ``sys.modules``).
 
     Some tests delete and re-import ``llm``; a module-level ``import llm`` can
@@ -31,6 +32,8 @@ def _llm_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestImportFallbacks:
     def test_perplexity_import_exception_coverage(self) -> None:
+        global llm
+
         llm_mod = _llm_live()
         original_import_module = importlib.import_module
         with patch("importlib.import_module") as mock_import:
@@ -46,10 +49,12 @@ class TestImportFallbacks:
             assert hasattr(llm_mod, "PerplexityLiteProvider")
 
         reload(_llm_live())
+        llm = importlib.import_module("llm")
 
     @pytest.mark.asyncio
     async def test_perplexity_lite_provider_generate_coverage(self) -> None:
-        provider = _llm_live().PerplexityLiteProvider()
+        llm_mod = _llm_live()
+        provider = llm_mod.PerplexityLiteProvider()
         assert provider.name == "perplexity"
         result = await provider.generate("test input")
         assert result.startswith("[perplexity-lite] ")


### PR DESCRIPTION
## Summary
Fixes CI failure on `test-main (3.12)` — **Run tests with coverage** exited 1.

**Failing run:** https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/23508671833/job/68423470901

## Root cause
`tests/test_remaining_coverage_simple.py::test_llm_ollama_timeout_invalid` deletes `sys.modules["llm"]` and re-imports `llm`, so the canonical module object in `sys.modules` no longer matches a **stale** module-level import in `tests/test_llm_import_coverage.py`. `importlib.reload()` then fails with `ImportError: module llm not in sys.modules` (Python 3.12) when the test suite order runs the eviction test before the reload test.

## Fix
- Resolve the live `llm` module via `importlib.import_module("llm")` before `reload()` and use it for assertions.
- Use the same helper for `PerplexityLiteProvider` construction.
- Follow-up (bot review): annotate `_llm_live() -> types.ModuleType`, reuse `llm_mod` in the async test, and rebind the module-level `llm` alias after reload (Cubic P2).

## Files
- `tests/test_llm_import_coverage.py`
- `.secrets.baseline` (detect-secrets refresh from pre-commit)
- `docs/review/PR_1235_FIXED_MAPPING.md` (Phase 2 / merge-governance SoT)

## Verification
- Repro order: `pytest tests/test_remaining_coverage_simple.py::test_llm_ollama_timeout_invalid tests/test_llm_import_coverage.py::TestImportFallbacks::test_perplexity_import_exception_coverage`
- `pytest -n 4 tests/test_llm_import_coverage.py`
- `make test-fast`

**Merge gate:** `make verify` per project policy (not claimed green here).

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical SoT: `docs/review/PR_1235_FIXED_MAPPING.md` (dispositions + proof).

## Merge Readiness
- [ ] All required checks pass on current head (see CI)
- [ ] `make verify` locally before merge

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Стабилизировать тесты покрытия импорта LLM, гарантируя, что они работают с актуальным экземпляром модуля `llm` после возможного удаления из `sys.modules`, и обновить эталонный файл для secrets.

Tests:
- Обновить тесты покрытия импорта LLM так, чтобы перед проверками они получали и перегружали канонический модуль `llm` через `importlib`, чтобы избежать `ImportError`, когда тесты удаляют `sys.modules['llm']`.
- Скорректировать тест покрытия `PerplexityLiteProvider`, чтобы создавать провайдера из актуального модуля `llm`, а не из потенциально устаревшего импорта модуля.

Chores:
- Обновить конфигурационный файл эталона для `detect-secrets`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize LLM import coverage tests by ensuring they operate on the live llm module instance after potential sys.modules eviction and refresh the secrets baseline.

Tests:
- Update LLM import coverage tests to resolve and reload the canonical llm module from importlib before assertions to avoid ImportError when tests evict sys.modules['llm'].
- Adjust PerplexityLiteProvider coverage test to construct the provider from the live llm module rather than a potentially stale module import.

Chores:
- Refresh the detect-secrets baseline configuration file.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `llm` reload tests on Python 3.12 to unblock CI. Aligns `reload()` with AST policy, refreshes `.secrets.baseline`, and adds merge-readiness mapping in `docs/review/PR_1235_FIXED_MAPPING.md` (includes NOT-A-BUG for `global llm` rebind).

- **Bug Fixes**
  - Use `reload(importlib.import_module("llm"))` as the reload target and for assertions/`PerplexityLiteProvider`, replacing `reload(_llm_live())`.
  - Rebind the module-level `llm` after reload and type `_llm_live() -> types.ModuleType` to keep access safe after `sys.modules` eviction.

<sup>Written for commit 5f19bac23b44cb8c9914cc1bf275550b9d343843. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security baseline metadata and timestamp to reflect recent test-coverage adjustments.
* **Tests**
  * Improved import and provider-coverage tests to reliably reload modules and validate provider behavior during runs.
* **Documentation**
  * Added a review/commit-mapping document summarizing fix disposition, evidence, review links, and a merge-readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
