### PR TITLE
fix(deps): replace Dependabot PR #1274 for ruff 0.15.8

### DIFF
--- a/docs/review/PR_1278_FIXED_MAPPING.md
+++ b/docs/review/PR_1278_FIXED_MAPPING.md
@@ -5,12 +5,13 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#discussion_r3006738235 -> COMMIT_SHA_PLACEHOLDER | Disposition: FIXED | Proof: commit COMMIT_SHA_PLACEHOLDER
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#pullrequestreview-4027226975 -> COMMIT_SHA_PLACEHOLDER | Disposition: FIXED | Proof: commit COMMIT_SHA_PLACEHOLDER
 
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
+- [ ] Pre-commit green
+- [ ] `make verify` green
 - Replacement lane for Dependabot source PR `#1274`.

--- a/docs/review/PR_1278_FIXED_MAPPING.md
+++ b/docs/review/PR_1278_FIXED_MAPPING.md
@@ -5,8 +5,12 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#discussion_r3006738235 -> 6f082ff6 | Disposition: FIXED | Proof: commit 6f082ff6
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#pullrequestreview-4027226975 -> 6f082ff6 | Disposition: FIXED | Proof: commit 6f082ff6
+Disposition: FIXED
+Commit: 6f082ff6
+Evidence: `docs/review/PR_1278_FIXED_MAPPING.md:19` keeps `Pre-commit green` unchecked and `docs/review/PR_1278_FIXED_MAPPING.md:20` keeps `make verify green` unchecked, so the merge-readiness checklist remains in final-cycle-only mode until the actual merge pass.
+Reason: CodeRabbit correctly flagged that the merge-readiness boxes must stay unchecked before the final merge cycle, even though local validation had already passed on the replacement branch.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#discussion_r3006738235 -> 6f082ff6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#pullrequestreview-4027226975 -> 6f082ff6
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1278_FIXED_MAPPING.md
+++ b/docs/review/PR_1278_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1278 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- Replacement lane for Dependabot source PR `#1274`.

--- a/docs/review/PR_1278_FIXED_MAPPING.md
+++ b/docs/review/PR_1278_FIXED_MAPPING.md
@@ -5,8 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#discussion_r3006738235 -> COMMIT_SHA_PLACEHOLDER | Disposition: FIXED | Proof: commit COMMIT_SHA_PLACEHOLDER
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#pullrequestreview-4027226975 -> COMMIT_SHA_PLACEHOLDER | Disposition: FIXED | Proof: commit COMMIT_SHA_PLACEHOLDER
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#discussion_r3006738235 -> 6f082ff6 | Disposition: FIXED | Proof: commit 6f082ff6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1278#pullrequestreview-4027226975 -> 6f082ff6 | Disposition: FIXED | Proof: commit 6f082ff6
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -27,5 +27,5 @@ mypy~=1.19.1
 types-pyyaml~=6.0.12
 yamllint~=1.38.0
 black~=26.3.1
-ruff~=0.15.7
+ruff~=0.15.8
 nh3>=0.3.2  # HTML sanitization (required for data_sanitizer security tests)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -204,6 +204,7 @@ pyyaml==6.0.3
 requests==2.33.0
     # via
     #   -c requirements.txt
+    #   -r requirements-dev.in
     #   cachecontrol
     #   detect-secrets
     #   pip-audit
@@ -212,7 +213,7 @@ rich==14.3.3
     #   -c requirements.txt
     #   bandit
     #   pip-audit
-ruff==0.15.7
+ruff==0.15.8
     # via -r requirements-dev.in
 sortedcontainers==2.4.0
     # via


### PR DESCRIPTION
## Summary
- replacement lane for Dependabot PR #1274
- carries only the ruff 0.15.8 dependency bump
- opened because the original Dependabot PR is blocked by repo governance artifact/body gates

## Supersedes
- #1274

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1278_FIXED_MAPPING.md`

## Summary by Sourcery

Обновить dev-зависимость `ruff` до версии 0.15.8 и зафиксировать связанные метаданные ревью для этого заменяющего PR.

Улучшения:
- Повысить версию dev-зависимости `ruff` до 0.15.8.

Документация:
- Добавить документ сопоставления обзоров «fixed in commit» для PR 1278.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update development dependency on ruff to version 0.15.8 and record the associated review metadata for this replacement PR.

Enhancements:
- Bump ruff development dependency to version 0.15.8.

Documentation:
- Add review "fixed in commit" mapping document for PR 1278.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PR review-status entry recording discussion completion, a fixed-in-commit mapping, and a merge-readiness checklist noting unresolved checks and review threads.

* **Chores**
  * Bumped a development tooling pin (ruff) from 0.15.7 to 0.15.8.
  * Clarified development requirements metadata to indicate an additional source reference for a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->