### PR TITLE
fix(security): suppress unfixed systemd image CVE

### DIFF
--- a/docs/review/PR_1288_FIXED_MAPPING.md
+++ b/docs/review/PR_1288_FIXED_MAPPING.md
@@ -1,0 +1,24 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1288 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments yet.
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [ ] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+Notes: Draft recovery PR for the two systemd image-alert findings on `main`.
+This branch was split from the earlier mixed-CVE draft so the suppression work
+stays compliant with the repo rule that security suppression PRs are CVE-scoped.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1288_FIXED_MAPPING.md
+++ b/docs/review/PR_1288_FIXED_MAPPING.md
@@ -3,12 +3,12 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments yet.
+- No actionable review comments
 
 ## Merge Readiness
 
@@ -17,7 +17,7 @@
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [ ] `make verify` green
-- [ ] Mandatory post-open bug-hunter pass completed
+- [x] Mandatory post-open bug-hunter pass completed
 Notes: Draft recovery PR for the two systemd image-alert findings on `main`.
 This branch was split from the earlier mixed-CVE draft so the suppression work
 stays compliant with the repo rule that security suppression PRs are CVE-scoped.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2400,6 +2400,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `pre-commit run --all-files` and `make verify` pass in follow-up PR
   - Blockers: None (deferred by scope, not blocked)
 
+- [ ] Remove Trivy suppression for systemd CVE (CVE-2026-29111)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Reason: Trivy reports `libsystemd0` and `libudev1` alerts on `main`, but
+    Debian bookworm still has no fixed package for CVE-2026-29111 at the time
+    of triage. The repo therefore uses a narrow `trivy/ignore-policy.rego`
+    suppression until Debian or Trivy exposes a fixed version.
+  - Links:
+    - `trivy/ignore-policy.rego` (rule for CVE-2026-29111)
+    - `docs/security/CVE-2026-29111-systemd.md`
+    - `.github/workflows/build.yml`
+  - DoD:
+    - Debian bookworm publishes fixed `systemd` binary packages (or Trivy publishes fixed-version metadata)
+    - Remove CVE-2026-29111 suppression from `trivy/ignore-policy.rego`
+    - Remove `docs/security/CVE-2026-29111-systemd.md` (or mark as resolved)
+    - Trivy code-scanning alerts 573/575 remain closed on `main`
+
 - [ ] Remove Trivy suppression for gpgv CVE (CVE-2026-24883)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/docs/security/CVE-2026-29111-systemd.md
+++ b/docs/security/CVE-2026-29111-systemd.md
@@ -1,0 +1,65 @@
+# CVE-2026-29111: systemd IPC API DoS / code-execution exposure
+
+## Summary
+
+- **CVE:** CVE-2026-29111
+- **Source package:** `systemd`
+- **Severity:** HIGH in Trivy alert classification
+- **Observed version:** `252.38-1~deb12u1`
+- **Fixed version:** None in Debian bookworm at time of triage
+- **Status:** SUPPRESSED (temporary, narrow package/version match)
+
+## Affected binary packages
+
+| Package | Version | Alert # |
+| --- | --- | --- |
+| `libsystemd0` | `252.38-1~deb12u1` | 573 |
+| `libudev1` | `252.38-1~deb12u1` | 575 |
+
+## Current situation
+
+The Debian security tracker reports bookworm as still vulnerable for this
+systemd issue. Upstream fixed package lines exist only in newer releases/sid,
+so the repository cannot remediate the live GitHub code-scanning alerts with a
+safe in-repo bookworm package bump today.
+
+## Why we suppress
+
+- This is an **OS package** alert in the container base image.
+- The live alert surface is limited to two exact runtime packages observed on `main`.
+- A narrow suppression keeps the security tab actionable while we wait for a
+  bookworm fix or updated Trivy metadata.
+
+## Monitor / upstream status
+
+- **Debian Security Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-29111>
+- **GitHub Security alert examples:** `security/code-scanning/573`, `575`
+
+## Removal condition
+
+Remove the suppression when any of the following becomes true:
+
+1. Debian bookworm publishes fixed `systemd` binary packages for these alerts, or
+2. Trivy metadata starts reporting a fixed version for the bookworm packages, or
+3. The runtime base image moves to a supported distro line that no longer ships the vulnerable versions.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-29111"`
+  - package set `{libsystemd0, libudev1}`
+  - `input.InstalledVersion == "252.38-1~deb12u1"`
+
+## Evidence
+
+- `trivy/ignore-policy.rego:178`
+- `trivy/ignore-policy.rego:203`
+- `.github/workflows/build.yml:230`
+- `Dockerfile:81`
+- `docs/roadmap/BACKLOG_LEDGER.md:2419`
+
+## Review / expiry
+
+- **Review-by:** 2026-05-27 (shared policy-file expiry window)
+- **Last updated:** 2026-03-30

--- a/docs/security/CVE-2026-29111-systemd.md
+++ b/docs/security/CVE-2026-29111-systemd.md
@@ -53,8 +53,8 @@ Remove the suppression when any of the following becomes true:
 
 ## Evidence
 
-- `trivy/ignore-policy.rego:178`
-- `trivy/ignore-policy.rego:203`
+- `trivy/ignore-policy.rego:138`
+- `trivy/ignore-policy.rego:163`
 - `.github/workflows/build.yml:230`
 - `Dockerfile:81`
 - `docs/roadmap/BACKLOG_LEDGER.md:2419`

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -11,7 +11,7 @@ default ignore := false
 #
 # Suppression expires: 2026-05-27 (manual removal)
 # Last reviewed: 2026-02-27
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-29111-systemd.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -133,4 +133,36 @@ ignore if {
 	input.VulnerabilityID == "CVE-2026-3184"
 	cve_2026_3184_pkg_match
 	cve_2026_3184_version_match
+}
+
+# CVE-2026-29111 (systemd family) - upstream unfixed in Debian bookworm
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Debian tracker marks bookworm vulnerable and fixed packages are only available in sid;
+#   no repo-local remediation exists while staying on supported bookworm base images.
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-29111
+# Documented in: docs/security/CVE-2026-29111-systemd.md
+# Removal condition: Remove when Debian bookworm publishes fixed systemd packages or Trivy metadata includes Fixed Version
+
+cve_2026_29111_pkg_match if {
+	systemd_pkgs := {"libsystemd0", "libudev1"}
+	systemd_pkgs[input.PkgName]
+}
+
+cve_2026_29111_version_match if {
+	input.InstalledVersion == "252.38-1~deb12u1"
+}
+
+cve_2026_29111_pkgid_match if {
+	startswith(input.PkgID, "libsystemd0@252.38-1~deb12u1")
+}
+
+cve_2026_29111_pkgid_match if {
+	startswith(input.PkgID, "libudev1@252.38-1~deb12u1")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-29111"
+	cve_2026_29111_pkg_match
+	cve_2026_29111_version_match
+	cve_2026_29111_pkgid_match
 }


### PR DESCRIPTION
## Summary
- add a narrow Trivy ignore-policy rule for the two live `main` code-scanning alerts tied to the unfixed Debian bookworm systemd package set
- document the systemd CVE triage in `docs/security/` and track the removal follow-up in `docs/roadmap/BACKLOG_LEDGER.md`
- validate the systemd-only recovery lane locally in a clean `origin/main` worktree

## Test plan
- [x] `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-29111-systemd.md`
- [x] `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
- [x] `"/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python" -m pre_commit run --files trivy/ignore-policy.rego docs/security/CVE-2026-29111-systemd.md docs/roadmap/BACKLOG_LEDGER.md`

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md` entry for removing the temporary systemd suppression remains open until Debian bookworm or Trivy metadata exposes a fixed version.

## Discussion Thread Pass
- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1288_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] Local validation complete
- [x] Mandatory post-open bug-hunter pass completed

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Добавить временное, узко сфокусированное правило игнорирования Trivy, чтобы подавить неисправленную уязвимость systemd для Debian bookworm и задокументировать её триаж, мониторинг и условия удаления.

Улучшения:
- Расширить политику игнорирования Trivy, чтобы охватывать CVE-2026-29111 только для определённых пакетов и версий, связанных с systemd, в Debian bookworm.
- Создать задачу в бэклоге для удаления временного подавления уязвимости systemd, как только апстрим предоставит исправление или будет обновлена метадата Trivy.

Документация:
- Добавить заметку по безопасности с описанием CVE-2026-29111 для systemd, включая область действия, обоснование подавления, ссылки для мониторинга и критерии удаления.
- Добавить специфичный для этого PR документ с отображением fixed-in-commit, отражающий статус ревью и готовность к слиянию для данного изменения по подавлению уязвимости.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a temporary, narrowly scoped Trivy ignore rule to suppress the unfixed Debian bookworm systemd CVE and document its triage, monitoring, and removal conditions.

Enhancements:
- Extend the Trivy ignore policy to cover CVE-2026-29111 only for specific systemd-related packages and versions in Debian bookworm.
- Record a backlog entry to remove the temporary systemd CVE suppression once upstream provides a fix or Trivy metadata is updated.

Documentation:
- Add a security note detailing CVE-2026-29111 for systemd, including scope, rationale for suppression, monitoring links, and removal criteria.
- Add a PR-specific fixed-in-commit mapping document capturing review status and merge readiness for this security suppression change.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавить временное, узко сфокусированное правило игнорирования Trivy, чтобы подавить неисправленную уязвимость systemd для Debian bookworm и задокументировать её триаж, мониторинг и условия удаления.

Улучшения:
- Расширить политику игнорирования Trivy, чтобы охватывать CVE-2026-29111 только для определённых пакетов и версий, связанных с systemd, в Debian bookworm.
- Создать задачу в бэклоге для удаления временного подавления уязвимости systemd, как только апстрим предоставит исправление или будет обновлена метадата Trivy.

Документация:
- Добавить заметку по безопасности с описанием CVE-2026-29111 для systemd, включая область действия, обоснование подавления, ссылки для мониторинга и критерии удаления.
- Добавить специфичный для этого PR документ с отображением fixed-in-commit, отражающий статус ревью и готовность к слиянию для данного изменения по подавлению уязвимости.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a temporary, narrowly scoped Trivy ignore rule to suppress the unfixed Debian bookworm systemd CVE and document its triage, monitoring, and removal conditions.

Enhancements:
- Extend the Trivy ignore policy to cover CVE-2026-29111 only for specific systemd-related packages and versions in Debian bookworm.
- Record a backlog entry to remove the temporary systemd CVE suppression once upstream provides a fix or Trivy metadata is updated.

Documentation:
- Add a security note detailing CVE-2026-29111 for systemd, including scope, rationale for suppression, monitoring links, and removal criteria.
- Add a PR-specific fixed-in-commit mapping document capturing review status and merge readiness for this security suppression change.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a narrow Trivy ignore-policy to temporarily suppress CVE-2026-29111 in Debian bookworm `systemd` (`libsystemd0`, `libudev1` at `252.38-1~deb12u1`), silencing two code-scanning alerts until an upstream fix exists. Document triage and removal conditions, add a backlog entry, and normalize the review artifact and evidence with correct file:line anchors.

<sup>Written for commit b0e4ea9205cbbe216213caeae7f18ea04ddf6cde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security documentation for CVE-2026-29111 (systemd) with suppression rationale and removal conditions.
  * Created backlog tracking for future suppression removal.

* **Chores**
  * Updated security suppression policies to address CVE-2026-29111 with targeted version and package matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->