### PR TITLE
fix managed PostgreSQL production deploy lane

### DIFF
--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -62,6 +62,8 @@ On the production server:
   - a compose file (`docker-compose.yml`, `docker-compose.production.yaml`, etc.)
   - `.env` (application runtime env; not committed)
   - `Caddyfile.production` (Caddy reverse proxy config; see Caddyfile Configuration below)
+- A managed PostgreSQL instance reachable from the production host via `DATABASE_URL`
+- Managed database backup / PITR handled by the provider; the production deploy script no longer runs local `pg_dump`
 - Compose must reference `IMAGE_REF` (recommended) or `TAG` (backwards-compatible):
 - **Firewall configured**: Ports 80 (HTTP) and 443 (HTTPS) must be open (see Firewall Setup below)
 
@@ -86,6 +88,8 @@ services:
     networks: [web]
     expose: ["8000"]  # Internal only, accessed via Caddy
     env_file: [".env"]
+    environment:
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
     command: >
       uvicorn app.main:app --host 0.0.0.0 --port 8000
       --proxy-headers
@@ -189,6 +193,7 @@ The following environment variables must be set in your `.env` file or exported 
 - **`PRODUCTION_DOMAIN`** (required): Your production domain name (e.g., `api.pulseplate.com`)
 - **`STAGING_FALLBACK_DOMAIN`** (optional): staging hostname served by production fallback vhost in build-only mode (default: `pulseplate-staging.duckdns.org`)
 - **`IMAGE_REF`** (required): Docker image reference (e.g., `ghcr.io/owner/repo@sha256:...`)
+- **`DATABASE_URL`** (required): external managed PostgreSQL DSN using `postgresql+psycopg://...`
 
 Example `.env` file:
 
@@ -196,10 +201,20 @@ Example `.env` file:
 PRODUCTION_DOMAIN=pulseplate.app
 STAGING_FALLBACK_DOMAIN=pulseplate-staging.duckdns.org
 IMAGE_REF=ghcr.io/owner/repo@sha256:abc123...
+DATABASE_URL=postgresql+psycopg://pulseplate:__replace_me__@db.example.com:25060/pulseplate  # pragma: allowlist secret
 # Add other application-specific variables here
 ```
 
 **Security Note:** Never commit `.env` files to the repository. If deploying via GitHub Actions, store sensitive variables as GitHub Secrets in the `production` environment.
+
+## Managed PostgreSQL Contract
+
+Canonical production is `managed PostgreSQL only`.
+
+- `deploy/docker-compose.production.yaml` must not define a local `postgres` service.
+- `DATABASE_URL` must target the external managed database, not `@postgres:5432`.
+- `scripts/deploy_production.sh` runs `alembic upgrade head` via a one-shot release container before it restarts `app` and `caddy`.
+- Provider-native snapshots / PITR are the production backup baseline. Local `scripts/ops/postgres_backup.sh` remains a self-hosted alternate helper, not part of the canonical production deploy path.
 
 ## Firewall Setup (Critical!)
 
@@ -366,6 +381,7 @@ High-level steps (run on the production server):
    - compose file (`docker-compose.production.yaml`)
    - `.env` (application runtime env)
    - `Caddyfile.production` (copied from `deploy/Caddyfile.production`)
+   - managed PostgreSQL credentials in `DATABASE_URL`
 3. Ensure the compose file uses `IMAGE_REF` (preferred) or `TAG` (backwards-compatible).
    - Production CD now also stages the current `frontend/`, `deploy/Caddyfile.production`,
      and `scripts/diagnose_web.sh` bundle before `scripts/deploy_production.sh` runs so the

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -72,6 +72,7 @@ git push origin main
 
 **Что делаем:**
 - ✅ `docker pull` нового образа
+- ✅ one-shot migrations через release image до рестарта приложения
 - ✅ `docker-compose up -d --force-recreate` (или `docker run`)
 - ✅ Проверка health endpoint
 
@@ -90,13 +91,16 @@ cd /srv/pulseplate-production
 # 1. Подтянуть новый образ
 docker-compose -f docker-compose.production.yaml pull
 
-# 2. Перезапустить сервисы
+# 2. Прогнать миграции через release image
+docker compose --env-file .env -f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head
+
+# 3. Перезапустить сервисы
 docker-compose -f docker-compose.production.yaml up -d --force-recreate
 
-# 3. Проверить статус
+# 4. Проверить статус
 docker-compose -f docker-compose.production.yaml ps
 
-# 4. Проверить health
+# 5. Проверить health
 curl -fsS https://pulseplate.app/health | jq .
 ```
 
@@ -152,8 +156,15 @@ ssh root@pulseplate.app
 # Перейти в deploy директорию
 cd /srv/pulseplate-production
 
-# Обновить образ app из registry (IMAGE_REF), затем пересобрать Caddy из синхронизированного release shell bundle и перезапустить стек
+# Canonical production contract: managed PostgreSQL lives outside compose and is reached via DATABASE_URL
+
+# Обновить образ app из registry (IMAGE_REF)
 docker compose -f docker-compose.production.yaml pull app
+
+# Прогнать миграции через one-shot release container
+docker compose --env-file .env -f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head
+
+# Затем пересобрать Caddy из синхронизированного release shell bundle и перезапустить стек
 docker compose -f docker-compose.production.yaml build caddy
 docker compose -f docker-compose.production.yaml up -d --force-recreate
 
@@ -181,7 +192,7 @@ curl -fsS https://pulseplate.app/health | jq .
 | ------------------ | ---------------------------------------------- | --------------------------------------- |
 | **Cursor**         | Код, фиксы, коммиты, PR                       | Правка на сервере                       |
 | **GitHub Actions** | Автоматическая сборка Docker image             | Ручная сборка                           |
-| **DigitalOcean**   | `docker compose pull app` + `build caddy` + `up` + `diagnose_web.sh` (см. `scripts/redeploy_caddy.sh`) | Правка кода, git clone, изменение файлов |
+| **DigitalOcean**   | `docker compose pull app` + one-shot `alembic upgrade head` + `build caddy` + `up` + `diagnose_web.sh` (см. `scripts/redeploy_caddy.sh`) | Правка кода, git clone, изменение файлов |
 
 ---
 
@@ -365,6 +376,7 @@ docker-compose -f docker-compose.production.yaml exec -T app env | grep -E 'APP_
 3. **Всегда проверяй health endpoint** после деплоя
 4. **Используй pinned digests** для production (не `latest`)
 5. **Делай backup `.env`** перед изменениями
+6. **Используй provider snapshots / PITR** как baseline backup для managed PostgreSQL, а не локальный `pg_dump` в hot path
 
 ---
 

--- a/deploy/docker-compose.production.yaml
+++ b/deploy/docker-compose.production.yaml
@@ -9,24 +9,6 @@ networks:
         - subnet: 172.30.100.0/24
 
 services:
-  postgres:
-    image: postgres:15-alpine
-    restart: unless-stopped
-    networks: [web]
-    env_file:
-      - .env
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
-      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-
   app:
     image: ${IMAGE_REF:?IMAGE_REF is required}
     restart: unless-stopped
@@ -37,10 +19,8 @@ services:
       - .env
     environment:
       - ENVIRONMENT=production
+      # Production uses an external managed PostgreSQL instance.
       - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
-    depends_on:
-      postgres:
-        condition: service_healthy
     command: >
       uvicorn app.main:app --host 0.0.0.0 --port 8000
       --proxy-headers
@@ -86,6 +66,5 @@ services:
       retries: 3
 
 volumes:
-  postgres_data:
   caddy_data:
   caddy_config:

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -1,6 +1,9 @@
 # Postgres Self-Hosted Droplet Foundation
 
-**Purpose:** Canonical production database baseline for PulsePlate on Droplet. Postgres is the required production/staging DB; SQLite remains for local/dev/test fallback only.
+> Alternate lane only. Canonical production now uses managed PostgreSQL via external `DATABASE_URL`.
+> Keep this document for self-hosted droplet operations, staging experiments, or disaster-recovery drills.
+
+**Purpose:** Self-hosted Postgres reference for PulsePlate on a Droplet. This is no longer the canonical production database baseline.
 
 **Design rationale (architecture):**
 
@@ -8,6 +11,7 @@
 - Production/staging fail closed on primary DB init errors; SQLite is not an accepted canonical runtime baseline there.
 - SQLite fallback remains local/dev/test only.
 - Health checks use `/health/db` for readiness; `DATABASE_URL` is required for production/staging.
+- Managed PostgreSQL with provider snapshots / PITR is the canonical production path; this document remains the self-hosted alternate.
 
 ---
 

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -74,4 +74,6 @@ Required for production:
 - **Docker Compose / Droplet:** `@postgres:5432` (service name in compose network)
 - **Native local run:** `@localhost:5432` (Postgres on host)
 
+These environment variables and host modes are specific to the self-hosted alternate lane; canonical production uses only `DATABASE_URL` pointing to an external managed instance.
+
 See `.env.example` for the canonical contract.

--- a/docs/review/PR_1302_FIXED_MAPPING.md
+++ b/docs/review/PR_1302_FIXED_MAPPING.md
@@ -1,0 +1,6 @@
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1302_FIXED_MAPPING.md
+++ b/docs/review/PR_1302_FIXED_MAPPING.md
@@ -3,4 +3,26 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 8774b214
+Evidence: `scripts/deploy_production.sh`, `scripts/fix_production_env.sh`, `tests/test_deploy_contract_scripts.py`, `tests/test_business_collateral_builders.py`, `tests/test_agent_input_guard.py`, `scripts/PRODUCTION_ENV_FIX.md`, `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
+Reason: Post-open bot review on PR `#1302` surfaced one real deploy-contract gap and several narrow governance/test hardening follow-ups on the current head. Commit `8774b214` closes them by fail-closing any compose-local `@postgres` DSN variant, tightening optional Node smoke skips so only missing modules are skipped, failing the GoPlus smoke test on unexpected runtime `None`, and aligning the operator docs with the managed-PostgreSQL-only production lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#pullrequestreview-4051828670 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029113504 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029113522 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029124710 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029124715 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#pullrequestreview-4051845044 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029130492 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029130502 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#pullrequestreview-4051915801 -> 8774b214
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1302#discussion_r3029198330 -> 8774b214
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+Notes: PR `#1302` remains a narrow managed-PostgreSQL deploy-lane hardening PR. Local `pre-commit` and `make verify` are green after commit `8774b214`; remaining merge readiness depends on current-head CI reruns plus explicit resolution of the mapped bot review threads.

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -35,10 +35,10 @@ bash scripts/fix_production_env.sh
 
 Скрипт:
 
-1. Требует отсутствие `postgres` service в canonical production compose
+1. Требует отсутствия `postgres` service в canonical production compose
 2. Нормализует `APP_ENV`, `ENVIRONMENT`, `SUBSCRIPTION_DB_ENABLED`, `ALLOW_DEV_API_KEY` и совместимый `API_KEY_REQUIRED`
 3. Проверяет `DATABASE_URL`
-4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://` или указывает на `@postgres:5432`
+4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://` или указывает на compose-local host `@postgres`
 5. Валидирует compose и перезапускает сервисы
 
 ## 🔍 Ручная проверка
@@ -58,7 +58,7 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 ## ⚠️ Важные замечания
 
 1. `postgres` не должен появляться даже optional через `profiles` для canonical production.
-2. `DATABASE_URL` не должен указывать на `@postgres:5432` внутри compose network.
+2. `DATABASE_URL` не должен указывать на compose-local host `@postgres` внутри compose network.
 3. SQLite разрешён только для local/dev/test fallback, не для canonical production deploy path.
 4. Backup / PITR для production managed Postgres должны обеспечиваться провайдером, а не hot-path скриптом деплоя.
 
@@ -71,7 +71,7 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 ## 📝 Чеклист
 
 - [ ] В `.env` задан Postgres DSN
-- [ ] DSN указывает на внешний managed Postgres host, не `@postgres:5432`
+- [ ] DSN указывает на внешний managed Postgres host, не compose-local `@postgres`
 - [ ] `SUBSCRIPTION_DB_ENABLED=true`
 - [ ] `ALLOW_DEV_API_KEY=false`
 - [ ] При необходимости для совместимости задан `API_KEY_REQUIRED=true`

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -2,10 +2,10 @@
 
 ## 🚨 Проблема
 
-Production deploy contract теперь Postgres-first и fail-closed. Сервер не должен запускаться с:
+Production deploy contract теперь managed-PostgreSQL-only и fail-closed. Сервер не должен запускаться с:
 
 - `DATABASE_URL=sqlite:///...`
-- отсутствующим `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD`
+- `DATABASE_URL`, указывающим на compose-local `@postgres:5432`
 - dev-friendly флагами вроде `ALLOW_DEV_API_KEY=true`
 
 ## ✅ Канонический production env contract
@@ -15,10 +15,7 @@ cd /srv/pulseplate-production
 
 cat >> .env <<'EOF'
 PRODUCTION_DOMAIN=yourdomain.com
-DATABASE_URL=postgresql+psycopg://<user>:<password>@postgres:5432/<dbname>
-POSTGRES_DB=pulseplate
-POSTGRES_USER=pulseplate
-POSTGRES_PASSWORD=replace-with-strong-secret
+DATABASE_URL=postgresql+psycopg://<user>:<password>@db.example.com:25060/<dbname>
 SUBSCRIPTION_DB_ENABLED=true
 ALLOW_DEV_API_KEY=false
 API_KEY_REQUIRED=true  # compatibility flag for request-time API-key enforcement
@@ -38,10 +35,10 @@ bash scripts/fix_production_env.sh
 
 Скрипт:
 
-1. Требует `postgres` service в production compose
+1. Требует отсутствие `postgres` service в canonical production compose
 2. Нормализует `APP_ENV`, `ENVIRONMENT`, `SUBSCRIPTION_DB_ENABLED`, `ALLOW_DEV_API_KEY` и совместимый `API_KEY_REQUIRED`
-3. Проверяет `DATABASE_URL`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
-4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://`
+3. Проверяет `DATABASE_URL`
+4. Падает, если `DATABASE_URL` не использует `postgresql+psycopg://` или указывает на `@postgres:5432`
 5. Валидирует compose и перезапускает сервисы
 
 ## 🔍 Ручная проверка
@@ -50,7 +47,6 @@ bash scripts/fix_production_env.sh
 cd /srv/pulseplate-production
 
 grep -E '^DATABASE_URL=' .env
-grep -E '^POSTGRES_(DB|USER|PASSWORD)=' .env
 
 docker compose --env-file .env -f docker-compose.production.yaml config >/dev/null
 docker compose --env-file .env -f docker-compose.production.yaml up -d --force-recreate
@@ -61,10 +57,10 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 
 ## ⚠️ Важные замечания
 
-1. `POSTGRES_PASSWORD=dummy` больше не является допустимым production workaround.
-2. `postgres` не должен становиться optional через `profiles` для production.
-3. `DATABASE_URL` должен указывать на `@postgres:5432` внутри compose network.
-4. SQLite разрешён только для local/dev/test fallback, не для canonical production deploy path.
+1. `postgres` не должен появляться даже optional через `profiles` для canonical production.
+2. `DATABASE_URL` не должен указывать на `@postgres:5432` внутри compose network.
+3. SQLite разрешён только для local/dev/test fallback, не для canonical production deploy path.
+4. Backup / PITR для production managed Postgres должны обеспечиваться провайдером, а не hot-path скриптом деплоя.
 
 ## 🔐 Security Notes
 
@@ -75,7 +71,7 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 ## 📝 Чеклист
 
 - [ ] В `.env` задан Postgres DSN
-- [ ] `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` заданы
+- [ ] DSN указывает на внешний managed Postgres host, не `@postgres:5432`
 - [ ] `SUBSCRIPTION_DB_ENABLED=true`
 - [ ] `ALLOW_DEV_API_KEY=false`
 - [ ] При необходимости для совместимости задан `API_KEY_REQUIRED=true`

--- a/scripts/PRODUCTION_ENV_FIX.md
+++ b/scripts/PRODUCTION_ENV_FIX.md
@@ -64,9 +64,9 @@ curl -fsS "https://${PRODUCTION_DOMAIN}/ready" | jq .
 
 ## 🔐 Security Notes
 
-- Используйте сильный `POSTGRES_PASSWORD` и храните `.env` с правами `600`.
+- Храните managed PostgreSQL credentials only inside `DATABASE_URL` and keep `.env` permissions at `600`.
 - Проверяйте readiness через `/ready` или `/health/db`, а не через liveness-only `/health`.
-- Не удаляйте `depends_on: postgres` из production compose: приложение должно ждать healthy DB.
+- Не добавляйте `depends_on: postgres` или local `postgres` service обратно в canonical production compose.
 
 ## 📝 Чеклист
 

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -66,11 +66,6 @@ elif [ -f "compose.yaml" ]; then
   compose_args=(-f "compose.yaml")
 fi
 
-HELPER_COMPOSE_FILE="${COMPOSE_FILE:-}"
-if [ -z "$HELPER_COMPOSE_FILE" ] && [ ${#compose_args[@]} -ge 2 ]; then
-  HELPER_COMPOSE_FILE="${compose_args[1]}"
-fi
-
 if [ -z "$ENV_FILE" ]; then
   ENV_FILE="$DEPLOY_DIR/.env"
 fi
@@ -89,16 +84,10 @@ IMAGE_REF="$DEPLOY_IMAGE_REF"
 TAG="$DEPLOY_TAG"
 export IMAGE_REF TAG
 
-: "${POSTGRES_USER:?POSTGRES_USER is required}"
-: "${POSTGRES_DB:?POSTGRES_DB is required}"
-: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
 : "${DATABASE_URL:?DATABASE_URL is required}"
 : "${PRODUCTION_DOMAIN:?PRODUCTION_DOMAIN is required}"
 
 export PRODUCTION_DOMAIN
-
-BACKUP_DIR="${BACKUP_DIR:-$DEPLOY_DIR/backups}"
-BACKUP_HELPER="${BACKUP_HELPER:-$DEPLOY_DIR/scripts/ops/postgres_backup.sh}"
 
 echo "Deploy dir: $DEPLOY_DIR"
 if [ ${#compose_args[@]} -gt 0 ]; then
@@ -157,29 +146,6 @@ sync_shell_bundle() {
   fi
 }
 
-wait_for_service_health() {
-  local service_name="$1"
-  local max_wait="${2:-60}"
-  local wait_count=0
-
-  while [ "$wait_count" -lt "$max_wait" ]; do
-    local container_id
-    local health_status
-    container_id="$(dc ps -q "$service_name" | tr -d '\n\r ')"
-    health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container_id:-missing}" 2>/dev/null || true)"
-    if [ -n "${container_id:-}" ] && [ "$health_status" = "healthy" ]; then
-      echo "$service_name is healthy"
-      return 0
-    fi
-    wait_count=$((wait_count + 1))
-    echo "Waiting for $service_name health... ($wait_count/$max_wait)"
-    sleep 1
-  done
-
-  echo "❌ $service_name failed to become healthy within $max_wait seconds" >&2
-  return 1
-}
-
 wait_for_app_ready() {
   local max_wait="${1:-30}"
   local wait_count=0
@@ -200,43 +166,46 @@ wait_for_app_ready() {
   return 1
 }
 
-if [ ! -x "$BACKUP_HELPER" ]; then
-  echo "❌ Missing Postgres backup helper: $BACKUP_HELPER" >&2
-  exit 1
-fi
+validate_managed_postgres_contract() {
+  case "$DATABASE_URL" in
+    postgresql+psycopg://*)
+      ;;
+    *)
+      echo "❌ DATABASE_URL must use canonical Postgres DSN (postgresql+psycopg://...)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$DATABASE_URL" in
+    *@postgres:5432/*)
+      echo "❌ Production deploy expects external managed PostgreSQL, not compose-local @postgres:5432" >&2
+      exit 1
+      ;;
+  esac
+}
 
 echo "Pulling production app image..."
 dc pull app
 
 sync_shell_bundle
 
-echo "Starting postgres first..."
-dc up -d --remove-orphans postgres
-wait_for_service_health postgres 60
+echo "Validating managed PostgreSQL production contract..."
+validate_managed_postgres_contract
 
-echo "Creating Postgres backup before migrations..."
-PROJECT_DIR="$DEPLOY_DIR" BACKUP_DIR="$BACKUP_DIR" COMPOSE_FILE="$HELPER_COMPOSE_FILE" POSTGRES_USER="$POSTGRES_USER" POSTGRES_DB="$POSTGRES_DB" \
-  "$BACKUP_HELPER"
+echo "Production DB backups are managed outside the deploy script (provider snapshots / PITR)."
+
+echo "Running database migrations via one-shot release container..."
+if dc run --rm --no-deps app alembic upgrade head; then
+  echo "✅ Database migrations completed successfully"
+else
+  migration_exit_code=$?
+  echo "❌ Database migrations failed (exit code: $migration_exit_code)" >&2
+  exit "$migration_exit_code"
+fi
 
 echo "Starting app before exposing traffic..."
 dc up -d --remove-orphans app
 wait_for_app_ready 30
-
-APP_CONTAINER="$(dc ps -q app | tr -d '\n\r ')"
-if [ -z "${APP_CONTAINER:-}" ]; then
-  echo "❌ Unable to resolve running app container for migrations" >&2
-  exit 1
-fi
-
-echo "Running database migrations in container: $APP_CONTAINER"
-if docker exec "$APP_CONTAINER" alembic upgrade head; then
-  echo "✅ Database migrations completed successfully in container: $APP_CONTAINER"
-else
-  migration_exit_code=$?
-  echo "❌ Database migrations failed in container: $APP_CONTAINER (exit code: $migration_exit_code)" >&2
-  echo "Check container logs with: docker logs $APP_CONTAINER" >&2
-  exit "$migration_exit_code"
-fi
 
 echo "Starting caddy after successful migrations..."
 dc build caddy

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -183,8 +183,8 @@ validate_managed_postgres_contract() {
   esac
 
   case "$DATABASE_URL" in
-    *@postgres:5432/*)
-      echo "❌ Production deploy expects external managed PostgreSQL, not compose-local @postgres:5432" >&2
+    *@postgres:*/* | *@postgres/*)
+      echo "❌ Production deploy expects external managed PostgreSQL, not compose-local @postgres" >&2
       exit 1
       ;;
   esac

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -167,6 +167,12 @@ wait_for_app_ready() {
 }
 
 validate_managed_postgres_contract() {
+  local compose_file_path=""
+
+  if [ ${#compose_args[@]} -gt 0 ]; then
+    compose_file_path="${compose_args[1]}"
+  fi
+
   case "$DATABASE_URL" in
     postgresql+psycopg://*)
       ;;
@@ -182,15 +188,18 @@ validate_managed_postgres_contract() {
       exit 1
       ;;
   esac
+
+  if [ -n "$compose_file_path" ] && grep -qE '^[[:space:]]+postgres:' "$compose_file_path"; then
+    echo "❌ Production compose still references local postgres; canonical lane is managed PostgreSQL only" >&2
+    exit 1
+  fi
 }
-
-echo "Pulling production app image..."
-dc pull app
-
-sync_shell_bundle
 
 echo "Validating managed PostgreSQL production contract..."
 validate_managed_postgres_contract
+
+echo "Pulling production app image..."
+dc pull app
 
 echo "Production DB backups are managed outside the deploy script (provider snapshots / PITR)."
 
@@ -202,6 +211,8 @@ else
   echo "❌ Database migrations failed (exit code: $migration_exit_code)" >&2
   exit "$migration_exit_code"
 fi
+
+sync_shell_bundle
 
 echo "Starting app before exposing traffic..."
 dc up -d --remove-orphans app

--- a/scripts/fix_production_env.sh
+++ b/scripts/fix_production_env.sh
@@ -51,12 +51,12 @@ fi
 echo "📍 Compose file: $COMPOSE_FILE"
 echo ""
 
-# Production deploy contract is Postgres-first and fail-closed.
+# Production deploy contract is managed-Postgres-only and fail-closed.
 if grep -qE "^\s+postgres:" "$COMPOSE_FILE"; then
-    echo "✅ Found postgres service in compose file"
-else
-    echo "❌ Production compose must define a postgres service"
+    echo "❌ Canonical production compose must not define a local postgres service"
     exit 1
+else
+    echo "✅ Production compose uses external managed PostgreSQL only"
 fi
 
 # Check if .env exists
@@ -99,7 +99,7 @@ set_env_var "ALLOW_DEV_API_KEY" "false"
 set_env_var "API_KEY_REQUIRED" "true"
 
 echo ""
-echo "=== Step 2: Validate required Postgres contract ==="
+echo "=== Step 2: Validate managed PostgreSQL contract ==="
 
 require_env_var() {
     local key="$1"
@@ -113,16 +113,22 @@ require_env_var() {
 }
 
 require_env_var "DATABASE_URL"
-require_env_var "POSTGRES_DB"
-require_env_var "POSTGRES_USER"
-require_env_var "POSTGRES_PASSWORD"
-
 DATABASE_URL_VALUE="$(grep -E '^DATABASE_URL=' .env | tail -1 | cut -d'=' -f2- | tr -d '\r\n')"
 case "$DATABASE_URL_VALUE" in
     postgresql+psycopg://*) echo "✅ DATABASE_URL uses Postgres DSN" ;;
     *)
         echo "❌ DATABASE_URL must use canonical Postgres DSN (postgresql+psycopg://...)"
         exit 1
+        ;;
+esac
+
+case "$DATABASE_URL_VALUE" in
+    *@postgres:5432/*)
+        echo "❌ DATABASE_URL must point to managed PostgreSQL, not compose-local @postgres:5432"
+        exit 1
+        ;;
+    *)
+        echo "✅ DATABASE_URL targets external managed PostgreSQL"
         ;;
 esac
 

--- a/scripts/fix_production_env.sh
+++ b/scripts/fix_production_env.sh
@@ -123,8 +123,8 @@ case "$DATABASE_URL_VALUE" in
 esac
 
 case "$DATABASE_URL_VALUE" in
-    *@postgres:5432/*)
-        echo "❌ DATABASE_URL must point to managed PostgreSQL, not compose-local @postgres:5432"
+    *@postgres:*/* | *@postgres/*)
+        echo "❌ DATABASE_URL must point to managed PostgreSQL, not compose-local @postgres"
         exit 1
         ;;
     *)

--- a/tests/test_agent_input_guard.py
+++ b/tests/test_agent_input_guard.py
@@ -366,8 +366,9 @@ def test_scan_text_with_goplus_agentguard_live_runtime_smoke() -> None:
         pytest.skip("local Node runtime or GoPlus scan script unavailable")
 
     result = scan_text_with_goplus_agentguard("How can I build a steady breakfast habit?")
+    if result is None:
+        pytest.skip("local GoPlus scanner runtime unavailable")
 
-    assert result is not None
     assert result.risk_level == "low"
     assert result.risk_tags == ()
     assert result.should_block is False

--- a/tests/test_agent_input_guard.py
+++ b/tests/test_agent_input_guard.py
@@ -23,6 +23,35 @@ from app.security.goplus_agentguard_bridge import (
 )
 
 
+def require_feature(feature_key: str, reason: str) -> None:
+    expected_reason = f"feature_disabled:{feature_key}"
+    if reason != expected_reason:
+        pytest.fail(f"invalid feature skip reason: expected {expected_reason!r}, got {reason!r}")
+    pytest.skip(reason)
+
+
+def _node_agentguard_dependency_available(node_binary: str) -> bool:
+    completed = subprocess.run(
+        [node_binary, "-e", 'require.resolve("@goplus/agentguard")'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return True
+
+    stderr = (completed.stderr or "").lower()
+    if "module_not_found" in stderr or "cannot find module" in stderr:
+        return False
+
+    pytest.fail(
+        "Node failed while checking @goplus/agentguard availability:\n"
+        f"exit code: {completed.returncode}\n"
+        f"stdout: {completed.stdout}\n"
+        f"stderr: {completed.stderr}"
+    )
+
+
 def test_scan_ai_agent_input_allows_benign_wellness_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -362,12 +391,25 @@ def test_scan_text_with_goplus_agentguard_live_runtime_smoke() -> None:
 
     from app.security import goplus_agentguard_bridge as bridge_mod
 
-    if bridge_mod.shutil.which("node") is None or not bridge_mod.AGENTGUARD_SCAN_SCRIPT.exists():
-        pytest.skip("local Node runtime or GoPlus scan script unavailable")
+    node_binary = bridge_mod.shutil.which("node")
+    if node_binary is None or not bridge_mod.AGENTGUARD_SCAN_SCRIPT.exists():
+        require_feature(
+            "goplus_scanner_runtime",
+            "feature_disabled:goplus_scanner_runtime",
+        )
+        raise AssertionError("require_feature should always raise pytest skip")
+    if not _node_agentguard_dependency_available(node_binary):
+        require_feature(
+            "goplus_scanner_runtime",
+            "feature_disabled:goplus_scanner_runtime",
+        )
 
     result = scan_text_with_goplus_agentguard("How can I build a steady breakfast habit?")
     if result is None:
-        pytest.skip("local GoPlus scanner runtime unavailable")
+        pytest.fail(
+            "GoPlus scanner returned no result despite Node/script availability; "
+            "runtime, dependency, or output contract likely failed"
+        )
 
     assert result.risk_level == "low"
     assert result.risk_tags == ()

--- a/tests/test_business_collateral_builders.py
+++ b/tests/test_business_collateral_builders.py
@@ -46,6 +46,12 @@ def _run_node_eval(script: str) -> subprocess.CompletedProcess[str]:
     return _run_subprocess([node_binary, "-e", script])
 
 
+def _node_package_or_skip(package_name: str) -> None:
+    result = _run_node_eval(f'require.resolve("{package_name}");')
+    if result.returncode != 0:
+        pytest.skip(f"optional node package '{package_name}' not installed")
+
+
 def _read_office_document_xml(output_path: Path, member_name: str) -> str:
     with zipfile.ZipFile(output_path) as archive:
         return archive.read(member_name).decode("utf-8")
@@ -59,6 +65,7 @@ def _extract_docx_text(document_xml: str) -> str:
 
 
 def test_b2b_proposal_builder_creates_docx(tmp_path: Path) -> None:
+    _node_package_or_skip("docx")
     output_path = tmp_path / "proposal.docx"
     result = _run_builder("scripts/business_collateral/build_b2b_proposal.js", output_path)
 
@@ -99,6 +106,7 @@ process.stdout.write(JSON.stringify(result));
 
 
 def test_b2b_pitch_deck_builder_creates_pptx(tmp_path: Path) -> None:
+    _node_package_or_skip("pptxgenjs")
     output_path = tmp_path / "deck.pptx"
     result = _run_builder("scripts/business_collateral/build_b2b_pitch_deck.js", output_path)
 

--- a/tests/test_business_collateral_builders.py
+++ b/tests/test_business_collateral_builders.py
@@ -14,10 +14,18 @@ WORDPROCESSING_ML_NAMESPACE = "{http://schemas.openxmlformats.org/wordprocessing
 SUBPROCESS_TIMEOUT_SECONDS = 120
 
 
+def require_feature(feature_key: str, reason: str) -> None:
+    expected_reason = f"feature_disabled:{feature_key}"
+    if reason != expected_reason:
+        pytest.fail(f"invalid feature skip reason: expected {expected_reason!r}, got {reason!r}")
+    pytest.skip(reason)
+
+
 def _node_binary_or_skip() -> str:
     node_binary = shutil.which("node")
     if node_binary is None:
-        pytest.skip("node executable not found in PATH")
+        require_feature("node_runtime", "feature_disabled:node_runtime")
+        raise AssertionError("require_feature should always raise pytest skip")
     return node_binary
 
 
@@ -48,8 +56,23 @@ def _run_node_eval(script: str) -> subprocess.CompletedProcess[str]:
 
 def _node_package_or_skip(package_name: str) -> None:
     result = _run_node_eval(f'require.resolve("{package_name}");')
-    if result.returncode != 0:
-        pytest.skip(f"optional node package '{package_name}' not installed")
+    if result.returncode == 0:
+        return
+
+    stderr = (result.stderr or "").lower()
+    if "module_not_found" in stderr or "cannot find module" in stderr:
+        require_feature(
+            f"node_package_{package_name}",
+            f"feature_disabled:node_package_{package_name}",
+        )
+
+    pytest.fail(
+        "Node failed while checking for optional package "
+        f"'{package_name}':\n"
+        f"exit code: {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
 
 
 def _read_office_document_xml(output_path: Path, member_name: str) -> str:

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -384,6 +384,84 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
 
 
+def test_deploy_production_keeps_shell_bundle_untouched_when_migrations_fail(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_root = project_dir.parent
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    shell_bundle_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "frontend").mkdir()
+    (shell_bundle_dir / "frontend" / "bundle-marker.txt").write_text(
+        "frontend-sync\n", encoding="utf-8"
+    )
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
+    )
+    (shell_root / "frontend").mkdir()
+    (shell_root / "frontend" / "stale.txt").write_text("old-shell\n", encoding="utf-8")
+    (shell_root / "scripts").mkdir()
+    (shell_root / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"-f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head"*)
+    printf 'migration failed\\n' >&2
+    exit 1
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert (shell_root / "frontend" / "stale.txt").read_text(encoding="utf-8") == "old-shell\n"
+    assert not (shell_root / "frontend" / "bundle-marker.txt").exists()
+    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+        encoding="utf-8"
+    ) == "stale-diagnose\n"
+
+
 def test_deploy_production_rejects_compose_local_postgres_dsn(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"
@@ -418,6 +496,45 @@ def test_deploy_production_rejects_compose_local_postgres_dsn(tmp_path: Path) ->
 
     assert completed.returncode == 1
     assert "external managed PostgreSQL" in completed.stderr
+
+
+def test_deploy_production_rejects_compose_with_local_postgres_reference(tmp_path: Path) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text(
+        "services:\n  app:\n    depends_on:\n      postgres:\n        condition: service_healthy\n  postgres:\n    image: postgres:16\n",
+        encoding="utf-8",
+    )
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+
+    docker_stub = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "still references local postgres" in completed.stderr
 
 
 def test_diagnose_web_reports_green_for_spa_and_api_contract(tmp_path: Path) -> None:

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -4,6 +4,8 @@ import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -462,14 +464,25 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     ) == "stale-diagnose\n"
 
 
-def test_deploy_production_rejects_compose_local_postgres_dsn(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+        "postgresql+psycopg://pulseplate:secret@postgres/pulseplate",  # pragma: allowlist secret
+        "postgresql+psycopg://pulseplate:secret@postgres:6543/pulseplate",  # pragma: allowlist secret
+    ],
+)
+def test_deploy_production_rejects_compose_local_postgres_dsn(
+    tmp_path: Path,
+    database_url: str,
+) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"
     project_dir.mkdir()
     bin_dir.mkdir()
     (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
     (project_dir / ".env").write_text(
-        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate\n",  # pragma: allowlist secret
+        f"DATABASE_URL={database_url}\n",
         encoding="utf-8",
     )
 

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -42,7 +42,7 @@ EOF
     _write_executable(bin_dir / "docker", docker_stub)
 
     env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"  # pragma: allowlist secret
     env["PROJECT_DIR"] = str(project_dir)
     env["BACKUP_DIR"] = str(backup_dir)
     env["COMPOSE_FILE"] = "docker-compose.staging.yaml"
@@ -124,36 +124,24 @@ def test_deploy_production_runs_migrations_before_caddy_and_external_ready(
 ) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"
-    scripts_dir = project_dir / "scripts" / "ops"
     log_file = tmp_path / "deploy.log"
     project_dir.mkdir()
     bin_dir.mkdir()
-    scripts_dir.mkdir(parents=True)
     (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
     (project_dir / ".env").write_text(
         "\n".join(
             [
-                "POSTGRES_USER=pulseplate",
-                "POSTGRES_DB=pulseplate",
-                "POSTGRES_PASSWORD=secret",
-                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
             ]
         )
         + "\n",
         encoding="utf-8",
     )
 
-    helper_stub = f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'helper %s %s\\n' "$PROJECT_DIR" "${{COMPOSE_FILE:-}}" >> "{log_file}"
-"""
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
 printf 'docker %s\\n' "$*" >> "{log_file}"
 case "$*" in
-  *"compose --env-file "*"-f docker-compose.production.yaml ps -q postgres"*)
-    printf 'postgres-id\\n'
-    ;;
   *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
     printf 'app-id\\n'
     ;;
@@ -170,7 +158,6 @@ set -euo pipefail
 printf 'curl %s\\n' "$*" >> "{log_file}"
 """
     sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
-    _write_executable(scripts_dir / "postgres_backup.sh", helper_stub)
     _write_executable(bin_dir / "docker", docker_stub)
     _write_executable(bin_dir / "curl", curl_stub)
     _write_executable(bin_dir / "sleep", sleep_stub)
@@ -194,27 +181,17 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
 
     log_lines = log_file.read_text(encoding="utf-8").splitlines()
-    postgres_up_index = _assert_log_index(
+    migrate_index = _assert_log_index(
         log_lines,
         predicate=lambda line: "compose --env-file" in line
-        and "up -d --remove-orphans postgres" in line,
-        message="Expected postgres docker-compose up step to appear in deploy log",
-    )
-    helper_index = _assert_log_index(
-        log_lines,
-        predicate=lambda line: line.startswith("helper "),
-        message="Expected backup helper step to appear in deploy log",
+        and "run --rm --no-deps app alembic upgrade head" in line,
+        message="Expected one-shot alembic migration step to appear in deploy log",
     )
     app_up_index = _assert_log_index(
         log_lines,
         predicate=lambda line: "compose --env-file" in line
         and "up -d --remove-orphans app" in line,
         message="Expected app docker-compose up step to appear in deploy log",
-    )
-    migrate_index = _assert_log_index(
-        log_lines,
-        predicate=lambda line: "exec app-id alembic upgrade head" in line,
-        message="Expected alembic migration step to appear in deploy log",
     )
     caddy_build_index = _assert_log_index(
         log_lines,
@@ -233,16 +210,9 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
         message="Expected external readiness check to appear in deploy log",
     )
 
-    assert (
-        postgres_up_index
-        < helper_index
-        < app_up_index
-        < migrate_index
-        < caddy_build_index
-        < caddy_up_index
-        < external_ready_index
-    )
-    assert any("helper " in line and "docker-compose.production.yaml" in line for line in log_lines)
+    assert migrate_index < app_up_index < caddy_build_index < caddy_up_index < external_ready_index
+    assert all("up -d --remove-orphans postgres" not in line for line in log_lines)
+    assert all("helper " not in line for line in log_lines)
 
 
 def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_path: Path) -> None:
@@ -250,20 +220,15 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
     shell_root = project_dir.parent
     shell_bundle_dir = tmp_path / "shell-bundle"
     bin_dir = tmp_path / "bin"
-    scripts_dir = project_dir / "scripts" / "ops"
     log_file = tmp_path / "deploy.log"
     project_dir.mkdir()
     shell_bundle_dir.mkdir()
     bin_dir.mkdir()
-    scripts_dir.mkdir(parents=True)
     (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
     (project_dir / ".env").write_text(
         "\n".join(
             [
-                "POSTGRES_USER=pulseplate",
-                "POSTGRES_DB=pulseplate",
-                "POSTGRES_PASSWORD=secret",
-                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
             ]
         )
         + "\n",
@@ -287,17 +252,10 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
     (shell_root / "scripts").mkdir()
     (shell_root / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
 
-    helper_stub = f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'helper %s %s\\n' "$PROJECT_DIR" "${{COMPOSE_FILE:-}}" >> "{log_file}"
-"""
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
 printf 'docker %s\\n' "$*" >> "{log_file}"
 case "$*" in
-  *"compose --env-file "*"-f docker-compose.production.yaml ps -q postgres"*)
-    printf 'postgres-id\\n'
-    ;;
   *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
     printf 'app-id\\n'
     ;;
@@ -314,7 +272,6 @@ set -euo pipefail
 printf 'curl %s\\n' "$*" >> "{log_file}"
 """
     sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
-    _write_executable(scripts_dir / "postgres_backup.sh", helper_stub)
     _write_executable(bin_dir / "docker", docker_stub)
     _write_executable(bin_dir / "curl", curl_stub)
     _write_executable(bin_dir / "sleep", sleep_stub)
@@ -355,43 +312,31 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
 def test_deploy_production_exits_non_zero_when_migrations_fail(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"
-    scripts_dir = project_dir / "scripts" / "ops"
     log_file = tmp_path / "deploy.log"
     project_dir.mkdir()
     bin_dir.mkdir()
-    scripts_dir.mkdir(parents=True)
     (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
     (project_dir / ".env").write_text(
         "\n".join(
             [
-                "POSTGRES_USER=pulseplate",
-                "POSTGRES_DB=pulseplate",
-                "POSTGRES_PASSWORD=secret",
-                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate",  # pragma: allowlist secret
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
             ]
         )
         + "\n",
         encoding="utf-8",
     )
 
-    helper_stub = f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'helper %s %s\\n' "$PROJECT_DIR" "${{COMPOSE_FILE:-}}" >> "{log_file}"
-"""
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
 printf 'docker %s\\n' "$*" >> "{log_file}"
 case "$*" in
-  *"compose --env-file "*"-f docker-compose.production.yaml ps -q postgres"*)
-    printf 'postgres-id\\n'
-    ;;
   *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
     printf 'app-id\\n'
     ;;
   *"inspect --format "*)
     printf 'healthy\\n'
     ;;
-  *"exec app-id alembic upgrade head"*)
+  *"compose --env-file "*"-f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head"*)
     printf 'migration failed\\n' >&2
     exit 1
     ;;
@@ -405,7 +350,6 @@ set -euo pipefail
 printf 'curl %s\\n' "$*" >> "{log_file}"
 """
     sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
-    _write_executable(scripts_dir / "postgres_backup.sh", helper_stub)
     _write_executable(bin_dir / "docker", docker_stub)
     _write_executable(bin_dir / "curl", curl_stub)
     _write_executable(bin_dir / "sleep", sleep_stub)
@@ -429,14 +373,51 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
 
     assert completed.returncode == 1
-    assert "Database migrations failed in container: app-id (exit code: 1)" in completed.stderr
+    assert "Database migrations failed (exit code: 1)" in completed.stderr
 
     log_lines = log_file.read_text(encoding="utf-8").splitlines()
-    assert any("exec app-id alembic upgrade head" in line for line in log_lines)
+    assert any("run --rm --no-deps app alembic upgrade head" in line for line in log_lines)
+    assert all("up -d --remove-orphans app" not in line for line in log_lines)
     assert all("up -d --remove-orphans caddy" not in line for line in log_lines)
     assert not any(
         line.startswith("curl ") and "https://pulseplate.test/ready" in line for line in log_lines
     )
+
+
+def test_deploy_production_rejects_compose_local_postgres_dsn(tmp_path: Path) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@postgres:5432/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+
+    docker_stub = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "external managed PostgreSQL" in completed.stderr
 
 
 def test_diagnose_web_reports_green_for_spa_and_api_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- fail the production deploy lane closed unless `DATABASE_URL` points to an external managed PostgreSQL instance and remove the local production `postgres` compose service
- run Alembic in a one-shot release container before app restart so the managed PostgreSQL lane matches canonical production operations
- harden optional local Node-based smoke tests so missing developer-only packages skip instead of causing false-red backend verify runs
- reject stale production compose files that still reference local `postgres` and keep the shell bundle untouched when migrations fail

## Test plan
- [x] `pytest -q tests/test_deploy_contract_scripts.py tests/test_cd_workflow_production_deploy_gate.py`
- [x] `pytest -q tests/test_agent_input_guard.py -k goplus_agentguard_live_runtime_smoke`
- [x] `pytest -q tests/test_business_collateral_builders.py`
- [x] `python -m pytest -q --maxfail=1`
- [x] `make verify`
- [x] `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1302_FIXED_MAPPING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Production deploys now require an external managed PostgreSQL via DATABASE_URL; local Postgres is disallowed.

* **Bug Fixes**
  * Migrations run as a one-shot container step before services restart.

* **Documentation**
  * Revised deployment guides and workflows to reflect managed-Postgres contract and provider-managed backups/PITR.
  * Added review/merge readiness notes documenting closure of deploy-contract gaps.

* **Tests**
  * Tests updated/added to enforce the managed-Postgres contract, migration behavior, and conditional skipping for optional deps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->