### PR TITLE
fix(frontend): harden welcome gate preview contract

### DIFF
--- a/docs/review/PR_1263_FIXED_MAPPING.md
+++ b/docs/review/PR_1263_FIXED_MAPPING.md
@@ -20,6 +20,11 @@ Disposition: NOT-A-BUG
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:1498; frontend/src/stories/PulsePlateDesignSystemGuidelines.mdx:12; frontend/src/__tests__/App.test.tsx:126; frontend/src/__tests__/App.test.tsx:136
 Reason: previewOnly classifies hidden mirror routes for design-review governance; direct route access remains intentional for `/design-system` and `/welcome-gate-v1`, and the repo already tests that these mirrors stay directly routable while hidden from the tab bar.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#pullrequestreview-4021005715 -> 5f08d7ad
+Disposition: FIXED
+Commit: 5f08d7ad
+Evidence: frontend/src/config/routes.ts:12; frontend/src/config/routes.ts:35; frontend/src/config/routes.ts:55; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:4; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:5; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:6
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1263_FIXED_MAPPING.md
+++ b/docs/review/PR_1263_FIXED_MAPPING.md
@@ -25,6 +25,16 @@ Disposition: FIXED
 Commit: 5f08d7ad
 Evidence: frontend/src/config/routes.ts:12; frontend/src/config/routes.ts:35; frontend/src/config/routes.ts:55; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:4; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:5; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:6
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#pullrequestreview-4021033426
+Disposition: NOT-A-BUG
+Evidence: frontend/src/config/routes.ts:12; frontend/src/config/routes.ts:35; frontend/src/config/routes.ts:55; docs/roadmap/BACKLOG_LEDGER.md:1498; frontend/src/stories/PulsePlateDesignSystemGuidelines.mdx:12; frontend/src/__tests__/App.test.tsx:126; frontend/src/__tests__/App.test.tsx:136
+Reason: current head already reuses `WELCOME_GATE_V1_ROUTE_PATH` instead of hardcoding `/welcome-gate-v1`, and repo canon keeps `previewOnly` as a navigation-classification flag for directly routable preview mirrors rather than a runtime production gate.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#discussion_r3000886092
+Disposition: NOT-A-BUG
+Evidence: frontend/src/config/routes.ts:12; frontend/src/config/routes.ts:35; frontend/src/config/routes.ts:55; docs/roadmap/BACKLOG_LEDGER.md:1498; frontend/src/stories/PulsePlateDesignSystemGuidelines.mdx:12; frontend/src/__tests__/App.test.tsx:126; frontend/src/__tests__/App.test.tsx:136
+Reason: the comment's path-duplication concern is already false on the current head, and the proposed runtime blocking for `previewOnly` would violate the approved preview-mirror contract for `/design-system` and `/welcome-gate-v1`.
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1263_FIXED_MAPPING.md
+++ b/docs/review/PR_1263_FIXED_MAPPING.md
@@ -5,7 +5,20 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#pullrequestreview-4020996186 -> 66e37726
+Disposition: FIXED
+Commit: 66e37726
+Evidence: frontend/src/config/routes.ts:12; frontend/src/config/routes.ts:35; frontend/src/config/routes.ts:55; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:4; frontend/src/pages/Onboarding/welcomeGateV1Policy.ts:5
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#discussion_r3000851555 -> 66e37726
+Disposition: FIXED
+Commit: 66e37726
+Evidence: frontend/src/config/__tests__/routes.design-preview.test.ts:5; frontend/src/config/__tests__/routes.design-preview.test.ts:30
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1263#discussion_r3000860263
+Disposition: NOT-A-BUG
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:1498; frontend/src/stories/PulsePlateDesignSystemGuidelines.mdx:12; frontend/src/__tests__/App.test.tsx:126; frontend/src/__tests__/App.test.tsx:136
+Reason: previewOnly classifies hidden mirror routes for design-review governance; direct route access remains intentional for `/design-system` and `/welcome-gate-v1`, and the repo already tests that these mirrors stay directly routable while hidden from the tab bar.
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1263_FIXED_MAPPING.md
+++ b/docs/review/PR_1263_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1263 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Final post-bot wait cycle completed
+- [ ] Pre-commit green
+- [ ] `make verify` green

--- a/frontend/src/config/__tests__/routes.design-preview.test.ts
+++ b/frontend/src/config/__tests__/routes.design-preview.test.ts
@@ -8,6 +8,7 @@ describe('design preview routes', (): void => {
         path: '/design-system',
         requiresAuth: false,
         hideTabBar: true,
+        previewOnly: true,
       })
     );
   });
@@ -18,6 +19,7 @@ describe('design preview routes', (): void => {
         path: '/welcome-gate-v1',
         requiresAuth: false,
         hideTabBar: true,
+        previewOnly: true,
       })
     );
   });

--- a/frontend/src/config/__tests__/routes.design-preview.test.ts
+++ b/frontend/src/config/__tests__/routes.design-preview.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { routes } from '../routes';
+import { WELCOME_GATE_V1_ROUTE_PATH } from '../../pages/Onboarding/welcomeGateV1Policy';
+
+const PREVIEW_ONLY_ROUTE_PATHS = ['/design-system', WELCOME_GATE_V1_ROUTE_PATH] as const;
 
 describe('design preview routes', (): void => {
   it('registers the design system preview as a hidden public route', (): void => {
@@ -16,11 +19,20 @@ describe('design preview routes', (): void => {
   it('registers the welcome gate preview as a hidden public route', () => {
     expect(routes).toContainEqual(
       expect.objectContaining({
-        path: '/welcome-gate-v1',
+        path: WELCOME_GATE_V1_ROUTE_PATH,
         requiresAuth: false,
         hideTabBar: true,
         previewOnly: true,
       })
     );
+  });
+
+  it('marks only the intended routes as preview-only', (): void => {
+    const previewOnlyPaths = routes
+      .filter(route => route.previewOnly)
+      .map(route => route.path)
+      .sort();
+
+    expect(previewOnlyPaths).toEqual([...PREVIEW_ONLY_ROUTE_PATHS].sort());
   });
 });

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -9,6 +9,7 @@ import NutritionSetup from '../pages/NutritionSetup';
 import BMICalculatePage from '../pages/BMI/BMICalculatePage';
 import ProPaywallPage from '../pages/Pro/ProPaywallPage';
 import DesignSystemPage from '../pages/DesignSystemPage';
+import { WELCOME_GATE_V1_ROUTE_PATH } from '../pages/Onboarding/welcomeGateV1Policy';
 
 export interface RouteConfig {
   path: string;
@@ -31,7 +32,7 @@ export type RoutePath =
   | '/bmi'
   | '/pro'
   | '/design-system'
-  | '/welcome-gate-v1';
+  | typeof WELCOME_GATE_V1_ROUTE_PATH;
 
 export const routes: RouteConfig[] = [
   { path: '/', label: 'Home', requiresAuth: false, component: Home },
@@ -51,7 +52,7 @@ export const routes: RouteConfig[] = [
     previewOnly: true,
   },
   {
-    path: '/welcome-gate-v1',
+    path: WELCOME_GATE_V1_ROUTE_PATH,
     label: 'WelcomeGateV1',
     requiresAuth: false,
     component: WelcomeGateV1,

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -16,6 +16,7 @@ export interface RouteConfig {
   requiresAuth: boolean;
   component: ComponentType;
   hideTabBar?: boolean;
+  previewOnly?: boolean;
   requiresVip?: boolean;
 }
 
@@ -41,13 +42,21 @@ export const routes: RouteConfig[] = [
   { path: '/progress', label: 'Progress', requiresAuth: true, component: Progress },
   { path: '/bmi', label: 'BMI', requiresAuth: false, component: BMICalculatePage, hideTabBar: true },
   { path: '/pro', label: 'Pro', requiresAuth: false, component: ProPaywallPage, hideTabBar: true },
-  { path: '/design-system', label: 'DesignSystem', requiresAuth: false, component: DesignSystemPage, hideTabBar: true },
+  {
+    path: '/design-system',
+    label: 'DesignSystem',
+    requiresAuth: false,
+    component: DesignSystemPage,
+    hideTabBar: true,
+    previewOnly: true,
+  },
   {
     path: '/welcome-gate-v1',
     label: 'WelcomeGateV1',
     requiresAuth: false,
     component: WelcomeGateV1,
     hideTabBar: true,
+    previewOnly: true,
   },
 ];
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -99,10 +99,14 @@
             "preview": {
                 "panelTitle": "WELCOME GATE / v1",
                 "panelFlowLabel": "flow:",
-                "panelFlowValue": "screen 1 preview -> setup",
+                "panelFlowValue": "screen-1-only preview route",
+                "panelTargetLabel": "target:",
+                "panelTargetValue": "/setup route mirror",
                 "panelLocalesLabel": "locales:",
                 "panelPolicyLabel": "policy:",
-                "panelPolicyValue": "preview only, no persistence"
+                "panelPolicyValue": "no persistence side-effects",
+                "panelBlockedLabel": "blocked:",
+                "panelBlockedValue": "screens 2-4 blocked by nodes"
             }
         },
         "enterKey": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -79,10 +79,14 @@
             "preview": {
                 "panelTitle": "WELCOME GATE / v1",
                 "panelFlowLabel": "flujo:",
-                "panelFlowValue": "vista previa de la pantalla 1 -> configuración",
+                "panelFlowValue": "ruta de vista previa solo para la pantalla 1",
+                "panelTargetLabel": "destino:",
+                "panelTargetValue": "espejo de la ruta /setup",
                 "panelLocalesLabel": "idiomas:",
                 "panelPolicyLabel": "política:",
-                "panelPolicyValue": "solo vista previa, sin persistencia"
+                "panelPolicyValue": "sin efectos laterales de persistencia",
+                "panelBlockedLabel": "bloqueado:",
+                "panelBlockedValue": "las pantallas 2-4 esperan captura exacta de nodos"
             }
         },
         "enterKey": {

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -99,10 +99,14 @@
             "preview": {
                 "panelTitle": "WELCOME GATE / v1",
                 "panelFlowLabel": "поток:",
-                "panelFlowValue": "превью экрана 1 -> настройка",
+                "panelFlowValue": "preview route только для экрана 1",
+                "panelTargetLabel": "цель:",
+                "panelTargetValue": "зеркало маршрута /setup",
                 "panelLocalesLabel": "языки:",
                 "panelPolicyLabel": "политика:",
-                "panelPolicyValue": "только превью, без сохранения"
+                "panelPolicyValue": "без side-effects сохранения",
+                "panelBlockedLabel": "блокировка:",
+                "panelBlockedValue": "экраны 2-4 ждут exact node capture"
             }
         },
         "enterKey": {

--- a/frontend/src/pages/Onboarding/WelcomeGateV1.tsx
+++ b/frontend/src/pages/Onboarding/WelcomeGateV1.tsx
@@ -2,11 +2,13 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import fitchefOnboardingWelcome from '../../assets/brand/fitchef-onboarding-welcome-v1.png';
 import { PulsePlateLogo } from '../../components/brand';
-
-const PREVIEW_LOCALES = ['ru', 'en', 'es'] as const;
-const PREVIEW_STEP = 1;
-const PREVIEW_STEP_COUNT = 1;
-const FEATURE_POINT_IDS = [1, 2, 3] as const;
+import {
+  WELCOME_GATE_V1_FEATURE_POINT_IDS,
+  WELCOME_GATE_V1_PREVIEW_LOCALES,
+  WELCOME_GATE_V1_PREVIEW_STEP,
+  WELCOME_GATE_V1_PREVIEW_STEP_COUNT,
+  WELCOME_GATE_V1_SETUP_TARGET,
+} from './welcomeGateV1Policy';
 
 function StepIndicator({ label }: { label: string }): JSX.Element {
   return (
@@ -20,8 +22,8 @@ function StepIndicator({ label }: { label: string }): JSX.Element {
 export default function WelcomeGateV1(): JSX.Element {
   const { t } = useTranslation();
   const stepLabel = t('onboarding.welcome.stepA11y', {
-    current: PREVIEW_STEP,
-    total: PREVIEW_STEP_COUNT,
+    current: WELCOME_GATE_V1_PREVIEW_STEP,
+    total: WELCOME_GATE_V1_PREVIEW_STEP_COUNT,
   });
 
   return (
@@ -36,7 +38,7 @@ export default function WelcomeGateV1(): JSX.Element {
               <span className="h-2 w-2 rounded-full bg-[var(--pp-green)]" />
               {t('onboarding.welcome.routeMirrorBadge')}
             </div>
-            <Link to="/setup" className="text-sm text-white/55 transition hover:text-white/78">
+            <Link to={WELCOME_GATE_V1_SETUP_TARGET} className="text-sm text-white/55 transition hover:text-white/78">
               {t('onboarding.welcome.skip')}
             </Link>
           </div>
@@ -57,7 +59,7 @@ export default function WelcomeGateV1(): JSX.Element {
               {t('onboarding.welcome.screen1.cardTitle')}
             </p>
             <ul className="mt-4 space-y-3 text-base leading-7 text-white/78">
-              {FEATURE_POINT_IDS.map((item) => (
+              {WELCOME_GATE_V1_FEATURE_POINT_IDS.map((item) => (
                 <li key={item}>{t(`onboarding.welcome.screen1.points.${item}`)}</li>
               ))}
             </ul>
@@ -68,7 +70,7 @@ export default function WelcomeGateV1(): JSX.Element {
           <div className="mt-auto flex flex-col gap-4 pt-8 sm:flex-row sm:items-center sm:justify-between">
             <StepIndicator label={stepLabel} />
             <Link
-              to="/setup"
+              to={WELCOME_GATE_V1_SETUP_TARGET}
               className="inline-flex items-center justify-center rounded-full bg-[var(--pp-green)] px-7 py-4 text-lg font-semibold text-[var(--pp-navy)] transition hover:brightness-105"
             >
               {t('onboarding.welcome.cta.start')}
@@ -95,10 +97,16 @@ export default function WelcomeGateV1(): JSX.Element {
                 {t('onboarding.welcome.preview.panelFlowLabel')} {t('onboarding.welcome.preview.panelFlowValue')}
               </p>
               <p>
-                {t('onboarding.welcome.preview.panelLocalesLabel')} {PREVIEW_LOCALES.join(' · ')}
+                {t('onboarding.welcome.preview.panelTargetLabel')} {t('onboarding.welcome.preview.panelTargetValue')}
+              </p>
+              <p>
+                {t('onboarding.welcome.preview.panelLocalesLabel')} {WELCOME_GATE_V1_PREVIEW_LOCALES.join(' / ')}
               </p>
               <p>
                 {t('onboarding.welcome.preview.panelPolicyLabel')} {t('onboarding.welcome.preview.panelPolicyValue')}
+              </p>
+              <p>
+                {t('onboarding.welcome.preview.panelBlockedLabel')} {t('onboarding.welcome.preview.panelBlockedValue')}
               </p>
             </div>
           </section>

--- a/frontend/src/pages/Onboarding/__tests__/WelcomeGateV1.test.tsx
+++ b/frontend/src/pages/Onboarding/__tests__/WelcomeGateV1.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import '../../../i18n';
 import i18n from '../../../i18n';
 import WelcomeGateV1 from '../WelcomeGateV1';
+import {
+  WELCOME_GATE_V1_PREVIEW_LOCALES,
+  WELCOME_GATE_V1_PREVIEW_STEP,
+  WELCOME_GATE_V1_PREVIEW_STEP_COUNT,
+  WELCOME_GATE_V1_SETUP_TARGET,
+} from '../welcomeGateV1Policy';
 
 async function waitForI18n(): Promise<void> {
   if (i18n.isInitialized) {
@@ -56,6 +62,8 @@ type WelcomeCopy = {
   heroAlt: string;
   mainA11y: string;
   panelFlowValue: string;
+  panelTargetValue: string;
+  panelBlockedValue: string;
   panelPolicyValue: string;
   panelTitle: string;
   step: string;
@@ -71,9 +79,14 @@ function getWelcomeCopy(language: 'en' | 'ru' | 'es'): WelcomeCopy {
     heroAlt: t('onboarding.welcome.heroAlt'),
     mainA11y: t('onboarding.welcome.mainA11y'),
     panelFlowValue: t('onboarding.welcome.preview.panelFlowValue'),
+    panelTargetValue: t('onboarding.welcome.preview.panelTargetValue'),
+    panelBlockedValue: t('onboarding.welcome.preview.panelBlockedValue'),
     panelPolicyValue: t('onboarding.welcome.preview.panelPolicyValue'),
     panelTitle: t('onboarding.welcome.preview.panelTitle'),
-    step: t('onboarding.welcome.stepA11y', { current: 1, total: 1 }),
+    step: t('onboarding.welcome.stepA11y', {
+      current: WELCOME_GATE_V1_PREVIEW_STEP,
+      total: WELCOME_GATE_V1_PREVIEW_STEP_COUNT,
+    }),
     title: t('onboarding.welcome.screen1.title'),
   };
 }
@@ -90,9 +103,11 @@ describe('WelcomeGateV1', () => {
 
     expect(screen.getByRole('main', { name: copy.mainA11y })).toBeInTheDocument();
     expect(screen.getByText(copy.body)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: copy.cta })).toHaveAttribute('href', '/setup');
+    expect(screen.getByRole('link', { name: copy.cta })).toHaveAttribute('href', WELCOME_GATE_V1_SETUP_TARGET);
     expect(screen.getByText(copy.step)).toBeInTheDocument();
     expect(screen.getByText(copy.panelTitle)).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes(copy.panelTargetValue))).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes(copy.panelBlockedValue))).toBeInTheDocument();
     expect(screen.getByAltText(copy.heroAlt)).toBeInTheDocument();
   });
 
@@ -104,9 +119,14 @@ describe('WelcomeGateV1', () => {
     await renderWelcomeGate('en');
 
     expect(screen.getByRole('main', { name: copy.mainA11y })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Skip' })).toHaveAttribute('href', '/setup');
+    expect(screen.getByRole('link', { name: 'Skip' })).toHaveAttribute('href', WELCOME_GATE_V1_SETUP_TARGET);
     expect(screen.getByText((content) => content.includes(copy.panelFlowValue))).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes(copy.panelTargetValue))).toBeInTheDocument();
     expect(screen.getByText((content) => content.includes(copy.panelPolicyValue))).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes(copy.panelBlockedValue))).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes(WELCOME_GATE_V1_PREVIEW_LOCALES.join(' / ')))
+    ).toBeInTheDocument();
     expect(setItemSpy.mock.calls.some(([key]) => key === persistenceKey)).toBe(false);
   });
 });

--- a/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
+++ b/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
@@ -3,4 +3,4 @@ export const WELCOME_GATE_V1_SETUP_TARGET = '/setup' as const;
 export const WELCOME_GATE_V1_PREVIEW_LOCALES = ['ru', 'en', 'es'] as const;
 export const WELCOME_GATE_V1_PREVIEW_STEP = 1 as const;
 export const WELCOME_GATE_V1_PREVIEW_STEP_COUNT = 1 as const;
-export const WELCOME_GATE_V1_FEATURE_POINT_IDS = [1, 2, 3] as const;
+export const WELCOME_GATE_V1_FEATURE_POINT_IDS = ['1', '2', '3'] as const;

--- a/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
+++ b/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
@@ -1,0 +1,6 @@
+export const WELCOME_GATE_V1_ROUTE_PATH = '/welcome-gate-v1' as const;
+export const WELCOME_GATE_V1_SETUP_TARGET = '/setup' as const;
+export const WELCOME_GATE_V1_PREVIEW_LOCALES = ['ru', 'en', 'es'] as const;
+export const WELCOME_GATE_V1_PREVIEW_STEP = 1;
+export const WELCOME_GATE_V1_PREVIEW_STEP_COUNT = 1;
+export const WELCOME_GATE_V1_FEATURE_POINT_IDS = [1, 2, 3] as const;

--- a/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
+++ b/frontend/src/pages/Onboarding/welcomeGateV1Policy.ts
@@ -1,6 +1,6 @@
 export const WELCOME_GATE_V1_ROUTE_PATH = '/welcome-gate-v1' as const;
 export const WELCOME_GATE_V1_SETUP_TARGET = '/setup' as const;
 export const WELCOME_GATE_V1_PREVIEW_LOCALES = ['ru', 'en', 'es'] as const;
-export const WELCOME_GATE_V1_PREVIEW_STEP = 1;
-export const WELCOME_GATE_V1_PREVIEW_STEP_COUNT = 1;
+export const WELCOME_GATE_V1_PREVIEW_STEP = 1 as const;
+export const WELCOME_GATE_V1_PREVIEW_STEP_COUNT = 1 as const;
 export const WELCOME_GATE_V1_FEATURE_POINT_IDS = [1, 2, 3] as const;


### PR DESCRIPTION
## Summary
- harden `/welcome-gate-v1` as an explicit preview-only runtime surface
- centralize welcome gate preview policy constants and reuse them across route config, UI, and tests
- align preview metadata copy with the approved Figma governance lane: screen-1-only, `/setup` mirror target, no persistence side-effects, future screens still blocked

## Why
Approved Figma/runtime canon still blocks the full 4-screen onboarding gate until exact Design URL + `nodeId` coverage exists for screens 2-4. This PR does not promote Welcome Gate into startup flow or introduce `has_seen_welcome_v1` persistence. It only makes the current preview contract harder to misread or accidentally promote.

## Validation
- `npm test`
- `npm run build`
- `pre-commit run --all-files`

## Figma Canon
- file: `2JDwOByQIbcPgp93FDzHii`
- blocked governance evidence: `20:172` `Welcome Gate States Board`
- approved screen-1 mascot/reference boards: `82:66`, `85:32`

## Deferred / Follow-ups
- Full runtime flow remains tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-welcome-gate-full-flow-after-node-capture`
- No startup interception or completion persistence in this PR

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1263_FIXED_MAPPING.md`

## Summary by Sourcery

Укрепить онбординг-экран Welcome Gate V1 как поверхность только для предпросмотра и централизовать его runtime-политику, пометив связанные маршруты как дизайн-превью.

Enhancements:
- Централизовать политику предпросмотра Welcome Gate V1 (путь маршрута, целевой объект настройки, локали, метаданные шагов и идентификаторы точек фич) в общем модуле политики, который переиспользуется страницей и тестами.
- Пометить маршруты design-system и Welcome Gate V1 как доступные только в режиме предпросмотра в конфигурации маршрутов, чтобы прояснить их непроизводственный статус.
- Расширить текст и проводку панели предпросмотра, чтобы отображать целевой маршрут, поддерживаемые локали и сообщения о заблокированном состоянии в соответствии с текущим governance-lane.

Documentation:
- Добавить артефакт ревью PR_1263_FIXED_MAPPING, документирующий статус обсуждения и чек-лист готовности к слиянию.

Tests:
- Обновить тесты Welcome Gate V1 для использования общих констант политики предпросмотра и проверки новых метаданных предпросмотра и целевого поведения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the Welcome Gate V1 onboarding screen as a preview-only surface and centralize its runtime policy while marking related routes as design previews.

Enhancements:
- Centralize Welcome Gate V1 preview policy (route path, setup target, locales, step metadata, and feature point IDs) into a shared policy module reused by the page and tests.
- Mark the design-system and Welcome Gate V1 routes as preview-only in the route configuration to clarify their non-production status.
- Expand preview panel copy and wiring to surface target route, supported locales, and blocked-state messaging aligned with the current governance lane.

Documentation:
- Add a PR_1263_FIXED_MAPPING review artifact documenting discussion status and merge readiness checklist.

Tests:
- Update Welcome Gate V1 tests to consume the shared preview policy constants and validate the new preview metadata and target behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Design System and Welcome Gate V1 routes marked preview-only; Welcome Gate preview now displays explicit target and blocked details with clearer messaging.
* **Tests**
  * Updated route and onboarding tests to assert preview-only routes, localized locale display, and new preview panel content.
* **Documentation**
  * Added PR review document mapping review dispositions to fixes and a merge-readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->