### PR TITLE
fix(security): suppress bookworm systemd Trivy alert

### DIFF
--- a/docs/review/PR_1289_FIXED_MAPPING.md
+++ b/docs/review/PR_1289_FIXED_MAPPING.md
@@ -6,9 +6,9 @@
 
 ## Fixed in Commit Mapping
 
-- Disposition: FIXED
-- Commit: `b9c42ac7`
-- Evidence: `trivy/ignore-policy.rego`, `docs/security/CVE-2026-29111-systemd.md`
+Disposition: FIXED
+Commit: b9c42ac7
+Evidence: trivy/ignore-policy.rego, docs/security/CVE-2026-29111-systemd.md
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#discussion_r3011982836 -> b9c42ac7
 
 ## Merge Readiness

--- a/docs/review/PR_1289_FIXED_MAPPING.md
+++ b/docs/review/PR_1289_FIXED_MAPPING.md
@@ -6,7 +6,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- Disposition: FIXED
+- Commit: `b9c42ac7`
+- Evidence: `trivy/ignore-policy.rego`, `docs/security/CVE-2026-29111-systemd.md`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#discussion_r3011982836 -> b9c42ac7
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1289_FIXED_MAPPING.md
+++ b/docs/review/PR_1289_FIXED_MAPPING.md
@@ -9,6 +9,8 @@
 Disposition: FIXED
 Commit: b9c42ac7
 Evidence: trivy/ignore-policy.rego, docs/security/CVE-2026-29111-systemd.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#pullrequestreview-4033073553 -> b9c42ac7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#pullrequestreview-4033084449 -> b9c42ac7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#discussion_r3011982836 -> b9c42ac7
 
 ## Merge Readiness

--- a/docs/review/PR_1289_FIXED_MAPPING.md
+++ b/docs/review/PR_1289_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1289 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- CVE-scoped security suppression lane for `CVE-2026-29111` (`systemd` family) covering GitHub alerts `#573` and `#575`.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2415,6 +2415,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Remove `docs/security/CVE-2026-24883-gpgv.md` (or mark as resolved)
     - Trivy Code Scanning alerts remain closed on `main`
 
+- [ ] Remove Trivy suppression for systemd-family CVE (CVE-2026-29111)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Reason: Trivy reports Debian bookworm `systemd` family packages
+    (`libsystemd0`, `libudev1`) as vulnerable at `252.38-1~deb12u1` with no
+    actionable fixed version in the current bookworm image line as of
+    2026-03-30; we suppress narrowly in `trivy/ignore-policy.rego` until
+    Debian bookworm or Trivy metadata catches up.
+  - Links:
+    - `trivy/ignore-policy.rego` (rule for CVE-2026-29111)
+    - `docs/security/CVE-2026-29111-systemd.md`
+    - `.github/workflows/build.yml`
+  - DoD:
+    - Debian bookworm publishes a fixed `systemd` package line (or Trivy reports
+      a fixed version in our image context)
+    - Remove CVE-2026-29111 suppression from `trivy/ignore-policy.rego`
+    - Remove `docs/security/CVE-2026-29111-systemd.md` (or mark as resolved)
+    - Trivy Code Scanning alerts `#573` and `#575` remain closed on `main`
+
 
 - [ ] Security suppression expiry monitoring
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/security/CVE-2026-29111-systemd.md
+++ b/docs/security/CVE-2026-29111-systemd.md
@@ -1,0 +1,83 @@
+# CVE-2026-29111 — systemd family (Debian bookworm) — Trivy code scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2026-29111
+- **Source package**: `systemd`
+- **Affected binary packages in our image alert set**:
+  - `libsystemd0`
+  - `libudev1`
+- **Observed installed version**: `252.38-1~deb12u1`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: High
+- **GitHub alerts**: `#573`, `#575`
+
+This finding is reported by Trivy against OS packages inherited from the Debian
+bookworm Python base image used by the publish image lane.
+
+At triage time, both Debian security metadata and Trivy alert payloads indicate
+that our current bookworm image context does not expose an actionable fixed
+version for these alerts.
+
+## Why we suppress (temporarily)
+
+- This is an **OS package** CVE in the distro base image, not an application
+  dependency shipped by this repository.
+- Repo-level Python/FastAPI code changes cannot patch `systemd` internals.
+- Trivy reports an empty `Fixed Version` for both open code-scanning alerts on
+  `main`.
+
+We therefore apply a **narrow suppression** scoped to:
+
+- `CVE-2026-29111`
+- packages `libsystemd0` and `libudev1`
+- exact observed installed version `252.38-1~deb12u1`
+- exact `PkgID` prefixes matching those observed alerts
+
+This keeps code-scanning noise actionable while we continue to monitor the
+upstream Debian bookworm package line.
+
+## Observed alert evidence
+
+Exact package/version evidence came from GitHub code-scanning alerts on `main`:
+
+```text
+$ gh api "repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts?state=open&per_page=100" --jq '.[] | select(.number == 573 or .number == 575) | [.number, .most_recent_instance.message.text] | @tsv'
+575	Package: libudev1\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
+573	Package: libsystemd0\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
+```
+
+That observed alert payload is why the policy rule is restricted to the two
+binary packages above and `InstalledVersion == "252.38-1~deb12u1"`.
+
+## Monitor / upstream status
+
+- **Debian Security Tracker**: <https://security-tracker.debian.org/tracker/CVE-2026-29111>
+- **NVD**: <https://nvd.nist.gov/vuln/detail/CVE-2026-29111>
+
+## Removal condition
+
+Remove this suppression when either:
+
+1. Debian bookworm publishes a fixed `systemd` package line for
+   `CVE-2026-29111`, or
+2. Trivy metadata starts reporting a non-empty `Fixed Version` for these alerts
+   in our base image context.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Evidence anchors:
+  - `trivy/ignore-policy.rego:138`
+  - `trivy/ignore-policy.rego:163`
+  - `docs/roadmap/BACKLOG_LEDGER.md:2418`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-29111"`
+  - `input.PkgName in {"libsystemd0", "libudev1"}`
+  - `input.InstalledVersion == "252.38-1~deb12u1"`
+  - `input.PkgID` starts with either
+    `libsystemd0@252.38-1~deb12u1` or `libudev1@252.38-1~deb12u1`
+
+## Review / expiry
+
+- **Review-by**: 2026-05-27 (shared policy-file expiry window)

--- a/docs/security/CVE-2026-29111-systemd.md
+++ b/docs/security/CVE-2026-29111-systemd.md
@@ -43,8 +43,8 @@ Exact package/version evidence came from GitHub code-scanning alerts on `main`:
 
 ```text
 $ gh api "repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts?state=open&per_page=100" --jq '.[] | select(.number == 573 or .number == 575) | [.number, .most_recent_instance.message.text] | @tsv'
-575	Package: libudev1\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
-573	Package: libsystemd0\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
+575  Package: libudev1\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
+573  Package: libsystemd0\nInstalled Version: 252.38-1~deb12u1\nVulnerability CVE-2026-29111\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-29111](https://avd.aquasec.com/nvd/cve-2026-29111)
 ```
 
 That observed alert payload is why the policy rule is restricted to the two
@@ -69,14 +69,17 @@ Remove this suppression when either:
 - Policy file: `trivy/ignore-policy.rego`
 - Evidence anchors:
   - `trivy/ignore-policy.rego:138`
-  - `trivy/ignore-policy.rego:163`
+  - `trivy/ignore-policy.rego:145`
+  - `trivy/ignore-policy.rego:164`
   - `docs/roadmap/BACKLOG_LEDGER.md:2418`
 - Rule matches:
   - `input.VulnerabilityID == "CVE-2026-29111"`
   - `input.PkgName in {"libsystemd0", "libudev1"}`
-  - `input.InstalledVersion == "252.38-1~deb12u1"`
+  - `cve_2026_29111_version := "252.38-1~deb12u1"`
+  - `input.InstalledVersion == cve_2026_29111_version`
   - `input.PkgID` starts with either
-    `libsystemd0@252.38-1~deb12u1` or `libudev1@252.38-1~deb12u1`
+    `libsystemd0@${cve_2026_29111_version}` or
+    `libudev1@${cve_2026_29111_version}`
 
 ## Review / expiry
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,8 +10,8 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-27 (manual removal)
-# Last reviewed: 2026-02-27
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md
+# Last reviewed: 2026-03-30
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-29111-systemd.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -133,4 +133,35 @@ ignore if {
 	input.VulnerabilityID == "CVE-2026-3184"
 	cve_2026_3184_pkg_match
 	cve_2026_3184_version_match
+}
+
+# CVE-2026-29111 (systemd family) - upstream unfixed in Debian bookworm
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Debian bookworm remains vulnerable; fix is published only in forky/sid at triage time
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-29111
+# Documented in: docs/security/CVE-2026-29111-systemd.md
+# Removal condition: Remove when Debian bookworm publishes a fixed systemd package line or Trivy metadata includes Fixed Version
+
+cve_2026_29111_pkg_match if {
+	systemd_pkgs := {"libsystemd0", "libudev1"}
+	systemd_pkgs[input.PkgName]
+}
+
+cve_2026_29111_version_match if {
+	input.InstalledVersion == "252.38-1~deb12u1"
+}
+
+cve_2026_29111_pkgid_match if {
+	startswith(input.PkgID, "libsystemd0@252.38-1~deb12u1")
+}
+
+cve_2026_29111_pkgid_match if {
+	startswith(input.PkgID, "libudev1@252.38-1~deb12u1")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-29111"
+	cve_2026_29111_pkg_match
+	cve_2026_29111_version_match
+	cve_2026_29111_pkgid_match
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -142,21 +142,23 @@ ignore if {
 # Documented in: docs/security/CVE-2026-29111-systemd.md
 # Removal condition: Remove when Debian bookworm publishes a fixed systemd package line or Trivy metadata includes Fixed Version
 
+cve_2026_29111_version := "252.38-1~deb12u1"
+
 cve_2026_29111_pkg_match if {
 	systemd_pkgs := {"libsystemd0", "libudev1"}
 	systemd_pkgs[input.PkgName]
 }
 
 cve_2026_29111_version_match if {
-	input.InstalledVersion == "252.38-1~deb12u1"
+	input.InstalledVersion == cve_2026_29111_version
 }
 
 cve_2026_29111_pkgid_match if {
-	startswith(input.PkgID, "libsystemd0@252.38-1~deb12u1")
+	startswith(input.PkgID, sprintf("libsystemd0@%s", [cve_2026_29111_version]))
 }
 
 cve_2026_29111_pkgid_match if {
-	startswith(input.PkgID, "libudev1@252.38-1~deb12u1")
+	startswith(input.PkgID, sprintf("libudev1@%s", [cve_2026_29111_version]))
 }
 
 ignore if {


### PR DESCRIPTION
## Summary
- add a narrow `CVE-2026-29111` Trivy suppression for the unfixed Debian bookworm `systemd` package line affecting `libsystemd0` and `libudev1`
- document the observed alert payload and upstream-monitoring rationale in `docs/security/CVE-2026-29111-systemd.md`
- track suppression removal in `docs/roadmap/BACKLOG_LEDGER.md`

## Test plan
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-29111-systemd.md`
- [x] `python scripts/ci/check_trivy_ignore_policy_expiry.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Deferred / Follow-ups
- [Remove Trivy suppression for systemd-family CVE (CVE-2026-29111)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/fix/security-cve-2026-29111/docs/roadmap/BACKLOG_LEDGER.md#remove-trivy-suppression-for-systemd-family-cve-cve-2026-29111)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Disposition: FIXED
- Commit: `b9c42ac7`
- Commit: `70420347`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1289#discussion_r3011982836 -> b9c42ac7
- Canonical artifact: `docs/review/PR_1289_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] `make verify` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security note documenting a scoped suppression for CVE-2026-29111 affecting Debian systemd packages, with observed version, evidence, removal criteria, and review/expiry info.
  * Added PR review/status tracking documentation capturing fix mapping and a merge-readiness checklist.

* **Chores**
  * Updated the vulnerability-suppression policy to include a targeted suppression for CVE-2026-29111.
  * Added a backlog entry to track removal of the suppression once a fixed package is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->