### PR TITLE
fix(security): guard pygments exception seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,33 @@ jobs:
         env:
           TRIVY_IGNORE_POLICY_PATH: trivy/ignore-policy.rego
 
+  pygments_exception_guard:
+    name: Pygments exception seam guard
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.COVERAGE_PY }}
+
+      - name: Guard temporary Pygments exception seam
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CI: "true"
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_pygments_exception_guard.py
+
   docs_phase1_gates:
     name: Docs Phase1 gates
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 # Periodically update these SHAs to newer versions for security updates and bug fixes.
 
 env:
-  COVERAGE_PY: "3.13.6"
+  COVERAGE_PY: "3.13"
   FRONTEND_NODE_VERSION_FILE: ".nvmrc"
 
 permissions:
@@ -286,7 +286,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/python-setup
         with:
-          python-version: "3.13.6"
+          python-version: ${{ env.COVERAGE_PY }}
           install-dev-deps: "true"
 
       - name: Pre-commit (lint/format/security quick checks)
@@ -305,7 +305,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/python-setup
         with:
-          python-version: "3.13.6"
+          python-version: ${{ env.COVERAGE_PY }}
           install-dev-deps: "true"
 
       - name: Security scan with Bandit
@@ -343,7 +343,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/python-setup
         with:
-          python-version: "3.13.6"
+          python-version: ${{ env.COVERAGE_PY }}
           install-dev-deps: "true"
 
       - name: Install backend dependencies
@@ -383,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13.6']
+        python-version: ['3.13']
 
     steps:
       - name: Checkout
@@ -472,7 +472,7 @@ jobs:
         if: always()
         uses: ./.github/actions/clean-python-cache
 
-      - name: Upload coverage artifact (3.13.6 only)
+      - name: Upload coverage artifact (single coverage runtime)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -501,7 +501,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13.6']
+        python-version: ['3.13']
 
     steps:
       - name: Checkout
@@ -590,7 +590,7 @@ jobs:
         if: always()
         uses: ./.github/actions/clean-python-cache
 
-      - name: Upload coverage artifact (3.13.6 only)
+      - name: Upload coverage artifact (single coverage runtime)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -746,7 +746,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Download coverage artifact (Python 3.13.6)
+      - name: Download coverage artifact (Python ${{ env.COVERAGE_PY }})
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
         with:
           name: coverage-xml-${{ env.COVERAGE_PY }}
@@ -776,7 +776,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Download coverage artifact (Python 3.13.6)
+      - name: Download coverage artifact (Python ${{ env.COVERAGE_PY }})
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
         with:
           name: coverage-xml-${{ env.COVERAGE_PY }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,6 +2,7 @@ name: Frontend CI
 
 env:
   FRONTEND_NODE_VERSION_FILE: ".nvmrc"
+  PYTHON_VERSION: "3.13"
 
 permissions:
   contents: read
@@ -113,7 +114,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13.6'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install backend dependencies
         run: |

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -2,6 +2,7 @@ name: PR Coverage Guard
 
 env:
   FRONTEND_NODE_VERSION_FILE: ".nvmrc"
+  PYTHON_VERSION: "3.13"
 
 on:
   pull_request:
@@ -19,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.13.6
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13.6'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,6 +3,7 @@ name: PR Tests (Fast)
 
 env:
   FRONTEND_NODE_VERSION_FILE: ".nvmrc"
+  PYTHON_VERSION: "3.13"
 
 on:
   pull_request:
@@ -46,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13.6'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -133,7 +134,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13.6'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 415
+        "line_number": 442
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T20:57:37Z"
+  "generated_at": "2026-03-26T05:58:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -173,7 +173,7 @@
         "filename": ".github/workflows/frontend-ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 82
       }
     ],
     ".github/workflows/nightly.yml": [
@@ -198,7 +198,7 @@
         "filename": ".github/workflows/pr-coverage.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 80
       }
     ],
     "conftest.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-26T05:58:58Z"
+  "generated_at": "2026-03-26T06:59:13Z"
 }

--- a/docs/review/PR_1239_FIXED_MAPPING.md
+++ b/docs/review/PR_1239_FIXED_MAPPING.md
@@ -33,3 +33,9 @@ Evidence: scripts/ci/check_pygments_exception_guard.py:156; tests/test_check_pyg
 Reason: Normalize trailing zero release tuple segments so equivalent versions like `2.19` and `2.19.0` compare equal; cubic identified this issue.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011970362 -> 8ba1c03b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992974893 -> 8ba1c03b
+
+Disposition: FIXED
+Commit: 1f4cd41c
+Evidence: tests/test_check_pygments_exception_guard.py:212; tests/test_check_pygments_exception_guard.py:246
+Reason: Harden pagination-test URL matching by parsing query params and cover both 401/403 retry branches requested by CodeRabbit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4012030662 -> 1f4cd41c

--- a/docs/review/PR_1239_FIXED_MAPPING.md
+++ b/docs/review/PR_1239_FIXED_MAPPING.md
@@ -26,3 +26,10 @@ Commit: 41bb6bc9
 Evidence: scripts/ci/check_pygments_exception_guard.py:19; scripts/ci/check_pygments_exception_guard.py:36; scripts/ci/check_pygments_exception_guard.py:156; scripts/ci/check_pygments_exception_guard.py:195; tests/test_check_pygments_exception_guard.py:171; tests/test_check_pygments_exception_guard.py:181; tests/test_check_pygments_exception_guard.py:220
 Reason: The guard no longer depends on `packaging` at runtime, the seam matcher now tolerates quoted/commented YAML list items, and the review-requested typing and regression coverage were added in the guard test module.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011831424 -> 41bb6bc9
+
+Disposition: FIXED
+Commit: 8ba1c03b
+Evidence: scripts/ci/check_pygments_exception_guard.py:156; tests/test_check_pygments_exception_guard.py:161
+Reason: Normalize trailing zero release tuple segments so equivalent versions like `2.19` and `2.19.0` compare equal; cubic identified this issue.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011970362 -> 8ba1c03b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992974893 -> 8ba1c03b

--- a/docs/review/PR_1239_FIXED_MAPPING.md
+++ b/docs/review/PR_1239_FIXED_MAPPING.md
@@ -8,7 +8,6 @@
 Disposition: FIXED
 Commit: 77dd3558
 Evidence: scripts/ci/check_pygments_exception_guard.py:44; scripts/ci/check_pygments_exception_guard.py:151; scripts/ci/check_pygments_exception_guard.py:182; scripts/ci/check_pygments_exception_guard.py:231; tests/test_check_pygments_exception_guard.py:138; tests/test_check_pygments_exception_guard.py:167; docs/security/GHSA-5239-wwwm-4pmq-pygments.md:40
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011711126 -> 77dd3558
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992728990 -> 77dd3558
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992728992 -> 77dd3558

--- a/docs/review/PR_1239_FIXED_MAPPING.md
+++ b/docs/review/PR_1239_FIXED_MAPPING.md
@@ -21,3 +21,9 @@ Evidence: scripts/ci/check_pygments_exception_guard.py:44; scripts/ci/check_pygm
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765404 -> 77dd3558
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765412 -> 77dd3558
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765418 -> 77dd3558
+
+Disposition: FIXED
+Commit: 41bb6bc9
+Evidence: scripts/ci/check_pygments_exception_guard.py:19; scripts/ci/check_pygments_exception_guard.py:36; scripts/ci/check_pygments_exception_guard.py:156; scripts/ci/check_pygments_exception_guard.py:195; tests/test_check_pygments_exception_guard.py:171; tests/test_check_pygments_exception_guard.py:181; tests/test_check_pygments_exception_guard.py:220
+Reason: The guard no longer depends on `packaging` at runtime, the seam matcher now tolerates quoted/commented YAML list items, and the review-requested typing and regression coverage were added in the guard test module.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011831424 -> 41bb6bc9

--- a/docs/review/PR_1239_FIXED_MAPPING.md
+++ b/docs/review/PR_1239_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+# PR 1239 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: 77dd3558
+Evidence: scripts/ci/check_pygments_exception_guard.py:44; scripts/ci/check_pygments_exception_guard.py:151; scripts/ci/check_pygments_exception_guard.py:182; scripts/ci/check_pygments_exception_guard.py:231; tests/test_check_pygments_exception_guard.py:138; tests/test_check_pygments_exception_guard.py:167; docs/security/GHSA-5239-wwwm-4pmq-pygments.md:40
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011711126 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992728990 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992728992 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992737981 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992737983 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011724760 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992742048 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#pullrequestreview-4011748005 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765400 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765404 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765412 -> 77dd3558
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1239#discussion_r2992765418 -> 77dd3558

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7541,7 +7541,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (dependency security / pre-push unblock follow-up)
   - Target PR: TBD after upstream patched release
-  - Status: Opened on 25 March 2026
+  - Status: Opened on 25 March 2026; upstream still blocked as of 26 March 2026
   - See ADR: `docs/architecture/ADR_PIP_AUDIT_PYGMENTS_SUPPRESSION_SEAM_2026-03-25.md`
   - Reason: `pip-audit` blocks unrelated narrow PRs because `GHSA-5239-wwwm-4pmq`
     currently has no patched `Pygments` release available to pin in the repo
@@ -7549,6 +7549,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     exception in `.pre-commit-config.yaml`, which must be removed as soon as a
     safe upstream version exists.
   - Links:
+    - GitHub alerts: `security/dependabot/58`, `security/dependabot/59`, `security/dependabot/60`
     - `docs/architecture/ADR_PIP_AUDIT_PYGMENTS_SUPPRESSION_SEAM_2026-03-25.md`
     - `.pre-commit-config.yaml`
     - `docs/security/GHSA-5239-wwwm-4pmq-pygments.md`
@@ -7557,6 +7558,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `requirements-lock.txt`
   - Blockers / Exit criteria:
     - `GHSA-5239-wwwm-4pmq` still has no patched upstream `Pygments` release
+    - CI guard must re-check Dependabot open alerts `#58/#59/#60` and fail once
+      `first_patched_version` appears or the alerts disappear while the seam remains
     - Seam removal must satisfy the ADR exit criteria before this item can close
   - DoD:
     - A patched `Pygments` release exists and is pinned across the tracked lock surfaces

--- a/docs/security/GHSA-5239-wwwm-4pmq-pygments.md
+++ b/docs/security/GHSA-5239-wwwm-4pmq-pygments.md
@@ -33,12 +33,20 @@ Scope of the exception:
 - does not remove the pinned `Pygments` evidence from requirement surfaces
 - remains tracked in `docs/roadmap/BACKLOG_LEDGER.md` until a patched release is available
 - is now watched by `scripts/ci/check_pygments_exception_guard.py`, which fails
-  CI as soon as Dependabot reports a patched version or the tracked alerts no
-  longer remain open
+  CI as soon as the public GHSA advisory reports a patched version; when repo
+  tokens can read Dependabot alerts, the same guard also checks that tracked
+  alerts no longer silently remain open
 
 ## Evidence Anchors
 
-- `.pre-commit-config.yaml:126`
+- `.pre-commit-config.yaml:132`
+- `.pre-commit-config.yaml:135`
+- `scripts/ci/check_pygments_exception_guard.py:44`
+- `scripts/ci/check_pygments_exception_guard.py:151`
+- `scripts/ci/check_pygments_exception_guard.py:158`
+- `scripts/ci/check_pygments_exception_guard.py:231`
+- `.github/workflows/ci.yml:117`
+- `.github/workflows/ci.yml:134`
 - `docs/roadmap/BACKLOG_LEDGER.md:7540`
 - `requirements.txt:230`
 - `requirements-dev.txt:163`

--- a/docs/security/GHSA-5239-wwwm-4pmq-pygments.md
+++ b/docs/security/GHSA-5239-wwwm-4pmq-pygments.md
@@ -12,8 +12,10 @@
 
 ## Current Triage Status
 
-As of `25 March 2026`, the repo has no patched Pygments release available to
-adopt for this advisory. Because of that, a strict `pip-audit` pre-push gate on
+As of `26 March 2026`, the repo still has no patched Pygments release available
+to adopt for this advisory. GitHub Dependabot alerts `#58`, `#59`, and `#60`
+remain open across `requirements-dev.txt`, `requirements-lock.txt`, and
+`requirements.txt`. Because of that, a strict `pip-audit` pre-push gate on
 `requirements.txt` blocks unrelated narrow PRs even when no dependency
 regression was introduced in the branch.
 
@@ -30,6 +32,9 @@ Scope of the exception:
 - limited to the `pip-audit` pre-push hook in `.pre-commit-config.yaml`
 - does not remove the pinned `Pygments` evidence from requirement surfaces
 - remains tracked in `docs/roadmap/BACKLOG_LEDGER.md` until a patched release is available
+- is now watched by `scripts/ci/check_pygments_exception_guard.py`, which fails
+  CI as soon as Dependabot reports a patched version or the tracked alerts no
+  longer remain open
 
 ## Evidence Anchors
 

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -16,11 +16,9 @@ import os
 import re
 import urllib.error
 import urllib.parse
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
-
-from packaging.version import InvalidVersion
-from packaging.version import Version
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -36,9 +34,11 @@ DEPENDABOT_ALERTS_PER_PAGE = 100
 
 _PIN_RE = re.compile(r"^\s*pygments==(?P<version>[^\s#]+)", re.IGNORECASE)
 _IGNORE_SEAM_RE = re.compile(
-    rf"--ignore-vuln\s+(?:-\s*)?{re.escape(ADVISORY_ID)}",
-    re.IGNORECASE,
+    rf'(?im)^\s*-\s*["\']?--ignore-vuln["\']?\s*$'
+    rf"(?:\n^\s*#.*$|\n^\s*$)*"
+    rf'\n^\s*-\s*["\']?{re.escape(ADVISORY_ID)}["\']?\s*$'
 )
+_RELEASE_VERSION_RE = re.compile(r"^\d+(?:\.\d+)*$")
 
 
 def _api_request_with_headers(
@@ -153,6 +153,14 @@ def _read_requirement_pins(repo_root: Path) -> dict[str, str | None]:
     return pins
 
 
+def _parse_release_version(identifier: str) -> tuple[int, ...] | None:
+    """Parse dotted numeric release versions without external packaging deps."""
+    normalized = identifier.strip()
+    if not _RELEASE_VERSION_RE.fullmatch(normalized):
+        return None
+    return tuple(int(part) for part in normalized.split("."))
+
+
 def _has_exception_seam(repo_root: Path) -> bool:
     """Return True when the temporary pip-audit ignore is still present."""
     pre_commit = repo_root / PRE_COMMIT_PATH
@@ -164,7 +172,7 @@ def evaluate_guard_state(
     *,
     alerts: list[dict[str, Any]] | None,
     advisory_patched_versions: set[str],
-    pins: dict[str, str | None],
+    pins: Mapping[str, str | None],
     exception_present: bool,
 ) -> list[str]:
     """Evaluate whether the temporary exception seam must now be removed."""
@@ -184,11 +192,19 @@ def evaluate_guard_state(
     if not patched_versions:
         return errors
 
-    try:
-        patched_floor = max(Version(identifier) for identifier in patched_versions)
-    except InvalidVersion as exc:
-        errors.append(f"Patched version metadata is invalid: {exc}")
+    parsed_patched_versions: dict[str, tuple[int, ...]] = {}
+    invalid_patched = sorted(
+        identifier for identifier in patched_versions if _parse_release_version(identifier) is None
+    )
+    if invalid_patched:
+        errors.append("Patched version metadata is invalid: " + ", ".join(invalid_patched))
         return errors
+    for identifier in patched_versions:
+        parsed = _parse_release_version(identifier)
+        if parsed is not None:
+            parsed_patched_versions[identifier] = parsed
+
+    patched_floor = max(parsed_patched_versions.values())
 
     patched_list = ", ".join(sorted(patched_versions))
     if exception_present:
@@ -202,13 +218,10 @@ def evaluate_guard_state(
         if version is None:
             stale_pins[path] = "missing"
             continue
-        try:
-            parsed_version = Version(version)
-        except InvalidVersion:
+        parsed_version = _parse_release_version(version)
+        if parsed_version is None:
             stale_pins[path] = f"invalid:{version}"
             continue
-        # EN: Treat the advisory as a minimum safe floor, not an exact pin.
-        # RU: Считаем advisory минимальным безопасным floor, а не точным pin.
         if parsed_version < patched_floor:
             stale_pins[path] = version
 

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -158,7 +158,10 @@ def _parse_release_version(identifier: str) -> tuple[int, ...] | None:
     normalized = identifier.strip()
     if not _RELEASE_VERSION_RE.fullmatch(normalized):
         return None
-    return tuple(int(part) for part in normalized.split("."))
+    parts = [int(part) for part in normalized.split(".")]
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
 
 
 def _has_exception_seam(repo_root: Path) -> bool:

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -231,7 +231,9 @@ def _resolve_token() -> str | None:
 def _fetch_dependabot_alerts(*, repo: str, token: str) -> list[dict[str, Any]]:
     """Fetch open Dependabot alerts for the repository."""
     alerts: list[dict[str, Any]] = []
-    url = f"https://api.github.com/repos/{repo}/dependabot/alerts?state=open&per_page=100"
+    url: str | None = (
+        f"https://api.github.com/repos/{repo}/dependabot/alerts?state=open&per_page=100"
+    )
     while url:
         payload, headers = _api_request_with_headers(url, token)
         if not isinstance(payload, list):

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -87,7 +87,12 @@ def _api_request(url: str, token: str | None = None) -> Any:
 
 def _public_api_request(url: str, token: str | None = None) -> Any:
     """Perform a GitHub REST API request that can fall back to public access."""
-    return _api_request(url, token)
+    try:
+        return _api_request(url, token)
+    except urllib.error.HTTPError as exc:
+        if token and exc.code in {401, 403}:
+            return _api_request(url, None)
+        raise
 
 
 def _extract_relevant_alerts(alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -1,9 +1,10 @@
 """Guard the temporary Pygments exception seam against upstream drift.
 
 This CI-oriented check keeps the documented `pip-audit --ignore-vuln` seam for
-`GHSA-5239-wwwm-4pmq` honest. As soon as GitHub Dependabot reports that a fixed
-version exists, or the tracked open alerts disappear, the guard fails until the
-repo removes the temporary exception and refreshes the pinned dependency state.
+`GHSA-5239-wwwm-4pmq` honest. As soon as the public GHSA advisory reports that
+a fixed version exists, or the tracked open alerts disappear when repository
+alerts are readable, the guard fails until the repo removes the temporary
+exception and refreshes the pinned dependency state.
 """
 
 from __future__ import annotations
@@ -18,6 +19,9 @@ import urllib.parse
 from pathlib import Path
 from typing import Any
 
+from packaging.version import InvalidVersion
+from packaging.version import Version
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 ADVISORY_ID = "GHSA-5239-wwwm-4pmq"
@@ -28,13 +32,20 @@ TRACKED_REQUIREMENTS = (
     "requirements-lock.txt",
 )
 PRE_COMMIT_PATH = ".pre-commit-config.yaml"
-TARGET_VERSION = "2.19.2"
+DEPENDABOT_ALERTS_PER_PAGE = 100
 
 _PIN_RE = re.compile(r"^\s*pygments==(?P<version>[^\s#]+)", re.IGNORECASE)
+_IGNORE_SEAM_RE = re.compile(
+    rf"--ignore-vuln\s+(?:-\s*)?{re.escape(ADVISORY_ID)}",
+    re.IGNORECASE,
+)
 
 
-def _api_request(url: str, token: str) -> Any:
-    """Perform a GitHub REST API request and return parsed JSON."""
+def _api_request_with_headers(
+    url: str,
+    token: str | None = None,
+) -> tuple[Any, http.client.HTTPMessage]:
+    """Perform a GitHub REST API request and return parsed JSON plus headers."""
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https" or parsed.netloc != "api.github.com":
         raise ValueError(f"Unsupported API URL: {url}")
@@ -44,16 +55,15 @@ def _api_request(url: str, token: str) -> Any:
         path = f"{path}?{parsed.query}"
 
     conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
-    conn.request(
-        "GET",
-        path,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "pulseplate-pygments-exception-guard",
-        },
-    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pulseplate-pygments-exception-guard",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    conn.request("GET", path, headers=headers)
     response = conn.getresponse()
     body = response.read().decode("utf-8")
     conn.close()
@@ -66,7 +76,18 @@ def _api_request(url: str, token: str) -> Any:
             hdrs=response.headers,
             fp=None,
         )
-    return json.loads(body)
+    return json.loads(body), response.headers
+
+
+def _api_request(url: str, token: str | None = None) -> Any:
+    """Perform a GitHub REST API request and return parsed JSON."""
+    payload, _headers = _api_request_with_headers(url, token)
+    return payload
+
+
+def _public_api_request(url: str, token: str | None = None) -> Any:
+    """Perform a GitHub REST API request that can fall back to public access."""
+    return _api_request(url, token)
 
 
 def _extract_relevant_alerts(alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -97,6 +118,21 @@ def _first_patched_versions(alerts: list[dict[str, Any]]) -> set[str]:
     return patched_versions
 
 
+def _advisory_first_patched_versions(advisory_payload: dict[str, Any]) -> set[str]:
+    """Collect first patched versions from the public GHSA advisory payload."""
+    patched_versions: set[str] = set()
+    for vulnerability in advisory_payload.get("vulnerabilities", []):
+        if not isinstance(vulnerability, dict):
+            continue
+        package = vulnerability.get("package", {})
+        if str(package.get("name", "")).lower() != PACKAGE_NAME:
+            continue
+        identifier = vulnerability.get("first_patched_version")
+        if identifier:
+            patched_versions.add(str(identifier))
+    return patched_versions
+
+
 def _read_requirement_pins(repo_root: Path) -> dict[str, str | None]:
     """Read the currently pinned Pygments versions from tracked requirement files."""
     pins: dict[str, str | None] = {}
@@ -116,29 +152,37 @@ def _has_exception_seam(repo_root: Path) -> bool:
     """Return True when the temporary pip-audit ignore is still present."""
     pre_commit = repo_root / PRE_COMMIT_PATH
     content = pre_commit.read_text(encoding="utf-8")
-    return f"--ignore-vuln\n          - {ADVISORY_ID}" in content
+    return _IGNORE_SEAM_RE.search(content) is not None
 
 
 def evaluate_guard_state(
     *,
-    alerts: list[dict[str, Any]],
+    alerts: list[dict[str, Any]] | None,
+    advisory_patched_versions: set[str],
     pins: dict[str, str | None],
     exception_present: bool,
 ) -> list[str]:
     """Evaluate whether the temporary exception seam must now be removed."""
     errors: list[str] = []
-    relevant_alerts = _extract_relevant_alerts(alerts)
-    patched_versions = _first_patched_versions(relevant_alerts)
+    relevant_alerts = _extract_relevant_alerts(alerts or [])
+    patched_versions = _first_patched_versions(relevant_alerts) | advisory_patched_versions
 
-    if not relevant_alerts:
+    if alerts is not None and not relevant_alerts:
         if exception_present:
             errors.append(
                 "No open Dependabot alerts remain for GHSA-5239-wwwm-4pmq, but the "
                 "temporary pip-audit exception seam is still present."
             )
-        return errors
+        if not patched_versions:
+            return errors
 
     if not patched_versions:
+        return errors
+
+    try:
+        patched_floor = max(Version(identifier) for identifier in patched_versions)
+    except InvalidVersion as exc:
+        errors.append(f"Patched version metadata is invalid: {exc}")
         return errors
 
     patched_list = ", ".join(sorted(patched_versions))
@@ -148,14 +192,24 @@ def evaluate_guard_state(
             f"({patched_list}), but .pre-commit-config.yaml still ignores the advisory."
         )
 
-    stale_pins = {
-        path: version
-        for path, version in pins.items()
-        if version is None or version == TARGET_VERSION
-    }
+    stale_pins: dict[str, str] = {}
+    for path, version in pins.items():
+        if version is None:
+            stale_pins[path] = "missing"
+            continue
+        try:
+            parsed_version = Version(version)
+        except InvalidVersion:
+            stale_pins[path] = f"invalid:{version}"
+            continue
+        # EN: Treat the advisory as a minimum safe floor, not an exact pin.
+        # RU: Считаем advisory минимальным безопасным floor, а не точным pin.
+        if parsed_version < patched_floor:
+            stale_pins[path] = version
+
     if stale_pins:
         stale_render = ", ".join(
-            f"{path}={version or 'missing'}" for path, version in sorted(stale_pins.items())
+            f"{path}={version}" for path, version in sorted(stale_pins.items())
         )
         errors.append(
             "Dependabot reports a patched release for GHSA-5239-wwwm-4pmq "
@@ -176,10 +230,37 @@ def _resolve_token() -> str | None:
 
 def _fetch_dependabot_alerts(*, repo: str, token: str) -> list[dict[str, Any]]:
     """Fetch open Dependabot alerts for the repository."""
+    alerts: list[dict[str, Any]] = []
     url = f"https://api.github.com/repos/{repo}/dependabot/alerts?state=open&per_page=100"
-    payload = _api_request(url, token)
-    if not isinstance(payload, list):
-        raise ValueError("Dependabot alerts API returned a non-list payload")
+    while url:
+        payload, headers = _api_request_with_headers(url, token)
+        if not isinstance(payload, list):
+            raise ValueError("Dependabot alerts API returned a non-list payload")
+        alerts.extend(payload)
+        url = _extract_next_link(headers.get("Link"))
+    return alerts
+
+
+def _extract_next_link(link_header: str | None) -> str | None:
+    """Extract the next-page URL from a GitHub Link header."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        section = part.strip()
+        if 'rel="next"' not in section:
+            continue
+        match = re.match(r"<(?P<url>[^>]+)>", section)
+        if match:
+            return match.group("url")
+    return None
+
+
+def _fetch_public_global_advisory(*, token: str | None) -> dict[str, Any]:
+    """Fetch the public GHSA advisory payload for the tracked advisory."""
+    url = f"https://api.github.com/advisories/{ADVISORY_ID}"
+    payload = _public_api_request(url, token=token)
+    if not isinstance(payload, dict):
+        raise ValueError("Global advisory API returned a non-dict payload")
     return payload
 
 
@@ -201,16 +282,33 @@ def main() -> int:
         print("SKIP: missing GitHub auth or repository context outside CI.")
         return 0
 
+    alerts: list[dict[str, Any]] | None = None
     try:
         alerts = _fetch_dependabot_alerts(repo=repo, token=token)
-    except (urllib.error.HTTPError, OSError, ValueError) as exc:
+    except urllib.error.HTTPError as exc:
+        if exc.code == 403:
+            print(
+                "WARN: Dependabot alerts endpoint is not accessible with the current token; "
+                "falling back to the public GHSA advisory."
+            )
+        else:
+            print(f"ERROR: failed to query Dependabot alerts: {exc}")
+            return 1 if in_ci else 0
+    except (OSError, ValueError) as exc:
         print(f"ERROR: failed to query Dependabot alerts: {exc}")
+        return 1 if in_ci else 0
+
+    try:
+        advisory_payload = _fetch_public_global_advisory(token=token)
+    except (urllib.error.HTTPError, OSError, ValueError) as exc:
+        print(f"ERROR: failed to query public GHSA advisory: {exc}")
         return 1 if in_ci else 0
 
     pins = _read_requirement_pins(REPO_ROOT)
     exception_present = _has_exception_seam(REPO_ROOT)
     errors = evaluate_guard_state(
         alerts=alerts,
+        advisory_patched_versions=_advisory_first_patched_versions(advisory_payload),
         pins=pins,
         exception_present=exception_present,
     )

--- a/scripts/ci/check_pygments_exception_guard.py
+++ b/scripts/ci/check_pygments_exception_guard.py
@@ -1,0 +1,228 @@
+"""Guard the temporary Pygments exception seam against upstream drift.
+
+This CI-oriented check keeps the documented `pip-audit --ignore-vuln` seam for
+`GHSA-5239-wwwm-4pmq` honest. As soon as GitHub Dependabot reports that a fixed
+version exists, or the tracked open alerts disappear, the guard fails until the
+repo removes the temporary exception and refreshes the pinned dependency state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ADVISORY_ID = "GHSA-5239-wwwm-4pmq"
+PACKAGE_NAME = "pygments"
+TRACKED_REQUIREMENTS = (
+    "requirements.txt",
+    "requirements-dev.txt",
+    "requirements-lock.txt",
+)
+PRE_COMMIT_PATH = ".pre-commit-config.yaml"
+TARGET_VERSION = "2.19.2"
+
+_PIN_RE = re.compile(r"^\s*pygments==(?P<version>[^\s#]+)", re.IGNORECASE)
+
+
+def _api_request(url: str, token: str) -> Any:
+    """Perform a GitHub REST API request and return parsed JSON."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+        raise ValueError(f"Unsupported API URL: {url}")
+
+    path = parsed.path
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+    conn.request(
+        "GET",
+        path,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "pulseplate-pygments-exception-guard",
+        },
+    )
+    response = conn.getresponse()
+    body = response.read().decode("utf-8")
+    conn.close()
+
+    if response.status >= 400:
+        raise urllib.error.HTTPError(
+            url=url,
+            code=response.status,
+            msg=response.reason,
+            hdrs=response.headers,
+            fp=None,
+        )
+    return json.loads(body)
+
+
+def _extract_relevant_alerts(alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return open Dependabot alerts for the tracked Pygments advisory."""
+    relevant: list[dict[str, Any]] = []
+    for alert in alerts:
+        dependency = alert.get("dependency", {})
+        package = dependency.get("package", {})
+        advisory = alert.get("security_advisory", {})
+        if package.get("name", "").lower() != PACKAGE_NAME:
+            continue
+        if advisory.get("ghsa_id") != ADVISORY_ID:
+            continue
+        relevant.append(alert)
+    return relevant
+
+
+def _first_patched_versions(alerts: list[dict[str, Any]]) -> set[str]:
+    """Collect first patched versions from all relevant alert surfaces."""
+    patched_versions: set[str] = set()
+    for alert in alerts:
+        security_vulnerability = alert.get("security_vulnerability", {})
+        patched = security_vulnerability.get("first_patched_version")
+        if isinstance(patched, dict):
+            identifier = patched.get("identifier")
+            if identifier:
+                patched_versions.add(identifier)
+    return patched_versions
+
+
+def _read_requirement_pins(repo_root: Path) -> dict[str, str | None]:
+    """Read the currently pinned Pygments versions from tracked requirement files."""
+    pins: dict[str, str | None] = {}
+    for relative_path in TRACKED_REQUIREMENTS:
+        path = repo_root / relative_path
+        version: str | None = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = _PIN_RE.match(line)
+            if match:
+                version = match.group("version")
+                break
+        pins[relative_path] = version
+    return pins
+
+
+def _has_exception_seam(repo_root: Path) -> bool:
+    """Return True when the temporary pip-audit ignore is still present."""
+    pre_commit = repo_root / PRE_COMMIT_PATH
+    content = pre_commit.read_text(encoding="utf-8")
+    return f"--ignore-vuln\n          - {ADVISORY_ID}" in content
+
+
+def evaluate_guard_state(
+    *,
+    alerts: list[dict[str, Any]],
+    pins: dict[str, str | None],
+    exception_present: bool,
+) -> list[str]:
+    """Evaluate whether the temporary exception seam must now be removed."""
+    errors: list[str] = []
+    relevant_alerts = _extract_relevant_alerts(alerts)
+    patched_versions = _first_patched_versions(relevant_alerts)
+
+    if not relevant_alerts:
+        if exception_present:
+            errors.append(
+                "No open Dependabot alerts remain for GHSA-5239-wwwm-4pmq, but the "
+                "temporary pip-audit exception seam is still present."
+            )
+        return errors
+
+    if not patched_versions:
+        return errors
+
+    patched_list = ", ".join(sorted(patched_versions))
+    if exception_present:
+        errors.append(
+            "Dependabot reports a patched release for GHSA-5239-wwwm-4pmq "
+            f"({patched_list}), but .pre-commit-config.yaml still ignores the advisory."
+        )
+
+    stale_pins = {
+        path: version
+        for path, version in pins.items()
+        if version is None or version == TARGET_VERSION
+    }
+    if stale_pins:
+        stale_render = ", ".join(
+            f"{path}={version or 'missing'}" for path, version in sorted(stale_pins.items())
+        )
+        errors.append(
+            "Dependabot reports a patched release for GHSA-5239-wwwm-4pmq "
+            f"({patched_list}), but tracked requirement pins are still unresolved: {stale_render}."
+        )
+    return errors
+
+
+def _resolve_repo() -> str | None:
+    """Resolve the GitHub repository slug from the environment."""
+    return os.environ.get("GITHUB_REPOSITORY", "").strip() or None
+
+
+def _resolve_token() -> str | None:
+    """Resolve a GitHub token from standard CI env vars."""
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def _fetch_dependabot_alerts(*, repo: str, token: str) -> list[dict[str, Any]]:
+    """Fetch open Dependabot alerts for the repository."""
+    url = f"https://api.github.com/repos/{repo}/dependabot/alerts?state=open&per_page=100"
+    payload = _api_request(url, token)
+    if not isinstance(payload, list):
+        raise ValueError("Dependabot alerts API returned a non-list payload")
+    return payload
+
+
+def main() -> int:
+    """Run the CI guard and return a process status code."""
+    parser = argparse.ArgumentParser(
+        description="Fail when the temporary Pygments exception seam should be removed."
+    )
+    parser.parse_args()
+
+    token = _resolve_token()
+    repo = _resolve_repo()
+    in_ci = os.environ.get("CI", "").lower() == "true"
+
+    if not token or not repo:
+        if in_ci:
+            print("ERROR: GH_TOKEN/GITHUB_TOKEN and GITHUB_REPOSITORY are required in CI.")
+            return 1
+        print("SKIP: missing GitHub auth or repository context outside CI.")
+        return 0
+
+    try:
+        alerts = _fetch_dependabot_alerts(repo=repo, token=token)
+    except (urllib.error.HTTPError, OSError, ValueError) as exc:
+        print(f"ERROR: failed to query Dependabot alerts: {exc}")
+        return 1 if in_ci else 0
+
+    pins = _read_requirement_pins(REPO_ROOT)
+    exception_present = _has_exception_seam(REPO_ROOT)
+    errors = evaluate_guard_state(
+        alerts=alerts,
+        pins=pins,
+        exception_present=exception_present,
+    )
+    if errors:
+        print("ERROR: Pygments exception guard failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("OK: Pygments exception seam remains upstream-blocked; no removal required yet.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import urllib.error
 from pathlib import Path
 
 from scripts.ci import check_pygments_exception_guard as guard
@@ -191,3 +192,20 @@ def test_fetch_dependabot_alerts_paginates(monkeypatch) -> None:
     alerts = guard._fetch_dependabot_alerts(repo="owner/repo", token="token")
 
     assert len(alerts) == guard.DEPENDABOT_ALERTS_PER_PAGE + 1
+
+
+def test_public_api_request_retries_without_token_on_auth_error(monkeypatch) -> None:
+    calls: list[str | None] = []
+
+    def fake_api_request(url: str, token: str | None = None) -> object:
+        calls.append(token)
+        if token == "token":
+            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
+        return {"ok": True}
+
+    monkeypatch.setattr(guard, "_api_request", fake_api_request)
+
+    payload = guard._public_api_request("https://api.github.com/advisories/example", "token")
+
+    assert payload == {"ok": True}
+    assert calls == ["token", None]

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from email.message import Message
 import urllib.error
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -219,9 +220,14 @@ def test_fetch_dependabot_alerts_paginates(monkeypatch: pytest.MonkeyPatch) -> N
         token: str | None,
     ) -> tuple[object, dict[str, str]]:
         assert token == "token"
-        if "after=cursor-2" in url:
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        assert parsed.path.endswith("/dependabot/alerts")
+        if query.get("after") == ["cursor-2"]:
             return second_page, {}
-        if "dependabot/alerts?state=open&per_page=100" in url:
+        if query.get("state") == ["open"] and query.get("per_page") == [
+            str(guard.DEPENDABOT_ALERTS_PER_PAGE)
+        ]:
             return first_page, {
                 "Link": (
                     "<https://api.github.com/repos/owner/repo/dependabot/alerts"
@@ -237,15 +243,17 @@ def test_fetch_dependabot_alerts_paginates(monkeypatch: pytest.MonkeyPatch) -> N
     assert len(alerts) == guard.DEPENDABOT_ALERTS_PER_PAGE + 1
 
 
+@pytest.mark.parametrize("status_code", [401, 403])
 def test_public_api_request_retries_without_token_on_auth_error(
     monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
 ) -> None:
     calls: list[str | None] = []
 
     def fake_api_request(url: str, token: str | None = None) -> object:
         calls.append(token)
         if token == "token":
-            raise urllib.error.HTTPError(url, 403, "Forbidden", Message(), None)
+            raise urllib.error.HTTPError(url, status_code, "Forbidden", Message(), None)
         return {"ok": True}
 
     monkeypatch.setattr(guard, "_api_request", fake_api_request)

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from email.message import Message
 import urllib.error
 from pathlib import Path
+
+import pytest
 
 from scripts.ci import check_pygments_exception_guard as guard
 
@@ -165,7 +168,27 @@ def test_has_exception_seam_tolerates_yaml_whitespace_changes(tmp_path: Path) ->
     assert guard._has_exception_seam(tmp_path) is True
 
 
-def test_fetch_dependabot_alerts_paginates(monkeypatch) -> None:
+def test_has_exception_seam_accepts_quoted_yaml_items(tmp_path: Path) -> None:
+    pre_commit = tmp_path / guard.PRE_COMMIT_PATH
+    pre_commit.write_text(
+        'args:\n  - "--ignore-vuln"\n' f'  - "{guard.ADVISORY_ID}"\n',
+        encoding="utf-8",
+    )
+
+    assert guard._has_exception_seam(tmp_path) is True
+
+
+def test_has_exception_seam_accepts_comment_between_yaml_items(tmp_path: Path) -> None:
+    pre_commit = tmp_path / guard.PRE_COMMIT_PATH
+    pre_commit.write_text(
+        "args:\n  - --ignore-vuln\n  # temporary seam\n" f"  - {guard.ADVISORY_ID}\n",
+        encoding="utf-8",
+    )
+
+    assert guard._has_exception_seam(tmp_path) is True
+
+
+def test_fetch_dependabot_alerts_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
     first_page = [
         _alert(first_patched_version=None) for _ in range(guard.DEPENDABOT_ALERTS_PER_PAGE)
     ]
@@ -194,13 +217,15 @@ def test_fetch_dependabot_alerts_paginates(monkeypatch) -> None:
     assert len(alerts) == guard.DEPENDABOT_ALERTS_PER_PAGE + 1
 
 
-def test_public_api_request_retries_without_token_on_auth_error(monkeypatch) -> None:
+def test_public_api_request_retries_without_token_on_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[str | None] = []
 
     def fake_api_request(url: str, token: str | None = None) -> object:
         calls.append(token)
         if token == "token":
-            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
+            raise urllib.error.HTTPError(url, 403, "Forbidden", Message(), None)
         return {"ok": True}
 
     monkeypatch.setattr(guard, "_api_request", fake_api_request)

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from scripts.ci import check_pygments_exception_guard as guard
 
 
@@ -23,6 +25,7 @@ def test_evaluate_guard_state_allows_blocked_upstream_with_exception() -> None:
 
     errors = guard.evaluate_guard_state(
         alerts=[_alert(first_patched_version=None)],
+        advisory_patched_versions=set(),
         pins=pins,
         exception_present=True,
     )
@@ -39,6 +42,7 @@ def test_evaluate_guard_state_fails_when_patch_exists_and_exception_remains() ->
 
     errors = guard.evaluate_guard_state(
         alerts=[_alert(first_patched_version="2.19.3")],
+        advisory_patched_versions=set(),
         pins=pins,
         exception_present=True,
     )
@@ -58,6 +62,7 @@ def test_evaluate_guard_state_fails_when_alerts_disappear_but_exception_remains(
 
     errors = guard.evaluate_guard_state(
         alerts=[],
+        advisory_patched_versions=set(),
         pins=pins,
         exception_present=True,
     )
@@ -82,6 +87,7 @@ def test_evaluate_guard_state_ignores_unrelated_alerts() -> None:
 
     errors = guard.evaluate_guard_state(
         alerts=[unrelated],
+        advisory_patched_versions=set(),
         pins=pins,
         exception_present=True,
     )
@@ -90,3 +96,98 @@ def test_evaluate_guard_state_ignores_unrelated_alerts() -> None:
         "No open Dependabot alerts remain for GHSA-5239-wwwm-4pmq, but the temporary "
         "pip-audit exception seam is still present."
     ]
+
+
+def test_evaluate_guard_state_allows_unreadable_alert_endpoint_while_unpatched() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=None,
+        advisory_patched_versions=set(),
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert errors == []
+
+
+def test_evaluate_guard_state_fails_when_public_advisory_reports_patch() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=None,
+        advisory_patched_versions={"2.19.3"},
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert len(errors) == 2
+    assert "patched release" in errors[0]
+    assert ".pre-commit-config.yaml still ignores" in errors[0]
+    assert "requirements.txt=2.19.2" in errors[1]
+
+
+def test_evaluate_guard_state_flags_versions_below_patched_floor() -> None:
+    pins = {
+        "requirements.txt": "2.19.1",
+        "requirements-dev.txt": "2.19.3",
+        "requirements-lock.txt": "2.19.3",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=None,
+        advisory_patched_versions={"2.19.3"},
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert len(errors) == 2
+    assert "requirements.txt=2.19.1" in errors[1]
+    assert "requirements-dev.txt" not in errors[1]
+
+
+def test_has_exception_seam_tolerates_yaml_whitespace_changes(tmp_path: Path) -> None:
+    pre_commit = tmp_path / guard.PRE_COMMIT_PATH
+    pre_commit.write_text(
+        "args:\n" "  - --ignore-vuln\n" f"    - {guard.ADVISORY_ID}\n",
+        encoding="utf-8",
+    )
+
+    assert guard._has_exception_seam(tmp_path) is True
+
+
+def test_fetch_dependabot_alerts_paginates(monkeypatch) -> None:
+    first_page = [
+        _alert(first_patched_version=None) for _ in range(guard.DEPENDABOT_ALERTS_PER_PAGE)
+    ]
+    second_page = [_alert(first_patched_version="2.19.3")]
+
+    def fake_api_request_with_headers(
+        url: str,
+        token: str | None,
+    ) -> tuple[object, dict[str, str]]:
+        assert token == "token"
+        if "after=cursor-2" in url:
+            return second_page, {}
+        if "dependabot/alerts?state=open&per_page=100" in url:
+            return first_page, {
+                "Link": (
+                    "<https://api.github.com/repos/owner/repo/dependabot/alerts"
+                    '?state=open&per_page=100&after=cursor-2>; rel="next"'
+                )
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(guard, "_api_request_with_headers", fake_api_request_with_headers)
+
+    alerts = guard._fetch_dependabot_alerts(repo="owner/repo", token="token")
+
+    assert len(alerts) == guard.DEPENDABOT_ALERTS_PER_PAGE + 1

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from scripts.ci import check_pygments_exception_guard as guard
+
+
+def _alert(*, first_patched_version: str | None) -> dict[str, object]:
+    patched_payload = (
+        {"identifier": first_patched_version} if first_patched_version is not None else None
+    )
+    return {
+        "dependency": {"package": {"name": "Pygments"}},
+        "security_advisory": {"ghsa_id": guard.ADVISORY_ID},
+        "security_vulnerability": {"first_patched_version": patched_payload},
+    }
+
+
+def test_evaluate_guard_state_allows_blocked_upstream_with_exception() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=[_alert(first_patched_version=None)],
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert errors == []
+
+
+def test_evaluate_guard_state_fails_when_patch_exists_and_exception_remains() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=[_alert(first_patched_version="2.19.3")],
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert len(errors) == 2
+    assert "patched release" in errors[0]
+    assert ".pre-commit-config.yaml still ignores" in errors[0]
+    assert "requirements.txt=2.19.2" in errors[1]
+
+
+def test_evaluate_guard_state_fails_when_alerts_disappear_but_exception_remains() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=[],
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert errors == [
+        "No open Dependabot alerts remain for GHSA-5239-wwwm-4pmq, but the temporary "
+        "pip-audit exception seam is still present."
+    ]
+
+
+def test_evaluate_guard_state_ignores_unrelated_alerts() -> None:
+    pins = {
+        "requirements.txt": "2.19.2",
+        "requirements-dev.txt": "2.19.2",
+        "requirements-lock.txt": "2.19.2",
+    }
+    unrelated = {
+        "dependency": {"package": {"name": "requests"}},
+        "security_advisory": {"ghsa_id": "GHSA-xxxx-yyyy-zzzz"},
+        "security_vulnerability": {"first_patched_version": {"identifier": "9.9.9"}},
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=[unrelated],
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert errors == [
+        "No open Dependabot alerts remain for GHSA-5239-wwwm-4pmq, but the temporary "
+        "pip-audit exception seam is still present."
+    ]

--- a/tests/test_check_pygments_exception_guard.py
+++ b/tests/test_check_pygments_exception_guard.py
@@ -158,6 +158,26 @@ def test_evaluate_guard_state_flags_versions_below_patched_floor() -> None:
     assert "requirements-dev.txt" not in errors[1]
 
 
+def test_evaluate_guard_state_treats_equivalent_release_tuples_as_equal() -> None:
+    pins = {
+        "requirements.txt": "2.19",
+        "requirements-dev.txt": "2.19.0",
+        "requirements-lock.txt": "2.19.1",
+    }
+
+    errors = guard.evaluate_guard_state(
+        alerts=None,
+        advisory_patched_versions={"2.19.0"},
+        pins=pins,
+        exception_present=True,
+    )
+
+    assert errors == [
+        "Dependabot reports a patched release for GHSA-5239-wwwm-4pmq (2.19.0), "
+        "but .pre-commit-config.yaml still ignores the advisory."
+    ]
+
+
 def test_has_exception_seam_tolerates_yaml_whitespace_changes(tmp_path: Path) -> None:
     pre_commit = tmp_path / guard.PRE_COMMIT_PATH
     pre_commit.write_text(


### PR DESCRIPTION
## Summary
- add a CI guard that watches the temporary `pip-audit` Pygments exception seam
- fail once Dependabot reports a patched release or the tracked open alerts disappear
- refresh the security note and ledger item with the concrete alert references and exit criteria

## Problem
`GHSA-5239-wwwm-4pmq` is still upstream-blocked for this repo: GitHub Dependabot alerts `#58`, `#59`, and `#60` remain open, and `first_patched_version` is still null. We already carry a narrow temporary `pip-audit --ignore-vuln` seam for this advisory so unrelated PRs are not blocked, but before this change nothing in CI forced that seam to be removed once upstream state changes.

## What Changed
- added `scripts/ci/check_pygments_exception_guard.py`
- added focused tests in `tests/test_check_pygments_exception_guard.py`
- wired `pygments_exception_guard` into `.github/workflows/ci.yml`
- updated the ledger and security note to point at alerts `#58/#59/#60` and the new re-check policy

## Validation
- `make verify`
- `pre-commit run --all-files`
- `pytest -q tests/test_check_pygments_exception_guard.py`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/GHSA-5239-wwwm-4pmq-pygments.md`

## Security Notes
- this PR does not dismiss or silence the Dependabot alerts
- this PR keeps the existing temporary seam honest by failing CI as soon as upstream is patchable
- current upstream state was re-checked before this PR: open alerts `#58/#59/#60`, patched version still unavailable

## Decision Log
- coordinator-first outcome: do not burn a PR on an impossible dependency bump while upstream is still blocked
- narrow lane chosen instead: add deterministic CI enforcement so the temporary exception cannot survive past the point where it is justified

## Summary by Sourcery

Ввести защитный механизм в CI, который обеспечивает удаление временного исключения `pip-audit` для Pygments, как только блокировка со стороны upstream будет снята.

Enhancements:
- Добавить скрипт-защиту для исключения Pygments, который анализирует оповещения Dependabot и закреплённые версии, чтобы определить, когда временное подавление должно быть удалено.

CI:
- Добавить отдельное задание GitHub Actions, которое запускает защиту для исключения Pygments в pull request’ах.

Documentation:
- Обновить заметку по безопасности Pygments и реестр бэклога с текущими идентификаторами оповещений Dependabot и явными критериями завершения на основе CI.

Tests:
- Добавить целевые модульные тесты, покрывающие логику оценки защиты для исключения Pygments.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a CI guard that enforces removal of the temporary Pygments pip-audit exception once upstream is no longer blocked.

Enhancements:
- Add a Pygments exception guard script that inspects Dependabot alerts and pinned versions to decide when the temporary suppression must be removed.

CI:
- Add a dedicated GitHub Actions job that runs the Pygments exception guard on pull requests.

Documentation:
- Update the Pygments security note and backlog ledger with current Dependabot alert IDs and explicit CI-based exit criteria.

Tests:
- Add focused unit tests covering the Pygments exception guard evaluation logic.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a PR-only CI guard that watches a temporary security exception for a Pygments advisory and fails CI when conditions change.
  * Standardized Python runtime variable across CI workflows (moved from a fixed patch to a shared version variable) and adjusted coverage naming.
  * Updated secrets baseline timestamp/entries.

* **Documentation**
  * Updated security advisory, backlog ledger, and review notes to reflect current triage, Dependabot alerts, and the new CI guard.

* **Tests**
  * Added tests validating the CI guard’s detection, pagination/fallback, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1239_FIXED_MAPPING.md`
