### PR TITLE
feat(ci): implement tier1 PR3 risk topology

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,14 @@
 - [ ] PR tests green (lint, type, unit)
 - [ ] Diff coverage ≥ 97% on changed lines
 
+## Split Justification
+
+(Required only when the PR is > 800 changed LoC under Tier 1 governance.)
+
+- Why this PR cannot be split safely:
+- What invariant, contract, or rollout constraint requires one PR:
+- What follow-up PRs remain after this large change:
+
 ## Discussion Thread Pass
 
 - [ ] Discussion-thread pass completed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,6 +574,7 @@ jobs:
 
       - name: Contract and risk suites
         if: ${{ needs.changes.outputs.contract_risk_groups != '' }}
+        shell: bash
         env:
           PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
           CONTRACT_RISK_GROUPS: "${{ needs.changes.outputs.contract_risk_groups }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,13 @@ jobs:
       run_backend_blocking: ${{ steps.risk_profile.outputs.run_backend_blocking }}
       run_security: ${{ steps.risk_profile.outputs.run_security }}
       run_openapi_sync: ${{ steps.risk_profile.outputs.run_openapi_sync }}
+      billing_entitlement: ${{ steps.risk_profile.outputs.billing_entitlement }}
+      insight_ai: ${{ steps.risk_profile.outputs.insight_ai }}
+      openapi_contract: ${{ steps.risk_profile.outputs.openapi_contract }}
+      route_contract_safety: ${{ steps.risk_profile.outputs.route_contract_safety }}
+      merge_governance: ${{ steps.risk_profile.outputs.merge_governance }}
       contract_risk_groups: ${{ steps.risk_profile.outputs.contract_risk_groups }}
+      changed_file_count: ${{ steps.risk_profile.outputs.changed_file_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,15 @@ jobs:
       pull-requests: read
     outputs:
       ios: ${{ steps.filter.outputs.ios }}
+      docs_only: ${{ steps.risk_profile.outputs.docs_only }}
+      frontend_only: ${{ steps.risk_profile.outputs.frontend_only }}
+      ios_only: ${{ steps.risk_profile.outputs.ios_only }}
+      workflow_privileged: ${{ steps.risk_profile.outputs.workflow_privileged }}
+      backend_shared: ${{ steps.risk_profile.outputs.backend_shared }}
+      run_backend_blocking: ${{ steps.risk_profile.outputs.run_backend_blocking }}
+      run_security: ${{ steps.risk_profile.outputs.run_security }}
+      run_openapi_sync: ${{ steps.risk_profile.outputs.run_openapi_sync }}
+      contract_risk_groups: ${{ steps.risk_profile.outputs.contract_risk_groups }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,6 +63,16 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
+      - name: Build PR risk profile
+        id: risk_profile
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/ci_risk_profile.py \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.sha }}" \
+            --github-output "$GITHUB_OUTPUT"
+
   pr_scope_guard:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -70,6 +89,14 @@ jobs:
 
           echo "Running PR Scope Guard script..."
           bash scripts/ci/pr_scope_guard.sh
+
+      - name: PR size governance
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_pr_size_governance.py \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.sha }}" \
+            --event-path "$GITHUB_EVENT_PATH"
 
       - name: Design invariant guard
         run: |
@@ -295,6 +322,8 @@ jobs:
           SKIP: no-commit-to-branch
 
   security:
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.run_security == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -421,6 +450,8 @@ jobs:
 
   openapi-sync:
     name: OpenAPI sync (backend -> frontend artifacts)
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.run_openapi_sync == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -461,10 +492,10 @@ jobs:
       - name: Fail if generated artifacts differ
         run: git diff --exit-code frontend/src/api/openapi.json frontend/src/api/schema.ts
 
-  # Fast testing for PRs (single Python version)
+  # Tier 1 PR testing: critical smoke + contract/risk suites
   test-pr:
-    if: github.event_name == 'pull_request'
-    needs: [pr_scope_guard, openapi-sync]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_backend_blocking == 'true'
+    needs: [changes, pr_scope_guard, openapi-sync]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -521,10 +552,9 @@ jobs:
           ENVIRONMENT: test
           PYTHONPATH: "${{ github.workspace }}"
 
-      - name: Run tests with coverage
+      - name: Critical smoke (deterministic merge blocker)
         env:
           PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
-          MATRIX_PYTHON_VERSION: "${{ matrix.python-version }}"
           VIP_MODULE_ENABLED: "true"
           APP_ENV: test
           ENVIRONMENT: test
@@ -534,29 +564,105 @@ jobs:
           PYTHONFAULTHANDLER: "1"
           PYTHONMALLOC: "malloc"
         run: |
-          # Use pytest-xdist for parallel execution with proper coverage collection
-          # Project standard: maintain 97% coverage for PR branches before merge
-          # See .cursorrules and AGENTS.md for coverage requirements
-          #
-          # CI stability: Python 3.13 has seen intermittent segfaults under xdist+coverage.
-          # Run sequentially on 3.13; keep parallelism for older versions.
-          # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
-          # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
-          PYVER="${MATRIX_PYTHON_VERSION}"
-          if [[ "$PYVER" == 3.13* ]]; then
-            # Fully disable xdist plugin on 3.13 (more stable than `-n 0`)
-            PYTEST_XDIST_ARGS=(-p no:xdist)
-          else
-            PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
+          set -euo pipefail
+          python -m coverage erase
+          python -m coverage run -m pytest -q \
+            tests/edges tests/test_remaining_modules.py \
+            --maxfail=3 \
+            --junitxml=tests/smoke-results.xml \
+            -o junit_family=legacy
+
+      - name: Contract and risk suites
+        if: ${{ needs.changes.outputs.contract_risk_groups != '' }}
+        env:
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
+          CONTRACT_RISK_GROUPS: "${{ needs.changes.outputs.contract_risk_groups }}"
+          VIP_MODULE_ENABLED: "true"
+          APP_ENV: test
+          ENVIRONMENT: test
+          FEATURE_PREMIUM_NUTRITION: "true"
+          API_KEY: "test_key"
+          PYTHONUNBUFFERED: "1"
+          PYTHONFAULTHANDLER: "1"
+          PYTHONMALLOC: "malloc"
+        run: |
+          set -euo pipefail
+
+          declare -A suite_targets=()
+
+          add_suite() {
+            for target in "$@"; do
+              suite_targets["$target"]=1
+            done
+          }
+
+          for group in ${CONTRACT_RISK_GROUPS//,/ }; do
+            case "$group" in
+              billing_entitlement)
+                add_suite \
+                  tests/test_api_tiers_db_lookup.py \
+                  tests/test_billing_openapi_contract.py \
+                  tests/test_ios_receipt_verification_api.py \
+                  tests/test_paid_route_guards.py \
+                  tests/test_payment_reconciliation_api.py \
+                  tests/test_payment_source_contract_api.py \
+                  tests/test_payment_webhook_signature_api.py \
+                  tests/test_pro_payments_openapi_contract.py \
+                  tests/test_subscription_activation_api.py
+                ;;
+              insight_ai)
+                add_suite \
+                  tests/test_core_ai_insight_runtime.py \
+                  tests/test_fitchef_insight_api.py \
+                  tests/test_insight_error_hygiene.py \
+                  tests/test_insight_vip_guard_api.py \
+                  tests/test_insight_vip_monthly_quota_api.py \
+                  tests/test_philosophy_validation_integration.py \
+                  tests/test_rate_limit_llm_and_exports_api.py
+                ;;
+              openapi_contract)
+                add_suite \
+                  tests/test_openapi_determinism.py \
+                  tests/test_openapi_import_safe_orm_guard.py \
+                  tests/test_openapi_namespace_guards.py
+                ;;
+              merge_governance)
+                add_suite \
+                  tests/test_check_pr_size_governance.py \
+                  tests/test_ci_risk_profile.py \
+                  tests/test_orchestration_merge_ready.py \
+                  tests/test_pr_body_phase2_gates.py \
+                  tests/test_pr_merge_readiness_gate.py \
+                  tests/test_review_threads_disposition_strict.py
+                ;;
+              *)
+                echo "::error::Unknown contract/risk group: $group"
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "${#suite_targets[@]}" -eq 0 ]; then
+            echo "No contract/risk suites selected."
+            exit 0
           fi
-          python -c "import sys; print('PY', sys.version)"
-          echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
-          python -X faulthandler -m pytest \
-            "${PYTEST_XDIST_ARGS[@]}" \
-            -m "not slow" \
-            --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
-            --junitxml=tests/results.xml -o junit_family=legacy \
-            tests
+
+          mapfile -t SELECTED_TARGETS < <(printf '%s\n' "${!suite_targets[@]}" | sort)
+          printf 'Selected contract/risk suites:\n'
+          printf '  - %s\n' "${SELECTED_TARGETS[@]}"
+
+          python -m coverage run --append -m pytest -q \
+            "${SELECTED_TARGETS[@]}" \
+            --junitxml=tests/contract-results.xml \
+            -o junit_family=legacy
+
+      - name: Finalize coverage artifacts
+        env:
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/tests"
+        run: |
+          set -euo pipefail
+          python -m coverage report -m
+          python -m coverage xml
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -576,7 +682,9 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: junit-${{ env.COVERAGE_PY }}
-          path: tests/results.xml
+          path: |
+            tests/smoke-results.xml
+            tests/contract-results.xml
           if-no-files-found: ignore
           retention-days: 7
 
@@ -824,8 +932,8 @@ jobs:
 
   # Coverage reporting for PRs
   coverage-pr:
-    if: github.event_name == 'pull_request'
-    needs: [pr_scope_guard, test-pr]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_backend_blocking == 'true'
+    needs: [changes, test-pr]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -854,8 +962,8 @@ jobs:
 
   diff-coverage:
     name: diff-coverage
-    if: github.event_name == 'pull_request'
-    needs: [pr_scope_guard, test-pr]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_backend_blocking == 'true'
+    needs: [changes, pr_scope_guard, test-pr]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,6 +626,13 @@ jobs:
                   tests/test_openapi_import_safe_orm_guard.py \
                   tests/test_openapi_namespace_guards.py
                 ;;
+              route_contract_safety)
+                add_suite \
+                  tests/test_api.py \
+                  tests/test_app_error_handling_combined.py \
+                  tests/test_app_extended_coverage.py \
+                  tests/test_legacy_app_diff_coverage.py
+                ;;
               merge_governance)
                 add_suite \
                   tests/test_check_pr_size_governance.py \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 532
+        "line_number": 562
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-26T11:24:33Z"
+  "generated_at": "2026-03-26T16:13:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 568
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-26T16:13:18Z"
+  "generated_at": "2026-03-26T18:53:31Z"
 }

--- a/docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md
@@ -54,6 +54,13 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 - removes duplicate PR-time CI responsibilities in PR2,
 - introduces lightweight operational metrics without turning them into merge blockers.
 
+## Current State
+
+- PR-1 governance/bootstrap already landed in merged PR `#1240` (`24c51f85`).
+- PR-2 workflow consolidation already landed on `origin/main` via PR `#1244` (`b7e029b4`).
+- This runbook now treats PR-3 as the active execution slice and PR-4 as the next follow-up wave.
+- Do not restart the series from PR-1; reconcile Tier 1 bookkeeping inside PR-3 and continue forward.
+
 ## PR Series
 
 ### PR-1: Governance and Canonical Matrix Sync
@@ -62,6 +69,7 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 - Align the CI/governance operating model with the existing contract matrix.
 - Record the Tier 1 epic and child PR slices in `docs/roadmap/BACKLOG_LEDGER.md`.
 - Resolve ledger drift where CI-classification work is already complete at the contract level.
+- Status: landed in PR `#1240`; retained here as completed baseline context.
 
 ### PR-2: Workflow Consolidation
 
@@ -70,18 +78,22 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 - `security.yml` is a scheduled/manual audit lane, and `trivy.yml` remains a `main`/schedule/manual image-security lane; neither is a canonical PR blocker.
 - Keep `build.yml`, frontend-only, and nightly-only surfaces separate.
 - Workflow/governance PRs may still trigger specialized repo-level lanes such as `Frontend CI`, CodeQL, or Docker/image workflows; PR2 only makes `ci.yml` the canonical backend/shared merge-truth surface.
+- Status: landed in PR `#1244`; retained here as completed baseline context.
 
 ### PR-3: Risk-Based PR Test Topology
 
+- Open with the required reconciliation step so Tier 1 docs/backlog reflect landed PR-1 / PR-2 state before new topology work starts.
 - Split PR execution into deterministic smoke, contract/risk suites, and nightly-only depth.
 - Keep PR blockers focused on business-critical surfaces.
-- Add PR-size governance and explicit split/justify rules.
+- Add PR-size governance and explicit `## Split Justification` PR-body proof for `>800` LoC cases.
+- Status: active next execution slice.
 
 ### PR-4: CI Metrics and Feedback Loop
 
 - Add lightweight non-blocking CI metrics collection under `scripts/ci/`.
 - Emit summary artifacts for critical-path duration, reruns, red-build rate, and xdist fallback frequency.
 - Wire a weekly reporting path without changing merge blockers.
+- Status: next/deferred until PR-3 lands.
 
 ## Routing Card
 
@@ -110,6 +122,7 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
    - duplicate PR-time lanes are retired as active PR lanes
    - required-check coverage is preserved
 3. **PR-3 risk topology**
+   - reconciliation step captures landed PR-1 / PR-2 evidence first
    - blocking smoke/contract lanes documented and enforced
    - nightly-only depth explicitly separated
    - PR-size governance documented and validated

--- a/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
+++ b/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
@@ -1,7 +1,7 @@
 # Tier 1 CI/CD Task Packet
 
 **Date:** 2026-03-26 (`America/New_York`)
-**Status:** Active PR-3 packet for the Tier 1 backend/shared CI consolidation wave after landed PR-1 / PR-2 baseline work.
+**Status:** Active PR-3 packet for the Tier 1 backend/shared CI consolidation wave following the landed PR-1 / PR-2 baseline work.
 **Wave:** stacked PRs, coordinator-first, governance-first.
 
 ## Goal

--- a/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
+++ b/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
@@ -1,7 +1,7 @@
 # Tier 1 CI/CD Task Packet
 
 **Date:** 2026-03-26 (`America/New_York`)
-**Status:** Active packet for the Tier 1 backend/shared CI consolidation wave.
+**Status:** Active PR-3 packet for the Tier 1 backend/shared CI consolidation wave after landed PR-1 / PR-2 baseline work.
 **Wave:** stacked PRs, coordinator-first, governance-first.
 
 ## Goal
@@ -20,6 +20,13 @@ without weakening current merge blockers or broadening runtime behavior.
   summarized here when a branch-local reminder is useful.
 
 ## Scope
+
+### Active execution state
+
+- PR-1 governance/bootstrap is already landed in PR `#1240` (`24c51f85`).
+- PR-2 workflow consolidation is already landed on `origin/main` in PR `#1244` (`b7e029b4`).
+- This packet therefore points to PR-3 as the live execution branch and keeps PR-4 as the next follow-up.
+- Reconciliation of Tier 1 bookkeeping is part of the opening commit set for PR-3, not a separate restart PR.
 
 ### In scope
 
@@ -77,6 +84,7 @@ Blocking surfaces for Tier 1 PR-lane decisions:
 - Tier 1 task packet
 - backlog epic + child slices
 - governance/runbook cross-links
+- Status: landed baseline (`#1240`)
 
 ### PR-2
 
@@ -85,28 +93,31 @@ Blocking surfaces for Tier 1 PR-lane decisions:
 - `security.yml` demoted to scheduled/manual audit lane; `trivy.yml` kept as `main`/schedule/manual image-security lane
 - `build.yml` kept as a specialized release/image lane
 - specialized repo-level PR workflows may still attach on workflow/governance diffs, but they stay outside canonical backend/shared merge truth unless branch protection promotes them
+- Status: landed baseline (`#1244`)
 
 ### PR-3
 
+- Tier 1 reconciliation pre-step for landed PR-1 / PR-2 evidence
 - risk-based PR topology
-- PR-size governance
+- PR-size governance with explicit `## Split Justification` PR-body proof for `>800` LoC cases
 - blocker/non-blocker split documented and enforced
+- Status: active next slice
 
 ### PR-4
 
 - `scripts/ci/` metrics collector
 - `ci-metrics-summary.json`
 - `ci-metrics-summary.md`
+- Status: deferred/next
 
 ## Acceptance Criteria
 
-- One canonical backend/shared PR workflow exists in `ci.yml`
-- `pr-tests.yml` and `pr-coverage.yml` are no longer active PR lanes
-- `security.yml` and `trivy.yml` are no longer PR-time canonical blockers and stay outside canonical merge truth
-- `build.yml` remains a specialized release/image lane
+- PR2's canonical backend/shared PR lane in `ci.yml` remains the only backend/shared merge-truth surface
+- PR3 makes the PR path explicit as critical smoke plus contract/risk suites, while keeping nightly/regression depth outside normal PR blocking flow
+- PR3 adds documented and enforced PR-size governance for `<300`, `300-800`, and `>800` LoC cases
 - Current-head merge-readiness remains deterministic and wrapper-backed
 - Local merge evidence remains `pre-commit run --all-files` + `make verify`
-- Mandatory post-open `qa-engineer-agent -> bug-hunter` lane is recorded and used
+- Mandatory post-open `qa-engineer-agent -> bug-hunter` lane remains recorded and used for this slice
 
 ## Validation Commands
 

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1248 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+No actionable review threads have been recorded yet.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -5,7 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996910355 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996910363 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996916795 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996925510 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996935078 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996935102 -> 4c950aa2
 
 ## Merge Readiness
 - [ ] All required checks pass
@@ -13,4 +18,4 @@
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [x] `make verify` green
-- Current head `a07ce7d3` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.
+- Current head `4c950aa2` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -14,6 +14,7 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018143 -> 886b694e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018155 -> 886b694e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018163 -> 886b694e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#pullrequestreview-4017050483 -> b794592c
 
 ## Merge Readiness
 - [ ] All required checks pass
@@ -21,4 +22,4 @@
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [x] `make verify` green
-- Current head `886b694e` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.
+- Current branch head requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -13,3 +13,4 @@
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [x] `make verify` green
+- Current head `a07ce7d3` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1248 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-No actionable review threads have been recorded yet.
+- No actionable review comments.
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1248_FIXED_MAPPING.md
+++ b/docs/review/PR_1248_FIXED_MAPPING.md
@@ -11,6 +11,9 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996925510 -> 4c950aa2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996935078 -> 4c950aa2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2996935102 -> 4c950aa2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018143 -> 886b694e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018155 -> 886b694e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1248#discussion_r2997018163 -> 886b694e
 
 ## Merge Readiness
 - [ ] All required checks pass
@@ -18,4 +21,4 @@
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [x] `make verify` green
-- Current head `4c950aa2` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.
+- Current head `886b694e` requires canonical `pull_request` revalidation because the last successful PR CI run reported on `fcc1356d`.

--- a/docs/review/PR_1250_FIXED_MAPPING.md
+++ b/docs/review/PR_1250_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1250 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review threads on PR `#1250` yet.
+- Carryover evidence from closed replacement-source PR `#1248` lives in `docs/review/PR_1248_FIXED_MAPPING.md`.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- Current branch head requires canonical `pull_request` validation on replacement PR `#1250`.

--- a/docs/review/PR_1250_FIXED_MAPPING.md
+++ b/docs/review/PR_1250_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - [ ] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review threads on PR `#1250` yet.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1250#discussion_r2997499001 -> 5b0bf7a9
 - Carryover evidence from closed replacement-source PR `#1248` lives in `docs/review/PR_1248_FIXED_MAPPING.md`.
 
 ## Merge Readiness

--- a/docs/review/PR_1250_FIXED_MAPPING.md
+++ b/docs/review/PR_1250_FIXED_MAPPING.md
@@ -6,6 +6,8 @@
 
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1250#discussion_r2997499001 -> 5b0bf7a9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1250#discussion_r2997517780 -> 777c4465
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1250#discussion_r2997517784 -> 777c4465
 - Carryover evidence from closed replacement-source PR `#1248` lives in `docs/review/PR_1248_FIXED_MAPPING.md`.
 
 ## Merge Readiness

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2044,7 +2044,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Tier 1 CI/CD consolidation via custom orchestration
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1240 -> PR #1244 -> PR #1248 -> PR-TBD-TIER1-CI-CD-PR4
+  - Target PR: PR #1240 -> PR #1244 -> PR #1250 -> PR-TBD-TIER1-CI-CD-PR4
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
   - Status: In progress
@@ -2105,10 +2105,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: PR3 risk-based PR test topology {#ledger-p1-tier1-ci-cd-pr3-risk-topology}
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: #1248
+  - Target PR: #1250
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: 🚧 In progress in PR `#1248` (PR3 risk-topology lane), following landed PR1/PR2 reconciliation (`#1240`, `#1244`).
+  - Status: 🚧 In progress in PR `#1250` (PR3 risk-topology lane), following landed PR1/PR2 reconciliation (`#1240`, `#1244`) after replacement of closed PR `#1248`.
   - Reason: PR blockers should stay focused on business-critical runtime paths, while nightly depth absorbs broad non-critical coverage tails.
   - Links:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-test-hygiene-wave`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2043,7 +2043,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Tier 1 CI/CD consolidation via custom orchestration
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-TIER1-CI-CD-PR1 -> PR-TBD-TIER1-CI-CD-PR4
+  - Target PR: PR #1240 -> PR #1244 -> PR-TBD-TIER1-CI-CD-PR3 -> PR-TBD-TIER1-CI-CD-PR4
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
   - Status: In progress
@@ -2064,13 +2064,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `ledger-p1-tier1-ci-cd-pr3-risk-topology`
     - `ledger-p1-tier1-ci-cd-pr4-metrics`
 
-- [ ] P1: PR1 governance and canonical matrix sync {#ledger-p1-tier1-ci-cd-pr1-governance}
+- [x] P1: PR1 governance and canonical matrix sync {#ledger-p1-tier1-ci-cd-pr1-governance}
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-TIER1-CI-CD-PR1
+  - Target PR: PR #1240
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: Planned
+  - Status: Materially completed in merged PR `#1240` (`24c51f85`); this slice now stays closed unless follow-up governance drift is reopened explicitly.
   - Reason: The repo already has merge-governance primitives, but Tier 1 cannot start safely until the canonical backend/shared lane, duplicate PR-time workflows, and specialized add-on lanes are named explicitly in docs.
   - Links:
     - `docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md`
@@ -2081,13 +2081,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Mandatory post-open `qa-engineer-agent -> bug-hunter` lane is recorded
     - Local validation passes: `check_preflight`, `check_agent_consistency`, `pre-commit run --all-files`, `make verify`
 
-- [ ] P1: PR2 workflow consolidation into canonical ci.yml {#ledger-p1-tier1-ci-cd-pr2-workflow}
+- [x] P1: PR2 workflow consolidation into canonical ci.yml {#ledger-p1-tier1-ci-cd-pr2-workflow}
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-TIER1-CI-CD-PR2
+  - Target PR: PR #1244
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: In progress in PR `#1244`; closure pending merge evidence.
+  - Status: Materially completed on `origin/main` in PR `#1244` (`b7e029b4`); this slice now serves as landed baseline input for PR3.
   - Reason: Backend/shared PR execution is now canonicalized in `ci.yml`; `pr-tests.yml` and `pr-coverage.yml` are no longer active PR lanes, `security.yml` moved to a scheduled/manual audit lane, `trivy.yml` remains a non-PR image-security lane on `main`/schedule/manual, and `build.yml` remains specialized.
   - Links:
     - `.github/workflows/ci.yml`
@@ -2107,16 +2107,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: PR-TBD-TIER1-CI-CD-PR3
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: Planned
+  - Status: Active next slice after landed PR1/PR2 reconciliation (`#1240`, `#1244`).
   - Reason: PR blockers should stay focused on business-critical runtime paths, while nightly depth absorbs broad non-critical coverage tails.
   - Links:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-test-hygiene-wave`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fastapi-compatibility-gates`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-llm-reliability-security-gates`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-classify-ci-checks-as-hard-soft-external`
     - `docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md`
   - DoD:
     - Deterministic smoke, contract/risk suites, and nightly-only depth are split
     - Blocking surfaces explicitly cover billing, entitlement, VIP insight, and OpenAPI determinism
-    - PR-size governance exists for `<300`, `300-800`, and `>800` LoC cases
+    - PR-size governance exists for `<300`, `300-800`, and `>800` LoC cases, and `>800` requires explicit `## Split Justification` proof in the PR body
     - No new flaky test class is introduced
 
 - [ ] P1: PR4 lightweight CI metrics and weekly feedback loop {#ledger-p1-tier1-ci-cd-pr4-metrics}
@@ -2125,7 +2127,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: PR-TBD-TIER1-CI-CD-PR4
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: Planned
+  - Status: Deferred/next after PR3 risk-topology rollout.
   - Reason: Tier 1 needs advisory metrics for critical-path duration, reruns, and flaky-signal tracking without turning observability into another merge blocker.
   - Links:
     - `docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2023,6 +2023,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Deterministic tests cover workflow/Fastlane/orchestration-path review routing
     - Merge-readiness docs explain that this is a default requirement, not optional reviewer theater
 
+<a id="ledger-p1-classify-ci-checks-as-hard-soft-external"></a>
 - [x] P1: Classify CI checks as hard / soft / external in AGENTS or CI governance
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
@@ -2104,10 +2105,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: PR3 risk-based PR test topology {#ledger-p1-tier1-ci-cd-pr3-risk-topology}
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-TIER1-CI-CD-PR3
+  - Target PR: #1248
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: Active next slice after landed PR1/PR2 reconciliation (`#1240`, `#1244`).
+  - Status: 🚧 In progress in PR `#1248` (PR3 risk-topology lane), following landed PR1/PR2 reconciliation (`#1240`, `#1244`).
   - Reason: PR blockers should stay focused on business-critical runtime paths, while nightly depth absorbs broad non-critical coverage tails.
   - Links:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-test-hygiene-wave`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2044,7 +2044,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Tier 1 CI/CD consolidation via custom orchestration
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1240 -> PR #1244 -> PR-TBD-TIER1-CI-CD-PR3 -> PR-TBD-TIER1-CI-CD-PR4
+  - Target PR: PR #1240 -> PR #1244 -> PR #1248 -> PR-TBD-TIER1-CI-CD-PR4
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
   - Status: In progress

--- a/scripts/ci/check_pr_size_governance.py
+++ b/scripts/ci/check_pr_size_governance.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""PR-size governance gate for Tier 1 CI/CD.
+
+RU: Проверяет размер PR по LoC и требует явное split-обоснование для больших PR.
+EN: Enforces the Tier 1 PR-size policy using changed-line counts and PR-body proof.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess  # nosec B404: subprocess is required for bounded local git diff execution (remove-by: 2026-09-30, ref: PR3-risk-topology)
+import sys
+import re
+import shutil
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NORMAL_MAX_LOC = 299
+WARNING_MAX_LOC = 800
+GIT_BINARY = shutil.which("git")
+SPLIT_JUSTIFICATION_PATTERN = re.compile(
+    r"(?im)^(?:##+\s*|[*]{0,2})?(?:pr size justification|split justification)\b",
+)
+
+
+def parse_numstat_output(numstat_output: str) -> tuple[int, int]:
+    """Return total changed lines and counted files from git --numstat output."""
+    total_changed_lines = 0
+    counted_files = 0
+    for raw_line in numstat_output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", maxsplit=2)
+        if len(parts) != 3:
+            continue
+        added_raw, deleted_raw, _path = parts
+        if added_raw == "-" or deleted_raw == "-":
+            continue
+        total_changed_lines += int(added_raw) + int(deleted_raw)
+        counted_files += 1
+    return total_changed_lines, counted_files
+
+
+def classify_pr_size(total_changed_lines: int) -> str:
+    """Classify PR size according to Tier 1 governance buckets."""
+    if total_changed_lines <= NORMAL_MAX_LOC:
+        return "normal"
+    if total_changed_lines <= WARNING_MAX_LOC:
+        return "warning"
+    return "requires_split_justification"
+
+
+def has_split_justification(pr_body: str) -> bool:
+    """Return True when the PR body contains an explicit split-justification block."""
+    return bool(SPLIT_JUSTIFICATION_PATTERN.search(pr_body or ""))
+
+
+def evaluate_pr_size_policy(
+    *,
+    total_changed_lines: int,
+    counted_files: int,
+    pr_body: str,
+) -> tuple[int, list[str]]:
+    """Evaluate size policy and return exit code plus deterministic terminal lines."""
+    bucket = classify_pr_size(total_changed_lines)
+    lines = [
+        f"PR size bucket: {bucket}",
+        f"Changed lines: {total_changed_lines}",
+        f"Counted files: {counted_files}",
+    ]
+    if bucket == "normal":
+        lines.append("PR size governance: OK (<300 LoC).")
+        return 0, lines
+
+    if bucket == "warning":
+        lines.append("PR size governance: WARNING (300-800 LoC). Review split opportunities.")
+        return 0, lines
+
+    if has_split_justification(pr_body):
+        lines.append(
+            "PR size governance: OK (>800 LoC) because explicit split justification is present.",
+        )
+        return 0, lines
+
+    lines.append("PR size governance: FAIL (>800 LoC without explicit split justification).")
+    lines.append("Add `## Split Justification` (or `Split justification:`) to the PR body.")
+    return 1, lines
+
+
+def collect_numstat_output(*, base_sha: str, head_sha: str) -> str:
+    """Collect git --numstat output between two revisions."""
+    if GIT_BINARY is None:
+        raise RuntimeError("git executable not found in PATH")
+    result = subprocess.run(  # nosec B603: fixed git argv without shell for local CI routing only (remove-by: 2026-09-30, ref: PR3-risk-topology)
+        [
+            GIT_BINARY,
+            "diff",
+            "--numstat",
+            f"{base_sha}...{head_sha}",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def extract_pr_body(event_path: Path) -> str:
+    """Extract PR body from a GitHub event payload."""
+    try:
+        payload = json.loads(event_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return ""
+    body = pull_request.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    base_sha = ""
+    head_sha = ""
+    pr_body = ""
+    event_path: Path | None = None
+
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument == "--base-sha":
+            index += 1
+            base_sha = argv[index]
+        elif argument == "--head-sha":
+            index += 1
+            head_sha = argv[index]
+        elif argument == "--body":
+            index += 1
+            pr_body = argv[index]
+        elif argument == "--event-path":
+            index += 1
+            event_path = Path(argv[index])
+        else:
+            raise SystemExit(f"Unknown argument: {argument}")
+        index += 1
+
+    if not base_sha or not head_sha:
+        raise SystemExit("Provide both --base-sha and --head-sha.")
+
+    if event_path is not None and not pr_body:
+        pr_body = extract_pr_body(event_path)
+
+    total_changed_lines, counted_files = parse_numstat_output(
+        collect_numstat_output(base_sha=base_sha, head_sha=head_sha),
+    )
+    exit_code, lines = evaluate_pr_size_policy(
+        total_changed_lines=total_changed_lines,
+        counted_files=counted_files,
+        pr_body=pr_body,
+    )
+    for line in lines:
+        print(line)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_pr_size_governance.py
+++ b/scripts/ci/check_pr_size_governance.py
@@ -64,26 +64,33 @@ def evaluate_pr_size_policy(
 ) -> tuple[int, list[str]]:
     """Evaluate size policy and return exit code plus deterministic terminal lines."""
     bucket = classify_pr_size(total_changed_lines)
+    normal_range_text = f"<={NORMAL_MAX_LOC} LoC"
+    warning_range_text = f"{NORMAL_MAX_LOC + 1}-{WARNING_MAX_LOC} LoC"
+    split_required_text = f">{WARNING_MAX_LOC} LoC"
     lines = [
         f"PR size bucket: {bucket}",
         f"Changed lines: {total_changed_lines}",
         f"Counted files: {counted_files}",
     ]
     if bucket == "normal":
-        lines.append("PR size governance: OK (<300 LoC).")
+        lines.append(f"PR size governance: OK ({normal_range_text}).")
         return 0, lines
 
     if bucket == "warning":
-        lines.append("PR size governance: WARNING (300-800 LoC). Review split opportunities.")
+        lines.append(
+            f"PR size governance: WARNING ({warning_range_text}). Review split opportunities.",
+        )
         return 0, lines
 
     if has_split_justification(pr_body):
         lines.append(
-            "PR size governance: OK (>800 LoC) because explicit split justification is present.",
+            f"PR size governance: OK ({split_required_text}) because explicit split justification is present.",
         )
         return 0, lines
 
-    lines.append("PR size governance: FAIL (>800 LoC without explicit split justification).")
+    lines.append(
+        f"PR size governance: FAIL ({split_required_text} without explicit split justification).",
+    )
     lines.append("Add `## Split Justification` (or `Split justification:`) to the PR body.")
     return 1, lines
 

--- a/scripts/ci/check_pr_size_governance.py
+++ b/scripts/ci/check_pr_size_governance.py
@@ -122,6 +122,14 @@ def extract_pr_body(event_path: Path) -> str:
     return body if isinstance(body, str) else ""
 
 
+def _read_flag_value(argv: list[str], index: int, flag: str) -> str:
+    """Return the next argv token for a flag or exit with a deterministic error."""
+    value_index = index + 1
+    if value_index >= len(argv):
+        raise SystemExit(f"Missing value for {flag}.")
+    return argv[value_index]
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     argv = list(sys.argv[1:] if argv is None else argv)
@@ -135,16 +143,16 @@ def main(argv: list[str] | None = None) -> int:
         argument = argv[index]
         if argument == "--base-sha":
             index += 1
-            base_sha = argv[index]
+            base_sha = _read_flag_value(argv, index - 1, argument)
         elif argument == "--head-sha":
             index += 1
-            head_sha = argv[index]
+            head_sha = _read_flag_value(argv, index - 1, argument)
         elif argument == "--body":
             index += 1
-            pr_body = argv[index]
+            pr_body = _read_flag_value(argv, index - 1, argument)
         elif argument == "--event-path":
             index += 1
-            event_path = Path(argv[index])
+            event_path = Path(_read_flag_value(argv, index - 1, argument))
         else:
             raise SystemExit(f"Unknown argument: {argument}")
         index += 1

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -250,14 +250,6 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
     }
     group_hits["route_contract_safety"] = any(
         _is_route_contract_surface(path) for path in normalized_files
-    ) and not any(
-        group_hits[group_name]
-        for group_name in (
-            "billing_entitlement",
-            "insight_ai",
-            "openapi_contract",
-            "merge_governance",
-        )
     )
     if workflow_privileged:
         selected_groups = ALL_RISK_GROUPS

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -21,6 +21,7 @@ ALL_RISK_GROUPS: tuple[str, ...] = (
     "billing_entitlement",
     "insight_ai",
     "openapi_contract",
+    "route_contract_safety",
     "merge_governance",
 )
 
@@ -133,6 +134,7 @@ class RiskProfile:
     billing_entitlement: bool
     insight_ai: bool
     openapi_contract: bool
+    route_contract_safety: bool
     merge_governance: bool
     contract_risk_groups: tuple[str, ...]
 
@@ -150,6 +152,7 @@ class RiskProfile:
             "billing_entitlement": _bool_text(self.billing_entitlement),
             "insight_ai": _bool_text(self.insight_ai),
             "openapi_contract": _bool_text(self.openapi_contract),
+            "route_contract_safety": _bool_text(self.route_contract_safety),
             "merge_governance": _bool_text(self.merge_governance),
             "contract_risk_groups": ",".join(self.contract_risk_groups),
             "changed_file_count": str(len(self.changed_files)),
@@ -203,6 +206,11 @@ def _risk_group_hit(group_name: str, changed_files: tuple[str, ...]) -> bool:
     return any(_matches_any(path, patterns) for path in changed_files)
 
 
+def _is_route_contract_surface(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized == "legacy_app.py" or normalized.startswith(("app/", "core/"))
+
+
 def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfile:
     """Build a deterministic risk profile from normalized changed paths."""
     normalized_files = tuple(
@@ -222,6 +230,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
             billing_entitlement=False,
             insight_ai=False,
             openapi_contract=False,
+            route_contract_safety=False,
             merge_governance=False,
             contract_risk_groups=(),
         )
@@ -235,8 +244,21 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
     ios_only = all(_is_ios_path(path) for path in normalized_files) and not workflow_privileged
 
     group_hits = {
-        group_name: _risk_group_hit(group_name, normalized_files) for group_name in ALL_RISK_GROUPS
+        group_name: _risk_group_hit(group_name, normalized_files)
+        for group_name in ALL_RISK_GROUPS
+        if group_name != "route_contract_safety"
     }
+    group_hits["route_contract_safety"] = any(
+        _is_route_contract_surface(path) for path in normalized_files
+    ) and not any(
+        group_hits[group_name]
+        for group_name in (
+            "billing_entitlement",
+            "insight_ai",
+            "openapi_contract",
+            "merge_governance",
+        )
+    )
     if workflow_privileged:
         selected_groups = ALL_RISK_GROUPS
     else:
@@ -244,9 +266,9 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
             group_name for group_name in ALL_RISK_GROUPS if group_hits[group_name]
         )
 
-    run_backend_blocking = workflow_privileged or backend_shared
+    run_backend_blocking = workflow_privileged or backend_shared or group_hits["openapi_contract"]
     run_security = run_backend_blocking
-    run_openapi_sync = run_backend_blocking
+    run_openapi_sync = run_backend_blocking or group_hits["openapi_contract"]
 
     return RiskProfile(
         changed_files=normalized_files,
@@ -261,6 +283,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
         billing_entitlement=group_hits["billing_entitlement"],
         insight_ai=group_hits["insight_ai"],
         openapi_contract=group_hits["openapi_contract"],
+        route_contract_safety=group_hits["route_contract_safety"],
         merge_governance=group_hits["merge_governance"],
         contract_risk_groups=selected_groups,
     )

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""PR risk-profile classifier for Tier 1 CI routing.
+
+RU: Определяет, какие backend/shared CI-ветки должны запускаться для PR.
+EN: Classifies changed files into deterministic CI routing outputs for PRs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import fnmatch
+import json
+from pathlib import Path
+import subprocess  # nosec B404: subprocess is required for bounded local git diff execution (remove-by: 2026-09-30, ref: PR3-risk-topology)
+import sys
+import shutil
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GIT_BINARY = shutil.which("git")
+ALL_RISK_GROUPS: tuple[str, ...] = (
+    "billing_entitlement",
+    "insight_ai",
+    "openapi_contract",
+    "merge_governance",
+)
+
+BACKEND_SHARED_EXACT: tuple[str, ...] = (
+    "Dockerfile",
+    "Makefile",
+    "constraints.txt",
+    "legacy_app.py",
+    "mcp_pulseplate_server.py",
+    "pyproject.toml",
+    "pytest.ini",
+    "requirements-dev.txt",
+    "requirements.txt",
+)
+BACKEND_SHARED_PREFIXES: tuple[str, ...] = (
+    "app/",
+    "core/",
+    "scripts/ci/",
+    "scripts/orchestration/",
+    "tests/",
+)
+DOCS_PREFIXES: tuple[str, ...] = ("docs/",)
+FRONTEND_EXACT: tuple[str, ...] = ("package.json", "package-lock.json", ".nvmrc")
+FRONTEND_PREFIXES: tuple[str, ...] = ("frontend/",)
+IOS_PREFIXES: tuple[str, ...] = ("ios/", "fastlane/")
+WORKFLOW_PRIVILEGED_EXACT: tuple[str, ...] = (
+    "AGENTS.md",
+    "RUNBOOK_AGENT.md",
+    "scripts/orchestration/check_agent_consistency.py",
+    "scripts/orchestration/check_merge_ready.py",
+    "scripts/orchestration/check_review_threads_disposition.py",
+)
+WORKFLOW_PRIVILEGED_PREFIXES: tuple[str, ...] = (
+    ".github/actions/",
+    ".github/workflows/",
+    "docs/orchestration/",
+    "scripts/ci/",
+)
+RISK_GROUP_PATTERNS: dict[str, tuple[str, ...]] = {
+    "billing_entitlement": (
+        "app/middleware/api_tiers.py",
+        "app/routers/billing.py",
+        "app/routers/pro_*.py",
+        "app/services/payments_*.py",
+        "core/billing*.py",
+        "tests/test_api_tiers_db_lookup.py",
+        "tests/test_billing_openapi_contract.py",
+        "tests/test_ios_receipt_verification_api.py",
+        "tests/test_paid_route_guards.py",
+        "tests/test_payment_source_contract_api.py",
+        "tests/test_payment_webhook_signature_api.py",
+        "tests/test_pro_payments_openapi_contract.py",
+        "tests/test_subscription_activation_api.py",
+    ),
+    "insight_ai": (
+        "app/routers/*insight*.py",
+        "app/security/agent_input_guard.py",
+        "app/security/rate_limit.py",
+        "core/insight/*.py",
+        "legacy_app.py",
+        "mcp_pulseplate_server.py",
+        "tests/test_core_ai_insight_runtime.py",
+        "tests/test_fitchef_insight_api.py",
+        "tests/test_insight_error_hygiene.py",
+        "tests/test_insight_vip_guard_api.py",
+        "tests/test_insight_vip_monthly_quota_api.py",
+        "tests/test_philosophy_validation_integration.py",
+        "tests/test_rate_limit_llm_and_exports_api.py",
+    ),
+    "openapi_contract": (
+        "app/main.py",
+        "app/routers/*.py",
+        "app/schemas/*.py",
+        "frontend/src/api/*",
+        "legacy_app.py",
+        "scripts/generate_openapi.py",
+        "tests/test_openapi_*.py",
+    ),
+    "merge_governance": (
+        ".github/actions/*",
+        ".github/workflows/*",
+        "AGENTS.md",
+        "RUNBOOK_AGENT.md",
+        "docs/orchestration/*",
+        "scripts/ci/*",
+        "scripts/orchestration/check_agent_consistency.py",
+        "scripts/orchestration/check_merge_ready.py",
+        "scripts/orchestration/check_review_threads_disposition.py",
+        "tests/test_orchestration_merge_ready.py",
+        "tests/test_pr_body_phase2_gates.py",
+        "tests/test_pr_merge_readiness_gate.py",
+        "tests/test_review_threads_disposition_strict.py",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RiskProfile:
+    """Deterministic routing profile for backend/shared PR CI."""
+
+    changed_files: tuple[str, ...]
+    docs_only: bool
+    frontend_only: bool
+    ios_only: bool
+    workflow_privileged: bool
+    backend_shared: bool
+    run_backend_blocking: bool
+    run_security: bool
+    run_openapi_sync: bool
+    billing_entitlement: bool
+    insight_ai: bool
+    openapi_contract: bool
+    merge_governance: bool
+    contract_risk_groups: tuple[str, ...]
+
+    def to_outputs(self) -> dict[str, str]:
+        """Return GitHub Actions-friendly outputs."""
+        outputs = {
+            "docs_only": _bool_text(self.docs_only),
+            "frontend_only": _bool_text(self.frontend_only),
+            "ios_only": _bool_text(self.ios_only),
+            "workflow_privileged": _bool_text(self.workflow_privileged),
+            "backend_shared": _bool_text(self.backend_shared),
+            "run_backend_blocking": _bool_text(self.run_backend_blocking),
+            "run_security": _bool_text(self.run_security),
+            "run_openapi_sync": _bool_text(self.run_openapi_sync),
+            "billing_entitlement": _bool_text(self.billing_entitlement),
+            "insight_ai": _bool_text(self.insight_ai),
+            "openapi_contract": _bool_text(self.openapi_contract),
+            "merge_governance": _bool_text(self.merge_governance),
+            "contract_risk_groups": ",".join(self.contract_risk_groups),
+            "changed_file_count": str(len(self.changed_files)),
+        }
+        return outputs
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _normalize_path(path: str) -> str:
+    return path.strip().lstrip("./").replace("\\", "/")
+
+
+def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _is_workflow_privileged(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized in WORKFLOW_PRIVILEGED_EXACT or normalized.startswith(
+        WORKFLOW_PRIVILEGED_PREFIXES,
+    )
+
+
+def _is_backend_shared(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized in BACKEND_SHARED_EXACT or normalized.startswith(
+        BACKEND_SHARED_PREFIXES,
+    )
+
+
+def _is_docs_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized.startswith(DOCS_PREFIXES) or normalized.endswith(".md")
+
+
+def _is_frontend_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized in FRONTEND_EXACT or normalized.startswith(FRONTEND_PREFIXES)
+
+
+def _is_ios_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized.startswith(IOS_PREFIXES)
+
+
+def _risk_group_hit(group_name: str, changed_files: tuple[str, ...]) -> bool:
+    patterns = RISK_GROUP_PATTERNS[group_name]
+    return any(_matches_any(path, patterns) for path in changed_files)
+
+
+def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfile:
+    """Build a deterministic risk profile from normalized changed paths."""
+    normalized_files = tuple(
+        path for path in (_normalize_path(item) for item in changed_files) if path
+    )
+    if not normalized_files:
+        return RiskProfile(
+            changed_files=(),
+            docs_only=False,
+            frontend_only=False,
+            ios_only=False,
+            workflow_privileged=False,
+            backend_shared=False,
+            run_backend_blocking=False,
+            run_security=False,
+            run_openapi_sync=False,
+            billing_entitlement=False,
+            insight_ai=False,
+            openapi_contract=False,
+            merge_governance=False,
+            contract_risk_groups=(),
+        )
+
+    workflow_privileged = any(_is_workflow_privileged(path) for path in normalized_files)
+    backend_shared = any(_is_backend_shared(path) for path in normalized_files)
+    docs_only = all(_is_docs_path(path) for path in normalized_files) and not workflow_privileged
+    frontend_only = (
+        all(_is_frontend_path(path) for path in normalized_files) and not workflow_privileged
+    )
+    ios_only = all(_is_ios_path(path) for path in normalized_files) and not workflow_privileged
+
+    group_hits = {
+        group_name: _risk_group_hit(group_name, normalized_files) for group_name in ALL_RISK_GROUPS
+    }
+    if workflow_privileged:
+        selected_groups = ALL_RISK_GROUPS
+    else:
+        selected_groups = tuple(
+            group_name for group_name in ALL_RISK_GROUPS if group_hits[group_name]
+        )
+
+    run_backend_blocking = workflow_privileged or backend_shared
+    run_security = run_backend_blocking
+    run_openapi_sync = run_backend_blocking
+
+    return RiskProfile(
+        changed_files=normalized_files,
+        docs_only=docs_only,
+        frontend_only=frontend_only,
+        ios_only=ios_only,
+        workflow_privileged=workflow_privileged,
+        backend_shared=backend_shared,
+        run_backend_blocking=run_backend_blocking,
+        run_security=run_security,
+        run_openapi_sync=run_openapi_sync,
+        billing_entitlement=group_hits["billing_entitlement"],
+        insight_ai=group_hits["insight_ai"],
+        openapi_contract=group_hits["openapi_contract"],
+        merge_governance=group_hits["merge_governance"],
+        contract_risk_groups=selected_groups,
+    )
+
+
+def collect_changed_files(*, base_sha: str, head_sha: str) -> tuple[str, ...]:
+    """Return changed files between two git revisions."""
+    if GIT_BINARY is None:
+        raise RuntimeError("git executable not found in PATH")
+    result = subprocess.run(  # nosec B603: fixed git argv without shell for local CI routing only (remove-by: 2026-09-30, ref: PR3-risk-topology)
+        [
+            GIT_BINARY,
+            "diff",
+            "--name-only",
+            f"{base_sha}...{head_sha}",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(path for path in result.stdout.splitlines() if path.strip())
+
+
+def _write_github_outputs(path: Path, outputs: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    base_sha = ""
+    head_sha = ""
+    explicit_files: list[str] = []
+    github_output_path: Path | None = None
+    json_mode = False
+
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument == "--base-sha":
+            index += 1
+            base_sha = argv[index]
+        elif argument == "--head-sha":
+            index += 1
+            head_sha = argv[index]
+        elif argument == "--file":
+            index += 1
+            explicit_files.append(argv[index])
+        elif argument == "--github-output":
+            index += 1
+            github_output_path = Path(argv[index])
+        elif argument == "--as-json":
+            json_mode = True
+        else:
+            raise SystemExit(f"Unknown argument: {argument}")
+        index += 1
+
+    if explicit_files:
+        changed_files = tuple(explicit_files)
+    else:
+        if not base_sha or not head_sha:
+            raise SystemExit(
+                "Provide either repeated --file values or both --base-sha and --head-sha."
+            )
+        changed_files = collect_changed_files(base_sha=base_sha, head_sha=head_sha)
+
+    profile = build_risk_profile(list(changed_files))
+    outputs = profile.to_outputs()
+
+    if github_output_path is not None:
+        _write_github_outputs(github_output_path, outputs)
+
+    if json_mode:
+        print(json.dumps(asdict(profile), sort_keys=True))
+    else:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -165,7 +165,7 @@ def _bool_text(value: bool) -> str:
 
 
 def _normalize_path(path: str) -> str:
-    return path.strip().lstrip("./").replace("\\", "/")
+    return path.strip().replace("\\", "/").removeprefix("./")
 
 
 def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
@@ -260,7 +260,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
 
     run_backend_blocking = workflow_privileged or backend_shared or group_hits["openapi_contract"]
     run_security = run_backend_blocking
-    run_openapi_sync = run_backend_blocking or group_hits["openapi_contract"]
+    run_openapi_sync = run_backend_blocking
 
     return RiskProfile(
         changed_files=normalized_files,

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -168,6 +168,14 @@ def _normalize_path(path: str) -> str:
     return path.strip().replace("\\", "/").removeprefix("./")
 
 
+def _read_flag_value(argv: list[str], index: int, flag: str) -> str:
+    """Return the next argv token for a flag or exit with a deterministic error."""
+    value_index = index + 1
+    if value_index >= len(argv):
+        raise SystemExit(f"Missing value for {flag}.")
+    return argv[value_index]
+
+
 def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
     return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
 
@@ -320,16 +328,16 @@ def main(argv: list[str] | None = None) -> int:
         argument = argv[index]
         if argument == "--base-sha":
             index += 1
-            base_sha = argv[index]
+            base_sha = _read_flag_value(argv, index - 1, argument)
         elif argument == "--head-sha":
             index += 1
-            head_sha = argv[index]
+            head_sha = _read_flag_value(argv, index - 1, argument)
         elif argument == "--file":
             index += 1
-            explicit_files.append(argv[index])
+            explicit_files.append(_read_flag_value(argv, index - 1, argument))
         elif argument == "--github-output":
             index += 1
-            github_output_path = Path(argv[index])
+            github_output_path = Path(_read_flag_value(argv, index - 1, argument))
         elif argument == "--as-json":
             json_mode = True
         else:

--- a/tests/test_check_pr_size_governance.py
+++ b/tests/test_check_pr_size_governance.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import scripts.ci.check_pr_size_governance as size_gate
 
 
@@ -74,3 +76,20 @@ def test_extract_pr_body_reads_github_event_payload(tmp_path: Path) -> None:
     )
 
     assert size_gate.extract_pr_body(event_path) == "## Split Justification\nRequired."
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["--base-sha"], "Missing value for --base-sha."),
+        (["--head-sha"], "Missing value for --head-sha."),
+        (["--body"], "Missing value for --body."),
+        (["--event-path"], "Missing value for --event-path."),
+    ],
+)
+def test_main_fails_cleanly_when_flag_value_is_missing(
+    argv: list[str],
+    message: str,
+) -> None:
+    with pytest.raises(SystemExit, match=message):
+        size_gate.main(argv)

--- a/tests/test_check_pr_size_governance.py
+++ b/tests/test_check_pr_size_governance.py
@@ -32,7 +32,7 @@ def test_evaluate_pr_size_policy_passes_for_normal_bucket() -> None:
     )
 
     assert exit_code == 0
-    assert any("OK (<300 LoC)" in line for line in lines)
+    assert any(f"OK (<={size_gate.NORMAL_MAX_LOC} LoC)" in line for line in lines)
 
 
 def test_evaluate_pr_size_policy_warns_for_medium_bucket() -> None:
@@ -43,7 +43,10 @@ def test_evaluate_pr_size_policy_warns_for_medium_bucket() -> None:
     )
 
     assert exit_code == 0
-    assert any("WARNING (300-800 LoC)" in line for line in lines)
+    assert any(
+        f"WARNING ({size_gate.NORMAL_MAX_LOC + 1}-{size_gate.WARNING_MAX_LOC} LoC)" in line
+        for line in lines
+    )
 
 
 def test_evaluate_pr_size_policy_fails_without_split_justification() -> None:
@@ -54,7 +57,10 @@ def test_evaluate_pr_size_policy_fails_without_split_justification() -> None:
     )
 
     assert exit_code == 1
-    assert any("FAIL (>800 LoC without explicit split justification)" in line for line in lines)
+    assert any(
+        f"FAIL (>{size_gate.WARNING_MAX_LOC} LoC without explicit split justification)" in line
+        for line in lines
+    )
 
 
 def test_evaluate_pr_size_policy_passes_with_split_justification() -> None:

--- a/tests/test_check_pr_size_governance.py
+++ b/tests/test_check_pr_size_governance.py
@@ -1,0 +1,76 @@
+"""Deterministic tests for PR-size governance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.ci.check_pr_size_governance as size_gate
+
+
+def test_parse_numstat_output_sums_text_rows_and_ignores_binary() -> None:
+    total_lines, counted_files = size_gate.parse_numstat_output(
+        "10\t5\tapp/main.py\n-\t-\tfrontend/src/assets/logo.png\n3\t2\tdocs/runbook.md\n",
+    )
+
+    assert total_lines == 20
+    assert counted_files == 2
+
+
+def test_has_split_justification_accepts_heading_and_label() -> None:
+    assert size_gate.has_split_justification("## Split Justification\nNeeded for parity.")
+    assert size_gate.has_split_justification("Split justification: workflow rename parity.")
+
+
+def test_evaluate_pr_size_policy_passes_for_normal_bucket() -> None:
+    exit_code, lines = size_gate.evaluate_pr_size_policy(
+        total_changed_lines=220,
+        counted_files=4,
+        pr_body="",
+    )
+
+    assert exit_code == 0
+    assert any("OK (<300 LoC)" in line for line in lines)
+
+
+def test_evaluate_pr_size_policy_warns_for_medium_bucket() -> None:
+    exit_code, lines = size_gate.evaluate_pr_size_policy(
+        total_changed_lines=540,
+        counted_files=8,
+        pr_body="",
+    )
+
+    assert exit_code == 0
+    assert any("WARNING (300-800 LoC)" in line for line in lines)
+
+
+def test_evaluate_pr_size_policy_fails_without_split_justification() -> None:
+    exit_code, lines = size_gate.evaluate_pr_size_policy(
+        total_changed_lines=1200,
+        counted_files=11,
+        pr_body="## Summary\nLarge PR.\n",
+    )
+
+    assert exit_code == 1
+    assert any("FAIL (>800 LoC without explicit split justification)" in line for line in lines)
+
+
+def test_evaluate_pr_size_policy_passes_with_split_justification() -> None:
+    exit_code, lines = size_gate.evaluate_pr_size_policy(
+        total_changed_lines=1200,
+        counted_files=11,
+        pr_body="## Summary\nLarge PR.\n\n## Split Justification\nWorkflow parity must land together.\n",
+    )
+
+    assert exit_code == 0
+    assert any("split justification is present" in line for line in lines)
+
+
+def test_extract_pr_body_reads_github_event_payload(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "## Split Justification\nRequired."}}),
+        encoding="utf-8",
+    )
+
+    assert size_gate.extract_pr_body(event_path) == "## Split Justification\nRequired."

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -47,9 +47,11 @@ def test_billing_router_change_hits_billing_and_openapi_groups() -> None:
     assert profile.backend_shared is True
     assert profile.billing_entitlement is True
     assert profile.openapi_contract is True
+    assert profile.route_contract_safety is True
     assert profile.contract_risk_groups == (
         "billing_entitlement",
         "openapi_contract",
+        "route_contract_safety",
     )
 
 
@@ -72,8 +74,12 @@ def test_insight_runtime_change_hits_insight_group_only() -> None:
 
     assert profile.backend_shared is True
     assert profile.insight_ai is True
+    assert profile.route_contract_safety is True
     assert profile.run_openapi_sync is True
-    assert profile.contract_risk_groups == ("insight_ai",)
+    assert profile.contract_risk_groups == (
+        "insight_ai",
+        "route_contract_safety",
+    )
 
 
 def test_generic_backend_change_hits_route_contract_safety_group() -> None:
@@ -85,6 +91,19 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
     assert profile.route_contract_safety is True
     assert profile.run_backend_blocking is True
     assert profile.contract_risk_groups == ("route_contract_safety",)
+
+
+def test_mixed_backend_surface_keeps_openapi_and_route_contract_groups() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["app/main.py", "app/dependencies.py"],
+    )
+
+    assert profile.openapi_contract is True
+    assert profile.route_contract_safety is True
+    assert profile.contract_risk_groups == (
+        "openapi_contract",
+        "route_contract_safety",
+    )
 
 
 def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -1,0 +1,86 @@
+"""Deterministic tests for Tier 1 PR risk-profile routing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.ci.ci_risk_profile as risk_profile
+
+
+def test_docs_only_changes_skip_backend_blocking() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["docs/release/notes.md", "README.md"],
+    )
+
+    assert profile.docs_only is True
+    assert profile.run_backend_blocking is False
+    assert profile.contract_risk_groups == ()
+
+
+def test_frontend_only_changes_skip_backend_blocking() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["frontend/src/components/Card.tsx", "frontend/package.json"],
+    )
+
+    assert profile.frontend_only is True
+    assert profile.run_backend_blocking is False
+    assert profile.run_openapi_sync is False
+
+
+def test_workflow_privileged_docs_force_full_contract_suites() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md"],
+    )
+
+    assert profile.workflow_privileged is True
+    assert profile.run_backend_blocking is True
+    assert profile.run_security is True
+    assert profile.contract_risk_groups == risk_profile.ALL_RISK_GROUPS
+
+
+def test_billing_router_change_hits_billing_and_openapi_groups() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["app/routers/billing.py"],
+    )
+
+    assert profile.backend_shared is True
+    assert profile.billing_entitlement is True
+    assert profile.openapi_contract is True
+    assert profile.contract_risk_groups == (
+        "billing_entitlement",
+        "openapi_contract",
+    )
+
+
+def test_insight_runtime_change_hits_insight_group_only() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["core/insight/fitchef_companion.py"],
+    )
+
+    assert profile.backend_shared is True
+    assert profile.insight_ai is True
+    assert profile.run_openapi_sync is True
+    assert profile.contract_risk_groups == ("insight_ai",)
+
+
+def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:
+    github_output = tmp_path / "github_output.txt"
+
+    result = risk_profile.main(
+        [
+            "--file",
+            "app/middleware/api_tiers.py",
+            "--github-output",
+            str(github_output),
+            "--as-json",
+        ],
+    )
+
+    assert result == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["billing_entitlement"] is True
+    written = github_output.read_text(encoding="utf-8")
+    assert "run_backend_blocking=true" in written
+    assert "billing_entitlement=true" in written

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -10,6 +10,26 @@ import pytest
 import scripts.ci.ci_risk_profile as risk_profile
 
 
+def test_empty_changed_files_uses_default_risk_profile() -> None:
+    profile = risk_profile.build_risk_profile([])
+
+    assert profile.changed_files == ()
+    assert profile.docs_only is False
+    assert profile.frontend_only is False
+    assert profile.ios_only is False
+    assert profile.workflow_privileged is False
+    assert profile.backend_shared is False
+    assert profile.run_backend_blocking is False
+    assert profile.run_security is False
+    assert profile.run_openapi_sync is False
+    assert profile.billing_entitlement is False
+    assert profile.insight_ai is False
+    assert profile.openapi_contract is False
+    assert profile.route_contract_safety is False
+    assert profile.merge_governance is False
+    assert profile.contract_risk_groups == ()
+
+
 def test_docs_only_changes_skip_backend_blocking() -> None:
     profile = risk_profile.build_risk_profile(
         ["docs/release/notes.md", "README.md"],

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -120,7 +120,10 @@ def test_mixed_backend_surface_keeps_openapi_and_route_contract_groups() -> None
     )
 
 
-def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:
+def test_cli_writes_github_outputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     github_output = tmp_path / "github_output.txt"
 
     result = risk_profile.main(

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import scripts.ci.ci_risk_profile as risk_profile
 
 
@@ -138,3 +140,20 @@ def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:
     written = github_output.read_text(encoding="utf-8")
     assert "run_backend_blocking=true" in written
     assert "billing_entitlement=true" in written
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["--base-sha"], "Missing value for --base-sha."),
+        (["--head-sha"], "Missing value for --head-sha."),
+        (["--file"], "Missing value for --file."),
+        (["--github-output"], "Missing value for --github-output."),
+    ],
+)
+def test_cli_fails_cleanly_when_flag_value_is_missing(
+    argv: list[str],
+    message: str,
+) -> None:
+    with pytest.raises(SystemExit, match=message):
+        risk_profile.main(argv)

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -39,6 +39,18 @@ def test_workflow_privileged_docs_force_full_contract_suites() -> None:
     assert profile.contract_risk_groups == risk_profile.ALL_RISK_GROUPS
 
 
+def test_hidden_workflow_path_preserves_leading_dot_for_routing() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["./.github/workflows/ci.yml"],
+    )
+
+    assert profile.workflow_privileged is True
+    assert profile.merge_governance is True
+    assert profile.run_backend_blocking is True
+    assert profile.run_openapi_sync is True
+    assert profile.contract_risk_groups == risk_profile.ALL_RISK_GROUPS
+
+
 def test_billing_router_change_hits_billing_and_openapi_groups() -> None:
     profile = risk_profile.build_risk_profile(
         ["app/routers/billing.py"],

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -53,6 +53,18 @@ def test_billing_router_change_hits_billing_and_openapi_groups() -> None:
     )
 
 
+def test_openapi_only_change_still_runs_blocking_and_sync() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["scripts/generate_openapi.py"],
+    )
+
+    assert profile.backend_shared is False
+    assert profile.openapi_contract is True
+    assert profile.run_backend_blocking is True
+    assert profile.run_openapi_sync is True
+    assert profile.contract_risk_groups == ("openapi_contract",)
+
+
 def test_insight_runtime_change_hits_insight_group_only() -> None:
     profile = risk_profile.build_risk_profile(
         ["core/insight/fitchef_companion.py"],
@@ -62,6 +74,17 @@ def test_insight_runtime_change_hits_insight_group_only() -> None:
     assert profile.insight_ai is True
     assert profile.run_openapi_sync is True
     assert profile.contract_risk_groups == ("insight_ai",)
+
+
+def test_generic_backend_change_hits_route_contract_safety_group() -> None:
+    profile = risk_profile.build_risk_profile(
+        ["app/dependencies.py"],
+    )
+
+    assert profile.backend_shared is True
+    assert profile.route_contract_safety is True
+    assert profile.run_backend_blocking is True
+    assert profile.contract_risk_groups == ("route_contract_safety",)
 
 
 def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- reconcile Tier 1 bookkeeping so landed PR1 (`#1240`) and PR2 (`#1244`) are reflected in the backlog and orchestration docs
- add deterministic Tier 1 PR risk-profile and PR-size-governance helpers with targeted tests
- wire the canonical backend/shared PR lane in `ci.yml` into critical smoke plus contract/risk routing

## Risk & Impact
- no product runtime API changes
- no billing, entitlement, or tier-contract changes
- CI and governance behavior changes are limited to backend/shared PR topology and blocking-surface classification

## Test Plan
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_repo_policy_guards.py`
- `pytest -q tests/test_check_pr_size_governance.py tests/test_ci_risk_profile.py`
- `pytest -q tests/test_business_collateral_builders.py`
- `pre-commit run --all-files`
- `make verify`
- `git push -u origin feat/tier1-ci-cd-pr3-risk-topology`

## CI Gates
- latest online PR validation was retriggered on the current head after the additive `route_contract_safety` fix
- mixed backend/shared runtime changes now keep additive `route_contract_safety` coverage alongside narrower risk groups
- `ci.yml` remains the canonical backend/shared PR merge-truth lane
- PR routing now distinguishes low-risk slices from workflow-privileged and backend/shared surfaces
- security, OpenAPI, diff-coverage, and merge-governance blockers remain active when their surfaces are touched

## Split Justification
- This PR is over the Tier 1 large-PR threshold because the docs reconciliation, helper scripts, tests, workflow wiring, and matching `detect-secrets` baseline update must land atomically to keep governance and CI behavior in sync.
- Splitting the workflow wiring away from the helper scripts would leave `ci.yml` referencing logic that is not yet present, while splitting the docs reconciliation away from PR3 would leave Tier 1 bookkeeping knowingly inconsistent with landed PR1/PR2 history.
- Follow-up work remains intentionally separated into PR4 metrics/feedback.

## Carryover
- This PR explicitly carries over Tier 1 bookkeeping reconciliation from already-landed PR1/PR2 into the active PR3 wave. That carryover is intentional and documented in `docs/roadmap/BACKLOG_LEDGER.md`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1250_FIXED_MAPPING.md`
- current FIXED thread mapping is recorded in the canonical artifact

## Merge Readiness (Mandatory)
- [ ] All required current-head checks pass
- [ ] No unresolved review threads remain
- [ ] No actionable bot comments remain
- [x] Local pre-commit is green
- [x] Local `make verify` is green

## Deferred / Follow-ups
- PR4 lightweight CI metrics and weekly feedback loop remain deferred and out of scope for this PR.

## Summary by Sourcery

Ввести маршрутизацию CI уровня Tier 1 на основе риска и управление размерами PR, а также согласовать оркестрацию Tier 1 и документацию по бэклогу так, чтобы PR3 рассматривался как активный исполняемый срез после влитых PR1/PR2.

New Features:
- Добавить скрипт классификации риск-профиля PR, который сопоставляет изменённые файлы с флагами маршрутизации backend/shared и группами контрактных/рисковых тестов для CI.
- Добавить скрипт и политику управления размером PR, которые распределяют PR по “корзинам” по количеству изменённых строк и требуют явного обоснования разбиения для очень больших PR, с соответствующим разделом в шаблоне PR.

Enhancements:
- Уточнить основной workflow CI так, чтобы блокирующие для backend тесты, проверка безопасности и синхронизация OpenAPI запускались только при изменении соответствующих поверхностей, а PR, затрагивающие backend/shared и workflow-привилегированные PR, проходили через критические smoke-тесты плюс выбранные контрактные/рисковые наборы.
- Разделить выполнение PR-тестов на детерминированные smoke- и контрактные/рисковые наборы с отдельными артефактами JUnit при сохранении единой отчётности по покрытию и diff-покрытию.
- Обновить runbook’и оркестрации Tier 1 и task packet, чтобы зафиксировать PR1/PR2 как влитые базовые варианты и сделать топологию рисков PR3 и управление размером PR активным срезом, пометив метрики PR4 как отложенные.

CI:
- Подключить новые помощники для риск-профиля и управления размером PR в `ci.yml`, чтобы PR заранее вычисляли выходные данные маршрутизации, блокирующие для backend линии зависели от этих результатов и условно запускались задачи безопасности, синхронизации OpenAPI, покрытия и diff-покрытия.

Documentation:
- Привести в соответствие документацию по оркестрации CI/CD Tier 1 и реестр бэклога с учётом влитых PR1/PR2, пометить PR3 как текущий в работе срез топологии рисков и задокументировать ожидания по управлению размером PR.
- Добавить документы сопоставления “fixed-in-commit” для PR #1248 и PR #1250, чтобы отслеживать, как был учтён отзыв при ревью.

Tests:
- Добавить целевые тесты для классификатора риск-профиля CI, чтобы гарантировать детерминированную маршрутизацию и выбор групп риска на основе изменённых путей.
- Добавить целевые тесты для гейта управления размером PR для валидации парсинга `numstat`, размерных “корзин”, распознавания обоснования разбиения и извлечения тела события GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Tier 1 risk-based CI routing and PR-size governance, and reconcile Tier 1 orchestration and backlog docs to treat PR3 as the active execution slice after landed PR1/PR2.

New Features:
- Add a PR risk-profile classifier script that maps changed files to backend/shared routing flags and contract/risk test groups for CI.
- Add a PR-size governance script and policy that buckets PRs by changed lines and requires explicit split justification for very large PRs, with a matching section in the PR template.

Enhancements:
- Refine the main CI workflow so backend-blocking tests, security, and OpenAPI sync only run when relevant surfaces change, while routing backend/shared and workflow-privileged PRs through critical smoke plus selected contract/risk suites.
- Split PR test execution into deterministic smoke and contract/risk suites with separate JUnit artifacts while preserving unified coverage and diff-coverage reporting.
- Update Tier 1 orchestration runbooks and task packet to record PR1/PR2 as landed baselines and make PR3 risk topology and PR-size governance the active slice, with PR4 metrics marked as deferred.

CI:
- Wire the new risk-profile and PR-size governance helpers into ci.yml so PRs compute routing outputs up front, gate backend-blocking lanes on those outputs, and conditionally run security, OpenAPI sync, coverage, and diff-coverage jobs.

Documentation:
- Align Tier 1 CI/CD orchestration docs and backlog ledger to reflect landed PR1/PR2, mark PR3 as the in-progress risk-topology slice, and document PR-size governance expectations.
- Add fixed-in-commit mapping documents for PR #1248 and PR #1250 to track how review feedback is resolved.

Tests:
- Add targeted tests for the CI risk-profile classifier to ensure deterministic routing and risk-group selection based on changed paths.
- Add targeted tests for the PR-size governance gate to validate numstat parsing, size buckets, split-justification recognition, and GitHub event-body extraction.

</details>

Новые возможности:
- Добавлен классификатор профиля риска PR и привязка к CI для маршрутизации pull‑request'ов в backend/shared в критический smoke‑набор и целевые контрактные/рисковые тестовые наборы на основе изменённых файлов.
- Введён контроль управления размером PR, который задаёт диапазоны размеров и требует явного обоснования разбиения для очень крупных pull‑request'ов.

Улучшения:
- Уточнен основной workflow CI, чтобы задачи по безопасности и синхронизации OpenAPI запускались только при изменении соответствующих поверхностей, а также чтобы lane для backend/shared PR стал каноническим Tier 1 путём слияния с критическим smoke и контрактными/рисковыми наборами.
- Скорректирован сбор покрытия и загрузка тестовых артефактов для разделения результатов smoke и контрактных/рисковых тестов при сохранении детерминированной отчётности по покрытию.

Документация:
- Согласованы документы по оркестрации Tier 1 и roadmap‑ledger, чтобы отразить уже выполненную работу PR1/PR2, объявить PR3 активным срезом risk‑topology и задокументировать новое управление размером PR и требования к обоснованию разбиения.
- Добавлен документ сопоставления fixed‑in‑commit для PR #1250 для фиксации устранённого ревью‑фидбэка.

Тесты:
- Добавлены целевые тесты для классификатора профиля риска CI и контроля управления размером PR, чтобы обеспечить детерминированную маршрутизацию и соблюдение политики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести маршрутизацию CI уровня Tier 1 на основе риска и управление размерами PR, а также согласовать оркестрацию Tier 1 и документацию по бэклогу так, чтобы PR3 рассматривался как активный исполняемый срез после влитых PR1/PR2.

New Features:
- Добавить скрипт классификации риск-профиля PR, который сопоставляет изменённые файлы с флагами маршрутизации backend/shared и группами контрактных/рисковых тестов для CI.
- Добавить скрипт и политику управления размером PR, которые распределяют PR по “корзинам” по количеству изменённых строк и требуют явного обоснования разбиения для очень больших PR, с соответствующим разделом в шаблоне PR.

Enhancements:
- Уточнить основной workflow CI так, чтобы блокирующие для backend тесты, проверка безопасности и синхронизация OpenAPI запускались только при изменении соответствующих поверхностей, а PR, затрагивающие backend/shared и workflow-привилегированные PR, проходили через критические smoke-тесты плюс выбранные контрактные/рисковые наборы.
- Разделить выполнение PR-тестов на детерминированные smoke- и контрактные/рисковые наборы с отдельными артефактами JUnit при сохранении единой отчётности по покрытию и diff-покрытию.
- Обновить runbook’и оркестрации Tier 1 и task packet, чтобы зафиксировать PR1/PR2 как влитые базовые варианты и сделать топологию рисков PR3 и управление размером PR активным срезом, пометив метрики PR4 как отложенные.

CI:
- Подключить новые помощники для риск-профиля и управления размером PR в `ci.yml`, чтобы PR заранее вычисляли выходные данные маршрутизации, блокирующие для backend линии зависели от этих результатов и условно запускались задачи безопасности, синхронизации OpenAPI, покрытия и diff-покрытия.

Documentation:
- Привести в соответствие документацию по оркестрации CI/CD Tier 1 и реестр бэклога с учётом влитых PR1/PR2, пометить PR3 как текущий в работе срез топологии рисков и задокументировать ожидания по управлению размером PR.
- Добавить документы сопоставления “fixed-in-commit” для PR #1248 и PR #1250, чтобы отслеживать, как был учтён отзыв при ревью.

Tests:
- Добавить целевые тесты для классификатора риск-профиля CI, чтобы гарантировать детерминированную маршрутизацию и выбор групп риска на основе изменённых путей.
- Добавить целевые тесты для гейта управления размером PR для валидации парсинга `numstat`, размерных “корзин”, распознавания обоснования разбиения и извлечения тела события GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Tier 1 risk-based CI routing and PR-size governance, and reconcile Tier 1 orchestration and backlog docs to treat PR3 as the active execution slice after landed PR1/PR2.

New Features:
- Add a PR risk-profile classifier script that maps changed files to backend/shared routing flags and contract/risk test groups for CI.
- Add a PR-size governance script and policy that buckets PRs by changed lines and requires explicit split justification for very large PRs, with a matching section in the PR template.

Enhancements:
- Refine the main CI workflow so backend-blocking tests, security, and OpenAPI sync only run when relevant surfaces change, while routing backend/shared and workflow-privileged PRs through critical smoke plus selected contract/risk suites.
- Split PR test execution into deterministic smoke and contract/risk suites with separate JUnit artifacts while preserving unified coverage and diff-coverage reporting.
- Update Tier 1 orchestration runbooks and task packet to record PR1/PR2 as landed baselines and make PR3 risk topology and PR-size governance the active slice, with PR4 metrics marked as deferred.

CI:
- Wire the new risk-profile and PR-size governance helpers into ci.yml so PRs compute routing outputs up front, gate backend-blocking lanes on those outputs, and conditionally run security, OpenAPI sync, coverage, and diff-coverage jobs.

Documentation:
- Align Tier 1 CI/CD orchestration docs and backlog ledger to reflect landed PR1/PR2, mark PR3 as the in-progress risk-topology slice, and document PR-size governance expectations.
- Add fixed-in-commit mapping documents for PR #1248 and PR #1250 to track how review feedback is resolved.

Tests:
- Add targeted tests for the CI risk-profile classifier to ensure deterministic routing and risk-group selection based on changed paths.
- Add targeted tests for the PR-size governance gate to validate numstat parsing, size buckets, split-justification recognition, and GitHub event-body extraction.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести маршрутизацию CI уровня Tier 1 на основе риска и управление размерами PR, а также согласовать оркестрацию Tier 1 и документацию по бэклогу так, чтобы PR3 рассматривался как активный исполняемый срез после влитых PR1/PR2.

New Features:
- Добавить скрипт классификации риск-профиля PR, который сопоставляет изменённые файлы с флагами маршрутизации backend/shared и группами контрактных/рисковых тестов для CI.
- Добавить скрипт и политику управления размером PR, которые распределяют PR по “корзинам” по количеству изменённых строк и требуют явного обоснования разбиения для очень больших PR, с соответствующим разделом в шаблоне PR.

Enhancements:
- Уточнить основной workflow CI так, чтобы блокирующие для backend тесты, проверка безопасности и синхронизация OpenAPI запускались только при изменении соответствующих поверхностей, а PR, затрагивающие backend/shared и workflow-привилегированные PR, проходили через критические smoke-тесты плюс выбранные контрактные/рисковые наборы.
- Разделить выполнение PR-тестов на детерминированные smoke- и контрактные/рисковые наборы с отдельными артефактами JUnit при сохранении единой отчётности по покрытию и diff-покрытию.
- Обновить runbook’и оркестрации Tier 1 и task packet, чтобы зафиксировать PR1/PR2 как влитые базовые варианты и сделать топологию рисков PR3 и управление размером PR активным срезом, пометив метрики PR4 как отложенные.

CI:
- Подключить новые помощники для риск-профиля и управления размером PR в `ci.yml`, чтобы PR заранее вычисляли выходные данные маршрутизации, блокирующие для backend линии зависели от этих результатов и условно запускались задачи безопасности, синхронизации OpenAPI, покрытия и diff-покрытия.

Documentation:
- Привести в соответствие документацию по оркестрации CI/CD Tier 1 и реестр бэклога с учётом влитых PR1/PR2, пометить PR3 как текущий в работе срез топологии рисков и задокументировать ожидания по управлению размером PR.
- Добавить документы сопоставления “fixed-in-commit” для PR #1248 и PR #1250, чтобы отслеживать, как был учтён отзыв при ревью.

Tests:
- Добавить целевые тесты для классификатора риск-профиля CI, чтобы гарантировать детерминированную маршрутизацию и выбор групп риска на основе изменённых путей.
- Добавить целевые тесты для гейта управления размером PR для валидации парсинга `numstat`, размерных “корзин”, распознавания обоснования разбиения и извлечения тела события GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Tier 1 risk-based CI routing and PR-size governance, and reconcile Tier 1 orchestration and backlog docs to treat PR3 as the active execution slice after landed PR1/PR2.

New Features:
- Add a PR risk-profile classifier script that maps changed files to backend/shared routing flags and contract/risk test groups for CI.
- Add a PR-size governance script and policy that buckets PRs by changed lines and requires explicit split justification for very large PRs, with a matching section in the PR template.

Enhancements:
- Refine the main CI workflow so backend-blocking tests, security, and OpenAPI sync only run when relevant surfaces change, while routing backend/shared and workflow-privileged PRs through critical smoke plus selected contract/risk suites.
- Split PR test execution into deterministic smoke and contract/risk suites with separate JUnit artifacts while preserving unified coverage and diff-coverage reporting.
- Update Tier 1 orchestration runbooks and task packet to record PR1/PR2 as landed baselines and make PR3 risk topology and PR-size governance the active slice, with PR4 metrics marked as deferred.

CI:
- Wire the new risk-profile and PR-size governance helpers into ci.yml so PRs compute routing outputs up front, gate backend-blocking lanes on those outputs, and conditionally run security, OpenAPI sync, coverage, and diff-coverage jobs.

Documentation:
- Align Tier 1 CI/CD orchestration docs and backlog ledger to reflect landed PR1/PR2, mark PR3 as the in-progress risk-topology slice, and document PR-size governance expectations.
- Add fixed-in-commit mapping documents for PR #1248 and PR #1250 to track how review feedback is resolved.

Tests:
- Add targeted tests for the CI risk-profile classifier to ensure deterministic routing and risk-group selection based on changed paths.
- Add targeted tests for the PR-size governance gate to validate numstat parsing, size buckets, split-justification recognition, and GitHub event-body extraction.

</details>

Новые возможности:
- Добавлен классификатор профиля риска PR и привязка к CI для маршрутизации pull‑request'ов в backend/shared в критический smoke‑набор и целевые контрактные/рисковые тестовые наборы на основе изменённых файлов.
- Введён контроль управления размером PR, который задаёт диапазоны размеров и требует явного обоснования разбиения для очень крупных pull‑request'ов.

Улучшения:
- Уточнен основной workflow CI, чтобы задачи по безопасности и синхронизации OpenAPI запускались только при изменении соответствующих поверхностей, а также чтобы lane для backend/shared PR стал каноническим Tier 1 путём слияния с критическим smoke и контрактными/рисковыми наборами.
- Скорректирован сбор покрытия и загрузка тестовых артефактов для разделения результатов smoke и контрактных/рисковых тестов при сохранении детерминированной отчётности по покрытию.

Документация:
- Согласованы документы по оркестрации Tier 1 и roadmap‑ledger, чтобы отразить уже выполненную работу PR1/PR2, объявить PR3 активным срезом risk‑topology и задокументировать новое управление размером PR и требования к обоснованию разбиения.
- Добавлен документ сопоставления fixed‑in‑commit для PR #1250 для фиксации устранённого ревью‑фидбэка.

Тесты:
- Добавлены целевые тесты для классификатора профиля риска CI и контроля управления размером PR, чтобы обеспечить детерминированную маршрутизацию и соблюдение политики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести маршрутизацию CI уровня Tier 1 на основе риска и управление размерами PR, а также согласовать оркестрацию Tier 1 и документацию по бэклогу так, чтобы PR3 рассматривался как активный исполняемый срез после влитых PR1/PR2.

New Features:
- Добавить скрипт классификации риск-профиля PR, который сопоставляет изменённые файлы с флагами маршрутизации backend/shared и группами контрактных/рисковых тестов для CI.
- Добавить скрипт и политику управления размером PR, которые распределяют PR по “корзинам” по количеству изменённых строк и требуют явного обоснования разбиения для очень больших PR, с соответствующим разделом в шаблоне PR.

Enhancements:
- Уточнить основной workflow CI так, чтобы блокирующие для backend тесты, проверка безопасности и синхронизация OpenAPI запускались только при изменении соответствующих поверхностей, а PR, затрагивающие backend/shared и workflow-привилегированные PR, проходили через критические smoke-тесты плюс выбранные контрактные/рисковые наборы.
- Разделить выполнение PR-тестов на детерминированные smoke- и контрактные/рисковые наборы с отдельными артефактами JUnit при сохранении единой отчётности по покрытию и diff-покрытию.
- Обновить runbook’и оркестрации Tier 1 и task packet, чтобы зафиксировать PR1/PR2 как влитые базовые варианты и сделать топологию рисков PR3 и управление размером PR активным срезом, пометив метрики PR4 как отложенные.

CI:
- Подключить новые помощники для риск-профиля и управления размером PR в `ci.yml`, чтобы PR заранее вычисляли выходные данные маршрутизации, блокирующие для backend линии зависели от этих результатов и условно запускались задачи безопасности, синхронизации OpenAPI, покрытия и diff-покрытия.

Documentation:
- Привести в соответствие документацию по оркестрации CI/CD Tier 1 и реестр бэклога с учётом влитых PR1/PR2, пометить PR3 как текущий в работе срез топологии рисков и задокументировать ожидания по управлению размером PR.
- Добавить документы сопоставления “fixed-in-commit” для PR #1248 и PR #1250, чтобы отслеживать, как был учтён отзыв при ревью.

Tests:
- Добавить целевые тесты для классификатора риск-профиля CI, чтобы гарантировать детерминированную маршрутизацию и выбор групп риска на основе изменённых путей.
- Добавить целевые тесты для гейта управления размером PR для валидации парсинга `numstat`, размерных “корзин”, распознавания обоснования разбиения и извлечения тела события GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Tier 1 risk-based CI routing and PR-size governance, and reconcile Tier 1 orchestration and backlog docs to treat PR3 as the active execution slice after landed PR1/PR2.

New Features:
- Add a PR risk-profile classifier script that maps changed files to backend/shared routing flags and contract/risk test groups for CI.
- Add a PR-size governance script and policy that buckets PRs by changed lines and requires explicit split justification for very large PRs, with a matching section in the PR template.

Enhancements:
- Refine the main CI workflow so backend-blocking tests, security, and OpenAPI sync only run when relevant surfaces change, while routing backend/shared and workflow-privileged PRs through critical smoke plus selected contract/risk suites.
- Split PR test execution into deterministic smoke and contract/risk suites with separate JUnit artifacts while preserving unified coverage and diff-coverage reporting.
- Update Tier 1 orchestration runbooks and task packet to record PR1/PR2 as landed baselines and make PR3 risk topology and PR-size governance the active slice, with PR4 metrics marked as deferred.

CI:
- Wire the new risk-profile and PR-size governance helpers into ci.yml so PRs compute routing outputs up front, gate backend-blocking lanes on those outputs, and conditionally run security, OpenAPI sync, coverage, and diff-coverage jobs.

Documentation:
- Align Tier 1 CI/CD orchestration docs and backlog ledger to reflect landed PR1/PR2, mark PR3 as the in-progress risk-topology slice, and document PR-size governance expectations.
- Add fixed-in-commit mapping documents for PR #1248 and PR #1250 to track how review feedback is resolved.

Tests:
- Add targeted tests for the CI risk-profile classifier to ensure deterministic routing and risk-group selection based on changed paths.
- Add targeted tests for the PR-size governance gate to validate numstat parsing, size buckets, split-justification recognition, and GitHub event-body extraction.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk-based PR testing: CI now runs targeted critical-smoke and contract/risk suites based on changed areas for faster feedback.
  * PR size governance: PRs >800 LoC must include a "Split Justification" section or CI will block.

* **Documentation**
  * Updated runbooks, task packet, backlog and review notes to reflect PR-series execution, reconciliation steps, and PR-size governance.

* **Tests**
  * Added deterministic tests validating PR-size checks and CI risk-profile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




## Carryover
- Replacement PR for closed PR `#1248` due GitHub event-routing anomaly: new heads stopped receiving `pull_request` workflow runs after `fcc1356d`, and `close/reopen` on 26 March 2026 did not restore them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Tier 1 risk‑based CI routing and PR-size governance, reconciles Tier 1 docs to make PR3 active, and aligns governance thresholds across code, tests, and docs. No runtime behavior changes.

- New Features
  - Deterministic PR risk profile via `scripts/ci/ci_risk_profile.py`; gates backend smoke, security, and OpenAPI sync; selects contract/risk suites: billing_entitlement, insight_ai, openapi_contract, route_contract_safety, merge_governance.
  - PR-size governance via `scripts/ci/check_pr_size_governance.py` with buckets (<300, 300–800, >800 LoC); requires “Split Justification” for >800 LoC; PR template updated.
  - `ci.yml` routes: docs/frontend/iOS-only skip backend blockers; backend/shared or workflow-privileged run smoke plus selected suites; security and OpenAPI sync gated by surface; smoke vs contract JUnit artifacts split; coverage and diff-coverage remain on when backend blockers run.
  - Focused tests for both helpers; Tier 1 runbooks/ledger set PR3 active after PR1/PR2; adds and updates fixed‑in‑commit mapping docs.
  - Governance thresholds aligned across scripts, tests, docs, and template.

- Migration
  - No runtime API, billing, or entitlement changes.
  - For PRs >800 LoC, include “Split Justification” in the PR body.
  - Backend/shared changes run critical smoke and relevant contract/risk suites; required-check coverage remains intact.

<sup>Written for commit 8e4ee1747073a5d3a971704456727355c1fcd05e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

