### PR TITLE
docs(ios): define App Store subscription offers governance and StoreKit-truth pricing contract

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -264,7 +264,7 @@
         "filename": "docs/MOBILE_API_MIGRATION_GUIDE.md",
         "hashed_secret": "c255aae88c50a9cde62e5cb95bd49d99f4e15088",
         "is_verified": false,
-        "line_number": 450
+        "line_number": 462
       }
     ],
     "fix_coverage_tests.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-02T22:15:27Z"
+  "generated_at": "2026-04-03T07:47:50Z"
 }

--- a/docs/MOBILE_API_MIGRATION_GUIDE.md
+++ b/docs/MOBILE_API_MIGRATION_GUIDE.md
@@ -10,6 +10,18 @@
 
 PulsePlate API has been consolidated into a clean, tiered structure optimized for mobile app integration with subscription-based access levels.
 
+### StoreKit copy contract for mobile consumers
+
+For iOS subscription surfaces, price / trial duration / eligibility messaging
+must come from StoreKit / App Store truth rather than manual UI copy.
+
+- Canonical governance source:
+  `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`
+- Mobile consumers may render live StoreKit fields when available.
+- If live truth is unavailable, mobile copy must use non-assertive fallback
+  wording rather than numeric price claims, exact trial-length claims, or
+  definite eligibility claims.
+
 ### What Changed
 
 **Before** (Legacy):

--- a/docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md
+++ b/docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md
@@ -19,6 +19,27 @@ It defines:
 - the validation rules that prevent client-side drift,
 - the copy contract for price / trial duration / eligibility messaging.
 
+## Definition: StoreKit / App Store truth
+
+For this contract, `StoreKit / App Store truth` means the currently effective
+subscription product and offer information exposed by Apple's App Store Connect
+configuration and the corresponding StoreKit runtime surface available to the
+app for the current storefront, region, and account context.
+
+In-scope truth sources:
+
+- canonical product and offer configuration maintained in App Store Connect
+- StoreKit-returned product, subscription, and offer fields visible to runtime
+- storefront- or region-specific availability and pricing exposed by that live
+  Apple surface
+
+Out-of-scope substitutes:
+
+- manually authored UI copy
+- cached or stale screenshots used as pricing evidence
+- product-marketing text that asserts price, trial, or eligibility without
+  current StoreKit / App Store confirmation
+
 ## Canonical products
 
 | product_id | tier | billing_interval | product_family | status | notes |
@@ -86,7 +107,10 @@ When live StoreKit / App Store truth is unavailable:
    - `See the App Store for current pricing`
    - `Trial availability may vary`
    - `Eligibility is determined by Apple / the App Store`
-3. Forbidden claims while live truth is unavailable:
+3. Localized currencies, regional offer differences, and country-specific
+   availability must not be restated as manual assertions when live truth is
+   unavailable; those surfaces must defer to the App Store.
+4. Forbidden claims while live truth is unavailable:
    - numeric price claims
    - exact trial-length claims
    - definite eligibility claims

--- a/docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md
+++ b/docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md
@@ -12,9 +12,12 @@ canonical product IDs.
 It defines:
 
 - the exact StoreKit / App Store Connect `product_id` values allowed in runtime,
+- the canonical App Store subscription offer surfaces governed by the same
+  StoreKit / App Store truth,
 - the backend entitlement tier mapping associated with each product,
 - the setup baseline for App Store Connect, sandbox, and TestFlight checks,
-- the validation rules that prevent client-side drift.
+- the validation rules that prevent client-side drift,
+- the copy contract for price / trial duration / eligibility messaging.
 
 ## Canonical products
 
@@ -41,6 +44,52 @@ It defines:
 7. If StoreKit returns a subset of canonical products, paywall may render only
    that approved subset and must not invent placeholders or fallback plans.
 8. Unknown StoreKit products must be ignored by runtime.
+
+## App Store subscription offers governance
+
+This document is also the canonical repository-owned source of truth for the
+subscription-offer surfaces tied to the canonical StoreKit catalog.
+
+Governed offer surfaces:
+
+- introductory offers
+- offer codes
+- promotional offers
+- win-back pricing
+
+Governance rules:
+
+1. These offer surfaces are governed by App Store Connect configuration plus
+   StoreKit runtime truth; they are not governed by ad hoc marketing copy.
+2. UI and release copy must not hardcode subscription price, trial duration, or
+   eligibility assertions outside StoreKit / App Store truth.
+3. Runtime and release-facing copy may only describe an offer when the current
+   StoreKit / App Store surface supports that description.
+4. Ownership boundary: this contract owns StoreKit/App Store offers governance;
+   payments contracts own receipt/activation routing, and asset/release lanes
+   own screenshots, metadata packaging, and submission execution.
+5. Future App Store submission, TestFlight, and billing follow-through docs must
+   link back to this contract instead of redefining offer governance elsewhere.
+
+## Copy fallback rules
+
+When live StoreKit / App Store truth is available:
+
+1. UI and release copy must reflect that truth and must not contradict it.
+2. Price, trial duration, and eligibility messaging must be derived from the
+   live StoreKit / App Store surface rather than manually asserted text.
+
+When live StoreKit / App Store truth is unavailable:
+
+1. Only non-assertive fallback wording is allowed.
+2. Approved examples:
+   - `See the App Store for current pricing`
+   - `Trial availability may vary`
+   - `Eligibility is determined by Apple / the App Store`
+3. Forbidden claims while live truth is unavailable:
+   - numeric price claims
+   - exact trial-length claims
+   - definite eligibility claims
 
 ## Setup baseline
 
@@ -104,6 +153,10 @@ instead of creating a parallel setup document.
   `ios/PulsePlate/Models/StoreKitProductCatalog.swift`.
 - `docs/IOS_API_INTEGRATION.md` points future operational/setup work back to
   this checklist instead of duplicating StoreKit setup truth elsewhere.
+- `docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md`,
+  `docs/MOBILE_API_MIGRATION_GUIDE.md`, and
+  `docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md` must treat this file as the
+  canonical offers-governance source for price / trial / eligibility copy.
 - Batch-B planning docs (`docs/roadmap/BACKLOG_LEDGER.md`,
   `docs/roadmap/PulsePlate_Master_Index_A-E.md`) treat the baseline as closed
   and point future release/setup work to this contract.
@@ -135,6 +188,5 @@ This contract does not govern:
 - backend entitlement truth,
 - receipt verification or activation routing,
 - Keychain or mobile secret storage,
-- pricing / trial / eligibility governance,
 - App Store screenshots, metadata, or asset rollout,
 - the actual submission/release decision for a future App Store build.

--- a/docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
+++ b/docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md
@@ -219,3 +219,14 @@ Required runtime PR gates:
 B1 scope: canonical sources, activation contract, reconciliation lifecycle, webhook signature contract, additive billing surface.
 
 **Non-goals (do not mix into B1):** Stripe/PayPal, Android billing, paywall UI redesign, StoreKit product IDs, iOS SubscriptionManager, OpenAPI namespace cleanup, AI/RAG/GTM scope.
+
+## 14. StoreKit offers governance pointer
+
+App Store subscription offers governance is not owned by this payments baseline.
+
+- Canonical source: `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`
+- Governed there: introductory offers, offer codes, promotional offers,
+  win-back pricing, and the copy contract for price / trial duration /
+  eligibility messaging
+- This document remains limited to payment-source normalization, receipt
+  verification, activation routing, and reconciliation truth

--- a/docs/review/PR_1312_FIXED_MAPPING.md
+++ b/docs/review/PR_1312_FIXED_MAPPING.md
@@ -5,7 +5,15 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 0c5a042f
+Evidence: `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md:22`, `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md:103`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1312#pullrequestreview-4054716735 -> 0c5a042f
+
+Disposition: NOT-A-BUG
+Evidence: cubic review `#pullrequestreview-4054726487` explicitly reports `No issues found` across the reviewed files.
+Reason: Informational pass-only review; no code or docs change was requested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1312#pullrequestreview-4054726487
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1312_FIXED_MAPPING.md
+++ b/docs/review/PR_1312_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR 1312 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -882,7 +882,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: App Store subscription offers governance and StoreKit-truth pricing contract
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-IOS-SUBSCRIPTION-OFFERS-GOVERNANCE
+  - Target PR: PR #1312
   - Status: 📋 Planned
   - Area: iOS / billing / App Store / growth
   - Finding Type: release-governance gap

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -888,6 +888,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Finding Type: release-governance gap
   - Reason (EN): App Store Connect introductory offers, offer codes, promotional offers, and win-back pricing are operationally separate from in-app UI, but the repo does not yet have a canonical contract that says pricing, trial duration, and eligibility copy must be StoreKit-truth rather than manually inferred in product copy.
   - Links:
+    - `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`
     - `docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md`
     - `docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md`
     - `docs/MOBILE_API_MIGRATION_GUIDE.md`

--- a/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
+++ b/docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md
@@ -101,6 +101,16 @@ This is the canonical mapping format for turning backend capability into a **shi
 - **Forbidden:** treat `GET /api/nutrition/{date}` legacy alias as iOS source-of-truth (deprecated; guard/contract drift risk).
 - **Tracking:** `docs/roadmap/BACKLOG_LEDGER.md` (entry marked ✅ merged; follow-ups remain separate), plus P0 security item for alias guard enforcement.
 
+#### Slice P3) App Store offers governance (docs-only prerequisite)
+
+- **Status:** next docs-only Wave 4 lane
+- **Canonical SoT:** `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md`
+- **Goal:** keep App Store Connect / StoreKit offer surfaces plus price / trial /
+  eligibility copy under one repository-owned governance source.
+- **Release follow-through rule:** future iOS / TestFlight / App Store release
+  lanes must reference that StoreKit contract instead of redefining pricing,
+  offer, or eligibility policy in parallel docs.
+
 #### Slice V1) Plan / Weekly plan reader (if backend supports)
 
 - **Goal:** show the plan in a “trustworthy Apple-native” way (loading/error/empty states).


### PR DESCRIPTION
## Summary

Make `docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md` the canonical repository-owned source of truth for App Store subscription offers governance and StoreKit-truth pricing / trial / eligibility copy.

## Scope
- resolve the internal contradiction in the StoreKit contract
- define governance for introductory offers, offer codes, promotional offers, and win-back pricing
- align billing, mobile migration, and iOS roadmap docs as consumers of the same SoT
- keep the PR strictly docs-only

## Non-goals
- no iOS runtime or backend billing changes
- no App Store assets rollout
- no semantic validators
- no Apple Server API migration
- no paywall redesign

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/contracts/IOS_STOREKIT_PRODUCTS_CONTRACT.md docs/contracts/PAYMENTS_RU_BY_IOS_BASELINE.md docs/MOBILE_API_MIGRATION_GUIDE.md docs/roadmap/IOS_BACKEND_REALIZATION_ROADMAP.md docs/roadmap/BACKLOG_LEDGER.md`
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1312_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Mandatory wait-window completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Established a canonical governance for iOS App Store subscription offers and StoreKit-derived pricing/trial/eligibility copy.
  * Added explicit copy-fallback rules requiring non-assertive wording when live StoreKit truth is unavailable.
  * Clarified ownership boundaries and added cross-references from payments baseline and roadmap/backlog entries.
  * Added a review status/checklist document capturing review disposition and merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->