### PR TITLE
fix(deploy): fail prod tag deploy before live rollout when env preflight fails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -466,16 +466,17 @@ jobs:
               exit 1
             fi
 
+            tmp_script="/tmp/pulseplate_deploy_production.sh"
+            echo "$DEPLOY_SCRIPT_B64" | base64 -d > "$tmp_script"
+            chmod +x "$tmp_script"
+            "$tmp_script" --preflight-only
+
             bundle_name="pulseplate-shell-bundle-${{ github.run_id }}-${{ github.run_attempt }}"
             tmp_bundle_dir="/tmp/${bundle_name}"
             rm -rf "$tmp_bundle_dir"
             mkdir -p "$tmp_bundle_dir"
             tar -xzf "/tmp/${bundle_name}.tgz" -C "$tmp_bundle_dir"
             export SHELL_BUNDLE_DIR="$tmp_bundle_dir"
-
-            tmp_script="/tmp/pulseplate_deploy_production.sh"
-            echo "$DEPLOY_SCRIPT_B64" | base64 -d > "$tmp_script"
-            chmod +x "$tmp_script"
             "$tmp_script"
             rm -f "/tmp/${bundle_name}.tgz"
             rm -rf "$tmp_bundle_dir"
@@ -501,6 +502,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Preflight production deploy on self-hosted runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DEPLOY_DIR='${{ vars.DEPLOY_DIR }}'
+          export PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
+          bash scripts/deploy_production.sh --preflight-only
 
       - name: Deploy on self-hosted runner (pinned digest)
         shell: bash

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -61,6 +61,10 @@ On the production server:
 - A deploy directory containing:
   - a compose file (`docker-compose.yml`, `docker-compose.production.yaml`, etc.)
   - `.env` (application runtime env; not committed)
+    - Tag-based production CD now runs `scripts/deploy_production.sh --preflight-only`
+      before the live deploy and fails fast if the resolved deploy directory is
+      missing `.env` (default path: `$DEPLOY_DIR/.env`, typically
+      `/srv/pulseplate-production/.env`).
   - `Caddyfile.production` (Caddy reverse proxy config; see Caddyfile Configuration below)
 - A managed PostgreSQL instance reachable from the production host via `DATABASE_URL`
 - Managed database backup / PITR handled by the provider; the production deploy script no longer runs local `pg_dump`
@@ -380,6 +384,8 @@ High-level steps (run on the production server):
 2. Ensure the production server deploy directory contains:
    - compose file (`docker-compose.production.yaml`)
    - `.env` (application runtime env)
+     - Required before pushing the release tag: production CD preflights this
+       path and stops immediately if `$DEPLOY_DIR/.env` is missing.
    - `Caddyfile.production` (copied from `deploy/Caddyfile.production`)
    - managed PostgreSQL credentials in `DATABASE_URL`
 3. Ensure the compose file uses `IMAGE_REF` (preferred) or `TAG` (backwards-compatible).

--- a/docs/review/PR_1317_FIXED_MAPPING.md
+++ b/docs/review/PR_1317_FIXED_MAPPING.md
@@ -5,7 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+Disposition: FIXED
+Commit: 9eb34174
+Evidence: tests/test_deploy_contract_scripts.py:256
+Reason: Tightened the missing-`.env` preflight regression to require a single no-side-effect outcome (`deploy.log` must not be created), which closes the actionable Sourcery review on the new deploy contract test.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1317#pullrequestreview-4055721831 -> 9eb34174
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1317_FIXED_MAPPING.md
+++ b/docs/review/PR_1317_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1317 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+Notes: PR `#1317` keeps scope limited to failing production tag deploys earlier when the host env contract is incomplete. It must not broaden into GitHub-to-host secret provisioning or a wider production deploy redesign.

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${IMAGE_REF:?IMAGE_REF is required (ghcr.io/<image>@sha256:...)}"
-: "${TAG:?TAG is required (prod-vX.Y.Z)}"
+MODE="deploy"
+if [ "$#" -gt 1 ]; then
+  echo "❌ Usage: $0 [--preflight-only]" >&2
+  exit 1
+fi
+if [ "$#" -eq 1 ]; then
+  case "$1" in
+    --preflight-only)
+      MODE="preflight-only"
+      ;;
+    *)
+      echo "❌ Unsupported argument: $1" >&2
+      echo "Usage: $0 [--preflight-only]" >&2
+      exit 1
+      ;;
+  esac
+fi
+readonly MODE
 
-DEPLOY_IMAGE_REF="$IMAGE_REF"
-DEPLOY_TAG="$TAG"
+DEPLOY_IMAGE_REF="${IMAGE_REF:-}"
+DEPLOY_TAG="${TAG:-}"
+if [ "$MODE" != "preflight-only" ]; then
+  : "${IMAGE_REF:?IMAGE_REF is required (ghcr.io/<image>@sha256:...)}"
+  : "${TAG:?TAG is required (prod-vX.Y.Z)}"
+fi
 
 # Healthcheck configuration
 HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-12}"
@@ -270,8 +290,16 @@ validate_managed_postgres_contract() {
   fi
 }
 
-echo "Validating managed PostgreSQL production contract..."
-validate_managed_postgres_contract
+run_preflight() {
+  echo "Validating managed PostgreSQL production contract..."
+  validate_managed_postgres_contract
+  echo "✅ Production deploy preflight passed"
+}
+
+run_preflight
+if [ "$MODE" = "preflight-only" ]; then
+  exit 0
+fi
 
 login_to_ghcr_if_configured
 

--- a/tests/test_cd_workflow_production_deploy_gate.py
+++ b/tests/test_cd_workflow_production_deploy_gate.py
@@ -112,3 +112,29 @@ def test_production_deploy_jobs_delegate_registry_login_to_deploy_script() -> No
         'echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin'
         not in self_hosted_section
     )
+
+
+def test_production_deploy_jobs_run_preflight_before_live_deploy() -> None:
+    """Fail fast on missing remote env files before bundle extraction or deploy."""
+
+    workflow_text = CD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    ssh_section = workflow_text.split("deploy-production:", maxsplit=1)[1].split(
+        "deploy-production-self-hosted:", maxsplit=1
+    )[0]
+    self_hosted_section = workflow_text.split("deploy-production-self-hosted:", maxsplit=1)[1]
+    ssh_lines = ssh_section.splitlines()
+    self_hosted_lines = self_hosted_section.splitlines()
+
+    assert '"$tmp_script" --preflight-only' in ssh_section
+    assert ssh_lines.index('            "$tmp_script" --preflight-only') < ssh_lines.index(
+        '            tar -xzf "/tmp/${bundle_name}.tgz" -C "$tmp_bundle_dir"'
+    )
+    assert ssh_lines.index('            "$tmp_script" --preflight-only') < ssh_lines.index(
+        '            "$tmp_script"'
+    )
+
+    assert "Preflight production deploy on self-hosted runner" in self_hosted_section
+    assert "bash scripts/deploy_production.sh --preflight-only" in self_hosted_section
+    assert self_hosted_lines.index(
+        "          bash scripts/deploy_production.sh --preflight-only"
+    ) < self_hosted_lines.index("          bash scripts/deploy_production.sh")

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -251,7 +251,9 @@ printf 'docker %s\\n' "$*" >> "{log_file}"
 
     assert completed.returncode == 1
     assert f"Missing production env file: {project_dir / '.env'}" in completed.stderr
-    assert not log_file.exists() or log_file.read_text(encoding="utf-8") == ""
+    # RU: Неуспешный --preflight-only запуск не должен создавать deploy log.
+    # EN: A failed --preflight-only run must not create a deploy log.
+    assert not log_file.exists()
 
 
 def test_deploy_production_logs_in_to_ghcr_with_resolved_docker_binary(tmp_path: Path) -> None:

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -218,6 +218,42 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     assert all("helper " not in line for line in log_lines)
 
 
+def test_deploy_production_preflight_only_exits_non_zero_when_default_env_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh"), "--preflight-only"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert f"Missing production env file: {project_dir / '.env'}" in completed.stderr
+    assert not log_file.exists() or log_file.read_text(encoding="utf-8") == ""
+
+
 def test_deploy_production_logs_in_to_ghcr_with_resolved_docker_binary(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     docker_home = tmp_path / "docker-home"


### PR DESCRIPTION
## Summary
- add a side-effect-free `--preflight-only` mode to `scripts/deploy_production.sh`
- run deploy-script preflight before live rollout in both production CD lanes so missing `$DEPLOY_DIR/.env` fails early
- document the tag-deploy env prerequisite in `deploy/PRODUCTION.md`

## Test plan
- [x] `pytest -q tests/test_cd_workflow_production_deploy_gate.py`
- [x] `pytest -q tests/test_deploy_contract_scripts.py -k \"preflight_only or deploy_production\"`
- [x] `pre-commit run --all-files`
- [x] `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: FIXED  
Commit: 9eb34174  
Evidence: `tests/test_deploy_contract_scripts.py`  
Reason: Tightened the missing-`.env` preflight regression to require a single no-side-effect outcome (`deploy.log` must not be created), which closes the actionable Sourcery review on the new deploy contract test.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1317#pullrequestreview-4055721831 -> 9eb34174

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green
- [x] `make verify` green

## Deferred / Follow-ups
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI preflight mode to run deployment prechecks and exit early without performing a live deploy.

* **Documentation**
  * Updated production deployment docs to require preflight validation and to fail if the production .env file is missing.

* **Tests**
  * Added regression tests to verify preflight behavior and workflow gating.

* **Chores**
  * Deployment workflow updated to run preflight checks before the live deployment step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->