### PR TITLE
infra: PostgreSQL canonical production/staging foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,17 +16,19 @@ APP_ENV=local
 ENVIRONMENT=local
 
 # === Database ===
-# Local/dev default: SQLite (works for native uvicorn runs).
-# For Docker Compose / Droplet: uncomment and set Postgres DSN.
-DATABASE_URL=sqlite:///./cache/app.db
+# Canonical production/staging baseline: Postgres.
+# Docker Compose / Droplet: use the postgres service name inside the compose network.
+# Native local Postgres runs can use localhost instead.
+DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
 # DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@postgres:5432/pulseplate
-# DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
+# Local/dev/test-only SQLite fallback example:
+# DATABASE_URL=sqlite:///./cache/app.db
 # Production/staging must set this to true; local/dev/test may keep false until
 # DB-backed entitlement routing is being validated end-to-end.
 SUBSCRIPTION_DB_ENABLED=false
 
 # === PostgreSQL (canonical prod DB) ===
-# Required for production. SQLite used for local/dev/test when Postgres DSN not set.
+# Required for production/staging. SQLite is local/dev/test only.
 POSTGRES_DB=pulseplate
 POSTGRES_USER=pulseplate
 POSTGRES_PASSWORD=__replace_me__

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ ENVIRONMENT=local
 # Canonical production/staging baseline: Postgres.
 # Docker Compose / Droplet: use the postgres service name inside the compose network.
 # Native local Postgres runs can use localhost instead.
-DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
-# DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@postgres:5432/pulseplate
+DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@postgres:5432/pulseplate
+# DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@localhost:5432/pulseplate
 # Local/dev/test-only SQLite fallback example:
 # DATABASE_URL=sqlite:///./cache/app.db
 # Production/staging must set this to true; local/dev/test may keep false until

--- a/.github/workflows/docker-openapi-smoke.yml
+++ b/.github/workflows/docker-openapi-smoke.yml
@@ -77,10 +77,10 @@ jobs:
             -e "${server_salt_name}=StrongServerSaltForCI1234567890!"
             -e "${apple_shared_secret_name}=StrongAppleSharedSecretForCI1234567890!"
             -e "${subscription_db_enabled_name}=true"
-            # CI smoke still needs an explicit DSN after the production-like startup guard.
+            # CI smoke is a local/CI contract check, not a production-like runtime.
             -e "${database_url_name}=sqlite:////app/cache/pulseplate-smoke.db"
-            -e APP_ENV=production
-            -e ENVIRONMENT=production
+            -e APP_ENV=ci
+            -e ENVIRONMENT=ci
             -e "${allow_dev_api_key_name}=false"
             --name
             pulseplate-smoke

--- a/.github/workflows/docker-openapi-smoke.yml
+++ b/.github/workflows/docker-openapi-smoke.yml
@@ -66,6 +66,7 @@ jobs:
           server_salt_name="SERVER""_SALT"
           apple_shared_secret_name="APPLE_SHARED""_SECRET"
           subscription_db_enabled_name="SUBSCRIPTION_DB""_ENABLED"
+          database_url_name="DATABASE""_URL"
 
           args=(
             -d
@@ -76,6 +77,8 @@ jobs:
             -e "${server_salt_name}=StrongServerSaltForCI1234567890!"
             -e "${apple_shared_secret_name}=StrongAppleSharedSecretForCI1234567890!"
             -e "${subscription_db_enabled_name}=true"
+            # CI smoke still needs an explicit DSN after the production-like startup guard.
+            -e "${database_url_name}=sqlite:////app/cache/pulseplate-smoke.db"
             -e APP_ENV=production
             -e ENVIRONMENT=production
             -e "${allow_dev_api_key_name}=false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,9 +149,9 @@ COPY --chown=pulseplate:pulseplate alembic.ini ./
 RUN mkdir -p /home/pulseplate/.config/matplotlib /app/cache/matplotlib /app/cache/food_db /app/data /app/logs && \
     chown -R pulseplate:pulseplate /home/pulseplate /app/cache /app/data /app/logs
 
-# Set environment variables for matplotlib and database
-ENV MPLCONFIGDIR=/app/cache/matplotlib \
-    DATABASE_URL=sqlite:////app/cache/pulseplate.db
+# Set environment variables for matplotlib only.
+# Production/staging must supply DATABASE_URL explicitly at runtime.
+ENV MPLCONFIGDIR=/app/cache/matplotlib
 
 # Switch to non-root user
 USER pulseplate

--- a/core/db.py
+++ b/core/db.py
@@ -120,6 +120,16 @@ def _extract_sqlite_path(database_url: str) -> str | None:
     return sqlite_path if sqlite_path else None
 
 
+def _is_sqlite_database_url(database_url: str) -> bool:
+    """Return True when the URL resolves to any SQLite backend variant."""
+
+    try:
+        return make_url(database_url).get_backend_name().lower() == "sqlite"
+    except Exception:
+        scheme = urlparse(database_url).scheme.lower()
+        return scheme == "sqlite" or scheme.startswith("sqlite+")
+
+
 def _ensure_sqlite_directory(database_url: str, env_provided: bool = False) -> None:
     """Create parent directory for SQLite file if path is file-based and controlled by app.
 
@@ -160,7 +170,7 @@ def _build_engine_url() -> str:
                 "SQLite fallback is allowed only for local/dev/test runtimes."
             )
 
-    if env_provided and is_production_like_env() and raw_database_url.startswith("sqlite:///"):
+    if env_provided and is_production_like_env() and _is_sqlite_database_url(raw_database_url):
         runtime_env = get_runtime_env_name() or "unknown"
         raise RuntimeError(
             f"SQLite DATABASE_URL is not allowed in production-like environments (resolved env: {runtime_env}). "

--- a/core/db.py
+++ b/core/db.py
@@ -150,16 +150,22 @@ def _build_engine_url() -> str:
     default_path = os.path.join("cache", "app.db")
     raw_database_url = (os.getenv("DATABASE_URL") or "").strip()
     env_provided = bool(raw_database_url)
+    from settings import get_runtime_env_name, is_production_like_env
 
     if not env_provided:
-        from settings import get_runtime_env_name, is_production_like_env
-
         if is_production_like_env():
             runtime_env = get_runtime_env_name() or "unknown"
             raise RuntimeError(
                 f"DATABASE_URL is required in production-like environments (resolved env: {runtime_env}). "
                 "SQLite fallback is allowed only for local/dev/test runtimes."
             )
+
+    if env_provided and is_production_like_env() and raw_database_url.startswith("sqlite:///"):
+        runtime_env = get_runtime_env_name() or "unknown"
+        raise RuntimeError(
+            f"SQLite DATABASE_URL is not allowed in production-like environments (resolved env: {runtime_env}). "
+            "Use a Postgres DATABASE_URL for production/staging runtimes."
+        )
 
     database_url = raw_database_url or f"sqlite:///{default_path}"
 

--- a/core/db.py
+++ b/core/db.py
@@ -152,11 +152,12 @@ def _build_engine_url() -> str:
     env_provided = bool(raw_database_url)
 
     if not env_provided:
-        from settings import is_production_like_env
+        from settings import get_runtime_env_name, is_production_like_env
 
         if is_production_like_env():
+            runtime_env = get_runtime_env_name() or "unknown"
             raise RuntimeError(
-                "DATABASE_URL is required in production-like environments. "
+                f"DATABASE_URL is required in production-like environments (resolved env: {runtime_env}). "
                 "SQLite fallback is allowed only for local/dev/test runtimes."
             )
 

--- a/core/db.py
+++ b/core/db.py
@@ -124,7 +124,8 @@ def _is_sqlite_database_url(database_url: str) -> bool:
     """Return True when the URL resolves to any SQLite backend variant."""
 
     try:
-        return make_url(database_url).get_backend_name().lower() == "sqlite"
+        backend_name = str(make_url(database_url).get_backend_name()).lower()
+        return backend_name == "sqlite"
     except Exception:
         scheme = urlparse(database_url).scheme.lower()
         return scheme == "sqlite" or scheme.startswith("sqlite+")

--- a/core/db.py
+++ b/core/db.py
@@ -148,8 +148,17 @@ def _ensure_sqlite_directory(database_url: str, env_provided: bool = False) -> N
 def _build_engine_url() -> str:
     """Return the database URL from env or fall back to local SQLite."""
     default_path = os.path.join("cache", "app.db")
-    env_provided = "DATABASE_URL" in os.environ
-    database_url = os.getenv("DATABASE_URL", f"sqlite:///{default_path}")
+    raw_database_url = (os.getenv("DATABASE_URL") or "").strip()
+    env_provided = bool(raw_database_url)
+    runtime_env = (os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or "local").strip().lower()
+
+    if not env_provided and runtime_env in {"production", "prod", "staging"}:
+        raise RuntimeError(
+            "DATABASE_URL is required in production/staging environments. "
+            "SQLite fallback is allowed only for local/dev/test runtimes."
+        )
+
+    database_url = raw_database_url or f"sqlite:///{default_path}"
 
     # Create directory only for non-env SQLite URLs that we control
     _ensure_sqlite_directory(database_url, env_provided)

--- a/core/db.py
+++ b/core/db.py
@@ -150,13 +150,15 @@ def _build_engine_url() -> str:
     default_path = os.path.join("cache", "app.db")
     raw_database_url = (os.getenv("DATABASE_URL") or "").strip()
     env_provided = bool(raw_database_url)
-    runtime_env = (os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or "local").strip().lower()
 
-    if not env_provided and runtime_env in {"production", "prod", "staging"}:
-        raise RuntimeError(
-            "DATABASE_URL is required in production/staging environments. "
-            "SQLite fallback is allowed only for local/dev/test runtimes."
-        )
+    if not env_provided:
+        from settings import is_production_like_env
+
+        if is_production_like_env():
+            raise RuntimeError(
+                "DATABASE_URL is required in production-like environments. "
+                "SQLite fallback is allowed only for local/dev/test runtimes."
+            )
 
     database_url = raw_database_url or f"sqlite:///{default_path}"
 

--- a/core/db_fallback.py
+++ b/core/db_fallback.py
@@ -56,40 +56,19 @@ def _check_production_constraints(
 ) -> None:
     """Enforce production-specific fallback constraints.
 
-    Production fallback requires ALLOW_DB_PERSISTENT_FALLBACK=1.
-    Raises db_err if constraints not met.
+    Production-like environments fail closed on DB init errors.
+    Raises db_err after logging the canonical production contract.
     """
-    allow_persistent_fallback = (
-        os.getenv("ALLOW_DB_PERSISTENT_FALLBACK") or ""
-    ).strip().lower() in truthy
-
-    if not allow_persistent_fallback:
-        logger.error(
-            "CRITICAL: Database initialization failed in production (%s). "
-            "Fallback is disabled unless ALLOW_DB_PERSISTENT_FALLBACK=1 is set. "
-            "In-memory fallbacks are not allowed in production. "
-            "Original error: %s",
-            env_name or "production",
-            db_err,
-        )
-        raise db_err
-
-    # Additional verification: ensure fallback URL is persistent
-    is_in_memory = fallback_url.startswith("sqlite:///:memory:")
-    if is_in_memory:
-        logger.error(
-            "CRITICAL: Production fallback URL must be persistent, not in-memory. "
-            "Current DB_FALLBACK_URL=%s is in-memory. Set DB_FALLBACK_URL to a file-based URL "
-            "(e.g., sqlite:///./fallback.db).",
-            fallback_url,
-        )
-        raise db_err
-
-    logger.warning(
-        "Database initialization failed in production (%s), attempting persistent fallback: %s",
+    del fallback_url, truthy
+    logger.error(
+        "CRITICAL: Database initialization failed in production-like environment (%s). "
+        "SQLite fallback is not an accepted production or staging baseline. "
+        "Configure a canonical Postgres DATABASE_URL and recover the primary database. "
+        "Original error: %s",
         env_name or "production",
-        fallback_url,
+        db_err,
     )
+    raise db_err
 
 
 def _initialize_fallback_engine(fallback_url: str, db_err: Exception) -> Engine:
@@ -153,7 +132,9 @@ def _configure_session_bindings(
             tags = [f"env:{env_label}", f"backend:{backend}"]
             with suppress(Exception):
                 client.increment("db_fallback_active", tags=tags)
-    except Exception:  # pragma: no cover - metrics are optional, safe to ignore  # nosec B110
+    except (
+        Exception
+    ):  # pragma: no cover  # nosec B110: metrics are non-critical (remove-by: 2026-06-30, ref: PR-1)
         # Metrics collection is non-critical; failures should not affect application startup
         pass
 
@@ -183,12 +164,8 @@ def _attempt_db_fallback(
 ) -> None:
     """Attempt to initialize database with fallback SQLite when primary DB fails.
 
-    Production environments never accept in-memory fallbacks. For production,
-    fallback is only allowed when:
-    1. ALLOW_DB_PERSISTENT_FALLBACK env var is set
-    2. DB_FALLBACK_URL points to a persistent storage URL (not in-memory SQLite)
-
-    Non-production environments can use any fallback URL including in-memory.
+    Production-like environments fail closed on primary DB errors.
+    Non-production environments can use fallback SQLite when explicitly allowed.
 
     Raises:
         db_err: Original database error if fallback fails or is not allowed
@@ -200,7 +177,7 @@ def _attempt_db_fallback(
     _validate_fallback_url(env_name, is_production, fallback_url, db_err)
 
     if is_production:
-        # Production: enforce strict constraints
+        # Production/staging: fail closed, Postgres is the canonical baseline
         _check_production_constraints(env_name, fallback_url, truthy, db_err)
     else:
         # Non-production: allow any fallback including in-memory

--- a/core/db_fallback.py
+++ b/core/db_fallback.py
@@ -1,10 +1,10 @@
 """
-RU: Каноническая реализация DB fallback (TP2). Refactor-only: поведение заморожено.
-EN: Canonical DB fallback implementation (TP2). Refactor-only: behavior is frozen.
+RU: Каноническая реализация DB fallback (TP2) для startup critical path.
+EN: Canonical DB fallback implementation (TP2) for the startup critical path.
 
 CRITICAL:
 - Startup critical path.
-- Keep behavior identical to legacy_app.py pre-TP2.
+- Production/staging fail closed; SQLite fallback is local/dev/test only.
 - No OpenAPI / contract changes.
 
 Location: core/db_fallback.py (flat module) to avoid core/db.py vs core/db/ package collision.
@@ -26,6 +26,19 @@ logger = logging.getLogger(__name__)
 _db_fallback_active = False
 
 
+def _redact_database_url(database_url: str) -> str:
+    """Return a log-safe database URL label without credentials."""
+    if not database_url:
+        return "<empty-db-url>"
+
+    if database_url.startswith("sqlite:///:memory:"):
+        return "sqlite:///:memory:"
+    if database_url.startswith("sqlite:///"):
+        return "sqlite:///<redacted>"
+
+    return "<redacted-db-url>"
+
+
 def _validate_fallback_url(
     env_name: Optional[str],
     is_production: bool,
@@ -44,8 +57,8 @@ def _validate_fallback_url(
     if is_production and is_in_memory:
         logger.error(
             "CRITICAL: In-memory database fallback is not allowed in production environment (%s). "
-            "Set DB_FALLBACK_URL to a persistent storage URL (e.g., sqlite:///./fallback.db) "
-            "and set ALLOW_DB_PERSISTENT_FALLBACK=1 if you need fallback in production.",
+            "SQLite fallback is not an accepted production or staging baseline. "
+            "Configure a canonical Postgres DATABASE_URL and recover the primary database.",
             env_name or "production",
         )
         raise db_err
@@ -93,7 +106,11 @@ def _initialize_fallback_engine(fallback_url: str, db_err: Exception) -> Engine:
         Base.metadata.create_all(bind=fallback_engine)
         return fallback_engine
     except Exception as fallback_err:
-        logger.error("Fallback database init failed (url=%s): %s", fallback_url, fallback_err)
+        logger.error(
+            "Fallback database init failed (url=%s): %s",
+            _redact_database_url(fallback_url),
+            fallback_err,
+        )
         raise db_err from fallback_err
 
 
@@ -134,7 +151,7 @@ def _configure_session_bindings(
                 client.increment("db_fallback_active", tags=tags)
     except (
         Exception
-    ):  # pragma: no cover  # nosec B110: metrics are non-critical (remove-by: 2026-06-30, ref: PR-1)
+    ):  # pragma: no cover  # nosec B110: metrics are non-critical (remove-by: 2026-06-30, ref: PR-1291)
         # Metrics collection is non-critical; failures should not affect application startup
         pass
 
@@ -146,7 +163,7 @@ def _configure_session_bindings(
             "Database initialized with fallback SQLite (env=%s, fallback_url=%s). "
             "os.environ['DATABASE_URL'] updated for compatibility.",
             env_name or "local",
-            fallback_url,
+            _redact_database_url(fallback_url),
         )
     else:
         # In production, only set DB_FALLBACK_URL for internal use
@@ -155,7 +172,7 @@ def _configure_session_bindings(
             "Database initialized with fallback SQLite (env=%s, fallback_url=%s). "
             "Using module-level fallback variable only.",
             env_name or "local",
-            fallback_url,
+            _redact_database_url(fallback_url),
         )
 
 
@@ -193,7 +210,7 @@ def _attempt_db_fallback(
             "Database initialization failed (%s env: %s), attempting fallback SQLite: %s (explicit override: %s, IO error: %s)",
             type(db_err).__name__,
             env_name or "local",
-            fallback_url,
+            _redact_database_url(fallback_url),
             explicit_override,
             fallback_exception,
         )

--- a/core/db_fallback.py
+++ b/core/db_fallback.py
@@ -187,16 +187,18 @@ def _attempt_db_fallback(
     Raises:
         db_err: Original database error if fallback fails or is not allowed
     """
-    # Get fallback URL (prefer DB_FALLBACK_URL env var, otherwise use in-memory SQLite)
-    fallback_url = os.getenv("DB_FALLBACK_URL", "sqlite:///:memory:")
-
-    # Validate fallback URL against production constraints
-    _validate_fallback_url(env_name, is_production, fallback_url, db_err)
-
     if is_production:
         # Production/staging: fail closed, Postgres is the canonical baseline
-        _check_production_constraints(env_name, fallback_url, truthy, db_err)
+        _check_production_constraints(
+            env_name, (os.getenv("DB_FALLBACK_URL") or "").strip(), truthy, db_err
+        )
     else:
+        # Get fallback URL (prefer DB_FALLBACK_URL env var, otherwise use in-memory SQLite)
+        fallback_url = (os.getenv("DB_FALLBACK_URL") or "").strip() or "sqlite:///:memory:"
+
+        # Validate fallback URL against non-production constraints
+        _validate_fallback_url(env_name, is_production, fallback_url, db_err)
+
         # Non-production: allow any fallback including in-memory
         explicit_override = (
             os.getenv("ALLOW_DB_INMEMORY_FALLBACK") or ""

--- a/deploy/docker-compose.production.yaml
+++ b/deploy/docker-compose.production.yaml
@@ -35,6 +35,9 @@ services:
       - "8000"
     env_file:
       - .env
+    environment:
+      - ENVIRONMENT=production
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/docker-compose.staging.yaml
+++ b/deploy/docker-compose.staging.yaml
@@ -31,6 +31,9 @@ services:
     networks: [web]
     expose:
       - "8000"
+    environment:
+      - ENVIRONMENT=staging
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -34,8 +34,8 @@ docker compose run --rm app alembic upgrade head
 
 ```bash
 docker compose up -d app caddy
-curl http://127.0.0.1:8000/health/db
-curl http://127.0.0.1:8000/ready
+curl http://127.0.0.1/health/db
+curl http://127.0.0.1/ready
 ```
 
 ---

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -1,12 +1,13 @@
 # Postgres Self-Hosted Droplet Foundation
 
-**Purpose:** Canonical production database baseline for PulsePlate on Droplet. Postgres is the primary prod DB; SQLite remains for local/dev/test fallback only.
+**Purpose:** Canonical production database baseline for PulsePlate on Droplet. Postgres is the required production/staging DB; SQLite remains for local/dev/test fallback only.
 
 **Design rationale (architecture):**
 
 - Postgres runs internal-only (no public 5432); app connects via `DATABASE_URL` within compose network.
-- DB fallback policy (`core/db_fallback.py`) is unchanged: SQLite is used when Postgres is unavailable or explicitly configured for dev/test.
-- Health checks use `/health/db` for readiness; `DATABASE_URL` is required for production.
+- Production/staging fail closed on primary DB init errors; SQLite is not an accepted canonical runtime baseline there.
+- SQLite fallback remains local/dev/test only.
+- Health checks use `/health/db` for readiness; `DATABASE_URL` is required for production/staging.
 
 ---
 
@@ -24,7 +25,7 @@ docker compose exec postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
 ## 2. How to apply migrations
 
 ```bash
-docker compose run --rm pulseplate alembic upgrade head
+docker compose run --rm app alembic upgrade head
 ```
 
 ---
@@ -32,7 +33,7 @@ docker compose run --rm pulseplate alembic upgrade head
 ## 3. How to start the application
 
 ```bash
-docker compose up -d pulseplate redis
+docker compose up -d app caddy
 curl http://127.0.0.1:8000/health/db
 curl http://127.0.0.1:8000/ready
 ```

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -6,12 +6,28 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+### FIXED
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014934202` -> `1c20cb1a`
+  - Evidence: `tests/test_app_lifespan_additional.py`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014943491` -> `1c20cb1a`
+  - Evidence: `.env.example`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961226` -> `1c20cb1a`
+  - Evidence: `.env.example`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961259` -> `1c20cb1a`
+  - Evidence: `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961264` -> `1c20cb1a`
+  - Evidence: `tests/test_app_lifespan_additional.py`
+
+### DEFERRED
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015018643`
+  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015051066`
+  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation`
 
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [ ] Pre-commit green
+- [x] Pre-commit green
 - [x] `make verify` green
 - PR-1 lane: canonical production/staging database foundation requires explicit Postgres `DATABASE_URL`; SQLite remains local/dev/test only.

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -21,6 +21,27 @@ Evidence: core/db.py, tests/test_app_lifespan_additional.py
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015455174 -> 24ecf7c4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015471248 -> 24ecf7c4
 
+Disposition: FIXED
+Commit: 8f227240
+Evidence: tests/test_app_lifespan_additional.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015455158 -> 8f227240
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015471255 -> 8f227240
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015570078 -> 8f227240
+
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_1291_FIXED_MAPPING.md
+Reason: These bot review summary URLs aggregate actionable child comments that are individually dispositioned in this artifact; the summary shells do not require separate code changes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036303560
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036332779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036343380
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036394604
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036431432
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036707659
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036871343
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036890357
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4036996074
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#pullrequestreview-4037004979
+
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015018643

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1291 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review threads mapped yet.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [x] `make verify` green
+- PR-1 lane: canonical production/staging database foundation requires explicit Postgres `DATABASE_URL`; SQLite remains local/dev/test only.

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -15,6 +15,12 @@ Evidence: .env.example, docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md, tests/test_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961259 -> 1c20cb1a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961264 -> 1c20cb1a
 
+Disposition: FIXED
+Commit: 24ecf7c4
+Evidence: core/db.py, tests/test_app_lifespan_additional.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015455174 -> 24ecf7c4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015471248 -> 24ecf7c4
+
 Disposition: DEFERRED
 Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015018643

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -6,23 +6,19 @@
 
 ## Fixed in Commit Mapping
 
-### FIXED
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014934202` -> `1c20cb1a`
-  - Evidence: `tests/test_app_lifespan_additional.py`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014943491` -> `1c20cb1a`
-  - Evidence: `.env.example`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961226` -> `1c20cb1a`
-  - Evidence: `.env.example`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961259` -> `1c20cb1a`
-  - Evidence: `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961264` -> `1c20cb1a`
-  - Evidence: `tests/test_app_lifespan_additional.py`
+Disposition: FIXED
+Commit: 1c20cb1a
+Evidence: .env.example, docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md, tests/test_app_lifespan_additional.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014934202 -> 1c20cb1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014943491 -> 1c20cb1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961226 -> 1c20cb1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961259 -> 1c20cb1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3014961264 -> 1c20cb1a
 
-### DEFERRED
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015018643`
-  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015051066`
-  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation`
+Disposition: DEFERRED
+Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015018643
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015051066
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -48,9 +48,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliati
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1291#discussion_r3015051066
 
 ## Merge Readiness
-- [ ] All required checks pass
-- [ ] No unresolved review threads (re-check on current head before merge)
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] All required checks pass
+- [x] No unresolved review threads (re-check on current head before merge)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
 - [x] `make verify` green
 - PR-1 lane: canonical production/staging database foundation requires explicit Postgres `DATABASE_URL`; SQLite remains local/dev/test only.

--- a/docs/review/PR_1291_FIXED_MAPPING.md
+++ b/docs/review/PR_1291_FIXED_MAPPING.md
@@ -1,12 +1,12 @@
 # PR 1291 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review threads mapped yet.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -290,6 +290,22 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P1
 
+<a id="ledger-p1-execution-doc-sot-reconciliation"></a>
+- [ ] P1: Execution-doc source-of-truth reconciliation after PR-1
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (fix/deploy-web-spa-routing)
+  - Area: docs / deploy / roadmap
+  - Reason: PR-1 intentionally kept the PR-2 deploy diagnosis packet out of scope, but `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md` still references source-of-truth documents that are missing or in transition. Reconcile the source-of-truth order in the PR-2 deploy shell lane instead of widening the Postgres foundation PR.
+  - Links:
+    - `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`
+    - `docs/roadmap/DEPLOY_WEB_DIAGNOSIS_AND_FIX.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md`
+  - DoD:
+    - The execution document source-of-truth list references only in-repo canonical artifacts
+    - `DEPLOY_WEB_DIAGNOSIS_AND_FIX.md` has a settled canonical location and is tracked in git
+    - Any remaining missing source-of-truth docs are either created or removed from the ordered list with rationale
+
 <a id="ledger-p1-ci-install-profile-split-after-disk-unblock"></a>
 - [ ] P1: CI install profile split after disk-regression unblock
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
+++ b/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
@@ -1,0 +1,180 @@
+# PulsePlate — P0/P1 Execution Document
+
+Date: 2026-03-30
+Status: operator execution map
+
+## Summary
+
+- Batch B is closed as a batch, but the paid contour is not fully release-ready.
+- The active critical path is now: deploy/runtime closure -> backend monetization follow-through -> web truth -> legal/release shell -> App Store closeout -> AI hardening follow-through.
+- Do not reopen B1-B4 baseline work. Use explicit follow-up items already open in the canonical ledger.
+
+## Source of truth order
+
+1. `BACKLOG_LEDGER.md`
+2. `DEPLOY_WEB_DIAGNOSIS_AND_FIX.md`
+3. `PulsePlate_Master_Index_A-E.md`
+4. `PulsePlate_Master_State_Document.md`
+5. `OPENAPI_VISIBILITY_MATRIX.md` + `API_CANONICAL_MAP.md` + `API_COMPAT.md`
+6. `PP_DESIGN_BRIDGE_REALIGNMENT_PACKET.md` + `FRONTEND_IOS_DESIGN_IMPLEMENTATION_ROADMAP.md`
+
+## Decision log
+
+- Do not treat Batch B as the next active lane.
+- Do not reopen StoreKit baseline / thin SubscriptionManager baseline.
+- Treat remaining monetization work as follow-up ledger items.
+- Put infra/runtime closure before AI/design expansion.
+
+## Execution order
+
+### Wave 1 — Deploy / runtime closure
+1. `infra/postgres-droplet-foundation`
+2. `fix/deploy-web-spa-routing`
+3. `docs/release-env-security-contract` only if it blocks deploy truth on staging/production
+
+### Wave 2 — Backend monetization follow-through
+4. `feat/billing-activation-and-persistence`
+5. `feat/billing-entitlement-routing`
+
+### Wave 3 — Web truth
+6. `feat/web-entitlement-truth`
+7. `feat/web-progress-contract`
+
+### Wave 4 — Legal / release shell
+8. `docs/legal-policy-publish`
+9. `feat/eu-compliance-control-plane-followthrough`
+10. `docs/ios-subscription-offers-governance`
+11. `feat/ios-appstore-assets-rollout`
+12. `feat/ios-appstore-semantic-validators`
+13. `feat/apple-server-api-migration`
+
+### Wave 5 — API / contract truth
+14. `chore/openapi-runtime-sync`
+15. `feat/openapi-decoupling-split`
+
+### Wave 6 — AI follow-through
+16. `feat/insight-fallback-chain`
+17. `feat/rag-hardening-followthrough`
+18. `docs/ai-bounded-context-packet`
+19. `feat/ai-bounded-context-extraction`
+20. `feat/llm-reliability-security-gates`
+
+### Wave 7 — Design bridge operationalization
+21. `docs/design-agent-runtime-realignment`
+22. `feat/design-bridge-preflight-and-capture`
+23. `feat/design-bridge-first-parity-pack`
+
+## PR map
+
+### 1. infra(postgres): promote self-hosted Postgres to canonical Droplet foundation
+- closes: `ledger-p0-self-hosted-postgres-droplet-foundation`
+- goal: remove optional/profile-gated posture, require `DATABASE_URL`, add health-gated dependency, backup/restore scripts, runbook
+- do not include: billing, pgvector, MinIO, search, analytics
+
+### 2. fix(deploy): restore SPA routing and production web shell
+- closes: deploy blocker from `DEPLOY_WEB_DIAGNOSIS_AND_FIX.md`
+- goal: Caddy SPA fallback, API proxy split, deep-route 200s, diagnose script, artifact path truth
+- do not include: visual polish, progress data refactor, legal copy changes
+
+### 3. feat(billing): activation + subscription persistence follow-through
+- closes together:
+  - `ledger-p0-billing-activation-service`
+  - `ledger-p0-billing-subscription-persistence`
+- goal: consume Apple verify contract, persist canonical subscription state, idempotent activation
+- do not include: entitlement routing, iOS UI, App Store migration
+
+### 4. feat(authz): enforce entitlement-backed routing after billing activation
+- closes: `ledger-p0-billing-entitlement-routing`
+- goal: backend entitlement truth for `/api/v1/pro/*` and `/api/v1/vip/*`; fail-closed startup contract; explicit RU/BY pre-entitlement rule
+- policy: manual RU/BY billing entry routes stay transport-auth only, not entitlement surfaces
+
+### 5. feat(frontend): move web premium truth to canonical backend/store state
+- closes: `ledger-p0-web-entitlement-truth`
+- goal: remove local premium source of truth; dev-only gate mock purchase/restore
+- do not include: backend subscription redesign
+
+### 6. feat(frontend): replace demo-grade progress data with backend/empty-state truth
+- closes: `ledger-p0-web-progress-contract`
+- goal: no fabricated chart values in release path
+
+### 7. docs(release): publish legal policy paths and align client links
+- closes: `ledger-p0-legal-policy-publish`
+- goal: canonical privacy/terms paths live in repo and are linked from web/iOS
+
+### 8. feat(compliance): EU-first compliance control plane follow-through
+- closes: `ledger-p0-eu-compliance-control-plane-follow-through`
+- goal: keep `/privacy`, docs/legal, and compliance runtime synchronized for AI/health surfaces
+
+### 9. docs/ios: subscription offers governance and StoreKit-truth pricing contract
+- closes: `ledger-p1-app-store-subscription-offers-governance`
+- goal: UI pricing/trial/eligibility copy must come from StoreKit/App Store truth
+
+### 10. feat(ios-release-ops): protected App Store asset rollout
+- closes together:
+  - `ledger-p1-ios-appstore-assets-rollout`
+  - `ledger-p1-pr1147-ios-appstore-asset-followups`
+- goal: protected environments, upload workflow, deterministic screenshot contract, runbook
+
+### 11. feat(ios-release-ops): semantic metadata/privacy validators
+- closes: `ledger-p1-ios-appstore-semantic-validators`
+- goal: block medical/promissory copy drift and privacy-package mismatches
+
+### 12. feat(billing): migrate Apple verification to App Store Server API
+- closes: `ledger-p1-apple-server-api-migration`
+- goal: move off classic `verifyReceipt` while keeping downstream activation contract stable
+
+### 13. chore(contracts): public OpenAPI/runtime/docs sync
+- goal: keep public schema restricted to bmi/pro/vip, mark premium as compat-only, regenerate FE artifacts
+
+### 14. feat(openapi): split backend schema generation from FE type generation
+- closes: `ledger-p1-openapi-decoupling-split`
+
+### 15. feat(ai-runtime): insight fallback chain and readiness visibility
+- closes: `ledger-p0-insight-fallback-chain`
+
+### 16. feat(rag): vector query hardening + confidence recomputation
+- closes/reduces:
+  - `vector_rag SQL assembly refactor`
+  - RAG follow-through packet scope
+
+### 17. docs(architecture): AI bounded-context packet
+- prepares, but does not close: `ledger-p1-ai-bounded-context-extraction`
+
+### 18. feat(ai-runtime): extract AI runtime into dedicated bounded context
+- closes: `ledger-p1-ai-bounded-context-extraction`
+
+### 19. feat(ai-quality): CI gates for retrieval, faithfulness, prompt-injection, privacy
+- closes: `ledger-p1-llm-reliability-security-gates`
+
+### 20. docs/design): design-agent runtime realignment bridge
+- goal: repo-first design bridge contract, no runtime mutations, Storybook-first web review, iOS simulator verifier path
+
+### 21. feat(design-ops): bridge preflight + screenshot capture + first parity pack
+- goal: make design bridge operational evidence pipeline, not principle-only documentation
+
+## What is already done and must not be reopened
+
+- B1 baseline runtime merged in PR #1182
+- StoreKit contract baseline merged in PR #1172
+- Apple verify -> activation normalization merged in PR #1185
+- B3 operational/setup close-out merged in PR #1189
+- B4 thin-client SubscriptionManager flow merged in PR #1207
+- iOS Keychain conformance merged in PR #1179
+
+## Non-goals
+
+- No new AI surface expansion before Waves 1–4 are stable
+- No GTM/brand work before runtime truth is stable
+- No design-tool automation that mutates runtime code directly
+- No reopening `/api/v1/premium/*` as product source of truth
+
+## Exit criteria for release-ready shell
+
+Release-ready shell is not achieved until all of the following are true:
+- production web serves SPA correctly on deep routes
+- Postgres is canonical prod DB on Droplet
+- activation + persistence + entitlement routing are server-side truth
+- web premium state and progress state are non-fabricated
+- legal policy paths are published and linked by clients
+- App Store pricing/metadata/assets path is operationally governed
+- fallback/echo mode is explicit in readiness state

--- a/tests/test_app_db_fallback_97.py
+++ b/tests/test_app_db_fallback_97.py
@@ -63,11 +63,11 @@ class TestAppDBFallback97:
     def test_attempt_db_fallback_production_no_override(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Production rejects fallback when ALLOW_DB_PERSISTENT_FALLBACK not set."""
+        """Production rejects persistent SQLite fallback without legacy override."""
         from core.db_fallback import _attempt_db_fallback
 
         monkeypatch.setenv("DB_FALLBACK_URL", "sqlite:///./fallback.db")
-        # Ensure ALLOW_DB_PERSISTENT_FALLBACK is NOT set
+        # Ensure the legacy override is not set.
         monkeypatch.delenv("ALLOW_DB_PERSISTENT_FALLBACK", raising=False)
 
         mock_err = Exception("Primary DB failed")

--- a/tests/test_app_db_fallback_97.py
+++ b/tests/test_app_db_fallback_97.py
@@ -208,6 +208,25 @@ class TestAppDBFallback97:
         fallback_mod.reset_fallback_state()
         assert fallback_mod.is_fallback_active() is False
 
+    @pytest.mark.parametrize(
+        ("database_url", "expected"),
+        [
+            ("", "<empty-db-url>"),
+            ("sqlite:///./fallback.db", "sqlite:///<redacted>"),
+            (
+                "postgresql+psycopg://db.example.invalid:5432/pulseplate",
+                "<redacted-db-url>",
+            ),
+        ],
+    )
+    def test_redact_database_url_masks_non_memory_values(
+        self, database_url: str, expected: str
+    ) -> None:
+        """Helper must redact empty, file SQLite, and external DSNs consistently."""
+        from core.db_fallback import _redact_database_url
+
+        assert _redact_database_url(database_url) == expected
+
     def test_attempt_db_fallback_fallback_init_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Fallback DB initialization failure re-raises original error."""
         from core.db_fallback import _attempt_db_fallback

--- a/tests/test_app_db_fallback_97.py
+++ b/tests/test_app_db_fallback_97.py
@@ -3,7 +3,7 @@ Targeted tests for core.db_fallback DB fallback logic to reach 97% coverage.
 
 Covers _attempt_db_fallback function branches:
 - Production in-memory fallback rejection
-- Production persistent fallback with/without ALLOW_DB_PERSISTENT_FALLBACK
+- Production persistent fallback rejection
 - Non-production fallback paths
 """
 
@@ -80,10 +80,10 @@ class TestAppDBFallback97:
                 truthy=self.TRUTHY,
             )
 
-    def test_attempt_db_fallback_production_persistent_allowed(
+    def test_attempt_db_fallback_production_persistent_rejected_even_with_override(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Production allows persistent fallback when explicitly enabled."""
+        """Production-like env rejects persistent SQLite even with legacy override."""
         from core.db_fallback import _attempt_db_fallback
 
         monkeypatch.setenv("DB_FALLBACK_URL", "sqlite:///./prod_fallback.db")
@@ -91,51 +91,35 @@ class TestAppDBFallback97:
 
         mock_err = Exception("Primary DB failed")
 
-        # Mock SQLAlchemy engine creation to avoid actual DB operations
-        with (
-            patch("core.db_fallback.create_engine") as mock_create_engine,
-            patch("core.models.Base") as mock_base,
-            patch("core.db.SessionLocal") as mock_session,
-        ):
-            mock_engine = MagicMock()
-            mock_create_engine.return_value = mock_engine
-            mock_base.metadata.create_all = MagicMock()
-            mock_session.configure = MagicMock()
+        with patch("core.db_fallback.create_engine") as mock_create_engine:
+            with pytest.raises(Exception, match="Primary DB failed"):
+                _attempt_db_fallback(
+                    env_name="production",
+                    is_production=True,
+                    db_err=mock_err,
+                    truthy=self.TRUTHY,
+                )
 
-            # Should not raise
-            _attempt_db_fallback(
-                env_name="production",
-                is_production=True,
-                db_err=mock_err,
-                truthy=self.TRUTHY,
-            )
-
-            # Verify fallback was attempted
-            mock_create_engine.assert_called_once()
-            assert "sqlite:///./prod_fallback.db" in str(mock_create_engine.call_args)
+            mock_create_engine.assert_not_called()
 
     def test_attempt_db_fallback_production_persistent_logs(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Cover db_fallback line 87: production persistent path logger.warning."""
+        """Production-like persistent SQLite path logs fail-closed guidance."""
         from core.db_fallback import _attempt_db_fallback
 
         monkeypatch.setenv("DB_FALLBACK_URL", "sqlite:///./prod_fallback.db")
         monkeypatch.setenv("ALLOW_DB_PERSISTENT_FALLBACK", "1")
         mock_err = Exception("Primary DB failed")
-        with (
-            patch("core.db_fallback.create_engine") as mock_create_engine,
-            patch("core.models.Base"),
-            patch("core.db.SessionLocal"),
-        ):
-            mock_create_engine.return_value = MagicMock()
+
+        with pytest.raises(Exception, match="Primary DB failed"):
             _attempt_db_fallback(
                 env_name="production",
                 is_production=True,
                 db_err=mock_err,
                 truthy=self.TRUTHY,
             )
-        assert "attempting persistent fallback" in caplog.text
+        assert "not an accepted production or staging baseline" in caplog.text
 
     def test_attempt_db_fallback_nonproduction_inmemory_allowed(
         self, monkeypatch: pytest.MonkeyPatch
@@ -241,13 +225,10 @@ class TestAppDBFallback97:
                     truthy=self.TRUTHY,
                 )
 
-    def test_check_production_constraints_inmemory_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Cover _check_production_constraints in-memory branch (lines 76-83)."""
+    def test_check_production_constraints_inmemory_raises(self) -> None:
+        """Production constraints fail closed for in-memory fallback."""
         from core.db_fallback import _check_production_constraints
 
-        monkeypatch.setenv("ALLOW_DB_PERSISTENT_FALLBACK", "1")
         db_err = ValueError("test")
         with pytest.raises(ValueError, match="test"):
             _check_production_constraints(
@@ -258,19 +239,19 @@ class TestAppDBFallback97:
             )
 
     def test_check_production_constraints_persistent_logs(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Cover _check_production_constraints persistent URL path (line 87)."""
+        """Production constraints reject persistent SQLite fallback too."""
         from core.db_fallback import _check_production_constraints
 
-        monkeypatch.setenv("ALLOW_DB_PERSISTENT_FALLBACK", "1")
-        _check_production_constraints(
-            env_name="production",
-            fallback_url="sqlite:///./fallback.db",
-            truthy=self.TRUTHY,
-            db_err=Exception("x"),
-        )
-        assert "attempting persistent fallback" in caplog.text
+        with pytest.raises(Exception, match="x"):
+            _check_production_constraints(
+                env_name="production",
+                fallback_url="sqlite:///./fallback.db",
+                truthy=self.TRUTHY,
+                db_err=Exception("x"),
+            )
+        assert "canonical Postgres DATABASE_URL" in caplog.text
 
     def test_configure_session_bindings_sessionlocal_none(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -214,6 +214,33 @@ async def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_env", ["production", "staging"])
+async def test_lifespan_requires_database_url_in_production_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_env: str,
+) -> None:
+    """Production-like startup must fail closed when DATABASE_URL is missing."""
+
+    lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
+    monkeypatch.setenv("ENVIRONMENT", runtime_env)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+    monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
+    monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
+    monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+        async with app.lifespan(app.app):
+            pass
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("runtime_env", ["local", "dev", "development", "test", "testing", "ci"])
 async def test_lifespan_allows_subscription_db_disabled_outside_production_like_env(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -9,6 +9,12 @@ from app.bootstrap import startup_guards as bootstrap_guards
 from tests.helpers.fast_update_stubs import patch_background_update_callables
 
 
+def _reset_core_db_state() -> None:
+    """Reset shared DB module state before and after env-driven tests."""
+
+    core_db.reset_db_for_tests()
+
+
 @pytest.mark.asyncio
 async def test_lifespan_validate_template_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
     lifespan_globals = app.lifespan.__wrapped__.__globals__
@@ -223,28 +229,29 @@ async def test_lifespan_requires_database_url_in_production_like_env(
 ) -> None:
     """Production-like startup must fail closed when DATABASE_URL is missing."""
 
-    existing_engine = getattr(core_db, "_RAW_ENGINE", None)
-    if existing_engine is not None:
-        existing_engine.dispose()
-    monkeypatch.setattr(core_db, "_RAW_ENGINE", None, raising=False)
+    _reset_core_db_state()
+    try:
+        lifespan_globals = app.lifespan.__wrapped__.__globals__
+        monkeypatch.setitem(
+            lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards
+        )
+        monkeypatch.setenv("ENVIRONMENT", runtime_env)
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+        monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+        monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
+        monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
+        monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+        monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+        monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
 
-    lifespan_globals = app.lifespan.__wrapped__.__globals__
-    monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
-    monkeypatch.setenv("ENVIRONMENT", runtime_env)
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
-    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
-    monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
-    monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
-    monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
-    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
-    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
-
-    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
-        async with app.lifespan(app.app):
-            pass
+        with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+            async with app.lifespan(app.app):
+                pass
+    finally:
+        _reset_core_db_state()
 
 
 def test_build_engine_url_requires_database_url_in_prod_env(
@@ -254,13 +261,17 @@ def test_build_engine_url_requires_database_url_in_prod_env(
 
     from core.db import _build_engine_url
 
-    monkeypatch.setenv("ENVIRONMENT", "prod")
-    monkeypatch.delenv("APP_ENV", raising=False)
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _reset_core_db_state()
+    try:
+        monkeypatch.setenv("ENVIRONMENT", "prod")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.delenv("DATABASE_URL", raising=False)
 
-    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
-        _build_engine_url()
+        with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+            _build_engine_url()
+    finally:
+        _reset_core_db_state()
 
 
 def test_build_engine_url_requires_database_url_when_app_env_is_production_like(
@@ -270,13 +281,17 @@ def test_build_engine_url_requires_database_url_when_app_env_is_production_like(
 
     from core.db import _build_engine_url
 
-    monkeypatch.delenv("ENVIRONMENT", raising=False)
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _reset_core_db_state()
+    try:
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.delenv("DATABASE_URL", raising=False)
 
-    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
-        _build_engine_url()
+        with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+            _build_engine_url()
+    finally:
+        _reset_core_db_state()
 
 
 def test_build_engine_url_treats_whitespace_database_url_as_missing_in_production_like_env(
@@ -286,13 +301,17 @@ def test_build_engine_url_treats_whitespace_database_url_as_missing_in_productio
 
     from core.db import _build_engine_url
 
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.delenv("APP_ENV", raising=False)
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.setenv("DATABASE_URL", "   \n\t")
+    _reset_core_db_state()
+    try:
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("DATABASE_URL", "   \n\t")
 
-    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
-        _build_engine_url()
+        with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+            _build_engine_url()
+    finally:
+        _reset_core_db_state()
 
 
 @pytest.mark.parametrize(
@@ -312,13 +331,17 @@ def test_build_engine_url_rejects_sqlite_database_url_in_production_like_env(
 
     from core.db import _build_engine_url
 
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.delenv("APP_ENV", raising=False)
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.setenv("DATABASE_URL", database_url)
+    _reset_core_db_state()
+    try:
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("DATABASE_URL", database_url)
 
-    with pytest.raises(RuntimeError, match="SQLite DATABASE_URL is not allowed"):
-        _build_engine_url()
+        with pytest.raises(RuntimeError, match="SQLite DATABASE_URL is not allowed"):
+            _build_engine_url()
+    finally:
+        _reset_core_db_state()
 
 
 def test_is_sqlite_database_url_falls_back_to_scheme_check_when_make_url_fails() -> None:

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -214,7 +214,7 @@ async def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("runtime_env", ["production", "staging"])
+@pytest.mark.parametrize("runtime_env", ["production", "staging", "prod", "live"])
 async def test_lifespan_requires_database_url_in_production_like_env(
     monkeypatch: pytest.MonkeyPatch,
     runtime_env: str,

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -295,20 +295,37 @@ def test_build_engine_url_treats_whitespace_database_url_as_missing_in_productio
         _build_engine_url()
 
 
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "sqlite:///./cache/app.db",
+        "sqlite+pysqlite:///./cache/app.db",
+        "sqlite+aiosqlite:///./cache/app.db",
+        "SQLITE:///./cache/app.db",
+    ],
+)
 def test_build_engine_url_rejects_sqlite_database_url_in_production_like_env(
     monkeypatch: pytest.MonkeyPatch,
+    database_url: str,
 ) -> None:
-    """Production-like environments must reject an explicit SQLite DATABASE_URL."""
+    """Production-like environments must reject SQLite DATABASE_URL variants."""
 
     from core.db import _build_engine_url
 
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.setenv("DATABASE_URL", "sqlite:///./cache/app.db")
+    monkeypatch.setenv("DATABASE_URL", database_url)
 
     with pytest.raises(RuntimeError, match="SQLite DATABASE_URL is not allowed"):
         _build_engine_url()
+
+
+def test_is_sqlite_database_url_falls_back_to_scheme_check_when_make_url_fails() -> None:
+    """Fallback scheme parsing must still reject dialect-qualified SQLite URLs."""
+
+    with patch.object(core_db, "make_url", side_effect=ValueError("invalid url")):
+        assert core_db._is_sqlite_database_url("SQLITE+Pysqlite:///./cache/app.db") is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 import app
+import core.db as core_db
 from app.bootstrap import startup_guards as bootstrap_guards
 from tests.helpers.fast_update_stubs import patch_background_update_callables
 
@@ -221,6 +222,11 @@ async def test_lifespan_requires_database_url_in_production_like_env(
 ) -> None:
     """Production-like startup must fail closed when DATABASE_URL is missing."""
 
+    existing_engine = getattr(core_db, "_RAW_ENGINE", None)
+    if existing_engine is not None:
+        existing_engine.dispose()
+    monkeypatch.setattr(core_db, "_RAW_ENGINE", None, raising=False)
+
     lifespan_globals = app.lifespan.__wrapped__.__globals__
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", runtime_env)
@@ -238,6 +244,54 @@ async def test_lifespan_requires_database_url_in_production_like_env(
     with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
         async with app.lifespan(app.app):
             pass
+
+
+def test_build_engine_url_requires_database_url_in_prod_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENVIRONMENT=prod without DATABASE_URL must fail closed."""
+
+    from core.db import _build_engine_url
+
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+        _build_engine_url()
+
+
+def test_build_engine_url_requires_database_url_when_app_env_is_production_like(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production-like APP_ENV without ENVIRONMENT set must still fail closed."""
+
+    from core.db import _build_engine_url
+
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+        _build_engine_url()
+
+
+def test_build_engine_url_treats_whitespace_database_url_as_missing_in_production_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace DATABASE_URL is treated as missing in production-like envs."""
+
+    from core.db import _build_engine_url
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("DATABASE_URL", "   \n\t")
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+        _build_engine_url()
 
 
 @pytest.mark.asyncio

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -175,6 +175,7 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     """
 
     lifespan_globals = app.lifespan.__wrapped__.__globals__
+    monkeypatch.setitem(lifespan_globals, "init_db", lambda: None)
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "false")
@@ -291,6 +292,22 @@ def test_build_engine_url_treats_whitespace_database_url_as_missing_in_productio
     monkeypatch.setenv("DATABASE_URL", "   \n\t")
 
     with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+        _build_engine_url()
+
+
+def test_build_engine_url_rejects_sqlite_database_url_in_production_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production-like environments must reject an explicit SQLite DATABASE_URL."""
+
+    from core.db import _build_engine_url
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./cache/app.db")
+
+    with pytest.raises(RuntimeError, match="SQLite DATABASE_URL is not allowed"):
         _build_engine_url()
 
 

--- a/tests/test_paid_route_guards.py
+++ b/tests/test_paid_route_guards.py
@@ -92,8 +92,8 @@ def _db_backed_paid_authz(
     """Force canonical paid routes onto persisted backend entitlement truth."""
 
     payments_activation.reset_state()
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("ENVIRONMENT", "test")
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -47,7 +47,8 @@ def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_
 
     original_override = app.dependency_overrides.pop(app_module.get_api_key, None)
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("APP_ENV", "test")
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
     monkeypatch.setenv("PRO_API_KEYS", pro_headers["X-API-Key"])

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -8,6 +8,8 @@ EN: Tests for remaining modules with low coverage
 
 from unittest.mock import patch
 
+import pytest
+
 
 class TestShoplistModule:
     """Test core.shoplist module."""
@@ -257,3 +259,188 @@ class TestTimeUtilsModule:
         # Test date validation
         assert is_valid_date("2024-01-01") is True
         assert is_valid_date("invalid") is False
+
+
+class TestDbGuardAndFallbackSmokeCoverage:
+    """RU: Smoke-visible coverage tail for DB guard/fallback helpers.
+
+    EN: Smoke-visible coverage tail for DB guard/fallback helpers.
+    """
+
+    TRUTHY = {"1", "true", "yes", "on"}
+
+    def test_build_engine_url_production_guards_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RU: Prod-like env must reject missing and SQLite URLs.
+
+        EN: Production-like env must reject missing and SQLite DATABASE_URL values.
+        """
+
+        import core.db as core_db
+
+        core_db.reset_db_for_tests()
+        try:
+            monkeypatch.setenv("ENVIRONMENT", "production")
+            monkeypatch.delenv("APP_ENV", raising=False)
+            monkeypatch.setenv("DEBUG", "false")
+            monkeypatch.delenv("DATABASE_URL", raising=False)
+
+            with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
+                core_db._build_engine_url()
+
+            monkeypatch.setenv("DATABASE_URL", "sqlite:///./cache/app.db")
+            with pytest.raises(RuntimeError, match="SQLite DATABASE_URL is not allowed"):
+                core_db._build_engine_url()
+        finally:
+            core_db.reset_db_for_tests()
+
+    def test_is_sqlite_database_url_uses_scheme_fallback_when_sqlalchemy_parse_fails(self) -> None:
+        """RU: Fallback parser must still detect SQLite dialect schemes.
+
+        EN: Fallback parser must still detect SQLite dialect schemes.
+        """
+
+        import core.db as core_db
+
+        with patch.object(core_db, "make_url", side_effect=ValueError("bad url")):
+            assert core_db._is_sqlite_database_url("sqlite+pysqlite:///./cache/app.db") is True
+
+    @pytest.mark.parametrize(
+        ("database_url", "expected"),
+        [
+            ("", "<empty-db-url>"),
+            ("sqlite:///:memory:", "sqlite:///:memory:"),
+            ("sqlite:///./fallback.db", "sqlite:///<redacted>"),
+            ("postgresql://db.example/pulseplate", "<redacted-db-url>"),
+        ],
+    )
+    def test_redact_database_url_variants(self, database_url: str, expected: str) -> None:
+        """RU: Redaction helper must cover empty, memory, file, and remote DSNs.
+
+        EN: Redaction helper must cover empty, memory, file, and remote DSNs.
+        """
+
+        from core.db_fallback import _redact_database_url
+
+        assert _redact_database_url(database_url) == expected
+
+    def test_check_production_constraints_logs_and_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RU: Production fallback constraint must fail closed with guidance.
+
+        EN: Production fallback constraint must fail closed with guidance.
+        """
+
+        from core.db_fallback import _check_production_constraints
+
+        with pytest.raises(RuntimeError, match="prod-db-error"):
+            _check_production_constraints(
+                env_name="production",
+                fallback_url="sqlite:///./fallback.db",
+                truthy=self.TRUTHY,
+                db_err=RuntimeError("prod-db-error"),
+            )
+
+        assert "canonical Postgres DATABASE_URL" in caplog.text
+
+    def test_initialize_fallback_engine_re_raises_original_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RU: Fallback engine init must preserve the original DB error.
+
+        EN: Fallback engine init must preserve the original DB error.
+        """
+
+        import core.db_fallback as fallback_mod
+
+        def _raise_create_engine(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("fallback init failed")
+
+        monkeypatch.setattr(fallback_mod, "create_engine", _raise_create_engine)
+
+        with pytest.raises(OSError, match="primary-db-error"):
+            fallback_mod._initialize_fallback_engine(
+                "sqlite:///:memory:",
+                OSError("primary-db-error"),
+            )
+
+    def test_attempt_db_fallback_routes_production_and_nonproduction_helpers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RU: _attempt_db_fallback must route prod and non-prod helper paths.
+
+        EN: _attempt_db_fallback must route prod and non-prod helper paths.
+        """
+
+        import core.db_fallback as fallback_mod
+
+        production_calls: list[tuple[object, ...]] = []
+        nonproduction_calls: list[tuple[str, object]] = []
+
+        def _fake_check(
+            env_name: str | None,
+            fallback_url: str,
+            truthy: set[str],
+            db_err: Exception,
+        ) -> None:
+            production_calls.append((env_name, fallback_url, truthy, str(db_err)))
+            raise db_err
+
+        def _fake_validate(
+            env_name: str | None,
+            is_production: bool,
+            fallback_url: str,
+            db_err: Exception,
+        ) -> None:
+            nonproduction_calls.append(
+                ("validate", (env_name, is_production, fallback_url, str(db_err)))
+            )
+
+        def _fake_initialize(fallback_url: str, db_err: Exception) -> str:
+            nonproduction_calls.append(("initialize", (fallback_url, str(db_err))))
+            return "engine-sentinel"
+
+        def _fake_configure(
+            engine: str,
+            is_production: bool,
+            fallback_url: str,
+            env_name: str | None,
+        ) -> None:
+            nonproduction_calls.append(
+                ("configure", (engine, is_production, fallback_url, env_name))
+            )
+
+        monkeypatch.setattr(fallback_mod, "_check_production_constraints", _fake_check)
+        monkeypatch.setattr(fallback_mod, "_validate_fallback_url", _fake_validate)
+        monkeypatch.setattr(fallback_mod, "_initialize_fallback_engine", _fake_initialize)
+        monkeypatch.setattr(fallback_mod, "_configure_session_bindings", _fake_configure)
+
+        monkeypatch.setenv("DB_FALLBACK_URL", "sqlite:///./prod-fallback.db")
+        with pytest.raises(RuntimeError, match="prod failure"):
+            fallback_mod._attempt_db_fallback(
+                env_name="production",
+                is_production=True,
+                db_err=RuntimeError("prod failure"),
+                truthy=self.TRUTHY,
+            )
+
+        assert production_calls == [
+            ("production", "sqlite:///./prod-fallback.db", self.TRUTHY, "prod failure")
+        ]
+
+        monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
+        monkeypatch.setenv("ALLOW_DB_INMEMORY_FALLBACK", "true")
+        fallback_mod._attempt_db_fallback(
+            env_name="dev",
+            is_production=False,
+            db_err=RuntimeError("dev failure"),
+            truthy=self.TRUTHY,
+        )
+
+        assert nonproduction_calls == [
+            ("validate", ("dev", False, "sqlite:///:memory:", "dev failure")),
+            ("initialize", ("sqlite:///:memory:", "dev failure")),
+            ("configure", ("engine-sentinel", False, "sqlite:///:memory:", "dev")),
+        ]


### PR DESCRIPTION
## Summary
- require an explicit Postgres `DATABASE_URL` for production-like startup instead of silently bootstrapping on SQLite
- fail closed for production/staging DB fallback paths, redact fallback DSNs in logs, and keep SQLite fallback local/dev/test only
- align Droplet deploy surfaces, Docker/OpenAPI smoke, and operator docs with the canonical Postgres runtime contract
- include `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md` in the branch so the agreed execution ladder stays in-repo with this PR

## Test plan
- [x] `python3 -m scripts.orchestration.check_preflight`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `pytest -q tests/test_app_db_fallback_97.py tests/test_app_lifespan_additional.py -q`
- [x] `pytest -q tests/test_deploy_contract_scripts.py`
- [x] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1291`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1291_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] `make verify` green

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-execution-doc-sot-reconciliation` — reconcile the execution-doc source-of-truth list in the PR-2 deploy shell lane instead of widening the Postgres foundation scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * PostgreSQL is now required for production/staging; SQLite is limited to local/dev/test and not accepted as a production fallback.
  * Runtime images no longer ship a default SQLite DB; DATABASE_URL must be provided at runtime.
  * Compose configs enforce DATABASE_URL at startup; example env updated to show Postgres-first DSN with a commented SQLite fallback.

* **Documentation**
  * Deployment guides updated with Postgres-first guidance, Docker vs native connection notes, and operational command/healthcheck clarifications.
  * New roadmap and review docs added.

* **Tests & CI**
  * Tests updated to assert fail-closed behavior for production-like envs; CI smoke run now supplies a runtime DATABASE_URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Split Justification
Why this PR cannot be split safely:
This work changes one production database contract across startup guards, fallback behavior, deploy manifests, runtime env examples, and deterministic tests. Splitting those surfaces would create a temporary state where production-like startup policy, deploy configuration, and test/governance evidence disagree about whether SQLite is allowed.

What invariant, contract, or rollout constraint requires one PR:
The canonical invariant is that PostgreSQL is the only supported production database and production-like environments must fail closed without a valid non-SQLite `DATABASE_URL`. The execution roadmap document for this lane also has to land in the same PR so the tracked PR sequence remains attached to the canonical foundation change.

What follow-up PRs remain after this large change:
Follow-up work continues in the P0/P1 ladder, starting with PR-2 (`fix(deploy): restore SPA routing and production web shell`) plus any separately tracked backlog follow-ups recorded in the ledger/artifact flow.
