### PR TITLE
fix(security): triage CVE-2026-4046 glibc alerts

### DIFF
--- a/docs/review/PR_1305_FIXED_MAPPING.md
+++ b/docs/review/PR_1305_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: de8b7a36
+Evidence: trivy/ignore-policy.rego:36
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1305#discussion_r3030302201 -> de8b7a36
 
 ## Merge Readiness
 - [ ] Local verification completed

--- a/docs/review/PR_1305_FIXED_MAPPING.md
+++ b/docs/review/PR_1305_FIXED_MAPPING.md
@@ -1,14 +1,14 @@
 # PR 1305 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass completed
+- [ ] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 - No actionable review comments
 
 ## Merge Readiness
-- [x] Local verification completed
+- [ ] Local verification completed
 - [ ] Current-head CI green
 - [ ] No unresolved review threads
 - [ ] Dependency lane merged

--- a/docs/review/PR_1305_FIXED_MAPPING.md
+++ b/docs/review/PR_1305_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1305 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [x] Local verification completed
+- [ ] Current-head CI green
+- [ ] No unresolved review threads
+- [ ] Dependency lane merged

--- a/docs/review/PR_1305_FIXED_MAPPING.md
+++ b/docs/review/PR_1305_FIXED_MAPPING.md
@@ -1,7 +1,7 @@
 # PR 1305 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
@@ -9,6 +9,12 @@ Disposition: FIXED
 Commit: de8b7a36
 Evidence: trivy/ignore-policy.rego:36
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1305#discussion_r3030302201 -> de8b7a36
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1305#pullrequestreview-4053137261 -> de8b7a36
+
+Disposition: NOT-A-BUG
+Evidence: docs/security/CVE-2026-4046-glibc.md:70; docs/roadmap/BACKLOG_LEDGER.md:2511
+Reason: The ledger evidence anchor exists in the updated lane, and the explicit two-package `PkgID` checks intentionally keep the suppression scoped to the exact observed `libc6` and `libc-bin` alerts.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1305#pullrequestreview-4053135922
 
 ## Merge Readiness
 - [ ] Local verification completed

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2511,7 +2511,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] Triage open Trivy glibc code-scanning alerts (CVE-2026-4046)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-SECURITY-CVE-2026-4046
+  - Target PR: PR #1305
   - Area: security / base-image / code-scanning
   - Finding Type: container base image vulnerability
   - Reason: GitHub code scanning on `main` currently reports open Trivy alerts `#579` (`libc-bin`) and `#580` (`libc6`) for `CVE-2026-4046` at version `2.36-9+deb12u13` with no fixed version published in Trivy metadata as of 2026-04-02. This CVE must stay on a single canonical tracker and be triaged in a dedicated security lane rather than being absorbed into the billing activation/persistence closeout.

--- a/docs/security/CVE-2026-4046-glibc.md
+++ b/docs/security/CVE-2026-4046-glibc.md
@@ -1,0 +1,82 @@
+# CVE-2026-4046 — glibc family (Debian bookworm) — Trivy code scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2026-4046
+- **Source package**: `glibc`
+- **Affected binary packages in our alert set**:
+  - `libc6`
+  - `libc-bin`
+- **Observed installed version**: `2.36-9+deb12u13`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: High
+- **GitHub alerts**: `#579`, `#580`
+
+Trivy reports this finding against OS packages inherited from the Debian
+bookworm base image used in our image-scanning lanes. At triage time, the alert
+payload and Debian tracker indicate there is no repo-local package upgrade or
+application-code remediation we can ship from this repository alone.
+
+## Why we suppress (temporarily)
+
+- This is an **OS package** CVE in the distro base image, not an application
+  dependency owned by this repository.
+- GitHub code-scanning currently reports an empty `Fixed Version` for both
+  open alerts on `main`.
+- The affected package/version tuple is stable and narrow enough to suppress
+  without masking unrelated future `glibc` findings.
+
+We therefore apply a narrow suppression scoped to:
+
+- `CVE-2026-4046`
+- packages `libc6` and `libc-bin`
+- exact observed installed version `2.36-9+deb12u13`
+- exact `PkgID` prefixes matching the observed alerts
+
+## Observed alert evidence
+
+Exact package/version evidence came from GitHub code-scanning alerts on `main`:
+
+```text
+$ gh api "repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts" --jq '.[] | select(.number == 579 or .number == 580) | [.number, .most_recent_instance.message.text] | @tsv'
+580  Package: libc6\nInstalled Version: 2.36-9+deb12u13\nVulnerability CVE-2026-4046\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-4046](https://avd.aquasec.com/nvd/cve-2026-4046)
+579  Package: libc-bin\nInstalled Version: 2.36-9+deb12u13\nVulnerability CVE-2026-4046\nSeverity: HIGH\nFixed Version: \nLink: [CVE-2026-4046](https://avd.aquasec.com/nvd/cve-2026-4046)
+```
+
+That observed payload is why the policy rule is restricted to
+`InstalledVersion == "2.36-9+deb12u13"` and matching `PkgID` prefixes only.
+
+## Monitor / upstream status
+
+- **Debian Security Tracker**: <https://security-tracker.debian.org/tracker/CVE-2026-4046>
+- **NVD / Aqua mirror**: <https://avd.aquasec.com/nvd/cve-2026-4046>
+
+## Removal condition
+
+Remove this suppression when either:
+
+1. Debian bookworm publishes a fixed `glibc` package line for
+   `CVE-2026-4046`, or
+2. Trivy metadata starts reporting a non-empty `Fixed Version` for these alerts
+   in our base-image context.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Evidence anchors:
+  - `trivy/ignore-policy.rego:14`
+  - `trivy/ignore-policy.rego:30`
+  - `trivy/ignore-policy.rego:39`
+  - `docs/roadmap/BACKLOG_LEDGER.md:2511`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-4046"`
+  - `input.PkgName in {"libc6", "libc-bin"}`
+  - `cve_2026_4046_version := "2.36-9+deb12u13"`
+  - `input.InstalledVersion == cve_2026_4046_version`
+  - `input.PkgID` starts with either
+    `libc6@${cve_2026_4046_version}` or
+    `libc-bin@${cve_2026_4046_version}`
+
+## Review / expiry
+
+- **Review-by**: 2026-05-27 (shared policy-file expiry window)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -10,8 +10,8 @@ default ignore := false
 # - CI enforces a single file-level expiry (exactly one "Suppression expires: YYYY-MM-DD" per policy file)
 #
 # Suppression expires: 2026-05-27 (manual removal)
-# Last reviewed: 2026-03-30
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md
+# Last reviewed: 2026-04-02
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2026-4046-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -25,6 +25,39 @@ ignore if {
 	input.PkgName == "libc-bin"
 	input.InstalledVersion == "2.36-9+deb12u13"
 	startswith(input.PkgID, "libc-bin@2.36-9+deb12u13")
+}
+
+# CVE-2026-4046 (glibc) - upstream unfixed in Debian bookworm at triage time
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Trivy code-scanning alerts on main report empty Fixed Version for libc6/libc-bin in the
+#   Debian bookworm base image; repo code cannot patch glibc in the upstream image layer
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-4046
+# Documented in: docs/security/CVE-2026-4046-glibc.md
+
+cve_2026_4046_version := "2.36-9+deb12u13"
+
+cve_2026_4046_pkg_match if {
+	glibc_pkgs := {"libc6", "libc-bin"}
+	glibc_pkgs[input.PkgName]
+}
+
+cve_2026_4046_version_match if {
+	input.InstalledVersion == cve_2026_4046_version
+}
+
+cve_2026_4046_pkgid_match if {
+	startswith(input.PkgID, sprintf("libc6@%s", [cve_2026_4046_version]))
+}
+
+cve_2026_4046_pkgid_match if {
+	startswith(input.PkgID, sprintf("libc-bin@%s", [cve_2026_4046_version]))
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-4046"
+	cve_2026_4046_pkg_match
+	cve_2026_4046_version_match
+	cve_2026_4046_pkgid_match
 }
 
 # CVE-2025-15281 (glibc) - upstream unfixed in GitHub runner base image

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -33,6 +33,7 @@ ignore if {
 #   Debian bookworm base image; repo code cannot patch glibc in the upstream image layer
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-4046
 # Documented in: docs/security/CVE-2026-4046-glibc.md
+# Removal condition: Remove when Debian bookworm publishes a fixed glibc package line or Trivy metadata includes Fixed Version
 
 cve_2026_4046_version := "2.36-9+deb12u13"
 


### PR DESCRIPTION
## Summary
- add a narrow `trivy/ignore-policy.rego` suppression for open `CVE-2026-4046` alerts on `libc6` and `libc-bin`
- document the evidence, upstream tracker, and removal condition in `docs/security/CVE-2026-4046-glibc.md`
- keep the triage in a dedicated security lane so dependency/release work stays separate

## Test plan
- [x] `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-4046-glibc.md`
- [x] `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1305_FIXED_MAPPING.md`

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-nightly-full-tests-node22-parity`

## Merge Readiness
- [x] Local verification completed
- [ ] Current-head CI green
- [ ] No unresolved review threads
- [ ] Dependency lane merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security documentation for CVE-2026-4046 affecting glibc on Debian bookworm, including suppression scope, matching criteria, tracking links, and expiry/removal conditions.
  * Recorded review status and evidence for the suppression decision.

* **Chores**
  * Updated backlog entry to reference PR 1305 and added a review record documenting the decision and mapping to the implemented suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->