### PR TITLE
docs(readme): sync homepage with public copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ cp .env.example .env
 For local contributor setup, make sure `.env` contains at least:
 
 - `PULSEPLATE_PYTHON_INDEX_URL` for `make`-driven bootstrap targets
-- `SERVER_SALT` for app startup validation
-
-For local-only boot, placeholder values from `.env.example` are acceptable for `SERVER_SALT`.
+- `SERVER_SALT` for app startup validation; replace the `.env.example` placeholder with a strong local value before boot
 
 Additional secrets are only required for specific features or production-like environments:
 

--- a/README.md
+++ b/README.md
@@ -1,722 +1,317 @@
-# PulsePlate (FastAPI)
+# PulsePlate
 
 [![CI](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml/badge.svg)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml)
-[![Tests + Coverage](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/coverage.yml/badge.svg)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/coverage.yml)
+[![Codecov Upload](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/codecov-upload.yml/badge.svg)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/codecov-upload.yml)
 [![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/branch/main/graph/badge.svg)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
+[![Food data: USDA + OFF](https://img.shields.io/badge/Food%20data-USDA%20%2B%20OFF-brightgreen)](docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md)
 
-[![Data sources: USDA, OFF](https://img.shields.io/badge/Data%20sources-USDA%2C%20OFF-brightgreen)](DATA_SOURCES.md)
+> **PulsePlate turns body-metric check-ins into practical meal decisions.**
+>
+> It is a planning-first wellness product built around one continuous flow:
+>
+> **check-in -> targets -> daily plate -> weekly plan -> shopping list**
 
-## 🤖 AI Agent Instructions
+PulsePlate is designed as a **wellness and meal-planning product**, not as a diagnosis, treatment, therapy, crisis-support, or emergency-care system. BMI and related outputs are informational wellness tools only, and the product should not replace clinician guidance for diagnosed conditions, pregnancy, eating disorders, medically prescribed diets, or emergencies.
 
-Before any changes, read `AGENTS.md` in the repo root and in the relevant module
-(for example `app/AGENTS.md`, `core/AGENTS.md`) and follow those rules.
+PulsePlate is currently in a **private staged rollout**. This repository is the clearest technical and product snapshot of the platform today.
 
-## 📚 Documentation navigation
+## From Metrics To Meals
 
-Quick links to the most important documentation sections:
+Most nutrition apps stop at logging. PulsePlate is being built to keep going:
 
-- 🧭 **Policy & invariants**
-  Architectural rules, hard constraints, and engineering lessons
-  → [`docs/policy/`](docs/policy/)
+1. Start from simple body-metric and nutrition inputs.
+2. Turn them into practical targets and daily plate guidance.
+3. Extend that into weekly planning and grocery workflows.
+4. Layer in AI-assisted support only where it adds real planning value.
 
-- 🛠 **Runbooks (CI / Debug / Ops)**
-  How to run checks, debug failures, and operate the system safely
-  → [`docs/runbooks/`](docs/runbooks/)
+The goal is straightforward: **less tracking noise, less decision fatigue, more repeatable nutrition planning**.
 
-- 🚀 **Deployment**
-  Production, staging, infrastructure, Docker, secrets, and platform setup
-  → [`docs/deploy/`](docs/deploy/)
+## Who PulsePlate Is For
 
-- 📐 **Specs & API contracts**
-  Backend API, mobile integration, premium targets, formats, sources & units
-  → [`docs/specs/`](docs/specs/)
+PulsePlate is aimed first at people who want nutrition planning to feel more actionable:
 
-- 🗺 **Roadmaps & plans**
-  Product and engineering roadmaps, rollout strategies
-  → [`docs/roadmap/`](docs/roadmap/)
+- users who want a clearer path from simple check-ins to actual meal decisions
+- people who want less decision friction around meals and groceries
+- users who want planning help, not just another calorie log
 
-- 📊 **Reports & status**
-  Progress summaries, fix logs, coverage reports, historical snapshots
-  → [`docs/reports/`](docs/reports/)
+### A concrete PulsePlate moment
 
-- 📋 **API Documentation**
-  - **VIP Shoplist API**: [`docs/VIP_Shoplist_API.md`](docs/VIP_Shoplist_API.md) — Contract freeze for generate/daily/weekly endpoints
+The target PulsePlate experience is simple: a user starts with a quick body-metric check-in, gets practical targets, sees what today's plate should look like, turns that into a weekly plan, and finishes with a shopping workflow. That is the product shape PulsePlate is optimizing for.
 
-## 🚀 Quick Start
+## Why PulsePlate Stands Out
 
-### 🐳 Docker Best Practices
+### 1. It is planning-first, not logging-first
 
-**Docker Image Management:**
+PulsePlate is structured around execution, not just record-keeping. The product thesis is that users need help moving from inputs to action:
 
-```bash
-# Build with versioning (recommended)
-make docker-build  # Creates both :latest and :<commit-hash> tags
+- `check-in -> targets -> plate -> weekly plan -> groceries`
 
-# Clean old images regularly
-make docker-clean-images  # Keeps latest 3 versions
+### 2. It combines domain logic with product workflows
 
-# Test locally before CI
-make docker-build && docker run -p 8000:8000 pulseplate:latest
-curl http://localhost:8000/health  # Verify it works
-```
+This repository already contains the core layers needed for a serious nutrition product:
 
-**Docker Quality Checklist:**
+- a backend/domain core for BMI and nutrition logic
+- planning surfaces for daily and weekly decision-making
+- shopping/export flows
+- thin web and iOS client layers
+- a food-data foundation that can support richer planning over time
 
-- ✅ Always test Docker builds locally before pushing
-- ✅ Use versioned tags for production deployments
-- ✅ Clean up old images regularly to save disk space
-- ✅ Verify health checks work: `curl http://localhost:8000/health`
+### 3. It uses a snapshot-first food-data model
 
-### ⚠️ Important: Pre-commit Setup
+Instead of relying on live third-party lookups for every request, PulsePlate is built around a local merged catalog strategy. That supports lower latency, more stable lookups, and future enrichment on top of a controlled data foundation.
 
-**Always run pre-commit checks before pushing:**
+### 4. Its AI direction is staged, not decorative
 
-```bash
-# Option 1: Use the existing pre-commit hook (recommended)
-git commit  # Automatically runs pre-commit hooks
+PulsePlate has a real AI research and product direction, but it is being rolled out carefully. Current and planned work explores:
 
-# Option 2: Manual pre-commit
-pre-commit run --all-files
+- retrieval-augmented support
+- consistency and contradiction checks
+- optional planning assistance
+- progressively stronger planning assistance
 
-# Option 3: Clean cache manually if needed
-./scripts/clean-cache.sh
-```
+Not all of these capabilities are user-facing, enabled by default, or fully deployed in production today.
 
-**Pre-commit hooks include:**
+## What Exists Today
 
-- ✅ **Black** formatting (line length 100)
-- ✅ **Ruff** linting and import sorting
-- ✅ **MyPy** type checking
-- ✅ **Bandit** security scanning
-- ✅ **Automatic cache cleanup** (removes `__pycache__` and `.pyc` files)
+| Layer | Current reality |
+|---|---|
+| FREE | BMI-based wellness check-ins and basic lookup surfaces |
+| PRO | Nutrition targets, daily nutrition guidance, planning and payment flows |
+| VIP | Higher-end planning, menu flows, recipes, export/shopping-list surfaces |
+| Data foundation | Local merged food catalog built from USDA and Open Food Facts inputs |
+| Clients | Active web and iOS codebases over a FastAPI backend |
 
-### Python Version
+### Live and staged surfaces
 
-- Закреплена версия Python: 3.13.6 (`.python-version`, `.tool-versions`).
-- Рекомендуемая установка через `pyenv` или `asdf`.
+- **Live core:** backend API, domain logic, food-data pipeline, PRO/VIP planning surfaces
+- **Selective rollout:** release packaging, monetization closure, and deploy/runtime polish
+- **Feature-gated exceptions:** `/api/v1/insight*` and `/api/v1/insight/fitchef*`
 
-Setup (pyenv):
+## Where The Product Stands
 
-```bash
-pyenv install 3.13.6 -s
-pyenv local 3.13.6
-python -V  # Python 3.13.6
-```
+PulsePlate is already **substantial at the backend/domain level**. Today the strongest parts are the planning core and the data foundation; advanced assistance and release packaging are being rolled out selectively around that base.
 
-Setup (asdf):
+At a high level, treat PulsePlate as an **active product platform in staged rollout**: the planning foundation is real today, while some packaging, monetization, and advanced assistance layers are still being tightened.
 
-```bash
-asdf plugin add python || true
-asdf install python 3.13.6
-asdf local python 3.13.6
-python -V  # Python 3.13.6
-```
+| Area | Status |
+|---|---|
+| Backend API and domain core | Active and substantially implemented |
+| Food-data pipeline | Active and substantially implemented |
+| Web app | Active |
+| iOS app | Active |
+| Monetization and entitlement closure | Selective rollout / hardening |
+| Release packaging and deployment polish | Selective rollout / hardening |
+| Advanced assistance surfaces | Partial / feature-gated |
 
-Create venv and install deps:
+## For Contributors And Integrators
 
-```bash
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
-python -m pip install -U pip setuptools wheel
-pip install -r requirements-dev.txt
-pip install -r requirements.txt
-```
+If you are reading this README primarily as a product visitor, the sections above are the main story. Everything below is contributor and integration context.
 
-**Important**: The `.venv` directory is not tracked in git and should never be committed. Each developer must create their own virtualenv locally using the command above. This ensures that activation scripts contain dynamic paths specific to each developer's environment, avoiding hardcoded absolute paths.
+If you are here primarily as a contributor, reviewer, or integration partner, use the paths below.
 
-## Инструменты автоматизации (cspell, husky, и т.д.)
+### Fastest first-success path
 
-```bash
-npm ci
+If you do not have access to the approved Python package proxy, the safest newcomer path today is:
 
-# Быстрый запуск окружения (shell + PYTHONPATH + алиасы)
-source scripts/dev_shell.sh
+- docs-only contributions
+- frontend work in `frontend/`
+- iOS exploration in `ios/`
 
-# Проверка типов (автоустановка missing types)
-./scripts/mypy_check.sh
+That lets you get productive without depending on full maintainer-only backend bootstrap.
 
-# (Опционально) Настроить git post-commit напоминание
-./scripts/install_post_commit_reminder.sh
-```
-
-**📋 Archived planning docs moved to `docs/archive/`**
-**⚡ [QUICK_START.md](docs/archive/2025-09-16/QUICK_START.md)** - Исторический быстрый старт
-
-## Database
-
-- Приложение использует SQLAlchemy 2.x + Alembic. Базовая конфигурация находится в `core/db.py`.
-- По умолчанию создаётся SQLite-файл `cache/app.db`. Переопределите `DATABASE_URL`, чтобы подключиться к PostgreSQL (через `psycopg[binary]`) или другой БД.
-- Миграции управляются Alembic (`alembic.ini`, каталог `alembic/`). Первичная ревизия создаёт таблицу `users`.
-- Быстрый старт data layer:
-  1. `alembic upgrade head` — применить миграции к текущему `DATABASE_URL`.
-  2. `uvicorn app.main:app --reload` — запустить API локально.
-  3. `curl -s http://127.0.0.1:8000/health/db` — убедиться, что подключение к БД работает.
-- Примеры запросов к пользовательскому API:
-
-  ```bash
-  curl -s -X POST http://127.0.0.1:8000/api/v1/users \
-       -H 'Content-Type: application/json' \
-       -d '{"email": "demo@example.com", "name": "Demo"}'
-  curl -s http://127.0.0.1:8000/api/v1/users
-  ```
-
-### Database fallback behavior (ops)
-
-When primary DB initialization fails, the app can fall back to SQLite based on
-explicit opt-in flags. Use these controls to keep production safe and observable:
-
-- `DB_FALLBACK_URL` (default: `sqlite:///:memory:`) — fallback SQLite URL used only
-  when fallback is triggered. Example: `sqlite:///./fallback.db`.
-- `ALLOW_DB_PERSISTENT_FALLBACK` (default: unset/false) — required in production to
-  allow any fallback. Production never accepts in-memory fallbacks.
-- `ALLOW_DB_INMEMORY_FALLBACK` (default: unset/false) — allows in-memory fallbacks in
-  non-production; otherwise non-prod only falls back on IO errors.
-
-**Production constraints**
-
-- In-memory fallback is never allowed in production.
-- Set `ALLOW_DB_PERSISTENT_FALLBACK=1` and a persistent `DB_FALLBACK_URL` to enable
-  fallback (for example `sqlite:///./fallback.db`).
-
-**Non-production behavior**
-
-- Fallback is allowed when `ALLOW_DB_INMEMORY_FALLBACK=1` or when the initial DB
-  error is an IO error (e.g., filesystem/network issue). Default fallback target is
-  in-memory unless `DB_FALLBACK_URL` is set.
-
-**Signals and monitoring**
-
-- `DB_HEALTH_DEGRADED=1` environment flag is set when fallback is active.
-- Module flag `_db_fallback_active` is toggled to `True`.
-- Metrics: `db_fallback_active` counter (tags `env:<env>` and `backend:<memory|sqlite>`).
-
-**Recommended actions when fallback is active**
-
-- Verify `DATABASE_URL` connectivity, credentials, and upstream DB health.
-- Confirm `DB_FALLBACK_URL` points to persistent storage before enabling production fallback.
-- Restore primary DB connectivity, then redeploy with fallback disabled to return to normal.
-
-## Overview
-
-PulsePlate is a comprehensive health and nutrition application that provides BMI calculations, body fat percentage analysis, and personalized nutrition recommendations.
-
-### Feature Flags and Auth
-
-- `FEATURE_PREMIUM_NUTRITION` — enable premium endpoints (plate/targets). Off by default.
-- `VIP_MODULE_ENABLED` — include VIP router if available (safe fallback if missing).
-- `FEATURE_RAG` — enable lightweight RAG context in `/insight` endpoints. Off by default.
-- `API_KEY` — API key for `/api/v1/*` routes. When set, strict equality is enforced.
-- `API_KEY_REQUIRED` — when `true` and `API_KEY` is not set, requests are rejected (prod safety).
-
-Fine-tuning options and integrating tuned models: see `docs/finetune/README.md`.
-
-## Features
-
-- BMI calculation with category classification
-- Body fat percentage analysis using multiple formulas
-- Personalized nutrition targets based on WHO recommendations
-- **Weekly meal planning with nutrient coverage analysis**
-- **Professional food database pipeline with data from USDA and Open Food Facts**
-
-## Professional Food Database Pipeline
-
-The application now includes a professional food database pipeline that merges data from multiple sources:
-
-- **USDA FoodData Central** - Primary source for nutrient data
-- **Open Food Facts** - Secondary source for additional foods and brand information
-- **Canonical mapping** - Eliminates duplicates and standardizes food names
-- **Automated merging** - Combines data with priority rules and conflict resolution
-- **CRON scheduling** - Automatic weekly updates
-
-### Data Pipeline Components
-
-```text
-core/
-  food_sources/
-    base.py          # Base adapter interface
-    usda.py          # USDA adapter
-    off.py           # Open Food Facts adapter
-  food_merge.py      # Data merging logic
-  units.py           # Unit conversion helpers
-  aliases.py         # Canonical name mapping
-data/
-  food_aliases.csv   # Alias to canonical name mapping
-  food_db.csv        # Merged food database (generated)
-  food_merge_report.json # Merge statistics and reports
-scripts/
-  build_food_db.py   # Build script
-  schedule_food_db_update.py # CRON scheduler
-external/
-  usda_fdc_sample.csv # USDA data sample
-  off_products_sample.csv # OFF data sample
-```
-
-### Food Database Schema
-
-The merged food database follows a standardized schema:
-
----
-
-## 📋 API Endpoints
-
-### Health & Monitoring
-
-- `GET /health` - Health check
-- `GET /api/v1/health` - V1 health check
-- `GET /metrics` - Uptime metrics
-- `GET /privacy` - Privacy policy
-
-### BMI Calculation
-
-- `POST /bmi` - Legacy BMI endpoint
-- `POST /api/v1/bmi` - V1 BMI calculation (requires X-API-Key header)
-  - Input: `{"weight_kg": 70, "height_cm": 170, "group": "general"}`
-  - Output: `{"bmi": 24.2, "category": "Healthy weight", "interpretation": ""}`
-
-### Web UI
-
-- `GET /` - Direct-API JSON probe when hitting FastAPI without Caddy (operators / scanners); apex browsers get the SPA from static hosting
-- `GET /legacy/bmi-calculator` - Legacy standalone HTML form for BMI (same UI historically served at `/`)
-
-### Body Fat Estimation
-
-- `POST /api/v1/bodyfat` - Body fat percentage estimation
-
-### Insight (AI-powered)
-
-- `POST /api/v1/insight` - AI insight on text (requires X-API-Key header)
-  - Input: `{"text": "I feel tired"}`
-  - Output: `{"provider": "stub", "insight": "insight::deriat"}`
-- `POST /api/v1/insight/fitchef` - VIP-only FitChef mascot coaching insight (feature-flagged)
-  - Input: `{"query": "I keep snacking late at night"}`
-  - Output: mascot coaching envelope with `message`, `action_items`, `sources`, and `warnings`
-- `POST /api/v1/insight/fitchef/weekly-reflection` - VIP-only FitChef weekly reflection coaching (feature-flagged)
-  - Input: `{"summary": "Late dinners made the week feel uneven", "goal": "more steady meals"}`
-  - Output: weekly reflection coaching envelope with `message`, `action_items`, `sources`, and `warnings`
-- `POST /api/v1/insight/fitchef/slip-support` - VIP-only FitChef slip-support coaching (feature-flagged)
-  - Input: `{"event_text": "I kept snacking after dinner", "goal": "more steady meals"}`
-  - Output: slip-support coaching envelope with `message`, `action_items`, `sources`, and `warnings`
-
-### Tiered Nutrition APIs
-
-For the current canonical tier map and compatibility surface, see `docs/contracts/API_CANONICAL_MAP.md`.
-
-#### Legacy-Compatible BMR/TDEE Endpoints
-
-- `POST /api/v1/premium/bmr` - Advanced BMR calculation using multiple formulas (requires X-API-Key header; legacy-compatible premium namespace)
-  - Input: `{"weight_kg": 70, "height_cm": 175, "age": 30, "sex": "male", "bodyfat": 15}`
-  - Output: BMR values using Harris-Benedict, Mifflin-St Jeor, and Katch-McArdle formulas
-
-- `POST /api/v1/premium/tdee` - TDEE calculation with activity factors (requires X-API-Key header; legacy-compatible premium namespace)
-  - Input: BMR data + `{"activity": "moderate"}`
-  - Output: TDEE values for different activity levels
-
-#### Plate / Targets / Weekly Planning
-
-- `POST /api/v1/premium/plate` remains available as a legacy compatibility surface.
-- Canonical PRO and VIP planning routes are documented in `docs/contracts/API_CANONICAL_MAP.md`.
-- Use the canonical map when choosing between `/api/v1/pro/*`, `/api/v1/vip/*`, and deprecated `/api/v1/premium/*` paths.
-
-**Request Example:**
-
-```json
-{
-  "name": "spinach_raw",
-  "group": "veg",
-  "per_g": 100.0,
-  "kcal": 23.0,
-  "protein_g": 2.9,
-  "fat_g": 0.4,
-  "carbs_g": 3.6,
-  "fiber_g": 2.2,
-  "Fe_mg": 2.7,
-  "Ca_mg": 99.0,
-  "VitD_IU": 0.0,
-  "B12_ug": 0.0,
-  "Folate_ug": 194.0,
-  "Iodine_ug": 20.0,
-  "K_mg": 558.0,
-  "Mg_mg": 79.0,
-  "flags": ["GF", "VEG"],
-  "price": 0.0,
-  "source": "MERGED(USDA,OFF)",
-  "version_date": "2025-09-04"
-}
-```
-
-**Response Example:**
-
-```json
-{
-  "kcal": 1846,
-  "macros": {
-    "protein_g": 117,
-    "fat_g": 52,
-    "carbs_g": 228,
-    "fiber_g": 25
-  },
-  "portions": {
-    "protein_palm": 1.3,
-    "fat_thumbs": 1.4,
-    "carb_cups": 1.9,
-    "veg_cups": 1.0
-  },
-  "layout": [
-    {
-      "kind": "plate_sector",
-      "fraction": 0.3,
-      "label": "Овощи/Зелень",
-      "tooltip": "Низкая калорийность, клетчатка 25–35 г/сут"
-    },
-    {
-      "kind": "plate_sector",
-      "fraction": 0.23,
-      "label": "Белок",
-      "tooltip": "117 г/сут"
-    },
-    {
-      "kind": "plate_sector",
-      "fraction": 0.35,
-      "label": "Крахмалы/Зерно",
-      "tooltip": "228 г/сут"
-    },
-    {
-      "kind": "plate_sector",
-      "fraction": 0.12,
-      "label": "Полезные жиры",
-      "tooltip": "52 г/сут"
-    },
-    {
-      "kind": "bowl",
-      "fraction": 1.0,
-      "label": "Чашка крупы",
-      "tooltip": "≈1 cup/приём"
-    },
-    {
-      "kind": "bowl",
-      "fraction": 1.0,
-      "label": "Чашка овощей",
-      "tooltip": "≈1–2 cup/приём"
-    }
-  ],
-  "meals": [
-    {
-      "title": "Овсянка + орехи + ягоды (бюджет)",
-      "kcal": 461,
-      "protein_g": 29,
-      "fat_g": 13,
-      "carbs_g": 57
-    },
-    {
-      "title": "Гречка + тофу + салат (бюджет)",
-      "kcal": 646,
-      "protein_g": 40,
-      "fat_g": 18,
-      "carbs_g": 79
-    },
-    {
-      "title": "Рис + нут + овощи (бюджет)",
-      "kcal": 738,
-      "protein_g": 46,
-      "fat_g": 20,
-      "carbs_g": 91
-    }
-  ],
-  "meals_per_day": 3,
-  "day_micros": {}
-}
-```
-
-**Enhanced Parameters:**
-
-- `sex` (required): Biological sex ("male" or "female")
-- `age` (required): Age in years (10-100)
-- `height_cm` (required): Height in centimeters (> 0)
-- `weight_kg` (required): Weight in kilograms (> 0)
-- `activity` (required): Activity level ("sedentary", "light", "moderate", "active", "very_active")
-- `goal` (required): Nutrition goal ("loss", "maintain", "gain")
-- `deficit_pct` (optional): Calorie deficit percentage for loss goal (5-25%)
-- `surplus_pct` (optional): Calorie surplus percentage for gain goal (5-20%)
-- `bodyfat` (optional): Body fat percentage (3-60%)
-- `diet_flags` (optional): Diet preferences (["VEG", "GF", "DAIRY_FREE", "LOW_COST"])
-
-**Response Fields:**
-
-- `meals_per_day` (int): Number of meals recommended per day
-- `day_micros` (Dict[str, float]): Daily micronutrient totals. Keys follow pattern `{nutrient}_{unit}` (e.g., `iron_mg`, `vitamin_d_iu`, `b12_ug`) with units `mg`, `ug`, or `iu`. Currently returns `{}`; will be populated in v2.0+. Frontend: map string keys to float values.
-
-**Visual Plate Features:**
-
-- **4 Plate Sectors**: Vegetables (30%), Protein, Carbs, Healthy Fats (proportional to macros)
-- **2 Serving Bowls**: Grain cup and vegetable cup visualization
-- **Hand/Cup Portions**: Real-world measurements (palms, thumbs, cups)
-- **Precise Control**: Custom deficit/surplus percentages vs. fixed goals
-- **Diet Adaptations**: Meal modifications for dietary preferences
-- **Frontend Ready**: JSON layout specification for SVG/Canvas rendering
-
-## Installation
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/Katsiarynakavaleuskaya/PulsePlate.git
-   cd PulsePlate
-   ```
-
-2. Install dependencies:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-3. Set up environment variables:
-
-   ```bash
-   cp .env.example .env
-   # Edit .env with your configuration
-   ```
-
-## Usage
-
-Start the application:
-
-```bash
-uvicorn app.main:app --host 0.0.0.0 --port 8000
-```
-
-Note: the ASGI entrypoint is now `app.main:app` (the legacy `legacy_app.py` entrypoint
-is deprecated), so update any local scripts or CI that still invoke `legacy_app.py`.
-
-Access the API at `http://localhost:8000`
-
-## API Endpoints
-
-- `POST /api/v1/bmi` - Calculate BMI
-- `POST /api/v1/bodyfat` - Calculate body fat percentage
-- `POST /api/v1/insight` - Generate AI insight text output (requires `API_KEY`)
-- `POST /api/v1/insight/fitchef` - Generate VIP-only FitChef mascot coaching output (requires VIP-tier `API_KEY` access and `FEATURE_FITCHEF_MASCOT`)
-- `POST /api/v1/insight/fitchef/weekly-reflection` - Generate VIP-only FitChef weekly reflection output (requires VIP-tier `API_KEY` access and `FEATURE_FITCHEF_MASCOT`)
-- `POST /api/v1/insight/fitchef/slip-support` - Generate VIP-only FitChef slip-support output (requires VIP-tier `API_KEY` access and `FEATURE_FITCHEF_MASCOT`)
-- Tiered nutrition, planning, payments, and compatibility routes are summarized in `docs/contracts/API_CANONICAL_MAP.md`
-
-### Weekly planning note
-
-- Canonical weekly planning surfaces live in the `/api/v1/pro/*` and `/api/v1/vip/*` namespaces.
-- The legacy compatibility route `/api/v1/premium/plan/week` is retained for migration, but it should not be treated as the canonical namespace.
-- Dev (default): open access to simplify local testing and CI for the compatibility weekly-plan route.
-- Prod (optional): set `FEATURE_ENFORCE_AUTH_WEEK=1` and `API_KEY=...` to enforce header `X-API-Key` for `/api/v1/premium/plan/week`.
-  - With the flag enabled, invalid or missing key returns `403`.
-  - Other premium endpoints remain protected by `API_KEY` as usual.
-
-## Testing
-
-Run tests:
-
-```bash
-pytest
-```
-
-## CRON Setup
-
-To automatically update the food database weekly, see [CRON.md](docs/runbooks/CRON.md)
-
-### Advanced Testing
-
-```bash
-pytest -q tests/test_food_apis_*.py
-```
-
-- Example env for endpoints requiring API key:
-
-```bash
-export API_KEY=test_key
-```
-
-Locally (without Makefile):
-
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt -r requirements-dev.txt
-pytest -q --maxfail=1 --cov=. --cov-report=term-missing
-```
-
-### Linting
-
-```bash
-make lint
-```
-
----
-
-## 🧪 CI & Coverage Policy
-
-- GitHub Actions runs on Python 3.13.6 with full coverage enforcement at 97%.
-- Coverage is enforced at 97% via `--cov-fail-under=97`.
-- Environment sets `APP_ENV=ci` to avoid auto-loading `.env` during tests.
-- Bandit & Safety run as non-blocking checks (artifacts available in CI logs).
-- Coverage report (`coverage.xml`) is uploaded as an artifact per job.
-
-## 🔒 Security & Compliance
-
-- API Key authentication for sensitive endpoints
-- Optional rate limiting with SlowAPI
-- GDPR compliance for health data (no storage, privacy policy)
-- Property-based testing with Hypothesis for robustness
-
----
-
-## 📊 Features
-
-- **Asynchronous Endpoints**: All endpoints are now async for better concurrency and scalability
-- **Free Tier**:
-  - BMI calculation with categories and special population support
-  - Body fat estimation using multiple formulas
-  - BMI visualization charts (when **matplotlib** available)
-  - AI insights via configurable LLM providers (Stub, Grok, Ollama)
-- **Premium Tier**:
-  - Advanced BMR calculations (Harris-Benedict, Mifflin-St Jeor, Katch-McArdle)
-  - TDEE calculations with activity level factors
-  - **Enhanced My Plate**: Visual nutrition planning with plate sectors and hand/cup portions
-  - Precise deficit/surplus percentage control (5-25% loss, 5-20% gain)
-  - Diet flag adaptations (VEG, GF, DAIRY_FREE, LOW_COST)
-  - Visual layout specification for frontend rendering (SVG/Canvas ready)
-  - Goal-specific macro optimization and meal suggestions
-  - Real-world portion measurements (palms, thumbs, cups)
-- **Development & Operations**:
-  - Comprehensive test suite with 97%+ coverage (enforced in CI)
-  - Docker support with optimized production builds
-  - CI/CD with GitHub Actions and automated security scans
-  - Legacy BMI HTML UI at `GET /legacy/bmi-calculator` (apex `/` is SPA or direct-API probe; see `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`)
-  - Structured logging and request monitoring
-  - **Pre-commit hooks** for code quality (Black, Ruff, MyPy, Bandit)
-  - **Automatic cache cleanup** in CI and pre-commit hooks
-  - API key authentication and optional rate limiting
-
-## 🚀 Staging Deployment
+## Maintainer Setup
 
 ### Prerequisites
 
-- VPS with Docker and Docker Compose installed
-- Domain name pointing to your server
-- GitHub repository with staging environment configured
+- Python `3.13.x`
+- Node `22.22.1` for the web client
+- Xcode for the iOS project in `ios/PulsePlate.xcodeproj`
+- Access to the approved Python package proxy for full backend bootstrap
 
-### Server Setup
+If you do **not** have access to the approved package proxy, stop here and use the first-success path above. Full backend bootstrap is currently maintainer-oriented.
 
-1. **Install Docker and Docker Compose**:
+If you need full backend access, coordinate with the maintainer before attempting backend/bootstrap work.
 
-   ```bash
-   sudo apt update && sudo apt install -y docker.io docker-compose-plugin
-   sudo usermod -aG docker $USER
-   ```
+### 1. Backend
 
-2. **Create staging directory**:
-
-   ```bash
-   sudo mkdir -p /srv/pulseplate-staging
-   ```
-
-3. **Copy deployment files**:
-
-   ```bash
-   sudo cp deploy/docker-compose.staging.yaml /srv/pulseplate-staging/
-   sudo cp deploy/Caddyfile /srv/pulseplate-staging/
-   sudo cp scripts/deploy.sh /srv/pulseplate-staging/
-   sudo chmod +x /srv/pulseplate-staging/deploy.sh
-   ```
-
-4. **Create environment file**:
-
-   ```bash
-   sudo touch /srv/pulseplate-staging/.env
-   # Add your application secrets and STAGING_DOMAIN=your-domain.com
-   ```
-
-### GitHub Environment Setup
-
-Configure the following secrets in GitHub → Settings → Environments → `staging`:
-
-- `SSH_HOST_STAGING` - Your server IP or domain
-- `SSH_USER` - SSH username
-- `SSH_KEY` - Private SSH key
-- `GHCR_READ_TOKEN` - GitHub PAT with read:packages permission
-- `STAGING_DOMAIN` - Your staging domain (e.g., staging.example.com)
-
-### Deployment
-
-Staging automatically deploys when you push to the `main` branch. The deployment process:
-
-1. Builds Docker image and pushes to GHCR
-2. Connects to staging server via SSH
-3. Pulls latest image
-4. Runs database migrations
-5. Restarts application stack
-6. Verifies health endpoint
-
-### Manual Deployment
-
-To deploy manually:
+Bootstrap environment values first:
 
 ```bash
-cd /srv/pulseplate-staging
-./deploy.sh latest
+cp .env.example .env
 ```
 
-## 🚀 Production Deployment
+For local contributor setup, make sure `.env` contains at least:
 
-Production deployments are automated via GitHub Actions with manual approval gates.
+- `PULSEPLATE_PYTHON_INDEX_URL`
+- `SERVER_SALT`
+- `APPLE_SHARED_SECRET`
+- `EXPORT_TOKEN_SECRET`
 
-### Production Prerequisites
+For local-only boot, non-empty placeholder values are acceptable for required secrets unless you are actively testing those integrations.
 
-- Production server configured (see [PRODUCTION.md](docs/deploy/PRODUCTION.md))
-- GitHub environment `production` configured with required secrets
-- Protection rules enabled for manual approval
+Export the env into your current shell, then run the supported bootstrap path:
 
-### Deployment Process
+```bash
+set -a && source .env && set +a
+make venv
+source .venv/bin/activate
+alembic upgrade head
+make dev
+```
 
-1. **Create a release tag**:
+Verify the API from another terminal:
 
-   ```bash
-   git tag v1.0.0
-   git push origin v1.0.0
-   ```
+```bash
+curl http://127.0.0.1:8001/health
+```
 
-2. **GitHub Actions will**:
-   - Build and push Docker image (triggered by tag push)
-   - Wait for manual approval (production environment)
-   - Wait for Docker image to be available (up to 5 minutes)
-   - Deploy to production server
-   - Run health checks
+### 2. Web app
 
-3. **Monitor deployment**:
-   - Check GitHub Actions logs
-   - Verify health endpoint: `https://yourdomain.com/health`
+```bash
+cd frontend
+nvm use
+npm ci
+npm run dev
+```
 
-## PulsePlate Copilot Agent
+`nvm use` reads the repo-root `.nvmrc` and selects Node `22.22.1`.
 
-Интеграция кастомного Copilot‑агента для проекта PulsePlate. Файл спецификации агента находится по пути [.github/agents/my-agent.md](.github/agents/my-agent.md). В нём описаны роли, миссия, режимы отчётов, технические и маркетинговые требования. Добавьте этот файл в репозиторий, чтобы активировать агента Copilot для разработки и аналитики.
+### 3. iOS app
 
-### Production Features
+Open `ios/PulsePlate.xcodeproj` in Xcode and run the `PulsePlate` scheme on a simulator.
 
-- ✅ **Manual approval gates** for safety
-- ✅ **Automatic database backups** before deployment (keeps last 30 backups for recovery flexibility)
-- ✅ **Health checks** with retry logic
-- ✅ **Rollback capability** via previous tags
-- ✅ **SSL/TLS** automatic via Caddy + Cloudflare Full Strict
-- ✅ **Security headers** (HSTS, CSP, X-Frame-Options, etc.)
-- ✅ **Server hardening** (UFW, fail2ban, SSH key-only access)
-- ✅ **Resource limits** and monitoring
-- ✅ **Monitoring & alerting** (Prometheus, Grafana, PagerDuty) - see [PRODUCTION.md](docs/deploy/PRODUCTION.md#monitoring)
+### 4. Docker
 
-For detailed setup instructions, see:
+Docker build also expects the approved Python package proxy and runtime env values that satisfy startup guards:
 
-- **[START_HERE_RU.md](docs/START_HERE_RU.md)** - Главная точка входа для новичков
-- [OVERVIEW.md](docs/deploy/OVERVIEW.md) - Полная пошаговая инструкция
-- [PRODUCTION.md](docs/deploy/PRODUCTION.md) - Детальная настройка production
+```bash
+set -a && source .env && set +a
+make docker-build
+docker compose up -d
+curl http://localhost:8000/health
+```
+
+## Architecture At A Glance
+
+```mermaid
+flowchart LR
+    CLIENTS["Web + iOS + API consumers"] --> APP["FastAPI platform<br/>app.main:app"]
+
+    APP --> FREE["FREE<br/>/api/v1/bmi/*"]
+    APP --> PRO["PRO<br/>/api/v1/pro/*"]
+    APP --> VIP["VIP<br/>/api/v1/vip/*"]
+    APP --> INSIGHT["Insight<br/>/api/v1/insight*"]
+
+    FREE --> DOMAIN["Core domain logic"]
+    PRO --> DOMAIN
+    VIP --> DOMAIN
+    INSIGHT --> AI["Feature-gated AI surfaces"]
+
+    DOMAIN --> DATA["Local food catalog + planning data"]
+    AI --> DATA
+    SOURCES["USDA + Open Food Facts inputs"] --> DATA
+```
+
+### Working rule of thumb
+
+- `app/` orchestrates HTTP/runtime behavior
+- `core/` owns domain logic
+- clients stay thin over backend truth
+- backend OpenAPI is the contract baseline
+
+## Product Tiers
+
+| Tier | Purpose | Typical surface |
+|---|---|---|
+| **FREE** | Entry point into the product | BMI-based check-ins, lookup, simple planning inputs |
+| **PRO** | Core planning value | Targets, daily nutrition, weekly planning, payment activation |
+| **VIP** | Advanced planning and AI-assisted surfaces | Weekly menu flows, recipes, shop/export, insight and FitChef lanes |
+
+## Canonical Product Surfaces
+
+For new backend or client work, the main canonical route families are:
+
+- `/api/v1/bmi/*`
+- `/api/v1/pro/*`
+- `/api/v1/vip/*`
+
+Important canonical exceptions also exist:
+
+- `/api/v1/insight*`
+- `/api/v1/insight/fitchef*`
+- `/api/v1/billing/apple/verify-receipt`
+
+Legacy `/api/v1/premium/*` routes remain compatibility surfaces only and should not be treated as the canonical namespace for new client work.
+
+## Repository Layout
+
+```text
+PulsePlate/
+├── app/            # FastAPI app layer: routers, middleware, schemas, services
+├── core/           # Domain engines and shared business logic
+├── frontend/       # React + TypeScript + Vite web client
+├── ios/            # SwiftUI iOS client
+├── providers/      # LLM/provider integrations
+├── data/           # Local food snapshots, merge outputs, recipe templates
+├── docs/           # Contracts, specs, runbooks, roadmap, architecture
+├── tests/          # Backend, client, and policy guard tests
+├── scripts/        # CI, ops, orchestration, and utility scripts
+└── alembic/        # Database migrations
+```
+
+## Data Foundation
+
+PulsePlate's food-data layer is built around reviewed local snapshots and merge workflows rather than a live-request dependency for every lookup.
+
+- Sources include **USDA FoodData Central** and **Open Food Facts**
+- Merge outputs live in `data/`
+- Architecture direction: `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
+- Source-policy boundaries: `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
+
+Food data can be incomplete or vary by market, manufacturer, and packaging updates. Critical nutrition information should always be verified against official labels or source records.
+
+## Go Deeper
+
+- `docs/architecture/system_overview.md` - system-level product and runtime map
+- `docs/contracts/API_CANONICAL_MAP.md` - canonical route map and namespace rules
+- `docs/contracts/PRODUCT_TIER_MAP.md` - FREE / PRO / VIP semantics
+- `docs/deploy/README.md` - deployment and infrastructure guidance
+- `docs/runbooks/ENGINEER_QUICKPATH.md` - operator quick path
+
+## Interested In PulsePlate?
+
+For demo, collaboration, integration, or licensing conversations:
+
+- email: [pulseplate@pm.me](mailto:pulseplate@pm.me)
+- topic examples: product demo, API/integration discussion, partnership, private rollout access
+
+## Contributing
+
+Before changing code:
+
+1. Required reading:
+   - `AGENTS.md`
+   - `docs/ENGINEERING_LESSONS.md`
+   - `RUNBOOK_AGENT.md`
+   - the nearest scoped `AGENTS.md` for the files you touch
+2. Use the checks that match your surface:
+
+- docs / copy changes: follow the relevant docs guidance and keep the PR docs-only
+- frontend-only changes: run the frontend-local checks for `frontend/`
+- iOS-only changes: run the iOS-local checks for `ios/`
+- maintainer full-stack/backend changes: run:
+
+```bash
+pre-commit run --all-files
+make verify
+```
+
+Public deployments should also ship with clear privacy and data-use notices for health-related inputs and any third-party services involved in processing them.
 
 ## License
 
-This project is proprietary software. All rights reserved. Unauthorized copying, distribution, modification, or use of this code is strictly prohibited without prior written permission from the author.
+This project is **proprietary software**. All rights reserved.
 
-For commercial or licensing inquiries, please contact: <lexakm532@gmail.com>
+Unauthorized copying, distribution, modification, or use of this code is prohibited without prior written permission from the author.
 
-See the [LICENSE](LICENSE) file for full details.
+For commercial or licensing inquiries: [pulseplate@pm.me](mailto:pulseplate@pm.me)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/branch/main/graph/badge.svg)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
 [![Food data: USDA + OFF](https://img.shields.io/badge/Food%20data-USDA%20%2B%20OFF-brightgreen)](docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md)
 
+Operational signals:
+- `CI` shows the main backend/shared validation lane.
+- `Codecov Upload` shows the artifact upload job that publishes coverage results.
+- `codecov` shows the latest published repository coverage snapshot.
+
 > **PulsePlate turns body-metric check-ins into practical meal decisions.**
 >
 > It is a planning-first wellness product built around one continuous flow:
@@ -14,6 +19,17 @@
 PulsePlate is designed as a **wellness and meal-planning product**, not as a diagnosis, treatment, therapy, crisis-support, or emergency-care system. BMI and related outputs are informational wellness tools only, and the product should not replace clinician guidance for diagnosed conditions, pregnancy, eating disorders, medically prescribed diets, or emergencies.
 
 PulsePlate is currently in a **private staged rollout**. This repository is the clearest technical and product snapshot of the platform today.
+
+## Developer And Contributor Entrypoint
+
+If you are here to build, review, or deploy rather than evaluate the product story first, start here:
+
+- `AGENTS.md` for repository-wide engineering rules and merge-governance policy
+- `RUNBOOK_AGENT.md` for CI triage, merge-readiness, and post-merge cleanup flow
+- `docs/deploy/README.md` for deployment navigation
+- `docs/contracts/API_CANONICAL_MAP.md` for the canonical public API surface
+
+If you need the shortest docs-only path first, you can contribute safely in markdown without depending on the full maintainer-only backend bootstrap.
 
 ## From Metrics To Meals
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are here to build, review, or deploy rather than evaluate the product sto
 - `docs/deploy/README.md` for deployment navigation
 - `docs/contracts/API_CANONICAL_MAP.md` for the canonical public API surface
 
-If you need the shortest docs-only path first, you can contribute safely in markdown without depending on the full maintainer-only backend bootstrap.
+If you need the shortest docs-only path first, you can contribute safely in Markdown without depending on the full maintainer-only backend bootstrap.
 
 ## From Metrics To Meals
 
@@ -158,12 +158,17 @@ cp .env.example .env
 
 For local contributor setup, make sure `.env` contains at least:
 
-- `PULSEPLATE_PYTHON_INDEX_URL`
-- `SERVER_SALT`
-- `APPLE_SHARED_SECRET`
-- `EXPORT_TOKEN_SECRET`
+- `PULSEPLATE_PYTHON_INDEX_URL` for `make`-driven bootstrap targets
+- `SERVER_SALT` for app startup validation
 
-For local-only boot, non-empty placeholder values are acceptable for required secrets unless you are actively testing those integrations.
+For local-only boot, placeholder values from `.env.example` are acceptable for `SERVER_SALT`.
+
+Additional secrets are only required for specific features or production-like environments:
+
+- `APPLE_SHARED_SECRET` for Apple receipt verification in production/staging-like setups
+- `EXPORT_TOKEN_SECRET` when `PRIVATE_EXPORTS_ENABLED=true` in production/staging-like setups
+
+For local-only boot, non-empty placeholder values remain acceptable for `APPLE_SHARED_SECRET` and `EXPORT_TOKEN_SECRET` unless you are actively testing those flows.
 
 Export the env into your current shell, then run the supported bootstrap path:
 

--- a/docs/review/PR_1292_FIXED_MAPPING.md
+++ b/docs/review/PR_1292_FIXED_MAPPING.md
@@ -6,7 +6,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: ed419e44
+Evidence: README.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#pullrequestreview-4036484509 -> ed419e44
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1292_FIXED_MAPPING.md
+++ b/docs/review/PR_1292_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1292 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [ ] `make verify` green
+- Docs-only lane: root `README.md` now mirrors the approved public-facing homepage copy without touching runtime or the active Postgres foundation branch.

--- a/docs/review/PR_1292_FIXED_MAPPING.md
+++ b/docs/review/PR_1292_FIXED_MAPPING.md
@@ -13,5 +13,5 @@
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green
-- [ ] `make verify` green
+- [x] `make verify` green
 - Docs-only lane: root `README.md` now mirrors the approved public-facing homepage copy without touching runtime or the active Postgres foundation branch.

--- a/docs/review/PR_1292_FIXED_MAPPING.md
+++ b/docs/review/PR_1292_FIXED_MAPPING.md
@@ -17,6 +17,12 @@ Evidence: README.md
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#discussion_r3015246376 -> 4c9f7584
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#pullrequestreview-4036644072 -> 4c9f7584
 
+Disposition: FIXED
+Commit: f4493a0f
+Evidence: README.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#discussion_r3015386076 -> f4493a0f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#pullrequestreview-4036796849 -> f4493a0f
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1292_FIXED_MAPPING.md
+++ b/docs/review/PR_1292_FIXED_MAPPING.md
@@ -11,6 +11,12 @@ Commit: ed419e44
 Evidence: README.md
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#pullrequestreview-4036484509 -> ed419e44
 
+Disposition: FIXED
+Commit: 4c9f7584
+Evidence: README.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#discussion_r3015246376 -> 4c9f7584
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1292#pullrequestreview-4036644072 -> 4c9f7584
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)


### PR DESCRIPTION
## Summary
- replace the root `README.md` with the public-facing homepage copy from the approved v2 draft
- make the GitHub repository landing page match the current PulsePlate product narrative and contributor entrypoint
- keep the PR docs-only and isolated from the active Postgres workstream

## Split Justification
This PR stays as one docs lane because the scope is one user-facing repository homepage update with one canonical review artifact and one governance surface. Splitting the README sync, Sourcery follow-up, and review-mapping update would create extra review overhead without reducing runtime risk or changing the validation path.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `make verify`
- [x] docs-only scope check returned no non-doc paths

## Notes
- This PR intentionally does not touch `infra/p0-postgres-droplet-foundation`.
- Local clean-worktree verification used repo-local links to the existing local `.venv` and `node_modules` only for local gate parity; no local artifacts are tracked in git after verification completed.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1292_FIXED_MAPPING.md`

## Summary by Sourcery

Обновить документацию домашней страницы репозитория в соответствии с актуальным повествованием о продукте PulsePlate и точками входа для контрибьюторов.

Документация:
- Заменить корневой README обновлённой, ориентированной на публичное использование версией главной страницы PulsePlate, которая акцентирует позиционирование продукта, тарифные планы, обзор архитектуры и пути для контрибьюторов.
- Добавить артефакт для ревью PR, документирующий проход по дискуссионным тредам и сопоставление «исправлено-в-коммите» для этого изменения, затрагивающего только документацию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the repository homepage documentation to align with the current PulsePlate product narrative and contributor entry points.

Documentation:
- Replace the root README with the updated, public-facing PulsePlate homepage copy that emphasizes product positioning, tiers, architecture overview, and contributor paths.
- Add a PR review artifact documenting the discussion-thread pass and fixed-in-commit mapping for this docs-only change.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured primary documentation into a product-focused overview organized around a single end-to-end user flow
  * Replaced detailed engineering/runbook content with high-level product tiers, architecture overview, and a contributor entrypoint
  * Clarified canonical API surface and notable exceptions
  * Simplified maintainer setup and listed required bootstrap environment variables
  * Updated badges/operational signals, privacy notice, and contact info
  * Added a review-tracking document capturing PR review resolution and merge-readiness notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->