### PR TITLE
fix(deps): bump marshmallow to 4.2.3

### DIFF
--- a/docs/review/PR_1279_FIXED_MAPPING.md
+++ b/docs/review/PR_1279_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1279 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- Replacement lane for Dependabot source PR `#1276`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -92,7 +92,7 @@ markupsafe==3.0.3
     # via
     #   -c requirements.txt
     #   jinja2
-marshmallow==4.2.2
+marshmallow==4.2.3
     # via -r requirements-dev.in
 mccabe==0.7.0
     # via flake8


### PR DESCRIPTION
## Summary
- replacement lane for Dependabot PR #1276
- bump marshmallow in requirements-dev.txt from 4.2.2 to 4.2.3
- preserve already-merged ruff 0.15.8 change from main

## Validation
- pre-commit run --all-files
- make verify

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green
- [ ] `make verify` green
- Replacement lane for Dependabot source PR `#1276`.

## Summary by Sourcery

Обновлены версии зависимостей для разработки и добавлены метаданные для ревью PR 1279.

Исправления ошибок:
- Обновлена dev-зависимость marshmallow до версии 4.2.3.

Документация:
- Добавлен чек-лист ревью PR_1279_FIXED_MAPPING и документация по готовности к merge в каталог `docs/review`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update development dependency versions and add review metadata for PR 1279.

Bug Fixes:
- Update marshmallow development dependency to version 4.2.3.

Documentation:
- Add PR_1279_FIXED_MAPPING review checklist and merge readiness documentation under docs/review.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added process documentation for pull request review and commit mapping workflows, including status tracking checklists, discussion thread verification, and merge readiness verification procedures with quality assurance checkpoints.

* **Chores**
  * Updated development dependencies to latest stable versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->