### PR TITLE
docs(frontend): close web progress contract drift

### DIFF
--- a/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
+++ b/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
@@ -14,12 +14,12 @@
 - **Frontend (Web):** 25% (много скелетов, отсутствует графика)
 - **iOS:** 50% (более развит, но много "Coming soon")
 - **Графика/Анимации:** 30% (базовые компоненты, нет брендинга)
-- **Соответствие бэкенду:** 60% (используются правильные endpoints, но много mock данных)
+- **Соответствие бэкенду:** 65% (часть stale mock narrative уже закрыта на web, но остаются скелеты и неподключённые поверхности)
 
 **Критические пробелы:**
 - ❌ Большинство страниц — скелеты ("Скелет страницы", "Coming soon")
 - ❌ Нет брендинга (FitChef только в iOS, нет во frontend)
-- ❌ Нет графики (ProgressCharts использует mock данные)
+- ⚠️ Нет реальной графики в release path (web progress теперь скрывает charts до появления real data)
 - ❌ Нет визуальных элементов (ECG, pulse animations отсутствуют)
 
 ---
@@ -35,7 +35,7 @@
 | **Home** | ❌ Скелет | Только текст | Нет | Нет | 10% |
 | **Profile** | ❌ Скелет | Только текст | Нет | Нет | 10% |
 | **Plate** | ⚠️ Базовая | PremiumGate | Нет | Нет | 20% |
-| **Progress** | ⚠️ Частично | ProgressCharts (mock) | Export PDF | Нет (mock) | 40% |
+| **Progress** | ⚠️ Частично | Trusted empty state | Export PDF (disabled) | Нет release chart endpoint | 45% |
 | **BMI Calculate** | ✅ Работает | Форма + результат | Submit, Reset | ✅ `/api/v1/bmi/calculate` | 80% |
 | **Nutrition Setup** | ✅ Работает | PlateChart, MacroCards | Calculate, Edit | ✅ `/api/v1/pro/nutrition/targets`, `/api/v1/pro/nutrition/plate` | 75% |
 | **Weekly Plan** | ⚠️ Частично | Список дней/блюд | Copy, Download | ✅ `/api/v1/pro/meal/weekly` | 60% |
@@ -62,10 +62,10 @@
    - ✅ Accessibility (ARIA labels)
 
 3. **ProgressCharts** (`features/progress/ProgressCharts.tsx`)
-   - ✅ LineChart (weight/BMI trends)
-   - ✅ BarChart (calorie balance)
-   - ✅ PieChart (macronutrient distribution)
-   - ⚠️ **НО:** Использует **mock данные** (не подключен к backend)
+   - ✅ Trusted empty state для release-safe web path
+   - ✅ Export PDF кнопка остаётся disabled до появления live data
+   - ✅ Явная copy-formula: charts скрыты до появления реальных nutrition/weight данных
+   - ⚠️ Dedicated backend history/chart contract по-прежнему не подключён
 
 4. **TabBar** (`components/TabBar.tsx`)
    - ✅ Навигация между страницами
@@ -260,17 +260,17 @@
 | `BMICalculatePage` | `/api/v1/bmi/calculate` | ✅ Правильно | Нет |
 | `NutritionSetup` | `/api/v1/pro/nutrition/targets`<br>`/api/v1/pro/nutrition/plate` | ✅ Правильно | Нет |
 | `WeeklyPlanViewer` | `/api/v1/pro/meal/weekly` | ✅ Правильно (мигрировано) | Нет |
-| `ProgressCharts` | ❌ Нет endpoint | ❌ **Mock данные** | Нет backend API для progress |
+| `ProgressCharts` | ❌ Нет endpoint | ⚠️ **Trusted empty state** | Нет backend API для chart/history progress |
 | `Home` | ❌ Нет endpoint | ❌ Нет функциональности | Страница — скелет |
 | `Profile` | ❌ Нет endpoint | ❌ Нет функциональности | Страница — скелет |
 | `Plate` | `/api/v1/pro/nutrition/daily` | ⚠️ Не используется | Страница — заглушка |
 
 **Проблемы:**
 
-1. **ProgressCharts использует mock данные**
-   - Нет backend API для progress tracking
-   - Данные hardcoded в компоненте
-   - Нет интеграции с реальными данными
+1. **ProgressCharts больше не показывает fabricated charts, но backend history всё ещё не реализован**
+   - Release path показывает явный trusted empty state
+   - Export intentionally disabled until real progress data exists
+   - Backend API для chart/history progress всё ещё отсутствует
 
 2. **Home/Profile — скелеты**
    - Нет backend endpoints
@@ -343,11 +343,11 @@
    - iOS: ❌ Нет экрана/компонента
    - Backend: ✅ Код готов (`core/sports_nutrition.py`)
 
-2. **Progress Tracking** — ❌ Не реализовано
+2. **Progress Tracking** — ⚠️ Частично закрыто
    - Анализ: `docs/analysis/DOMAIN_ANALYSIS.md` — Progress tracking domain
-   - Фронтенд: ⚠️ `ProgressCharts` использует **mock данные**
+   - Фронтенд: ⚠️ web release path показывает trusted empty state вместо fabricated charts
    - iOS: ❌ `ProgressViewPP` — "Charts coming…"
-   - Backend: ❌ Нет endpoint для progress tracking
+   - Backend: ❌ Нет dedicated endpoint для progress tracking/history
 
 3. **Bayesian Adherence** — ❌ Не реализовано
    - Анализ: `docs/analysis/CORE_MODULES_ANALYSIS_REVIEW.md` — "Bayesian Adherence Domain"
@@ -476,22 +476,22 @@
 
 ---
 
-### 3. ❌ Нет графики (mock данные)
+### 3. ⚠️ Нет реальной progress-графики в release path
 
 **Проблема:**
-- `ProgressCharts.tsx` использует **hardcoded mock данные**
-- Нет backend API для progress tracking
-- iOS `ProgressViewPP` — "Charts coming…"
+- `ProgressCharts.tsx` больше не использует fabricated charts, но и не подключён к backend history/chart API
+- Web release path intentionally hides charts until real data exists
+- iOS `ProgressViewPP` всё ещё не подтверждён как parity-runtime с web
 
 **Влияние:**
-- Пользователи видят фиктивные данные
-- Нет реального progress tracking
-- Плохой UX
+- Пользователи больше не видят фиктивные данные
+- Longitudinal progress tracking как feature всё ещё не реализован
+- UX безопаснее для release truth, но остаётся intentionally minimal
 
 **Рекомендация:**
-- Создать backend API для progress tracking
-- Подключить `ProgressCharts` к реальным данным
-- Реализовать iOS progress charts
+- Не возвращать fabricated charts в release path
+- Если product later решит развивать progress, делать это отдельным backend/history lane
+- iOS progress не выравнивать по narrative с web без отдельного runtime evidence
 
 ---
 

--- a/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
+++ b/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
@@ -652,19 +652,23 @@
 
 ## 🎯 Приоритетные действия
 
-### Immediate Actions (This Week)
+### Immediate Actions (Post-Gate Window)
 
-1. **P0 CRITICAL**
+Do not start this follow-up lane before the upstream remediation and cleanup
+sequence is merged, backend guards are green, and `make verify` passes. The
+roadmap order remains strict: PR-A -> PR-B -> PR-C -> PR-D.
+
+1. **P0 CRITICAL (after backend stabilization gates)**
    - Реализовать Home page (dashboard)
    - Реализовать Progress page (backend API + графики)
    - Добавить брендинг (FitChef, слоган, ECG)
 
-2. **P1 HIGH**
+2. **P1 HIGH (post-gate)**
    - Реализовать Profile page
    - Подключить Daily Plate к API
    - Добавить анимации (Lottie, pulse)
 
-### Short-Term (Next Month)
+### Short-Term (After P0 Gate Completion)
 
 1. **P1 MEDIUM**
    - Реализовать Sports Nutrition UI

--- a/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
+++ b/docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md
@@ -319,7 +319,7 @@
 
 ### Соответствие `docs/analysis/*`
 
-#### ✅ Что соответствует:
+#### ✅ Что соответствует
 
 1. **BMI Calculation** — ✅ Работает
    - Frontend: `BMICalculatePage` → `/api/v1/bmi/calculate`
@@ -335,7 +335,7 @@
    - iOS: `WeeklyPlanReaderView` → `/api/v1/pro/meal/weekly`
    - Соответствует: `docs/analysis/DOMAIN_ANALYSIS.md` (Meal Planning Domain)
 
-#### ❌ Что НЕ соответствует:
+#### ❌ Что НЕ соответствует
 
 1. **Sports Nutrition** — ❌ Не реализовано
    - Анализ: `docs/analysis/FINAL_ASSESSMENT_REVIEW.md` — "Sports Nutrition не используется"
@@ -359,7 +359,7 @@
 
 ### Соответствие `docs/audit/*`
 
-#### ✅ Что соответствует:
+#### ✅ Что соответствует
 
 1. **Design Tokens** — ✅ Реализовано
    - Frontend: `styles/tokens.ts`, `styles/tokens.css`
@@ -376,7 +376,7 @@
    - iOS: Использует `APIClient`
    - Соответствует: `docs/audit/PR_586_WEB_THIN_HTTP_ADAPTER_AUDIT.md`
 
-#### ❌ Что НЕ соответствует:
+#### ❌ Что НЕ соответствует
 
 1. **Brand Slogan** — ❌ Не реализовано
    - Аудит: `docs/audit/DESIGN_CONCEPT_IMPLEMENTATION_AUDIT.md` — "Brand Slogan не реализован"
@@ -410,7 +410,7 @@
 
 ### Соответствие `docs/roadmap/BACKLOG_LEDGER.md`
 
-#### ✅ Что соответствует:
+#### ✅ Что соответствует
 
 1. **Thin HTTP Adapter (iOS)** — ✅ Завершено
    - Backlog: `PR-563 Thin HTTP Adapter (iOS) — merged`
@@ -422,7 +422,7 @@
    - Frontend: Использует `api()` из `client.ts`
    - Статус: ✅ Соответствует
 
-#### ❌ Что НЕ соответствует:
+#### ❌ Что НЕ соответствует
 
 1. **Wire soft paywall CTA to real paywall router (iOS)** — ❌ Не реализовано
    - Backlog: `Wire soft paywall CTA to real paywall router (iOS)`
@@ -525,7 +525,7 @@
 | Daily Plate | `/api/v1/pro/nutrition/daily` | ❌ Не используется | ⚠️ Fallback | ⚠️ **ЧАСТИЧНО** |
 | Weekly Plan | `/api/v1/pro/meal/weekly` | ✅ Работает | ✅ Работает | ✅ **ГОТОВО** |
 | Shopping List | `/api/v1/vip/shoplist/*` | ⚠️ Preview | ✅ Работает | ⚠️ **ЧАСТИЧНО** |
-| Progress Tracking | ❌ Нет endpoint | ⚠️ Mock | ❌ Скелет | ❌ **НЕ РЕАЛИЗОВАНО** |
+| Progress Tracking | ❌ Нет endpoint | ⚠️ Trusted empty state | ❌ Скелет | ❌ **НЕ РЕАЛИЗОВАНО** |
 | Sports Nutrition | ❌ Нет endpoint | ❌ Нет | ❌ Нет | ❌ **НЕ РЕАЛИЗОВАНО** |
 | Bayesian Adherence | `/api/v1/pro/nutrition/log` | ❌ Нет UI | ❌ Нет UI | ❌ **НЕ РЕАЛИЗОВАНО** |
 
@@ -562,29 +562,29 @@
 
 ### P1 — High Priority
 
-4. **Реализовать Profile page**
+1. **Реализовать Profile page**
    - Настройки пользователя
    - Статистика
    - Подписка (PRO/VIP)
 
-5. **Подключить Daily Plate**
+2. **Подключить Daily Plate**
    - Использовать `/api/v1/pro/nutrition/daily` в Plate page
    - Убрать PremiumGate заглушку
    - Реальная визуализация тарелки
 
-6. **Реализовать Sports Nutrition UI**
+3. **Реализовать Sports Nutrition UI**
    - Frontend: страница/компонент
    - iOS: экран/компонент
    - Интеграция с `/api/v1/vip/sports/nutrition` (после реализации endpoint)
 
 ### P2 — Medium Priority
 
-7. **Добавить анимации**
+1. **Добавить анимации**
    - Lottie integration во frontend
    - Pulse animations
    - Smooth transitions
 
-8. **Улучшить графику**
+2. **Улучшить графику**
    - Интерактивные tooltips
    - Target range indicators
    - ECG-style visualizations
@@ -596,7 +596,7 @@
 | Категория | Frontend | iOS | Backend | Статус |
 |-----------|----------|-----|---------|--------|
 | **Страницы/Экраны** | 4/8 скелеты | 2/8 скелеты | N/A | ❌ **КРИТИЧНО** |
-| **Графика** | 2 компонента (mock) | 3 компонента | N/A | ⚠️ **ЧАСТИЧНО** |
+| **Графика** | 2 компонента (trusted empty state / partial) | 3 компонента | N/A | ⚠️ **ЧАСТИЧНО** |
 | **Брендинг** | 0% | 30% | N/A | ❌ **КРИТИЧНО** |
 | **Кнопки/Интерактивность** | 3/8 работают | 4/8 работают | N/A | ⚠️ **ЧАСТИЧНО** |
 | **Backend Integration** | 3/8 работают | 4/8 работают | 8/8 endpoints | ⚠️ **ЧАСТИЧНО** |
@@ -630,12 +630,12 @@
 
 ## 📊 Соответствие BACKLOG_LEDGER.md
 
-### ✅ Уже в BACKLOG:
+### ✅ Уже в BACKLOG
 
 1. **Wire soft paywall CTA to real paywall router (iOS)** — ✅ Записано
 2. **Stabilize/restore PlateViewTests in CI (iOS)** — ✅ Записано
 
-### ❌ НЕ в BACKLOG (требует добавления):
+### ❌ НЕ в BACKLOG (требует добавления)
 
 1. **Реализовать Home page (Frontend/iOS)** — ❌ НЕ записано
 2. **Реализовать Progress page (Frontend/iOS)** — ❌ НЕ записано
@@ -652,21 +652,21 @@
 
 ## 🎯 Приоритетные действия
 
-### Immediate Actions (This Week):
+### Immediate Actions (This Week)
 
-1. **P0 CRITICAL:**
+1. **P0 CRITICAL**
    - Реализовать Home page (dashboard)
    - Реализовать Progress page (backend API + графики)
    - Добавить брендинг (FitChef, слоган, ECG)
 
-2. **P1 HIGH:**
+2. **P1 HIGH**
    - Реализовать Profile page
    - Подключить Daily Plate к API
    - Добавить анимации (Lottie, pulse)
 
-### Short-Term (Next Month):
+### Short-Term (Next Month)
 
-3. **P1 MEDIUM:**
+1. **P1 MEDIUM**
    - Реализовать Sports Nutrition UI
    - Создать backend API для progress tracking
    - Улучшить графику (tooltips, indicators)

--- a/docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md
+++ b/docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md
@@ -1,0 +1,76 @@
+# PR Audit: Web Progress Contract Closeout
+
+**Date:** 2026-04-02
+**Status:** docs-only closeout evidence packet
+**Scope:** web progress truth reconciliation only
+
+## Summary
+
+Current `main` no longer renders fabricated progress charts on the web release
+path. `ProgressCharts` now shows a trusted empty state and keeps PDF export
+disabled until real data exists.
+
+This packet closes stale documentation drift only. It does not add a backend
+progress API, chart-history contract, or new frontend runtime behavior.
+
+## Scope In
+
+- roadmap truth for `ledger-p0-web-progress-contract`
+- execution sequencing truth after merged PRs `#1298` and `#1299`
+- stale secondary docs that still claim web Progress uses mock chart data
+- one canonical evidence packet for the current shipped behavior
+
+## Scope Out
+
+- backend progress/history API design
+- OpenAPI or generated frontend types
+- frontend runtime implementation
+- chart rendering or historical-data feature expansion
+- iOS runtime claims beyond explicitly verified web evidence
+
+## Evidence Snapshot
+
+- The web Progress page still mounts the shared progress surface and range
+  selector, but it does not inject fabricated chart payloads:
+  `frontend/src/pages/Progress.tsx:9`,
+  `frontend/src/pages/Progress.tsx:36`,
+  `frontend/src/pages/Progress.tsx:69`.
+- `ProgressCharts` renders a release-safe empty state instead of trend charts
+  and keeps export disabled while live data is absent:
+  `frontend/src/features/progress/ProgressCharts.tsx:25`,
+  `frontend/src/features/progress/ProgressCharts.tsx:33`,
+  `frontend/src/features/progress/ProgressCharts.tsx:40`,
+  `frontend/src/features/progress/ProgressCharts.tsx:42`.
+- Targeted frontend tests lock the current truth:
+  `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx:24`,
+  `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx:32`,
+  `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx:36`.
+
+## Closeout Decision
+
+- The original release-trust gap for web progress was fabricated chart data in
+  the release path.
+- That runtime gap is already removed on current `main`.
+- The remaining work in this lane is documentation reconciliation only.
+- Any future backend-fed progress history or chart lane must be tracked as a
+  separate feature and must not be implied by this closeout packet.
+
+## Sequencing Note
+
+After merged PR `#1299`, the active work for web progress is documentation
+alignment, not a new runtime feature packet. The next active lane after this
+closeout is `docs/legal-policy-publish` in
+`docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`.
+
+## Security Notes
+
+- Web progress no longer risks fabricating health-adjacent chart history in the
+  release path.
+- The current empty-state posture is fail-safe: no fake trend values are
+  displayed when real data is unavailable.
+
+## Decision
+
+This PR should stay narrow and docs-only. If product later wants live progress
+history, that work belongs in a separate implementation lane with its own
+backend/frontend contract and release evidence.

--- a/docs/figma/PULSEPLATE_FIGMA_DESIGN_SPECIFICATION.md
+++ b/docs/figma/PULSEPLATE_FIGMA_DESIGN_SPECIFICATION.md
@@ -632,6 +632,10 @@ Circular progress ring overlay.
 
 Figma Component Set: `PP/Web/DataViz/ProgressCharts`
 
+Note: this section describes the target design language for a future chart-rich
+progress surface. Current shipped web runtime does not render fabricated charts;
+it uses a trusted empty state until real progress data exists.
+
 Three chart types in a stacked layout.
 
 **LineChart (Weight/BMI Trends):**
@@ -1492,7 +1496,7 @@ Status claims below are target/roadmap assessments based on codebase analysis; f
 | **GlassCard** | Implemented | Implemented | - |
 | **TabBar/Navigation** | Implemented | Implemented | - |
 | **PlateChart** | Implemented | Implemented (PlateSegments) | - |
-| **ProgressCharts** | Implemented (mock data) | Skeleton only | P0-A |
+| **ProgressCharts** | Trusted empty state in release path; chart-rich design remains target-only | Skeleton only | P0-A |
 | **PremiumGate** | Implemented | N/A (StoreKit paywall) | - |
 | **SoftPaywallHook** | Implemented | Implemented | - |
 | **BeforeAfter Modal** | Implemented | N/A | - |

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -42,6 +42,18 @@ Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/review/PR_1301_
 Reason: The latest CodeRabbit summary review consolidated two real follow-ups from the current head snapshot: the post-gate sequencing language in the analysis packet and the `Markdown` capitalization fix in this artifact. Commit `3fd28eb6` applies those narrow docs-only adjustments.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051920285 -> 3fd28eb6
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md:11`
+Reason: The capitalization thread for `Markdown` is already satisfied on current head. CodeRabbit itself marks `discussion_r3029238264` as addressed in commits `3fd28eb` to `163d9d8`, so no additional follow-up beyond the existing artifact evidence is required.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029238264
+
+Disposition: FIXED
+Commit: cfd4b4cd
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md:10`, `docs/review/PR_1301_FIXED_MAPPING.md:29`
+Reason: The latest artifact cleanup round tightened the first FIXED block with precise `file:line` anchors and removed the redundant `needed required` phrasing in the cubic NOT-A-BUG block. That satisfies the remaining actionable parts of the newest CodeRabbit review round.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051959067 -> cfd4b4cd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029238272 -> cfd4b4cd
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -5,9 +5,17 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: 15de9223
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed markdown docs still contained numbering/heading patterns that violate markdownlint conventions. The same fix pack also normalizes the closeout packet wording around the shared web progress runtime truth so the audit and review artifacts do not drift.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051808021 -> 15de9223
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051824357 -> 15de9223
+
 Disposition: NOT-A-BUG
-Evidence: `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `frontend/src/features/progress/ProgressCharts.tsx:24`, `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx:32`
-Reason: At artifact creation time PR `#1301` has no actionable review comments yet. The lane is a narrow docs-only closeout that reconciles roadmap/audit/design docs to the already shipped web progress truth: no fabricated charts on the release path, trusted empty state until real data exists, and no claim of backend-fed history implementation.
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: The Codex connector review on PR `#1301` is informational only and does not include actionable code or docs changes beyond the canonical governance loop already being followed here.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051809148
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 Disposition: FIXED
 Commit: 15de9223
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
-Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed markdown docs still contained numbering/heading patterns that violate markdownlint conventions. The same fix pack also normalizes the closeout packet wording around the shared web progress runtime truth so the audit and review artifacts do not drift.
+Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed Markdown docs still contained numbering/heading patterns that violate markdownlint conventions. The same fix pack also normalizes the closeout packet wording around the shared web progress runtime truth so the audit and review artifacts do not drift.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051808021 -> 15de9223
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029109125 -> 15de9223
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051824357 -> 15de9223

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -6,8 +6,8 @@
 
 ## Fixed in Commit Mapping
 Disposition: NOT-A-BUG
-Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
-Reason: Initial post-open artifact creation found no actionable review threads or bot comments on PR `#1301`. This lane is docs-only and narrows scope to roadmap/design/audit truth reconciliation for the shipped web progress empty-state contract.
+Evidence: `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `frontend/src/features/progress/ProgressCharts.tsx:24`, `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx:32`
+Reason: At artifact creation time PR `#1301` has no actionable review comments yet. The lane is a narrow docs-only closeout that reconciles roadmap/audit/design docs to the already shipped web progress truth: no fabricated charts on the release path, trusted empty state until real data exists, and no claim of backend-fed history implementation.
 
 ## Merge Readiness
 - [ ] All required checks pass
@@ -16,4 +16,4 @@ Reason: Initial post-open artifact creation found no actionable review threads o
 - [x] Pre-commit green
 - [x] `make verify` green
 - [ ] Mandatory post-open bug-hunter pass completed
-- Scope: docs-only closeout for the web progress contract drift. No backend progress API, OpenAPI, generated types, or runtime/frontend implementation changes are included in this PR.
+Notes: Draft PR `#1301` must stay docs-only. It must not widen into frontend runtime changes, backend progress/history API work, OpenAPI changes, or iOS parity claims beyond confirmed runtime evidence.

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1301 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: Initial post-open artifact creation found no actionable review threads or bot comments on PR `#1301`. This lane is docs-only and narrows scope to roadmap/design/audit truth reconciliation for the shipped web progress empty-state contract.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+- Scope: docs-only closeout for the web progress contract drift. No backend progress API, OpenAPI, generated types, or runtime/frontend implementation changes are included in this PR.

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -54,6 +54,18 @@ Reason: The latest artifact cleanup round tightened the first FIXED block with p
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051959067 -> cfd4b4cd
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029238272 -> cfd4b4cd
 
+Disposition: FIXED
+Commit: 8f2e7685
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md:23`, `docs/review/PR_1301_FIXED_MAPPING.md:41`
+Reason: The latest CodeRabbit round asked for stronger `file:line` anchors in the FIXED proof records. Commit `8f2e7685` upgrades the previously file-only evidence in the `7bcd28b0` and `3fd28eb6` blocks to precise anchored proof, satisfying the remaining traceability requirement in this review cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4052415827 -> 8f2e7685
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029642955 -> 8f2e7685
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md:29`
+Reason: CodeRabbit review `4052387198` is a duplicate summary of the already-fixed `needed required` wording issue from the prior round. The underlying content has already been normalized in the current artifact lineage, so no new docs/runtime change is required for that duplicate review wrapper.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4052387198
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -24,6 +24,13 @@ Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
 Reason: The Codex connector thread at `discussion_r3029094050` flagged that the canonical artifact lacked required thread-marker lines. The follow-up governance commit adds valid review-thread entries plus disposition/proof lines, so the artifact now passes `check_pr_body_phase2_gates.py` on current head.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029094050 -> 7bcd28b0
 
+Disposition: NOT-A-BUG
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: Cubic's later summary review and follow-up discussion threads restated the same two governance issues already captured in this artifact: the closed ledger item needed a concrete target PR, and the canonical review artifact needed required thread-marker lines. Current head already contains those fixes, and the cubic discussion threads were auto-resolved against commits `15de9223` and `7bcd28b0`, so no additional docs/runtime change is required after the review timestamp.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051906474
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189839
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189843
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -31,6 +31,11 @@ Reason: Cubic's later summary review and follow-up discussion threads restated t
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189839
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189843
 
+Disposition: NOT-A-BUG
+Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:655`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:657`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:662`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:667`
+Reason: The current head already uses post-gate sequencing language in the touched analysis packet: the section heading is `Immediate Actions (Post-Gate Window)`, the note explicitly requires upstream remediation/backend guards/`make verify`, and the follow-up headings are scoped to post-gate windows. The CodeRabbit thread therefore reflects stale context rather than a remaining docs drift issue.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029202761
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -7,8 +7,8 @@
 ## Fixed in Commit Mapping
 Disposition: FIXED
 Commit: 15de9223
-Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
-Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed Markdown docs still contained numbering/heading patterns that violate markdownlint conventions. The same fix pack also normalizes the closeout packet wording around the shared web progress runtime truth so the audit and review artifacts do not drift.
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:205`, `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md:47`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:322`
+Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed Markdown docs still contained numbering/heading patterns that violated markdownlint conventions. Commit `15de9223` replaces the placeholder target PR reference and normalizes the affected heading/list syntax in the touched docs packet.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051808021 -> 15de9223
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029109125 -> 15de9223
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051824357 -> 15de9223
@@ -25,8 +25,8 @@ Reason: The Codex connector thread at `discussion_r3029094050` flagged that the 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029094050 -> 7bcd28b0
 
 Disposition: NOT-A-BUG
-Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
-Reason: Cubic's later summary review and follow-up discussion threads restated the same two governance issues already captured in this artifact: the closed ledger item needed a concrete target PR, and the canonical review artifact needed required thread-marker lines. Current head already contains those fixes, and the cubic discussion threads were auto-resolved against commits `15de9223` and `7bcd28b0`, so no additional docs/runtime change is required after the review timestamp.
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:205`, `docs/review/PR_1301_FIXED_MAPPING.md:12`
+Reason: Cubic's later summary review and follow-up discussion threads restated the same two governance issues already captured in this artifact: the closed ledger item needed a concrete target PR, and the canonical review artifact needed thread-marker lines. Current head already contains those fixes, and the cubic discussion threads were auto-resolved against commits `15de9223` and `7bcd28b0`, so no additional docs/runtime change is required after the review timestamp.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051906474
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189839
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029189843

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ Reason: The Codex connector review on PR `#1301` is informational only and does 
 
 Disposition: FIXED
 Commit: 7bcd28b0
-Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md:21`, `docs/review/PR_1301_FIXED_MAPPING.md:25`
 Reason: The Codex connector thread at `discussion_r3029094050` flagged that the canonical artifact lacked required thread-marker lines. The follow-up governance commit adds valid review-thread entries plus disposition/proof lines, so the artifact now passes `check_pr_body_phase2_gates.py` on current head.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029094050 -> 7bcd28b0
 
@@ -38,7 +38,7 @@ Reason: The current head already uses post-gate sequencing language in the touch
 
 Disposition: FIXED
 Commit: 3fd28eb6
-Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
+Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:655`, `docs/review/PR_1301_FIXED_MAPPING.md:11`
 Reason: The latest CodeRabbit summary review consolidated two real follow-ups from the current head snapshot: the post-gate sequencing language in the analysis packet and the `Markdown` capitalization fix in this artifact. Commit `3fd28eb6` applies those narrow docs-only adjustments.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051920285 -> 3fd28eb6
 

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -36,6 +36,12 @@ Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md:655`, `docs/analysis/FR
 Reason: The current head already uses post-gate sequencing language in the touched analysis packet: the section heading is `Immediate Actions (Post-Gate Window)`, the note explicitly requires upstream remediation/backend guards/`make verify`, and the follow-up headings are scoped to post-gate windows. The CodeRabbit thread therefore reflects stale context rather than a remaining docs drift issue.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029202761
 
+Disposition: FIXED
+Commit: 3fd28eb6
+Evidence: `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: The latest CodeRabbit summary review consolidated two real follow-ups from the current head snapshot: the post-gate sequencing language in the analysis packet and the `Markdown` capitalization fix in this artifact. Commit `3fd28eb6` applies those narrow docs-only adjustments.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051920285 -> 3fd28eb6
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1301_FIXED_MAPPING.md
+++ b/docs/review/PR_1301_FIXED_MAPPING.md
@@ -10,12 +10,19 @@ Commit: 15de9223
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`, `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`, `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`, `docs/review/PR_1301_FIXED_MAPPING.md`
 Reason: Sourcery and CodeRabbit raised two narrow docs/governance issues on the current head: the closed ledger item still used a placeholder target PR label, and the changed markdown docs still contained numbering/heading patterns that violate markdownlint conventions. The same fix pack also normalizes the closeout packet wording around the shared web progress runtime truth so the audit and review artifacts do not drift.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051808021 -> 15de9223
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029109125 -> 15de9223
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051824357 -> 15de9223
 
 Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
 Reason: The Codex connector review on PR `#1301` is informational only and does not include actionable code or docs changes beyond the canonical governance loop already being followed here.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#pullrequestreview-4051809148
+
+Disposition: FIXED
+Commit: 7bcd28b0
+Evidence: `docs/review/PR_1301_FIXED_MAPPING.md`
+Reason: The Codex connector thread at `discussion_r3029094050` flagged that the canonical artifact lacked required thread-marker lines. The follow-up governance commit adds valid review-thread entries plus disposition/proof lines, so the artifact now passes `check_pr_body_phase2_gates.py` on current head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1301#discussion_r3029094050 -> 7bcd28b0
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -199,23 +199,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Funnel/recovery UX stays additive and contract-safe
 
 <a id="ledger-p0-web-progress-contract"></a>
-- [ ] P0: Web progress route must not ship demo-grade health data
+- [x] P0: Web progress route must not ship demo-grade health data
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-WEB-PROGRESS-CONTRACT
+  - Target PR: PR-TBD-WEB-PROGRESS-CONTRACT-CLOSEOUT
   - Area: frontend / progress UX / trust
   - Finding Type: user-facing data integrity gap
-  - Reason: The live progress route still renders hard-coded mock chart data, which makes the product feel demo-only and creates a direct trust/conversion risk on a health-facing surface.
+  - Status: ✅ Runtime closeout already landed on `main`; this docs-only lane reconciles roadmap/design/audit truth to the shipped release-safe behavior.
+  - Reason: The release path no longer renders fabricated progress charts. Current web behavior is an explicit trusted empty state with export disabled until real data exists, so the remaining gap is documentation drift rather than a new frontend/backend feature lane.
   - Links:
     - `frontend/src/features/progress/ProgressCharts.tsx`
     - `frontend/src/pages/Progress.tsx`
     - `frontend/src/features/progress/__tests__/ProgressCharts.test.tsx`
+    - `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`
     - `docs/analysis/FRONTEND_IOS_VISUAL_ANALYSIS.md`
   - DoD:
-    - Progress route renders backend-fed data or explicit empty/loading states instead of fabricated chart fixtures
-    - Tests no longer lock demo-only values as release behavior
+    - Progress route renders explicit empty/loading states instead of fabricated chart fixtures in the release path
+    - Tests lock the trusted empty-state behavior rather than demo-only chart values
     - UX remains clear when historical data is absent
     - Release screenshots/copy cannot imply fabricated trend data
+    - Future backend-fed history/chart work remains a separate optional lane and is not claimed as implemented here
 
 <a id="ledger-p0-eu-compliance-control-plane-follow-through"></a>
 - [ ] P0: EU-first compliance control plane follow-through

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -202,7 +202,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P0: Web progress route must not ship demo-grade health data
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-WEB-PROGRESS-CONTRACT-CLOSEOUT
+  - Target PR: PR #1299 (runtime truth hardening) -> PR #1301 (docs closeout)
   - Area: frontend / progress UX / trust
   - Finding Type: user-facing data integrity gap
   - Status: ✅ Runtime closeout already landed on `main`; this docs-only lane reconciles roadmap/design/audit truth to the shipped release-safe behavior.

--- a/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
+++ b/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
@@ -14,8 +14,10 @@ Status: operator execution map
 - PR1 Postgres foundation is already merged; do not reopen it inside the authz closeout lane.
 - PR2 deploy shell lane materially landed via `#1293`, with the extra CD env-token follow-up in `#1297`.
 - PR3 activation + persistence truth merged as `#1296`; shadow runtime truth is removed from the active monetization critical path.
-- The next real implementation PR is PR4: entitlement-backed routing after billing activation.
-- After PR4, the sequence moves to web entitlement truth, legal/release shell follow-through, App Store/provider modernization, and only then the remaining AI waves.
+- PR4 is no longer pending implementation; that closeout merged as `#1298`.
+- PR4 closeout landed as docs/authz packet `#1298`, and web entitlement truth hardening landed via `#1299`.
+- Web progress no longer ships fabricated charts on the release path; the current lane is a docs-only closeout that reconciles stale narrative to the trusted empty-state runtime truth.
+- After this closeout, the next active lane moves to `docs/legal-policy-publish`, then App Store/provider modernization, and only then the remaining AI waves.
 - WebSocket foundation is no longer a stub-only surface; it is sufficiently wired for foundation scope, but it is not the current release priority.
 
 ## Source of truth order
@@ -47,7 +49,7 @@ Status: operator execution map
 
 ### Wave 3 — Web truth
 6. `feat/web-entitlement-truth`
-7. `feat/web-progress-contract`
+7. `docs/web-progress-contract-closeout`
 
 ### Wave 4 — Legal / release shell
 8. `docs/legal-policy-publish`
@@ -96,19 +98,22 @@ Status: operator execution map
 - do not include: entitlement routing, iOS UI, App Store migration
 
 ### 4. feat(authz): enforce entitlement-backed routing after billing activation
-- status: next real implementation PR
+- status: closeout merged as `#1298`
 - closes: `ledger-p0-billing-entitlement-routing`
 - goal: backend entitlement truth for `/api/v1/pro/*` and `/api/v1/vip/*`; fail-closed startup contract; explicit RU/BY pre-entitlement rule
 - policy: manual RU/BY billing entry routes stay transport-auth only, not entitlement surfaces
 
 ### 5. feat(frontend): move web premium truth to canonical backend/store state
+- status: merged as `#1299`
 - closes: `ledger-p0-web-entitlement-truth`
 - goal: remove local premium source of truth; dev-only gate mock purchase/restore
 - do not include: backend subscription redesign
 
-### 6. feat(frontend): replace demo-grade progress data with backend/empty-state truth
+### 6. docs(frontend): close web progress contract drift
+- status: docs-only closeout lane after shipped runtime hardening
 - closes: `ledger-p0-web-progress-contract`
-- goal: no fabricated chart values in release path
+- goal: reconcile docs to the shipped web truth: no fabricated chart values in release path and an explicit trusted empty state until real data exists
+- do not include: backend progress API, chart-history implementation, or new frontend runtime data contracts
 
 ### 7. docs(release): publish legal policy paths and align client links
 - closes: `ledger-p0-legal-policy-publish`

--- a/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
+++ b/docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md
@@ -44,36 +44,36 @@ Status: operator execution map
 3. `docs/release-env-security-contract` only if it blocks deploy truth on staging/production
 
 ### Wave 2 — Backend monetization follow-through
-4. `feat/billing-activation-and-persistence`
-5. `feat/billing-entitlement-routing`
+1. `feat/billing-activation-and-persistence`
+2. `feat/billing-entitlement-routing`
 
 ### Wave 3 — Web truth
-6. `feat/web-entitlement-truth`
-7. `docs/web-progress-contract-closeout`
+1. `feat/web-entitlement-truth`
+2. `docs/web-progress-contract-closeout`
 
 ### Wave 4 — Legal / release shell
-8. `docs/legal-policy-publish`
-9. `feat/eu-compliance-control-plane-followthrough`
-10. `docs/ios-subscription-offers-governance`
-11. `feat/ios-appstore-assets-rollout`
-12. `feat/ios-appstore-semantic-validators`
-13. `feat/apple-server-api-migration`
+1. `docs/legal-policy-publish`
+2. `feat/eu-compliance-control-plane-followthrough`
+3. `docs/ios-subscription-offers-governance`
+4. `feat/ios-appstore-assets-rollout`
+5. `feat/ios-appstore-semantic-validators`
+6. `feat/apple-server-api-migration`
 
 ### Wave 5 — API / contract truth
-14. `chore/openapi-runtime-sync`
-15. `feat/openapi-decoupling-split`
+1. `chore/openapi-runtime-sync`
+2. `feat/openapi-decoupling-split`
 
 ### Wave 6 — AI follow-through
-16. `feat/insight-fallback-chain`
-17. `feat/rag-hardening-followthrough`
-18. `docs/ai-bounded-context-packet`
-19. `feat/ai-bounded-context-extraction`
-20. `feat/llm-reliability-security-gates`
+1. `feat/insight-fallback-chain`
+2. `feat/rag-hardening-followthrough`
+3. `docs/ai-bounded-context-packet`
+4. `feat/ai-bounded-context-extraction`
+5. `feat/llm-reliability-security-gates`
 
 ### Wave 7 — Design bridge operationalization
-21. `docs/design-agent-runtime-realignment`
-22. `feat/design-bridge-preflight-and-capture`
-23. `feat/design-bridge-first-parity-pack`
+1. `docs/design-agent-runtime-realignment`
+2. `feat/design-bridge-preflight-and-capture`
+3. `feat/design-bridge-first-parity-pack`
 
 ## PR map
 


### PR DESCRIPTION
## Summary
Current `main` no longer renders fabricated charts on web Progress; it shows a trusted empty state until real data exists.

This PR is docs-only and reconciles roadmap, audit, analysis, and design docs to that shipped runtime truth.

## Scope
- update `docs/roadmap/BACKLOG_LEDGER.md`
- update `docs/roadmap/PulsePlate_P0_P1_Execution_Document_2026-03-30.md`
- add canonical audit packet `docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`
- clean stale secondary docs that still implied mock web progress charts
- maintain canonical review artifact `docs/review/PR_1301_FIXED_MAPPING.md`

## Out Of Scope
- backend progress/history API
- OpenAPI or generated type changes
- frontend runtime implementation
- chart/history feature expansion
- iOS parity claims beyond confirmed web runtime evidence

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/audit/PR_WEB_PROGRESS_CLOSEOUT_AUDIT_2026-04-02.md`
- `npx -y -p node@22.22.1 -c 'node -v && npm test -- --run src/features/progress/__tests__/ProgressCharts.test.tsx'`
- `npx -y -p node@22.22.1 -c 'node -v && npm test -- --run src/pages/__tests__/Progress.test.tsx'`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1301_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] `make verify` green
- [ ] Mandatory post-open bug-hunter pass completed

Notes: The lane must stay docs-only and must not widen into frontend runtime changes, backend progress/history API work, OpenAPI changes, or unverified iOS parity claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Web progress charts now documented as rendering a trusted empty state until real progress data exists; PDF export disabled in that state.
  * Added audit/closeout evidence capturing runtime behavior, scope boundaries, sequencing, and verification notes.
  * Clarified design spec: chart-rich visuals remain a future target; current release shows empty state.
  * Updated roadmap/backlog/execution items to mark closeout completion, adjust PR sequencing, and record priority/DoD changes.
  * Added review/merge-readiness artifact summarizing dispositions and checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->