### PR TITLE
fix(security): suppress ncurses CVE-2025-69720

### DIFF
--- a/docs/review/PR_1285_FIXED_MAPPING.md
+++ b/docs/review/PR_1285_FIXED_MAPPING.md
@@ -9,6 +9,8 @@
 Disposition: FIXED
 Commit: a21707c4
 Evidence: docs/security/CVE-2025-69720-ncurses.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#pullrequestreview-4033073677 -> a21707c4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#pullrequestreview-4033091855 -> a21707c4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011982993 -> a21707c4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011983005 -> a21707c4
 

--- a/docs/review/PR_1285_FIXED_MAPPING.md
+++ b/docs/review/PR_1285_FIXED_MAPPING.md
@@ -6,7 +6,11 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- Disposition: FIXED
+- Commit: `a21707c4`
+- Evidence: `docs/security/CVE-2025-69720-ncurses.md`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011982993 -> a21707c4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011983005 -> a21707c4
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1285_FIXED_MAPPING.md
+++ b/docs/review/PR_1285_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1285 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- CVE-scoped security suppression lane for `CVE-2025-69720` (`ncurses` family) covering GitHub alerts `#572`, `#574`, `#576`, and `#577`.

--- a/docs/review/PR_1285_FIXED_MAPPING.md
+++ b/docs/review/PR_1285_FIXED_MAPPING.md
@@ -6,9 +6,9 @@
 
 ## Fixed in Commit Mapping
 
-- Disposition: FIXED
-- Commit: `a21707c4`
-- Evidence: `docs/security/CVE-2025-69720-ncurses.md`
+Disposition: FIXED
+Commit: a21707c4
+Evidence: docs/security/CVE-2025-69720-ncurses.md
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011982993 -> a21707c4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011983005 -> a21707c4
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2415,6 +2415,27 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Remove `docs/security/CVE-2026-24883-gpgv.md` (or mark as resolved)
     - Trivy Code Scanning alerts remain closed on `main`
 
+- [ ] Remove Trivy suppression for ncurses CVE (CVE-2025-69720)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Reason: Trivy reports Debian bookworm `ncurses` family packages
+    (`libncursesw6`, `libtinfo6`, `ncurses-base`, `ncurses-bin`) as vulnerable at
+    `6.4-4` with no actionable fixed version in the current bookworm image line as
+    of 2026-03-30; we suppress narrowly in `trivy/ignore-policy.rego` until
+    Debian bookworm or Trivy metadata catches up.
+  - Links:
+    - `trivy/ignore-policy.rego` (rule for CVE-2025-69720)
+    - `docs/security/CVE-2025-69720-ncurses.md`
+    - `.github/workflows/build.yml`
+  - DoD:
+    - Debian bookworm publishes a fixed `ncurses` package line (or Trivy reports a
+      fixed version in our image context)
+    - Remove CVE-2025-69720 suppression from `trivy/ignore-policy.rego`
+    - Remove `docs/security/CVE-2025-69720-ncurses.md` (or mark as resolved)
+    - Trivy Code Scanning alerts #572, #574, #576, and #577 remain closed on
+      `main`
+
 
 - [ ] Security suppression expiry monitoring
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/security/CVE-2025-69720-ncurses.md
+++ b/docs/security/CVE-2025-69720-ncurses.md
@@ -19,14 +19,14 @@ bookworm Python base image used by the publish image lane.
 
 ## Why a repo-level fix is not currently available
 
-At triage time, a repo-level real remediation was evaluated first:
+At triage time, a real repo-level remediation was evaluated first:
 
 1. The current production image is built from `python:3.13.6-slim-bookworm` in
    `Dockerfile`.
 2. Docker Hub metadata shows newer Python 3.13 slim-bookworm tags exist, so a
    stale patch pin alone is not the whole explanation.
 3. Debian Security Tracker still marks **bookworm** `ncurses 6.4-4` as
-   **vulnerable**, with the fix only available in `forky, sid`
+   **vulnerable**, with the fix only available in `forky` and `sid`
    (`6.6+20251231-1`).
 
 That means a normal bookworm refresh in this repository does **not** currently
@@ -38,7 +38,7 @@ produce a patched ncurses package line for the affected binary packages.
   <https://security-tracker.debian.org/tracker/CVE-2025-69720>
 - **Tracker status at triage time**:
   - `bookworm` `6.4-4` — vulnerable
-  - `forky, sid` `6.6+20251231-1` — fixed
+  - `forky` and `sid` `6.6+20251231-1` — fixed
 - **Tracker note**: bookworm is marked `<no-dsa>` / minor issue, which still
   leaves the package vulnerable for Trivy/GitHub code scanning purposes.
 
@@ -65,10 +65,10 @@ Exact package/version evidence came from GitHub code-scanning alerts on `main`:
 
 ```text
 $ gh api "repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts?state=open&per_page=100" --jq '.[] | select(.number == 572 or .number == 574 or .number == 576 or .number == 577) | [.number, .most_recent_instance.message.text] | @tsv'
-572	Package: libncursesw6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
-574	Package: libtinfo6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
-576	Package: ncurses-base\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
-577	Package: ncurses-bin\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+572  Package: libncursesw6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+574  Package: libtinfo6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+576  Package: ncurses-base\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+577  Package: ncurses-bin\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
 ```
 
 That observed alert payload is why the policy rule is restricted to the four

--- a/docs/security/CVE-2025-69720-ncurses.md
+++ b/docs/security/CVE-2025-69720-ncurses.md
@@ -59,6 +59,21 @@ The suppression in `trivy/ignore-policy.rego` is intentionally narrow:
 This keeps the suppression limited to the current bookworm image context and
 prevents it from masking future fixed versions.
 
+## Observed alert evidence
+
+Exact package/version evidence came from GitHub code-scanning alerts on `main`:
+
+```text
+$ gh api "repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts?state=open&per_page=100" --jq '.[] | select(.number == 572 or .number == 574 or .number == 576 or .number == 577) | [.number, .most_recent_instance.message.text] | @tsv'
+572	Package: libncursesw6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+574	Package: libtinfo6\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+576	Package: ncurses-base\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+577	Package: ncurses-bin\nInstalled Version: 6.4-4\nVulnerability CVE-2025-69720
+```
+
+That observed alert payload is why the policy rule is restricted to the four
+binary packages above and `InstalledVersion == "6.4-4"`.
+
 ## Removal condition
 
 Remove this suppression when either:

--- a/docs/security/CVE-2025-69720-ncurses.md
+++ b/docs/security/CVE-2025-69720-ncurses.md
@@ -1,0 +1,83 @@
+# CVE-2025-69720 — ncurses family (Debian bookworm) — Trivy code scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2025-69720
+- **Source package**: `ncurses`
+- **Affected binary packages in our image alert set**:
+  - `libncursesw6`
+  - `libtinfo6`
+  - `ncurses-base`
+  - `ncurses-bin`
+- **Observed installed version**: `6.4-4`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: High
+- **GitHub alerts**: `#572`, `#574`, `#576`, `#577`
+
+This finding is reported by Trivy against OS packages inherited from the Debian
+bookworm Python base image used by the publish image lane.
+
+## Why a repo-level fix is not currently available
+
+At triage time, a repo-level real remediation was evaluated first:
+
+1. The current production image is built from `python:3.13.6-slim-bookworm` in
+   `Dockerfile`.
+2. Docker Hub metadata shows newer Python 3.13 slim-bookworm tags exist, so a
+   stale patch pin alone is not the whole explanation.
+3. Debian Security Tracker still marks **bookworm** `ncurses 6.4-4` as
+   **vulnerable**, with the fix only available in `forky, sid`
+   (`6.6+20251231-1`).
+
+That means a normal bookworm refresh in this repository does **not** currently
+produce a patched ncurses package line for the affected binary packages.
+
+## Upstream status
+
+- **Debian Security Tracker**:
+  <https://security-tracker.debian.org/tracker/CVE-2025-69720>
+- **Tracker status at triage time**:
+  - `bookworm` `6.4-4` — vulnerable
+  - `forky, sid` `6.6+20251231-1` — fixed
+- **Tracker note**: bookworm is marked `<no-dsa>` / minor issue, which still
+  leaves the package vulnerable for Trivy/GitHub code scanning purposes.
+
+## Suppression scope
+
+The suppression in `trivy/ignore-policy.rego` is intentionally narrow:
+
+- `input.VulnerabilityID == "CVE-2025-69720"`
+- package restricted to:
+  - `libncursesw6`
+  - `libtinfo6`
+  - `ncurses-base`
+  - `ncurses-bin`
+- `input.InstalledVersion == "6.4-4"`
+- `PkgID` restricted to the exact package/version family observed in the alert
+  set
+
+This keeps the suppression limited to the current bookworm image context and
+prevents it from masking future fixed versions.
+
+## Removal condition
+
+Remove this suppression when either:
+
+1. Debian bookworm publishes a fixed `ncurses` package line for
+   CVE-2025-69720, or
+2. Trivy metadata starts reporting a `Fixed Version` for these package alerts in
+   our image context.
+
+## Evidence anchors
+
+- `Dockerfile:8`
+- `Dockerfile:81`
+- `trivy/ignore-policy.rego:12`
+- `trivy/ignore-policy.rego:139`
+- `.github/workflows/build.yml:145`
+- GitHub alerts: `#572`, `#574`, `#576`, `#577`
+
+## References
+
+- [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2025-69720)
+- [Aquasec advisory page](https://avd.aquasec.com/nvd/cve-2025-69720)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,8 +10,8 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-27 (manual removal)
-# Last reviewed: 2026-02-27
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md
+# Last reviewed: 2026-03-30
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2025-69720-ncurses.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -133,4 +133,43 @@ ignore if {
 	input.VulnerabilityID == "CVE-2026-3184"
 	cve_2026_3184_pkg_match
 	cve_2026_3184_version_match
+}
+
+# CVE-2025-69720 (ncurses family) - upstream unfixed in Debian bookworm
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Debian bookworm remains vulnerable; fix is published only in forky/sid at triage time
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2025-69720
+# Documented in: docs/security/CVE-2025-69720-ncurses.md
+# Removal condition: Remove when Debian bookworm publishes a fixed ncurses package or Trivy metadata includes Fixed Version
+
+cve_2025_69720_pkg_match if {
+	ncurses_pkgs := {"libncursesw6", "libtinfo6", "ncurses-base", "ncurses-bin"}
+	ncurses_pkgs[input.PkgName]
+}
+
+cve_2025_69720_version_match if {
+	input.InstalledVersion == "6.4-4"
+}
+
+cve_2025_69720_pkgid_match if {
+	startswith(input.PkgID, "libncursesw6@6.4-4")
+}
+
+cve_2025_69720_pkgid_match if {
+	startswith(input.PkgID, "libtinfo6@6.4-4")
+}
+
+cve_2025_69720_pkgid_match if {
+	startswith(input.PkgID, "ncurses-base@6.4-4")
+}
+
+cve_2025_69720_pkgid_match if {
+	startswith(input.PkgID, "ncurses-bin@6.4-4")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2025-69720"
+	cve_2025_69720_pkg_match
+	cve_2025_69720_version_match
+	cve_2025_69720_pkgid_match
 }


### PR DESCRIPTION
## Summary
- add a version-scoped Trivy suppression for the four `CVE-2025-69720` ncurses-family image alerts on `main`
- document the Debian bookworm unfixed status, observed alert payload, and accepted-risk rationale in `docs/security/CVE-2025-69720-ncurses.md`
- record the removal follow-up in `docs/roadmap/BACKLOG_LEDGER.md`

## Test plan
- [x] `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2025-69720-ncurses.md`
- [x] `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Disposition: FIXED
- Commit: `a21707c4`
- Commit: `e17febda`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011982993 -> a21707c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1285#discussion_r3011983005 -> a21707c4
- Canonical artifact: `docs/review/PR_1285_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] `make verify` green

## Deferred / Follow-ups
- `CVE-2026-29111` is intentionally split into a separate CVE-scoped follow-up PR to match repo security suppression policy.
- Backlog follow-up: [remove ncurses suppression after upstream fix](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/fix/security-code-scanning-main-2026-03-30/docs/roadmap/BACKLOG_LEDGER.md)
- Remove this suppression when Debian bookworm or Trivy metadata provides a fixed ncurses package line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security docs recording a targeted suppression for CVE-2025-69720 (ncurses), listing affected packages, observed version, evidence anchors, removal criteria, and a merge-readiness checklist (several checks left unchecked).
  * Added a backlog entry to track removal of the suppression with acceptance criteria and follow-up steps.
  * Added PR review notes documenting mapping and resolution status.

* **Chores**
  * Updated security policy metadata and precise matching rules to narrowly scope the suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->