### PR TITLE
Coordinator automation PR4 — PR lifecycle automation

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -70,6 +70,13 @@ instructions still match the live contract:
 - See canonical definition: `AGENTS.md` (Agent Coordination section)
 - Templates: `docs/orchestration/*.template.md`
 - Full workflow: `docs/orchestration/workflow.md`
+- For PR lifecycle packets, bootstrap may now accept `--pr-phase`:
+  - `pre_open` for pre-PR scope lock without review-lane synthesis
+  - `post_open_review` after PR creation to surface the mandatory
+    `qa-engineer-agent -> bug-hunter` lane
+  - `merge_ready` for explicit current-head merge-preparation packets
+- `post_open_review` remains deterministic once invoked; it is not a raw-session
+  or host-runtime auto-trigger by itself.
 
 **Postponed items:** Always record in `docs/roadmap/BACKLOG_LEDGER.md` immediately.
 

--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -102,7 +102,11 @@ Optional packet-level automation metadata (PR2 bootstrap hardening):
   `coordinator_first_required`, `skill_routing_applied`,
   `native_subagent_bridge_available`, `security_review_required`,
   `judgment_lane_enabled`, `pr_lifecycle_enabled`, `design_lane_enabled`)
-- `inputs.pr_phase` (string; current bootstrap baseline uses `"none"`)
+- `inputs.pr_phase` (string; default bootstrap baseline uses `"none"`; PR4
+  lifecycle packets may use `"pre_open"`, `"post_open_review"`, or
+  `"merge_ready"`)
+- `inputs.pr_lifecycle_contract` (object; additive lifecycle metadata derived
+  from `pr_phase`, including post-open review lane and current-head truth)
 - `inputs.design_lane_mode` (string; current bootstrap baseline uses `"disabled"`)
 - `inputs.needs_backlog_update` (boolean; deterministic sync signal)
 - `inputs.needs_docs_sync` (boolean; deterministic sync signal)
@@ -226,10 +230,19 @@ Task packet:
       "native_subagent_bridge_available": true,
       "security_review_required": true,
       "judgment_lane_enabled": false,
-      "pr_lifecycle_enabled": false,
+      "pr_lifecycle_enabled": true,
       "design_lane_enabled": false
     },
-    "pr_phase": "none",
+    "pr_phase": "post_open_review",
+    "pr_lifecycle_contract": {
+      "requires_pr": true,
+      "post_open_review_required": true,
+      "review_lane": ["qa-engineer-agent", "bug-hunter"],
+      "artifact_template": "docs/review/PR_<N>_FIXED_MAPPING.md",
+      "current_head_required": true,
+      "current_head_truth": "latest-current-head",
+      "merge_readiness_entrypoint": ""
+    },
     "design_lane_mode": "disabled",
     "needs_backlog_update": false,
     "needs_docs_sync": false,

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -83,7 +83,7 @@ unconditionally guaranteed by Markdown alone.
 | Coordinator-first task handling | Yes | Partial | Usually yes | Yes | Policy-required, not guaranteed raw-session auto-start |
 | Bootstrap task packet generation | Yes | Yes | No for manual invocation; yes for auto-start | Low | Deterministic once invoked |
 | Skill auto-selection | Yes | Yes | Yes for raw-session auto-start | Medium | Automatic after bootstrap, not at raw chat start |
-| Mandatory post-open bug-hunter pass | Yes | Partial | No | Medium | Mandatory by policy, not globally event-triggered |
+| Mandatory post-open bug-hunter pass | Yes | Yes | No | Medium | Deterministic once invoked via PR phase packet; not globally event-triggered |
 | Creative research lane | Partial | Planned | Likely yes | Medium | Not yet canonical automatic behavior |
 | Figma execution lane | Partial | Planned | Likely yes | High | Conditional only, never unconditional |
 | Post-merge local sync / cleanup gating next PR | Yes | N/A | No | Low | Required by process, enforced by canon/runbook discipline |
@@ -104,8 +104,8 @@ Current approved wording:
 - Coordinator-first is **policy-required**.
 - Bootstrap packet generation is **deterministic once invoked**.
 - Skill routing is **automatic after bootstrap**, not automatic at raw chat start.
-- Bug-hunter post-open pass is **mandatory by policy**, not yet globally
-  event-triggered.
+- Bug-hunter post-open pass is **deterministic once invoked** via
+  `pr_phase=post_open_review`, not yet globally event-triggered.
 - Figma execution is **conditionally automatic**, never unconditional.
 
 ## Approved PR Series For This Wave

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -95,6 +95,12 @@ Artifact-only governance findings are fixed in the canonical artifact itself, bu
 - Unresolved review threads must be zero
 - Actionable bot comments must be mapped
 - Cancelled/stale runs do not define mergeability
+- PR lifecycle packets may distinguish `post_open_review` from `merge_ready`,
+  but both phases still use current-head truth and the canonical artifact
+  `docs/review/PR_<N>_FIXED_MAPPING.md`
+- `post_open_review` is the packet-level phase where the canonical
+  `qa-engineer-agent -> bug-hunter` lane is synthesized; `merge_ready` keeps the
+  current-head merge-wrapper contract explicit without widening the review lane
 
 Evidence:
 - `scripts/ci/check_pr_merge_readiness.py:1`

--- a/docs/orchestration/workflow.md
+++ b/docs/orchestration/workflow.md
@@ -124,9 +124,13 @@ derivable from existing inputs:
 - `recommended_skills` remains backward-compatible and is derived from
   `skill_routing.required + skill_routing.recommended`
 - `automation_flags.judgment_lane_enabled` mirrors `decision_contract.judgment_enabled`
-- `automation_flags.pr_lifecycle_enabled = false`
+- `automation_flags.pr_lifecycle_enabled = false` by default and becomes `true`
+  only when bootstrap is invoked with an explicit PR lifecycle phase
 - `automation_flags.design_lane_enabled = false`
 - `pr_phase = "none"`
+- `pr_lifecycle_contract` is additive lifecycle metadata derived from the
+  explicit `pr_phase`; `post_open_review` must surface the canonical
+  `qa-engineer-agent -> bug-hunter` lane and current-head preparation contract
 - `design_lane_mode = "disabled"`
 - `needs_backlog_update`, `needs_docs_sync`, and `needs_agents_sync` are deterministic
   sync signals derived from task text and candidate paths
@@ -135,6 +139,13 @@ PR2 scope note:
 
 - This baseline does not enable PR lifecycle automation, design/Figma routing, or
   local launcher/runtime rollout. Those belong to later PR slices.
+
+PR4 scope note:
+
+- PR lifecycle automation stays deterministic only after explicit bootstrap
+  invocation with `pr_phase` such as `post_open_review` or `merge_ready`.
+- Post-open review lane synthesis is packet-level contract, not raw-session or
+  host-runtime event automation.
 
 ---
 

--- a/docs/orchestration/workflow.md
+++ b/docs/orchestration/workflow.md
@@ -144,7 +144,7 @@ PR4 scope note:
 
 - PR lifecycle automation stays deterministic only after explicit bootstrap
   invocation with `pr_phase` such as `post_open_review` or `merge_ready`.
-- Post-open review lane synthesis is packet-level contract, not raw-session or
+- Post-open review lane synthesis is a packet-level contract, not raw-session or
   host-runtime event automation.
 
 ---

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -51,6 +51,11 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discuss
 Reason: The review-level wrapper aggregates the mapped post-open lane regression and does not require a separate code change beyond commit `e78825aa`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025475730
 
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025487008 contains only a maintainability nitpick about extracting a shared test packet factory and introduces no new review thread or blocking defect.
+Reason: The comment is advisory refactor guidance for duplicated test fixtures, not a correctness, governance, or merge-blocking issue for this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025487008
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -31,10 +31,20 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullreq
 Reason: cubic reported no actionable findings, so the review wrapper is informational only and does not require a follow-up change.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025456211
 
+Disposition: FIXED
+Commit: d0616e2b
+Evidence: `scripts/orchestration/task_bootstrap.py:336`; `python -m flake8 scripts/orchestration/task_bootstrap.py`; `pytest -q tests/test_task_bootstrap.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004686369 -> d0616e2b
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004686369 is mapped explicitly as the only actionable CodeRabbit thread from this review batch.
+Reason: The review-level wrapper aggregates the mapped F841 finding and does not require a separate code change beyond commit `d0616e2b`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025464734
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] Pre-commit green
 - [ ] `make verify` green
-Notes: Post-open review findings from Sourcery and Codex are mapped in this artifact. Local `pre-commit run --all-files` is green on head `815f0e12`, but merge-readiness boxes stay unchecked until the current-head CI/bot cycle completes and all review threads are explicitly resolved on GitHub.
+Notes: Post-open review findings from Sourcery, Codex, and CodeRabbit are mapped in this artifact. Local `pre-commit run --all-files` is green on head `d0616e2b`, but merge-readiness boxes stay unchecked until the current-head CI/bot cycle completes and all review threads are explicitly resolved on GitHub.

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -41,10 +41,20 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discuss
 Reason: The review-level wrapper aggregates the mapped F841 finding and does not require a separate code change beyond commit `d0616e2b`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025464734
 
+Disposition: FIXED
+Commit: e78825aa
+Evidence: `scripts/orchestration/task_bootstrap.py:288`; `tests/test_task_bootstrap.py:194`; `pytest -q tests/test_task_bootstrap.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004698551 -> e78825aa
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004698551 is mapped explicitly as the only actionable CodeRabbit thread from this review batch.
+Reason: The review-level wrapper aggregates the mapped post-open lane regression and does not require a separate code change beyond commit `e78825aa`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025475730
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] Pre-commit green
 - [ ] `make verify` green
-Notes: Post-open review findings from Sourcery, Codex, and CodeRabbit are mapped in this artifact. Local `pre-commit run --all-files` is green on head `d0616e2b`, but merge-readiness boxes stay unchecked until the current-head CI/bot cycle completes and all review threads are explicitly resolved on GitHub.
+Notes: Post-open review findings from Sourcery, Codex, and CodeRabbit are mapped in this artifact. Local `pre-commit run --all-files` is green on head `e78825aa`, but merge-readiness boxes stay unchecked until the current-head CI/bot cycle completes and all review threads are explicitly resolved on GitHub.

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -5,7 +5,15 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 7a91800f
+Evidence: `docs/orchestration/workflow.md:148`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004669178 -> 7a91800f
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004669178 is mapped explicitly as the only actionable thread from this Sourcery review batch.
+Reason: The review-level wrapper also contains high-level maintainability suggestions, but they are advisory design guidance rather than a separate blocking defect requiring an additional code change in this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025447129
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -15,10 +15,26 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discuss
 Reason: The review-level wrapper also contains high-level maintainability suggestions, but they are advisory design guidance rather than a separate blocking defect requiring an additional code change in this PR.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025447129
 
+Disposition: FIXED
+Commit: 815f0e12
+Evidence: `scripts/orchestration/task_bootstrap.py:267`; `tests/test_task_bootstrap.py:169`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004670684 -> 815f0e12
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004670687 -> 815f0e12
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004670684 and https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#discussion_r3004670687 are mapped explicitly as the actionable Codex review threads.
+Reason: The review-level wrapper comment is an aggregator for the mapped thread findings and does not require a separate code change beyond commit `815f0e12`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025449314
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025456211 states `No issues found across 9 files`.
+Reason: cubic reported no actionable findings, so the review wrapper is informational only and does not require a follow-up change.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1266#pullrequestreview-4025456211
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] Pre-commit green
 - [ ] `make verify` green
-Notes: Draft PR opened for PR4 lifecycle automation. Mandatory post-open `qa-engineer-agent -> bug-hunter` lane is pending. Local `pre-commit run --all-files` and `make verify` passed on commit `5adc5ca3`, but merge-readiness boxes stay unchecked until the current-head review and CI cycle complete.
+Notes: Post-open review findings from Sourcery and Codex are mapped in this artifact. Local `pre-commit run --all-files` is green on head `815f0e12`, but merge-readiness boxes stay unchecked until the current-head CI/bot cycle completes and all review threads are explicitly resolved on GitHub.

--- a/docs/review/PR_1266_FIXED_MAPPING.md
+++ b/docs/review/PR_1266_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1266 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+Notes: Draft PR opened for PR4 lifecycle automation. Mandatory post-open `qa-engineer-agent -> bug-hunter` lane is pending. Local `pre-commit run --all-files` and `make verify` passed on commit `5adc5ca3`, but merge-readiness boxes stay unchecked until the current-head review and CI cycle complete.

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -238,6 +238,7 @@ def compute_task_packet_id(
     domain: str,
     candidate_paths: list[str] | tuple[str, ...],
     requested_agents: list[str] | tuple[str, ...] = (),
+    pr_phase: str = "none",
 ) -> str:
     """Return deterministic short task packet id."""
 
@@ -246,6 +247,7 @@ def compute_task_packet_id(
             goal.strip(),
             task_class.strip(),
             domain.strip(),
+            pr_phase.strip(),
             *repo_relative_paths(candidate_paths),
             *requested_agents,
         ]

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -333,10 +333,6 @@ def _reconcile_requested_agent_dispositions(
 ) -> None:
     """Align requested-agent disposition metadata with the final packet roles."""
 
-    advisory_statuses = {
-        REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
-        REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
-    }
     secondary_honored_statuses = {
         REQUESTED_AGENT_STATUS_PROMOTED,
         REQUESTED_AGENT_STATUS_HONORED_PRIMARY,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -293,6 +293,8 @@ def _apply_pr_lifecycle_review_path(
             canonical_secondary=bug_hunter_agent,
             previous_primary=primary_agent,
         )
+        if adjusted_reviewer == bug_hunter_agent:
+            adjusted_reviewer = "agent-coordinator"
         adjusted_secondary_agents = [
             candidate
             for candidate in [bug_hunter_agent, *adjusted_secondary_agents]

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -88,6 +88,19 @@ JUDGMENT_REQUIRED_CONTEXT_FILES: tuple[str, ...] = (
     "docs/orchestration/EVIDENCE_RECONCILIATION_PROTOCOL.md",
 )
 SUPPORTED_JUDGMENT_DECISION_MODE = "verification_first"
+PR_PHASE_NONE = "none"
+PR_PHASE_PRE_OPEN = "pre_open"
+PR_PHASE_POST_OPEN_REVIEW = "post_open_review"
+PR_PHASE_MERGE_READY = "merge_ready"
+PR_PHASES: tuple[str, ...] = (
+    PR_PHASE_NONE,
+    PR_PHASE_PRE_OPEN,
+    PR_PHASE_POST_OPEN_REVIEW,
+    PR_PHASE_MERGE_READY,
+)
+POST_OPEN_REVIEW_LANE: tuple[str, ...] = ("qa-engineer-agent", "bug-hunter")
+PR_REVIEW_ARTIFACT_TEMPLATE = "docs/review/PR_<N>_FIXED_MAPPING.md"
+MERGE_READINESS_ENTRYPOINT = "scripts/orchestration/check_merge_ready.py"
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -212,6 +225,71 @@ def _validated_judgment_activation(
             f"{activation.decision_mode}. Supported: {SUPPORTED_JUDGMENT_DECISION_MODE}"
         )
     return activation
+
+
+def _normalize_pr_phase(pr_phase: str) -> str:
+    """Return a validated PR lifecycle phase.
+
+    RU: PR4 adds explicit lifecycle phases without changing the safe default.
+    EN: PR4 adds explicit lifecycle phases without changing the safe default.
+    """
+
+    normalized_phase = pr_phase.strip().lower()
+    if normalized_phase not in PR_PHASES:
+        supported_phases = ", ".join(PR_PHASES)
+        raise ValueError(f"Unsupported pr_phase: {pr_phase}. Supported: {supported_phases}")
+    return normalized_phase
+
+
+def _build_pr_lifecycle_contract(pr_phase: str) -> dict[str, Any]:
+    """Return deterministic packet metadata for the requested PR phase."""
+
+    requires_pr = pr_phase in {PR_PHASE_POST_OPEN_REVIEW, PR_PHASE_MERGE_READY}
+    requires_current_head = requires_pr
+    if pr_phase == PR_PHASE_POST_OPEN_REVIEW:
+        review_lane = list(POST_OPEN_REVIEW_LANE)
+    else:
+        review_lane = []
+    return {
+        "requires_pr": requires_pr,
+        "post_open_review_required": pr_phase == PR_PHASE_POST_OPEN_REVIEW,
+        "review_lane": review_lane,
+        "artifact_template": PR_REVIEW_ARTIFACT_TEMPLATE if requires_pr else "",
+        "current_head_required": requires_current_head,
+        "current_head_truth": "latest-current-head" if requires_current_head else "not-applicable",
+        "merge_readiness_entrypoint": (
+            MERGE_READINESS_ENTRYPOINT if pr_phase == PR_PHASE_MERGE_READY else ""
+        ),
+    }
+
+
+def _apply_pr_lifecycle_review_path(
+    *,
+    pr_phase: str,
+    primary_agent: str,
+    secondary_agents: list[str],
+    reviewer: str,
+) -> tuple[list[str], str]:
+    """Inject the canonical post-open review lane for PR lifecycle work.
+
+    RU: post-open review обязан держать `qa-engineer-agent -> bug-hunter`.
+    EN: post-open review must keep `qa-engineer-agent -> bug-hunter`.
+    """
+
+    if pr_phase != PR_PHASE_POST_OPEN_REVIEW:
+        return secondary_agents, reviewer
+
+    adjusted_secondary_agents = list(secondary_agents)
+    adjusted_reviewer = reviewer
+
+    if primary_agent == POST_OPEN_REVIEW_LANE[0]:
+        adjusted_reviewer = POST_OPEN_REVIEW_LANE[1]
+    else:
+        adjusted_reviewer = POST_OPEN_REVIEW_LANE[0]
+        if POST_OPEN_REVIEW_LANE[1] not in adjusted_secondary_agents:
+            adjusted_secondary_agents.append(POST_OPEN_REVIEW_LANE[1])
+
+    return adjusted_secondary_agents, adjusted_reviewer
 
 
 def _partition_native_secondaries(
@@ -409,12 +487,14 @@ def build_task_packet(
     task_class: str,
     candidate_paths: list[str],
     requested_agents: list[str] | tuple[str, ...] = (),
+    pr_phase: str = PR_PHASE_NONE,
     telemetry_path: Path = TELEMETRY_PATH,
 ) -> dict[str, Any]:
     """Build a deterministic task packet for orchestration tooling."""
 
     normalized_paths = repo_relative_paths(candidate_paths)
     normalized_requested_agents = normalize_requested_agents(requested_agents)
+    normalized_pr_phase = _normalize_pr_phase(pr_phase)
     domain = resolve_domain(
         task_class=task_class,
         candidate_paths=normalized_paths,
@@ -434,6 +514,7 @@ def build_task_packet(
         domain=decision.domain,
         candidate_paths=normalized_paths,
         requested_agents=normalized_requested_agents,
+        pr_phase=normalized_pr_phase,
     )
     context_pack = collect_context_pack(
         normalized_paths,
@@ -458,6 +539,14 @@ def build_task_packet(
         if not security_in_review_path:
             secondary_agents.append("security-auditor")
         requested_agent_resolution["secondary_agents"] = secondary_agents
+    lifecycle_secondary_agents, lifecycle_reviewer = _apply_pr_lifecycle_review_path(
+        pr_phase=normalized_pr_phase,
+        primary_agent=requested_agent_resolution["primary_agent"],
+        secondary_agents=requested_agent_resolution["secondary_agents"],
+        reviewer=requested_agent_resolution["reviewer"],
+    )
+    requested_agent_resolution["secondary_agents"] = lifecycle_secondary_agents
+    requested_agent_resolution["reviewer"] = lifecycle_reviewer
     skill_routing = route_skills(
         goal=goal,
         task_class=task_class,
@@ -501,6 +590,7 @@ def build_task_packet(
     )
     needs_docs_sync = _needs_docs_sync(normalized_paths)
     needs_agents_sync = _needs_agents_sync(normalized_paths)
+    pr_lifecycle_contract = _build_pr_lifecycle_contract(normalized_pr_phase)
     if judgment_enabled:
         context_pack = sorted(set(context_pack).union(JUDGMENT_REQUIRED_CONTEXT_FILES))
         decision_contract = {
@@ -565,10 +655,11 @@ def build_task_packet(
             "native_subagent_bridge_available": True,
             "security_review_required": security_review_required,
             "judgment_lane_enabled": judgment_enabled,
-            "pr_lifecycle_enabled": False,
+            "pr_lifecycle_enabled": normalized_pr_phase != PR_PHASE_NONE,
             "design_lane_enabled": False,
         },
-        "pr_phase": "none",
+        "pr_phase": normalized_pr_phase,
+        "pr_lifecycle_contract": pr_lifecycle_contract,
         "design_lane_mode": "disabled",
         "needs_backlog_update": needs_backlog_update,
         "needs_docs_sync": needs_docs_sync,
@@ -614,6 +705,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=[],
         help="Optional requested agent slug. May be repeated.",
     )
+    parser.add_argument(
+        "--pr-phase",
+        default=PR_PHASE_NONE,
+        choices=PR_PHASES,
+        help="Optional PR lifecycle phase for deterministic review-lane synthesis.",
+    )
     parser.add_argument("--telemetry", default=str(TELEMETRY_PATH))
     parser.add_argument(
         "--output",
@@ -630,6 +727,7 @@ def main(argv: list[str] | None = None) -> int:
         task_class=args.task_class,
         candidate_paths=args.path,
         requested_agents=args.requested_agent,
+        pr_phase=args.pr_phase,
         telemetry_path=Path(args.telemetry),
     )
     try:

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -55,6 +55,7 @@ TASK_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "task_packet
 REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN = "rejected_unknown_agent"
 REQUESTED_AGENT_STATUS_HONORED_PRIMARY = "honored_primary"
 REQUESTED_AGENT_STATUS_HONORED_SECONDARY = "honored_secondary"
+REQUESTED_AGENT_STATUS_HONORED_REVIEWER = "honored_reviewer"
 REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE = "advisory_non_routable"
 REQUESTED_AGENT_STATUS_PROMOTED = "promoted_requested_agent"
 REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH = "advisory_domain_mismatch"
@@ -292,6 +293,57 @@ def _apply_pr_lifecycle_review_path(
     return adjusted_secondary_agents, adjusted_reviewer
 
 
+def _normalize_secondary_review_path(
+    *,
+    primary_agent: str,
+    secondary_agents: list[str],
+    reviewer: str,
+) -> list[str]:
+    """Keep packet review roles unique before building the native bridge."""
+
+    normalized_secondary_agents: list[str] = []
+    blocked_agents = {primary_agent, reviewer}
+    for agent_slug in secondary_agents:
+        if agent_slug in blocked_agents or agent_slug in normalized_secondary_agents:
+            continue
+        normalized_secondary_agents.append(agent_slug)
+    return normalized_secondary_agents
+
+
+def _reconcile_requested_agent_dispositions(
+    *,
+    requested_agent_disposition: list[dict[str, str]],
+    primary_agent: str,
+    secondary_agents: list[str],
+    reviewer: str,
+) -> None:
+    """Align requested-agent disposition metadata with the final packet roles."""
+
+    advisory_statuses = {
+        REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
+        REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
+    }
+    secondary_agent_set = set(secondary_agents)
+    for disposition in requested_agent_disposition:
+        agent_slug = disposition["agent"]
+        status = disposition["status"]
+        if status == REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN:
+            continue
+        if agent_slug == primary_agent:
+            continue
+        if agent_slug == reviewer and status != REQUESTED_AGENT_STATUS_HONORED_REVIEWER:
+            disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_REVIEWER
+            disposition["reason"] = (
+                "Requested agent stayed honored as reviewer after PR lifecycle synthesis."
+            )
+            continue
+        if agent_slug in secondary_agent_set and status in advisory_statuses:
+            disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
+            disposition["reason"] = (
+                "Requested agent stayed honored in secondary after PR lifecycle synthesis."
+            )
+
+
 def _partition_native_secondaries(
     *,
     secondary_agents: list[str],
@@ -348,11 +400,18 @@ def _promote_forced_secondary_dispositions(
             continue
         if disposition["status"] not in advisory_statuses:
             continue
+        if disposition["agent"] == "security-auditor":
+            reason = (
+                "Requested agent is required for the privileged review path and stays "
+                "executable in secondary."
+            )
+        else:
+            reason = (
+                "Requested agent is required for the PR lifecycle review path and stays "
+                "executable in secondary."
+            )
         disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
-        disposition["reason"] = (
-            "Requested agent is required for the privileged review path and stays "
-            "executable in secondary."
-        )
+        disposition["reason"] = reason
 
 
 def _apply_requested_agent_overrides(
@@ -545,7 +604,11 @@ def build_task_packet(
         secondary_agents=requested_agent_resolution["secondary_agents"],
         reviewer=requested_agent_resolution["reviewer"],
     )
-    requested_agent_resolution["secondary_agents"] = lifecycle_secondary_agents
+    requested_agent_resolution["secondary_agents"] = _normalize_secondary_review_path(
+        primary_agent=requested_agent_resolution["primary_agent"],
+        secondary_agents=lifecycle_secondary_agents,
+        reviewer=lifecycle_reviewer,
+    )
     requested_agent_resolution["reviewer"] = lifecycle_reviewer
     skill_routing = route_skills(
         goal=goal,
@@ -555,10 +618,19 @@ def build_task_packet(
         requested_agents=normalized_requested_agents,
     )
     forced_executable_agents = {"security-auditor"} if security_review_required else set()
+    if normalized_pr_phase == PR_PHASE_POST_OPEN_REVIEW:
+        forced_executable_agents.update(POST_OPEN_REVIEW_LANE)
     if forced_executable_agents:
         _promote_forced_secondary_dispositions(
             requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
             forced_executable_agents=forced_executable_agents,
+        )
+    if normalized_pr_phase != PR_PHASE_NONE:
+        _reconcile_requested_agent_dispositions(
+            requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
+            primary_agent=requested_agent_resolution["primary_agent"],
+            secondary_agents=requested_agent_resolution["secondary_agents"],
+            reviewer=requested_agent_resolution["reviewer"],
         )
     executable_secondaries, advisory_agents = _partition_native_secondaries(
         secondary_agents=requested_agent_resolution["secondary_agents"],

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -270,7 +270,7 @@ def _apply_pr_lifecycle_review_path(
     primary_agent: str,
     secondary_agents: list[str],
     reviewer: str,
-) -> tuple[list[str], str]:
+) -> tuple[str, list[str], str]:
     """Inject the canonical post-open review lane for PR lifecycle work.
 
     RU: post-open review обязан держать `qa-engineer-agent -> bug-hunter`.
@@ -278,19 +278,33 @@ def _apply_pr_lifecycle_review_path(
     """
 
     if pr_phase != PR_PHASE_POST_OPEN_REVIEW:
-        return secondary_agents, reviewer
+        return primary_agent, secondary_agents, reviewer
 
+    adjusted_primary_agent = primary_agent
     adjusted_secondary_agents = list(secondary_agents)
     adjusted_reviewer = reviewer
+    qa_agent, bug_hunter_agent = POST_OPEN_REVIEW_LANE
 
-    if primary_agent == POST_OPEN_REVIEW_LANE[0]:
-        adjusted_reviewer = POST_OPEN_REVIEW_LANE[1]
+    if primary_agent == bug_hunter_agent:
+        adjusted_primary_agent = qa_agent
+        adjusted_reviewer = _select_independent_reviewer(
+            primary_agent=adjusted_primary_agent,
+            canonical_reviewer=reviewer,
+            canonical_secondary=bug_hunter_agent,
+            previous_primary=primary_agent,
+        )
+        adjusted_secondary_agents = [
+            candidate
+            for candidate in [bug_hunter_agent, *adjusted_secondary_agents]
+            if candidate != adjusted_primary_agent
+        ]
+    elif primary_agent == qa_agent:
+        adjusted_secondary_agents = [bug_hunter_agent, *adjusted_secondary_agents]
     else:
-        adjusted_reviewer = POST_OPEN_REVIEW_LANE[0]
-        if POST_OPEN_REVIEW_LANE[1] not in adjusted_secondary_agents:
-            adjusted_secondary_agents.append(POST_OPEN_REVIEW_LANE[1])
+        adjusted_reviewer = qa_agent
+        adjusted_secondary_agents = [bug_hunter_agent, *adjusted_secondary_agents]
 
-    return adjusted_secondary_agents, adjusted_reviewer
+    return adjusted_primary_agent, adjusted_secondary_agents, adjusted_reviewer
 
 
 def _normalize_secondary_review_path(
@@ -323,6 +337,10 @@ def _reconcile_requested_agent_dispositions(
         REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
         REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
     }
+    secondary_honored_statuses = {
+        REQUESTED_AGENT_STATUS_PROMOTED,
+        REQUESTED_AGENT_STATUS_HONORED_PRIMARY,
+    }
     secondary_agent_set = set(secondary_agents)
     for disposition in requested_agent_disposition:
         agent_slug = disposition["agent"]
@@ -337,7 +355,7 @@ def _reconcile_requested_agent_dispositions(
                 "Requested agent stayed honored as reviewer after PR lifecycle synthesis."
             )
             continue
-        if agent_slug in secondary_agent_set and status in advisory_statuses:
+        if agent_slug in secondary_agent_set and status in secondary_honored_statuses:
             disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
             disposition["reason"] = (
                 "Requested agent stayed honored in secondary after PR lifecycle synthesis."
@@ -598,14 +616,19 @@ def build_task_packet(
         if not security_in_review_path:
             secondary_agents.append("security-auditor")
         requested_agent_resolution["secondary_agents"] = secondary_agents
-    lifecycle_secondary_agents, lifecycle_reviewer = _apply_pr_lifecycle_review_path(
+    (
+        lifecycle_primary_agent,
+        lifecycle_secondary_agents,
+        lifecycle_reviewer,
+    ) = _apply_pr_lifecycle_review_path(
         pr_phase=normalized_pr_phase,
         primary_agent=requested_agent_resolution["primary_agent"],
         secondary_agents=requested_agent_resolution["secondary_agents"],
         reviewer=requested_agent_resolution["reviewer"],
     )
+    requested_agent_resolution["primary_agent"] = lifecycle_primary_agent
     requested_agent_resolution["secondary_agents"] = _normalize_secondary_review_path(
-        primary_agent=requested_agent_resolution["primary_agent"],
+        primary_agent=lifecycle_primary_agent,
         secondary_agents=lifecycle_secondary_agents,
         reviewer=lifecycle_reviewer,
     )

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -22,6 +22,8 @@ from scripts.orchestration.routing_graph_loader import (
     REQUIRED_BOOTSTRAP_LANE,
 )
 from scripts.orchestration.task_bootstrap import (
+    _apply_pr_lifecycle_review_path,
+    _normalize_secondary_review_path,
     _matches_any_prefix,
     _resolve_output_path,
     build_task_packet,
@@ -187,6 +189,27 @@ def test_task_bootstrap_preserves_qa_then_bug_hunter_order_in_qa_post_open_lane(
             "reason": "Requested agent stayed honored in secondary after PR lifecycle synthesis.",
         }
     ]
+
+
+def test_post_open_review_path_keeps_bug_hunter_executable_when_primary_was_bug_hunter() -> None:
+    """Helper-level regression: reviewer independence must not drop bug-hunter from secondary."""
+
+    primary_agent, secondary_agents, reviewer = _apply_pr_lifecycle_review_path(
+        pr_phase="post_open_review",
+        primary_agent="bug-hunter",
+        secondary_agents=[],
+        reviewer="qa-engineer-agent",
+    )
+
+    normalized_secondary_agents = _normalize_secondary_review_path(
+        primary_agent=primary_agent,
+        secondary_agents=secondary_agents,
+        reviewer=reviewer,
+    )
+
+    assert primary_agent == "qa-engineer-agent"
+    assert reviewer == "agent-coordinator"
+    assert normalized_secondary_agents == ["bug-hunter"]
 
 
 def test_task_bootstrap_deduplicates_reviewer_from_secondary_in_post_open_lane() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -96,10 +96,72 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
         "design_lane_enabled": False,
     }
     assert packet["pr_phase"] == "none"
+    assert packet["pr_lifecycle_contract"] == {
+        "requires_pr": False,
+        "post_open_review_required": False,
+        "review_lane": [],
+        "artifact_template": "",
+        "current_head_required": False,
+        "current_head_truth": "not-applicable",
+        "merge_readiness_entrypoint": "",
+    }
     assert packet["design_lane_mode"] == "disabled"
     assert packet["needs_backlog_update"] is False
     assert packet["needs_docs_sync"] is False
     assert packet["needs_agents_sync"] is False
+
+
+def test_task_bootstrap_enables_post_open_review_lane_for_pr_phase() -> None:
+    """Post-open review packets must synthesize the canonical QA -> bug-hunter lane."""
+
+    packet = build_task_packet(
+        goal="Prepare post-open PR review loop for orchestration automation",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        pr_phase="post_open_review",
+    )
+
+    assert packet["automation_flags"]["pr_lifecycle_enabled"] is True
+    assert packet["pr_phase"] == "post_open_review"
+    assert packet["pr_lifecycle_contract"] == {
+        "requires_pr": True,
+        "post_open_review_required": True,
+        "review_lane": ["qa-engineer-agent", "bug-hunter"],
+        "artifact_template": "docs/review/PR_<N>_FIXED_MAPPING.md",
+        "current_head_required": True,
+        "current_head_truth": "latest-current-head",
+        "merge_readiness_entrypoint": "",
+    }
+    assert packet["reviewer"] == "qa-engineer-agent"
+    assert "bug-hunter" in packet["secondary_agents"]
+    assert "bug-hunter" in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
+    }
+
+
+def test_task_bootstrap_sets_merge_ready_contract_without_post_open_lane() -> None:
+    """Merge-ready packets should keep lifecycle prep explicit without re-adding QA loop."""
+
+    packet = build_task_packet(
+        goal="Prepare merge readiness packet for orchestration automation",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        pr_phase="merge_ready",
+    )
+
+    assert packet["automation_flags"]["pr_lifecycle_enabled"] is True
+    assert packet["pr_phase"] == "merge_ready"
+    assert packet["pr_lifecycle_contract"] == {
+        "requires_pr": True,
+        "post_open_review_required": False,
+        "review_lane": [],
+        "artifact_template": "docs/review/PR_<N>_FIXED_MAPPING.md",
+        "current_head_required": True,
+        "current_head_truth": "latest-current-head",
+        "merge_readiness_entrypoint": "scripts/orchestration/check_merge_ready.py",
+    }
+    assert packet["reviewer"] != "qa-engineer-agent"
+    assert "bug-hunter" not in packet["secondary_agents"]
 
 
 def test_task_bootstrap_enables_judgment_lane_for_relevant_work() -> None:
@@ -654,6 +716,24 @@ def test_task_bootstrap_keeps_packet_id_stable_for_identical_inputs() -> None:
     assert first_packet["needs_agents_sync"] == second_packet["needs_agents_sync"]
 
 
+def test_task_bootstrap_changes_packet_id_when_pr_phase_changes() -> None:
+    """Lifecycle phase must affect packet identity to avoid artifact collisions."""
+
+    baseline_packet = build_task_packet(
+        goal="Refresh docs sync guidance",
+        task_class="Documentation",
+        candidate_paths=["docs/orchestration/AGENT_MESSAGE_PROTOCOL.md"],
+    )
+    review_packet = build_task_packet(
+        goal="Refresh docs sync guidance",
+        task_class="Documentation",
+        candidate_paths=["docs/orchestration/AGENT_MESSAGE_PROTOCOL.md"],
+        pr_phase="post_open_review",
+    )
+
+    assert baseline_packet["task_packet_id"] != review_packet["task_packet_id"]
+
+
 def test_matches_any_prefix_covers_exact_and_nested_paths() -> None:
     """Prefix matcher must honor exact directory roots and nested repo paths."""
 
@@ -985,3 +1065,77 @@ def test_main_passes_requested_agent_flags(monkeypatch, capsys) -> None:
         "security-auditor",
     ]
     assert json.loads(captured.out)["primary_native_agent_type"] == "default"
+
+
+def test_main_passes_pr_phase_flag(monkeypatch, capsys) -> None:
+    """CLI should propagate --pr-phase into the packet builder."""
+
+    observed: dict[str, object] = {}
+
+    def _fake_build_task_packet(**kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        return {
+            "schema_version": "2.0",
+            "task_packet_id": "pr-phase-packet",
+            "goal": "Use explicit PR phase",
+            "task_class": "Orchestration",
+            "domain": "orchestration",
+            "cluster": "ops",
+            "candidate_paths": ["scripts/orchestration/task_bootstrap.py"],
+            "primary_agent": "agent-coordinator",
+            "secondary_agents": ["bug-hunter"],
+            "reviewer": "qa-engineer-agent",
+            "requested_agents": [],
+            "requested_agent_disposition": [],
+            "required_context": ["AGENTS.md"],
+            "recommended_skills": ["pulseplate-workflow"],
+            "skill_routing": {
+                "policy_version": "2026-03-27",
+                "selection_mode": "deterministic-weighted",
+                "requested_agents": [],
+                "task_classification": {
+                    "label": "implementation",
+                    "score": 0,
+                    "reasons": ["fallback:default-implementation"],
+                },
+                "required": [
+                    {
+                        "skill": "pulseplate-workflow",
+                        "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                        "reasons": ["always-on"],
+                    }
+                ],
+                "recommended": [],
+                "conditional": [],
+                "blocked": [],
+            },
+            "native_subagent_bridge": {
+                "protocol_version": "1.0",
+                "transport": "codex-native-subagents",
+                "primary": {"native_agent_type": "default"},
+                "secondary": [{"native_agent_type": "worker"}],
+                "reviewer": {"native_agent_type": "explorer"},
+            },
+            "routing_rationale": {"source": "canonical_only"},
+        }
+
+    monkeypatch.setattr(
+        "scripts.orchestration.task_bootstrap.build_task_packet",
+        _fake_build_task_packet,
+    )
+
+    exit_code = main(
+        [
+            "--goal",
+            "Run post-open review phase",
+            "--task-class",
+            "Orchestration",
+            "--pr-phase",
+            "post_open_review",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert observed["pr_phase"] == "post_open_review"
+    assert json.loads(captured.out)["task_packet_id"] == "pr-phase-packet"

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -166,6 +166,29 @@ def test_task_bootstrap_keeps_requested_bug_hunter_executable_in_post_open_lane(
     ]
 
 
+def test_task_bootstrap_preserves_qa_then_bug_hunter_order_in_qa_post_open_lane() -> None:
+    """QA-domain post-open packets must not allow bug-hunter to remain primary."""
+
+    packet = build_task_packet(
+        goal="Run qa post-open review with explicit bug hunter request",
+        task_class="QA",
+        candidate_paths=["tests/test_task_bootstrap.py"],
+        requested_agents=["bug-hunter"],
+        pr_phase="post_open_review",
+    )
+
+    assert packet["primary_agent"] == "qa-engineer-agent"
+    assert packet["reviewer"] == "agent-coordinator"
+    assert packet["secondary_agents"] == ["bug-hunter"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "bug-hunter",
+            "status": "honored_secondary",
+            "reason": "Requested agent stayed honored in secondary after PR lifecycle synthesis.",
+        }
+    ]
+
+
 def test_task_bootstrap_deduplicates_reviewer_from_secondary_in_post_open_lane() -> None:
     """Canonical packet identities must not list the reviewer twice."""
 
@@ -184,6 +207,30 @@ def test_task_bootstrap_deduplicates_reviewer_from_secondary_in_post_open_lane()
             "agent": "qa-engineer-agent",
             "status": "honored_reviewer",
             "reason": "Requested agent stayed honored as reviewer after PR lifecycle synthesis.",
+        }
+    ]
+
+
+def test_task_bootstrap_keeps_non_routable_requested_agent_advisory_in_post_open_lane() -> None:
+    """Lifecycle reconciliation must not upgrade advisory-only agents to executable roles."""
+
+    packet = build_task_packet(
+        goal="Prepare ML post-open review packet with advisory collaborator",
+        task_class="AI / ML",
+        candidate_paths=["docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md"],
+        requested_agents=["ml-engineer-agent"],
+        pr_phase="post_open_review",
+    )
+
+    assert "ml-engineer-agent" in packet["secondary_agents"]
+    assert [
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
+    ] == ["ml-engineer-agent"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "ml-engineer-agent",
+            "status": "advisory_non_routable",
+            "reason": "Agent is canonical but non-routable; kept as an advisory collaborator.",
         }
     ]
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -139,6 +139,55 @@ def test_task_bootstrap_enables_post_open_review_lane_for_pr_phase() -> None:
     }
 
 
+def test_task_bootstrap_keeps_requested_bug_hunter_executable_in_post_open_lane() -> None:
+    """Requested bug-hunter must stay runnable in the canonical post-open lane."""
+
+    packet = build_task_packet(
+        goal="Run post-open review with explicit bug hunter request",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["bug-hunter"],
+        pr_phase="post_open_review",
+    )
+
+    assert "bug-hunter" in packet["secondary_agents"]
+    assert "bug-hunter" in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
+    }
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "bug-hunter",
+            "status": "honored_secondary",
+            "reason": (
+                "Requested agent is required for the PR lifecycle review path and stays "
+                "executable in secondary."
+            ),
+        }
+    ]
+
+
+def test_task_bootstrap_deduplicates_reviewer_from_secondary_in_post_open_lane() -> None:
+    """Canonical packet identities must not list the reviewer twice."""
+
+    packet = build_task_packet(
+        goal="Run post-open review with explicit QA request",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["qa-engineer-agent"],
+        pr_phase="post_open_review",
+    )
+
+    assert packet["reviewer"] == "qa-engineer-agent"
+    assert "qa-engineer-agent" not in packet["secondary_agents"]
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "qa-engineer-agent",
+            "status": "honored_reviewer",
+            "reason": "Requested agent stayed honored as reviewer after PR lifecycle synthesis.",
+        }
+    ]
+
+
 def test_task_bootstrap_sets_merge_ready_contract_without_post_open_lane() -> None:
     """Merge-ready packets should keep lifecycle prep explicit without re-adding QA loop."""
 


### PR DESCRIPTION
## Summary
- add explicit bootstrap PR phases for `pre_open`, `post_open_review`, and `merge_ready`
- synthesize the canonical post-open review lane `qa-engineer-agent -> bug-hunter` in task packets
- sync lifecycle contract across orchestration docs and deterministic tests

## Validation
- `pytest -q tests/test_task_bootstrap.py`
- `make verify`
- `pre-commit run --all-files`

## Post-open lane
- mandatory `qa-engineer-agent -> bug-hunter` pass will run after PR creation per canon

## Summary by Sourcery

Ввести явные фазы жизненного цикла PR в bootstrap оркестрационной задачи и сделать поведение post-open QA → bug-hunter‑ревью детерминированным для кода, ID и документации.

New Features:
- Добавить явные фазы жизненного цикла PR (`none`, `pre_open`, `post_open_review`, `merge_ready`) в bootstrap задач и CLI через флаг `--pr-phase`.
- Выводить и прикреплять объект `pr_lifecycle_contract` на основе выбранной фазы PR, включая ревью‑лейн, шаблон артефакта, требования к текущему head и entrypoint готовности к merge.
- Автоматически синтезировать канонический ревью‑лейн `qa-engineer-agent -> bug-hunter` для post-open‑ревью в task‑пакетах при `pr_phase=post_open_review` и принудительно делать этих агентов исполняемыми во вторичных, где это требуется.
- Включить фазу PR в детерминированное вычисление ID task‑пакетов, чтобы пакеты, зависящие от жизненного цикла, оставались различными.

Bug Fixes:
- Нормализовать роли ревьюера и вторичных агентов в post-open‑ревью‑пакетах, гарантируя, что ревьюер не дублируется во вторичных агентах и native subagent bridge остаётся согласованным.
- Согласовать disposition запрошенных агентов после синтеза жизненного цикла, включая учёт запрошенных ревьюеров с выделенным статусом и апгрейд консультационных вторичных запросов, которые остаются исполняемыми.

Enhancements:
- Уточнить логику промоушена запрошенных агентов, чтобы разные принудительные вторичные (например, security auditor vs. lifecycle‑агенты) получали phase-appropriate причины disposition.
- Расширить документацию по оркестрации и описания workflow, чтобы зафиксировать новые фазы жизненного цикла PR, детерминизм post-open‑лейна и флаги автоматизации с поддержкой жизненного цикла.
- Задокументировать поведение жизненного цикла PR и ожидания по fixed-in-commit в каноническом шаблоне артефакта для маппинга PR‑ревью.

Documentation:
- Обновить документацию по протоколу оркестрации, workflow, готовности к автоматизации и матрице PR‑контрактов, описав явные фазы жизненного цикла PR, lifecycle‑контракты и детерминированное post-open QA → bug-hunter‑поведение.
- Добавить каноничный ревью‑артефакт `PR_1266_FIXED_MAPPING.md`, документирующий ожидания по маппингу discussion‑thread и fixed-in-commit.

Tests:
- Добавить модульные тесты, покрывающие значения по умолчанию для PR lifecycle contract, фазы post-open‑ревью и merge-ready, согласование disposition запрошенных агентов, влияние PR‑фазы на ID пакетов и распространение флага `--pr-phase` в CLI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce explicit PR lifecycle phases to orchestration task bootstrap and make post-open QA → bug-hunter review behavior deterministic across code, IDs, and docs.

New Features:
- Add explicit PR lifecycle phases (`none`, `pre_open`, `post_open_review`, `merge_ready`) to task bootstrap and CLI via the `--pr-phase` flag.
- Derive and attach a `pr_lifecycle_contract` object from the selected PR phase, including review lane, artifact template, current-head requirements, and merge-readiness entrypoint.
- Automatically synthesize the canonical `qa-engineer-agent -> bug-hunter` post-open review lane in task packets when `pr_phase=post_open_review`, and force those agents executable in secondary where required.
- Include the PR phase in deterministic task packet ID computation so lifecycle-specific packets remain distinct.

Bug Fixes:
- Normalize reviewer and secondary agent roles in post-open review packets, ensuring the reviewer is not duplicated in secondary agents and the native subagent bridge stays aligned.
- Reconcile requested-agent dispositions after lifecycle synthesis, including honoring requested reviewers with a dedicated status and upgrading advisory secondary requests that remain executable.

Enhancements:
- Refine requested-agent promotion logic so different forced secondaries (e.g., security auditor vs. lifecycle agents) receive phase-appropriate disposition reasons.
- Extend orchestration docs and workflow descriptions to capture the new PR lifecycle phases, post-open lane determinism, and lifecycle-enabled automation flags.
- Document PR lifecycle behavior and fixed-in-commit expectations in a canonical artifact template for PR review mapping.

Documentation:
- Update orchestration protocol, workflow, automation readiness, and PR contract matrix docs to describe explicit PR lifecycle phases, lifecycle contracts, and deterministic post-open QA → bug-hunter behavior.
- Add a canonical `PR_1266_FIXED_MAPPING.md` review artifact documenting discussion-thread and fixed-in-commit mapping expectations.

Tests:
- Add unit tests covering PR lifecycle contract defaults, post-open review and merge-ready phases, requested-agent disposition reconciliation, PR-phase impact on packet IDs, and CLI propagation of the `--pr-phase` flag.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести явные фазы жизненного цикла PR в bootstrap оркестрационной задачи и сделать поведение post-open QA → bug-hunter‑ревью детерминированным для кода, ID и документации.

New Features:
- Добавить явные фазы жизненного цикла PR (`none`, `pre_open`, `post_open_review`, `merge_ready`) в bootstrap задач и CLI через флаг `--pr-phase`.
- Выводить и прикреплять объект `pr_lifecycle_contract` на основе выбранной фазы PR, включая ревью‑лейн, шаблон артефакта, требования к текущему head и entrypoint готовности к merge.
- Автоматически синтезировать канонический ревью‑лейн `qa-engineer-agent -> bug-hunter` для post-open‑ревью в task‑пакетах при `pr_phase=post_open_review` и принудительно делать этих агентов исполняемыми во вторичных, где это требуется.
- Включить фазу PR в детерминированное вычисление ID task‑пакетов, чтобы пакеты, зависящие от жизненного цикла, оставались различными.

Bug Fixes:
- Нормализовать роли ревьюера и вторичных агентов в post-open‑ревью‑пакетах, гарантируя, что ревьюер не дублируется во вторичных агентах и native subagent bridge остаётся согласованным.
- Согласовать disposition запрошенных агентов после синтеза жизненного цикла, включая учёт запрошенных ревьюеров с выделенным статусом и апгрейд консультационных вторичных запросов, которые остаются исполняемыми.

Enhancements:
- Уточнить логику промоушена запрошенных агентов, чтобы разные принудительные вторичные (например, security auditor vs. lifecycle‑агенты) получали phase-appropriate причины disposition.
- Расширить документацию по оркестрации и описания workflow, чтобы зафиксировать новые фазы жизненного цикла PR, детерминизм post-open‑лейна и флаги автоматизации с поддержкой жизненного цикла.
- Задокументировать поведение жизненного цикла PR и ожидания по fixed-in-commit в каноническом шаблоне артефакта для маппинга PR‑ревью.

Documentation:
- Обновить документацию по протоколу оркестрации, workflow, готовности к автоматизации и матрице PR‑контрактов, описав явные фазы жизненного цикла PR, lifecycle‑контракты и детерминированное post-open QA → bug-hunter‑поведение.
- Добавить каноничный ревью‑артефакт `PR_1266_FIXED_MAPPING.md`, документирующий ожидания по маппингу discussion‑thread и fixed-in-commit.

Tests:
- Добавить модульные тесты, покрывающие значения по умолчанию для PR lifecycle contract, фазы post-open‑ревью и merge-ready, согласование disposition запрошенных агентов, влияние PR‑фазы на ID пакетов и распространение флага `--pr-phase` в CLI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce explicit PR lifecycle phases to orchestration task bootstrap and make post-open QA → bug-hunter review behavior deterministic across code, IDs, and docs.

New Features:
- Add explicit PR lifecycle phases (`none`, `pre_open`, `post_open_review`, `merge_ready`) to task bootstrap and CLI via the `--pr-phase` flag.
- Derive and attach a `pr_lifecycle_contract` object from the selected PR phase, including review lane, artifact template, current-head requirements, and merge-readiness entrypoint.
- Automatically synthesize the canonical `qa-engineer-agent -> bug-hunter` post-open review lane in task packets when `pr_phase=post_open_review`, and force those agents executable in secondary where required.
- Include the PR phase in deterministic task packet ID computation so lifecycle-specific packets remain distinct.

Bug Fixes:
- Normalize reviewer and secondary agent roles in post-open review packets, ensuring the reviewer is not duplicated in secondary agents and the native subagent bridge stays aligned.
- Reconcile requested-agent dispositions after lifecycle synthesis, including honoring requested reviewers with a dedicated status and upgrading advisory secondary requests that remain executable.

Enhancements:
- Refine requested-agent promotion logic so different forced secondaries (e.g., security auditor vs. lifecycle agents) receive phase-appropriate disposition reasons.
- Extend orchestration docs and workflow descriptions to capture the new PR lifecycle phases, post-open lane determinism, and lifecycle-enabled automation flags.
- Document PR lifecycle behavior and fixed-in-commit expectations in a canonical artifact template for PR review mapping.

Documentation:
- Update orchestration protocol, workflow, automation readiness, and PR contract matrix docs to describe explicit PR lifecycle phases, lifecycle contracts, and deterministic post-open QA → bug-hunter behavior.
- Add a canonical `PR_1266_FIXED_MAPPING.md` review artifact documenting discussion-thread and fixed-in-commit mapping expectations.

Tests:
- Add unit tests covering PR lifecycle contract defaults, post-open review and merge-ready phases, requested-agent disposition reconciliation, PR-phase impact on packet IDs, and CLI propagation of the `--pr-phase` flag.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit PR lifecycle phases to `task_bootstrap` and makes the post-open QA → bug-hunter review lane deterministic. Ships a canonical “Fixed in Commit” artifact and updates docs/tests to lock down lane behavior and merge-ready handling.

- **New Features**
  - `--pr-phase` supports `pre_open`, `post_open_review`, `merge_ready`; phase is included in `task_packet_id`.
  - Synthesizes QA → `bug-hunter` lane for `post_open_review`; adds `pr_lifecycle_contract` and enables `automation_flags.pr_lifecycle_enabled`.
  - `merge_ready` sets current-head contract and calls `scripts/orchestration/check_merge_ready.py`.

- **Bug Fixes**
  - Enforces QA-first ordering; keeps `bug-hunter` executable; prevents lane drop when `bug-hunter` was primary; non-routable requests remain advisory.
  - Deduplicates reviewer from secondaries; reconciles requested-agent statuses and native bridge after lifecycle synthesis.
  - Removes a dead review status and updates `docs/review/PR_1266_FIXED_MAPPING.md` with CodeRabbit post-open lane and nitpick-wrapper mappings.

<sup>Written for commit 0c8793352fe9ef4d271cd3441016fd0f0532ca85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1266_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PR lifecycle phase control (pre_open, post_open_review, merge_ready) that influences packet identity, merge-readiness handling, and deterministic post-open behavior; post_open_review now enforces a synthesized QA → bug-hunter review lane.

* **Documentation**
  * Updated orchestration docs, protocol, contract matrix, readiness matrix, runbook, workflow, and review mapping to describe PR lifecycle semantics and packet-level contracts.

* **Tests**
  * Added tests for lifecycle flags, review-lane synthesis, role reconciliation, packet identity changes, and CLI phase propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->