### PR TITLE
docs(release): publish legal policy paths and align client links

### DIFF
--- a/docs/review/PR_1304_FIXED_MAPPING.md
+++ b/docs/review/PR_1304_FIXED_MAPPING.md
@@ -1,14 +1,11 @@
 # PR 1304 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-Disposition: FIXED
-Commit: f66c1679
-Evidence: `legacy_app.py:1541`, `frontend/src/pages/Profile.tsx:5`, `frontend/src/pages/Profile.tsx:120`, `frontend/src/pages/__tests__/Profile.test.tsx:47`, `tests/test_app_endpoints_1383_1401.py:168`
-Reason: Initial narrow legal-policy implementation aligns the legacy `/terms` publication path to the canonical typed helper, adds canonical web legal links to `/privacy` and `/terms`, and adds targeted backend/frontend regressions for those release-safety contracts.
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1304_FIXED_MAPPING.md
+++ b/docs/review/PR_1304_FIXED_MAPPING.md
@@ -1,12 +1,19 @@
 # PR 1304 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030648709` -> `603fda1c`
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030654644` -> `603fda1c`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030648709 -> 603fda1c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#pullrequestreview-4053494042 -> 603fda1c
+Disposition: FIXED
+Commit: 603fda1c
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030654644 -> 603fda1c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#pullrequestreview-4053500597 -> 603fda1c
+Disposition: FIXED
+Commit: 603fda1c
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1304_FIXED_MAPPING.md
+++ b/docs/review/PR_1304_FIXED_MAPPING.md
@@ -1,17 +1,19 @@
 # PR 1304 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass completed
-- [x] Fixed in commit mapping completed
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- Pending current-head actionables before resolution:
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030648709` — pending FIXED (`target="_blank"` legal links should use `rel="noopener noreferrer"`).
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030654644` — pending FIXED (merge-readiness checkboxes must stay unchecked until rerun on current head).
 
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
+- [ ] Pre-commit green
+- [ ] `make verify` green
 - [ ] Mandatory post-open bug-hunter pass completed
 Notes: PR `#1304` must stay narrowly scoped to legal publication paths, web/iOS client-link alignment, and runtime source-of-truth normalization for `/terms`. It must not widen into broader compliance control-plane, App Store/provider modernization, or new public legal URL work.

--- a/docs/review/PR_1304_FIXED_MAPPING.md
+++ b/docs/review/PR_1304_FIXED_MAPPING.md
@@ -1,0 +1,20 @@
+# PR 1304 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: f66c1679
+Evidence: `legacy_app.py:1541`, `frontend/src/pages/Profile.tsx:5`, `frontend/src/pages/Profile.tsx:120`, `frontend/src/pages/__tests__/Profile.test.tsx:47`, `tests/test_app_endpoints_1383_1401.py:168`
+Reason: Initial narrow legal-policy implementation aligns the legacy `/terms` publication path to the canonical typed helper, adds canonical web legal links to `/privacy` and `/terms`, and adds targeted backend/frontend regressions for those release-safety contracts.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+Notes: PR `#1304` must stay narrowly scoped to legal publication paths, web/iOS client-link alignment, and runtime source-of-truth normalization for `/terms`. It must not widen into broader compliance control-plane, App Store/provider modernization, or new public legal URL work.

--- a/docs/review/PR_1304_FIXED_MAPPING.md
+++ b/docs/review/PR_1304_FIXED_MAPPING.md
@@ -5,9 +5,8 @@
 - [ ] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- Pending current-head actionables before resolution:
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030648709` — pending FIXED (`target="_blank"` legal links should use `rel="noopener noreferrer"`).
-- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030654644` — pending FIXED (merge-readiness checkboxes must stay unchecked until rerun on current head).
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030648709` -> `603fda1c`
+- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1304#discussion_r3030654644` -> `603fda1c`
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -247,8 +247,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: Legal policy publish and client-link alignment
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-LEGAL-POLICY-PUBLISH
-  - Status: 📋 Planned
+  - Target PR: PR-1304
+  - Status: 🟡 In progress (PR-1304)
   - Area: docs / legal / release readiness
   - Finding Type: policy publication gap
   - Reason (EN): Privacy and Terms posture has been materially clarified in runtime and compliance docs, but canonical published policy paths and client references still need one explicit release-blocker item.

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,6 +2,9 @@ import { Link } from 'react-router-dom';
 import { pageCardStyle } from '../components/ui/pageCardStyle';
 import { useAuth } from '../lib/auth';
 
+const CANONICAL_PRIVACY_URL = 'https://pulseplate.app/privacy';
+const CANONICAL_TERMS_URL = 'https://pulseplate.app/terms';
+
 export default function Profile() {
   const { isAuthenticated, isLoading } = useAuth();
   const connectionLabel = isLoading ? 'Checking' : isAuthenticated ? 'Connected' : 'Missing';
@@ -111,6 +114,36 @@ export default function Profile() {
               <p className="mt-4 text-xs text-[var(--color-text-muted)]">
                 Version 1.0 • Made with care for your wellness journey
               </p>
+            </div>
+          </section>
+
+          <section className="mt-6 overflow-hidden rounded-xl" style={pageCardStyle}>
+            <div className="p-6">
+              <h3 className="text-base font-semibold text-[var(--color-text)]">
+                Legal
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[var(--color-text-muted)]">
+                Review the current privacy and terms publications before using paid or personalized
+                wellness features.
+              </p>
+              <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href={CANONICAL_PRIVACY_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-text)] transition-all hover:bg-[var(--color-surface)] hover:shadow-sm"
+                >
+                  Privacy Policy
+                </a>
+                <a
+                  href={CANONICAL_TERMS_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-text)] transition-all hover:bg-[var(--color-surface)] hover:shadow-sm"
+                >
+                  Terms of Use
+                </a>
+              </div>
             </div>
           </section>
         </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -130,7 +130,7 @@ export default function Profile() {
                 <a
                   href={CANONICAL_PRIVACY_URL}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-text)] transition-all hover:bg-[var(--color-surface)] hover:shadow-sm"
                 >
                   Privacy Policy
@@ -138,7 +138,7 @@ export default function Profile() {
                 <a
                   href={CANONICAL_TERMS_URL}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm font-semibold text-[var(--color-text)] transition-all hover:bg-[var(--color-surface)] hover:shadow-sm"
                 >
                   Terms of Use

--- a/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/__tests__/Profile.test.tsx
@@ -44,6 +44,14 @@ describe('Profile', () => {
     expect(screen.getByText('Configuration Status')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Configure API Key' })).toHaveAttribute('href', '/enter-key');
     expect(screen.getByRole('link', { name: 'Configure Nutrition Profile' })).toHaveAttribute('href', '/setup');
+    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+      'href',
+      'https://pulseplate.app/privacy'
+    );
+    expect(screen.getByRole('link', { name: 'Terms of Use' })).toHaveAttribute(
+      'href',
+      'https://pulseplate.app/terms'
+    );
   });
 
   it('shows connected status for authenticated cookie session', () => {

--- a/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/__tests__/Profile.test.tsx
@@ -48,9 +48,17 @@ describe('Profile', () => {
       'href',
       'https://pulseplate.app/privacy'
     );
+    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    );
     expect(screen.getByRole('link', { name: 'Terms of Use' })).toHaveAttribute(
       'href',
       'https://pulseplate.app/terms'
+    );
+    expect(screen.getByRole('link', { name: 'Terms of Use' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
     );
   });
 
@@ -93,5 +101,4 @@ describe('Profile', () => {
     expect(main).toHaveClass('min-h-screen');
     expect(main).toHaveClass('flex-col');
   });
-
 });

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -1538,41 +1538,9 @@ async def terms() -> Dict[str, Any]:
     RU: Эндпоинт условий использования для канонической legal-публикации.
     EN: Terms of use endpoint for canonical legal publication.
     """
+    from app.routers.legal import build_terms_endpoint_payload
 
-    return {
-        "terms_of_use": (
-            "PulsePlate provides wellness-oriented planning, nutrition, and coaching-style features. "
-            "It does not provide medical diagnosis, treatment, emergency response, or licensed clinical services."
-        ),
-        "service_scope": {
-            "category": "wellness / nutrition planning / coaching support",
-            "medical_boundary": (
-                "Content is informational and product-guidance only. Users must not treat the service as "
-                "medical, psychiatric, or emergency advice."
-            ),
-            "age_requirement": "The service is intended for adults unless a specific flow states otherwise.",
-        },
-        "billing_and_subscriptions": {
-            "ios_app_store": "Apple-managed digital subscription flow with server-side verification.",
-            "manual_rails": "Operational fallback rails may include ERIP QR or SWIFT manual reconciliation.",
-            "cancellation": "Users manage subscription cancellation in the original purchase channel.",
-            "entitlement_truth": "Subscription entitlement is determined by backend verification and audit state.",
-        },
-        "acceptable_use": {
-            "forbidden": [
-                "attempting to bypass tier controls or payment verification",
-                "submitting unlawful, abusive, or malicious content",
-                "using the service for medical triage or emergency decisions",
-            ],
-            "security_note": "Abuse-prevention and platform-protection controls may block unsafe or fraudulent use.",
-        },
-        "liability_boundary": (
-            "The service is provided on a best-effort basis for wellness support. "
-            "Users remain responsible for critical health, legal, and financial decisions."
-        ),
-        "contact": "For legal or billing questions, please contact the application administrator.",
-        "effective_date": "2026-03-08",
-    }
+    return build_terms_endpoint_payload().model_dump()
 
 
 @app.post("/admin/logs/cleanup", dependencies=[Depends(_get_api_key_dynamic)])

--- a/tests/test_app_endpoints_1383_1401.py
+++ b/tests/test_app_endpoints_1383_1401.py
@@ -13,6 +13,8 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from app.routers.legal import build_terms_endpoint_payload
+
 
 class TestAppEndpoints1383_1401:
     """Tests for app.py endpoints lines 1383-1401."""
@@ -162,3 +164,11 @@ class TestAppEndpoints1383_1401:
         assert "does not provide medical diagnosis" in data["terms_of_use"].lower()
         forbidden = data["acceptable_use"]["forbidden"]
         assert "using the service for medical triage or emergency decisions" in forbidden
+
+    def test_terms_endpoint_matches_canonical_helper(self, client: TestClient) -> None:
+        """/terms must serialize the canonical typed helper payload."""
+        response = client.get("/terms")
+        assert response.status_code == 200
+        assert response.headers["content-type"].lower().startswith("application/json")
+
+        assert response.json() == build_terms_endpoint_payload().model_dump()

--- a/tests/test_app_endpoints_1383_1401.py
+++ b/tests/test_app_endpoints_1383_1401.py
@@ -8,6 +8,7 @@ Covers:
 - /terms endpoint
 """
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -172,3 +173,9 @@ class TestAppEndpoints1383_1401:
         assert response.headers["content-type"].lower().startswith("application/json")
 
         assert response.json() == build_terms_endpoint_payload().model_dump()
+
+    def test_legacy_terms_wrapper_matches_canonical_helper(self) -> None:
+        """legacy_app /terms wrapper must delegate to the canonical typed helper."""
+        import legacy_app
+
+        assert asyncio.run(legacy_app.terms()) == build_terms_endpoint_payload().model_dump()

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 
 import legacy_app
+from app.routers.legal import build_terms_endpoint_payload
 
 
 def test_language_cookie_has_samesite_and_secure_guard() -> None:
@@ -28,6 +29,12 @@ def test_language_cookie_has_samesite_and_secure_guard() -> None:
     assert "SameSite=Lax" in resp.text
     assert "window.location.protocol === 'https:'" in resp.text
     assert "; Secure" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_terms_wrapper_matches_canonical_helper() -> None:
+    """Cover legacy /terms wrapper lines used by diff-cover in PR CI."""
+    assert await legacy_app.terms() == build_terms_endpoint_payload().model_dump()
 
 
 def test_export_pdf_generic_requires_api_key() -> None:


### PR DESCRIPTION
## Summary

Publish canonical legal policy paths and align web/iOS client links to them.

## Scope
- keep `/privacy` and `/terms` as canonical published paths
- normalize `/terms` runtime publication to typed canonical helper
- align web legal links to canonical published destinations
- keep iOS unchanged unless a concrete mismatch is found
- keep legal copy aligned with existing wellness-safe posture

## Non-goals
- no EU compliance control-plane follow-through
- no App Store/provider modernization
- no new legal/public URL expansion
- no broader product/legal regime work

## Ledger
- target: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-legal-policy-publish`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1304_FIXED_MAPPING.md`
- No actionable review comments

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Mandatory wait-window completed

## Summary by Sourcery

Нормализовать публикацию юридических условий через канонический вспомогательный модуль и согласовать клиентские юридические ссылки и документы с путями опубликованных политик.

New Features:
- Добавить явные ссылки на Privacy Policy и Terms of Use на веб-странице профиля (Profile), указывающие на канонические публичные юридические URL.

Enhancements:
- Рефакторить устаревший endpoint `/terms`, чтобы он делегировал обработку каноническому типизированному вспомогательному модулю, используемому основным приложением, сохраняя юридический текст централизованным.
- Обновить запись в журнале (ledger) юридического бэклога, чтобы ссылаться на этот PR и его текущий статус.
- Добавить служебный документ для ревью, фиксирующий соответствие «исправлено в коммите» и заметки о готовности к слиянию для этого PR.

Tests:
- Расширить backend-тесты, чтобы проверять, что и основной, и устаревший endpoint `/terms` сериализуют полезную нагрузку канонического вспомогательного модуля.
- Расширить frontend-тесты, чтобы проверять, что новые юридические ссылки на странице профиля (Profile) указывают на канонические URL политики конфиденциальности и условий использования.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize legal terms publication to a canonical helper and align client-facing legal links and docs around the published policy paths.

New Features:
- Expose explicit Privacy Policy and Terms of Use links on the web Profile page pointing to the canonical public legal URLs.

Enhancements:
- Refactor the legacy /terms endpoint to delegate to the canonical typed helper used by the main app, keeping legal copy centralized.
- Update the legal backlog ledger entry to reference this PR and current status.
- Add a review bookkeeping document capturing the fixed-in-commit mapping and merge readiness notes for this PR.

Tests:
- Extend backend tests to assert that both the main and legacy /terms endpoints serialize the canonical helper payload.
- Extend frontend tests to verify the new legal links on the Profile page target the canonical privacy and terms URLs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Legal” card on the Profile page with Privacy Policy and Terms of Use links that open in a new tab.
* **Documentation**
  * Added a PR review note for PR-1304 with fixed-in-commit mapping and updated the backlog entry to mark PR-1304 as in progress.
* **Tests**
  * Added/updated tests to verify the profile links and to validate the canonical /terms response payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->