### PR TITLE
feat(deploy): align postgres deploy contract

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           set -euo pipefail
           for i in 1 2 3; do
-            if curl -fsS --max-time 10 "https://${{ secrets.STAGING_DOMAIN }}/health" > /dev/null; then
+            if curl -fsS --max-time 10 "https://${{ secrets.STAGING_DOMAIN }}/ready" > /dev/null; then
               echo "Healthcheck passed"
               exit 0
             fi

--- a/deploy/docker-compose.production.yaml
+++ b/deploy/docker-compose.production.yaml
@@ -9,6 +9,24 @@ networks:
         - subnet: 172.30.100.0/24
 
 services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    networks: [web]
+    env_file:
+      - .env
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   app:
     image: ${IMAGE_REF:?IMAGE_REF is required}
     restart: unless-stopped
@@ -17,6 +35,9 @@ services:
       - "8000"
     env_file:
       - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
     command: >
       uvicorn app.main:app --host 0.0.0.0 --port 8000
       --proxy-headers
@@ -27,7 +48,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()",
         ]
       interval: 30s
       timeout: 10s
@@ -53,7 +74,8 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - app
+      app:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "caddy", "version"]
       interval: 30s
@@ -61,5 +83,6 @@ services:
       retries: 3
 
 volumes:
+  postgres_data:
   caddy_data:
   caddy_config:

--- a/deploy/docker-compose.staging.yaml
+++ b/deploy/docker-compose.staging.yaml
@@ -5,6 +5,24 @@ networks:
     external: false
 
 services:
+  postgres:
+    image: postgres:15-alpine
+    env_file:
+      - /srv/pulseplate-staging/.env
+    restart: always
+    networks: [web]
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   app:
     image: ghcr.io/katsiarynakavaleuskaya/pulseplate:${TAG:-latest}
     env_file:
@@ -13,10 +31,11 @@ services:
     networks: [web]
     expose:
       - "8000"
-    volumes:
-      - app_data:/app/cache
+    depends_on:
+      postgres:
+        condition: service_healthy
     command: >
-      uvicorn app:app --host 0.0.0.0 --port 8000
+      uvicorn app.main:app --host 0.0.0.0 --port 8000
       --proxy-headers --forwarded-allow-ips="caddy"
     deploy:
       resources:
@@ -27,7 +46,7 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -47,9 +66,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - app
+      app:
+        condition: service_healthy
 
 volumes:
+  postgres_data:
   caddy_data:
   caddy_config:
-  app_data:

--- a/docs/deploy/PRODUCTION.md
+++ b/docs/deploy/PRODUCTION.md
@@ -142,11 +142,11 @@ sudo chown $USER:$USER /srv/pulseplate-production
 ```bash
 # Copy deployment templates
 sudo cp deploy/Caddyfile /srv/pulseplate-production/
-sudo cp scripts/deploy.sh /srv/pulseplate-production/
+sudo cp scripts/deploy_production.sh /srv/pulseplate-production/
 sudo mkdir -p /srv/pulseplate-production/scripts/ops
 sudo cp scripts/ops/postgres_backup.sh /srv/pulseplate-production/scripts/ops/
 sudo cp scripts/ops/postgres_restore.sh /srv/pulseplate-production/scripts/ops/
-sudo chmod +x /srv/pulseplate-production/deploy.sh
+sudo chmod +x /srv/pulseplate-production/deploy_production.sh
 sudo chmod +x /srv/pulseplate-production/scripts/ops/postgres_backup.sh
 sudo chmod +x /srv/pulseplate-production/scripts/ops/postgres_restore.sh
 ```
@@ -283,14 +283,17 @@ docker compose --env-file .env -f docker-compose.production.yaml exec -T postgre
   pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
 
 PROJECT_DIR=/srv/pulseplate-production \
+COMPOSE_FILE=/srv/pulseplate-production/docker-compose.production.yaml \
 BACKUP_DIR=/srv/pulseplate-production/backups \
 POSTGRES_USER="$POSTGRES_USER" \
 POSTGRES_DB="$POSTGRES_DB" \
 /srv/pulseplate-production/scripts/ops/postgres_backup.sh
 
-docker compose --env-file .env -f docker-compose.production.yaml up -d app caddy
-curl -fsS http://127.0.0.1:8000/ready
+docker compose --env-file .env -f docker-compose.production.yaml up -d app
+docker compose --env-file .env -f docker-compose.production.yaml exec app \
+  python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()"
 docker compose --env-file .env -f docker-compose.production.yaml exec app alembic upgrade head
+docker compose --env-file .env -f docker-compose.production.yaml up -d caddy
 curl -fsS https://yourdomain.com/ready
 ```
 
@@ -444,7 +447,10 @@ To reduce disk usage, consider compressing backups. Common approaches:
 - **Always test restores** after implementing compression:
 
   ```bash
-  POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh /absolute/path/to/pulseplate_20260101_010101.dump
+  PROJECT_DIR=/srv/pulseplate-production \
+  COMPOSE_FILE=/srv/pulseplate-production/docker-compose.production.yaml \
+  POSTGRES_USER=... POSTGRES_DB=... \
+  scripts/ops/postgres_restore.sh /absolute/path/to/pulseplate_20260101_010101.dump
   ```
 
 - Monitor compressed backup sizes when setting retention thresholds
@@ -455,6 +461,7 @@ To reduce disk usage, consider compressing backups. Common approaches:
 
 ```bash
 PROJECT_DIR=/srv/pulseplate-production \
+COMPOSE_FILE=/srv/pulseplate-production/docker-compose.production.yaml \
 BACKUP_DIR=/srv/pulseplate-production/backups \
 POSTGRES_USER="$POSTGRES_USER" \
 POSTGRES_DB="$POSTGRES_DB" \
@@ -620,9 +627,9 @@ du -sh /srv/pulseplate-production/backups/pulseplate_*.dump | head -1
 
 ```bash
 # Test the production configuration locally
-docker compose -f deploy/docker-compose.staging.yaml up -d
+docker compose --env-file deploy/.env -f deploy/docker-compose.production.yaml up -d postgres app
 curl -f http://localhost:8000/ready
-docker compose -f deploy/docker-compose.staging.yaml down
+docker compose --env-file deploy/.env -f deploy/docker-compose.production.yaml down
 ```
 
 ### 2. Production Test
@@ -630,7 +637,9 @@ docker compose -f deploy/docker-compose.staging.yaml down
 ```bash
 # On your production server
 cd /srv/pulseplate-production
-./deploy.sh latest
+export IMAGE_REF=ghcr.io/katsiarynakavaleuskaya/pulseplate:prod-vX.Y.Z
+export TAG=prod-vX.Y.Z
+./deploy_production.sh
 
 # Check readiness
 curl -f https://yourdomain.com/ready
@@ -662,8 +671,9 @@ curl -f https://yourdomain.com/ready
 ```bash
 # On production server
 cd /srv/pulseplate-production
+export IMAGE_REF=ghcr.io/katsiarynakavaleuskaya/pulseplate:previous-tag
 export TAG=previous-tag
-./deploy.sh $TAG
+./deploy_production.sh
 ```
 
 ## 📞 Support

--- a/docs/deploy/PRODUCTION.md
+++ b/docs/deploy/PRODUCTION.md
@@ -143,7 +143,12 @@ sudo chown $USER:$USER /srv/pulseplate-production
 # Copy deployment templates
 sudo cp deploy/Caddyfile /srv/pulseplate-production/
 sudo cp scripts/deploy.sh /srv/pulseplate-production/
+sudo mkdir -p /srv/pulseplate-production/scripts/ops
+sudo cp scripts/ops/postgres_backup.sh /srv/pulseplate-production/scripts/ops/
+sudo cp scripts/ops/postgres_restore.sh /srv/pulseplate-production/scripts/ops/
 sudo chmod +x /srv/pulseplate-production/deploy.sh
+sudo chmod +x /srv/pulseplate-production/scripts/ops/postgres_backup.sh
+sudo chmod +x /srv/pulseplate-production/scripts/ops/postgres_restore.sh
 ```
 
 ### 4. Configure Production Environment
@@ -153,7 +158,13 @@ sudo chmod +x /srv/pulseplate-production/deploy.sh
 sudo tee /srv/pulseplate-production/.env > /dev/null << 'EOF'
 # Production Configuration
 PRODUCTION_DOMAIN=yourdomain.com
-DATABASE_URL=sqlite:///app/cache/app.db
+DATABASE_URL=postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>
+POSTGRES_DB=pulseplate
+POSTGRES_USER=pulseplate
+POSTGRES_PASSWORD=replace-with-strong-secret
+SUBSCRIPTION_DB_ENABLED=true
+ALLOW_DEV_API_KEY=false
+API_KEY_REQUIRED=true
 SECRET_KEY=your-production-secret-key-here
 DEBUG=false
 
@@ -175,6 +186,24 @@ networks:
     external: false
 
 services:
+  postgres:
+    image: postgres:15-alpine
+    env_file:
+      - /srv/pulseplate-production/.env
+    restart: always
+    networks: [web]
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   app:
     image: ghcr.io/katsiarynakavaleuskaya/pulseplate:${TAG:-latest}
     env_file:
@@ -183,18 +212,14 @@ services:
     networks: [web]
     expose:
       - "8000"
-    # RU: Bind mount БД на хост для персистентности и бэкапов
-    # EN: Bind mount DB to host for persistence and backups
-    volumes:
-      - /srv/pulseplate-production/app_data:/app/cache
+    depends_on:
+      postgres:
+        condition: service_healthy
     command: >
-      uvicorn app:app --host 0.0.0.0 --port 8000
+      uvicorn app.main:app --host 0.0.0.0 --port 8000
       --proxy-headers --forwarded-allow-ips="caddy"
-    # RU: Resource limits (deploy: блок удалён из примера, т.к. работает только в Swarm)
-    # EN: Resource limits (deploy: block removed from example as it only works in Swarm)
-    # Limits can be set via docker-compose CLI flags if needed
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -214,13 +239,13 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - app
+      app:
+        condition: service_healthy
 
 volumes:
+  postgres_data:
   caddy_data:
   caddy_config:
-  # RU: app_data volume не используется, т.к. БД монтируется через bind mount
-  # EN: app_data volume not used, as DB is mounted via bind mount
 EOF
 ```
 
@@ -248,147 +273,28 @@ sudo tee /srv/pulseplate-production/Caddyfile > /dev/null << 'EOF'
 EOF
 ```
 
-### 7. Update Deploy Script for Production
+### 7. Update Deploy Flow for Production
 
 ```bash
-# Update deploy.sh for production
-sudo tee /srv/pulseplate-production/deploy.sh > /dev/null << 'EOF'
-#!/usr/bin/env bash
-# Production deployment script
-set -euo pipefail
+# Canonical production sequence (Postgres-first, fail-closed)
+docker compose --env-file .env -f docker-compose.production.yaml pull app
+docker compose --env-file .env -f docker-compose.production.yaml up -d postgres
+docker compose --env-file .env -f docker-compose.production.yaml exec -T postgres \
+  pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
 
-# Validate required environment variables
-PRODUCTION_DOMAIN=${PRODUCTION_DOMAIN:?"PRODUCTION_DOMAIN not set"}
-GHCR_TOKEN=${GHCR_TOKEN:?"GHCR_TOKEN not set"}
-GHCR_USER=${GHCR_USER:?"GHCR_USER not set"}
+PROJECT_DIR=/srv/pulseplate-production \
+BACKUP_DIR=/srv/pulseplate-production/backups \
+POSTGRES_USER="$POSTGRES_USER" \
+POSTGRES_DB="$POSTGRES_DB" \
+/srv/pulseplate-production/scripts/ops/postgres_backup.sh
 
-IMG_REF="${1:-latest}"
-COMPOSE="docker compose -f /srv/pulseplate-production/docker-compose.production.yaml"
-
-# Warn if using latest tag
-if [ "$IMG_REF" = "latest" ]; then
-  echo "⚠️  WARNING: Using 'latest' tag. For production deployments, use specific commit SHA tags."
-fi
-
-echo "[1/4] Login GHCR"
-echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
-
-echo "[2/4] Pull image $IMG_REF"
-export TAG="$IMG_REF"
-$COMPOSE pull app
-
-echo "[3/4] Start stack and DB backup"
-$COMPOSE up -d app caddy
-
-# Wait for app container to be ready
-echo "Waiting for app container to be ready..."
-max_wait=60
-wait_count=0
-while [ $wait_count -lt $max_wait ]; do
-  if $COMPOSE ps app | grep -q "Up"; then
-    echo "App container is running"
-    break
-  fi
-  wait_count=$((wait_count + 1))
-  echo "Waiting for app container... ($wait_count/$max_wait)"
-  sleep 1
-done
-
-if [ $wait_count -eq $max_wait ]; then
-  echo "❌ App container failed to start within $max_wait seconds"
-  exit 1
-fi
-
-# Get the actual container name dynamically
-APP_CONTAINER=$($COMPOSE ps -q app | tr -d '\n\r ')
-if [ -z "$APP_CONTAINER" ]; then
-  echo "❌ Failed to find app container"
-  exit 1
-fi
-echo "Using app container: $APP_CONTAINER"
-
-# Create database backup if it exists
-if docker exec "$APP_CONTAINER" test -f /app/cache/app.db 2>/dev/null; then
-  timestamp=$(date +"%Y%m%d_%H%M%S")
-  backup_dir="/srv/pulseplate-production/backups"
-  mkdir -p "$backup_dir"
-  backup_path="$backup_dir/app.db.backup-$timestamp"
-  echo "Creating database backup: $backup_path"
-  docker cp "$APP_CONTAINER:/app/cache/app.db" "$backup_path"
-
-  # RU: Храним 30 последних бэкапов для production
-  # EN: Keep last 30 backups for production
-  ls -t "$backup_dir"/app.db.backup-* 2>/dev/null | tail -n +31 | xargs -r rm -f
-  # See section 7.2 for detailed disk usage and compression guidance
-  echo "Database backup completed"
-else
-  echo "No existing database found, skipping backup"
-fi
-
-echo "[4/4] Run migrations"
-# Wait for app to be ready
-echo "Waiting for app to be ready for migrations..."
-max_wait=30
-wait_count=0
-while [ $wait_count -lt $max_wait ]; do
-  if docker exec "$APP_CONTAINER" python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()" 2>/dev/null; then
-    echo "App is ready for migrations"
-    break
-  fi
-  wait_count=$((wait_count + 1))
-  echo "Waiting for app readiness... ($wait_count/$max_wait)"
-  sleep 1
-done
-
-if [ $wait_count -eq $max_wait ]; then
-  echo "❌ App failed to become ready within $max_wait seconds"
-  exit 1
-fi
-
-# Run migrations
-echo "Running database migrations in container: $APP_CONTAINER"
-if docker exec "$APP_CONTAINER" alembic upgrade head; then
-  echo "✅ Database migrations completed successfully in container: $APP_CONTAINER"
-else
-  migration_exit_code=$?
-  echo "❌ Database migrations failed in container: $APP_CONTAINER (exit code: $migration_exit_code)" >&2
-  echo "Check container logs with: docker logs $APP_CONTAINER" >&2
-  exit $migration_exit_code
-fi
-
-echo "[post] Production health check"
-max_attempts=30
-attempt=0
-while [ $attempt -lt $max_attempts ]; do
-  attempt=$((attempt + 1))
-  echo "Health check attempt $attempt/$max_attempts..."
-
-  curl_output=$(curl -fsS "https://${PRODUCTION_DOMAIN}/health" 2>&1)
-  curl_exit_code=$?
-
-  if [ $curl_exit_code -eq 0 ]; then
-    echo "✅ Production health check successful"
-    break
-  else
-    echo "❌ Health check failed (exit code: $curl_exit_code)" >&2
-    echo "Error details: $curl_output" >&2
-
-    if [ $attempt -eq $max_attempts ]; then
-      echo "❌ Production health check failed after ${max_attempts} attempts" >&2
-      echo "Final error: $curl_output" >&2
-      exit 1
-    fi
-
-    echo "Waiting 2 seconds before retry..."
-    sleep 2
-  fi
-done
-
-echo "✅ Production deployed: $IMG_REF"
-EOF
-
-sudo chmod +x /srv/pulseplate-production/deploy.sh
+docker compose --env-file .env -f docker-compose.production.yaml up -d app caddy
+curl -fsS http://127.0.0.1:8000/ready
+docker compose --env-file .env -f docker-compose.production.yaml exec app alembic upgrade head
+curl -fsS https://yourdomain.com/ready
 ```
+
+Do not use SQLite file copies such as `/app/cache/app.db` in production deploy flow. Production backup/restore must go through `scripts/ops/postgres_backup.sh` and `scripts/ops/postgres_restore.sh`.
 
 ### 7.1. Set Up Disk Space Monitoring and Alerts
 
@@ -497,7 +403,7 @@ This section provides detailed guidance on managing disk space for database back
 To estimate the size of a single backup, use:
 
 ```bash
-du -sh "$backup_dir"/app.db.backup-* | head -1
+du -sh "$backup_dir"/pulseplate_*.dump | head -1
 ```
 
 **Example Calculation**:
@@ -518,18 +424,18 @@ To reduce disk usage, consider compressing backups. Common approaches:
 
    ```bash
    gzip "$backup_path"
-   # Creates: app.db.backup-YYYYMMDD_HHMMSS.gz
+   # Creates: pulseplate_YYYYMMDD_HHMMSS.dump.gz
    ```
 
-2. **SQLite dump with compression**:
+2. **Archive completed dumps after retention pruning**:
 
    ```bash
-   sqlite3 app.db .dump | gzip > "$backup_dir/backup-$timestamp.sql.gz"
+   find "$backup_dir" -type f -name 'pulseplate_*.dump' -mtime +7 -exec gzip {} \;
    ```
 
 **Compression Ratios**:
 
-- Typical SQLite compression: **2-5x** for common databases
+- `pg_dump -Fc` already produces a compact custom-format dump
 - Example: if uncompressed backup ≈ 500MB, after compression ≈ 100-250MB
 - 30 compressed backups ≈ 3-7.5GB (vs 15GB uncompressed)
 
@@ -538,9 +444,7 @@ To reduce disk usage, consider compressing backups. Common approaches:
 - **Always test restores** after implementing compression:
 
   ```bash
-  # Test decompression and restore
-  gunzip backup.sql.gz
-  sqlite3 restored.db < backup.sql
+  POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh /absolute/path/to/pulseplate_20260101_010101.dump
   ```
 
 - Monitor compressed backup sizes when setting retention thresholds
@@ -550,16 +454,11 @@ To reduce disk usage, consider compressing backups. Common approaches:
 **Modified Backup Script with Compression** (example):
 
 ```bash
-# Create compressed backup
-timestamp=$(date +"%Y%m%d_%H%M%S")
-backup_dir="/srv/pulseplate-production/backups"
-mkdir -p "$backup_dir"
-backup_path="$backup_dir/app.db.backup-$timestamp"
-docker cp "$APP_CONTAINER:/app/cache/app.db" "$backup_path"
-gzip "$backup_path"  # Compress immediately after creation
-
-# Retention: keep last 30 compressed backups
-ls -t "$backup_dir"/app.db.backup-*.gz 2>/dev/null | tail -n +31 | xargs -r rm -f
+PROJECT_DIR=/srv/pulseplate-production \
+BACKUP_DIR=/srv/pulseplate-production/backups \
+POSTGRES_USER="$POSTGRES_USER" \
+POSTGRES_DB="$POSTGRES_DB" \
+scripts/ops/postgres_backup.sh
 ```
 
 ## 🔑 GitHub Environment Setup
@@ -623,7 +522,7 @@ git push origin v1.0.0
 
 ### Monitoring
 
-1. **Health checks**: Automatic monitoring of `/health` endpoint
+1. **Health checks**: Automatic monitoring of `/ready` (or `/health/db`) endpoint
 2. **Logs**: Available via `docker logs` commands
 3. **Backups**: Automatic database backups before deployments
 4. **Rollback**: Previous image tags available for quick rollback
@@ -669,7 +568,7 @@ fi
 # Check if usage exceeds threshold
 if [ "$USED" -gt "$THRESHOLD" ]; then
     # Remove older backups while retaining the last 30
-    ls -t "$BACKUP_DIR"/app.db.backup-* 2>/dev/null | tail -n +31 | xargs -r rm -f
+    ls -t "$BACKUP_DIR"/pulseplate_*.dump 2>/dev/null | tail -n +31 | xargs -r rm -f
     echo "$(date): Cleaned up old backups (disk usage was ${USED}%)"
 fi
 EOF
@@ -708,7 +607,7 @@ du -sh /srv/pulseplate-production/backups
 df -h
 
 # Estimate backup retention impact
-du -sh /srv/pulseplate-production/backups/app.db.backup-* | head -1
+du -sh /srv/pulseplate-production/backups/pulseplate_*.dump | head -1
 ```
 
 **RU:** Рекомендуется регулярно проверять использование диска и корректировать retention-политики в зависимости от размера бэкапов и доступного места.
@@ -722,7 +621,7 @@ du -sh /srv/pulseplate-production/backups/app.db.backup-* | head -1
 ```bash
 # Test the production configuration locally
 docker compose -f deploy/docker-compose.staging.yaml up -d
-curl -f http://localhost:8000/health
+curl -f http://localhost:8000/ready
 docker compose -f deploy/docker-compose.staging.yaml down
 ```
 
@@ -733,8 +632,8 @@ docker compose -f deploy/docker-compose.staging.yaml down
 cd /srv/pulseplate-production
 ./deploy.sh latest
 
-# Check health
-curl -f https://yourdomain.com/health
+# Check readiness
+curl -f https://yourdomain.com/ready
 ```
 
 ## 📋 Production Checklist

--- a/docs/deploy/PRODUCTION.md
+++ b/docs/deploy/PRODUCTION.md
@@ -450,7 +450,7 @@ To reduce disk usage, consider compressing backups. Common approaches:
   PROJECT_DIR=/srv/pulseplate-production \
   COMPOSE_FILE=/srv/pulseplate-production/docker-compose.production.yaml \
   POSTGRES_USER=... POSTGRES_DB=... \
-  scripts/ops/postgres_restore.sh /absolute/path/to/pulseplate_20260101_010101.dump
+  /srv/pulseplate-production/scripts/ops/postgres_restore.sh /absolute/path/to/pulseplate_20260101_010101.dump
   ```
 
 - Monitor compressed backup sizes when setting retention thresholds
@@ -465,7 +465,7 @@ COMPOSE_FILE=/srv/pulseplate-production/docker-compose.production.yaml \
 BACKUP_DIR=/srv/pulseplate-production/backups \
 POSTGRES_USER="$POSTGRES_USER" \
 POSTGRES_DB="$POSTGRES_DB" \
-scripts/ops/postgres_backup.sh
+/srv/pulseplate-production/scripts/ops/postgres_backup.sh
 ```
 
 ## 🔑 GitHub Environment Setup

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -76,7 +76,12 @@ sudo chown $USER:$USER /srv/pulseplate-staging
 sudo cp deploy/docker-compose.staging.yaml /srv/pulseplate-staging/
 sudo cp deploy/Caddyfile /srv/pulseplate-staging/
 sudo cp scripts/deploy.sh /srv/pulseplate-staging/
+sudo mkdir -p /srv/pulseplate-staging/scripts/ops
+sudo cp scripts/ops/postgres_backup.sh /srv/pulseplate-staging/scripts/ops/
+sudo cp scripts/ops/postgres_restore.sh /srv/pulseplate-staging/scripts/ops/
 sudo chmod +x /srv/pulseplate-staging/deploy.sh
+sudo chmod +x /srv/pulseplate-staging/scripts/ops/postgres_backup.sh
+sudo chmod +x /srv/pulseplate-staging/scripts/ops/postgres_restore.sh
 ```
 
 ### 4. Configure Environment
@@ -86,7 +91,13 @@ sudo chmod +x /srv/pulseplate-staging/deploy.sh
 sudo tee /srv/pulseplate-staging/.env > /dev/null << 'EOF'
 # Application Configuration
 STAGING_DOMAIN=staging.yourdomain.com
-DATABASE_URL=sqlite:///app/cache/app.db
+DATABASE_URL=postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>
+POSTGRES_DB=pulseplate
+POSTGRES_USER=pulseplate
+POSTGRES_PASSWORD=replace-with-strong-secret
+SUBSCRIPTION_DB_ENABLED=true
+ALLOW_DEV_API_KEY=false
+API_KEY_REQUIRED=true
 SECRET_KEY=your-secret-key-here
 DEBUG=false
 
@@ -95,6 +106,8 @@ EOF
 
 sudo chown $USER:$USER /srv/pulseplate-staging/.env
 ```
+
+Staging uses the same Postgres-first deploy contract as production: the compose stack includes an internal-only `postgres` service, deploy backups go through `scripts/ops/postgres_backup.sh`, and readiness must be verified via `/ready` or `/health/db`.
 
 ### 5. Configure Firewall
 
@@ -289,7 +302,7 @@ cd /srv/pulseplate-staging
 1. Push a commit to `main` branch
 2. Check GitHub Actions → CD workflow
 3. Visit your staging domain
-4. Verify `/health` endpoint returns 200
+4. Verify `/ready` endpoint returns 200
 
 ## 🔍 Troubleshooting
 
@@ -344,10 +357,13 @@ free -h
 
 ```bash
 # Check if application is running
-curl -f https://staging.yourdomain.com/health
+curl -f https://staging.yourdomain.com/ready
+
+# Optional DB-specific readiness check
+curl -f https://staging.yourdomain.com/health/db
 
 # Check response time
-curl -w "@curl-format.txt" -o /dev/null -s https://staging.yourdomain.com/health
+curl -w "@curl-format.txt" -o /dev/null -s https://staging.yourdomain.com/ready
 ```
 
 ### Log Monitoring

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -33,6 +33,7 @@ Disposition: FIXED
 Commit: 1d03adc8
 Evidence: scripts/PRODUCTION_ENV_FIX.md:24, scripts/PRODUCTION_ENV_FIX.md:42, scripts/PRODUCTION_ENV_FIX.md:81
 Reason: The production env runbook now treats `API_KEY_REQUIRED` as a compatibility request-time flag instead of describing it as a startup fail-closed production guard, matching the current runtime contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026074209 -> 1d03adc8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005374426 -> 1d03adc8
 
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1271 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+No review comments mapped yet.
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -1,14 +1,28 @@
 # PR 1271 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-No review comments mapped yet.
+- Internal post-open review lane completed on `28 марта 2026 года`:
+  `qa-engineer-agent (Linnaeus) -> bug-hunter (Faraday)`.
+- `qa-engineer-agent`: backup/restore helpers now honor non-default compose files via
+  `PROJECT_DIR` + `COMPOSE_FILE` -> `0a3dc812`
+  Evidence: `scripts/ops/postgres_backup.sh`, `scripts/ops/postgres_restore.sh`,
+  `tests/test_deploy_contract_scripts.py`
+- `qa-engineer-agent` + `bug-hunter`: production/staging deploy flow now enforces
+  `postgres -> backup -> app -> migrations -> caddy -> /ready` instead of exposing
+  traffic before migrations -> `0a3dc812`
+  Evidence: `scripts/deploy.sh`, `scripts/deploy_production.sh`,
+  `tests/test_deploy_contract_scripts.py`
+- `qa-engineer-agent` + `bug-hunter`: production runbook no longer points operators
+  at staging-only `deploy.sh` and now documents `deploy_production.sh` with the
+  Postgres-first contract -> `0a3dc812`
+  Evidence: `docs/deploy/PRODUCTION.md`
 
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
+- [x] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -29,9 +29,15 @@ Reason: The quick-fix script now counts duplicate keys safely, resolves the read
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353306 -> de778e4a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353309 -> de778e4a
 
+Disposition: FIXED
+Commit: 1d03adc8
+Evidence: scripts/PRODUCTION_ENV_FIX.md:24, scripts/PRODUCTION_ENV_FIX.md:42, scripts/PRODUCTION_ENV_FIX.md:81
+Reason: The production env runbook now treats `API_KEY_REQUIRED` as a compatibility request-time flag instead of describing it as a startup fail-closed production guard, matching the current runtime contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005374426 -> 1d03adc8
+
 Disposition: NOT-A-BUG
 Evidence: app/AGENTS.md:27-36, docs/deploy/PRODUCTION.md:222, deploy/docker-compose.production.yaml:51, deploy/docker-compose.staging.yaml:49
-Reason: The repository health-endpoint contract explicitly reserves `/health` for liveness and `/ready` for dependency-aware readiness, and it states that orchestrators such as Docker and Caddy should use `/ready` for traffic gating. CodeRabbit's `/health` suggestion conflicts with that source-of-truth contract, while the other actionable points from the same review were already fixed in `de778e4a`.
+Reason: The repository health-endpoint contract explicitly reserves `/health` for liveness and `/ready` for dependency-aware readiness, and it states that orchestrators such as Docker and Caddy should use `/ready` for traffic gating. CodeRabbit's `/health` suggestion conflicts with that source-of-truth contract; the separate `API_KEY_REQUIRED` doc wording comment was fixed in `1d03adc8`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026052294
 
 ## Merge Readiness

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -5,21 +5,7 @@
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-- Internal post-open review lane completed on `28 марта 2026 года`:
-  `qa-engineer-agent (Linnaeus) -> bug-hunter (Faraday)`.
-- `qa-engineer-agent`: backup/restore helpers now honor non-default compose files via
-  `PROJECT_DIR` + `COMPOSE_FILE` -> `0a3dc812`
-  Evidence: `scripts/ops/postgres_backup.sh`, `scripts/ops/postgres_restore.sh`,
-  `tests/test_deploy_contract_scripts.py`
-- `qa-engineer-agent` + `bug-hunter`: production/staging deploy flow now enforces
-  `postgres -> backup -> app -> migrations -> caddy -> /ready` instead of exposing
-  traffic before migrations -> `0a3dc812`
-  Evidence: `scripts/deploy.sh`, `scripts/deploy_production.sh`,
-  `tests/test_deploy_contract_scripts.py`
-- `qa-engineer-agent` + `bug-hunter`: production runbook no longer points operators
-  at staging-only `deploy.sh` and now documents `deploy_production.sh` with the
-  Postgres-first contract -> `0a3dc812`
-  Evidence: `docs/deploy/PRODUCTION.md`
+- No actionable review comments
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)
@@ -27,3 +13,12 @@
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments
 - [ ] Final post-bot wait cycle completed
+
+## Post-open QA Evidence
+- Mandatory post-open lane completed on `28 марта 2026 года`:
+  `qa-engineer-agent (Linnaeus) -> bug-hunter (Faraday)`.
+- Internal post-open fixes shipped in commit `0a3dc812`.
+- Evidence surface:
+  `scripts/ops/postgres_backup.sh`, `scripts/ops/postgres_restore.sh`,
+  `scripts/deploy.sh`, `scripts/deploy_production.sh`,
+  `docs/deploy/PRODUCTION.md`, `tests/test_deploy_contract_scripts.py`.

--- a/docs/review/PR_1271_FIXED_MAPPING.md
+++ b/docs/review/PR_1271_FIXED_MAPPING.md
@@ -5,7 +5,34 @@
 - [x] Fixed in commit mapping completed
 
 ### Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: de778e4a
+Evidence: scripts/deploy_production.sh:7-8, scripts/deploy_production.sh:82-89
+Reason: The production deploy script now restores CI-provided `IMAGE_REF` and `TAG` after sourcing `.env`, so repo-local env files cannot silently override the pinned rollout image selected by CI.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026050229 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005351120 -> de778e4a
+
+Disposition: FIXED
+Commit: de778e4a
+Evidence: scripts/ops/postgres_backup.sh:11-12, scripts/ops/postgres_restore.sh:15-16, tests/test_deploy_contract_scripts.py:15-23, tests/test_deploy_contract_scripts.py:197-229
+Reason: The Postgres helpers now fail fast when `POSTGRES_USER` or `POSTGRES_DB` is missing, and the deploy-contract test now reports missing log steps with explicit assertions instead of a bare `StopIteration`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026047834 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005349493 -> de778e4a
+
+Disposition: FIXED
+Commit: de778e4a
+Evidence: scripts/QUICK_FIX_PRODUCTION.sh:55, scripts/QUICK_FIX_PRODUCTION.sh:165-170, scripts/PRODUCTION_ENV_FIX.md:58-59, docs/deploy/PRODUCTION.md:450-468
+Reason: The quick-fix script now counts duplicate keys safely, resolves the readiness domain from `PRODUCTION_DOMAIN`, handles `jq` availability explicitly, and the production docs now use absolute backup/restore helper paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026053309 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353298 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353303 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353306 -> de778e4a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#discussion_r3005353309 -> de778e4a
+
+Disposition: NOT-A-BUG
+Evidence: app/AGENTS.md:27-36, docs/deploy/PRODUCTION.md:222, deploy/docker-compose.production.yaml:51, deploy/docker-compose.staging.yaml:49
+Reason: The repository health-endpoint contract explicitly reserves `/health` for liveness and `/ready` for dependency-aware readiness, and it states that orchestrators such as Docker and Caddy should use `/ready` for traffic gating. CodeRabbit's `/health` suggestion conflicts with that source-of-truth contract, while the other actionable points from the same review were already fixed in `de778e4a`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1271#pullrequestreview-4026052294
 
 ## Merge Readiness
 - [x] Local hard gate passed (`make verify`)

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -2,203 +2,81 @@
 
 ## 🚨 Проблема
 
-На сервере compose не может распарсить файл из-за отсутствующих переменных:
-- `POSTGRES_PASSWORD` (если в compose есть postgres сервис)
-- `APP_ENV=production`
-- `ENVIRONMENT=production`
+Production deploy contract теперь Postgres-first и fail-closed. Сервер не должен запускаться с:
 
-## ✅ Быстрое решение (Вариант B - dummy env)
+- `DATABASE_URL=sqlite:///...`
+- отсутствующим `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD`
+- dev-friendly флагами вроде `ALLOW_DEV_API_KEY=true`
 
-Если нужно поднять app **прямо сейчас**:
-
-> Если `GIT_SHA` отсутствует или некорректен, сервис вернёт `git_sha` как `"unknown"`.
+## ✅ Канонический production env contract
 
 ```bash
 cd /srv/pulseplate-production
 
-# 1. Очистить дубли переменных и добавить правильные значения
-sed -i '/^APP_ENV=/d;/^ENVIRONMENT=/d;/^POSTGRES_PASSWORD=/d' .env
-printf "\nAPP_ENV=production\nENVIRONMENT=production\nPOSTGRES_PASSWORD=dummy\n" >> .env  # pragma: allowlist secret
-
-# 2. Проверить compose движок (v1 имеет приоритет на серверах)
-if command -v docker-compose >/dev/null 2>&1; then
-  DC="docker-compose"
-  echo "Using: docker-compose (v1)"
-elif docker compose version >/dev/null 2>&1; then
-  DC="docker compose"
-  echo "Using: docker compose (v2)"
-else
-  echo "❌ Neither docker-compose nor docker compose found"
-  exit 1
-fi
-
-# 3. Валидировать compose
-# Note: docker-compose v1 читает .env автоматически, --env-file не нужен
-if [ "$DC" = "docker-compose" ]; then
-  $DC -f docker-compose.production.yaml config >/dev/null
-else
-  $DC --env-file .env -f docker-compose.production.yaml config >/dev/null
-fi
-
-# 4. Подтянуть свежие образы (важно для обновления Caddy!)
-if [ "$DC" = "docker-compose" ]; then
-  $DC -f docker-compose.production.yaml pull
-else
-  $DC --env-file .env -f docker-compose.production.yaml pull
-fi
-
-# 5. Перезапустить все сервисы
-if [ "$DC" = "docker-compose" ]; then
-  $DC -f docker-compose.production.yaml up -d --force-recreate
-else
-  $DC --env-file .env -f docker-compose.production.yaml up -d --force-recreate
-fi
-
-# 6. Проверить статус
-if [ "$DC" = "docker-compose" ]; then
-  $DC -f docker-compose.production.yaml ps
-else
-  $DC --env-file .env -f docker-compose.production.yaml ps
-fi
-
-# 7. Проверить env внутри контейнера
-docker exec pulseplate-production_app_1 python -c "import os; print('APP_ENV:', os.getenv('APP_ENV')); print('ENVIRONMENT:', os.getenv('ENVIRONMENT'))"
-
-# 8. Проверить health
-curl -fsS https://pulseplate.app/health | jq .
+cat >> .env <<'EOF'
+PRODUCTION_DOMAIN=yourdomain.com
+DATABASE_URL=postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>
+POSTGRES_DB=pulseplate
+POSTGRES_USER=pulseplate
+POSTGRES_PASSWORD=replace-with-strong-secret
+SUBSCRIPTION_DB_ENABLED=true
+ALLOW_DEV_API_KEY=false
+API_KEY_REQUIRED=true
+APP_ENV=production
+ENVIRONMENT=production
+EOF
 ```
 
-Пример ответа:
+## 🔧 Автоматизированное решение
 
-```json
-{
-  "status": "ok",
-  "version": "1.0.0",
-  "git_sha": "f4c8b72e593f",  # pragma: allowlist secret
-  "timestamp": "2026-01-01T13:25:47.488673+00:00",
-  "environment": "production"
-}
-```
-
-> Примечание:
-> Значение `git_sha` берётся из env `GIT_SHA` и приводится к короткому виду
-> (12 символов) для удобства визуальной проверки деплоя.
-> Если `GIT_SHA` отсутствует или некорректен, сервис вернёт `git_sha` как `"unknown"`.
-
-## 🔧 Автоматизированное решение (скрипт)
-
-Используйте готовый скрипт:
+Используйте готовый fail-closed helper:
 
 ```bash
 cd /srv/pulseplate-production
 bash scripts/fix_production_env.sh
 ```
 
-Скрипт автоматически:
-1. Находит deploy директорию **и** определяет версию docker compose (v2 или v1)
-2. Выбирает правильную команду **и** валидирует compose
-3. Проверяет, есть ли postgres в compose
-4. Пытается найти существующий `POSTGRES_PASSWORD` из контейнера
-5. Обновляет `.env` файл
-6. Валидирует compose файл
-7. Перезапускает app сервис
+Скрипт:
 
-## 📋 Правильное решение (Вариант A - profiles)
+1. Требует `postgres` service в production compose
+2. Нормализует `APP_ENV`, `ENVIRONMENT`, `SUBSCRIPTION_DB_ENABLED`, `ALLOW_DEV_API_KEY`, `API_KEY_REQUIRED`
+3. Проверяет `DATABASE_URL`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
+4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://`
+5. Валидирует compose и перезапускает сервисы
 
-Если в compose есть postgres, но он пока не нужен, используйте profiles:
-
-### 1. Добавить profile к postgres в `docker-compose.production.yaml`:
-
-```yaml
-services:
-  postgres:
-    profiles: ["postgres"]
-    # ... остальная конфигурация
-```
-
-### 2. Убрать `depends_on: [postgres]` у app (если есть)
-
-### 3. Запуск без postgres:
-
-```bash
-docker compose -f docker-compose.production.yaml up -d
-```
-
-### 4. Когда понадобится postgres:
-
-```bash
-docker compose --profile postgres -f docker-compose.production.yaml up -d
-```
-
-## 🔍 Проверка текущего состояния
-
-### Проверить, есть ли postgres в compose:
+## 🔍 Ручная проверка
 
 ```bash
 cd /srv/pulseplate-production
-grep -E "^\s+(postgres|db):" docker-compose.production.yaml || echo "No postgres service found"
-```
 
-### Проверить зависимости app:
+grep -E '^DATABASE_URL=' .env
+grep -E '^POSTGRES_(DB|USER|PASSWORD)=' .env
 
-```bash
-grep -A 10 "^\s+app:" docker-compose.production.yaml | grep -E "depends_on|DATABASE_URL"
-```
+docker compose --env-file .env -f docker-compose.production.yaml config >/dev/null
+docker compose --env-file .env -f docker-compose.production.yaml up -d --force-recreate
 
-### Проверить существующий postgres контейнер:
-
-```bash
-docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}' | grep -i postgres
-```
-
-Если контейнер есть, можно извлечь пароль:
-
-```bash
-CID="$(docker ps -q --filter "name=postgres" | head -1)"
-docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep POSTGRES_PASSWORD
+curl -fsS https://pulseplate.app/ready | jq .
 ```
 
 ## ⚠️ Важные замечания
 
-1. **`POSTGRES_PASSWORD=dummy`** - это временное решение. Если postgres не используется, лучше использовать profiles (Вариант A).
-
-2. **Проверка compose движка** - всегда используйте проверку версии:
-   ```bash
-   if docker compose version >/dev/null 2>&1; then
-     DC="docker compose"
-   else
-     DC="docker-compose"
-   fi
-   ```
-
-3. **Валидация перед запуском** - всегда проверяйте compose файл:
-   ```bash
-   # Для docker-compose v1 (читает .env автоматически)
-   docker-compose -f docker-compose.production.yaml config >/dev/null
-
-   # Для docker compose v2 (нужен --env-file)
-   docker compose --env-file .env -f docker-compose.production.yaml config >/dev/null
-   ```
-
-4. **Важно: docker-compose v1 vs docker compose v2**:
-   - `docker-compose` (v1) автоматически читает `.env` из текущей директории
-   - `docker compose` (v2) требует `--env-file .env` явно
-   - На большинстве серверов установлен v1, поэтому скрипт проверяет v1 первым
-
-4. **Backup .env** - скрипт автоматически создаёт backup перед изменениями.
+1. `POSTGRES_PASSWORD=dummy` больше не является допустимым production workaround.
+2. `postgres` не должен становиться optional через `profiles` для production.
+3. `DATABASE_URL` должен указывать на `@postgres:5432` внутри compose network.
+4. SQLite разрешён только для local/dev/test fallback, не для canonical production deploy path.
 
 ## 🔐 Security Notes
 
-- `POSTGRES_PASSWORD=dummy` безопасен, если postgres не используется
-- Для реального postgres используйте сильный пароль из GitHub Secrets
-- `.env` файл должен иметь права `600`: `chmod 600 .env`
+- Используйте сильный `POSTGRES_PASSWORD` и храните `.env` с правами `600`.
+- Проверяйте readiness через `/ready` или `/health/db`, а не через liveness-only `/health`.
+- Не удаляйте `depends_on: postgres` из production compose: приложение должно ждать healthy DB.
 
 ## 📝 Чеклист
 
-- [ ] Проверить версию docker compose
-- [ ] Проверить наличие postgres в compose
-- [ ] Добавить необходимые переменные в `.env`
-- [ ] Валидировать compose файл
-- [ ] Перезапустить app сервис
-- [ ] Проверить health endpoint: `curl https://pulseplate.app/health | jq .`
-- [ ] Убедиться, что `environment: "production"`
+- [ ] В `.env` задан Postgres DSN
+- [ ] `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` заданы
+- [ ] `SUBSCRIPTION_DB_ENABLED=true`
+- [ ] `ALLOW_DEV_API_KEY=false`
+- [ ] `API_KEY_REQUIRED=true`
+- [ ] `docker compose ... config` проходит
+- [ ] `curl https://pulseplate.app/ready | jq .` возвращает 200

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -55,7 +55,8 @@ grep -E '^POSTGRES_(DB|USER|PASSWORD)=' .env
 docker compose --env-file .env -f docker-compose.production.yaml config >/dev/null
 docker compose --env-file .env -f docker-compose.production.yaml up -d --force-recreate
 
-curl -fsS https://pulseplate.app/ready | jq .
+PRODUCTION_DOMAIN="$(grep '^PRODUCTION_DOMAIN=' .env | tail -1 | cut -d'=' -f2- | tr -d '\r\n')"
+curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 ```
 
 ## ⚠️ Важные замечания
@@ -79,4 +80,4 @@ curl -fsS https://pulseplate.app/ready | jq .
 - [ ] `ALLOW_DEV_API_KEY=false`
 - [ ] `API_KEY_REQUIRED=true`
 - [ ] `docker compose ... config` проходит
-- [ ] `curl https://pulseplate.app/ready | jq .` возвращает 200
+- [ ] `curl "https://${PRODUCTION_DOMAIN}/ready" | jq .` возвращает 200

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -21,7 +21,7 @@ POSTGRES_USER=pulseplate
 POSTGRES_PASSWORD=replace-with-strong-secret
 SUBSCRIPTION_DB_ENABLED=true
 ALLOW_DEV_API_KEY=false
-API_KEY_REQUIRED=true
+API_KEY_REQUIRED=true  # compatibility flag for request-time API-key enforcement
 APP_ENV=production
 ENVIRONMENT=production
 EOF
@@ -39,7 +39,7 @@ bash scripts/fix_production_env.sh
 Скрипт:
 
 1. Требует `postgres` service в production compose
-2. Нормализует `APP_ENV`, `ENVIRONMENT`, `SUBSCRIPTION_DB_ENABLED`, `ALLOW_DEV_API_KEY`, `API_KEY_REQUIRED`
+2. Нормализует `APP_ENV`, `ENVIRONMENT`, `SUBSCRIPTION_DB_ENABLED`, `ALLOW_DEV_API_KEY` и совместимый `API_KEY_REQUIRED`
 3. Проверяет `DATABASE_URL`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
 4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://`
 5. Валидирует compose и перезапускает сервисы
@@ -78,6 +78,6 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 - [ ] `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` заданы
 - [ ] `SUBSCRIPTION_DB_ENABLED=true`
 - [ ] `ALLOW_DEV_API_KEY=false`
-- [ ] `API_KEY_REQUIRED=true`
+- [ ] При необходимости для совместимости задан `API_KEY_REQUIRED=true`
 - [ ] `docker compose ... config` проходит
 - [ ] `curl "https://${PRODUCTION_DOMAIN}/ready" | jq .` возвращает 200

--- a/scripts/QUICK_FIX_PRODUCTION.sh
+++ b/scripts/QUICK_FIX_PRODUCTION.sh
@@ -52,7 +52,7 @@ echo ""
 
 # Check for duplicates
 echo "=== Step 1: Check for duplicate env vars ==="
-DUPLICATES=$(grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|DATABASE_URL)=' .env 2>/dev/null | wc -l || echo "0")
+DUPLICATES=$({ grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|DATABASE_URL)=' .env 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
 if [ "$DUPLICATES" -gt 6 ]; then
     echo "⚠️  Found potential duplicates in .env"
     grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|DATABASE_URL)=' .env || true
@@ -162,9 +162,13 @@ echo ""
 
 # Check health
 echo "=== Step 8: Health check ==="
-PUBLIC_DOMAIN=$(grep PRODUCTION_DOMAIN .env 2>/dev/null | cut -d'=' -f2 | tr -d '\n\r' || echo "pulseplate.app")
+PUBLIC_DOMAIN=$(grep '^PRODUCTION_DOMAIN=' .env 2>/dev/null | tail -1 | cut -d'=' -f2- | tr -d '\n\r' || echo "pulseplate.app")
 echo "Checking: https://${PUBLIC_DOMAIN}/ready"
-curl -fsS "https://${PUBLIC_DOMAIN}/ready" | jq . 2>/dev/null || curl -fsS "https://${PUBLIC_DOMAIN}/ready" || echo "⚠️  Health check failed"
+if command -v jq >/dev/null 2>&1; then
+    curl -fsS "https://${PUBLIC_DOMAIN}/ready" | jq . 2>/dev/null || echo "⚠️  Health check failed"
+else
+    curl -fsS "https://${PUBLIC_DOMAIN}/ready" || echo "⚠️  Health check failed"
+fi
 echo ""
 
 echo "=========================================="

--- a/scripts/QUICK_FIX_PRODUCTION.sh
+++ b/scripts/QUICK_FIX_PRODUCTION.sh
@@ -52,10 +52,10 @@ echo ""
 
 # Check for duplicates
 echo "=== Step 1: Check for duplicate env vars ==="
-DUPLICATES=$(grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_PASSWORD)=' .env 2>/dev/null | wc -l || echo "0")
-if [ "$DUPLICATES" -gt 3 ]; then
+DUPLICATES=$(grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|DATABASE_URL)=' .env 2>/dev/null | wc -l || echo "0")
+if [ "$DUPLICATES" -gt 6 ]; then
     echo "⚠️  Found potential duplicates in .env"
-    grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_PASSWORD)=' .env || true
+    grep -nE '^(APP_ENV|ENVIRONMENT|POSTGRES_DB|POSTGRES_USER|POSTGRES_PASSWORD|DATABASE_URL)=' .env || true
 fi
 echo ""
 
@@ -67,10 +67,34 @@ fi
 
 # Clean and set env vars
 echo "=== Step 2: Clean and set environment variables ==="
-sed -i '/^APP_ENV=/d;/^ENVIRONMENT=/d;/^POSTGRES_PASSWORD=/d' .env 2>/dev/null || true
-printf "\nAPP_ENV=production\nENVIRONMENT=production\nPOSTGRES_PASSWORD=dummy\n" >> .env  # pragma: allowlist secret
-echo "✅ Set: APP_ENV=production, ENVIRONMENT=production, POSTGRES_PASSWORD=dummy"
+sed -i '/^APP_ENV=/d;/^ENVIRONMENT=/d;/^SUBSCRIPTION_DB_ENABLED=/d;/^ALLOW_DEV_API_KEY=/d;/^API_KEY_REQUIRED=/d' .env 2>/dev/null || true
+{
+    echo ""
+    echo "APP_ENV=production"
+    echo "ENVIRONMENT=production"
+    echo "SUBSCRIPTION_DB_ENABLED=true"
+    echo "ALLOW_DEV_API_KEY=false"
+    echo "API_KEY_REQUIRED=true"
+} >> .env
+echo "✅ Set: APP_ENV=production, ENVIRONMENT=production, SUBSCRIPTION_DB_ENABLED=true, ALLOW_DEV_API_KEY=false, API_KEY_REQUIRED=true"
 echo ""
+
+echo "=== Step 2.1: Validate required Postgres env ==="
+for key in DATABASE_URL POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD; do
+    if ! grep -qE "^${key}=" .env 2>/dev/null; then
+        echo "❌ Missing required env var: ${key}"
+        exit 1
+    fi
+done
+
+DATABASE_URL_VALUE="$(grep '^DATABASE_URL=' .env | tail -1 | cut -d'=' -f2- | tr -d '\r\n')"
+case "$DATABASE_URL_VALUE" in
+    postgresql+psycopg://*) echo "✅ DATABASE_URL uses Postgres DSN" ;;
+    *)
+        echo "❌ DATABASE_URL must use canonical Postgres DSN (postgresql+psycopg://...)"
+        exit 1
+        ;;
+esac
 
 # Validate compose
 echo "=== Step 3: Validate compose file ==="
@@ -139,8 +163,8 @@ echo ""
 # Check health
 echo "=== Step 8: Health check ==="
 PUBLIC_DOMAIN=$(grep PRODUCTION_DOMAIN .env 2>/dev/null | cut -d'=' -f2 | tr -d '\n\r' || echo "pulseplate.app")
-echo "Checking: https://${PUBLIC_DOMAIN}/health"
-curl -fsS "https://${PUBLIC_DOMAIN}/health" | jq . 2>/dev/null || curl -fsS "https://${PUBLIC_DOMAIN}/health" || echo "⚠️  Health check failed"
+echo "Checking: https://${PUBLIC_DOMAIN}/ready"
+curl -fsS "https://${PUBLIC_DOMAIN}/ready" | jq . 2>/dev/null || curl -fsS "https://${PUBLIC_DOMAIN}/ready" || echo "⚠️  Health check failed"
 echo ""
 
 echo "=========================================="
@@ -151,4 +175,4 @@ echo "Expected results:"
 echo "  - Caddy image: caddy:2.10.2 (or latest)"
 echo "  - APP_ENV: production"
 echo "  - ENVIRONMENT: production"
-echo "  - Health endpoint: environment='production'"
+echo "  - Readiness endpoint: environment='production'"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,7 @@ GHCR_TOKEN=${GHCR_TOKEN:?"GHCR_TOKEN not set"}
 GHCR_USER=${GHCR_USER:?"GHCR_USER not set"}
 POSTGRES_USER=${POSTGRES_USER:?"POSTGRES_USER not set"}
 POSTGRES_DB=${POSTGRES_DB:?"POSTGRES_DB not set"}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?"POSTGRES_PASSWORD not set"}
 DATABASE_URL=${DATABASE_URL:?"DATABASE_URL not set"}
 
 # Healthcheck configuration
@@ -82,11 +83,11 @@ if [ ! -x "${BACKUP_HELPER}" ]; then
 fi
 
 echo "Creating Postgres backup before migrations..."
-PROJECT_DIR="${PROJECT_DIR}" BACKUP_DIR="${BACKUP_DIR}" POSTGRES_USER="${POSTGRES_USER}" POSTGRES_DB="${POSTGRES_DB}" \
+PROJECT_DIR="${PROJECT_DIR}" BACKUP_DIR="${BACKUP_DIR}" COMPOSE_FILE="${COMPOSE_FILE}" POSTGRES_USER="${POSTGRES_USER}" POSTGRES_DB="${POSTGRES_DB}" \
   "${BACKUP_HELPER}"
 
-echo "Starting app and caddy..."
-"${COMPOSE[@]}" up -d app caddy
+echo "Starting app before exposing traffic..."
+"${COMPOSE[@]}" up -d app
 
 echo "[4/4] Run migrations"
 echo "Waiting for app readiness..."
@@ -118,6 +119,9 @@ else
   echo "Check container logs with: docker logs $APP_CONTAINER" >&2
   exit $migration_exit_code
 fi
+
+echo "Starting caddy after successful migrations..."
+"${COMPOSE[@]}" up -d caddy
 
 echo "[post] Smoke check with retry"
 # Healthcheck using --resolve to avoid DNS dependency (works even if DNS is temporarily unavailable)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,10 +2,34 @@
 # RU: Атомарный деплой на staging. Требует: docker, docker-compose, доступ к GHCR.
 set -euo pipefail
 
+PROJECT_DIR="/srv/pulseplate-staging"
+ENV_FILE="${PROJECT_DIR}/.env"
+COMPOSE_FILE="${PROJECT_DIR}/docker-compose.staging.yaml"
+BACKUP_DIR="${PROJECT_DIR}/backups"
+BACKUP_HELPER="${PROJECT_DIR}/scripts/ops/postgres_backup.sh"
+COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}")
+
+# RU: Загружаем server-local env до валидации, чтобы backup и migrations видели
+# обязательные Postgres переменные.
+# EN: Load server-local env before validation so backup and migrations see the
+# required Postgres variables.
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "❌ Missing staging env file: ${ENV_FILE}"
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "${ENV_FILE}"
+set +a
+
 # Validate required environment variables
 STAGING_DOMAIN=${STAGING_DOMAIN:?"STAGING_DOMAIN not set"}
 GHCR_TOKEN=${GHCR_TOKEN:?"GHCR_TOKEN not set"}
 GHCR_USER=${GHCR_USER:?"GHCR_USER not set"}
+POSTGRES_USER=${POSTGRES_USER:?"POSTGRES_USER not set"}
+POSTGRES_DB=${POSTGRES_DB:?"POSTGRES_DB not set"}
+DATABASE_URL=${DATABASE_URL:?"DATABASE_URL not set"}
 
 # Healthcheck configuration
 HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-30}"
@@ -13,7 +37,6 @@ HEALTH_SLEEP_S="${HEALTH_SLEEP_S:-2}"
 HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
 
 IMG_REF="${1:-latest}"         # тег/диджест образа
-COMPOSE="docker compose -f /srv/pulseplate-staging/docker-compose.staging.yaml"
 
 # Warn if using latest tag (should be specific commit SHA in production)
 if [ "$IMG_REF" = "latest" ]; then
@@ -26,63 +49,53 @@ echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
 echo "[2/4] Pull image $IMG_REF"
 export TAG="$IMG_REF"
-$COMPOSE pull app
+"${COMPOSE[@]}" pull app
 
 echo "[3/4] Start stack and DB backup"
-# Start the stack first to ensure network exists
-$COMPOSE up -d app caddy
+# Start Postgres first to ensure backup and app startup use a healthy DB.
+echo "Starting postgres first..."
+"${COMPOSE[@]}" up -d postgres
 
-# Wait for app container to be ready with active checks
-echo "Waiting for app container to be ready..."
+echo "Waiting for postgres health..."
 max_wait=60
 wait_count=0
 while [ $wait_count -lt $max_wait ]; do
-  if $COMPOSE ps app | grep -q "Up"; then
-    echo "App container is running"
+  POSTGRES_CONTAINER=$("${COMPOSE[@]}" ps -q postgres | tr -d '\n\r ')
+  POSTGRES_HEALTH="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${POSTGRES_CONTAINER:-missing}" 2>/dev/null || true)"
+  if [ -n "${POSTGRES_CONTAINER:-}" ] && [ "$POSTGRES_HEALTH" = "healthy" ]; then
+    echo "Postgres is healthy"
     break
   fi
   wait_count=$((wait_count + 1))
-  echo "Waiting for app container... ($wait_count/$max_wait)"
+  echo "Waiting for postgres... ($wait_count/$max_wait)"
   sleep 1
 done
 
 if [ $wait_count -eq $max_wait ]; then
-  echo "❌ App container failed to start within $max_wait seconds"
+  echo "❌ Postgres failed to become healthy within $max_wait seconds"
   exit 1
 fi
 
-# Get the actual container name dynamically (trim whitespace)
-APP_CONTAINER=$($COMPOSE ps -q app | tr -d '\n\r ')
-if [ -z "$APP_CONTAINER" ]; then
-  echo "❌ Failed to find app container"
+if [ ! -x "${BACKUP_HELPER}" ]; then
+  echo "❌ Missing Postgres backup helper: ${BACKUP_HELPER}"
   exit 1
 fi
-echo "Using app container: $APP_CONTAINER"
 
-# Create database backup if it exists in the running container
-if docker exec "$APP_CONTAINER" test -f /app/cache/app.db 2>/dev/null; then
-  timestamp=$(date +"%Y%m%d_%H%M%S")
-  backup_dir="/srv/pulseplate-staging/backups"
-  mkdir -p "$backup_dir"
-  backup_path="$backup_dir/app.db.backup-$timestamp"
-  echo "Creating database backup: $backup_path"
-  docker cp "$APP_CONTAINER:/app/cache/app.db" "$backup_path"
+echo "Creating Postgres backup before migrations..."
+PROJECT_DIR="${PROJECT_DIR}" BACKUP_DIR="${BACKUP_DIR}" POSTGRES_USER="${POSTGRES_USER}" POSTGRES_DB="${POSTGRES_DB}" \
+  "${BACKUP_HELPER}"
 
-  # Remove old backups (keep last 5)
-  ls -t "$backup_dir"/app.db.backup-* 2>/dev/null | tail -n +6 | xargs -r rm -f
-  echo "Database backup completed"
-else
-  echo "No existing database found, skipping backup"
-fi
+echo "Starting app and caddy..."
+"${COMPOSE[@]}" up -d app caddy
 
 echo "[4/4] Run migrations"
-# Wait for app to be ready to accept connections
-echo "Waiting for app to be ready for migrations..."
+echo "Waiting for app readiness..."
 max_wait=30
 wait_count=0
 while [ $wait_count -lt $max_wait ]; do
-  if docker exec "$APP_CONTAINER" python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()" 2>/dev/null; then
-    echo "App is ready for migrations"
+  APP_CONTAINER=$("${COMPOSE[@]}" ps -q app | tr -d '\n\r ')
+  if [ -n "${APP_CONTAINER:-}" ] && docker exec "$APP_CONTAINER" python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()" 2>/dev/null; then
+    echo "App is ready"
     break
   fi
   wait_count=$((wait_count + 1))
@@ -110,13 +123,13 @@ echo "[post] Smoke check with retry"
 # Healthcheck using --resolve to avoid DNS dependency (works even if DNS is temporarily unavailable)
 # This checks locally via 127.0.0.1 but uses the domain for Host/SNI headers (TLS works correctly)
 DOMAIN="${STAGING_DOMAIN}"
-HEALTH_URL="https://${DOMAIN}/health"
+HEALTH_URL="https://${DOMAIN}/ready"
 attempt=0
 
 # Quick non-blocking HTTP smoke check (diagnostic only; expected 308 -> HTTPS redirect)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
-  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
+  "http://${DOMAIN}/ready" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
 
 # Main healthcheck on HTTPS (does not depend on external DNS)
 while [ $attempt -lt "$HEALTH_MAX_ATTEMPTS" ]; do

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 : "${IMAGE_REF:?IMAGE_REF is required (ghcr.io/<image>@sha256:...)}"
 : "${TAG:?TAG is required (prod-vX.Y.Z)}"
 
-export IMAGE_REF TAG
+DEPLOY_IMAGE_REF="$IMAGE_REF"
+DEPLOY_TAG="$TAG"
 
 # Healthcheck configuration
 HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-12}"
@@ -82,6 +83,10 @@ set -a
 # shellcheck disable=SC1090
 . "$ENV_FILE"
 set +a
+
+IMAGE_REF="$DEPLOY_IMAGE_REF"
+TAG="$DEPLOY_TAG"
+export IMAGE_REF TAG
 
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
 : "${POSTGRES_DB:?POSTGRES_DB is required}"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 : "${IMAGE_REF:?IMAGE_REF is required (ghcr.io/<image>@sha256:...)}"
 : "${TAG:?TAG is required (prod-vX.Y.Z)}"
-: "${PRODUCTION_DOMAIN:?PRODUCTION_DOMAIN is required}"
 
-export IMAGE_REF TAG PRODUCTION_DOMAIN
+export IMAGE_REF TAG
 
 # Healthcheck configuration
 HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-12}"
@@ -14,6 +13,7 @@ HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
 
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 DEPLOY_DIR="${DEPLOY_DIR:-}"
+ENV_FILE="${ENV_FILE:-}"
 
 resolve_deploy_dir() {
   if [ -n "$DEPLOY_DIR" ]; then
@@ -64,6 +64,36 @@ elif [ -f "compose.yaml" ]; then
   compose_args=(-f "compose.yaml")
 fi
 
+HELPER_COMPOSE_FILE="${COMPOSE_FILE:-}"
+if [ -z "$HELPER_COMPOSE_FILE" ] && [ ${#compose_args[@]} -ge 2 ]; then
+  HELPER_COMPOSE_FILE="${compose_args[1]}"
+fi
+
+if [ -z "$ENV_FILE" ]; then
+  ENV_FILE="$DEPLOY_DIR/.env"
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "❌ Missing production env file: $ENV_FILE" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+: "${DATABASE_URL:?DATABASE_URL is required}"
+: "${PRODUCTION_DOMAIN:?PRODUCTION_DOMAIN is required}"
+
+export PRODUCTION_DOMAIN
+
+BACKUP_DIR="${BACKUP_DIR:-$DEPLOY_DIR/backups}"
+BACKUP_HELPER="${BACKUP_HELPER:-$DEPLOY_DIR/scripts/ops/postgres_backup.sh}"
+
 echo "Deploy dir: $DEPLOY_DIR"
 if [ ${#compose_args[@]} -gt 0 ]; then
   echo "Compose file: ${compose_args[*]}"
@@ -72,28 +102,108 @@ else
 fi
 echo "TAG: $TAG"
 echo "IMAGE_REF: $IMAGE_REF"
+echo "ENV_FILE: $ENV_FILE"
 
 dc() {
+  local base=(docker compose --env-file "$ENV_FILE")
   if [ ${#compose_args[@]} -gt 0 ]; then
-    docker compose "${compose_args[@]}" "$@"
-  else
-    docker compose "$@"
+    base+=("${compose_args[@]}")
   fi
+  "${base[@]}" "$@"
 }
 
-dc pull
-dc up -d --remove-orphans
+wait_for_service_health() {
+  local service_name="$1"
+  local max_wait="${2:-60}"
+  local wait_count=0
+
+  while [ "$wait_count" -lt "$max_wait" ]; do
+    local container_id
+    local health_status
+    container_id="$(dc ps -q "$service_name" | tr -d '\n\r ')"
+    health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container_id:-missing}" 2>/dev/null || true)"
+    if [ -n "${container_id:-}" ] && [ "$health_status" = "healthy" ]; then
+      echo "$service_name is healthy"
+      return 0
+    fi
+    wait_count=$((wait_count + 1))
+    echo "Waiting for $service_name health... ($wait_count/$max_wait)"
+    sleep 1
+  done
+
+  echo "❌ $service_name failed to become healthy within $max_wait seconds" >&2
+  return 1
+}
+
+wait_for_app_ready() {
+  local max_wait="${1:-30}"
+  local wait_count=0
+
+  while [ "$wait_count" -lt "$max_wait" ]; do
+    local app_container
+    app_container="$(dc ps -q app | tr -d '\n\r ')"
+    if [ -n "${app_container:-}" ] && docker exec "$app_container" python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready').read()" 2>/dev/null; then
+      echo "app is ready"
+      return 0
+    fi
+    wait_count=$((wait_count + 1))
+    echo "Waiting for app readiness... ($wait_count/$max_wait)"
+    sleep 1
+  done
+
+  echo "❌ App failed to become ready within $max_wait seconds" >&2
+  return 1
+}
+
+if [ ! -x "$BACKUP_HELPER" ]; then
+  echo "❌ Missing Postgres backup helper: $BACKUP_HELPER" >&2
+  exit 1
+fi
+
+echo "Pulling production app image..."
+dc pull app
+
+echo "Starting postgres first..."
+dc up -d --remove-orphans postgres
+wait_for_service_health postgres 60
+
+echo "Creating Postgres backup before migrations..."
+PROJECT_DIR="$DEPLOY_DIR" BACKUP_DIR="$BACKUP_DIR" COMPOSE_FILE="$HELPER_COMPOSE_FILE" POSTGRES_USER="$POSTGRES_USER" POSTGRES_DB="$POSTGRES_DB" \
+  "$BACKUP_HELPER"
+
+echo "Starting app before exposing traffic..."
+dc up -d --remove-orphans app
+wait_for_app_ready 30
+
+APP_CONTAINER="$(dc ps -q app | tr -d '\n\r ')"
+if [ -z "${APP_CONTAINER:-}" ]; then
+  echo "❌ Unable to resolve running app container for migrations" >&2
+  exit 1
+fi
+
+echo "Running database migrations in container: $APP_CONTAINER"
+if docker exec "$APP_CONTAINER" alembic upgrade head; then
+  echo "✅ Database migrations completed successfully in container: $APP_CONTAINER"
+else
+  migration_exit_code=$?
+  echo "❌ Database migrations failed in container: $APP_CONTAINER (exit code: $migration_exit_code)" >&2
+  echo "Check container logs with: docker logs $APP_CONTAINER" >&2
+  exit "$migration_exit_code"
+fi
+
+echo "Starting caddy after successful migrations..."
+dc up -d --remove-orphans caddy
 
 # Healthcheck using --resolve to avoid DNS dependency (works even if DNS is temporarily unavailable)
 # This checks locally via 127.0.0.1 but uses the domain for Host/SNI headers (TLS works correctly)
 DOMAIN="${PRODUCTION_DOMAIN}"
-HEALTH_URL="https://${DOMAIN}/health"
+HEALTH_URL="https://${DOMAIN}/ready"
 attempt=1
 
 # Quick non-blocking HTTP smoke check (diagnostic only; expected 308 -> HTTPS redirect)
 echo "Smoke check HTTP..."
 curl -sS -o /dev/null -w "HTTP:%{http_code}\n" \
-  "http://${DOMAIN}/health" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
+  "http://${DOMAIN}/ready" --resolve "${DOMAIN}:80:127.0.0.1" --max-time "${HEALTH_CURL_MAX_TIME_S}" || true
 
 # Main healthcheck on HTTPS (does not depend on external DNS)
 echo "Healthcheck HTTPS (attempt ${attempt}/${HEALTH_MAX_ATTEMPTS})..."

--- a/scripts/fix_production_env.sh
+++ b/scripts/fix_production_env.sh
@@ -51,11 +51,12 @@ fi
 echo "📍 Compose file: $COMPOSE_FILE"
 echo ""
 
-# Check if postgres service exists in compose file
-HAS_POSTGRES=false
-if grep -qE "^\s+postgres:" "$COMPOSE_FILE" || grep -qE "^\s+db:" "$COMPOSE_FILE"; then
-    HAS_POSTGRES=true
-    echo "⚠️  Found postgres/db service in compose file"
+# Production deploy contract is Postgres-first and fail-closed.
+if grep -qE "^\s+postgres:" "$COMPOSE_FILE"; then
+    echo "✅ Found postgres service in compose file"
+else
+    echo "❌ Production compose must define a postgres service"
+    exit 1
 fi
 
 # Check if .env exists
@@ -64,31 +65,7 @@ if [ ! -f ".env" ]; then
     touch .env
 fi
 
-echo "=== Step 1: Check current POSTGRES_PASSWORD ==="
-if [ "$HAS_POSTGRES" = true ]; then
-    # Try to get password from existing postgres container
-    POSTGRES_CONTAINER=$(docker ps -q --filter "name=postgres" --filter "name=db" | head -1)
-    if [ -n "$POSTGRES_CONTAINER" ]; then
-        echo "✅ Found existing postgres container: $POSTGRES_CONTAINER"
-        EXISTING_PASSWORD=$(docker inspect "$POSTGRES_CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep -E '^POSTGRES_PASSWORD=' | cut -d'=' -f2- || true)
-        if [ -n "$EXISTING_PASSWORD" ]; then
-            echo "✅ Found existing POSTGRES_PASSWORD in container"
-            POSTGRES_PASSWORD_VALUE="$EXISTING_PASSWORD"
-        else
-            echo "⚠️  POSTGRES_PASSWORD not found in container, will use dummy"
-            POSTGRES_PASSWORD_VALUE="dummy"  # pragma: allowlist secret
-        fi
-    else
-        echo "⚠️  No existing postgres container found, will use dummy password"
-        POSTGRES_PASSWORD_VALUE="dummy"  # pragma: allowlist secret
-    fi
-else
-    echo "ℹ️  No postgres service in compose file, skipping POSTGRES_PASSWORD"
-    POSTGRES_PASSWORD_VALUE=""
-fi
-
-echo ""
-echo "=== Step 2: Update .env file ==="
+echo "=== Step 1: Update .env file ==="
 
 # Backup .env
 if [ -f ".env" ]; then
@@ -115,13 +92,39 @@ set_env_var() {
     echo "   Set: ${key}=${value}"
 }
 
-# Set required variables
-if [ "$HAS_POSTGRES" = true ] && [ -n "$POSTGRES_PASSWORD_VALUE" ]; then
-    set_env_var "POSTGRES_PASSWORD" "$POSTGRES_PASSWORD_VALUE"
-fi
-
 set_env_var "APP_ENV" "production"
 set_env_var "ENVIRONMENT" "production"
+set_env_var "SUBSCRIPTION_DB_ENABLED" "true"
+set_env_var "ALLOW_DEV_API_KEY" "false"
+set_env_var "API_KEY_REQUIRED" "true"
+
+echo ""
+echo "=== Step 2: Validate required Postgres contract ==="
+
+require_env_var() {
+    local key="$1"
+    local value=""
+    value="$(grep -E "^${key}=" .env 2>/dev/null | tail -1 | cut -d'=' -f2- | tr -d '\r\n' || true)"
+    if [ -z "$value" ]; then
+        echo "❌ Missing required env var in .env: ${key}"
+        exit 1
+    fi
+    echo "✅ Found ${key}"
+}
+
+require_env_var "DATABASE_URL"
+require_env_var "POSTGRES_DB"
+require_env_var "POSTGRES_USER"
+require_env_var "POSTGRES_PASSWORD"
+
+DATABASE_URL_VALUE="$(grep -E '^DATABASE_URL=' .env | tail -1 | cut -d'=' -f2- | tr -d '\r\n')"
+case "$DATABASE_URL_VALUE" in
+    postgresql+psycopg://*) echo "✅ DATABASE_URL uses Postgres DSN" ;;
+    *)
+        echo "❌ DATABASE_URL must use canonical Postgres DSN (postgresql+psycopg://...)"
+        exit 1
+        ;;
+esac
 
 # Check for other required vars from compose
 if grep -qE '\$\{PRODUCTION_DOMAIN' "$COMPOSE_FILE"; then
@@ -204,12 +207,12 @@ echo "Fix Complete"
 echo "=========================================="
 echo ""
 echo "Next steps:"
-echo "1. Check health endpoint:"
+echo "1. Check readiness endpoint:"
 PROD_DOMAIN="$(grep -E '^PRODUCTION_DOMAIN=' .env 2>/dev/null | head -1 | cut -d'=' -f2- | tr -d '\r\n' || true)"
 if [ -z "${PROD_DOMAIN}" ]; then
     PROD_DOMAIN="YOUR_DOMAIN"
 fi
-echo "   curl -fsS https://${PROD_DOMAIN}/health | jq ."
+echo "   curl -fsS https://${PROD_DOMAIN}/ready | jq ."
 if [ "${PROD_DOMAIN}" = "YOUR_DOMAIN" ]; then
     echo "   (If it prints YOUR_DOMAIN — set PRODUCTION_DOMAIN in .env)"
 fi

--- a/scripts/ops/postgres_backup.sh
+++ b/scripts/ops/postgres_backup.sh
@@ -8,6 +8,9 @@ BACKUP_DIR="${BACKUP_DIR:-/srv/pulseplate-production/backups}"
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+
 mkdir -p "${BACKUP_DIR}"
 
 if [ -n "${COMPOSE_FILE}" ] && [ "${COMPOSE_FILE#/}" = "${COMPOSE_FILE}" ]; then

--- a/scripts/ops/postgres_backup.sh
+++ b/scripts/ops/postgres_backup.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
-# Backup Postgres database for PulsePlate production.
-# Usage: POSTGRES_USER=... POSTGRES_DB=... [PROJECT_DIR=...] [BACKUP_DIR=...] scripts/ops/postgres_backup.sh
+# Backup Postgres database for PulsePlate production/staging.
+# Usage: POSTGRES_USER=... POSTGRES_DB=... [PROJECT_DIR=...] [BACKUP_DIR=...] [COMPOSE_FILE=...] scripts/ops/postgres_backup.sh
 set -euo pipefail
 
 PROJECT_DIR="${PROJECT_DIR:-/srv/pulseplate-production}"
 BACKUP_DIR="${BACKUP_DIR:-/srv/pulseplate-production/backups}"
+COMPOSE_FILE="${COMPOSE_FILE:-}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 
 mkdir -p "${BACKUP_DIR}"
 
-cd "${PROJECT_DIR}"
+if [ -n "${COMPOSE_FILE}" ] && [ "${COMPOSE_FILE#/}" = "${COMPOSE_FILE}" ]; then
+  COMPOSE_FILE="${PROJECT_DIR}/${COMPOSE_FILE}"
+fi
+
+compose_exec() {
+  local compose_cmd=(docker compose --project-directory "${PROJECT_DIR}")
+  if [ -n "${COMPOSE_FILE}" ]; then
+    compose_cmd+=(-f "${COMPOSE_FILE}")
+  fi
+  "${compose_cmd[@]}" exec -T postgres "$@"
+}
 
 OUTPUT="${BACKUP_DIR}/pulseplate_${TIMESTAMP}.dump"
-docker compose exec -T postgres \
+compose_exec \
   pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -Fc \
   > "${OUTPUT}" || { rm -f "${OUTPUT}"; exit 1; }
 

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -12,6 +12,9 @@ BACKUP_FILE="$1"
 PROJECT_DIR="${PROJECT_DIR:-/srv/pulseplate-production}"
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+
 if [ ! -f "${BACKUP_FILE}" ]; then
   echo "Backup file not found: ${BACKUP_FILE}"
   exit 1

--- a/scripts/ops/postgres_restore.sh
+++ b/scripts/ops/postgres_restore.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Restore Postgres database from backup.
-# Usage: POSTGRES_USER=... POSTGRES_DB=... scripts/ops/postgres_restore.sh path/to/backup.dump
+# Usage: POSTGRES_USER=... POSTGRES_DB=... [PROJECT_DIR=...] [COMPOSE_FILE=...] scripts/ops/postgres_restore.sh path/to/backup.dump
 set -euo pipefail
 
 if [ "${#}" -ne 1 ]; then
@@ -10,6 +10,7 @@ fi
 
 BACKUP_FILE="$1"
 PROJECT_DIR="${PROJECT_DIR:-/srv/pulseplate-production}"
+COMPOSE_FILE="${COMPOSE_FILE:-}"
 
 if [ ! -f "${BACKUP_FILE}" ]; then
   echo "Backup file not found: ${BACKUP_FILE}"
@@ -21,12 +22,22 @@ if [ "${BACKUP_FILE#/}" = "${BACKUP_FILE}" ]; then
   BACKUP_FILE="$(cd "$(dirname "${BACKUP_FILE}")" && pwd)/$(basename "${BACKUP_FILE}")"
 fi
 
-cd "${PROJECT_DIR}"
+if [ -n "${COMPOSE_FILE}" ] && [ "${COMPOSE_FILE#/}" = "${COMPOSE_FILE}" ]; then
+  COMPOSE_FILE="${PROJECT_DIR}/${COMPOSE_FILE}"
+fi
 
-docker compose exec -T postgres \
+compose_exec() {
+  local compose_cmd=(docker compose --project-directory "${PROJECT_DIR}")
+  if [ -n "${COMPOSE_FILE}" ]; then
+    compose_cmd+=(-f "${COMPOSE_FILE}")
+  fi
+  "${compose_cmd[@]}" exec -T postgres "$@"
+}
+
+compose_exec \
   psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
-docker compose exec -T postgres \
+compose_exec \
   pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists \
   < "${BACKUP_FILE}"
 

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -1,0 +1,218 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_postgres_backup_helper_passes_project_dir_and_compose_file(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    bin_dir = tmp_path / "bin"
+    backup_dir = tmp_path / "backups"
+    log_file = tmp_path / "docker.log"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    backup_dir.mkdir()
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "{log_file}"
+cat <<'EOF'
+FAKE_BACKUP
+EOF
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PROJECT_DIR"] = str(project_dir)
+    env["BACKUP_DIR"] = str(backup_dir)
+    env["COMPOSE_FILE"] = "docker-compose.staging.yaml"
+    env["POSTGRES_USER"] = "pulseplate"
+    env["POSTGRES_DB"] = "pulseplate"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/ops/postgres_backup.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "Backup created:" in completed.stdout
+    docker_call = log_file.read_text(encoding="utf-8")
+    assert f"compose --project-directory {project_dir}" in docker_call
+    assert f"-f {project_dir / 'docker-compose.staging.yaml'}" in docker_call
+    assert "exec -T postgres pg_dump -U pulseplate -d pulseplate -Fc" in docker_call
+    backup_files = list(backup_dir.glob("pulseplate_*.dump"))
+    assert len(backup_files) == 1
+    assert backup_files[0].read_text(encoding="utf-8").strip() == "FAKE_BACKUP"
+
+
+def test_postgres_restore_helper_passes_project_dir_and_compose_file(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "docker.log"
+    backup_file = tmp_path / "pulseplate.dump"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    backup_file.write_text("FAKE_RESTORE", encoding="utf-8")
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "{log_file}"
+if printf '%s\\n' "$*" | grep -q 'pg_restore'; then
+  cat >/dev/null
+fi
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PROJECT_DIR"] = str(project_dir)
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["POSTGRES_USER"] = "pulseplate"
+    env["POSTGRES_DB"] = "pulseplate"
+
+    completed = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/ops/postgres_restore.sh"),
+            str(backup_file),
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "Restore completed from:" in completed.stdout
+    docker_calls = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(docker_calls) == 2
+    assert all(f"compose --project-directory {project_dir}" in call for call in docker_calls)
+    assert all(
+        f"-f {project_dir / 'docker-compose.production.yaml'}" in call for call in docker_calls
+    )
+    assert "DROP SCHEMA public CASCADE; CREATE SCHEMA public;" in docker_calls[0]
+    assert (
+        "exec -T postgres pg_restore -U pulseplate -d pulseplate --clean --if-exists"
+        in docker_calls[1]
+    )
+
+
+def test_deploy_production_runs_migrations_before_caddy_and_external_ready(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    scripts_dir = project_dir / "scripts" / "ops"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    scripts_dir.mkdir(parents=True)
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "\n".join(
+            [
+                "POSTGRES_USER=pulseplate",
+                "POSTGRES_DB=pulseplate",
+                "POSTGRES_PASSWORD=secret",
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    helper_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'helper %s %s\\n' "$PROJECT_DIR" "${{COMPOSE_FILE:-}}" >> "{log_file}"
+"""
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"-f docker-compose.production.yaml ps -q postgres"*)
+    printf 'postgres-id\\n'
+    ;;
+  *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(scripts_dir / "postgres_backup.sh", helper_stub)
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_lines = log_file.read_text(encoding="utf-8").splitlines()
+    postgres_up_index = next(
+        index
+        for index, line in enumerate(log_lines)
+        if "compose --env-file" in line and "up -d --remove-orphans postgres" in line
+    )
+    helper_index = next(index for index, line in enumerate(log_lines) if line.startswith("helper "))
+    app_up_index = next(
+        index
+        for index, line in enumerate(log_lines)
+        if "compose --env-file" in line and "up -d --remove-orphans app" in line
+    )
+    migrate_index = next(
+        index for index, line in enumerate(log_lines) if "exec app-id alembic upgrade head" in line
+    )
+    caddy_up_index = next(
+        index
+        for index, line in enumerate(log_lines)
+        if "compose --env-file" in line and "up -d --remove-orphans caddy" in line
+    )
+    external_ready_index = next(
+        index
+        for index, line in enumerate(log_lines)
+        if line.startswith("curl ") and "https://pulseplate.test/ready" in line
+    )
+
+    assert (
+        postgres_up_index
+        < helper_index
+        < app_up_index
+        < migrate_index
+        < caddy_up_index
+        < external_ready_index
+    )
+    assert any("helper " in line and "docker-compose.production.yaml" in line for line in log_lines)

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -1,6 +1,7 @@
 import os
 import stat
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -9,6 +10,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def _write_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _assert_log_index(
+    log_lines: list[str],
+    *,
+    predicate: Callable[[str], bool],
+    message: str,
+) -> int:
+    index = next((position for position, line in enumerate(log_lines) if predicate(line)), None)
+    assert index is not None, message
+    return index
 
 
 def test_postgres_backup_helper_passes_project_dir_and_compose_file(tmp_path: Path) -> None:
@@ -182,29 +194,38 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
 
     log_lines = log_file.read_text(encoding="utf-8").splitlines()
-    postgres_up_index = next(
-        index
-        for index, line in enumerate(log_lines)
-        if "compose --env-file" in line and "up -d --remove-orphans postgres" in line
+    postgres_up_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: "compose --env-file" in line
+        and "up -d --remove-orphans postgres" in line,
+        message="Expected postgres docker-compose up step to appear in deploy log",
     )
-    helper_index = next(index for index, line in enumerate(log_lines) if line.startswith("helper "))
-    app_up_index = next(
-        index
-        for index, line in enumerate(log_lines)
-        if "compose --env-file" in line and "up -d --remove-orphans app" in line
+    helper_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: line.startswith("helper "),
+        message="Expected backup helper step to appear in deploy log",
     )
-    migrate_index = next(
-        index for index, line in enumerate(log_lines) if "exec app-id alembic upgrade head" in line
+    app_up_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: "compose --env-file" in line
+        and "up -d --remove-orphans app" in line,
+        message="Expected app docker-compose up step to appear in deploy log",
     )
-    caddy_up_index = next(
-        index
-        for index, line in enumerate(log_lines)
-        if "compose --env-file" in line and "up -d --remove-orphans caddy" in line
+    migrate_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: "exec app-id alembic upgrade head" in line,
+        message="Expected alembic migration step to appear in deploy log",
     )
-    external_ready_index = next(
-        index
-        for index, line in enumerate(log_lines)
-        if line.startswith("curl ") and "https://pulseplate.test/ready" in line
+    caddy_up_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: "compose --env-file" in line
+        and "up -d --remove-orphans caddy" in line,
+        message="Expected caddy docker-compose up step to appear in deploy log",
+    )
+    external_ready_index = _assert_log_index(
+        log_lines,
+        predicate=lambda line: line.startswith("curl ") and "https://pulseplate.test/ready" in line,
+        message="Expected external readiness check to appear in deploy log",
     )
 
     assert (
@@ -216,3 +237,90 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
         < external_ready_index
     )
     assert any("helper " in line and "docker-compose.production.yaml" in line for line in log_lines)
+
+
+def test_deploy_production_exits_non_zero_when_migrations_fail(tmp_path: Path) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    scripts_dir = project_dir / "scripts" / "ops"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    scripts_dir.mkdir(parents=True)
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "\n".join(
+            [
+                "POSTGRES_USER=pulseplate",
+                "POSTGRES_DB=pulseplate",
+                "POSTGRES_PASSWORD=secret",
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    helper_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'helper %s %s\\n' "$PROJECT_DIR" "${{COMPOSE_FILE:-}}" >> "{log_file}"
+"""
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"-f docker-compose.production.yaml ps -q postgres"*)
+    printf 'postgres-id\\n'
+    ;;
+  *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"exec app-id alembic upgrade head"*)
+    printf 'migration failed\\n' >&2
+    exit 1
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(scripts_dir / "postgres_backup.sh", helper_stub)
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "Database migrations failed in container: app-id (exit code: 1)" in completed.stderr
+
+    log_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert any("exec app-id alembic upgrade head" in line for line in log_lines)
+    assert not any("up -d --remove-orphans caddy" in line for line in log_lines)
+    assert not any(
+        line.startswith("curl ") and "https://pulseplate.test/ready" in line for line in log_lines
+    )


### PR DESCRIPTION
## Summary
- align `deploy/docker-compose.production.yaml` and `deploy/docker-compose.staging.yaml` to a Postgres-first deploy contract
- switch staging/production deploy execution to `postgres -> backup -> app -> migrations -> caddy -> /ready`
- replace SQLite-style deploy/backup docs with Postgres helper usage and production-safe `deploy_production.sh` guidance

## Why
- root `docker-compose.yaml` and `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md` already define Postgres as the canonical production database
- deploy manifests, helpers, and runbooks still had SQLite-shaped or pre-migration traffic paths that drifted from the canonical contract
- this PR stays scoped to deploy-contract alignment only; no runtime `core/` DB fallback changes

## How to validate
- `bash -n scripts/deploy.sh scripts/deploy_production.sh scripts/fix_production_env.sh scripts/QUICK_FIX_PRODUCTION.sh scripts/ops/postgres_backup.sh scripts/ops/postgres_restore.sh`
- `pytest -q tests/test_deploy_contract_scripts.py`
- compose render validation for production/staging with temp env overrides (`docker compose ... config`)
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1271_FIXED_MAPPING.md`
- post-open mandatory lane completed: `qa-engineer-agent (Linnaeus) -> bug-hunter (Faraday)`
- implementation commit: `0a3dc812`
- latest artifact normalization commit: `65aeb403`

## Split Justification
Keeping compose manifests, deploy scripts, Postgres backup helpers, deterministic regression tests, and the mirrored production runbook in one PR avoids an intermediate broken state where staging/production would reference incompatible deploy entrypoints or helper contracts. The change is intentionally limited to deploy-contract alignment; runtime DB fallback, billing, and unrelated security cleanup remain out of scope for follow-up PRs.

## Merge Readiness
- [x] Local hard gate passed (`make verify`)
- [ ] Required checks PASS with no pending required jobs
- [ ] No unresolved review threads
- [ ] No actionable bot comments
- [ ] Final post-bot wait cycle completed

## Risk / rollout notes
- staging/prod now require real `DATABASE_URL`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`
- backup/restore helpers now require the non-default compose path when used outside default `compose.yaml` discovery
- production manual rollout must use `deploy_production.sh`; staging-only `deploy.sh` is no longer referenced for prod

## Summary by Sourcery

Унифицировать процессы деплоя и документацию для стейджинга и продакшена вокруг «Postgres‑first», fail-closed контракта деплоя, включая обновлённые compose-манифесты, скрипты и endpoints для проверки готовности.

Enhancements:
- Добавить явные сервисы postgres с health checks и зависимостями приложений в docker-compose манифестах стейджинга и продакшена, а также переключить health checks приложения на endpoint `/ready`.
- Обновить скрипты деплоя в продакшен и стейджинг, чтобы они требовали Postgres-переменные окружения, выполняли последовательность Postgres-first backup -> app -> migrations -> caddy и опирались на общие Postgres backup helpers.
- Укрепить помощники исправления production env, чтобы они требовали каноничную конфигурацию Postgres (DATABASE_URL, POSTGRES_*), нормализовали критические feature flags и запрещали fallback на SQLite.
- Расширить Postgres backup/restore helpers так, чтобы они учитывали PROJECT_DIR и COMPOSE_FILE для стеков стейджинга и продакшена.
- Добавить детерминированные тесты для валидации порядка выполнения скриптов деплоя и контрактов backup/restore helpers для деплоев, основанных на Postgres.

Documentation:
- Переработать runbooks деплоя для продакшена и стейджинга, чтобы они использовали Postgres-настройки подключения, Postgres-специфичные процессы backup/restore, readiness-проверки на основе `/ready` и точку входа `deploy_production.sh`.
- Задокументировать обновлённое соответствие fixed-in-commit и QA-доказательства для этого изменения по выравниванию контракта деплоя.

Tests:
- Добавить автоматические тесты, чтобы гарантировать, что `deploy_production.sh` запускает postgres, backup, app, migrations и caddy в правильном порядке и что Postgres backup/restore helpers вызываются с ожидаемой конфигурацией проекта и compose.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align staging and production deployment flows and documentation around a Postgres-first, fail-closed deploy contract, including updated compose manifests, scripts, and readiness endpoints.

Enhancements:
- Introduce explicit postgres services with health checks and app dependencies in staging and production docker-compose manifests, and switch application health checks to the /ready endpoint.
- Update production and staging deployment scripts to enforce Postgres environment variables, run Postgres-first backup -> app -> migrations -> caddy sequences, and rely on shared Postgres backup helpers.
- Harden production env fix helpers to require canonical Postgres configuration (DATABASE_URL, POSTGRES_*), normalize critical feature flags, and disallow SQLite-based fallbacks.
- Extend Postgres backup/restore helpers to respect PROJECT_DIR and COMPOSE_FILE for both staging and production stacks.
- Add deterministic tests to validate deploy script ordering and backup/restore helper contracts for Postgres-based deployments.

Documentation:
- Revise production and staging deployment runbooks to use Postgres connection settings, Postgres-specific backup/restore workflows, /ready-based readiness checks, and the deploy_production.sh entrypoint.
- Document the updated fixed-in-commit mapping and QA evidence for this deploy-contract alignment change.

Tests:
- Add automated tests to ensure deploy_production.sh runs postgres, backup, app, migrations, and caddy in the correct order and that Postgres backup/restore helpers are invoked with the intended project and compose configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL support for production and staging with persisted data and service health gating.
  * Postgres backup and restore workflows.

* **Bug Fixes**
  * Health probes switched to a readiness endpoint for more accurate startup checks.

* **Chores**
  * Hardened deployment scripts and stricter env validation; deployment now enforces DB-first startup order.

* **Documentation**
  * Deployment docs updated for Postgres-first flows, backup/restore guidance, and readiness contract.

* **Tests**
  * New tests validating deploy flow and Postgres helper behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->