### PR TITLE
feat(automation): add skill intent routing

### DIFF
--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -92,7 +92,7 @@ Minimum required keys:
 - `constraints` (array of strings)
 - `inputs.must_read_paths` (array of strings; paths)
 - `inputs.recommended_skills` (array of strings; optional but recommended when skill routing is enabled)
-- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected)
+- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `required`, `recommended`, `conditional`, and `blocked`)
 - `output_requirements.must_return` (array of strings)
 - `budgets` (object; recommended when cost/latency matters)
 
@@ -166,11 +166,59 @@ Task packet:
     ],
     "recommended_skills": [
       "pulseplate-workflow",
-      "docs-sync"
+      "docs-sync",
+      "pulseplate-gates"
     ],
     "skill_routing": {
       "selection_mode": "deterministic-weighted",
-      "policy_version": "2026-03-08"
+      "policy_version": "2026-03-27",
+      "task_classification": {
+        "label": "pr_governance",
+        "score": 5,
+        "reasons": [
+          "lexeme:review thread(+2)",
+          "lexeme:merge readiness(+2)"
+        ]
+      },
+      "required": [
+        {
+          "skill": "pulseplate-workflow",
+          "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+          "reasons": ["always-on"]
+        },
+        {
+          "skill": "docs-sync",
+          "rationale": "Keep orchestration, runbooks, and product docs aligned with the implementation.",
+          "reasons": ["classification:pr_governance-required"]
+        },
+        {
+          "skill": "pulseplate-gates",
+          "rationale": "Run PulsePlate quality gates for code, docs, and contract-safe changes.",
+          "reasons": ["classification:pr_governance-required"]
+        }
+      ],
+      "recommended": [
+        {
+          "skill": "pulseplate-guards",
+          "score": 8,
+          "category": "repo-tracked",
+          "rationale": "Handle architecture guards, fail-closed policy checks, and security-oriented invariants.",
+          "reasons": [
+            "privileged-surface:docs/review/(+4)"
+          ]
+        }
+      ],
+      "conditional": [
+        {
+          "skill": "gh-address-comments",
+          "when": "Enable when the task explicitly enters PR/review/merge-governance execution.",
+          "rationale": "GitHub review-thread handling should use the dedicated comment workflow.",
+          "reasons": [
+            "lexeme:review thread(+2)"
+          ]
+        }
+      ],
+      "blocked": []
     },
     "automation_flags": {
       "coordinator_first_required": true,

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -49,10 +49,59 @@ Deterministic coverage lives in `tests/test_task_bootstrap.py` and `tests/test_e
 
 The bootstrap packet should expose:
 
-- `recommended_skills` for execution order
-- `skill_routing` for compact evidence and blocked-pattern metadata
+- `recommended_skills` for backward-compatible execution order
+- `skill_routing` for compact evidence, routing buckets, and blocked-pattern metadata
 
 This keeps routing explainable without relying on hidden reasoning.
+
+Packet contract note:
+
+- `recommended_skills` is a deterministic flatten of:
+  1. `skill_routing.required[*].skill`
+  2. `skill_routing.recommended[*].skill`
+- `skill_routing.conditional` does not leak into `recommended_skills`.
+- `skill_routing` must expose:
+  - `task_classification`
+  - `required`
+  - `recommended`
+  - `conditional`
+  - `blocked`
+
+### 2a. Deterministic Task Classification
+
+The router must emit a finite-state classifier under
+`skill_routing.task_classification` with these canonical labels:
+
+- `implementation`
+- `bugfix`
+- `review`
+- `design`
+- `creative_research`
+- `experiment`
+- `pr_governance`
+
+Tie-break precedence is canonical and must stay explicit:
+
+1. `pr_governance`
+2. `design`
+3. `creative_research`
+4. `experiment`
+5. `review`
+6. `bugfix`
+7. `implementation`
+
+### 2b. Routing Bucket Semantics
+
+- `required`: non-optional skills for the classified lane. `pulseplate-workflow`
+  is always required. `pr_governance` additionally requires the minimal
+  governance baseline: `docs-sync` and `pulseplate-gates`.
+- `recommended`: deterministic ranked helpers that are safe to auto-promote into
+  execution order for the current task.
+- `conditional`: task-fit helpers that need a stronger trigger before promotion.
+  This bucket is used for partial design signals, weak research/report intent,
+  or PR/CI helpers on non-PR/non-failing tasks.
+- `blocked`: deterministic low-fit or disallowed patterns. Pattern-based blocks
+  must carry `kind: "pattern"` for forward compatibility.
 
 For experimentation tasks, the bootstrap packet should also reference:
 

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -158,6 +158,8 @@ In:
 
 - minimal-optimal skill stack selection,
 - deterministic task-class classifier,
+- nested `inputs.skill_routing.task_classification`,
+- backward-compatible `recommended_skills = required + recommended`,
 - required/recommended/conditional/blocked routing outputs.
 
 Out:

--- a/docs/orchestration/workflow.md
+++ b/docs/orchestration/workflow.md
@@ -99,6 +99,7 @@ Automation note:
 - [ ] Назначены secondary agents (если multi-domain)
 - [ ] Проставлены зависимости / handoff / sync points (если multi-agent)
 - [ ] Определён `recommended_skills` packet по `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+- [ ] `skill_routing` содержит `task_classification`, `required`, `recommended`, `conditional`, `blocked`
 - [ ] Task packet содержит additive automation metadata:
   `automation_flags`, `pr_phase`, `design_lane_mode`,
   `needs_backlog_update`, `needs_docs_sync`, `needs_agents_sync`
@@ -120,6 +121,8 @@ derivable from existing inputs:
 - `automation_flags.skill_routing_applied = true`
 - `automation_flags.native_subagent_bridge_available = true`
 - `automation_flags.security_review_required` mirrors the privileged-surface rule
+- `recommended_skills` remains backward-compatible and is derived from
+  `skill_routing.required + skill_routing.recommended`
 - `automation_flags.judgment_lane_enabled` mirrors `decision_contract.judgment_enabled`
 - `automation_flags.pr_lifecycle_enabled = false`
 - `automation_flags.design_lane_enabled = false`

--- a/docs/review/PR_1265_FIXED_MAPPING.md
+++ b/docs/review/PR_1265_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1265 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+Notes: Draft PR opened with no review comments yet. Local `pre-commit run --all-files` and `make verify` passed on commit `5bc96098`, but merge-readiness boxes stay unchecked until the final current-head review cycle.

--- a/docs/review/PR_1265_FIXED_MAPPING.md
+++ b/docs/review/PR_1265_FIXED_MAPPING.md
@@ -5,12 +5,20 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003475440` -> `08ed7c2b`
-  Evidence: `scripts/orchestration/skill_router.py:248`, `scripts/orchestration/skill_router.py:779`, `tests/test_skill_router.py:211`, `tests/test_skill_router.py:220`
-- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485202` -> `d3c3a9d1`
-  Evidence: `scripts/orchestration/skill_router.py:123`, `tests/test_skill_router.py:254`
-- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485207` -> `d3c3a9d1`
-  Evidence: `scripts/orchestration/skill_router.py:954`, `tests/test_skill_router.py:405`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003475440 -> 08ed7c2b
+Disposition: FIXED
+Commit: 08ed7c2b
+Evidence: scripts/orchestration/skill_router.py:248, scripts/orchestration/skill_router.py:779, tests/test_skill_router.py:211, tests/test_skill_router.py:220
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485202 -> d3c3a9d1
+Disposition: FIXED
+Commit: d3c3a9d1
+Evidence: scripts/orchestration/skill_router.py:123, tests/test_skill_router.py:254
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485207 -> d3c3a9d1
+Disposition: FIXED
+Commit: d3c3a9d1
+Evidence: scripts/orchestration/skill_router.py:954, tests/test_skill_router.py:405
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1265_FIXED_MAPPING.md
+++ b/docs/review/PR_1265_FIXED_MAPPING.md
@@ -20,6 +20,16 @@ Disposition: FIXED
 Commit: d3c3a9d1
 Evidence: scripts/orchestration/skill_router.py:954, tests/test_skill_router.py:405
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#pullrequestreview-4023951708
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_1265_FIXED_MAPPING.md:8, scripts/orchestration/skill_router.py:26, scripts/orchestration/skill_router.py:121
+Reason: This aggregate Sourcery review body bundles the already-mapped runtime bug-risk thread `discussion_r3003475440` with non-blocking architecture suggestions; the concrete actionable defect is tracked and fixed at thread level, while the remaining guidance is advisory rather than a separate unresolved bug.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#pullrequestreview-4023986587
+Disposition: NOT-A-BUG
+Evidence: tests/test_skill_router.py:67, tests/test_skill_router.py:73
+Reason: The reported helper signatures already carry `-> str` return annotations in the current code, so this summary review is stale and does not identify a remaining defect on the current head.
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1265_FIXED_MAPPING.md
+++ b/docs/review/PR_1265_FIXED_MAPPING.md
@@ -5,7 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003475440` -> `08ed7c2b`
+  Evidence: `scripts/orchestration/skill_router.py:248`, `scripts/orchestration/skill_router.py:779`, `tests/test_skill_router.py:211`, `tests/test_skill_router.py:220`
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1265_FIXED_MAPPING.md
+++ b/docs/review/PR_1265_FIXED_MAPPING.md
@@ -7,6 +7,10 @@
 ## Fixed in Commit Mapping
 - FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003475440` -> `08ed7c2b`
   Evidence: `scripts/orchestration/skill_router.py:248`, `scripts/orchestration/skill_router.py:779`, `tests/test_skill_router.py:211`, `tests/test_skill_router.py:220`
+- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485202` -> `d3c3a9d1`
+  Evidence: `scripts/orchestration/skill_router.py:123`, `tests/test_skill_router.py:254`
+- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485207` -> `d3c3a9d1`
+  Evidence: `scripts/orchestration/skill_router.py:954`, `tests/test_skill_router.py:405`
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/scripts/orchestration/experiment_bootstrap.py
+++ b/scripts/orchestration/experiment_bootstrap.py
@@ -45,7 +45,7 @@ from scripts.orchestration.experiment_contract import (
 )
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import load_routing_graph
-from scripts.orchestration.skill_router import route_skills
+from scripts.orchestration.skill_router import flatten_recommended_skills, route_skills
 
 EXPERIMENT_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "experiments"
 
@@ -310,7 +310,7 @@ def build_experiment_packet(
         "primary_agent": PRIMARY_AGENT,
         "reviewer": REVIEWER,
         "recommended_agents": deduped_agents,
-        "recommended_skills": [item["skill"] for item in skill_routing["recommended"]],
+        "recommended_skills": flatten_recommended_skills(skill_routing),
         "skill_routing": skill_routing,
         "routing_context": {
             "cluster": routing_decision.cluster,

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -245,6 +245,29 @@ TASK_CLASSIFICATION_RULES: tuple[TaskClassificationRule, ...] = (
 )
 
 
+def _validate_task_classification_contract() -> None:
+    """Fail fast when classifier precedence and rule labels diverge."""
+
+    precedence_labels = tuple(dict.fromkeys(CLASSIFICATION_PRECEDENCE))
+    if precedence_labels != CLASSIFICATION_PRECEDENCE:
+        raise ValueError("CLASSIFICATION_PRECEDENCE must not contain duplicate labels")
+
+    rule_labels = tuple(rule.label for rule in TASK_CLASSIFICATION_RULES)
+    if len(set(rule_labels)) != len(rule_labels):
+        raise ValueError("TASK_CLASSIFICATION_RULES must not contain duplicate labels")
+
+    missing_labels = tuple(label for label in CLASSIFICATION_PRECEDENCE if label not in rule_labels)
+    extra_labels = tuple(label for label in rule_labels if label not in CLASSIFICATION_PRECEDENCE)
+    if missing_labels or extra_labels:
+        raise ValueError(
+            "Task classification labels are out of sync: "
+            f"missing={missing_labels}, extra={extra_labels}"
+        )
+
+
+_validate_task_classification_contract()
+
+
 @dataclass(frozen=True)
 class SkillRule:
     """Weighted routing rule for one skill."""
@@ -753,13 +776,15 @@ def _classify_task(
     winning_score = -1
 
     for label in CLASSIFICATION_PRECEDENCE:
-        candidate = scored_by_label[label]
+        candidate = scored_by_label.get(label)
+        if candidate is None:
+            continue
         candidate_score = int(candidate["score"])
         if candidate_score > winning_score:
             winning_label = label
             winning_score = candidate_score
 
-    winner = scored_by_label[winning_label]
+    winner = scored_by_label.get(winning_label)
     if winning_score <= 0:
         return {
             "label": "implementation",
@@ -770,9 +795,12 @@ def _classify_task(
     tied_labels = [
         label
         for label in CLASSIFICATION_PRECEDENCE
-        if int(scored_by_label[label]["score"]) == winning_score
+        if (
+            scored_by_label.get(label) is not None
+            and int(scored_by_label[label]["score"]) == winning_score
+        )
     ]
-    reasons = list(winner["reasons"])
+    reasons = list(winner["reasons"]) if winner is not None else []
     if len(tied_labels) > 1:
         reasons.append(
             f"tie-break:{winning_label}>{', '.join(label for label in tied_labels if label != winning_label)}"

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -162,10 +162,9 @@ TASK_CLASSIFICATION_RULES: tuple[TaskClassificationRule, ...] = (
     ),
     TaskClassificationRule(
         label="creative_research",
-        domain_weights={"research": 3, "business": 2, "wellness": 2, "docs": 1},
+        domain_weights={"research": 3, "business": 2, "wellness": 2},
         path_prefixes=("docs/reports/", "docs/insights/", "docs/audience_pack/"),
         keywords=(
-            "report",
             "weekly",
             "monthly",
             "quarterly",
@@ -239,7 +238,7 @@ TASK_CLASSIFICATION_RULES: tuple[TaskClassificationRule, ...] = (
             "cv": 1,
             "qa": 1,
         },
-        path_prefixes=("app/", "core/", "frontend/", "scripts/", "docs/", "ios/"),
+        path_prefixes=("app/", "core/", "frontend/", "scripts/", "ios/"),
         keywords=("implement", "add", "build", "wire", "update", "refactor"),
     ),
 )
@@ -955,6 +954,8 @@ def route_skills(
     for requested_agent in normalized_requested_agents:
         bundle = REQUESTED_AGENT_SKILL_BUNDLES.get(requested_agent, ())
         for bundled_skill in bundle:
+            if bundled_skill in required_skill_names:
+                continue
             boost = 6 if bundled_skill not in selected_by_skill else 2
             _apply_bundle_reason(
                 selected_by_skill=selected_by_skill,

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -14,10 +14,49 @@ from typing import Any
 from scripts.orchestration.context_pack import normalize_text, repo_relative_paths
 from scripts.orchestration.requested_agents import normalize_requested_agents
 
-ROUTING_POLICY_VERSION = "2026-03-21"
+ROUTING_POLICY_VERSION = "2026-03-27"
 SELECTION_MODE = "deterministic-weighted"
 
 ALWAYS_ON_SKILLS: tuple[str, ...] = ("pulseplate-workflow",)
+PR_GOVERNANCE_REQUIRED_SKILLS: tuple[str, ...] = (
+    "pulseplate-workflow",
+    "docs-sync",
+    "pulseplate-gates",
+)
+CLASSIFICATION_PRECEDENCE: tuple[str, ...] = (
+    "pr_governance",
+    "design",
+    "creative_research",
+    "experiment",
+    "review",
+    "bugfix",
+    "implementation",
+)
+PR_GOVERNANCE_CONDITIONAL_SKILLS: frozenset[str] = frozenset(
+    {
+        "create-pr",
+        "commit-work",
+        "release-notes",
+        "gh-address-comments",
+        "gh-fix-ci",
+        "ci-fix",
+    }
+)
+DESIGN_CONDITIONAL_SKILLS: frozenset[str] = frozenset(
+    {
+        "figma",
+        "figma-implement-design",
+    }
+)
+RESEARCH_CONDITIONAL_SKILLS: frozenset[str] = frozenset(
+    {
+        "pulseplate-ai-reports",
+        "notion-research-documentation",
+        "notion-knowledge-capture",
+        "linear",
+    }
+)
+CI_CONDITIONAL_SKILLS: frozenset[str] = frozenset({"ci-fix", "gh-fix-ci"})
 
 REQUESTED_AGENT_SKILL_BUNDLES: dict[str, tuple[str, ...]] = {
     "agent-coordinator": ("docs-sync", "agents-md", "pulseplate-gates"),
@@ -66,6 +105,143 @@ SCRAPING_BLOCK_PATTERNS: tuple[tuple[str, str], ...] = (
     ("google maps", "Google Maps scraping is not approved for the current repo."),
     ("scrape any site", "Universal scraping is out of scope for PulsePlate."),
     ("entire internet", "Broad internet scraping is outside project-fit boundaries."),
+)
+
+
+@dataclass(frozen=True)
+class TaskClassificationRule:
+    """Deterministic scoring rule for the task-intent classifier."""
+
+    label: str
+    domain_weights: dict[str, int]
+    path_prefixes: tuple[str, ...] = ()
+    keywords: tuple[str, ...] = ()
+
+
+TASK_CLASSIFICATION_RULES: tuple[TaskClassificationRule, ...] = (
+    TaskClassificationRule(
+        label="pr_governance",
+        domain_weights={"orchestration": 2, "qa": 1, "release": 1},
+        path_prefixes=(
+            ".github/workflows/",
+            "scripts/ci/",
+            "docs/review/",
+        ),
+        keywords=(
+            "pull request",
+            "open pr",
+            "create pr",
+            "review thread",
+            "review comment",
+            "merge",
+            "merge readiness",
+            "fixed mapping",
+            "disposition",
+            "code rabbit",
+            "sourcery",
+            "cubic",
+            "gh pr checks",
+            "governance",
+        ),
+    ),
+    TaskClassificationRule(
+        label="design",
+        domain_weights={"design": 3, "frontend": 1},
+        path_prefixes=("docs/design/",),
+        keywords=(
+            "figma",
+            "node-id",
+            "node id",
+            "design system",
+            "design fidelity",
+            "ui fidelity",
+            "prototype",
+            "screen",
+            "frame",
+        ),
+    ),
+    TaskClassificationRule(
+        label="creative_research",
+        domain_weights={"research": 3, "business": 2, "wellness": 2, "docs": 1},
+        path_prefixes=("docs/reports/", "docs/insights/", "docs/audience_pack/"),
+        keywords=(
+            "report",
+            "weekly",
+            "monthly",
+            "quarterly",
+            "trend",
+            "research brief",
+            "gtm",
+            "aso",
+            "seo",
+            "wellness",
+            "market",
+            "industry",
+        ),
+    ),
+    TaskClassificationRule(
+        label="experiment",
+        domain_weights={"ml": 3, "cv": 3},
+        path_prefixes=("core/rag/", "core/insight/", "docs/orchestration/CV_"),
+        keywords=(
+            "experiment",
+            "benchmark",
+            "eval",
+            "evaluation",
+            "reliability",
+            "optimization",
+            "ablation",
+            "offline eval",
+            "confidence drift",
+        ),
+    ),
+    TaskClassificationRule(
+        label="review",
+        domain_weights={"qa": 2, "orchestration": 1},
+        path_prefixes=("docs/review/",),
+        keywords=(
+            "review",
+            "code review",
+            "audit",
+            "comments",
+            "thread",
+        ),
+    ),
+    TaskClassificationRule(
+        label="bugfix",
+        domain_weights={"qa": 1, "backend": 1, "frontend": 1},
+        path_prefixes=("tests/",),
+        keywords=(
+            "bug",
+            "fix",
+            "failure",
+            "failing",
+            "regression",
+            "flaky",
+            "broken",
+            "error",
+        ),
+    ),
+    TaskClassificationRule(
+        label="implementation",
+        domain_weights={
+            "backend": 1,
+            "frontend": 1,
+            "orchestration": 1,
+            "docs": 1,
+            "design": 1,
+            "research": 1,
+            "business": 1,
+            "wellness": 1,
+            "release": 1,
+            "security": 1,
+            "ml": 1,
+            "cv": 1,
+            "qa": 1,
+        },
+        path_prefixes=("app/", "core/", "frontend/", "scripts/", "docs/", "ios/"),
+        keywords=("implement", "add", "build", "wire", "update", "refactor"),
+    ),
 )
 
 
@@ -523,6 +699,171 @@ def _apply_bundle_reason(
         existing["reasons"].append(reason)
 
 
+def _score_task_classification(
+    *,
+    rule: TaskClassificationRule,
+    normalized_paths: list[str],
+    normalized_text: str,
+    domain: str,
+) -> dict[str, Any]:
+    """Return score and evidence for one task-classification rule."""
+
+    score = 0
+    reasons: list[str] = []
+
+    if domain in rule.domain_weights:
+        weight = rule.domain_weights[domain]
+        score += weight
+        reasons.append(f"domain:{domain}(+{weight})")
+
+    matched_prefixes = _match_path_prefixes(rule.path_prefixes, normalized_paths)
+    if matched_prefixes:
+        prefix_score = len(matched_prefixes) * 3
+        score += prefix_score
+        reasons.append(f"path:{', '.join(matched_prefixes)}(+{prefix_score})")
+
+    matched_keywords = _match_keywords(rule.keywords, normalized_text)
+    if matched_keywords:
+        keyword_score = min(len(matched_keywords), 3) * 2
+        score += keyword_score
+        reasons.append(f"lexeme:{', '.join(matched_keywords[:3])}(+{keyword_score})")
+
+    return {"label": rule.label, "score": score, "reasons": reasons}
+
+
+def _classify_task(
+    *,
+    normalized_paths: list[str],
+    normalized_text: str,
+    domain: str,
+) -> dict[str, Any]:
+    """Return deterministic task classification metadata."""
+
+    scored = [
+        _score_task_classification(
+            rule=rule,
+            normalized_paths=normalized_paths,
+            normalized_text=normalized_text,
+            domain=domain,
+        )
+        for rule in TASK_CLASSIFICATION_RULES
+    ]
+    scored_by_label = {item["label"]: item for item in scored}
+    winning_label = "implementation"
+    winning_score = -1
+
+    for label in CLASSIFICATION_PRECEDENCE:
+        candidate = scored_by_label[label]
+        candidate_score = int(candidate["score"])
+        if candidate_score > winning_score:
+            winning_label = label
+            winning_score = candidate_score
+
+    winner = scored_by_label[winning_label]
+    if winning_score <= 0:
+        return {
+            "label": "implementation",
+            "score": 0,
+            "reasons": ["fallback:default-implementation"],
+        }
+
+    tied_labels = [
+        label
+        for label in CLASSIFICATION_PRECEDENCE
+        if int(scored_by_label[label]["score"]) == winning_score
+    ]
+    reasons = list(winner["reasons"])
+    if len(tied_labels) > 1:
+        reasons.append(
+            f"tie-break:{winning_label}>{', '.join(label for label in tied_labels if label != winning_label)}"
+        )
+    return {"label": winning_label, "score": winning_score, "reasons": reasons}
+
+
+def _build_required_skills(
+    *,
+    task_classification: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return deterministic required skills for the classified lane."""
+
+    if task_classification["label"] == "pr_governance":
+        required_skills = PR_GOVERNANCE_REQUIRED_SKILLS
+    else:
+        required_skills = ALWAYS_ON_SKILLS
+
+    required: list[dict[str, Any]] = []
+    for skill in required_skills:
+        rule = SKILL_RULES_BY_SKILL.get(skill)
+        rationale = (
+            rule.rationale
+            if rule is not None
+            else f"Required for the `{task_classification['label']}` lane."
+        )
+        reasons = (
+            ["always-on"]
+            if skill in ALWAYS_ON_SKILLS
+            else [f"classification:{task_classification['label']}-required"]
+        )
+        required.append(
+            {
+                "skill": skill,
+                "rationale": rationale,
+                "reasons": reasons,
+            }
+        )
+    return required
+
+
+def _conditional_when_for_skill(*, skill: str, task_classification_label: str) -> str | None:
+    """Return a deterministic conditional explanation for supported helper families."""
+
+    if skill in CI_CONDITIONAL_SKILLS and task_classification_label not in {
+        "bugfix",
+        "pr_governance",
+    }:
+        return "Enable when a failing CI job, workflow run, or check log is explicitly in scope."
+    if skill in PR_GOVERNANCE_CONDITIONAL_SKILLS and task_classification_label != "pr_governance":
+        return "Enable when the task explicitly enters PR/review/merge-governance execution."
+    if skill in DESIGN_CONDITIONAL_SKILLS and task_classification_label != "design":
+        return (
+            "Enable when a concrete Figma/design node-id or fidelity requirement becomes explicit."
+        )
+    if skill in RESEARCH_CONDITIONAL_SKILLS and task_classification_label != "creative_research":
+        return "Enable when the task requires a report/research deliverable or durable knowledge capture."
+    return None
+
+
+def _build_conditional_skills(
+    *,
+    scored: list[dict[str, Any]],
+    selected_skills: set[str],
+    task_classification: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return deterministic conditional skills for partial or out-of-lane signals."""
+
+    conditional: list[dict[str, Any]] = []
+    for item in sorted(scored, key=lambda entry: entry["skill"]):
+        if item["skill"] in selected_skills:
+            continue
+        if not item["reasons"]:
+            continue
+        when = _conditional_when_for_skill(
+            skill=item["skill"],
+            task_classification_label=task_classification["label"],
+        )
+        if when is None:
+            continue
+        conditional.append(
+            {
+                "skill": item["skill"],
+                "when": when,
+                "rationale": item["rationale"],
+                "reasons": list(item["reasons"]),
+            }
+        )
+    return conditional
+
+
 def route_skills(
     *,
     goal: str,
@@ -537,9 +878,14 @@ def route_skills(
     normalized_text = normalize_text(goal, task_class, *normalized_paths)
     normalized_request_text = normalize_text(goal, task_class)
     normalized_requested_agents = tuple(normalize_requested_agents(requested_agents))
+    task_classification = _classify_task(
+        normalized_paths=normalized_paths,
+        normalized_text=normalized_text,
+        domain=domain,
+    )
 
     blocked = [
-        {"label": pattern, "reason": reason}
+        {"label": pattern, "reason": reason, "kind": "pattern"}
         for pattern, reason in SCRAPING_BLOCK_PATTERNS
         if pattern in normalized_request_text
     ]
@@ -553,10 +899,14 @@ def route_skills(
         )
         for rule in SKILL_RULES
     ]
+    required = _build_required_skills(task_classification=task_classification)
+    required_skill_names = {item["skill"] for item in required}
+
     selected = [
         result
         for result, rule in zip(scored, SKILL_RULES)
-        if result["score"] >= rule.min_score or rule.skill in ALWAYS_ON_SKILLS
+        if (result["score"] >= rule.min_score or rule.skill in ALWAYS_ON_SKILLS)
+        and result["skill"] not in required_skill_names
     ]
 
     selected_by_skill = {item["skill"]: item for item in selected}
@@ -590,12 +940,20 @@ def route_skills(
 
     selected = list(selected_by_skill.values())
     selected.sort(key=lambda item: (-int(item["score"]), item["skill"]))
+    conditional = _build_conditional_skills(
+        scored=scored,
+        selected_skills=required_skill_names.union(item["skill"] for item in selected),
+        task_classification=task_classification,
+    )
 
     return {
         "policy_version": ROUTING_POLICY_VERSION,
         "selection_mode": SELECTION_MODE,
         "requested_agents": list(normalized_requested_agents),
+        "task_classification": task_classification,
+        "required": required,
         "recommended": selected,
+        "conditional": conditional,
         "blocked": blocked,
     }
 
@@ -617,4 +975,20 @@ def select_recommended_skills(
         domain=domain,
         requested_agents=requested_agents,
     )
-    return [item["skill"] for item in decision["recommended"]]
+    return flatten_recommended_skills(decision)
+
+
+def flatten_recommended_skills(decision: dict[str, Any]) -> list[str]:
+    """Return the backward-compatible ordered skill slug list.
+
+    RU: Flatten required + recommended без conditional lanes.
+    EN: Flatten required + recommended while excluding conditional suggestions.
+    """
+
+    ordered: list[str] = []
+    for bucket in ("required", "recommended"):
+        for item in decision.get(bucket, []):
+            skill = item["skill"]
+            if skill not in ordered:
+                ordered.append(skill)
+    return ordered

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -48,7 +48,7 @@ from scripts.orchestration.routing_graph_loader import (
     require_bootstrap_lane_activation,
 )
 from scripts.orchestration.requested_agents import normalize_requested_agents
-from scripts.orchestration.skill_router import route_skills
+from scripts.orchestration.skill_router import flatten_recommended_skills, route_skills
 
 SCHEMA_VERSION = "2.0"
 TASK_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "task_packets"
@@ -557,7 +557,7 @@ def build_task_packet(
         "requested_agents": normalized_requested_agents,
         "requested_agent_disposition": requested_agent_resolution["requested_agent_disposition"],
         "required_context": context_pack,
-        "recommended_skills": [item["skill"] for item in skill_routing["recommended"]],
+        "recommended_skills": flatten_recommended_skills(skill_routing),
         "skill_routing": skill_routing,
         "automation_flags": {
             "coordinator_first_required": True,

--- a/tests/test_experiment_bootstrap.py
+++ b/tests/test_experiment_bootstrap.py
@@ -462,9 +462,23 @@ def test_main_writes_relative_output_inside_repo(
         "recommended_agents": ["agent-coordinator", "data-scientist-agent"],
         "recommended_skills": ["pulseplate-workflow", "pulseplate-gates"],
         "skill_routing": {
-            "policy_version": "2026-03-08",
+            "policy_version": "2026-03-27",
             "selection_mode": "deterministic-weighted",
-            "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
+            "requested_agents": [],
+            "task_classification": {
+                "label": "experiment",
+                "score": 6,
+                "reasons": ["lexeme:experiment(+2)", "lexeme:benchmark(+2)"],
+            },
+            "required": [
+                {
+                    "skill": "pulseplate-workflow",
+                    "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                    "reasons": ["always-on"],
+                }
+            ],
+            "recommended": [{"skill": "pulseplate-gates", "score": 4}],
+            "conditional": [],
             "blocked": [],
         },
         "routing_context": {

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -251,6 +251,24 @@ def test_task_classifier_prioritizes_pr_governance_over_review() -> None:
     assert decision["task_classification"]["label"] == "pr_governance"
 
 
+def test_task_classifier_prioritizes_pr_governance_for_docs_review_updates() -> None:
+    """Docs-review mapping updates should stay in the PR-governance lane."""
+
+    decision = route_skills(
+        goal="Update fixed mapping notes",
+        task_class="Documentation",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="docs",
+    )
+
+    assert decision["task_classification"]["label"] == "pr_governance"
+    assert [item["skill"] for item in decision["required"]] == [
+        "pulseplate-workflow",
+        "docs-sync",
+        "pulseplate-gates",
+    ]
+
+
 def test_task_classifier_prioritizes_design_over_implementation() -> None:
     """Design signals should override generic implementation wording."""
 
@@ -305,7 +323,7 @@ def test_requested_agent_bundle_parity_is_covered(
     requested_agent: str,
     expected_bundle: tuple[str, ...],
 ) -> None:
-    """Every documented auto-routed requested-agent bundle should be emitted."""
+    """Every documented requested-agent bundle should appear in required or recommended lanes."""
 
     decision = route_skills(
         goal="Need deterministic agent bundle parity coverage",
@@ -315,15 +333,20 @@ def test_requested_agent_bundle_parity_is_covered(
         requested_agents=[requested_agent],
     )
 
+    required_by_skill = {item["skill"]: item for item in decision["required"]}
     recommended_by_skill = {item["skill"]: item for item in decision["recommended"]}
+    routed_skill_names = set(required_by_skill) | set(recommended_by_skill)
 
     assert decision["requested_agents"] == [requested_agent]
     for skill in expected_bundle:
-        assert skill in recommended_by_skill
-        assert any(
-            reason.startswith(f"requested-agent:{requested_agent}(+")
-            for reason in recommended_by_skill[skill]["reasons"]
-        )
+        assert skill in routed_skill_names
+        if skill in recommended_by_skill:
+            assert any(
+                reason.startswith(f"requested-agent:{requested_agent}(+")
+                for reason in recommended_by_skill[skill]["reasons"]
+            )
+        else:
+            assert skill in required_by_skill
 
 
 def test_requested_agent_companion_guidance_stays_manual_only() -> None:
@@ -377,6 +400,29 @@ def test_pr_governance_required_lane_adds_governance_baseline() -> None:
         "docs-sync",
         "pulseplate-gates",
     ]
+
+
+def test_pr_governance_requested_agent_bundle_keeps_required_skills_out_of_recommended() -> None:
+    """Requested-agent boosts must not duplicate required governance skills."""
+
+    decision = route_skills(
+        goal="Prepare pull request merge readiness and fixed mapping governance pass",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+        requested_agents=["agent-coordinator"],
+    )
+
+    required_skill_names = {item["skill"] for item in decision["required"]}
+    recommended_skill_names = {item["skill"] for item in decision["recommended"]}
+
+    assert required_skill_names == {
+        "pulseplate-workflow",
+        "docs-sync",
+        "pulseplate-gates",
+    }
+    assert "agents-md" in recommended_skill_names
+    assert required_skill_names.isdisjoint(recommended_skill_names)
 
 
 @pytest.mark.parametrize("expected_row", EXPECTED_REQUESTED_AGENT_POLICY_ROWS)

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -6,16 +6,21 @@ from pathlib import Path
 import pytest
 
 from scripts.orchestration.skill_router import (
+    CLASSIFICATION_PRECEDENCE,
     PRIVILEGED_SURFACE_PREFIXES,
     REQUESTED_AGENT_COMPANION_SKILL_BUNDLES,
     REQUESTED_AGENT_SKILL_BUNDLES,
     ROUTING_POLICY_VERSION,
+    flatten_recommended_skills,
     route_skills,
     select_recommended_skills,
 )
 
 POLICY_DOC_PATH = (
     Path(__file__).resolve().parents[1] / "docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md"
+)
+MESSAGE_PROTOCOL_DOC_PATH = (
+    Path(__file__).resolve().parents[1] / "docs/orchestration/AGENT_MESSAGE_PROTOCOL.md"
 )
 
 EXPECTED_REQUESTED_AGENT_POLICY_ROWS: tuple[str, ...] = (
@@ -40,12 +45,33 @@ EXPECTED_PRIVILEGED_SURFACE_POLICY_LINES: tuple[str, ...] = (
     "- merge-governance scripts under `scripts/ci/**`",
     "- merge-governance docs under `docs/orchestration/**` and `docs/review/**`",
 )
+EXPECTED_CLASSIFICATION_POLICY_LINES: tuple[str, ...] = (
+    "- `implementation`",
+    "- `bugfix`",
+    "- `review`",
+    "- `design`",
+    "- `creative_research`",
+    "- `experiment`",
+    "- `pr_governance`",
+)
+EXPECTED_ROUTING_BUCKET_POLICY_LINES: tuple[str, ...] = (
+    "- `required`: non-optional skills for the classified lane. `pulseplate-workflow`",
+    "- `recommended`: deterministic ranked helpers that are safe to auto-promote into",
+    "- `conditional`: task-fit helpers that need a stronger trigger before promotion.",
+    "- `blocked`: deterministic low-fit or disallowed patterns. Pattern-based blocks",
+)
 
 
 def _read_policy_doc() -> str:
     """Load the canonical policy markdown for doc-to-implementation parity checks."""
 
     return POLICY_DOC_PATH.read_text(encoding="utf-8")
+
+
+def _read_message_protocol_doc() -> str:
+    """Load the canonical message protocol markdown."""
+
+    return MESSAGE_PROTOCOL_DOC_PATH.read_text(encoding="utf-8")
 
 
 def test_skill_router_prefers_orchestration_docs_skills() -> None:
@@ -62,9 +88,12 @@ def test_skill_router_prefers_orchestration_docs_skills() -> None:
         domain="orchestration",
     )
 
-    skills = [item["skill"] for item in decision["recommended"]]
+    required_skills = [item["skill"] for item in decision["required"]]
+    skills = flatten_recommended_skills(decision)
     assert decision["policy_version"] == ROUTING_POLICY_VERSION
     assert decision["selection_mode"] == "deterministic-weighted"
+    assert decision["task_classification"]["label"] == "implementation"
+    assert required_skills == ["pulseplate-workflow"]
     assert skills[0] == "pulseplate-workflow"
     assert "docs-sync" in skills
     assert "agents-md" in skills
@@ -86,6 +115,154 @@ def test_skill_router_applies_requested_agent_default_bundle() -> None:
     assert "pulseplate-frontend-ui" in skills
     assert "pulseplate-gates" in skills
     assert "vercel-react-best-practices" in skills
+
+
+@pytest.mark.parametrize(
+    ("goal", "task_class", "candidate_paths", "domain", "expected_label"),
+    (
+        (
+            "Implement backend endpoint contract for nutrition insights",
+            "Backend API",
+            ["app/routers/insight.py"],
+            "backend",
+            "implementation",
+        ),
+        (
+            "Fix flaky regression in frontend dashboard chart",
+            "Frontend",
+            ["frontend/src/pages/Dashboard.tsx", "tests/test_dashboard.py"],
+            "frontend",
+            "bugfix",
+        ),
+        (
+            "Perform code review for this frontend change",
+            "Frontend",
+            ["frontend/src/App.tsx"],
+            "frontend",
+            "review",
+        ),
+        (
+            "Implement design fidelity from Figma node-id 42-7",
+            "Frontend",
+            ["frontend/src/components/Hero.tsx"],
+            "frontend",
+            "design",
+        ),
+        (
+            "Prepare weekly wellness AI trend report and GTM brief",
+            "Research",
+            ["docs/audience_pack/ENGINEERING_OVERVIEW.md"],
+            "research",
+            "creative_research",
+        ),
+        (
+            "Run benchmark eval for RAG reliability optimization",
+            "Experimentation",
+            ["core/rag/vector_rag.py"],
+            "ml",
+            "experiment",
+        ),
+        (
+            "Update merge readiness review thread mapping for the pull request",
+            "QA",
+            ["docs/review/PR_999_FIXED_MAPPING.md"],
+            "qa",
+            "pr_governance",
+        ),
+    ),
+)
+def test_task_classifier_supports_all_canonical_labels(
+    goal: str,
+    task_class: str,
+    candidate_paths: list[str],
+    domain: str,
+    expected_label: str,
+) -> None:
+    """Classifier should deterministically cover the canonical label set."""
+
+    decision = route_skills(
+        goal=goal,
+        task_class=task_class,
+        candidate_paths=candidate_paths,
+        domain=domain,
+    )
+
+    assert decision["task_classification"]["label"] == expected_label
+    assert isinstance(decision["task_classification"]["score"], int)
+    assert decision["task_classification"]["reasons"]
+
+
+def test_task_classifier_uses_documented_precedence_order() -> None:
+    """Classifier precedence list should remain explicit and stable."""
+
+    assert CLASSIFICATION_PRECEDENCE == (
+        "pr_governance",
+        "design",
+        "creative_research",
+        "experiment",
+        "review",
+        "bugfix",
+        "implementation",
+    )
+
+
+def test_task_classifier_prioritizes_pr_governance_over_review() -> None:
+    """PR governance should win when review-thread and merge signals are both present."""
+
+    decision = route_skills(
+        goal="Address review thread mapping before merge readiness pass",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+    )
+
+    assert decision["task_classification"]["label"] == "pr_governance"
+
+
+def test_task_classifier_prioritizes_design_over_implementation() -> None:
+    """Design signals should override generic implementation wording."""
+
+    decision = route_skills(
+        goal="Implement Figma node-id fidelity for the dashboard hero",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/components/Hero.tsx"],
+        domain="frontend",
+    )
+
+    assert decision["task_classification"]["label"] == "design"
+
+
+def test_task_classifier_prioritizes_experiment_over_implementation() -> None:
+    """Experiment signals should override generic implementation wording."""
+
+    decision = route_skills(
+        goal="Implement benchmark eval harness for reliability optimization",
+        task_class="Experimentation",
+        candidate_paths=["core/rag/vector_rag.py"],
+        domain="ml",
+    )
+
+    assert decision["task_classification"]["label"] == "experiment"
+
+
+def test_task_classifier_requires_review_signals_to_dominate_bugfix() -> None:
+    """Review should only beat bugfix when review evidence is stronger."""
+
+    review_dominant = route_skills(
+        goal="Review bugfix comments and code review disposition",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+    )
+    bugfix_dominant = route_skills(
+        goal="Fix failing flaky regression in the dashboard chart",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/pages/Dashboard.tsx", "tests/test_dashboard.py"],
+        domain="frontend",
+    )
+
+    assert review_dominant["task_classification"]["label"] == "review"
+    assert bugfix_dominant["task_classification"]["label"] == "bugfix"
 
 
 @pytest.mark.parametrize(
@@ -135,6 +312,41 @@ def test_requested_agent_companion_guidance_stays_manual_only() -> None:
     )
 
 
+def test_required_lane_always_contains_pulseplate_workflow() -> None:
+    """Every routed task must keep pulseplate-workflow in required lane metadata."""
+
+    decision = route_skills(
+        goal="Implement backend endpoint contract for nutrition insights",
+        task_class="Backend API",
+        candidate_paths=["app/routers/insight.py"],
+        domain="backend",
+    )
+
+    assert [item["skill"] for item in decision["required"]] == ["pulseplate-workflow"]
+
+
+def test_pr_governance_required_lane_adds_governance_baseline() -> None:
+    """PR-governance tasks should require the minimal governance baseline."""
+
+    decision = route_skills(
+        goal="Prepare pull request merge readiness and fixed mapping governance pass",
+        task_class="QA",
+        candidate_paths=["docs/review/PR_999_FIXED_MAPPING.md"],
+        domain="qa",
+    )
+
+    assert [item["skill"] for item in decision["required"]] == [
+        "pulseplate-workflow",
+        "docs-sync",
+        "pulseplate-gates",
+    ]
+    assert flatten_recommended_skills(decision)[:3] == [
+        "pulseplate-workflow",
+        "docs-sync",
+        "pulseplate-gates",
+    ]
+
+
 @pytest.mark.parametrize("expected_row", EXPECTED_REQUESTED_AGENT_POLICY_ROWS)
 def test_requested_agent_policy_rows_stay_in_sync(expected_row: str) -> None:
     """Canonical policy rows should stay explicit so router parity tests have a stable contract."""
@@ -146,6 +358,30 @@ def test_requested_agent_policy_agent_set_stays_in_sync() -> None:
     """Documented requested-agent names should match the implementation exactly."""
 
     assert EXPECTED_REQUESTED_AGENT_NAMES == frozenset(REQUESTED_AGENT_SKILL_BUNDLES.keys())
+
+
+@pytest.mark.parametrize("expected_line", EXPECTED_CLASSIFICATION_POLICY_LINES)
+def test_classification_policy_lines_stay_in_sync(expected_line: str) -> None:
+    """Canonical classifier labels must remain locked between docs and implementation."""
+
+    assert expected_line in _read_policy_doc()
+
+
+@pytest.mark.parametrize("expected_line", EXPECTED_ROUTING_BUCKET_POLICY_LINES)
+def test_routing_bucket_policy_lines_stay_in_sync(expected_line: str) -> None:
+    """Routing bucket semantics must remain explicit in the policy doc."""
+
+    assert expected_line in _read_policy_doc()
+
+
+def test_message_protocol_example_mentions_expanded_skill_routing_contract() -> None:
+    """Message protocol should document the nested skill_routing fields."""
+
+    doc = _read_message_protocol_doc()
+    assert '"task_classification": {' in doc
+    assert '"required": [' in doc
+    assert '"recommended": [' in doc
+    assert '"conditional": [' in doc
 
 
 def test_requested_agent_bundle_boosts_existing_skill_without_duplication() -> None:
@@ -389,6 +625,88 @@ def test_skill_router_selects_github_comment_skill_for_review_threads() -> None:
     assert "gh-address-comments" in skills
 
 
+def test_skill_router_keeps_pr_helpers_conditional_outside_pr_governance() -> None:
+    """PR helper skills should stay conditional when the task is not in PR lane yet."""
+
+    decision = route_skills(
+        goal="Implement backend contract and open PR later when execution is ready",
+        task_class="Backend API",
+        candidate_paths=["app/routers/example.py"],
+        domain="backend",
+    )
+
+    conditional_by_skill = {item["skill"]: item for item in decision["conditional"]}
+    assert "create-pr" in conditional_by_skill
+    assert (
+        conditional_by_skill["create-pr"]["when"]
+        == "Enable when the task explicitly enters PR/review/merge-governance execution."
+    )
+    assert "create-pr" not in [item["skill"] for item in decision["recommended"]]
+
+
+def test_skill_router_keeps_design_helpers_conditional_for_partial_signals() -> None:
+    """Partial design language should not force design helpers into recommended lane."""
+
+    decision = route_skills(
+        goal="Review component polish for the dashboard hero",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/components/Hero.tsx"],
+        domain="frontend",
+    )
+
+    assert "figma" not in [item["skill"] for item in decision["recommended"]]
+
+    partial_design = route_skills(
+        goal="Refresh screen polish before design handoff",
+        task_class="Frontend",
+        candidate_paths=["frontend/src/components/Hero.tsx"],
+        domain="frontend",
+    )
+
+    conditional_by_skill = {item["skill"]: item for item in partial_design["conditional"]}
+    assert "figma" in conditional_by_skill
+    assert (
+        conditional_by_skill["figma"]["when"]
+        == "Enable when a concrete Figma/design node-id or fidelity requirement becomes explicit."
+    )
+
+
+def test_skill_router_keeps_research_helpers_conditional_for_weak_research_intent() -> None:
+    """Weak research/report signals should stay conditional until the deliverable is explicit."""
+
+    decision = route_skills(
+        goal="Capture a quick report note for later",
+        task_class="Documentation",
+        candidate_paths=["docs/ENGINEERING_LESSONS.md"],
+        domain="docs",
+    )
+
+    conditional_by_skill = {item["skill"]: item for item in decision["conditional"]}
+    assert "pulseplate-ai-reports" in conditional_by_skill
+    assert (
+        conditional_by_skill["pulseplate-ai-reports"]["when"]
+        == "Enable when the task requires a report/research deliverable or durable knowledge capture."
+    )
+
+
+def test_skill_router_keeps_ci_helpers_conditional_without_explicit_failure_scope() -> None:
+    """CI repair helpers should stay conditional unless failure scope is explicit."""
+
+    decision = route_skills(
+        goal="Document a CI note for later workflow follow-up",
+        task_class="Documentation",
+        candidate_paths=["docs/orchestration/workflow.md"],
+        domain="docs",
+    )
+
+    conditional_by_skill = {item["skill"]: item for item in decision["conditional"]}
+    assert "ci-fix" in conditional_by_skill
+    assert (
+        conditional_by_skill["ci-fix"]["when"]
+        == "Enable when a failing CI job, workflow run, or check log is explicitly in scope."
+    )
+
+
 def test_skill_router_selects_threat_model_for_explicit_security_intent() -> None:
     """Threat-model requests should cross the explicit security threshold."""
 
@@ -511,6 +829,7 @@ def test_skill_router_records_blocked_scraping_patterns() -> None:
     assert "tiktok" in blocked_labels
     assert "google maps" in blocked_labels
     assert "entire internet" in blocked_labels
+    assert all(item["kind"] == "pattern" for item in decision["blocked"])
 
 
 def test_skill_router_ignores_scraping_tokens_from_candidate_paths() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import pytest
+import scripts.orchestration.skill_router as skill_router_module
 
 from scripts.orchestration.skill_router import (
     CLASSIFICATION_PRECEDENCE,
@@ -11,6 +12,7 @@ from scripts.orchestration.skill_router import (
     REQUESTED_AGENT_COMPANION_SKILL_BUNDLES,
     REQUESTED_AGENT_SKILL_BUNDLES,
     ROUTING_POLICY_VERSION,
+    TASK_CLASSIFICATION_RULES,
     flatten_recommended_skills,
     route_skills,
     select_recommended_skills,
@@ -204,6 +206,36 @@ def test_task_classifier_uses_documented_precedence_order() -> None:
         "bugfix",
         "implementation",
     )
+
+
+def test_task_classifier_rule_labels_match_precedence_contract() -> None:
+    """Rule labels should stay in lockstep with the precedence contract."""
+
+    rule_labels = tuple(rule.label for rule in TASK_CLASSIFICATION_RULES)
+
+    assert len(rule_labels) == len(set(rule_labels))
+    assert set(rule_labels) == set(CLASSIFICATION_PRECEDENCE)
+
+
+def test_task_classifier_skips_unknown_precedence_labels_without_key_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown precedence labels should not crash the classifier during routing."""
+
+    monkeypatch.setattr(
+        skill_router_module,
+        "CLASSIFICATION_PRECEDENCE",
+        ("unknown_lane", *CLASSIFICATION_PRECEDENCE),
+    )
+
+    decision = route_skills(
+        goal="Implement backend endpoint contract for nutrition insights",
+        task_class="Backend API",
+        candidate_paths=["app/routers/insight.py"],
+        domain="backend",
+    )
+
+    assert decision["task_classification"]["label"] == "implementation"
 
 
 def test_task_classifier_prioritizes_pr_governance_over_review() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -733,10 +733,23 @@ def test_main_writes_relative_output_inside_repo(tmp_path, monkeypatch, capsys) 
         "required_context": ["AGENTS.md"],
         "recommended_skills": ["pulseplate-workflow"],
         "skill_routing": {
-            "policy_version": "2026-03-08",
+            "policy_version": "2026-03-27",
             "selection_mode": "deterministic-weighted",
             "requested_agents": [],
-            "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
+            "task_classification": {
+                "label": "implementation",
+                "score": 0,
+                "reasons": ["fallback:default-implementation"],
+            },
+            "required": [
+                {
+                    "skill": "pulseplate-workflow",
+                    "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                    "reasons": ["always-on"],
+                }
+            ],
+            "recommended": [],
+            "conditional": [],
             "blocked": [],
         },
         "decision_contract": {
@@ -820,10 +833,23 @@ def test_main_writes_repo_root_output_as_relative_path(monkeypatch, capsys) -> N
         "required_context": ["AGENTS.md"],
         "recommended_skills": ["pulseplate-workflow"],
         "skill_routing": {
-            "policy_version": "2026-03-08",
+            "policy_version": "2026-03-27",
             "selection_mode": "deterministic-weighted",
             "requested_agents": [],
-            "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
+            "task_classification": {
+                "label": "implementation",
+                "score": 0,
+                "reasons": ["fallback:default-implementation"],
+            },
+            "required": [
+                {
+                    "skill": "pulseplate-workflow",
+                    "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                    "reasons": ["always-on"],
+                }
+            ],
+            "recommended": [],
+            "conditional": [],
             "blocked": [],
         },
         "decision_contract": {
@@ -904,10 +930,23 @@ def test_main_passes_requested_agent_flags(monkeypatch, capsys) -> None:
             "required_context": ["AGENTS.md"],
             "recommended_skills": ["pulseplate-workflow"],
             "skill_routing": {
-                "policy_version": "2026-03-08",
+                "policy_version": "2026-03-27",
                 "selection_mode": "deterministic-weighted",
                 "requested_agents": ["agent-coordinator", "security-auditor"],
-                "recommended": [{"skill": "pulseplate-workflow", "score": 100}],
+                "task_classification": {
+                    "label": "implementation",
+                    "score": 0,
+                    "reasons": ["fallback:default-implementation"],
+                },
+                "required": [
+                    {
+                        "skill": "pulseplate-workflow",
+                        "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                        "reasons": ["always-on"],
+                    }
+                ],
+                "recommended": [],
+                "conditional": [],
                 "blocked": [],
             },
             "native_subagent_bridge": {


### PR DESCRIPTION
## Summary
- add deterministic task classes for `implementation`, `bugfix`, `review`, `design`, `creative_research`, `experiment`, and `pr_governance`
- expose skill-routing decisions with `required`, `recommended`, `conditional`, and `blocked` semantics
- sync orchestration docs/readiness matrix/workflow to the routing contract
- add deterministic tests for `skill_router` plus bootstrap integration coverage

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files` on code head `5bc96098`
- `make verify` on code head `5bc96098`
- `pre-commit run --all-files` on artifact head `475587d8`
- git pre-push hooks on artifact head `475587d8` (`pip-audit`, backend pre-push pytest, full-repo bandit)

## Carryover
- Continues the deferred lane `PR-TBD-AUTOMATION-PR3-SKILL-INTENT` from `docs/roadmap/BACKLOG_LEDGER.md`
- Broader lifecycle/design automation remains deferred to tracked follow-up slices `PR-TBD-AUTOMATION-PR4-PR-LIFECYCLE` and `PR-TBD-AUTOMATION-PR5-DESIGN-CREATIVE`

## Split Justification
This PR intentionally keeps the full skill-routing slice together because the deterministic task classes, routing semantics, orchestration docs, and bootstrap integration tests define one reviewable contract. Splitting `skill_router.py`, the policy/docs updates, and the tests into separate PRs would temporarily break the canonical routing specification or leave the implementation without its required deterministic proof. Remaining broader automation work is already deferred to `PR-TBD-AUTOMATION-PR4-PR-LIFECYCLE` and `PR-TBD-AUTOMATION-PR5-DESIGN-CREATIVE`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1265_FIXED_MAPPING.md`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003475440` -> `08ed7c2b`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485202` -> `d3c3a9d1`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#discussion_r3003485207` -> `d3c3a9d1`
- NOT-A-BUG: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#pullrequestreview-4023951708`
- NOT-A-BUG: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1265#pullrequestreview-4023986587`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] `pre-commit run --all-files`
- [ ] `make verify`

## Summary by Sourcery

Ввести детерминированную маршрутизацию по намерениям с классификацией задач и разбивкой по «корзинам» (buckets), а также обновить бутстрапы оркестрации и документацию в соответствии с новым контрактом маршрутизации.

Новые возможности:
- Добавить детерминированный классификатор задач по намерениям, который относит задачи к каноническим категориям (lanes), таким как implementation, bugfix, review, design, creative_research, experiment и pr_governance.
- Экспортировать структурированные метаданные маршрутизации навыков, включая task_classification, а также корзины навыков required, recommended, conditional и blocked, при этом сохранить обратную совместимость поля recommended_skills с помощью вспомогательной функции «сплющивания».
- Требовать минимальную базовую компетенцию по governance для задач типа pr_governance, при этом сохранять pulseplate-workflow как всегда обязательный входной навык для всех задач.

Улучшения:
- Расширить логику решений по маршрутизации навыков, чтобы помечать заблокированные элементы полем kind для перспективной (forward-compatible) обработки паттернов.
- Обновить бутстрапы задач и экспериментов, чтобы они выдавали в сгенерированных пакетах новый вложенный контракт skill_routing.

Документация:
- Описать расширенный контракт skill_routing и семантику корзин в AGENT_MESSAGE_PROTOCOL и AGENT_SKILL_ROUTING_POLICY, а также указать, как recommended_skills выводится из required и recommended.
- Обновить документацию по оркестрационному workflow и матрице готовности, чтобы ссылаться на новый task_classification и корзины маршрутизации.
- Добавить документ сопоставления fixed-in-commit для PR 1265 в docs/review.

Тесты:
- Добавить детерминированные тесты для классификатора задач, корзин маршрутизации и поведения обязательных категорий (lane) для всех канонических меток.
- Расширить тесты маршрутизатора навыков для покрытия поведения вспомогательных функций для conditional, метаданных паттернов blocked и соответствия задокументированной политике маршрутизации и протоколу сообщений.
- Обновить тесты бутстрапов задач и экспериментов, чтобы проверять новую форму skill_routing и версию политики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce deterministic skill intent routing with task classification and bucketed outputs, and update orchestration bootstraps and docs to match the new routing contract.

New Features:
- Add a deterministic task-intent classifier that assigns tasks to canonical lanes such as implementation, bugfix, review, design, creative_research, experiment, and pr_governance.
- Expose structured skill routing metadata, including task_classification plus required, recommended, conditional, and blocked skill buckets, while keeping recommended_skills backward-compatible via a flattening helper.
- Require a minimal governance skill baseline for pr_governance tasks while preserving pulseplate-workflow as an always-required entry skill for all tasks.

Enhancements:
- Expand skill routing decisions to mark blocked entries with a kind field for forward-compatible pattern handling.
- Update task and experiment bootstrap logic to emit the new nested skill_routing contract in generated packets.

Documentation:
- Document the expanded skill_routing contract and bucket semantics in AGENT_MESSAGE_PROTOCOL and AGENT_SKILL_ROUTING_POLICY, and note how recommended_skills is derived from required and recommended.
- Refresh orchestration workflow and readiness matrix docs to reference the new task_classification and routing buckets.
- Add a fixed-in-commit mapping document for PR 1265 under docs/review.

Tests:
- Add deterministic tests for the task classifier, routing buckets, and required lane behavior across all canonical labels.
- Extend skill router tests to cover conditional helper behavior, blocked pattern metadata, and parity with the documented routing policy and message protocol.
- Update task and experiment bootstrap tests to assert the new skill_routing shape and policy version.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic task classification with canonical labels/precedence; routing now emits structured task_classification, required, recommended, conditional, and blocked. recommended_skills is deterministically composed from required+recommended.

* **Documentation**
  * Orchestration docs, pre-flight checklist, and policy guidance updated; added a review-tracking note for PR mapping.

* **Tests**
  * Expanded classifier, routing-invariant, conditional/blocked, and documentation-parity tests.

* **Chores**
  * Policy version bumped to 2026-03-27; bootstrap/packet generation updated to use the new recommended_skills composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->