### PR TITLE
fix(tests): stabilize main CI rate-limit bootstrap

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -463,7 +463,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 381
+        "line_number": 387
       }
     ],
     "tests/disabled_hypothesis/test_life_stage_error_branches_hypothesis.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-27T11:10:08Z"
+  "generated_at": "2026-04-01T21:32:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -463,7 +463,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 406
       }
     ],
     "tests/disabled_hypothesis/test_life_stage_error_branches_hypothesis.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T21:32:30Z"
+  "generated_at": "2026-04-01T22:18:49Z"
 }

--- a/docs/review/PR_1295_FIXED_MAPPING.md
+++ b/docs/review/PR_1295_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1295 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- Scope: main-CI stabilization for the canonical pytest bootstrap path only; no runtime or product-surface behavior changes are included in this lane.

--- a/docs/review/PR_1295_FIXED_MAPPING.md
+++ b/docs/review/PR_1295_FIXED_MAPPING.md
@@ -10,6 +10,12 @@ Commit: d7374150
 Evidence: `tests/conftest.py`; `tests/test_env_guards.py`; `pytest -q tests/test_env_guards.py`; `make verify`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1295#pullrequestreview-4047385078 -> d7374150
 
+Disposition: FIXED
+Commit: 6fe762de
+Evidence: `tests/test_env_guards.py`; `docs/review/PR_1295_FIXED_MAPPING.md`; `pytest -q tests/test_env_guards.py`; `pre-commit run --all-files`; `make verify`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1295#pullrequestreview-4047395662 -> 6fe762de
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1295#discussion_r3024942621 -> 6fe762de
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1295_FIXED_MAPPING.md
+++ b/docs/review/PR_1295_FIXED_MAPPING.md
@@ -14,6 +14,6 @@ Evidence: `tests/conftest.py`; `tests/test_env_guards.py`; `pytest -q tests/test
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
+- [ ] Pre-commit green
+- [ ] `make verify` green
 - Scope: main-CI stabilization for the canonical pytest bootstrap path only; no runtime or product-surface behavior changes are included in this lane.

--- a/docs/review/PR_1295_FIXED_MAPPING.md
+++ b/docs/review/PR_1295_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: d7374150
+Evidence: `tests/conftest.py`; `tests/test_env_guards.py`; `pytest -q tests/test_env_guards.py`; `make verify`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1295#pullrequestreview-4047385078 -> d7374150
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,11 +147,30 @@ os.environ.setdefault("SERVER_SALT", "StrongServerSaltForTests123456789!")
 # Configure logger for test cleanup operations
 logger = logging.getLogger(__name__)
 
+_TESTING_ENV_WAS_SET = False
+_PREVIOUS_TESTING_ENV: str | None = None
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Set import-time test env before any app bootstrap happens."""
+    global _PREVIOUS_TESTING_ENV, _TESTING_ENV_WAS_SET
     del config
+    _TESTING_ENV_WAS_SET = "TESTING" in os.environ
+    _PREVIOUS_TESTING_ENV = os.environ.get("TESTING")
     os.environ["TESTING"] = "true"
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore the original TESTING env after the pytest session ends."""
+    del config
+    if _TESTING_ENV_WAS_SET:
+        if _PREVIOUS_TESTING_ENV is not None:
+            os.environ["TESTING"] = _PREVIOUS_TESTING_ENV
+        else:
+            os.environ.pop("TESTING", None)
+        return
+
+    os.environ.pop("TESTING", None)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,12 @@ os.environ.setdefault("SERVER_SALT", "StrongServerSaltForTests123456789!")
 logger = logging.getLogger(__name__)
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Set import-time test env before any app bootstrap happens."""
+    del config
+    os.environ["TESTING"] = "true"
+
+
 @pytest.fixture
 def reset_payments_state() -> Generator[None, None, None]:
     """Reset in-memory payment activation state for deterministic payment tests."""

--- a/tests/test_env_guards.py
+++ b/tests/test_env_guards.py
@@ -33,9 +33,3 @@ def test_app_is_legacy_instance() -> None:
 def test_rate_limit_bootstrap_disabled_for_canonical_app_import(app: FastAPI) -> None:
     """Guard: canonical app.main bootstrap must not attach active rate limiting in tests."""
     assert not hasattr(app.state, "limiter")
-
-    import app.security.rate_limit as rate_limit
-
-    assert rate_limit._rate_limiting_enabled() is False
-    if rate_limit.limiter is not None:
-        assert getattr(rate_limit.limiter, "enabled", True) is False

--- a/tests/test_env_guards.py
+++ b/tests/test_env_guards.py
@@ -5,7 +5,8 @@ routes are registered. They catch import-order and feature-flag issues early.
 """
 
 import os
-from types import ModuleType
+
+from fastapi import FastAPI
 
 
 def test_testing_env_enabled() -> None:
@@ -29,8 +30,10 @@ def test_app_is_legacy_instance() -> None:
     assert app.app is legacy_app.app, "app.app must be legacy_app.app instance"
 
 
-def test_rate_limit_bootstrap_disabled_for_canonical_app_import(app_module: ModuleType) -> None:
-    """Guard: canonical test bootstrap must disable rate limiting before app import."""
+def test_rate_limit_bootstrap_disabled_for_canonical_app_import(app: FastAPI) -> None:
+    """Guard: canonical app.main bootstrap must not attach active rate limiting in tests."""
+    assert not hasattr(app.state, "limiter")
+
     import app.security.rate_limit as rate_limit
 
     assert rate_limit._rate_limiting_enabled() is False

--- a/tests/test_env_guards.py
+++ b/tests/test_env_guards.py
@@ -32,4 +32,5 @@ def test_app_is_legacy_instance() -> None:
 
 def test_rate_limit_bootstrap_disabled_for_canonical_app_import(app: FastAPI) -> None:
     """Guard: canonical app.main bootstrap must not attach active rate limiting in tests."""
-    assert not hasattr(app.state, "limiter")
+    limiter_on_state = getattr(app.state, "limiter", None)
+    assert limiter_on_state is None or getattr(limiter_on_state, "enabled", False) is False

--- a/tests/test_env_guards.py
+++ b/tests/test_env_guards.py
@@ -5,6 +5,7 @@ routes are registered. They catch import-order and feature-flag issues early.
 """
 
 import os
+from types import ModuleType
 
 
 def test_testing_env_enabled() -> None:
@@ -26,3 +27,12 @@ def test_app_is_legacy_instance() -> None:
     import legacy_app
 
     assert app.app is legacy_app.app, "app.app must be legacy_app.app instance"
+
+
+def test_rate_limit_bootstrap_disabled_for_canonical_app_import(app_module: ModuleType) -> None:
+    """Guard: canonical test bootstrap must disable rate limiting before app import."""
+    import app.security.rate_limit as rate_limit
+
+    assert rate_limit._rate_limiting_enabled() is False
+    if rate_limit.limiter is not None:
+        assert getattr(rate_limit.limiter, "enabled", True) is False


### PR DESCRIPTION
## Summary
- set `TESTING=true` during pytest bootstrap so canonical app imports disable rate limiting before legacy route wiring
- preserve and restore the original `TESTING` environment around the pytest session so the bootstrap override does not leak outside the canonical test lane
- keep the regression guard on the canonical `app.main` bootstrap path and maintain the required review-governance artifact for PR 1295

## Test plan
- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `pytest -q tests/test_env_guards.py`
- [x] `python scripts/ci/check_docs_phase1_gates.py --files docs/review/PR_1295_FIXED_MAPPING.md`
- [x] `pre-commit run --files tests/conftest.py tests/test_env_guards.py docs/review/PR_1295_FIXED_MAPPING.md`
- [x] `make test-fast`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1295_FIXED_MAPPING.md`

## Risks
- coverage is focused on the canonical pytest bootstrap path; alternate bootstrap paths remain outside this scoped CI stabilization lane
- release remains blocked until this PR merges and the resulting `main` head is green on `CI`, `Nightly Tests`, and `Nightly Full Tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test session environment setup/teardown to ensure consistent test initialization.
  * Added a guard test verifying rate-limit bootstrap behavior during canonical application import.

* **Docs**
  * Added a review record documenting discussion, fix mappings, evidence commands, and a merge-readiness checklist.

* **Chores**
  * Updated security baseline metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->