### PR TITLE
chore(deps): bump frontend lodash to 4.18.1

### DIFF
--- a/docs/review/PR_1303_FIXED_MAPPING.md
+++ b/docs/review/PR_1303_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 - No actionable review comments
 
 ## Merge Readiness
-- [x] Local verification completed
+- [ ] Local verification completed
 - [ ] Current-head CI green
 - [ ] No unresolved review threads
 - [ ] Dedicated security lane merged

--- a/docs/review/PR_1303_FIXED_MAPPING.md
+++ b/docs/review/PR_1303_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1303 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local verification completed
+- [ ] Current-head CI green
+- [ ] No unresolved review threads
+- [ ] Dedicated security lane merged

--- a/docs/review/PR_1303_FIXED_MAPPING.md
+++ b/docs/review/PR_1303_FIXED_MAPPING.md
@@ -1,7 +1,7 @@
 # PR 1303 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
@@ -9,6 +9,7 @@ Disposition: FIXED
 Commit: e726e4ea
 Evidence: docs/review/PR_1303_FIXED_MAPPING.md:11
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1303#discussion_r3030240503 -> e726e4ea
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1303#pullrequestreview-4053072985 -> e726e4ea
 
 ## Merge Readiness
 - [ ] Local verification completed

--- a/docs/review/PR_1303_FIXED_MAPPING.md
+++ b/docs/review/PR_1303_FIXED_MAPPING.md
@@ -1,11 +1,14 @@
 # PR 1303 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass completed
+- [ ] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: e726e4ea
+Evidence: docs/review/PR_1303_FIXED_MAPPING.md:11
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1303#discussion_r3030240503 -> e726e4ea
 
 ## Merge Readiness
 - [ ] Local verification completed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7895,9 +7895,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
- bump `frontend/package-lock.json` from `lodash` `4.17.23` to `4.18.1`
- replace stale Dependabot lane with a fresh branch from current `origin/main`
- supersedes #1300 so dependency/security closure can proceed on a clean current-head PR

## Test plan
- [x] `cd frontend && npm run test:ci`
- [x] `cd frontend && npm run build`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1303_FIXED_MAPPING.md`

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-nightly-full-tests-node22-parity`

## Merge Readiness
- [x] Local verification completed
- [ ] Current-head CI green
- [ ] No unresolved review threads
- [ ] Dedicated security lane merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a review-status document capturing the discussion-thread pass, a confirmed “fixed” mapping with evidence links, and a merge-readiness checklist covering verification, CI, unresolved threads, and security lane status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->