### PR TITLE
ci(deps): add repo-managed python dependency submission

### DIFF
--- a/.github/workflows/python-dependency-submission.yml
+++ b/.github/workflows/python-dependency-submission.yml
@@ -18,6 +18,17 @@ on:
       - "constraints.txt"
       - "pyproject.toml"
       - ".github/workflows/python-dependency-submission.yml"
+  pull_request:
+    paths:
+      - "requirements.in"
+      - "requirements.txt"
+      - "requirements-dev.in"
+      - "requirements-dev.txt"
+      - "requirements-lock.txt"
+      - "requirements-all.txt"
+      - "constraints.txt"
+      - "pyproject.toml"
+      - ".github/workflows/python-dependency-submission.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-dependency-submission.yml
+++ b/.github/workflows/python-dependency-submission.yml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Python Dependency Submission
+
+# Repo-managed dependency submission replaces the GitHub-managed dynamic lane.
+# RU: После merge нужно вручную отключить Automatic dependency submission в GitHub Settings.
+# EN: After merge, disable Automatic dependency submission in GitHub Settings.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "requirements.in"
+      - "requirements.txt"
+      - "requirements-dev.in"
+      - "requirements-dev.txt"
+      - "requirements-lock.txt"
+      - "requirements-all.txt"
+      - "constraints.txt"
+      - "pyproject.toml"
+      - ".github/workflows/python-dependency-submission.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    name: Submit Python dependency snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect and submit Python dependencies
+        uses: advanced-security/component-detection-dependency-submission-action@b876b8cc341a53970394b33ea0ca4e86c25542de # v0.1.3
+        with:
+          correlator: python-dependency-submission
+          detectorArgs: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff

--- a/docs/review/PR_1241_FIXED_MAPPING.md
+++ b/docs/review/PR_1241_FIXED_MAPPING.md
@@ -1,0 +1,12 @@
+# PR 1241 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: The upstream action README still documents `permissions: id-token: write` together with `contents: write` in the canonical example workflow for `advanced-security/component-detection-dependency-submission-action`: https://github.com/advanced-security/component-detection-dependency-submission-action#example-workflows
+Reason: This PR intentionally mirrors the upstream permission contract for the dependency-submission action. Dropping `id-token: write` without upstream documentation or a proven reduced-permission run would add avoidable risk to the new repo-managed submission lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#pullrequestreview-4012983822
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#discussion_r2993656146

--- a/docs/review/PR_1241_FIXED_MAPPING.md
+++ b/docs/review/PR_1241_FIXED_MAPPING.md
@@ -8,5 +8,5 @@
 Disposition: NOT-A-BUG
 Evidence: The upstream action README still documents `permissions: id-token: write` together with `contents: write` in the canonical example workflow for `advanced-security/component-detection-dependency-submission-action`: https://github.com/advanced-security/component-detection-dependency-submission-action#example-workflows
 Reason: This PR intentionally mirrors the upstream permission contract for the dependency-submission action. Dropping `id-token: write` without upstream documentation or a proven reduced-permission run would add avoidable risk to the new repo-managed submission lane.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#pullrequestreview-4012983822
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#pullrequestreview-4012731918
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#discussion_r2993656146


### PR DESCRIPTION
## Summary
- add a repo-managed Python dependency submission workflow
- pin the Node24-capable `advanced-security/component-detection-dependency-submission-action@b876b8cc341a53970394b33ea0ca4e86c25542de`
- exercise the dependency-submission lane on PR heads before merge
- keep the existing `Pygments` seam, guard, and backlog policy unchanged

## Why
The current GitHub-managed dynamic run `dynamic/dependency-graph/auto-submission` is still using the legacy Node20 action path and emits the deprecation warning. This PR moves Python dependency submission under repo control so the repo can use a pinned Node24-capable action.

## Scope
- adds `.github/workflows/python-dependency-submission.yml`
- runs the new workflow on matching `pull_request` changes and on `push` to `main`
- no application API changes
- no `Pygments` remediation attempt in this PR
- no CI guard or backlog policy changes in this PR

## Testing
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `pre-commit run --all-files`
- `make verify`
- pre-push hooks on `git push` passed

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: NOT-A-BUG
Evidence: The upstream action README still documents `permissions: id-token: write` together with `contents: write` in the canonical example workflow for `advanced-security/component-detection-dependency-submission-action`: https://github.com/advanced-security/component-detection-dependency-submission-action#example-workflows
Reason: This PR intentionally mirrors the upstream permission contract for the dependency-submission action. Dropping `id-token: write` without upstream documentation or a proven reduced-permission run would add avoidable risk to the new repo-managed submission lane.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#pullrequestreview-4012731918
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1241#discussion_r2993656146

## Manual Post-Merge Step
After this PR merges, disable GitHub automatic dependency submission in repository settings:
- `Settings -> Advanced Security -> Dependency graph -> Automatic dependency submission -> Disable`
- keep dependency graph and Dependabot alerts enabled

## Notes
- This PR intentionally does not change the open low-severity `Pygments` Dependabot alerts (`#58/#59/#60`) because upstream still reports `first_patched_version = none`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated Python dependency-submission workflow to improve dependency tracking and security visibility; it runs on dependency file changes and supports manual triggering, with concurrency controls and required repository permissions.
* **Documentation**
  * Added a review document recording the PR status, resolution rationale, and links to the review discussion for traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->