### PR TITLE
fix(playwright): add repo mcp doctor

### DIFF
--- a/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
+++ b/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
@@ -20,15 +20,36 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
 
 ## Prerequisites (local)
 
-1. Ensure Node toolchain is available:
+1. Run the repo-owned Playwright MCP doctor from repo root:
 
    ```bash
-   command -v npx >/dev/null 2>&1
-   node --version
-   npm --version
+   python3 scripts/playwright_mcp.py doctor
    ```
 
-2. Resolve Playwright CLI wrapper path:
+   This is a hard preflight for local MCP/browser work:
+   - exact Node parity with `.nvmrc` is required
+   - `npm` / `npx` must be present
+   - `frontend/node_modules` must exist
+   - local Playwright package must exist
+   - Codex Playwright wrapper must exist
+
+2. Install frontend dependencies if doctor reports missing packages:
+
+   ```bash
+   cd frontend
+   npm ci
+   cd ..
+   ```
+
+3. Install the Chromium payload via the repo-owned helper:
+
+   ```bash
+   cd frontend
+   npm run test:e2e:install
+   cd ..
+   ```
+
+4. Resolve Playwright CLI wrapper path only after doctor passes:
 
    ```bash
    export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -36,13 +57,14 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
    "$PWCLI" --help
    ```
 
-3. Prepare frontend dependencies:
+### Tooling contract
 
-   ```bash
-   cd frontend
-   npm ci
-   cd ..
-   ```
+- Repo-local Playwright runtime comes from `frontend/node_modules/playwright`.
+- Repo-local diagnostics/bootstrap come from `scripts/playwright_mcp.py`.
+- Codex browser automation still enters through the wrapper at
+  `$CODEX_HOME/skills/playwright/scripts/playwright_cli.sh`.
+- Do not treat a globally available `node` or `npx` as sufficient unless the
+  doctor confirms exact `.nvmrc` parity and local browser payload presence.
 
 ## Local execution profile
 
@@ -61,6 +83,8 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
 From `frontend/`:
 
 ```bash
+npm run test:e2e:doctor
+npm run test:e2e:install
 npm run test:e2e
 ```
 
@@ -90,6 +114,7 @@ npm run storybook
 Use element references from the latest snapshot only. Do not hardcode `e*` ids.
 
 ```bash
+python3 scripts/playwright_mcp.py doctor
 "$PWCLI" open http://127.0.0.1:4173/plate --headed
 "$PWCLI" snapshot
 "$PWCLI" click eX

--- a/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
+++ b/docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md
@@ -20,7 +20,13 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
 
 ## Prerequisites (local)
 
-1. Run the repo-owned Playwright MCP doctor from repo root:
+1. Export `CODEX_HOME` first when your Codex install is not under the default `~/.codex`:
+
+   ```bash
+   export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+   ```
+
+2. Run the repo-owned Playwright MCP doctor from repo root:
 
    ```bash
    python3 scripts/playwright_mcp.py doctor
@@ -33,7 +39,7 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
    - local Playwright package must exist
    - Codex Playwright wrapper must exist
 
-2. Install frontend dependencies if doctor reports missing packages:
+3. Install frontend dependencies if doctor reports missing packages:
 
    ```bash
    cd frontend
@@ -41,7 +47,7 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
    cd ..
    ```
 
-3. Install the Chromium payload via the repo-owned helper:
+4. Install the Chromium payload via the repo-owned helper:
 
    ```bash
    cd frontend
@@ -49,10 +55,9 @@ This runbook defines the Step 3 browser E2E extension for the PulsePlate product
    cd ..
    ```
 
-4. Resolve Playwright CLI wrapper path only after doctor passes:
+5. Resolve Playwright CLI wrapper path only after doctor passes:
 
    ```bash
-   export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
    export PWCLI="$CODEX_HOME/skills/playwright/scripts/playwright_cli.sh"
    "$PWCLI" --help
    ```

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -1,0 +1,14 @@
+# PR 1316 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -20,13 +20,19 @@ Evidence: `scripts/playwright_mcp.py:22`, `scripts/playwright_mcp.py:25`, `scrip
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824973 -> a2669244
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824976 -> a2669244
 
+Disposition: FIXED
+Commit: 6b246d26
+Evidence: `scripts/playwright_mcp.py:25`, `scripts/playwright_mcp.py:30`, `scripts/playwright_mcp.py:33`, `tests/test_playwright_mcp.py:72`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032939364 -> 6b246d26
+
 Disposition: NOT-A-BUG
-Evidence: This artifact maps every actionable inline thread to `a2669244`; the review shells only aggregate those child findings and do not require separate code changes.
-Reason: Summary review shells remain informational once the mapped inline discussion URLs above are fixed on the current head.
+Evidence: This artifact maps review-shell children to post-comment fix commits `a2669244` and `6b246d26`; the review shells only aggregate those child findings and do not require separate code changes.
+Reason: Summary review shells remain informational once the mapped inline discussion URLs above are fixed on the current head, including the final hermetic-path finding identified by cubic.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055652452
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055653685
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055659521
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055784204
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055792680
 
 Disposition: NOT-A-BUG
 Evidence: `scripts/playwright_mcp.py:270`, `docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md:23`, `docs/review/PR_1316_FIXED_MAPPING.md:23`

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -25,14 +25,20 @@ Commit: 6b246d26
 Evidence: `scripts/playwright_mcp.py:25`, `scripts/playwright_mcp.py:30`, `scripts/playwright_mcp.py:33`, `tests/test_playwright_mcp.py:72`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032939364 -> 6b246d26
 
+Disposition: FIXED
+Commit: ae77d79c
+Evidence: `scripts/playwright_mcp.py:66`, `scripts/playwright_mcp.py:77`, `scripts/playwright_mcp.py:97`, `tests/test_playwright_mcp.py:113`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3033006303 -> ae77d79c
+
 Disposition: NOT-A-BUG
-Evidence: This artifact maps review-shell children to post-comment fix commits `a2669244` and `6b246d26`; the review shells only aggregate those child findings and do not require separate code changes.
-Reason: Summary review shells remain informational once the mapped inline discussion URLs above are fixed on the current head, including the final hermetic-path finding identified by cubic.
+Evidence: This artifact maps review-shell children to post-comment fix commits `a2669244`, `6b246d26`, and `ae77d79c`; the review shells only aggregate those child findings and do not require separate code changes.
+Reason: Summary review shells remain informational once the mapped inline discussion URLs above are fixed on the current head, including the final hermetic-path finding identified by cubic and the final `.nvmrc` normalization finding identified by CodeRabbit.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055652452
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055653685
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055659521
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055784204
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055792680
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055864005
 
 Disposition: NOT-A-BUG
 Evidence: `scripts/playwright_mcp.py:270`, `docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md:23`, `docs/review/PR_1316_FIXED_MAPPING.md:23`

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -5,7 +5,38 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+
+Disposition: FIXED
+Commit: a2669244
+Evidence: `scripts/playwright_mcp.py:22`, `scripts/playwright_mcp.py:25`, `scripts/playwright_mcp.py:85`, `scripts/playwright_mcp.py:270`, `tests/test_playwright_mcp.py:36`, `tests/test_playwright_mcp.py:100`, `tests/test_playwright_mcp.py:171`, `tests/test_playwright_mcp.py:236`, `docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md:23`, `tools/codex_skills/pulseplate-playwright-e2e/SKILL.md:71`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032805726 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032805728 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032807025 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032807027 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032812666 -> a2669244
+
+Disposition: NOT-A-BUG
+Evidence: This artifact maps every actionable inline thread to `a2669244`; the review shells only aggregate those child findings and do not require separate code changes.
+Reason: Summary review shells remain informational once the mapped inline discussion URLs above are fixed on the current head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055652452
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055653685
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055659521
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/playwright_mcp.py:270`, `docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md:23`, `docs/review/PR_1316_FIXED_MAPPING.md:23`
+Reason: Cubic identified four issues. Three are fixed in `a2669244`; the remaining claim about missing-node install gating is not a standalone defect because `node-version` is already included in the blocking preflight set for `install-browser`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055672293
+
+Disposition: NOT-A-BUG
+Evidence: Project merge truth is enforced by repo-local gates and canonical PR body/strict wrapper, not by third-party advisory summaries; `pre-commit` passed on commit `a2669244`, and Phase 2 PR-body gates are checked separately by the canonical wrapper.
+Reason: These issue comments are advisory walkthrough/pre-merge summaries and do not introduce standalone unresolved defects beyond the inline/review-shell items already dispositioned above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#issuecomment-4183390918
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#issuecomment-4183392591
+
+Disposition: NOT-A-BUG
+Evidence: `tests/test_playwright_mcp.py:171`, `tests/test_playwright_mcp.py:236`, `docs/review/PR_1316_FIXED_MAPPING.md:39`
+Reason: Codecov reports fully covered modified lines and is purely advisory; it does not contain actionable remediation for this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#issuecomment-4183431379
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -26,6 +26,7 @@ Reason: Summary review shells remain informational once the mapped inline discus
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055652452
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055653685
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055659521
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#pullrequestreview-4055784204
 
 Disposition: NOT-A-BUG
 Evidence: `scripts/playwright_mcp.py:270`, `docs/dev/PLAYWRIGHT_E2E_RUNBOOK.md:23`, `docs/review/PR_1316_FIXED_MAPPING.md:23`

--- a/docs/review/PR_1316_FIXED_MAPPING.md
+++ b/docs/review/PR_1316_FIXED_MAPPING.md
@@ -14,6 +14,11 @@ Evidence: `scripts/playwright_mcp.py:22`, `scripts/playwright_mcp.py:25`, `scrip
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032807025 -> a2669244
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032807027 -> a2669244
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032812666 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824954 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824961 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824967 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824973 -> a2669244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1316#discussion_r3032824976 -> a2669244
 
 Disposition: NOT-A-BUG
 Evidence: This artifact maps every actionable inline thread to `a2669244`; the review shells only aggregate those child findings and do not require separate code changes.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "test:precommit": "vitest run --environment jsdom --testTimeout=30000 --reporter=verbose",
     "test:coverage": "vitest run --coverage",
     "test:accessibility": "vitest run --environment jsdom --testTimeout=30000 --reporter=verbose src/**/__tests__/*Accessibility.test.tsx",
+    "test:e2e:doctor": "python3 ../scripts/playwright_mcp.py doctor",
+    "test:e2e:install": "python3 ../scripts/playwright_mcp.py install-browser",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "generate-types": "openapi-typescript src/api/openapi.json --output src/api/schema.ts --alphabetize"

--- a/scripts/playwright_mcp.py
+++ b/scripts/playwright_mcp.py
@@ -15,11 +15,33 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FRONTEND_DIR = REPO_ROOT / "frontend"
 NVMRC_PATH = REPO_ROOT / ".nvmrc"
-PLAYWRIGHT_CACHE_DIR = Path.home() / "Library" / "Caches" / "ms-playwright"
 CODEX_HOME = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
 PLAYWRIGHT_WRAPPER_PATH = CODEX_HOME / "skills" / "playwright" / "scripts" / "playwright_cli.sh"
 PLAYWRIGHT_PACKAGE_PATH = FRONTEND_DIR / "node_modules" / "playwright"
 NODE_MODULES_PATH = FRONTEND_DIR / "node_modules"
+CHROMIUM_BROWSER_PREFIXES = ("chromium-", "chromium_headless_shell-")
+
+
+def _playwright_cache_dir() -> Path:
+    """Return the platform-aware Playwright browser cache directory."""
+    configured_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    if configured_path and configured_path != "0":
+        return Path(configured_path).expanduser()
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "ms-playwright"
+    if sys.platform == "win32":
+        local_appdata = os.environ.get(
+            "LOCALAPPDATA",
+            str(Path.home() / "AppData" / "Local"),
+        )
+        return Path(local_appdata).expanduser() / "ms-playwright"
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME", "").strip()
+    if xdg_cache_home:
+        return Path(xdg_cache_home).expanduser() / "ms-playwright"
+    return Path.home() / ".cache" / "ms-playwright"
+
+
+PLAYWRIGHT_CACHE_DIR = _playwright_cache_dir()
 
 
 @dataclass(frozen=True)
@@ -32,9 +54,12 @@ class CheckResult:
     remediation: str | None = None
 
 
-def _read_expected_node_version() -> str:
-    """Return the repo-canonical Node version from .nvmrc."""
-    return NVMRC_PATH.read_text(encoding="utf-8").strip()
+def _read_expected_node_version() -> str | None:
+    """Return the repo-canonical Node version from .nvmrc, if present."""
+    if not NVMRC_PATH.is_file():
+        return None
+    expected_node_version = NVMRC_PATH.read_text(encoding="utf-8").strip()
+    return expected_node_version or None
 
 
 def _resolve_binary(name: str) -> str | None:
@@ -58,64 +83,98 @@ def _current_node_version(node_bin: str) -> str | None:
 
 
 def _playwright_browser_cache_present() -> bool:
-    """Return True when the Playwright browser cache has at least one browser payload."""
+    """Return True when the Playwright cache contains a Chromium payload."""
     if not PLAYWRIGHT_CACHE_DIR.is_dir():
         return False
-    return any(child.is_dir() for child in PLAYWRIGHT_CACHE_DIR.iterdir())
+    try:
+        return any(
+            child.is_dir() and child.name.startswith(CHROMIUM_BROWSER_PREFIXES)
+            for child in PLAYWRIGHT_CACHE_DIR.iterdir()
+        )
+    except OSError:
+        return False
 
 
 def _build_doctor_report() -> list[CheckResult]:
     """Collect the repo-local MCP/toolchain health checks."""
     results: list[CheckResult] = []
     expected_node_version = _read_expected_node_version()
+    if expected_node_version is None:
+        results.append(
+            CheckResult(
+                name="node-version",
+                ok=False,
+                detail="Repo Node baseline is missing because .nvmrc is absent or empty.",
+                remediation="Restore a non-empty `.nvmrc` with the repo-required Node version.",
+            )
+        )
 
     node_bin = _resolve_binary("node")
     if node_bin is None:
         results.append(
             CheckResult(
-                name="node",
-                ok=False,
-                detail=f"Node {expected_node_version} is required on PATH.",
-                remediation=f"Activate Node {expected_node_version} via your local toolchain.",
-            )
-        )
-        return results
-
-    current_node_version = _current_node_version(node_bin)
-    if current_node_version is None:
-        results.append(
-            CheckResult(
-                name="node-version",
-                ok=False,
-                detail="Unable to resolve the current Node runtime version.",
-                remediation="Verify that `node -p process.versions.node` works in this shell.",
-            )
-        )
-    elif current_node_version != expected_node_version:
-        # RU: Для Codex MCP нужен exact runtime parity, а не только совпадение major.
-        # EN: Codex MCP needs exact runtime parity, not only a matching major version.
-        results.append(
-            CheckResult(
                 name="node-version",
                 ok=False,
                 detail=(
-                    f"Repo baseline is Node {expected_node_version}, current runtime is "
-                    f"{current_node_version}."
+                    f"Node {expected_node_version} is required on PATH."
+                    if expected_node_version is not None
+                    else "Node is missing on PATH and the repo baseline cannot be verified."
                 ),
                 remediation=(
-                    f"Switch the shell/tooling to Node {expected_node_version} before using "
-                    "Playwright MCP."
+                    f"Activate Node {expected_node_version} via your local toolchain."
+                    if expected_node_version is not None
+                    else "Install the repo-required Node runtime and restore `.nvmrc`."
                 ),
             )
         )
     else:
-        results.append(
-            CheckResult(
-                name="node-version",
-                ok=True,
-                detail=f"Node runtime matches repo baseline ({expected_node_version}).",
+        current_node_version = _current_node_version(node_bin)
+        if current_node_version is None:
+            results.append(
+                CheckResult(
+                    name="node-version",
+                    ok=False,
+                    detail="Unable to resolve the current Node runtime version.",
+                    remediation="Verify that `node -p process.versions.node` works in this shell.",
+                )
             )
-        )
+        elif expected_node_version is None:
+            results.append(
+                CheckResult(
+                    name="node-version",
+                    ok=False,
+                    detail=(
+                        f"Current Node runtime is {current_node_version}, but the repo baseline "
+                        "is missing."
+                    ),
+                    remediation="Restore a non-empty `.nvmrc` before using Playwright MCP.",
+                )
+            )
+        elif current_node_version != expected_node_version:
+            # RU: Для Codex MCP нужен exact runtime parity, а не только совпадение major.
+            # EN: Codex MCP needs exact runtime parity, not only a matching major version.
+            results.append(
+                CheckResult(
+                    name="node-version",
+                    ok=False,
+                    detail=(
+                        f"Repo baseline is Node {expected_node_version}, current runtime is "
+                        f"{current_node_version}."
+                    ),
+                    remediation=(
+                        f"Switch the shell/tooling to Node {expected_node_version} before using "
+                        "Playwright MCP."
+                    ),
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name="node-version",
+                    ok=True,
+                    detail=f"Node runtime matches repo baseline ({expected_node_version}).",
+                )
+            )
 
     for binary_name in ("npm", "npx"):
         resolved = _resolve_binary(binary_name)
@@ -215,7 +274,15 @@ def _run_install_browser() -> int:
     blocking_names = {
         result.name
         for result in results
-        if not result.ok and result.name in {"node-version", "npm", "npx", "frontend-node-modules"}
+        if not result.ok
+        and result.name
+        in {
+            "node-version",
+            "npm",
+            "npx",
+            "frontend-node-modules",
+            "frontend-playwright-package",
+        }
     }
     if blocking_names:
         _print_text_report(results)
@@ -276,7 +343,6 @@ def main(argv: list[str] | None = None) -> int:
         return _run_install_browser()
 
     parser.error(f"Unsupported command: {args.command}")
-    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/playwright_mcp.py
+++ b/scripts/playwright_mcp.py
@@ -22,10 +22,19 @@ NODE_MODULES_PATH = FRONTEND_DIR / "node_modules"
 CHROMIUM_BROWSER_PREFIXES = ("chromium-", "chromium_headless_shell-")
 
 
+def _playwright_hermetic_browser_dir() -> Path:
+    """Return the repo-local Playwright browser path used for hermetic installs."""
+    return FRONTEND_DIR / "node_modules" / "playwright-core" / ".local-browsers"
+
+
 def _playwright_cache_dir() -> Path:
     """Return the platform-aware Playwright browser cache directory."""
     configured_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
-    if configured_path and configured_path != "0":
+    if configured_path == "0":
+        # RU: `0` в Playwright означает hermetic install рядом с пакетом, а не global cache.
+        # EN: `0` means Playwright's package-local hermetic browser directory, not the global cache.
+        return _playwright_hermetic_browser_dir()
+    if configured_path:
         return Path(configured_path).expanduser()
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Caches" / "ms-playwright"

--- a/scripts/playwright_mcp.py
+++ b/scripts/playwright_mcp.py
@@ -63,11 +63,18 @@ class CheckResult:
     remediation: str | None = None
 
 
+def _normalize_node_version(version: str) -> str:
+    """Normalize Node version strings before parity checks."""
+    # RU: `.nvmrc` может хранить версию как `v22.22.1`, а runtime возвращает `22.22.1`.
+    # EN: `.nvmrc` may store `v22.22.1` while the runtime reports `22.22.1`.
+    return version.strip().lstrip("vV")
+
+
 def _read_expected_node_version() -> str | None:
     """Return the repo-canonical Node version from .nvmrc, if present."""
     if not NVMRC_PATH.is_file():
         return None
-    expected_node_version = NVMRC_PATH.read_text(encoding="utf-8").strip()
+    expected_node_version = _normalize_node_version(NVMRC_PATH.read_text(encoding="utf-8"))
     return expected_node_version or None
 
 
@@ -87,7 +94,7 @@ def _current_node_version(node_bin: str) -> str | None:
     )
     if process.returncode != 0:
         return None
-    version = (process.stdout or "").strip()
+    version = _normalize_node_version(process.stdout or "")
     return version or None
 
 

--- a/scripts/playwright_mcp.py
+++ b/scripts/playwright_mcp.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Repo-owned Playwright MCP/toolchain doctor and bootstrap helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess  # nosec B404: subprocess is required for bounded local Node/Playwright diagnostics with absolute binaries only (remove-by: 2026-07-31, ref: PR-playwright-mcp-node22)
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_DIR = REPO_ROOT / "frontend"
+NVMRC_PATH = REPO_ROOT / ".nvmrc"
+PLAYWRIGHT_CACHE_DIR = Path.home() / "Library" / "Caches" / "ms-playwright"
+CODEX_HOME = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+PLAYWRIGHT_WRAPPER_PATH = CODEX_HOME / "skills" / "playwright" / "scripts" / "playwright_cli.sh"
+PLAYWRIGHT_PACKAGE_PATH = FRONTEND_DIR / "node_modules" / "playwright"
+NODE_MODULES_PATH = FRONTEND_DIR / "node_modules"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Single doctor check result."""
+
+    name: str
+    ok: bool
+    detail: str
+    remediation: str | None = None
+
+
+def _read_expected_node_version() -> str:
+    """Return the repo-canonical Node version from .nvmrc."""
+    return NVMRC_PATH.read_text(encoding="utf-8").strip()
+
+
+def _resolve_binary(name: str) -> str | None:
+    """Return an absolute executable path for a required binary."""
+    return shutil.which(name)
+
+
+def _current_node_version(node_bin: str) -> str | None:
+    """Return the current Node runtime version without a leading `v`."""
+    process = subprocess.run(  # nosec B603: argv uses absolute node path from shutil.which() with fixed diagnostic flags only (remove-by: 2026-07-31, ref: PR-playwright-mcp-node22)
+        [node_bin, "-p", "process.versions.node"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        return None
+    version = (process.stdout or "").strip()
+    return version or None
+
+
+def _playwright_browser_cache_present() -> bool:
+    """Return True when the Playwright browser cache has at least one browser payload."""
+    if not PLAYWRIGHT_CACHE_DIR.is_dir():
+        return False
+    return any(child.is_dir() for child in PLAYWRIGHT_CACHE_DIR.iterdir())
+
+
+def _build_doctor_report() -> list[CheckResult]:
+    """Collect the repo-local MCP/toolchain health checks."""
+    results: list[CheckResult] = []
+    expected_node_version = _read_expected_node_version()
+
+    node_bin = _resolve_binary("node")
+    if node_bin is None:
+        results.append(
+            CheckResult(
+                name="node",
+                ok=False,
+                detail=f"Node {expected_node_version} is required on PATH.",
+                remediation=f"Activate Node {expected_node_version} via your local toolchain.",
+            )
+        )
+        return results
+
+    current_node_version = _current_node_version(node_bin)
+    if current_node_version is None:
+        results.append(
+            CheckResult(
+                name="node-version",
+                ok=False,
+                detail="Unable to resolve the current Node runtime version.",
+                remediation="Verify that `node -p process.versions.node` works in this shell.",
+            )
+        )
+    elif current_node_version != expected_node_version:
+        # RU: Для Codex MCP нужен exact runtime parity, а не только совпадение major.
+        # EN: Codex MCP needs exact runtime parity, not only a matching major version.
+        results.append(
+            CheckResult(
+                name="node-version",
+                ok=False,
+                detail=(
+                    f"Repo baseline is Node {expected_node_version}, current runtime is "
+                    f"{current_node_version}."
+                ),
+                remediation=(
+                    f"Switch the shell/tooling to Node {expected_node_version} before using "
+                    "Playwright MCP."
+                ),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="node-version",
+                ok=True,
+                detail=f"Node runtime matches repo baseline ({expected_node_version}).",
+            )
+        )
+
+    for binary_name in ("npm", "npx"):
+        resolved = _resolve_binary(binary_name)
+        results.append(
+            CheckResult(
+                name=binary_name,
+                ok=resolved is not None,
+                detail=(
+                    f"{binary_name} resolved to {resolved}."
+                    if resolved is not None
+                    else f"{binary_name} is missing on PATH."
+                ),
+                remediation=(
+                    None
+                    if resolved is not None
+                    else f"Install {binary_name} with the Node toolchain."
+                ),
+            )
+        )
+
+    results.append(
+        CheckResult(
+            name="frontend-node-modules",
+            ok=NODE_MODULES_PATH.is_dir(),
+            detail=(
+                f"Frontend dependencies present at {NODE_MODULES_PATH}."
+                if NODE_MODULES_PATH.is_dir()
+                else "frontend/node_modules is missing."
+            ),
+            remediation="Run `cd frontend && npm ci`.",
+        )
+    )
+
+    results.append(
+        CheckResult(
+            name="frontend-playwright-package",
+            ok=PLAYWRIGHT_PACKAGE_PATH.exists(),
+            detail=(
+                f"Local Playwright package present at {PLAYWRIGHT_PACKAGE_PATH}."
+                if PLAYWRIGHT_PACKAGE_PATH.exists()
+                else "Local Playwright package is missing from frontend/node_modules."
+            ),
+            remediation="Run `cd frontend && npm ci` to install @playwright/test and Playwright.",
+        )
+    )
+
+    browser_cache_present = _playwright_browser_cache_present()
+    results.append(
+        CheckResult(
+            name="playwright-browser-cache",
+            ok=browser_cache_present,
+            detail=(
+                f"Browser cache found at {PLAYWRIGHT_CACHE_DIR}."
+                if browser_cache_present
+                else f"No Playwright browser payloads found under {PLAYWRIGHT_CACHE_DIR}."
+            ),
+            remediation="Run `cd frontend && npx playwright install chromium`.",
+        )
+    )
+
+    results.append(
+        CheckResult(
+            name="codex-playwright-wrapper",
+            ok=PLAYWRIGHT_WRAPPER_PATH.is_file(),
+            detail=(
+                f"Codex Playwright wrapper found at {PLAYWRIGHT_WRAPPER_PATH}."
+                if PLAYWRIGHT_WRAPPER_PATH.is_file()
+                else f"Codex Playwright wrapper is missing at {PLAYWRIGHT_WRAPPER_PATH}."
+            ),
+            remediation=(
+                "Reinstall the local Codex Playwright skill or restore the wrapper path under "
+                "$CODEX_HOME."
+            ),
+        )
+    )
+
+    return results
+
+
+def _print_text_report(results: list[CheckResult]) -> None:
+    """Render the doctor output for humans."""
+    for result in results:
+        status = "PASS" if result.ok else "FAIL"
+        print(f"[{status}] {result.name}: {result.detail}")
+        if not result.ok and result.remediation:
+            print(f"  remediation: {result.remediation}")
+
+
+def _doctor_exit_code(results: list[CheckResult]) -> int:
+    """Return non-zero when any doctor check blocks MCP usage."""
+    return 0 if all(result.ok for result in results) else 1
+
+
+def _run_install_browser() -> int:
+    """Install the Chromium browser payload used by the repo Playwright flows."""
+    results = _build_doctor_report()
+    blocking_names = {
+        result.name
+        for result in results
+        if not result.ok and result.name in {"node-version", "npm", "npx", "frontend-node-modules"}
+    }
+    if blocking_names:
+        _print_text_report(results)
+        print(
+            "Refusing to install Playwright browsers because the repo toolchain is not ready.",
+            file=sys.stderr,
+        )
+        return 1
+
+    npx_bin = _resolve_binary("npx")
+    if npx_bin is None:  # pragma: no cover - defensive fallback after guarded precheck
+        print("npx is not available on PATH.", file=sys.stderr)
+        return 1
+    process = subprocess.run(  # nosec B603: argv uses absolute npx path from shutil.which() with fixed Playwright install args only (remove-by: 2026-07-31, ref: PR-playwright-mcp-node22)
+        [npx_bin, "playwright", "install", "chromium"],
+        cwd=FRONTEND_DIR,
+        check=False,
+    )
+    return process.returncode
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Create the CLI parser."""
+    parser = argparse.ArgumentParser(
+        prog="playwright_mcp.py",
+        description="Repo-owned Playwright MCP/toolchain doctor and bootstrap helper.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor_parser = subparsers.add_parser("doctor", help="Validate Node/MCP/browser prerequisites.")
+    doctor_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the doctor report as JSON.",
+    )
+
+    subparsers.add_parser(
+        "install-browser",
+        help="Install the Chromium browser payload from the repo frontend directory.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "doctor":
+        results = _build_doctor_report()
+        if args.json:
+            print(json.dumps([asdict(result) for result in results], indent=2))
+        else:
+            _print_text_report(results)
+        return _doctor_exit_code(results)
+
+    if args.command == "install-browser":
+        return _run_install_browser()
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_playwright_mcp.py
+++ b/tests/test_playwright_mcp.py
@@ -33,6 +33,42 @@ def _configure_fake_repo_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(playwright_mcp, "NVMRC_PATH", nvmrc_path)
 
 
+@pytest.mark.parametrize(
+    ("platform_name", "env_name", "env_value", "expected"),
+    [
+        ("darwin", None, None, Path.home() / "Library" / "Caches" / "ms-playwright"),
+        ("linux", "XDG_CACHE_HOME", "/tmp/xdg-cache", Path("/tmp/xdg-cache") / "ms-playwright"),
+        (
+            "win32",
+            "LOCALAPPDATA",
+            "C:/Users/test/AppData/Local",
+            Path("C:/Users/test/AppData/Local") / "ms-playwright",
+        ),
+    ],
+)
+def test_playwright_cache_dir_is_platform_aware(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_name: str,
+    env_name: str | None,
+    env_value: str | None,
+    expected: Path,
+) -> None:
+    monkeypatch.setattr(playwright_mcp.sys, "platform", platform_name)
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    if env_name is not None and env_value is not None:
+        monkeypatch.setenv(env_name, env_value)
+
+    assert playwright_mcp._playwright_cache_dir() == expected
+
+
+def test_playwright_cache_dir_prefers_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "~/custom-cache")
+
+    assert playwright_mcp._playwright_cache_dir() == Path("~/custom-cache").expanduser()
+
+
 def test_doctor_fails_on_exact_node_version_mismatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -59,6 +95,22 @@ def test_doctor_passes_when_repo_prerequisites_are_present(
 
     assert all(result.ok for result in results)
     assert playwright_mcp._doctor_exit_code(results) == 0
+
+
+def test_doctor_reports_missing_nvmrc_without_hiding_other_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_fake_repo_paths(tmp_path, monkeypatch)
+    monkeypatch.setattr(playwright_mcp, "NVMRC_PATH", tmp_path / ".nvmrc-missing")
+    monkeypatch.setattr(playwright_mcp, "_resolve_binary", lambda name: None)
+
+    results = playwright_mcp._build_doctor_report()
+
+    details_by_name = {result.name: result.detail for result in results}
+    assert "node-version" in details_by_name
+    assert "npm" in details_by_name
+    assert "npx" in details_by_name
+    assert "codex-playwright-wrapper" in details_by_name
 
 
 def test_main_doctor_json_output(
@@ -116,6 +168,33 @@ def test_install_browser_runs_repo_local_playwright_install(
     assert recorded["check"] is False
 
 
+def test_install_browser_refuses_when_local_playwright_package_is_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_build_doctor_report",
+        lambda: [
+            playwright_mcp.CheckResult(name="node-version", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="npm", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="npx", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="frontend-node-modules", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(
+                name="frontend-playwright-package",
+                ok=False,
+                detail="Local Playwright package is missing.",
+                remediation="Run npm ci.",
+            ),
+        ],
+    )
+
+    exit_code = playwright_mcp.main(["install-browser"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Refusing to install Playwright browsers" in captured.err
+
+
 def test_install_browser_refuses_when_toolchain_is_not_ready(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -137,3 +216,33 @@ def test_install_browser_refuses_when_toolchain_is_not_ready(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "Refusing to install Playwright browsers" in captured.err
+
+
+def test_playwright_browser_cache_present_handles_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(playwright_mcp, "PLAYWRIGHT_CACHE_DIR", cache_dir)
+
+    def raise_permission_error(self: Path) -> object:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "iterdir", raise_permission_error)
+
+    assert playwright_mcp._playwright_browser_cache_present() is False
+
+
+def test_playwright_browser_cache_requires_chromium_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "firefox-9999").mkdir()
+    monkeypatch.setattr(playwright_mcp, "PLAYWRIGHT_CACHE_DIR", cache_dir)
+
+    assert playwright_mcp._playwright_browser_cache_present() is False
+
+    (cache_dir / "chromium-1234").mkdir()
+
+    assert playwright_mcp._playwright_browser_cache_present() is True

--- a/tests/test_playwright_mcp.py
+++ b/tests/test_playwright_mcp.py
@@ -1,0 +1,139 @@
+"""Tests for the repo-owned Playwright MCP/toolchain helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import playwright_mcp
+
+
+def _configure_fake_repo_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    frontend_dir = tmp_path / "frontend"
+    node_modules_dir = frontend_dir / "node_modules"
+    playwright_pkg_dir = node_modules_dir / "playwright"
+    wrapper_path = tmp_path / ".codex" / "skills" / "playwright" / "scripts" / "playwright_cli.sh"
+    browser_cache_dir = tmp_path / "Library" / "Caches" / "ms-playwright" / "chromium-1234"
+
+    playwright_pkg_dir.mkdir(parents=True)
+    wrapper_path.parent.mkdir(parents=True)
+    wrapper_path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    browser_cache_dir.mkdir(parents=True)
+    nvmrc_path = tmp_path / ".nvmrc"
+    nvmrc_path.write_text("22.22.1\n", encoding="utf-8")
+
+    monkeypatch.setattr(playwright_mcp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(playwright_mcp, "FRONTEND_DIR", frontend_dir)
+    monkeypatch.setattr(playwright_mcp, "NODE_MODULES_PATH", node_modules_dir)
+    monkeypatch.setattr(playwright_mcp, "PLAYWRIGHT_PACKAGE_PATH", playwright_pkg_dir)
+    monkeypatch.setattr(playwright_mcp, "PLAYWRIGHT_WRAPPER_PATH", wrapper_path)
+    monkeypatch.setattr(playwright_mcp, "PLAYWRIGHT_CACHE_DIR", browser_cache_dir.parent)
+    monkeypatch.setattr(playwright_mcp, "NVMRC_PATH", nvmrc_path)
+
+
+def test_doctor_fails_on_exact_node_version_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_fake_repo_paths(tmp_path, monkeypatch)
+    monkeypatch.setattr(playwright_mcp, "_resolve_binary", lambda name: f"/usr/local/bin/{name}")
+    monkeypatch.setattr(playwright_mcp, "_current_node_version", lambda node_bin: "25.6.1")
+
+    results = playwright_mcp._build_doctor_report()
+
+    node_result = next(result for result in results if result.name == "node-version")
+    assert node_result.ok is False
+    assert "22.22.1" in node_result.detail
+    assert "25.6.1" in node_result.detail
+
+
+def test_doctor_passes_when_repo_prerequisites_are_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_fake_repo_paths(tmp_path, monkeypatch)
+    monkeypatch.setattr(playwright_mcp, "_resolve_binary", lambda name: f"/usr/local/bin/{name}")
+    monkeypatch.setattr(playwright_mcp, "_current_node_version", lambda node_bin: "22.22.1")
+
+    results = playwright_mcp._build_doctor_report()
+
+    assert all(result.ok for result in results)
+    assert playwright_mcp._doctor_exit_code(results) == 0
+
+
+def test_main_doctor_json_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_build_doctor_report",
+        lambda: [playwright_mcp.CheckResult(name="node-version", ok=True, detail="ok")],
+    )
+
+    exit_code = playwright_mcp.main(["doctor", "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload == [{"name": "node-version", "ok": True, "detail": "ok", "remediation": None}]
+
+
+def test_install_browser_runs_repo_local_playwright_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_build_doctor_report",
+        lambda: [
+            playwright_mcp.CheckResult(name="node-version", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="npm", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="npx", ok=True, detail="ok"),
+            playwright_mcp.CheckResult(name="frontend-node-modules", ok=True, detail="ok"),
+        ],
+    )
+    monkeypatch.setattr(playwright_mcp, "_resolve_binary", lambda name: f"/usr/local/bin/{name}")
+
+    recorded: dict[str, object] = {}
+
+    def fake_run(argv: list[str], cwd: Path, check: bool) -> object:
+        recorded["argv"] = argv
+        recorded["cwd"] = cwd
+        recorded["check"] = check
+        return type("Process", (), {"returncode": 0})()
+
+    monkeypatch.setattr(playwright_mcp.subprocess, "run", fake_run)
+
+    exit_code = playwright_mcp.main(["install-browser"])
+
+    assert exit_code == 0
+    assert recorded["argv"] == [
+        "/usr/local/bin/npx",
+        "playwright",
+        "install",
+        "chromium",
+    ]
+    assert recorded["cwd"] == playwright_mcp.FRONTEND_DIR
+    assert recorded["check"] is False
+
+
+def test_install_browser_refuses_when_toolchain_is_not_ready(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_build_doctor_report",
+        lambda: [
+            playwright_mcp.CheckResult(
+                name="node-version",
+                ok=False,
+                detail="Repo baseline is Node 22.22.1, current runtime is 25.6.1.",
+                remediation="Switch to Node 22.22.1.",
+            )
+        ],
+    )
+
+    exit_code = playwright_mcp.main(["install-browser"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Refusing to install Playwright browsers" in captured.err

--- a/tests/test_playwright_mcp.py
+++ b/tests/test_playwright_mcp.py
@@ -69,6 +69,19 @@ def test_playwright_cache_dir_prefers_env_override(monkeypatch: pytest.MonkeyPat
     assert playwright_mcp._playwright_cache_dir() == Path("~/custom-cache").expanduser()
 
 
+def test_playwright_cache_dir_uses_repo_local_browsers_when_env_is_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    frontend_dir = tmp_path / "frontend"
+    monkeypatch.setattr(playwright_mcp, "FRONTEND_DIR", frontend_dir)
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "0")
+
+    assert (
+        playwright_mcp._playwright_cache_dir()
+        == frontend_dir / "node_modules" / "playwright-core" / ".local-browsers"
+    )
+
+
 def test_doctor_fails_on_exact_node_version_mismatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_playwright_mcp.py
+++ b/tests/test_playwright_mcp.py
@@ -110,6 +110,21 @@ def test_doctor_passes_when_repo_prerequisites_are_present(
     assert playwright_mcp._doctor_exit_code(results) == 0
 
 
+def test_doctor_accepts_nvmrc_version_with_v_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_fake_repo_paths(tmp_path, monkeypatch)
+    playwright_mcp.NVMRC_PATH.write_text("v22.22.1\n", encoding="utf-8")
+    monkeypatch.setattr(playwright_mcp, "_resolve_binary", lambda name: f"/usr/local/bin/{name}")
+    monkeypatch.setattr(playwright_mcp, "_current_node_version", lambda node_bin: "22.22.1")
+
+    results = playwright_mcp._build_doctor_report()
+
+    node_result = next(result for result in results if result.name == "node-version")
+    assert node_result.ok is True
+    assert "22.22.1" in node_result.detail
+
+
 def test_doctor_reports_missing_nvmrc_without_hiding_other_failures(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tools/codex_skills/pulseplate-playwright-e2e/SKILL.md
+++ b/tools/codex_skills/pulseplate-playwright-e2e/SKILL.md
@@ -31,13 +31,27 @@ description: Execute controlled Playwright browser E2E checks for PulsePlate web
    cd ..
    ```
 
-2. Use Playwright skill/tooling to run browser automation against selected flows.
-3. Capture deterministic artifacts:
+2. Run the repo-owned Playwright MCP doctor before any browser flow:
+
+   ```bash
+   python3 scripts/playwright_mcp.py doctor
+   ```
+
+3. Install the local Chromium payload via the repo-owned helper:
+
+   ```bash
+   cd frontend
+   npm run test:e2e:install
+   cd ..
+   ```
+
+4. Use Playwright skill/tooling to run browser automation against selected flows.
+5. Capture deterministic artifacts:
    - command and config used
    - failing step and selector/action
    - screenshot path or trace path when available
-4. Re-run only failing flow after fix.
-5. Follow the runbook evidence contract for every flow.
+6. Re-run only failing flow after fix.
+7. Follow the runbook evidence contract for every flow.
 
 ## Output format
 
@@ -54,6 +68,8 @@ description: Execute controlled Playwright browser E2E checks for PulsePlate web
 - Do not use Playwright to bypass thin-client policy or API contracts.
 - Keep runs targeted; avoid broad unstable suites without need.
 - Do not claim release readiness solely from E2E; keep hard backend gates mandatory.
+- Treat doctor failures as blocking: do not continue to Playwright MCP runs on a
+  mismatched Node runtime or missing browser payloads.
 
 ## SoT links
 

--- a/tools/codex_skills/pulseplate-playwright-e2e/SKILL.md
+++ b/tools/codex_skills/pulseplate-playwright-e2e/SKILL.md
@@ -68,7 +68,7 @@ description: Execute controlled Playwright browser E2E checks for PulsePlate web
 - Do not use Playwright to bypass thin-client policy or API contracts.
 - Keep runs targeted; avoid broad unstable suites without need.
 - Do not claim release readiness solely from E2E; keep hard backend gates mandatory.
-- Treat doctor failures as blocking: do not continue to Playwright MCP runs on a
+- Treat doctor failures as blocking: do not continue with Playwright MCP runs on a
   mismatched Node runtime or missing browser payloads.
 
 ## SoT links


### PR DESCRIPTION
## Summary
- add a repo-owned Playwright MCP/toolchain doctor helper
- document canonical Node/browser prerequisites for local MCP flows
- wire the helper into frontend and PulsePlate Playwright runbooks

## Validation
- pre-commit run --all-files
- make verify
- git push -u origin fix/playwright-mcp-node22

## Notes
- this PR was created from a dedicated worktree per project orchestration policy
- canonical review disposition source of truth lives in `docs/review/PR_1316_FIXED_MAPPING.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1316_FIXED_MAPPING.md`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green

## Summary by Sourcery

Ввести принадлежащий репозиторию Playwright MCP doctor/helper и встроить его в E2E‑процессы Playwright и документацию.

Новые возможности:
- Добавить основанный на Python скрипт Playwright MCP doctor и установщик браузера для проверки Node, npm/npx, фронтенд-зависимостей, пакета Playwright, кэша браузера и путей к оболочкам Codex.
- Экспортировать npm‑скрипты во frontend‑пакете для запуска Playwright MCP doctor и установки браузерного payload’а Chromium.

Улучшения:
- Обновить runbook для Playwright E2E и документацию по навыку PulsePlate Playwright, чтобы определить каноничный контракт MCP/браузерного инструментария и требовать успешного прохождения проверок doctor перед запуском сценариев.

Документация:
- Добавить артефакт ревью, документирующий соответствие между исправлениями и коммитами для PR 1316.

Тесты:
- Добавить модульные тесты для Playwright MCP helper, покрывающие поведение doctor, JSON‑вывод и защищённый процесс установки браузера.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a repo-owned Playwright MCP doctor/helper and wire it into Playwright E2E workflows and documentation.

New Features:
- Add a Python-based Playwright MCP doctor and browser installer script to validate Node, npm/npx, frontend dependencies, Playwright package, browser cache, and Codex wrapper paths.
- Expose npm scripts in the frontend package to run the Playwright MCP doctor and install the Chromium browser payload.

Enhancements:
- Update Playwright E2E runbook and PulsePlate Playwright skill documentation to define the canonical MCP/browser tooling contract and require successful doctor checks before running flows.

Documentation:
- Add review artifact documenting fixed-in-commit mapping for PR 1316.

Tests:
- Add unit tests for the Playwright MCP helper covering doctor behavior, JSON output, and guarded browser installation flow.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repo-owned preflight ("doctor") and a guarded browser-install step that run before end-to-end tests; exposed as new npm-invokable scripts and reordered E2E execution to enforce the checks.

* **Documentation**
  * Updated runbooks and review notes to document preflight expectations, execution ordering, and a tooling contract for E2E gating.

* **Tests**
  * Added tests covering diagnostics, install gating, CLI behavior, and platform/browser cache detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->