### PR TITLE
fix(orchestration): relax advisory fallback for non-required lanes

### DIFF
--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -61,6 +61,10 @@ Underlying enforcement scripts remain canonical for their own domains:
 Raw `gh pr checks` output remains diagnostic only because it can include
 superseded historical failures after the latest PR head is already clean. The
 wrapper is the canonical filtered current-head view.
+When branch-protection metadata is unavailable, the current-head filter blocks
+only on canonical `CI` workflow `check_run` entries; specialized lanes such as
+Docker/image, optional CI, iOS, and release-ops workflows remain visible but
+advisory.
 
 ---
 

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -62,9 +62,9 @@ Raw `gh pr checks` output remains diagnostic only because it can include
 superseded historical failures after the latest PR head is already clean. The
 wrapper is the canonical filtered current-head view.
 When branch-protection metadata is unavailable, the current-head filter blocks
-only on canonical `CI` workflow `check_run` entries; specialized lanes such as
-Docker/image, optional CI, iOS, and release-ops workflows remain visible but
-advisory.
+only on canonical ordinary-PR `CI` signals and the aggregate `StatusContext`
+named `CI`; specialized lanes such as Docker/image, optional CI, iOS, and
+release-ops workflows remain visible but advisory.
 
 ---
 

--- a/docs/review/PR_1315_FIXED_MAPPING.md
+++ b/docs/review/PR_1315_FIXED_MAPPING.md
@@ -1,0 +1,25 @@
+# PR 1315 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:84`, `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:86`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:204`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:205`
+Reason: PR `#1315` intentionally stays in draft while the coordinator cycle is still reconciling artifact, review, and local-gate state. The CodeRabbit skip note is an expected draft-phase automation status, not a code or governance defect in this lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#issuecomment-4183256082
+
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:15`, `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:17`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:202`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:205`
+Reason: The Sourcery issue comment is an auto-generated reviewer guide that summarizes the change surface, but it does not raise a concrete actionable defect. Governance blocks actionable bot findings, not descriptive review-guide output.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#issuecomment-4183258209
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+- Scope: narrow tooling/governance lane for PR `#1315` only. This PR fixes fallback semantics in `check_current_head_pr_checks.py` and keeps wrapper/release/front-end/iOS surfaces out of scope.

--- a/docs/review/PR_1315_FIXED_MAPPING.md
+++ b/docs/review/PR_1315_FIXED_MAPPING.md
@@ -20,12 +20,20 @@ Commit: 1942e483
 Evidence: `scripts/ci/check_current_head_pr_checks.py:32`, `scripts/ci/check_current_head_pr_checks.py:326`, `tests/test_current_head_pr_checks.py:492`
 Reason: The actionable testing gap from Sourcery is fixed by adding the missing `mergeStateStatus="CLEAN"` fallback failure coverage, and the hard-coded aggregate status-context literal is now centralized behind a named fallback constant to reduce local drift in the same lane.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055620911
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#discussion_r3032774608
 
 Disposition: FIXED
 Commit: 1beb3d55
 Evidence: `scripts/ci/check_current_head_pr_checks.py:334`, `scripts/ci/check_current_head_pr_checks.py:446`, `tests/test_current_head_pr_checks.py:42`, `tests/test_current_head_pr_checks.py:429`
 Reason: The latest CodeRabbit review is addressed by adding a workflow drift-guard test for the canonical fallback allowlist and by splitting fallback-blocking output from purely advisory output so merge triage text is no longer contradictory.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055652830
+
+Disposition: FIXED
+Commit: c114dfbb
+Evidence: `scripts/ci/check_current_head_pr_checks.py:33`, `tests/test_current_head_pr_checks.py:65`, `tests/test_current_head_pr_checks.py:69`
+Reason: The follow-up CodeRabbit thread is fixed with a post-review commit that locks the matrix-expanded `test-pr (3.13)` display name and asserts the frontend-only `build-and-test` job never appears in the canonical fallback allowlist, so future workflow drift cannot silently reintroduce the mismatch.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055668571
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#discussion_r3032821618
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1315_FIXED_MAPPING.md
+++ b/docs/review/PR_1315_FIXED_MAPPING.md
@@ -15,6 +15,12 @@ Evidence: `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:15`, `docs/or
 Reason: The Sourcery issue comment is an auto-generated reviewer guide that summarizes the change surface, but it does not raise a concrete actionable defect. Governance blocks actionable bot findings, not descriptive review-guide output.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#issuecomment-4183258209
 
+Disposition: FIXED
+Commit: `1942e483`
+Evidence: `scripts/ci/check_current_head_pr_checks.py:32`, `scripts/ci/check_current_head_pr_checks.py:326`, `tests/test_current_head_pr_checks.py:492`
+Reason: The actionable testing gap from Sourcery is fixed by adding the missing `mergeStateStatus="CLEAN"` fallback failure coverage, and the hard-coded aggregate status-context literal is now centralized behind a named fallback constant to reduce local drift in the same lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055620911
+
 ## Merge Readiness
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)

--- a/docs/review/PR_1315_FIXED_MAPPING.md
+++ b/docs/review/PR_1315_FIXED_MAPPING.md
@@ -16,10 +16,16 @@ Reason: The Sourcery issue comment is an auto-generated reviewer guide that summ
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#issuecomment-4183258209
 
 Disposition: FIXED
-Commit: `1942e483`
+Commit: 1942e483
 Evidence: `scripts/ci/check_current_head_pr_checks.py:32`, `scripts/ci/check_current_head_pr_checks.py:326`, `tests/test_current_head_pr_checks.py:492`
 Reason: The actionable testing gap from Sourcery is fixed by adding the missing `mergeStateStatus="CLEAN"` fallback failure coverage, and the hard-coded aggregate status-context literal is now centralized behind a named fallback constant to reduce local drift in the same lane.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055620911
+
+Disposition: FIXED
+Commit: 1beb3d55
+Evidence: `scripts/ci/check_current_head_pr_checks.py:334`, `scripts/ci/check_current_head_pr_checks.py:446`, `tests/test_current_head_pr_checks.py:42`, `tests/test_current_head_pr_checks.py:429`
+Reason: The latest CodeRabbit review is addressed by adding a workflow drift-guard test for the canonical fallback allowlist and by splitting fallback-blocking output from purely advisory output so merge triage text is no longer contradictory.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#pullrequestreview-4055652830
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1315_FIXED_MAPPING.md
+++ b/docs/review/PR_1315_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 ## Fixed in Commit Mapping
 Disposition: NOT-A-BUG
 Evidence: `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:84`, `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md:86`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:204`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:205`
-Reason: PR `#1315` intentionally stays in draft while the coordinator cycle is still reconciling artifact, review, and local-gate state. The CodeRabbit skip note is an expected draft-phase automation status, not a code or governance defect in this lane.
+Reason: The CodeRabbit skip note was emitted during the earlier draft-phase review cycle and is a historical automation status, not a code or governance defect in this lane.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1315#issuecomment-4183256082
 
 Disposition: NOT-A-BUG

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -33,7 +33,6 @@ CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES = {"CI"}
 CANONICAL_FALLBACK_CI_CHECK_NAMES = {
     "Determine changed paths (for conditional jobs)",
     "pr_scope_guard",
-    "build-and-test",
     "Trivy ignore-policy expiry",
     "Pygments exception seam guard",
     "Docs Phase1 gates",
@@ -42,7 +41,6 @@ CANONICAL_FALLBACK_CI_CHECK_NAMES = {
     "lint",
     "security",
     "OpenAPI sync (backend -> frontend artifacts)",
-    "test-pr",
     "test-pr (3.13)",
     "coverage-pr",
     "diff-coverage",
@@ -331,6 +329,25 @@ def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
     )
 
 
+def _partition_fallback_advisory_entries(
+    entries: list[CheckEntry],
+) -> tuple[list[CheckEntry], list[CheckEntry]]:
+    """Split fallback-blocking entries from advisory-only entries.
+
+    RU: В fallback-режиме часть advisory-проверок все еще блокирует merge.
+    EN: In fallback mode, some advisory checks still remain merge-blocking.
+    """
+
+    blocking_entries: list[CheckEntry] = []
+    advisory_only_entries: list[CheckEntry] = []
+    for entry in entries:
+        if _is_blocking_fallback_advisory(entry):
+            blocking_entries.append(entry)
+        else:
+            advisory_only_entries.append(entry)
+    return blocking_entries, advisory_only_entries
+
+
 def _suppress_stale_latest_entries_with_newer_workflow_activity(
     entries: list[CheckEntry],
     latest: dict[str, CheckEntry],
@@ -438,15 +455,22 @@ def main(argv: list[str] | None = None) -> int:
         _required_snapshot(latest, required_names) if required_metadata_available else []
     )
     advisory_entries = list(latest.values()) if not required_metadata_available else []
+    advisory_blocking_entries: list[CheckEntry] = []
     _print_entries("Current-head required checks:", current_required)
 
     if not required_metadata_available:
+        advisory_blocking_entries, advisory_entries = _partition_fallback_advisory_entries(
+            advisory_entries
+        )
         print(
             "Required check metadata unavailable; merge gating falls back to GitHub "
             "mergeStateStatus. Current-head checks stay advisory unless a canonical "
             "ordinary-PR CI signal remains pending or failed."
         )
-        _print_entries("Current-head advisory checks:", advisory_entries)
+        if advisory_blocking_entries:
+            _print_entries("Current-head blocking fallback checks:", advisory_blocking_entries)
+        if advisory_entries:
+            _print_entries("Current-head advisory checks:", advisory_entries)
 
     noisy_superseded = [entry for entry in superseded if entry.state != "passed"]
     if noisy_superseded:
@@ -457,9 +481,6 @@ def main(argv: list[str] | None = None) -> int:
     blocking_entries = [entry for entry in current_required if entry.state in {"pending", "failed"}]
     # RU: В fallback-режиме без metadata блокирует только канонический workflow CI.
     # EN: In metadata-unavailable fallback, only the canonical CI workflow remains blocking.
-    advisory_blocking_entries = [
-        entry for entry in advisory_entries if _is_blocking_fallback_advisory(entry)
-    ]
     merge_state_note_needed = not required_metadata_available and merge_state != "CLEAN"
     if blocking_entries or advisory_blocking_entries:
         print("ERROR: current-head check filter failed.")

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -29,6 +29,7 @@ class CheckEntry:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PENDING_STATUS_CONTEXT_STATES = {"EXPECTED", "PENDING"}
+CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES = {"CI"}
 CANONICAL_FALLBACK_CI_CHECK_NAMES = {
     "Determine changed paths (for conditional jobs)",
     "pr_scope_guard",
@@ -322,7 +323,7 @@ def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
     if entry.state not in {"pending", "failed"}:
         return False
     if entry.source_kind == "status_context":
-        return entry.name == "CI"
+        return entry.name in CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES
     return (
         entry.source_kind == "check_run"
         and entry.workflow_name == "CI"

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -30,6 +30,8 @@ class CheckEntry:
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PENDING_STATUS_CONTEXT_STATES = {"EXPECTED", "PENDING"}
 CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES = {"CI"}
+# Keep this list aligned to the GitHub check-run display names emitted by the
+# canonical `.github/workflows/ci.yml` workflow, including matrix suffixes.
 CANONICAL_FALLBACK_CI_CHECK_NAMES = {
     "Determine changed paths (for conditional jobs)",
     "pr_scope_guard",

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -29,6 +29,23 @@ class CheckEntry:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PENDING_STATUS_CONTEXT_STATES = {"EXPECTED", "PENDING"}
+CANONICAL_FALLBACK_CI_CHECK_NAMES = {
+    "Determine changed paths (for conditional jobs)",
+    "pr_scope_guard",
+    "build-and-test",
+    "Trivy ignore-policy expiry",
+    "Pygments exception seam guard",
+    "Docs Phase1 gates",
+    "PR Body Phase2 gates",
+    "Merge readiness gate",
+    "lint",
+    "security",
+    "OpenAPI sync (backend -> frontend artifacts)",
+    "test-pr",
+    "test-pr (3.13)",
+    "coverage-pr",
+    "diff-coverage",
+}
 
 
 def _github_token() -> str:
@@ -302,10 +319,14 @@ def _required_snapshot(
 
 def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
     """Return whether fallback merge gating must still block on this advisory entry."""
+    if entry.state not in {"pending", "failed"}:
+        return False
+    if entry.source_kind == "status_context":
+        return entry.name == "CI"
     return (
         entry.source_kind == "check_run"
         and entry.workflow_name == "CI"
-        and entry.state in {"pending", "failed"}
+        and entry.name in CANONICAL_FALLBACK_CI_CHECK_NAMES
     )
 
 
@@ -422,7 +443,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Required check metadata unavailable; merge gating falls back to GitHub "
             "mergeStateStatus. Current-head checks stay advisory unless a canonical "
-            "CI workflow check remains pending or failed."
+            "ordinary-PR CI signal remains pending or failed."
         )
         _print_entries("Current-head advisory checks:", advisory_entries)
 

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -300,6 +300,15 @@ def _required_snapshot(
     return snapshot
 
 
+def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
+    """Return whether fallback merge gating must still block on this advisory entry."""
+    return (
+        entry.source_kind == "check_run"
+        and entry.workflow_name == "CI"
+        and entry.state in {"pending", "failed"}
+    )
+
+
 def _suppress_stale_latest_entries_with_newer_workflow_activity(
     entries: list[CheckEntry],
     latest: dict[str, CheckEntry],
@@ -412,7 +421,8 @@ def main(argv: list[str] | None = None) -> int:
     if not required_metadata_available:
         print(
             "Required check metadata unavailable; merge gating falls back to GitHub "
-            "mergeStateStatus and reports current-head checks as advisory only."
+            "mergeStateStatus. Current-head checks stay advisory unless a canonical "
+            "CI workflow check remains pending or failed."
         )
         _print_entries("Current-head advisory checks:", advisory_entries)
 
@@ -423,8 +433,10 @@ def main(argv: list[str] | None = None) -> int:
             print(_format_entry(entry))
 
     blocking_entries = [entry for entry in current_required if entry.state in {"pending", "failed"}]
+    # RU: В fallback-режиме без metadata блокирует только канонический workflow CI.
+    # EN: In metadata-unavailable fallback, only the canonical CI workflow remains blocking.
     advisory_blocking_entries = [
-        entry for entry in advisory_entries if entry.state in {"pending", "failed"}
+        entry for entry in advisory_entries if _is_blocking_fallback_advisory(entry)
     ]
     merge_state_note_needed = not required_metadata_available and merge_state != "CLEAN"
     if blocking_entries or advisory_blocking_entries:
@@ -434,9 +446,7 @@ def main(argv: list[str] | None = None) -> int:
         if blocking_entries:
             print("- Blocking current-head checks remain pending or failed.")
         if advisory_blocking_entries:
-            # RU: Без branch protection опираемся на актуальные advisory checks.
-            # EN: Without branch protection metadata, the latest advisory checks are the fallback truth.
-            print("- Blocking advisory current-head checks remain pending or failed.")
+            print("- Blocking canonical fallback current-head checks remain pending or failed.")
         return 1
 
     if merge_state_note_needed:

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -489,6 +489,47 @@ def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_i
     )
 
 
+def test_main_fails_when_merge_state_is_clean_and_canonical_fallback_check_is_pending(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "CLEAN",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "Docs Phase1 gates",
+                    "status": "IN_PROGRESS",
+                    "conclusion": None,
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": None,
+                    "detailsUrl": "https://example.invalid/pending-ci-docs-clean",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), False)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "GitHub mergeStateStatus=CLEAN" not in captured.out
+    assert (
+        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
+    )
+
+
 def test_main_passes_when_required_check_set_is_empty_but_available(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -1,8 +1,65 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scripts.ci import check_current_head_pr_checks as current_head_checks
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_FALLBACK_JOB_IDS = {
+    "changes",
+    "pr_scope_guard",
+    "trivy_ignore_policy_expiry",
+    "pygments_exception_guard",
+    "docs_phase1_gates",
+    "pr_body_phase2_gates",
+    "merge_readiness_gate",
+    "lint",
+    "security",
+    "openapi-sync",
+    "test-pr",
+    "coverage-pr",
+    "diff-coverage",
+}
+ADVISORY_PULL_REQUEST_JOB_IDS = {
+    "test-main",
+    "test-feature",
+    "coverage-feature",
+    "coverage-main",
+    "ios-tests",
+    "ios-ui-smoke",
+}
+
+
+def _load_ci_workflow_jobs() -> dict[str, dict[str, object]]:
+    import yaml
+
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _job_display_name(job_id: str, definition: dict[str, object]) -> str:
+    name = str(definition.get("name") or job_id)
+    matrix = (definition.get("strategy") or {}).get("matrix") or {}
+    python_versions = matrix.get("python-version")
+    if job_id == "test-pr" and python_versions == ["3.13"]:
+        return f"{name} (3.13)"
+    return name
+
+
+def test_fallback_ci_allowlist_matches_ci_workflow() -> None:
+    jobs = _load_ci_workflow_jobs()
+    classified_job_ids = CANONICAL_FALLBACK_JOB_IDS | ADVISORY_PULL_REQUEST_JOB_IDS
+
+    assert set(jobs) == classified_job_ids
+    expected_display_names = {
+        _job_display_name(job_id, jobs[job_id]) for job_id in CANONICAL_FALLBACK_JOB_IDS
+    }
+
+    assert current_head_checks.CANONICAL_FALLBACK_CI_CHECK_NAMES == expected_display_names
 
 
 @pytest.mark.parametrize(
@@ -22,7 +79,7 @@ from scripts.ci import check_current_head_pr_checks as current_head_checks
         ),
         (
             current_head_checks.CheckEntry(
-                name="build-and-test",
+                name="coverage-pr",
                 source_kind="check_run",
                 state="failed",
                 timestamp="2026-03-12T08:36:42Z",
@@ -406,6 +463,7 @@ def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_chec
     assert "Required check metadata unavailable" in captured.out
     assert "Current-head advisory checks:" in captured.out
     assert "- security-scan: pending [Docker Build and Push]" in captured.out
+    assert "Current-head blocking fallback checks:" not in captured.out
     assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
 
 
@@ -445,6 +503,7 @@ def test_main_passes_when_specialized_ci_job_is_pending_in_fallback_mode(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "- iOS unit tests (xcodebuild): pending [CI]" in captured.out
+    assert "Current-head blocking fallback checks:" not in captured.out
     assert "current-head-checks: passed." in captured.out
 
 
@@ -484,6 +543,8 @@ def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_i
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "GitHub mergeStateStatus=UNSTABLE" in captured.out
+    assert "Current-head blocking fallback checks:" in captured.out
+    assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
         "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
     )
@@ -525,6 +586,8 @@ def test_main_fails_when_merge_state_is_clean_and_canonical_fallback_check_is_pe
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "GitHub mergeStateStatus=CLEAN" not in captured.out
+    assert "Current-head blocking fallback checks:" in captured.out
+    assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
         "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
     )

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -66,6 +66,18 @@ from scripts.ci import check_current_head_pr_checks as current_head_checks
                 workflow_name="",
                 conclusion="",
             ),
+            True,
+        ),
+        (
+            current_head_checks.CheckEntry(
+                name="iOS unit tests (xcodebuild)",
+                source_kind="check_run",
+                state="pending",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/ios-pending",
+                workflow_name="CI",
+                conclusion="",
+            ),
             False,
         ),
     ],
@@ -395,6 +407,45 @@ def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_chec
     assert "Current-head advisory checks:" in captured.out
     assert "- security-scan: pending [Docker Build and Push]" in captured.out
     assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
+
+
+def test_main_passes_when_specialized_ci_job_is_pending_in_fallback_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "UNSTABLE",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "iOS unit tests (xcodebuild)",
+                    "status": "IN_PROGRESS",
+                    "conclusion": None,
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": None,
+                    "detailsUrl": "https://example.invalid/pending-ios-unit",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), False)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "- iOS unit tests (xcodebuild): pending [CI]" in captured.out
+    assert "current-head-checks: passed." in captured.out
 
 
 def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_is_pending(

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -62,6 +62,14 @@ def test_fallback_ci_allowlist_matches_ci_workflow() -> None:
     assert current_head_checks.CANONICAL_FALLBACK_CI_CHECK_NAMES == expected_display_names
 
 
+def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
+    jobs = _load_ci_workflow_jobs()
+
+    assert _job_display_name("test-pr", jobs["test-pr"]) == "test-pr (3.13)"
+    assert "build-and-test" not in jobs
+    assert "build-and-test" not in current_head_checks.CANONICAL_FALLBACK_CI_CHECK_NAMES
+
+
 @pytest.mark.parametrize(
     ("entry", "expected"),
     [

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -5,6 +5,77 @@ import pytest
 from scripts.ci import check_current_head_pr_checks as current_head_checks
 
 
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        (
+            current_head_checks.CheckEntry(
+                name="lint",
+                source_kind="check_run",
+                state="pending",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/ci-pending",
+                workflow_name="CI",
+                conclusion="",
+            ),
+            True,
+        ),
+        (
+            current_head_checks.CheckEntry(
+                name="build-and-test",
+                source_kind="check_run",
+                state="failed",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/ci-failed",
+                workflow_name="CI",
+                conclusion="FAILURE",
+            ),
+            True,
+        ),
+        (
+            current_head_checks.CheckEntry(
+                name="security-scan",
+                source_kind="check_run",
+                state="pending",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/docker-pending",
+                workflow_name="Docker Build and Push",
+                conclusion="",
+            ),
+            False,
+        ),
+        (
+            current_head_checks.CheckEntry(
+                name="optional-e2e",
+                source_kind="check_run",
+                state="failed",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/optional-failed",
+                workflow_name="Optional CI",
+                conclusion="FAILURE",
+            ),
+            False,
+        ),
+        (
+            current_head_checks.CheckEntry(
+                name="CI",
+                source_kind="status_context",
+                state="pending",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/status-context",
+                workflow_name="",
+                conclusion="",
+            ),
+            False,
+        ),
+    ],
+)
+def test_is_blocking_fallback_advisory(
+    entry: current_head_checks.CheckEntry, expected: bool
+) -> None:
+    assert current_head_checks._is_blocking_fallback_advisory(entry) is expected
+
+
 def test_latest_entries_prefers_newest_duplicate_and_marks_older_superseded() -> None:
     older = current_head_checks.CheckEntry(
         name="build",
@@ -285,7 +356,7 @@ def test_main_passes_when_merge_state_is_not_clean_but_advisory_snapshot_is_clea
     assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
 
 
-def test_main_fails_when_merge_state_is_not_clean_and_advisory_snapshot_has_pending_check(
+def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_check_is_pending(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -319,9 +390,52 @@ def test_main_fails_when_merge_state_is_not_clean_and_advisory_snapshot_has_pend
     )
 
     captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Required check metadata unavailable" in captured.out
+    assert "Current-head advisory checks:" in captured.out
+    assert "- security-scan: pending [Docker Build and Push]" in captured.out
+    assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
+
+
+def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_is_pending(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
+    monkeypatch.setattr(
+        current_head_checks,
+        "_fetch_pr_metadata",
+        lambda *args: (
+            False,
+            "UNSTABLE",
+            "main",
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "Docs Phase1 gates",
+                    "status": "IN_PROGRESS",
+                    "conclusion": None,
+                    "startedAt": "2026-03-12T05:05:00Z",
+                    "completedAt": None,
+                    "detailsUrl": "https://example.invalid/pending-ci-docs",
+                    "checkSuite": {"workflowRun": {"workflow": {"name": "CI"}}},
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        current_head_checks, "_fetch_required_check_names", lambda *args: (set(), False)
+    )
+
+    exit_code = current_head_checks.main(
+        ["--pr-number", "1127", "--repo", "Katsiarynakavaleuskaya/PulsePlate"]
+    )
+
+    captured = capsys.readouterr()
     assert exit_code == 1
     assert "GitHub mergeStateStatus=UNSTABLE" in captured.out
-    assert "Blocking advisory current-head checks remain pending or failed." in captured.out
+    assert (
+        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
+    )
 
 
 def test_main_passes_when_required_check_set_is_empty_but_available(
@@ -435,7 +549,7 @@ def test_main_fails_when_github_metadata_query_errors(
     assert "ERROR: failed to query GitHub check state: HTTP 503" in captured.out
 
 
-def test_main_fails_when_required_check_metadata_is_unavailable_and_advisory_check_fails(
+def test_main_passes_when_required_check_metadata_is_unavailable_and_optional_lane_fails(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -469,8 +583,8 @@ def test_main_fails_when_required_check_metadata_is_unavailable_and_advisory_che
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 1
+    assert exit_code == 0
     assert "Required check metadata unavailable" in captured.out
     assert "Current-head advisory checks:" in captured.out
     assert "- optional-e2e: failed [Optional CI]" in captured.out
-    assert "Blocking advisory current-head checks remain pending or failed." in captured.out
+    assert "current-head-checks: passed." in captured.out


### PR DESCRIPTION
## Summary
- relax `check_current_head_pr_checks.py` fallback semantics when required check metadata is unavailable
- keep canonical ordinary-PR `CI` signals merge-blocking in fallback mode
- keep specialized lanes like `Docker Build and Push`, optional CI, and specialized iOS jobs visible but advisory

## Changes
- add `_is_blocking_fallback_advisory(...)` classifier keyed to canonical fallback signals only
- treat aggregate `StatusContext` named `CI` as blocking fallback truth when branch-protection metadata is unavailable
- narrow `CI` workflow `check_run` fallback blocking to explicit ordinary-PR job names instead of all `CI` jobs
- update deterministic tests for helper and fallback `main()` paths
- align coordinator merge-readiness wording with the checker contract

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_current_head_pr_checks.py`
- `make test-fast`
- `pre-commit run --all-files`
- `make verify`

## Out of Scope
- workflow YAML changes
- branch protection changes
- wrapper semantic rewrites
- runtime/backend/frontend/iOS/Sentry work

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1315_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green
- [ ] `make verify` green
- [ ] Mandatory post-open bug-hunter pass completed

## Summary by Sourcery

Ослабить семантику резервного механизма для merge-gating так, чтобы при недоступности метаданных о обязательных проверках блокирующими оставались только канонические обычные CI-сигналы для PR и агрегированный контекст статуса CI, в то время как специализированные линии оставались рекомендательными.

Bug Fixes:
- Предотвратить ситуацию, при которой необязательные и специализированные CI-линии (например, Docker, Optional CI, iOS) ошибочно блокируют слияния при недоступности метаданных защиты ветки, за счёт ужесточения правил резервного gating-механизма.

Enhancements:
- Ввести явный классификатор блокирующих рекомендательных записей в резервном режиме, привязанный к курируемому набору канонических CI-проверок и контексту статуса CI.
- Обновить документацию по готовности к слиянию в координаторе, чтобы чётко описать поведение в резервном режиме и различие между каноническими CI-сигналами и рекомендательными линиями.
- Зафиксировать управленческую мотивацию и результаты для PR #1315 в документе сопоставления fixed-in-commit.

Documentation:
- Уточнить документацию по правилам готовности к слиянию, чтобы явно указать, какие CI-сигналы являются блокирующими, а какие — рекомендательными, когда метаданные защиты ветки недоступны.

Tests:
- Добавить и скорректировать тесты, чтобы покрыть новый резервный классификатор рекомендательных проверок, поведение специализированных CI-линий и обновлённые сообщения о готовности к слиянию при отсутствии метаданных об обязательных проверках.

Chores:
- Добавить специфичный для PR документ сопоставления fixed-in-commit, фиксирующий итоги обсуждения и рамки управленческого решения для PR #1315.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax merge-gating fallback semantics so that, when required check metadata is unavailable, only canonical ordinary-PR CI signals and the aggregate CI status context remain blocking while specialized lanes stay advisory.

Bug Fixes:
- Prevent optional and specialized CI lanes (e.g., Docker, Optional CI, iOS) from erroneously blocking merges when branch-protection metadata is unavailable by tightening the fallback gating rules.

Enhancements:
- Introduce an explicit classifier for blocking advisory entries in fallback mode, keyed to a curated set of canonical CI checks and the CI status context.
- Update coordinator merge-readiness documentation to clearly describe fallback behavior and the distinction between canonical CI signals and advisory lanes.
- Record the governance rationale and outcomes for PR #1315 in a fixed-in-commit mapping document.

Documentation:
- Clarify merge readiness rules documentation to specify which CI signals are blocking vs advisory when branch-protection metadata is unavailable.

Tests:
- Add and adjust tests to cover the new fallback advisory classifier, specialized CI behavior, and updated merge-readiness messaging when required check metadata is missing.

Chores:
- Add a PR-specific fixed-in-commit mapping document capturing discussion outcomes and governance scope for PR #1315.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified behavior when branch-protection metadata is unavailable: only canonical CI signals block merges; specialized lanes (Docker/image, iOS, optional CI, release workflows) are advisory.
  * Added a review record summarizing PR #1315 dispositions and a merge-readiness checklist.

* **Bug Fixes**
  * Adjusted fallback merge-filtering so only canonical fallback checks are treated as blocking; specialized checks remain advisory.

* **Tests**
  * Added tests covering fallback blocking logic, workflow-display-name sync, and specialized-lane scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->