### PR TITLE
feat(ios-release-ops): protected App Store assets rollout

### DIFF
--- a/.github/workflows/ios-appstore-assets.yml
+++ b/.github/workflows/ios-appstore-assets.yml
@@ -151,6 +151,26 @@ jobs:
           echo "::error::Privileged App Store uploads may run only from main or release refs. Got ${GITHUB_REF}"
           exit 1
 
+      - name: Preflight protected App Store upload secrets
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+          APP_STORE_BUNDLE_IDENTIFIER: ${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in ASC_KEY_ID ASC_ISSUER_ID ASC_KEY_P8_BASE64 APP_STORE_BUNDLE_IDENTIFIER; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing protected App Store upload secret(s): ${missing[*]}. See docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md"
+            exit 1
+          fi
+
       - name: Upload metadata and screenshots
         working-directory: ios
         env:
@@ -194,6 +214,27 @@ jobs:
 
           echo "::error::Privileged App Store uploads may run only from main or release refs. Got ${GITHUB_REF}"
           exit 1
+
+      - name: Preflight protected App Privacy secrets
+        env:
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
+          FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
+          FASTLANE_TEAM_NAME: ${{ secrets.FASTLANE_TEAM_NAME }}
+          APP_STORE_BUNDLE_IDENTIFIER: ${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in FASTLANE_USER FASTLANE_SESSION FASTLANE_TEAM_ID FASTLANE_TEAM_NAME APP_STORE_BUNDLE_IDENTIFIER; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing protected App Privacy secret(s): ${missing[*]}. See docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md"
+            exit 1
+          fi
 
       - name: Upload App Privacy
         working-directory: ios

--- a/docs/review/PR_1318_FIXED_MAPPING.md
+++ b/docs/review/PR_1318_FIXED_MAPPING.md
@@ -5,7 +5,11 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+
+Disposition: FIXED
+Commit: b5984f92
+Evidence: identified by cubic in `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#pullrequestreview-4055966995`. `ios/fastlane/Fastfile:89` now enforces `fastlane/metadata` as a directory via `require_existing_directory!`, `ios/fastlane/Fastfile:95` now enforces `app_privacy_details.json` as a file via `require_existing_file!`, and `tests/test_ios_appstore_assets_workflow_contract.py:148` plus `tests/test_ios_appstore_assets_workflow_contract.py:162` lock the helper contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#pullrequestreview-4055966995 -> b5984f92
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1318_FIXED_MAPPING.md
+++ b/docs/review/PR_1318_FIXED_MAPPING.md
@@ -10,6 +10,8 @@ Disposition: FIXED
 Commit: b5984f92
 Evidence: identified by cubic in `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#pullrequestreview-4055966995`. `ios/fastlane/Fastfile:89` now enforces `fastlane/metadata` as a directory via `require_existing_directory!`, `ios/fastlane/Fastfile:95` now enforces `app_privacy_details.json` as a file via `require_existing_file!`, and `tests/test_ios_appstore_assets_workflow_contract.py:148` plus `tests/test_ios_appstore_assets_workflow_contract.py:162` lock the helper contract.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#pullrequestreview-4055966995 -> b5984f92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033101077 -> b5984f92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033101084 -> b5984f92
 
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)

--- a/docs/review/PR_1318_FIXED_MAPPING.md
+++ b/docs/review/PR_1318_FIXED_MAPPING.md
@@ -13,6 +13,13 @@ Evidence: identified by cubic in `https://github.com/Katsiarynakavaleuskaya/Puls
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033101077 -> b5984f92
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033101084 -> b5984f92
 
+Disposition: FIXED
+Commit: 356a2083
+Evidence: identified by CodeRabbit. `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md:83` now includes `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py` in the validation-only checklist, while `ios/fastlane/Fastfile:176` now requires `FASTLANE_TEAM_ID` and `FASTLANE_TEAM_NAME` before App Privacy upload and `tests/test_ios_appstore_assets_workflow_contract.py:153` locks the expanded fail-closed env contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#pullrequestreview-4055985256 -> 356a2083
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033118348 -> 356a2083
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033118351 -> 356a2083
+
 ## Merge Readiness
 - [ ] Local hard gate passed (`make verify`)
 - [ ] Required checks PASS with no pending required jobs

--- a/docs/review/PR_1318_FIXED_MAPPING.md
+++ b/docs/review/PR_1318_FIXED_MAPPING.md
@@ -1,0 +1,18 @@
+# PR 1318 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] Local hard gate passed (`make verify`)
+- [ ] Required checks PASS with no pending required jobs
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments
+- [ ] Final post-bot wait cycle completed
+Notes: Implementation-only App Store assets activation-prep PR. This PR does not
+claim rollout closeout; protected post-merge evidence on `main` and a separate
+docs-only follow-up PR are still required.

--- a/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+++ b/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
@@ -80,6 +80,8 @@ Purpose:
 Use validation-only flow before any protected upload:
 
 1. Run implementation PR checks locally:
+   - `python3 scripts/orchestration/check_preflight.py`
+   - `python3 scripts/orchestration/check_agent_consistency.py`
    - `pytest -q tests/test_ios_appstore_assets_workflow_contract.py`
    - `pytest -q tests/test_ios_appstore_asset_validators.py`
    - `pre-commit run --all-files`

--- a/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+++ b/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
@@ -1,0 +1,182 @@
+# iOS App Store Assets Rollout
+
+This runbook defines the protected release-ops flow for App Store metadata,
+screenshots, and App Privacy uploads.
+
+## Scope
+
+This lane governs only:
+
+- localized App Store metadata uploads
+- screenshot uploads to App Store Connect draft state
+- App Privacy questionnaire uploads
+- protected evidence collection after merge
+
+This lane does not govern:
+
+- semantic validator expansion
+- screenshot scenario redesign
+- token semantic changes
+- visual redesign driven by Figma/Canva
+- Apple Server API migration
+- backend or web deploy truth
+
+## Source Of Truth
+
+Protected rollout must stay aligned with the current repo-owned contract:
+
+- Workflow: `.github/workflows/ios-appstore-assets.yml`
+- Fastlane lanes: `ios/fastlane/Fastfile`
+- Screenshot validator suite: `tests/test_ios_appstore_asset_validators.py`
+- Workflow contract suite: `tests/test_ios_appstore_assets_workflow_contract.py`
+- Screenshot scenarios: `ios/PulsePlateUITests/AppStoreScreenshotTests.swift`
+- Design-token SoT:
+  - `docs/design/TOKENS_SOT.md`
+  - `frontend/src/styles/tokens.ts`
+  - `ios/PulsePlate/DesignSystem/DesignTokens.swift`
+
+## Secret Ownership And Placement
+
+Protected secrets must live in GitHub protected environments, not in repo files
+and not in PR branches.
+
+### Environment: `appstore-assets`
+
+Required secrets:
+
+- `ASC_KEY_ID`
+- `ASC_ISSUER_ID`
+- `ASC_KEY_P8_BASE64`
+- `APP_STORE_BUNDLE_IDENTIFIER`
+
+Purpose:
+
+- unlock `upload_to_asc=true` manual dispatch
+- provide App Store Connect API authentication
+
+### Environment: `appstore-privacy`
+
+Required secrets:
+
+- `FASTLANE_USER`
+- `FASTLANE_SESSION`
+- `FASTLANE_TEAM_ID`
+- `FASTLANE_TEAM_NAME`
+- `APP_STORE_BUNDLE_IDENTIFIER`
+
+Purpose:
+
+- unlock `upload_app_privacy=true` manual dispatch
+- provide Apple ID session authentication for App Privacy upload
+
+### Ownership Rule
+
+- release-ops owner manages protected environment configuration
+- implementation PR must not claim rollout completion without protected-run evidence
+- missing secrets are a fail-closed operator condition, not a reason to weaken guards
+
+## Validation-Only Path
+
+Use validation-only flow before any protected upload:
+
+1. Run implementation PR checks locally:
+   - `pytest -q tests/test_ios_appstore_assets_workflow_contract.py`
+   - `pytest -q tests/test_ios_appstore_asset_validators.py`
+   - `pre-commit run --all-files`
+   - `make verify`
+2. Confirm the workflow/Fastlane contract is merged to `main`.
+3. Use PR validation and normal CI to ensure screenshot capture and validator
+   surfaces stay green without touching protected upload paths.
+
+## Protected Upload Procedure
+
+Protected uploads are allowed only from:
+
+- `refs/heads/main`
+- `refs/heads/release/*`
+- `refs/tags/release-*`
+
+### Upload metadata and screenshots
+
+1. Merge the implementation PR to `main`.
+2. Open GitHub Actions for `ios-appstore-assets`.
+3. Start `workflow_dispatch` with:
+   - `upload_to_asc=true`
+   - `upload_app_privacy=false`
+4. Verify the run reaches:
+   - screenshot artifact download
+   - protected ref guard pass
+   - protected secret preflight pass
+   - successful `bundle exec fastlane ios upload_metadata_and_screenshots`
+5. Record the run URL / run ID for evidence.
+
+### Upload App Privacy
+
+1. Open GitHub Actions for `ios-appstore-assets`.
+2. Start `workflow_dispatch` with:
+   - `upload_to_asc=false`
+   - `upload_app_privacy=true`
+3. Verify the run reaches:
+   - metadata package validation
+   - protected ref guard pass
+   - protected secret preflight pass
+   - successful `bundle exec fastlane ios upload_app_privacy`
+4. Record the run URL / run ID for evidence.
+
+## Reviewer Notes Update Procedure
+
+Before the protected metadata/screenshots upload:
+
+1. Review `ios/fastlane/metadata/review_information/notes.txt`.
+2. Confirm reviewer notes still match:
+   - current HealthKit behavior
+   - wellness-only positioning
+   - read-only integration claims
+3. If notes changed in the implementation lane, re-run:
+   - `pytest -q tests/test_ios_appstore_asset_validators.py`
+4. Do not treat reviewer-notes edits as a semantic-validator expansion lane.
+
+## Rollback Procedure
+
+If a protected upload fails or pushes incorrect draft state:
+
+1. Stop and do not mark ledger items closed.
+2. Preserve evidence:
+   - workflow run URL / run ID
+   - relevant logs
+   - screenshot artifact name if applicable
+3. Revert only the draft-facing App Store Connect changes that were part of the
+   failed run.
+4. Fix the contract or metadata issue in a new PR.
+5. Re-run protected dispatch only after the fix merges to an allowed ref.
+
+## Design-System Guardrails
+
+This rollout lane may reference the current design-system SoT, but it must not
+change runtime composition.
+
+Allowed:
+
+- docs/parity/guard touches around App Store surfaces
+- SoT references for tokens and design ownership
+
+Not allowed:
+
+- screenshot composition changes
+- token semantic changes that alter visuals
+- iOS/web component layout changes
+- Figma/Canva-driven visual refresh by default
+
+## Evidence And Closeout Rule
+
+Implementation PR does not itself close rollout.
+
+Rollout is considered closed only when all of the following are true:
+
+1. implementation PR is merged
+2. protected `upload_to_asc=true` dispatch succeeds on `main` or allowed release ref
+3. protected `upload_app_privacy=true` dispatch succeeds on `main` or allowed release ref
+4. evidence links are collected in repo docs or review artifact
+5. a docs-only follow-up PR updates ledger and closeout references
+
+Without protected draft-upload evidence, this lane remains activation-prep only.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -173,7 +173,13 @@ platform :ios do
   desc "Upload App Privacy questionnaire answers using Apple ID session auth"
   lane :upload_app_privacy do
     require_env_vars!(
-      %w[FASTLANE_USER FASTLANE_SESSION APP_STORE_BUNDLE_IDENTIFIER],
+      %w[
+        FASTLANE_USER
+        FASTLANE_SESSION
+        FASTLANE_TEAM_ID
+        FASTLANE_TEAM_NAME
+        APP_STORE_BUNDLE_IDENTIFIER
+      ],
       context: "App Privacy protected upload"
     )
     require_existing_file!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -86,17 +86,20 @@ def fastlane_path(*parts)
   File.expand_path(File.join(*parts), __dir__)
 end
 
-def require_existing_path!(path, description)
-  return if File.exist?(path)
+def require_existing_directory!(path, description)
+  return if File.directory?(path)
+
+  UI.user_error!("Missing #{description} at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
+end
+
+def require_existing_file!(path, description)
+  return if File.file?(path)
 
   UI.user_error!("Missing #{description} at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
 end
 
 def require_non_empty_directory!(path, description)
-  require_existing_path!(path, description)
-  unless File.directory?(path)
-    UI.user_error!("Expected #{description} to be a directory at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
-  end
+  require_existing_directory!(path, description)
   return unless Dir.children(path).empty?
 
   UI.user_error!("Expected non-empty #{description} at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
@@ -149,7 +152,7 @@ platform :ios do
   desc "Upload localized metadata and screenshots to App Store Connect draft"
   lane :upload_metadata_and_screenshots do
     require_env_vars!(%w[APP_STORE_BUNDLE_IDENTIFIER], context: "App Store metadata/screenshots upload")
-    require_existing_path!(fastlane_path("metadata"), "App Store metadata directory")
+    require_existing_directory!(fastlane_path("metadata"), "App Store metadata directory")
     require_non_empty_directory!(fastlane_path("screenshots"), "App Store screenshots directory")
 
     deliver(
@@ -173,7 +176,7 @@ platform :ios do
       %w[FASTLANE_USER FASTLANE_SESSION APP_STORE_BUNDLE_IDENTIFIER],
       context: "App Privacy protected upload"
     )
-    require_existing_path!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")
+    require_existing_file!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")
 
     upload_app_privacy_details_to_app_store(
       username: ENV["FASTLANE_USER"],

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -3,6 +3,7 @@ require "shellwords"
 default_platform(:ios)
 
 APP_STORE_LOCALES = %w[ru-RU en-US es-ES].freeze
+IOS_APPSTORE_ASSETS_RUNBOOK = "docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md".freeze
 IPHONE_DEVICE_CANDIDATES = [
   # Prefer stable 18.5/18.6 runtimes on CI before falling back to 26.x simulators.
   "iPhone 16 Pro Max",
@@ -52,18 +53,26 @@ def app_store_bundle_identifier
   bundle_id = ENV["APP_STORE_BUNDLE_IDENTIFIER"]&.strip
   return bundle_id unless bundle_id.to_s.empty?
 
-  UI.user_error!("APP_STORE_BUNDLE_IDENTIFIER is required for App Store upload lanes")
+  UI.user_error!(
+    "APP_STORE_BUNDLE_IDENTIFIER is required for App Store upload lanes. See #{IOS_APPSTORE_ASSETS_RUNBOOK}"
+  )
 end
 
-def require_env_vars!(names)
+def require_env_vars!(names, context: nil)
   missing = names.select { |name| ENV[name].to_s.strip.empty? }
   return if missing.empty?
 
-  UI.user_error!("Missing required environment variables: #{missing.join(', ')}")
+  details = ["Missing required environment variables: #{missing.join(', ')}"]
+  details << "Context: #{context}" if context
+  details << "See #{IOS_APPSTORE_ASSETS_RUNBOOK}"
+  UI.user_error!(details.join(". "))
 end
 
 def asc_api_key
-  require_env_vars!(%w[APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID APP_STORE_CONNECT_API_KEY])
+  require_env_vars!(
+    %w[APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID APP_STORE_CONNECT_API_KEY],
+    context: "App Store Connect API key preflight"
+  )
 
   app_store_connect_api_key(
     key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
@@ -75,6 +84,22 @@ end
 
 def fastlane_path(*parts)
   File.expand_path(File.join(*parts), __dir__)
+end
+
+def require_existing_path!(path, description)
+  return if File.exist?(path)
+
+  UI.user_error!("Missing #{description} at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
+end
+
+def require_non_empty_directory!(path, description)
+  require_existing_path!(path, description)
+  unless File.directory?(path)
+    UI.user_error!("Expected #{description} to be a directory at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
+  end
+  return unless Dir.children(path).empty?
+
+  UI.user_error!("Expected non-empty #{description} at #{path}. See #{IOS_APPSTORE_ASSETS_RUNBOOK}")
 end
 
 platform :ios do
@@ -123,7 +148,9 @@ platform :ios do
 
   desc "Upload localized metadata and screenshots to App Store Connect draft"
   lane :upload_metadata_and_screenshots do
-    require_env_vars!(%w[APP_STORE_BUNDLE_IDENTIFIER])
+    require_env_vars!(%w[APP_STORE_BUNDLE_IDENTIFIER], context: "App Store metadata/screenshots upload")
+    require_existing_path!(fastlane_path("metadata"), "App Store metadata directory")
+    require_non_empty_directory!(fastlane_path("screenshots"), "App Store screenshots directory")
 
     deliver(
       api_key: asc_api_key,
@@ -142,7 +169,11 @@ platform :ios do
 
   desc "Upload App Privacy questionnaire answers using Apple ID session auth"
   lane :upload_app_privacy do
-    require_env_vars!(%w[FASTLANE_USER FASTLANE_SESSION APP_STORE_BUNDLE_IDENTIFIER])
+    require_env_vars!(
+      %w[FASTLANE_USER FASTLANE_SESSION APP_STORE_BUNDLE_IDENTIFIER],
+      context: "App Privacy protected upload"
+    )
+    require_existing_path!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")
 
     upload_app_privacy_details_to_app_store(
       username: ENV["FASTLANE_USER"],

--- a/tests/test_ios_appstore_assets_workflow_contract.py
+++ b/tests/test_ios_appstore_assets_workflow_contract.py
@@ -151,6 +151,13 @@ def test_fastlane_upload_lanes_stay_fail_closed() -> None:
     assert 'context: "App Store metadata/screenshots upload"' in fastfile_text
     assert 'context: "App Privacy protected upload"' in fastfile_text
     assert (
+        "FASTLANE_USER\n"
+        "        FASTLANE_SESSION\n"
+        "        FASTLANE_TEAM_ID\n"
+        "        FASTLANE_TEAM_NAME\n"
+        "        APP_STORE_BUNDLE_IDENTIFIER"
+    ) in fastfile_text
+    assert (
         'require_existing_directory!(fastlane_path("metadata"), "App Store metadata directory")'
         in fastfile_text
     )

--- a/tests/test_ios_appstore_assets_workflow_contract.py
+++ b/tests/test_ios_appstore_assets_workflow_contract.py
@@ -145,11 +145,13 @@ def test_fastlane_upload_lanes_stay_fail_closed() -> None:
         in fastfile_text
     )
     assert "def require_env_vars!(names, context: nil)" in fastfile_text
+    assert "def require_existing_directory!(path, description)" in fastfile_text
+    assert "def require_existing_file!(path, description)" in fastfile_text
     assert 'context: "App Store Connect API key preflight"' in fastfile_text
     assert 'context: "App Store metadata/screenshots upload"' in fastfile_text
     assert 'context: "App Privacy protected upload"' in fastfile_text
     assert (
-        'require_existing_path!(fastlane_path("metadata"), "App Store metadata directory")'
+        'require_existing_directory!(fastlane_path("metadata"), "App Store metadata directory")'
         in fastfile_text
     )
     assert (
@@ -157,7 +159,7 @@ def test_fastlane_upload_lanes_stay_fail_closed() -> None:
         in fastfile_text
     )
     assert (
-        'require_existing_path!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")'
+        'require_existing_file!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")'
         in fastfile_text
     )
     assert "See #{IOS_APPSTORE_ASSETS_RUNBOOK}" in fastfile_text

--- a/tests/test_ios_appstore_assets_workflow_contract.py
+++ b/tests/test_ios_appstore_assets_workflow_contract.py
@@ -1,0 +1,170 @@
+"""Contract tests for the protected iOS App Store release-ops workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ios-appstore-assets.yml"
+FASTFILE_PATH = REPO_ROOT / "ios" / "fastlane" / "Fastfile"
+EXPECTED_ALLOWED_REFS_REGEX = "^refs/heads/main$|^refs/heads/release/.+$|^refs/tags/release-.+$"
+
+
+def _load_workflow() -> dict[str, object]:
+    """Load GitHub Actions YAML without coercing `on` into a boolean key."""
+
+    return yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _job(job_name: str) -> dict[str, object]:
+    workflow = _load_workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[job_name]
+    assert isinstance(job, dict)
+    return job
+
+
+def _step_by_name(job_name: str, step_name: str) -> dict[str, object]:
+    steps = _job(job_name)["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        assert isinstance(step, dict)
+        if step.get("name") == step_name:
+            return step
+    raise AssertionError(f"Missing step {step_name!r} in job {job_name!r}")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _fastfile_text() -> str:
+    return FASTFILE_PATH.read_text(encoding="utf-8")
+
+
+def test_workflow_dispatch_inputs_match_release_ops_contract() -> None:
+    workflow = _load_workflow()
+    workflow_on = workflow["on"]
+    assert isinstance(workflow_on, dict)
+    workflow_dispatch = workflow_on["workflow_dispatch"]
+    assert isinstance(workflow_dispatch, dict)
+    inputs = workflow_dispatch["inputs"]
+    assert isinstance(inputs, dict)
+
+    assert set(inputs) == {"upload_to_asc", "upload_app_privacy"}
+
+
+def test_protected_environment_names_are_exact() -> None:
+    assert _job("upload-assets")["environment"] == "appstore-assets"
+    assert _job("upload-app-privacy")["environment"] == "appstore-privacy"
+
+
+def test_asc_upload_step_uses_exact_secret_mapping() -> None:
+    upload_step = _step_by_name("upload-assets", "Upload metadata and screenshots")
+    env = upload_step["env"]
+    assert isinstance(env, dict)
+    assert env == {
+        "APP_STORE_CONNECT_API_KEY_ID": "${{ secrets.ASC_KEY_ID }}",
+        "APP_STORE_CONNECT_API_ISSUER_ID": "${{ secrets.ASC_ISSUER_ID }}",
+        "APP_STORE_CONNECT_API_KEY": "${{ secrets.ASC_KEY_P8_BASE64 }}",
+        "APP_STORE_BUNDLE_IDENTIFIER": "${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}",
+    }
+
+
+def test_app_privacy_step_uses_exact_secret_mapping() -> None:
+    upload_step = _step_by_name("upload-app-privacy", "Upload App Privacy")
+    env = upload_step["env"]
+    assert isinstance(env, dict)
+    assert env == {
+        "FASTLANE_USER": "${{ secrets.FASTLANE_USER }}",
+        "FASTLANE_SESSION": "${{ secrets.FASTLANE_SESSION }}",
+        "FASTLANE_TEAM_ID": "${{ secrets.FASTLANE_TEAM_ID }}",
+        "FASTLANE_TEAM_NAME": "${{ secrets.FASTLANE_TEAM_NAME }}",
+        "APP_STORE_BUNDLE_IDENTIFIER": "${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}",
+    }
+
+
+def test_workflow_preflight_steps_require_exact_protected_secrets() -> None:
+    asc_preflight = _step_by_name("upload-assets", "Preflight protected App Store upload secrets")
+    asc_env = asc_preflight["env"]
+    assert isinstance(asc_env, dict)
+    assert asc_env == {
+        "ASC_KEY_ID": "${{ secrets.ASC_KEY_ID }}",
+        "ASC_ISSUER_ID": "${{ secrets.ASC_ISSUER_ID }}",
+        "ASC_KEY_P8_BASE64": "${{ secrets.ASC_KEY_P8_BASE64 }}",
+        "APP_STORE_BUNDLE_IDENTIFIER": "${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}",
+    }
+
+    privacy_preflight = _step_by_name(
+        "upload-app-privacy", "Preflight protected App Privacy secrets"
+    )
+    privacy_env = privacy_preflight["env"]
+    assert isinstance(privacy_env, dict)
+    assert privacy_env == {
+        "FASTLANE_USER": "${{ secrets.FASTLANE_USER }}",
+        "FASTLANE_SESSION": "${{ secrets.FASTLANE_SESSION }}",
+        "FASTLANE_TEAM_ID": "${{ secrets.FASTLANE_TEAM_ID }}",
+        "FASTLANE_TEAM_NAME": "${{ secrets.FASTLANE_TEAM_NAME }}",
+        "APP_STORE_BUNDLE_IDENTIFIER": "${{ secrets.APP_STORE_BUNDLE_IDENTIFIER }}",
+    }
+
+
+def test_privileged_upload_jobs_guard_allowed_refs() -> None:
+    for job_name in ("upload-assets", "upload-app-privacy"):
+        guard_step = _step_by_name(job_name, "Guard privileged upload ref")
+        env = guard_step["env"]
+        assert isinstance(env, dict)
+        assert env == {"ALLOWED_UPLOAD_REFS_REGEX": EXPECTED_ALLOWED_REFS_REGEX}
+        run_script = guard_step["run"]
+        assert isinstance(run_script, str)
+        assert "Privileged App Store uploads may run only from main or release refs." in run_script
+
+
+def test_pull_request_path_cannot_execute_privileged_uploads() -> None:
+    validate_assets_if = _job("validate-assets")["if"]
+    upload_assets_if = _job("upload-assets")["if"]
+    upload_app_privacy_if = _job("upload-app-privacy")["if"]
+
+    assert validate_assets_if == (
+        "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_asc)"
+    )
+    assert upload_assets_if == "github.event_name == 'workflow_dispatch' && inputs.upload_to_asc"
+    assert upload_app_privacy_if == (
+        "github.event_name == 'workflow_dispatch' && inputs.upload_app_privacy"
+    )
+
+
+def test_fastlane_upload_lanes_stay_fail_closed() -> None:
+    fastfile_text = _fastfile_text()
+
+    assert (
+        'IOS_APPSTORE_ASSETS_RUNBOOK = "docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md".freeze'
+        in fastfile_text
+    )
+    assert "def require_env_vars!(names, context: nil)" in fastfile_text
+    assert 'context: "App Store Connect API key preflight"' in fastfile_text
+    assert 'context: "App Store metadata/screenshots upload"' in fastfile_text
+    assert 'context: "App Privacy protected upload"' in fastfile_text
+    assert (
+        'require_existing_path!(fastlane_path("metadata"), "App Store metadata directory")'
+        in fastfile_text
+    )
+    assert (
+        'require_non_empty_directory!(fastlane_path("screenshots"), "App Store screenshots directory")'
+        in fastfile_text
+    )
+    assert (
+        'require_existing_path!(fastlane_path("app_privacy_details.json"), "App Privacy JSON package")'
+        in fastfile_text
+    )
+    assert "See #{IOS_APPSTORE_ASSETS_RUNBOOK}" in fastfile_text
+
+
+def test_runbook_reference_is_present_in_workflow_preflight_errors() -> None:
+    workflow_text = _workflow_text()
+    assert "docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md" in workflow_text
+    assert "Missing protected App Store upload secret(s):" in workflow_text
+    assert "Missing protected App Privacy secret(s):" in workflow_text


### PR DESCRIPTION
## Summary
- implementation PR only for protected App Store assets activation-prep
- closes the workflow contract / runbook / fail-closed hardening gap on top of the already-landed workflow and Fastlane baseline
- does not claim rollout closeout in this PR

## In Scope
- add `tests/test_ios_appstore_assets_workflow_contract.py`
- add `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
- minimal fail-closed/operator-message hardening in:
  - `.github/workflows/ios-appstore-assets.yml`
  - `ios/fastlane/Fastfile`

## Out Of Scope
- semantic validator expansion
- screenshot scenario redesign
- visual redesign / Figma / Canva asset refresh
- Apple Server API migration
- backend/web deploy truth
- ledger closeout in this implementation PR

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_ios_appstore_assets_workflow_contract.py`
- `pytest -q tests/test_ios_appstore_asset_validators.py`
- `pre-commit run --all-files`
- `make verify`

## Post-Merge Rule
Protected evidence is still required after merge on `main`:
- one `workflow_dispatch` with `upload_to_asc=true`
- one `workflow_dispatch` with `upload_app_privacy=true`
- separate docs-only follow-up PR for ledger closeout

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1318_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive iOS App Store Assets rollout runbook and a review page documenting rollout decisions and validation steps.

* **Bug Fixes**
  * CI/workflow now performs fail-closed preflight checks for required protected secrets and stops uploads with clear error messages linking to the runbook.
  * Fastlane preflight checks added for required environment variables, files, and directories.

* **Tests**
  * Added contract tests validating workflow inputs, protected-environment usage, preflight guards, and Fastlane fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->