### PR TITLE
chore(ci): add advisory Tier 1 metrics lane

### DIFF
--- a/.github/workflows/ci-metrics.yml
+++ b/.github/workflows/ci-metrics.yml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: CI Metrics
+
+on:
+  schedule:
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  collect-ci-metrics:
+    name: collect-ci-metrics
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Collect Tier 1 CI metrics
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/collect_ci_metrics.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json-out ci-metrics-summary.json \
+            --markdown-out ci-metrics-summary.md
+
+      - name: Publish metrics to step summary
+        run: |
+          set -euo pipefail
+          cat ci-metrics-summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload CI metrics artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ci-metrics-summary
+          path: |
+            ci-metrics-summary.json
+            ci-metrics-summary.md
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Version:** 2026-03-26 (`America/New_York`)
 **Scope:** Governance-first CI/CD consolidation wave for backend/shared PR lanes.
-**Execution surface:** repo root with coordinator-first routing; no runtime product-surface mutation in PR1.
+**Execution surface:** repo root with coordinator-first routing; no runtime product-surface mutation in this wave.
 
 ## Purpose
 
@@ -58,8 +58,9 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 
 - PR-1 governance/bootstrap already landed in merged PR `#1240` (`24c51f85`).
 - PR-2 workflow consolidation already landed on `origin/main` via PR `#1244` (`b7e029b4`).
-- This runbook now treats PR-3 as the active execution slice and PR-4 as the next follow-up wave.
-- Do not restart the series from PR-1; reconcile Tier 1 bookkeeping inside PR-3 and continue forward.
+- PR-3 risk topology already landed on `main` in merged PR `#1253` (`3be5debf`).
+- This runbook now treats PR-4 as the active execution slice.
+- Do not restart the series from PR-1; continue forward from the landed PR1-PR3 baseline.
 
 ## PR Series
 
@@ -86,14 +87,15 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 - Split PR execution into deterministic smoke, contract/risk suites, and nightly-only depth.
 - Keep PR blockers focused on business-critical surfaces.
 - Add PR-size governance and explicit `## Split Justification` PR-body proof for `>800` LoC cases.
-- Status: active next execution slice.
+- Status: landed baseline in PR `#1253`.
 
 ### PR-4: CI Metrics and Feedback Loop
 
 - Add lightweight non-blocking CI metrics collection under `scripts/ci/`.
 - Emit summary artifacts for critical-path duration, reruns, red-build rate, and xdist fallback frequency.
-- Wire a weekly reporting path without changing merge blockers.
-- Status: next/deferred until PR-3 lands.
+- Wire a weekly reporting path via artifacts + `GITHUB_STEP_SUMMARY` without changing merge blockers.
+- Keep PR4 explicitly advisory and outside canonical merge truth / branch-protection widening.
+- Status: active next execution slice.
 
 ## Routing Card
 
@@ -129,6 +131,7 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 4. **PR-4 metrics**
    - metrics collector exists
    - artifacts emit deterministically
+   - weekly/manual reporting path uses artifact + `GITHUB_STEP_SUMMARY` only
    - metrics remain advisory only
 
 ## Hard Rules
@@ -145,6 +148,7 @@ Deliver a Tier 1 CI/CD consolidation program in stacked PRs that:
 - Isolate runtime/API behavior changes from PR-1 and PR-2 unless the workflow change cannot be isolated from the contract.
 - Keep `build.yml` isolated as a specialized lane; do not reintroduce duplicate PR-time blockers.
 - Treat Tier 1 metrics as advisory rather than merge blockers.
+- Keep the new `ci-metrics.yml` workflow on `schedule` / `workflow_dispatch` only; it must not become an ordinary PR required check.
 
 ## Validation
 

--- a/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
+++ b/docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md
@@ -1,7 +1,7 @@
 # Tier 1 CI/CD Task Packet
 
 **Date:** 2026-03-26 (`America/New_York`)
-**Status:** Active PR-3 packet for the Tier 1 backend/shared CI consolidation wave following the landed PR-1 / PR-2 baseline work.
+**Status:** Active PR-4 packet for the Tier 1 backend/shared CI consolidation wave following the landed PR1-PR3 baseline work.
 **Wave:** stacked PRs, coordinator-first, governance-first.
 
 ## Goal
@@ -25,8 +25,8 @@ without weakening current merge blockers or broadening runtime behavior.
 
 - PR-1 governance/bootstrap is already landed in PR `#1240` (`24c51f85`).
 - PR-2 workflow consolidation is already landed on `origin/main` in PR `#1244` (`b7e029b4`).
-- This packet therefore points to PR-3 as the live execution branch and keeps PR-4 as the next follow-up.
-- Reconciliation of Tier 1 bookkeeping is part of the opening commit set for PR-3, not a separate restart PR.
+- PR-3 risk topology is already landed on `main` in PR `#1253` (`3be5debf`).
+- This packet therefore points to PR-4 as the live execution branch.
 
 ### In scope
 
@@ -101,20 +101,23 @@ Blocking surfaces for Tier 1 PR-lane decisions:
 - risk-based PR topology
 - PR-size governance with explicit `## Split Justification` PR-body proof for `>800` LoC cases
 - blocker/non-blocker split documented and enforced
-- Status: active next slice
+- Status: landed baseline (`#1253`)
 
 ### PR-4
 
 - `scripts/ci/` metrics collector
 - `ci-metrics-summary.json`
 - `ci-metrics-summary.md`
-- Status: deferred/next
+- `ci-metrics.yml` advisory schedule/manual workflow
+- `GITHUB_STEP_SUMMARY` publication path
+- Status: active next slice
 
 ## Acceptance Criteria
 
 - PR2's canonical backend/shared PR lane in `ci.yml` remains the only backend/shared merge-truth surface
 - PR3 makes the PR path explicit as critical smoke plus contract/risk suites, while keeping nightly/regression depth outside normal PR blocking flow
 - PR3 adds documented and enforced PR-size governance for `<300`, `300-800`, and `>800` LoC cases
+- PR4 keeps metrics advisory-only and publishes artifact + step summary without widening merge blockers
 - Current-head merge-readiness remains deterministic and wrapper-backed
 - Local merge evidence remains `pre-commit run --all-files` + `make verify`
 - Mandatory post-open `qa-engineer-agent -> bug-hunter` lane remains recorded and used for this slice
@@ -139,6 +142,7 @@ For non-draft PRs:
 - Duplicate workflow removal can create hidden required-check gaps in GitHub branch protection.
 - Python 3.13 + xdist + coverage instability can regress if PR topology changes are too aggressive.
 - CI/governance docs can drift again unless the backlog epic and runbook stay authoritative.
+- Advisory metrics can become noisy if the collector treats missing log data as hard failure; unknown states must stay non-blocking.
 
 ## Deferred / Follow-ups
 
@@ -148,4 +152,4 @@ carry-forward list is:
 - preview environments
 - mutation testing
 - full test-impact analysis
-- broader CI observability platform work
+- broader CI observability platform work beyond the weekly artifact/summary loop

--- a/docs/review/PR_1286_FIXED_MAPPING.md
+++ b/docs/review/PR_1286_FIXED_MAPPING.md
@@ -5,9 +5,9 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-## Fixed in Commit Mapping
+### Fixed in Commit Mapping
 
-- No actionable review comments yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1286_FIXED_MAPPING.md
+++ b/docs/review/PR_1286_FIXED_MAPPING.md
@@ -1,14 +1,16 @@
 # PR 1286 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
 - No actionable review comments yet.
 
 ## Merge Readiness
+
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

--- a/docs/review/PR_1286_FIXED_MAPPING.md
+++ b/docs/review/PR_1286_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1286 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments yet.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- PR4 advisory Tier 1 metrics lane opened from the clean `chore/tier1-ci-cd-pr4-metrics-r2` branch.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2320,13 +2320,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `build.yml`, frontend-only lanes, and nightly/release lanes stay isolated
     - Required-check parity is preserved on current-head PR checks
 
-- [ ] P1: PR3 risk-based PR test topology {#ledger-p1-tier1-ci-cd-pr3-risk-topology}
+- [x] P1: PR3 risk-based PR test topology {#ledger-p1-tier1-ci-cd-pr3-risk-topology}
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: #1253
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: 🚧 In progress in PR `#1253` (PR3 risk-topology lane), following landed PR1/PR2 reconciliation (`#1240`, `#1244`) after clean-topology replacement of PR `#1250` and earlier closed PR `#1248`.
+  - Status: Materially completed on `main` in merged PR `#1253` (`3be5debf`); this slice now serves as landed baseline input for PR4.
   - Reason: PR blockers should stay focused on business-critical runtime paths, while nightly depth absorbs broad non-critical coverage tails.
   - Links:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-test-hygiene-wave`
@@ -2346,15 +2346,19 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: PR-TBD-TIER1-CI-CD-PR4
   - Area: orchestration / CI / review governance
   - Finding Type: process hardening
-  - Status: Deferred/next after PR3 risk-topology rollout.
-  - Reason: Tier 1 needs advisory metrics for critical-path duration, reruns, and flaky-signal tracking without turning observability into another merge blocker.
+  - Status: Active next execution slice after merged PR `#1253`; implementation starts from a clean worktree off `origin/main`.
+  - Reason: Tier 1 needs advisory metrics for critical-path duration, reruns, red-build rate, and xdist fallback tracking without turning observability into another merge blocker or widening branch-protection truth.
   - Links:
     - `docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md`
+    - `docs/orchestration/TIER1_CI_CD_TASK_PACKET_2026-03-26.md`
+    - `.github/workflows/ci-metrics.yml`
+    - `scripts/ci/collect_ci_metrics.py`
   - DoD:
     - `scripts/ci/` emits `ci-metrics-summary.json` and `ci-metrics-summary.md`
-    - Metrics remain informational only
-    - Weekly reporting path is documented
-    - Artifact absence degrades gracefully
+    - Metrics remain informational only and outside canonical merge truth
+    - Weekly reporting path uses artifact + `GITHUB_STEP_SUMMARY` only
+    - Artifact absence degrades gracefully with explicit `unknown`/`unavailable` metric states
+    - Tier 1 docs/runbook/task packet all point to PR4 as the active slice
 
 
 - [ ] P1: Disposition guard — ban mapping to trigger-only commits

--- a/scripts/ci/collect_ci_metrics.py
+++ b/scripts/ci/collect_ci_metrics.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""Collect lightweight CI metrics for the canonical Tier 1 backend/shared lane."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+GITHUB_API_HOST = "api.github.com"
+USER_AGENT = "pulseplate-ci-metrics"
+CI_XDIST_FALLBACK_MARKER = "PYTEST_XDIST_ARGS=-p no:xdist"
+DEFAULT_LOOKBACK_DAYS = 7
+DEFAULT_MAX_RUNS = 20
+DEFAULT_WORKFLOW_FILE = "ci.yml"
+DEFAULT_WORKFLOW_NAME = "CI"
+DEFAULT_BRANCH = "main"
+DEFAULT_PYTHON313_JOB_NAME = "test-main (3.13)"
+MAX_REDIRECT_HOPS = 5
+GITHUB_API_ONLY_HEADERS = frozenset({"authorization", "accept", "x-github-api-version"})
+WARNING_URL_RE = re.compile(r"https://\S+")
+ADVISORY_NETWORK_EXCEPTIONS = (RuntimeError, urllib.error.HTTPError, ValueError, OSError)
+
+
+def _github_token() -> str:
+    """Return the preferred GitHub auth token from environment."""
+
+    return os.getenv("GH_TOKEN", "").strip() or os.getenv("GITHUB_TOKEN", "").strip()
+
+
+def _python313_job_name() -> str:
+    """Return the canonical Python 3.13 job name for the Tier 1 CI lane."""
+
+    return os.getenv("CI_METRICS_PYTHON313_JOB_NAME", "").strip() or DEFAULT_PYTHON313_JOB_NAME
+
+
+def _headers_for_request_host(headers: dict[str, str], *, host: str) -> dict[str, str]:
+    """Keep API auth headers only for api.github.com requests.
+
+    RU: Signed log URLs уже авторизованы, поэтому GitHub API bearer нельзя отправлять на другой host.
+    EN: Signed log URLs are already authorized, so never forward GitHub API bearer headers cross-host.
+    """
+
+    if host == GITHUB_API_HOST:
+        return dict(headers)
+    return {
+        key: value for key, value in headers.items() if key.lower() not in GITHUB_API_ONLY_HEADERS
+    }
+
+
+def _warning_detail(exc: Exception) -> str:
+    """Return a warning-safe exception detail without leaking signed URLs."""
+
+    sanitized = WARNING_URL_RE.sub("<redacted-url>", str(exc)).strip()
+    if sanitized:
+        return sanitized
+    return exc.__class__.__name__
+
+
+def _parse_iso8601(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp into UTC-aware datetime."""
+
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _duration_seconds(started_at: str, completed_at: str) -> int | None:
+    """Return whole-second duration when both timestamps are available."""
+
+    started = _parse_iso8601(started_at)
+    completed = _parse_iso8601(completed_at)
+    if started is None or completed is None:
+        return None
+    return max(0, int((completed - started).total_seconds()))
+
+
+def _api_json(url: str, *, token: str) -> Any:
+    """Perform one GitHub API request and decode JSON response."""
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != GITHUB_API_HOST:
+        raise ValueError(f"Unsupported API URL: {url}")
+
+    path = parsed.path
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": USER_AGENT,
+    }
+    try:
+        conn.request("GET", path, headers=headers)
+        response = conn.getresponse()
+        body = response.read()
+    finally:
+        conn.close()
+
+    if response.status >= 400:
+        raise urllib.error.HTTPError(
+            url=url,
+            code=response.status,
+            msg=response.reason,
+            hdrs=response.headers,
+            fp=None,
+        )
+    return json.loads(body.decode("utf-8"))
+
+
+def _read_text_url(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    max_redirect_hops: int = MAX_REDIRECT_HOPS,
+) -> str:
+    """Fetch plain-text content and follow one redirect when GitHub returns signed URLs.
+
+    RU: Для job logs GitHub API отдаёт 302 на временный URL, поэтому follow делаем явно.
+    EN: Job logs come back as 302 redirects to signed URLs, so follow them explicitly.
+    """
+
+    current_url = url
+    current_headers = _headers_for_request_host(
+        dict(headers or {}),
+        host=urllib.parse.urlparse(current_url).netloc,
+    )
+    for redirect_hop in range(max_redirect_hops + 1):
+        parsed = urllib.parse.urlparse(current_url)
+        if parsed.scheme != "https":
+            raise ValueError(f"Unsupported URL scheme: {current_url}")
+
+        path = parsed.path
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+
+        conn = http.client.HTTPSConnection(parsed.netloc, timeout=30)
+        try:
+            conn.request("GET", path, headers=current_headers)
+            response = conn.getresponse()
+            body = response.read()
+            location = response.headers.get("Location", "")
+        finally:
+            conn.close()
+
+        if response.status in {301, 302, 303, 307, 308}:
+            if not location:
+                raise RuntimeError(f"Redirect without location for {current_url}")
+            if redirect_hop >= max_redirect_hops:
+                raise RuntimeError(
+                    "Redirect limit exceeded while fetching " f"{url}; last location was {location}"
+                )
+            current_url = urllib.parse.urljoin(current_url, location)
+            current_headers = _headers_for_request_host(
+                current_headers,
+                host=urllib.parse.urlparse(current_url).netloc,
+            )
+            continue
+
+        if response.status >= 400:
+            raise urllib.error.HTTPError(
+                url=current_url,
+                code=response.status,
+                msg=response.reason,
+                hdrs=response.headers,
+                fp=None,
+            )
+        return body.decode("utf-8", errors="replace")
+
+    raise RuntimeError(f"Redirect limit exceeded while fetching {url}")
+
+
+def _fetch_workflow_runs(
+    *,
+    repo: str,
+    workflow_file: str,
+    branch: str,
+    lookback_days: int,
+    max_runs: int,
+    token: str,
+) -> list[dict[str, Any]]:
+    """Fetch completed runs until the lookback boundary is reached."""
+
+    owner, name = repo.split("/", maxsplit=1)
+    recent_runs: list[dict[str, Any]] = []
+    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+    page = 1
+
+    while True:
+        url = (
+            f"https://{GITHUB_API_HOST}/repos/{owner}/{name}/actions/workflows/"
+            f"{urllib.parse.quote(workflow_file, safe='')}/runs"
+            f"?branch={urllib.parse.quote(branch, safe='')}"
+            f"&status=completed&per_page={max_runs}&page={page}"
+        )
+        payload = _api_json(url, token=token)
+        page_runs = list(payload.get("workflow_runs") or [])
+        if not page_runs:
+            break
+
+        recent_runs.extend(page_runs)
+        oldest_created_at = _parse_iso8601(str(page_runs[-1].get("created_at") or ""))
+        if len(page_runs) < max_runs or (
+            oldest_created_at is not None and oldest_created_at < cutoff
+        ):
+            break
+        page += 1
+
+    return recent_runs
+
+
+def _fetch_run_jobs(*, jobs_url: str, token: str) -> list[dict[str, Any]]:
+    """Fetch jobs for one workflow run."""
+
+    payload = _api_json(jobs_url, token=token)
+    return list(payload.get("jobs") or [])
+
+
+def _fetch_job_log_text(*, repo: str, job_id: int, token: str) -> str:
+    """Fetch raw log text for one job by following the API redirect."""
+
+    owner, name = repo.split("/", maxsplit=1)
+    url = f"https://{GITHUB_API_HOST}/repos/{owner}/{name}/actions/jobs/{job_id}/logs"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": USER_AGENT,
+    }
+    return _read_text_url(url, headers=headers)
+
+
+def _filter_recent_runs(runs: list[dict[str, Any]], *, lookback_days: int) -> list[dict[str, Any]]:
+    """Keep only runs whose creation timestamp falls within the lookback window."""
+
+    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+    filtered: list[dict[str, Any]] = []
+    for run in runs:
+        created_at = _parse_iso8601(str(run.get("created_at") or ""))
+        if created_at is not None and created_at >= cutoff:
+            filtered.append(run)
+    return filtered
+
+
+def _rerun_summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute rerun count/rate from repeated workflow runs on the same SHA."""
+
+    if not runs:
+        return {
+            "state": "unavailable",
+            "reason": "No completed CI runs found inside the lookback window.",
+        }
+
+    counts_by_sha: dict[str, int] = {}
+    for run in runs:
+        head_sha = str(run.get("head_sha") or "").strip()
+        if not head_sha:
+            continue
+        counts_by_sha[head_sha] = counts_by_sha.get(head_sha, 0) + 1
+
+    rerun_count = sum(max(0, count - 1) for count in counts_by_sha.values())
+    scanned_runs = len(runs)
+    rerun_rate = round(rerun_count / scanned_runs, 4)
+    return {
+        "state": "available",
+        "rerun_count": rerun_count,
+        "rerun_rate": rerun_rate,
+        "unique_head_shas": len(counts_by_sha),
+    }
+
+
+def _red_build_rate_summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute failed/cancelled rate across the scanned CI runs."""
+
+    scanned_runs = len(runs)
+    if scanned_runs == 0:
+        return {
+            "state": "unavailable",
+            "reason": "No completed CI runs found inside the lookback window.",
+        }
+
+    red_conclusions = {"failure", "cancelled", "timed_out", "startup_failure", "stale"}
+    red_runs = 0
+    success_runs = 0
+    neutral_runs = 0
+    for run in runs:
+        conclusion = str(run.get("conclusion") or "").strip().lower()
+        if conclusion == "success":
+            success_runs += 1
+        elif conclusion in red_conclusions:
+            red_runs += 1
+        else:
+            neutral_runs += 1
+
+    return {
+        "state": "available",
+        "red_runs": red_runs,
+        "successful_runs": success_runs,
+        "neutral_runs": neutral_runs,
+        "red_build_rate": round(red_runs / scanned_runs, 4),
+    }
+
+
+def _critical_path_summary(
+    latest_run: dict[str, Any] | None, latest_jobs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Summarize duration of the latest completed canonical CI run and its jobs."""
+
+    if latest_run is None:
+        return {
+            "state": "unavailable",
+            "reason": "No completed CI runs found inside the lookback window.",
+        }
+
+    latest_run_duration_seconds = _duration_seconds(
+        str(latest_run.get("run_started_at") or ""),
+        str(latest_run.get("updated_at") or ""),
+    )
+    jobs: list[dict[str, Any]] = []
+    for job in latest_jobs:
+        if str(job.get("conclusion") or "").strip().lower() == "skipped":
+            continue
+        duration_seconds = _duration_seconds(
+            str(job.get("started_at") or ""),
+            str(job.get("completed_at") or ""),
+        )
+        jobs.append(
+            {
+                "name": str(job.get("name") or ""),
+                "conclusion": str(job.get("conclusion") or ""),
+                "duration_seconds": duration_seconds,
+            }
+        )
+
+    return {
+        "state": "available",
+        "latest_run_id": latest_run.get("id"),
+        "latest_run_number": latest_run.get("run_number"),
+        "latest_run_conclusion": latest_run.get("conclusion"),
+        "latest_run_duration_seconds": latest_run_duration_seconds,
+        "jobs": jobs,
+    }
+
+
+def _find_python313_job(jobs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Find the canonical main-branch Python 3.13 job when present."""
+
+    canonical_name = _python313_job_name().casefold()
+    for job in jobs:
+        name = str(job.get("name") or "").strip().casefold()
+        if name == canonical_name:
+            return job
+    return None
+
+
+def _xdist_fallback_summary(
+    *,
+    repo: str,
+    latest_run: dict[str, Any] | None,
+    latest_jobs: list[dict[str, Any]],
+    runs: list[dict[str, Any]],
+    token: str,
+) -> tuple[dict[str, Any], list[str]]:
+    """Estimate xdist fallback frequency from the Python 3.13 canonical main job logs."""
+
+    warnings: list[str] = []
+    python313_job_name = _python313_job_name()
+    if latest_run is None:
+        return (
+            {
+                "state": "unavailable",
+                "reason": "No completed CI runs found inside the lookback window.",
+            },
+            warnings,
+        )
+
+    observed_runs = 0
+    fallback_hits = 0
+    for run in runs:
+        jobs_url = str(run.get("jobs_url") or "")
+        if not jobs_url:
+            continue
+        try:
+            jobs = (
+                latest_jobs
+                if run.get("id") == latest_run.get("id")
+                else _fetch_run_jobs(jobs_url=jobs_url, token=token)
+            )
+        except ADVISORY_NETWORK_EXCEPTIONS as exc:
+            warnings.append(
+                "xdist fallback frequency is unknown because jobs for run "
+                f"{run.get('id')} could not be loaded: {_warning_detail(exc)}"
+            )
+            return (
+                {
+                    "state": "unknown",
+                    "reason": "Python 3.13 job metadata could not be loaded.",
+                },
+                warnings,
+            )
+        python313_job = _find_python313_job(jobs)
+        if python313_job is None:
+            continue
+        observed_runs += 1
+        raw_job_id = python313_job.get("id")
+        if raw_job_id is None:
+            warnings.append(
+                "xdist fallback frequency is unknown because Python 3.13 job metadata "
+                f"for run {run.get('id')} did not include a job id"
+            )
+            return (
+                {
+                    "state": "unknown",
+                    "reason": "Python 3.13 job metadata was incomplete.",
+                },
+                warnings,
+            )
+        try:
+            job_id = int(str(raw_job_id))
+            log_text = _fetch_job_log_text(repo=repo, job_id=job_id, token=token)
+        except ADVISORY_NETWORK_EXCEPTIONS as exc:
+            warnings.append(
+                "xdist fallback frequency is unknown because Python 3.13 job logs "
+                f"could not be read for run {run.get('id')}: {_warning_detail(exc)}"
+            )
+            return (
+                {
+                    "state": "unknown",
+                    "reason": "Python 3.13 job logs were unavailable.",
+                },
+                warnings,
+            )
+        if CI_XDIST_FALLBACK_MARKER in log_text:
+            fallback_hits += 1
+
+    if observed_runs == 0:
+        warnings.append(
+            "xdist fallback frequency is unknown because no canonical "
+            f"'{python313_job_name}' jobs were found in the scanned CI runs."
+        )
+        return (
+            {
+                "state": "unknown",
+                "reason": f"No canonical Python 3.13 job '{python313_job_name}' was found.",
+            },
+            warnings,
+        )
+
+    return (
+        {
+            "state": "available",
+            "observed_runs": observed_runs,
+            "fallback_hits": fallback_hits,
+            "fallback_rate": round(fallback_hits / observed_runs, 4),
+            "marker": CI_XDIST_FALLBACK_MARKER,
+        },
+        warnings,
+    )
+
+
+def _latest_completed_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the newest completed run from the filtered set."""
+
+    if not runs:
+        return None
+    return max(runs, key=lambda run: str(run.get("created_at") or ""))
+
+
+def _render_markdown_summary(payload: dict[str, Any]) -> str:
+    """Render a compact Markdown report suitable for artifacts and step summary."""
+
+    critical_path = payload["critical_path_duration"]
+    reruns = payload["reruns"]
+    red_build_rate = payload["red_build_rate"]
+    xdist_fallback = payload["xdist_fallback_frequency"]
+    warnings = list(payload.get("warnings") or [])
+    notes = list(payload.get("notes") or [])
+
+    lines = [
+        "# Tier 1 CI Metrics Summary",
+        "",
+        f"- Generated at: `{payload['generated_at']}`",
+        f"- Repo: `{payload['repo']}`",
+        f"- Workflow: `{payload['ci_workflow']}` on branch `{payload['branch']}`",
+        f"- Lookback window: `{payload['lookback_days']}` days",
+        f"- Scanned runs: `{payload['scanned_runs']}`",
+        "",
+        "## Highlights",
+    ]
+
+    if critical_path["state"] == "available":
+        lines.append(
+            f"- Latest CI run `{critical_path['latest_run_id']}` took "
+            f"`{critical_path['latest_run_duration_seconds']}` seconds "
+            f"with conclusion `{critical_path['latest_run_conclusion']}`."
+        )
+    else:
+        lines.append(f"- Critical-path duration: {critical_path['reason']}")
+
+    if reruns["state"] == "available":
+        lines.append(
+            f"- Reruns: `{reruns['rerun_count']}` across `{payload['scanned_runs']}` scanned runs "
+            f"(rate `{reruns['rerun_rate']}`)."
+        )
+    else:
+        lines.append(f"- Reruns: {reruns['reason']}")
+
+    if red_build_rate["state"] == "available":
+        lines.append(
+            f"- Red-build rate: `{red_build_rate['red_build_rate']}` "
+            f"(`{red_build_rate['red_runs']}` red, `{red_build_rate['successful_runs']}` successful)."
+        )
+    else:
+        lines.append(f"- Red-build rate: {red_build_rate['reason']}")
+
+    if xdist_fallback["state"] == "available":
+        lines.append(
+            f"- Python 3.13 xdist fallback frequency: `{xdist_fallback['fallback_rate']}` "
+            f"(`{xdist_fallback['fallback_hits']}` / `{xdist_fallback['observed_runs']}`)."
+        )
+    else:
+        lines.append(f"- Python 3.13 xdist fallback frequency: {xdist_fallback['reason']}")
+
+    if critical_path["state"] == "available":
+        lines.extend(["", "## Latest Run Job Durations"])
+        for job in critical_path["jobs"]:
+            lines.append(
+                f"- `{job['name']}`: `{job['duration_seconds']}` seconds "
+                f"({job['conclusion'] or 'unknown'})"
+            )
+
+    if warnings:
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in warnings)
+
+    if notes:
+        lines.extend(["", "## Notes"])
+        lines.extend(f"- {note}" for note in notes)
+
+    return "\n".join(lines) + "\n"
+
+
+def _build_summary(
+    *,
+    repo: str,
+    branch: str,
+    workflow_name: str,
+    workflow_file: str,
+    lookback_days: int,
+    max_runs: int,
+    token: str,
+) -> dict[str, Any]:
+    """Collect workflow metrics and return the canonical summary payload."""
+
+    warnings: list[str] = []
+    notes = [
+        f"Headline metrics are calculated from workflow '{workflow_name}' on branch '{branch}'."
+    ]
+    if workflow_name == DEFAULT_WORKFLOW_NAME and branch == DEFAULT_BRANCH:
+        notes.append(
+            "Specialized add-on lanes remain contextual and do not influence the headline Tier 1 rates."
+        )
+
+    try:
+        runs = _fetch_workflow_runs(
+            repo=repo,
+            workflow_file=workflow_file,
+            branch=branch,
+            lookback_days=lookback_days,
+            max_runs=max_runs,
+            token=token,
+        )
+    except ADVISORY_NETWORK_EXCEPTIONS as exc:
+        unavailable_reason = "Workflow run metadata was unavailable."
+        warnings.append(
+            "CI metrics collection degraded because workflow runs could not be loaded: "
+            f"{_warning_detail(exc)}"
+        )
+        return {
+            "repo": repo,
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "lookback_days": lookback_days,
+            "max_runs": max_runs,
+            "scanned_runs": 0,
+            "branch": branch,
+            "ci_workflow": workflow_name,
+            "critical_path_duration": {
+                "state": "unavailable",
+                "reason": unavailable_reason,
+            },
+            "reruns": {
+                "state": "unavailable",
+                "reason": unavailable_reason,
+            },
+            "red_build_rate": {
+                "state": "unavailable",
+                "reason": unavailable_reason,
+            },
+            "xdist_fallback_frequency": {
+                "state": "unavailable",
+                "reason": unavailable_reason,
+            },
+            "notes": notes,
+            "warnings": warnings,
+        }
+
+    recent_runs = _filter_recent_runs(runs, lookback_days=lookback_days)
+    latest_run = _latest_completed_run(recent_runs)
+    latest_jobs: list[dict[str, Any]] = []
+    if latest_run is not None:
+        latest_jobs_url = str(latest_run.get("jobs_url") or "")
+        if latest_jobs_url:
+            try:
+                latest_jobs = _fetch_run_jobs(jobs_url=latest_jobs_url, token=token)
+            except ADVISORY_NETWORK_EXCEPTIONS as exc:
+                warnings.append(
+                    "Latest CI run jobs could not be loaded; critical-path job details are incomplete: "
+                    f"{_warning_detail(exc)}"
+                )
+
+    xdist_fallback_summary, xdist_warnings = _xdist_fallback_summary(
+        repo=repo,
+        latest_run=latest_run,
+        latest_jobs=latest_jobs,
+        runs=recent_runs,
+        token=token,
+    )
+    warnings.extend(xdist_warnings)
+
+    return {
+        "repo": repo,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "lookback_days": lookback_days,
+        "max_runs": max_runs,
+        "scanned_runs": len(recent_runs),
+        "branch": branch,
+        "ci_workflow": workflow_name,
+        "critical_path_duration": _critical_path_summary(latest_run, latest_jobs),
+        "reruns": _rerun_summary(recent_runs),
+        "red_build_rate": _red_build_rate_summary(recent_runs),
+        "xdist_fallback_frequency": xdist_fallback_summary,
+        "notes": notes,
+        "warnings": warnings,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.getenv("GITHUB_REPOSITORY", "").strip(),
+        help="Repository in owner/name format (default: GITHUB_REPOSITORY).",
+    )
+    parser.add_argument(
+        "--workflow-file",
+        default=DEFAULT_WORKFLOW_FILE,
+        help=f"Workflow file to query (default: {DEFAULT_WORKFLOW_FILE}).",
+    )
+    parser.add_argument(
+        "--workflow-name",
+        default=DEFAULT_WORKFLOW_NAME,
+        help=f"Display name for the workflow summary (default: {DEFAULT_WORKFLOW_NAME}).",
+    )
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help=f"Branch to scan for workflow runs (default: {DEFAULT_BRANCH}).",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help=f"Lookback window in days (default: {DEFAULT_LOOKBACK_DAYS}).",
+    )
+    parser.add_argument(
+        "--max-runs",
+        type=int,
+        default=DEFAULT_MAX_RUNS,
+        help=(
+            "Page size when scanning completed workflow runs before filtering by lookback "
+            f"(default: {DEFAULT_MAX_RUNS})."
+        ),
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        required=True,
+        help="Path to the JSON summary artifact.",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        required=True,
+        help="Path to the Markdown summary artifact.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if "/" not in args.repo:
+        parser.error("--repo must be provided in owner/name format.")
+    if args.lookback_days <= 0:
+        parser.error("--lookback-days must be positive.")
+    if args.max_runs <= 0:
+        parser.error("--max-runs must be positive.")
+
+    token = _github_token()
+    if not token:
+        print("ERROR: GH_TOKEN or GITHUB_TOKEN is required for CI metrics collection.")
+        return 1
+
+    payload = _build_summary(
+        repo=args.repo,
+        branch=args.branch,
+        workflow_name=args.workflow_name,
+        workflow_file=args.workflow_file,
+        lookback_days=args.lookback_days,
+        max_runs=args.max_runs,
+        token=token,
+    )
+    markdown = _render_markdown_summary(payload)
+
+    args.json_out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.markdown_out.write_text(markdown, encoding="utf-8")
+
+    print(
+        f"ci-metrics: wrote {args.json_out} and {args.markdown_out} "
+        f"for workflow '{args.workflow_name}' on '{args.branch}'."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_collect_ci_metrics.py
+++ b/tests/test_collect_ci_metrics.py
@@ -812,3 +812,20 @@ def test_main_requires_repo_token_and_paths(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "GH_TOKEN or GITHUB_TOKEN is required" in captured.out
+
+
+def test_ci_metrics_workflow_remains_advisory_only() -> None:
+    import yaml
+
+    repo_root = Path(__file__).resolve().parents[1]
+    workflow = yaml.load(
+        (repo_root / ".github" / "workflows" / "ci-metrics.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+    triggers = workflow["on"]
+
+    assert set(triggers) == {"schedule", "workflow_dispatch"}
+    assert "pull_request" not in triggers
+    assert "push" not in triggers
+    assert triggers["schedule"] == [{"cron": "0 13 * * 1"}]

--- a/tests/test_collect_ci_metrics.py
+++ b/tests/test_collect_ci_metrics.py
@@ -1,0 +1,814 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from scripts.ci import collect_ci_metrics
+
+
+def _anchor_now() -> datetime:
+    """Return a stable UTC anchor for relative timestamp generation."""
+
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def _iso_utc(value: datetime) -> str:
+    """Render a UTC datetime using the GitHub API timestamp shape."""
+
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    runs: list[dict[str, Any]],
+    jobs_by_run_id: dict[int, list[dict[str, Any]]],
+    logs_by_job_id: dict[int, str] | None = None,
+    log_exc: Exception | None = None,
+) -> tuple[int, dict[str, Any], str]:
+    logs_by_job_id = logs_by_job_id or {}
+    json_out = tmp_path / "ci-metrics-summary.json"
+    markdown_out = tmp_path / "ci-metrics-summary.md"
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setattr(
+        collect_ci_metrics,
+        "_fetch_workflow_runs",
+        lambda **kwargs: runs,
+    )
+    monkeypatch.setattr(
+        collect_ci_metrics,
+        "_fetch_run_jobs",
+        lambda **kwargs: jobs_by_run_id[int(str(kwargs["jobs_url"]).rsplit("/", 1)[-1])],
+    )
+
+    def fake_fetch_job_log_text(**kwargs: Any) -> str:
+        job_id = int(kwargs["job_id"])
+        if log_exc is not None:
+            raise log_exc
+        return logs_by_job_id[job_id]
+
+    monkeypatch.setattr(collect_ci_metrics, "_fetch_job_log_text", fake_fetch_job_log_text)
+
+    exit_code = collect_ci_metrics.main(
+        [
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+            "--lookback-days",
+            "30",
+            "--max-runs",
+            "20",
+        ]
+    )
+
+    payload = cast(dict[str, Any], json.loads(json_out.read_text(encoding="utf-8")))
+    markdown = markdown_out.read_text(encoding="utf-8")
+    return exit_code, payload, markdown
+
+
+def test_main_writes_metrics_for_successful_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 301,
+            "run_number": 9,
+            "head_sha": "sha-1",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=54)),
+            "jobs_url": "https://example.invalid/jobs/301",
+        },
+        {
+            "id": 300,
+            "run_number": 8,
+            "head_sha": "sha-0",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(days=1, hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(days=1, minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(days=1, minutes=56)),
+            "jobs_url": "https://example.invalid/jobs/300",
+        },
+    ]
+    jobs_by_run_id = {
+        301: [
+            {
+                "id": 901,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            },
+            {
+                "id": 902,
+                "name": "diff-coverage",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=55)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=54)),
+            },
+        ],
+        300: [
+            {
+                "id": 903,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(days=1, minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(days=1, minutes=55)),
+            }
+        ],
+    }
+    logs_by_job_id = {
+        901: f"...\n{collect_ci_metrics.CI_XDIST_FALLBACK_MARKER}\n...",
+        903: f"...\n{collect_ci_metrics.CI_XDIST_FALLBACK_MARKER}\n...",
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        logs_by_job_id=logs_by_job_id,
+    )
+
+    assert exit_code == 0
+    assert payload["scanned_runs"] == 2
+    assert payload["critical_path_duration"]["latest_run_id"] == 301
+    assert payload["critical_path_duration"]["latest_run_duration_seconds"] == 300
+    assert payload["reruns"]["rerun_count"] == 0
+    assert payload["red_build_rate"]["red_build_rate"] == 0.0
+    assert payload["xdist_fallback_frequency"]["fallback_hits"] == 2
+    assert payload["xdist_fallback_frequency"]["fallback_rate"] == 1.0
+    assert "Tier 1 CI Metrics Summary" in markdown
+    assert "Latest CI run `301` took `300` seconds" in markdown
+
+
+def test_main_counts_reruns_and_red_builds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 401,
+            "run_number": 12,
+            "head_sha": "sha-rerun",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=54)),
+            "jobs_url": "https://example.invalid/jobs/401",
+        },
+        {
+            "id": 400,
+            "run_number": 11,
+            "head_sha": "sha-rerun",
+            "conclusion": "failure",
+            "created_at": _iso_utc(anchor - timedelta(hours=2)),
+            "run_started_at": _iso_utc(anchor - timedelta(hours=2) + timedelta(minutes=1)),
+            "updated_at": _iso_utc(anchor - timedelta(hours=2) + timedelta(minutes=4)),
+            "jobs_url": "https://example.invalid/jobs/400",
+        },
+        {
+            "id": 399,
+            "run_number": 10,
+            "head_sha": "sha-cancelled",
+            "conclusion": "cancelled",
+            "created_at": _iso_utc(anchor - timedelta(days=1, hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(days=1, hours=1) + timedelta(minutes=1)),
+            "updated_at": _iso_utc(anchor - timedelta(days=1, hours=1) + timedelta(minutes=2)),
+            "jobs_url": "https://example.invalid/jobs/399",
+        },
+    ]
+    jobs_by_run_id = {
+        401: [
+            {
+                "id": 911,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ],
+        400: [
+            {
+                "id": 912,
+                "name": "test-main (3.13)",
+                "conclusion": "failure",
+                "started_at": _iso_utc(anchor - timedelta(hours=2) + timedelta(minutes=1)),
+                "completed_at": _iso_utc(anchor - timedelta(hours=2) + timedelta(minutes=3)),
+            }
+        ],
+        399: [
+            {
+                "id": 913,
+                "name": "test-main (3.13)",
+                "conclusion": "cancelled",
+                "started_at": _iso_utc(anchor - timedelta(days=1, hours=1) + timedelta(minutes=1)),
+                "completed_at": _iso_utc(
+                    anchor - timedelta(days=1, hours=1) + timedelta(minutes=2)
+                ),
+            }
+        ],
+    }
+    logs_by_job_id = {
+        911: f"...\n{collect_ci_metrics.CI_XDIST_FALLBACK_MARKER}\n...",
+        912: "...",
+        913: "...",
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        logs_by_job_id=logs_by_job_id,
+    )
+
+    assert exit_code == 0
+    assert payload["reruns"]["rerun_count"] == 1
+    assert payload["reruns"]["rerun_rate"] == pytest.approx(1 / 3, rel=1e-3)
+    assert payload["red_build_rate"]["red_runs"] == 2
+    assert payload["red_build_rate"]["red_build_rate"] == pytest.approx(2 / 3, rel=1e-3)
+    assert "Reruns: `1` across `3` scanned runs" in markdown
+
+
+def test_main_marks_xdist_metric_unknown_when_log_lookup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 501,
+            "run_number": 4,
+            "head_sha": "sha-1",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=54)),
+            "jobs_url": "https://example.invalid/jobs/501",
+        }
+    ]
+    jobs_by_run_id = {
+        501: [
+            {
+                "id": 921,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        log_exc=RuntimeError("logs unavailable"),
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert payload["warnings"]
+    assert (
+        "Python 3.13 xdist fallback frequency: Python 3.13 job logs were unavailable." in markdown
+    )
+
+
+def test_main_marks_xdist_metric_unknown_when_log_lookup_raises_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 502,
+            "run_number": 5,
+            "head_sha": "sha-1",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=54)),
+            "jobs_url": "https://example.invalid/jobs/502",
+        }
+    ]
+    jobs_by_run_id = {
+        502: [
+            {
+                "id": 922,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        log_exc=TimeoutError("timed out while fetching logs"),
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert any("timed out while fetching logs" in warning for warning in payload["warnings"])
+    assert (
+        "Python 3.13 xdist fallback frequency: Python 3.13 job logs were unavailable." in markdown
+    )
+
+
+def test_main_marks_xdist_metric_unknown_when_no_canonical_python313_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CI_METRICS_PYTHON313_JOB_NAME", "custom-main-3.13")
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 601,
+            "run_number": 5,
+            "head_sha": "sha-2",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=55)),
+            "jobs_url": "https://example.invalid/jobs/601",
+        }
+    ]
+    jobs_by_run_id = {
+        601: [
+            {
+                "id": 931,
+                "name": "test-main (3.12)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        logs_by_job_id={},
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert "No canonical Python 3.13 job 'custom-main-3.13' was found." in markdown
+    assert any("no canonical 'custom-main-3.13' jobs" in warning for warning in payload["warnings"])
+
+
+def test_main_marks_xdist_metric_unknown_when_python313_job_id_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 701,
+            "run_number": 6,
+            "head_sha": "sha-3",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=55)),
+            "jobs_url": "https://example.invalid/jobs/701",
+        }
+    ]
+    jobs_by_run_id = {
+        701: [
+            {
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        logs_by_job_id={},
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert "Python 3.13 job metadata was incomplete." in markdown
+    assert any("did not include a job id" in warning for warning in payload["warnings"])
+
+
+def test_main_marks_xdist_metric_unknown_when_python313_job_id_is_malformed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 702,
+            "run_number": 7,
+            "head_sha": "sha-4",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=55)),
+            "jobs_url": "https://example.invalid/jobs/702",
+        }
+    ]
+    jobs_by_run_id = {
+        702: [
+            {
+                "id": "not-an-int",
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        logs_by_job_id={},
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert "Python 3.13 job logs were unavailable." in markdown
+    assert any("invalid literal for int()" in warning for warning in payload["warnings"])
+
+
+def test_main_writes_valid_outputs_when_no_runs_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=[],
+        jobs_by_run_id={},
+        logs_by_job_id={},
+    )
+
+    assert exit_code == 0
+    assert payload["scanned_runs"] == 0
+    assert payload["critical_path_duration"]["state"] == "unavailable"
+    assert payload["reruns"]["state"] == "unavailable"
+    assert payload["red_build_rate"]["state"] == "unavailable"
+    assert payload["xdist_fallback_frequency"]["state"] == "unavailable"
+    assert "No completed CI runs found inside the lookback window." in markdown
+    assert "Reruns: No completed CI runs found inside the lookback window." in markdown
+
+
+def test_main_degrades_to_unavailable_when_workflow_runs_cannot_be_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    json_out = tmp_path / "ci-metrics-summary.json"
+    markdown_out = tmp_path / "ci-metrics-summary.md"
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setattr(
+        collect_ci_metrics,
+        "_fetch_workflow_runs",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("github api unavailable")),
+    )
+
+    exit_code = collect_ci_metrics.main(
+        [
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 0
+    assert payload["critical_path_duration"]["state"] == "unavailable"
+    assert payload["reruns"]["state"] == "unavailable"
+    assert payload["red_build_rate"]["state"] == "unavailable"
+    assert payload["xdist_fallback_frequency"]["state"] == "unavailable"
+    assert any("workflow runs could not be loaded" in warning for warning in payload["warnings"])
+    assert "Workflow run metadata was unavailable." in markdown
+
+
+def test_main_degrades_to_unavailable_when_workflow_runs_raise_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    json_out = tmp_path / "ci-metrics-summary.json"
+    markdown_out = tmp_path / "ci-metrics-summary.md"
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setattr(
+        collect_ci_metrics,
+        "_fetch_workflow_runs",
+        lambda **kwargs: (_ for _ in ()).throw(ConnectionResetError("github socket reset")),
+    )
+
+    exit_code = collect_ci_metrics.main(
+        [
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 0
+    assert payload["critical_path_duration"]["state"] == "unavailable"
+    assert payload["reruns"]["state"] == "unavailable"
+    assert payload["red_build_rate"]["state"] == "unavailable"
+    assert payload["xdist_fallback_frequency"]["state"] == "unavailable"
+    assert any("github socket reset" in warning for warning in payload["warnings"])
+    assert "Workflow run metadata was unavailable." in markdown
+
+
+def test_main_sanitizes_signed_urls_from_warning_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    anchor = _anchor_now()
+    runs = [
+        {
+            "id": 503,
+            "run_number": 6,
+            "head_sha": "sha-1",
+            "conclusion": "success",
+            "created_at": _iso_utc(anchor - timedelta(hours=1)),
+            "run_started_at": _iso_utc(anchor - timedelta(minutes=59)),
+            "updated_at": _iso_utc(anchor - timedelta(minutes=54)),
+            "jobs_url": "https://example.invalid/jobs/503",
+        }
+    ]
+    jobs_by_run_id = {
+        503: [
+            {
+                "id": 923,
+                "name": "test-main (3.13)",
+                "conclusion": "success",
+                "started_at": _iso_utc(anchor - timedelta(minutes=59)),
+                "completed_at": _iso_utc(anchor - timedelta(minutes=55)),
+            }
+        ]
+    }
+
+    exit_code, payload, markdown = _run(
+        tmp_path,
+        monkeypatch,
+        runs=runs,
+        jobs_by_run_id=jobs_by_run_id,
+        log_exc=RuntimeError(
+            "Redirect limit exceeded while fetching https://api.github.com/foo; "
+            "last location was https://pipelines.actions.githubusercontent.com/logs/download"
+        ),
+    )
+
+    assert exit_code == 0
+    assert payload["xdist_fallback_frequency"]["state"] == "unknown"
+    assert all("https://" not in warning for warning in payload["warnings"])
+    assert any("<redacted-url>" in warning for warning in payload["warnings"])
+    assert "https://" not in markdown
+    assert "<redacted-url>" in markdown
+
+
+def test_fetch_workflow_runs_paginates_until_the_lookback_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    anchor = _anchor_now()
+    requested_urls: list[str] = []
+    page_payloads = {
+        1: {
+            "workflow_runs": [
+                {"id": 801, "created_at": _iso_utc(anchor - timedelta(days=1))},
+                {"id": 800, "created_at": _iso_utc(anchor - timedelta(days=2))},
+            ]
+        },
+        2: {
+            "workflow_runs": [
+                {"id": 799, "created_at": _iso_utc(anchor - timedelta(days=3))},
+                {"id": 798, "created_at": _iso_utc(anchor - timedelta(days=10))},
+            ]
+        },
+    }
+
+    def fake_api_json(url: str, *, token: str) -> object:
+        requested_urls.append(url)
+        page = int(urllib.parse.parse_qs(urllib.parse.urlparse(url).query)["page"][0])
+        return page_payloads[page]
+
+    monkeypatch.setattr(collect_ci_metrics, "_api_json", fake_api_json)
+
+    runs = collect_ci_metrics._fetch_workflow_runs(
+        repo="Katsiarynakavaleuskaya/PulsePlate",
+        workflow_file="ci.yml",
+        branch="main",
+        lookback_days=7,
+        max_runs=2,
+        token="token",
+    )
+
+    assert [run["id"] for run in runs] == [801, 800, 799, 798]
+    assert requested_urls == [
+        "https://api.github.com/repos/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=2&page=1",
+        "https://api.github.com/repos/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml/runs?branch=main&status=completed&per_page=2&page=2",
+    ]
+
+
+def test_parse_iso8601_returns_none_for_malformed_values() -> None:
+    assert collect_ci_metrics._parse_iso8601("not-a-timestamp") is None
+
+
+def test_read_text_url_raises_when_redirect_limit_is_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, *, status: int, location: str = "", body: bytes = b"") -> None:
+            self.status = status
+            self.reason = "Found" if status < 400 else "Error"
+            self.headers = {"Location": location} if location else {}
+            self._body = body
+
+        def read(self) -> bytes:
+            return self._body
+
+    class FakeConnection:
+        def __init__(self, netloc: str, timeout: int) -> None:
+            self.netloc = netloc
+            self.timeout = timeout
+
+        def request(self, method: str, path: str, headers: dict[str, str]) -> None:
+            self.method = method
+            self.path = path
+            self.headers = headers
+
+        def getresponse(self) -> FakeResponse:
+            return FakeResponse(status=302, location="https://example.invalid/loop")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(collect_ci_metrics.http.client, "HTTPSConnection", FakeConnection)
+
+    with pytest.raises(RuntimeError, match="Redirect limit exceeded"):
+        collect_ci_metrics._read_text_url("https://example.invalid/start", max_redirect_hops=2)
+
+
+def test_read_text_url_drops_github_api_headers_after_cross_host_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, *, status: int, location: str = "", body: bytes = b"") -> None:
+            self.status = status
+            self.reason = "Found" if status < 400 else "Error"
+            self.headers = {"Location": location} if location else {}
+            self._body = body
+
+        def read(self) -> bytes:
+            return self._body
+
+    recorded_requests: list[dict[str, object]] = []
+
+    class FakeConnection:
+        def __init__(self, netloc: str, timeout: int) -> None:
+            self.netloc = netloc
+            self.timeout = timeout
+
+        def request(self, method: str, path: str, headers: dict[str, str]) -> None:
+            recorded_requests.append(
+                {"host": self.netloc, "method": method, "path": path, "headers": dict(headers)}
+            )
+
+        def getresponse(self) -> FakeResponse:
+            if self.netloc == collect_ci_metrics.GITHUB_API_HOST:
+                return FakeResponse(
+                    status=302,
+                    location="https://pipelines.actions.githubusercontent.com/logs/download",
+                )
+            return FakeResponse(status=200, body=b"log output")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(collect_ci_metrics.http.client, "HTTPSConnection", FakeConnection)
+
+    body = collect_ci_metrics._read_text_url(
+        "https://api.github.com/repos/octo/test/actions/jobs/1/logs",
+        headers={
+            "Authorization": "Bearer secret",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": collect_ci_metrics.USER_AGENT,
+        },
+    )
+
+    assert body == "log output"
+    assert len(recorded_requests) == 2
+    assert recorded_requests[0]["host"] == collect_ci_metrics.GITHUB_API_HOST
+    assert recorded_requests[0]["headers"]["Authorization"] == "Bearer secret"
+    redirected_headers = recorded_requests[1]["headers"]
+    assert recorded_requests[1]["host"] == "pipelines.actions.githubusercontent.com"
+    assert "Authorization" not in redirected_headers
+    assert "Accept" not in redirected_headers
+    assert "X-GitHub-Api-Version" not in redirected_headers
+    assert redirected_headers["User-Agent"] == collect_ci_metrics.USER_AGENT
+
+
+def test_find_python313_job_uses_configurable_canonical_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_METRICS_PYTHON313_JOB_NAME", "custom-main-3.13")
+
+    found = collect_ci_metrics._find_python313_job(
+        [
+            {"id": 1, "name": "test-main (3.13)"},
+            {"id": 2, "name": "custom-main-3.13"},
+        ]
+    )
+
+    assert found == {"id": 2, "name": "custom-main-3.13"}
+
+
+def test_main_uses_requested_workflow_and_branch_in_summary_notes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    json_out = tmp_path / "ci-metrics-summary.json"
+    markdown_out = tmp_path / "ci-metrics-summary.md"
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setattr(collect_ci_metrics, "_fetch_workflow_runs", lambda **kwargs: [])
+
+    exit_code = collect_ci_metrics.main(
+        [
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--branch",
+            "release/hotfix",
+            "--workflow-name",
+            "CI Metrics Preview",
+            "--workflow-file",
+            "ci-metrics.yml",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 0
+    assert payload["notes"] == [
+        "Headline metrics are calculated from workflow 'CI Metrics Preview' on branch 'release/hotfix'."
+    ]
+    assert (
+        "Headline metrics are calculated from workflow 'CI Metrics Preview' on branch 'release/hotfix'."
+        in markdown
+    )
+    assert "Specialized add-on lanes remain contextual" not in markdown
+
+
+def test_main_requires_repo_token_and_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    exit_code = collect_ci_metrics.main(
+        [
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--json-out",
+            str(tmp_path / "summary.json"),
+            "--markdown-out",
+            str(tmp_path / "summary.md"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "GH_TOKEN or GITHUB_TOKEN is required" in captured.out


### PR DESCRIPTION
## Summary
- add the PR4 advisory CI metrics workflow plus JSON/Markdown summary artifacts for critical-path duration, reruns, red-build rate, and Python 3.13 xdist fallback tracking
- harden the collector so missing workflow data degrades to informational `unknown`/`unavailable` states without leaking signed URLs or becoming merge-blocking truth
- align the Tier 1 runbook, task packet, backlog entry, and review artifact with PR4 as the active metrics slice

## Test plan
- [x] `. .venv/bin/activate && pytest -q tests/test_collect_ci_metrics.py tests/test_repo_policy_guards.py`
- [x] `. .venv/bin/activate && pytest -q tests/test_collect_ci_metrics.py`
- [x] `. .venv/bin/activate && pre-commit run --all-files`
- [x] `. .venv/bin/activate && make verify`

## Split Justification
- keep PR4 limited to the advisory metrics workflow, collector/tests, and the minimal Tier 1 documentation updates required to keep the canonical packet and backlog in sync

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- No actionable review comments

## Deferred / Follow-ups
- None.

## Summary by Sourcery

Добавлен вспомогательный (advisory) workflow и сборщик метрик CI для Tier 1 backend/shared lane с необязательными (не блокирующими) отчётными артефактами и обновлённой документацией, фиксирующей PR4 как активный срез выполнения.

Enhancements:
- Добавлен скрипт сборщика метрик CI, который агрегирует результаты запусков workflow Tier 1 в артефакты JSON и Markdown, включая длительность критического пути, количество перезапусков, частоту «red-build» и частоту откатов на Python 3.13 xdist.
- Усилена надёжность сбора метрик CI: отсутствие или недоступность данных GitHub workflow и логов теперь явно понижаются в состояния `unknown`/`unavailable`, при этом из предупреждений удаляются подписанные URL.
- Добавлен запланированный и запускаемый по запросу workflow GitHub Actions для метрик CI, который запускает сборщик, публикует результаты в step summary и выгружает артефакты без влияния на обязательные проверки PR.
- Обновлены документы по Tier 1 backlog, runbook и task packet, чтобы зафиксировать PR3 как принятую базу, PR4 как активный срез метрик и формально обозначить, что метрики остаются исключительно advisory и не входят в merge-truth поверхность.

Documentation:
- Добавлен документ сопоставления Fixed-in-Commit для этого PR и обновлена документация по Tier 1 CI/CD с описанием нового вспомогательного канала метрик, пути репортинга и ограничений против расширения правил защиты веток.

Tests:
- Добавлены комплексные тесты для сборщика метрик CI, покрывающие пагинацию workflow, вычисление перезапусков и «red-build» показателей, обнаружение откатов xdist, сценарии деградации при сбоях/таймаутах, обработку заголовков при редиректах и сохранение статуса триггеров workflow как исключительно advisory.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an advisory CI metrics workflow and collector for the Tier 1 backend/shared lane, with non-blocking reporting artifacts and documentation updates aligning PR4 as the active execution slice.

Enhancements:
- Introduce a CI metrics collector script that summarizes Tier 1 workflow runs into JSON and Markdown artifacts, including critical-path duration, reruns, red-build rate, and Python 3.13 xdist fallback frequency.
- Harden CI metrics collection to degrade missing or unreachable GitHub workflow and log data into explicit `unknown`/`unavailable` states while sanitizing signed URLs from warnings.
- Add a scheduled, dispatchable CI metrics GitHub Actions workflow that runs the collector, publishes results to the step summary, and uploads artifacts without affecting required PR checks.
- Update Tier 1 backlog, runbook, and task packet documentation to reflect PR3 as landed baseline, PR4 as the active metrics slice, and to codify that metrics remain advisory-only and outside merge-truth surfaces.

Documentation:
- Add a Fixed-in-Commit mapping document for this PR and refresh Tier 1 CI/CD docs to describe the new advisory metrics lane, reporting path, and guardrails against expanding branch protection.

Tests:
- Add comprehensive tests for the CI metrics collector covering workflow pagination, rerun and red-build calculations, xdist fallback detection, failure/timeout degradation paths, header handling on redirects, and workflow triggers remaining advisory-only.

</details>