### PR TITLE
docs(ios-release-ops): sync post-merge notes for PR 1318

### DIFF
--- a/docs/review/PR_1318_FIXED_MAPPING.md
+++ b/docs/review/PR_1318_FIXED_MAPPING.md
@@ -20,12 +20,19 @@ Evidence: identified by CodeRabbit. `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.m
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033118348 -> 356a2083
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1318#discussion_r3033118351 -> 356a2083
 
+## Post-Merge State
+
+- GitHub PR status: `merged=true`
+- Merge commit: `52053dd8953fd48bcac98e1754ee4104d33b9ea6`
+- Merged at: `2026-04-03T15:08:49Z`
+
 ## Merge Readiness
-- [ ] Local hard gate passed (`make verify`)
-- [ ] Required checks PASS with no pending required jobs
-- [ ] No unresolved review threads
-- [ ] No actionable bot comments
-- [ ] Final post-bot wait cycle completed
-Notes: Implementation-only App Store assets activation-prep PR. This PR does not
-claim rollout closeout; protected post-merge evidence on `main` and a separate
-docs-only follow-up PR are still required.
+- [x] Discussion-thread mapping preserved after merge
+- [x] Merge commit and merged timestamp recorded
+- [ ] Protected `main` dispatch evidence collected
+- [ ] Rollout closeout follow-up completed
+Notes: PR 1318 merged as the implementation-only App Store assets
+activation-prep change. Rollout closeout is still deferred until protected
+`upload_to_asc=true` and `upload_app_privacy=true` evidence is collected on
+`main`, after which a separate docs-only closeout PR should update the ledger
+and evidence references.

--- a/docs/review/PR_1320_FIXED_MAPPING.md
+++ b/docs/review/PR_1320_FIXED_MAPPING.md
@@ -1,0 +1,33 @@
+# PR 1320 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ios-appstore-assets-rollout`
+Evidence: identified by Sourcery in `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1320#pullrequestreview-4056155318`. The requested clarification about what counts as protected `main` dispatch evidence and the exact workflow/job identifiers belongs to the already-tracked rollout activation lane, while this tiny follow-up PR intentionally stays limited to the runbook env mapping note plus post-merge sync for PR `#1318`.
+Reason: Existing rollout follow-up is already tracked in the canonical backlog and remains intentionally outside this narrow docs-sync PR scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1320#pullrequestreview-4056155318
+
+Disposition: NOT-A-BUG
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:906` already tracks `ledger-p1-ios-appstore-assets-rollout` with owner, priority, links, and DoD for the protected App Store Connect rollout closeout, and `docs/review/PR_1318_FIXED_MAPPING.md:33` explicitly records that rollout closeout remains deferred pending protected evidence on `main`.
+Reason: CodeRabbit reports the deferred rollout closeout as untracked, but the canonical backlog item already exists.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1320#pullrequestreview-4056167062
+
+Disposition: NOT-A-BUG
+Evidence: identified by cubic in `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1320#pullrequestreview-4056169437` as "No issues found" across the 2 changed files.
+Reason: Informational non-actionable bot summary only.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1320#pullrequestreview-4056169437
+
+## Merge Readiness
+- [ ] Required current-head checks PASS
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] `pre-commit run --all-files` green
+- [x] `make validate-min` green
+Notes: This PR is a docs-only governance sync for PR `#1320`. It adds the
+canonical mapping artifact and PR-body mirror while keeping rollout evidence
+collection and ledger/evidence closeout work in their separate follow-up lane.

--- a/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+++ b/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
@@ -49,6 +49,18 @@ Required secrets:
 - `ASC_KEY_P8_BASE64`
 - `APP_STORE_BUNDLE_IDENTIFIER`
 
+Workflow / Fastlane env mapping:
+
+| GitHub protected secret | Workflow / Fastlane env var |
+| --- | --- |
+| `ASC_KEY_ID` | `APP_STORE_CONNECT_API_KEY_ID` |
+| `ASC_ISSUER_ID` | `APP_STORE_CONNECT_API_ISSUER_ID` |
+| `ASC_KEY_P8_BASE64` | `APP_STORE_CONNECT_API_KEY` |
+| `APP_STORE_BUNDLE_IDENTIFIER` | `APP_STORE_BUNDLE_IDENTIFIER` |
+
+The GitHub secret names above are mapped by the workflow into the env vars used
+by Fastlane preflight checks and upload logs.
+
 Purpose:
 
 - unlock `upload_to_asc=true` manual dispatch


### PR DESCRIPTION
## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1320_FIXED_MAPPING.md`

## Summary
- add an explicit `ASC_*` secret to `APP_STORE_CONNECT_*` env mapping note to the rollout runbook
- sync `docs/review/PR_1318_FIXED_MAPPING.md` with the merged state for PR `#1318`
- record that rollout closeout remains deferred until protected dispatch evidence is collected on `main`

## Carryover
This PR intentionally carries missed post-merge docs sync from already merged PR `#1318`.

Included:
- runbook mapping note
- post-merge sync for `PR_1318_FIXED_MAPPING.md`

Excluded:
- ledger closeout
- protected evidence claim
- code or workflow changes

## Validation
- `pre-commit run --all-files`
- `make validate-min`

## Сводка от Sourcery

Задокументировать состояние после слияния и оставшиеся задачи по развёртыванию для rollout’а ассетов iOS App Store, а также согласовать runbook по развёртыванию с текущими сопоставлениями секретов App Store Connect.

Документация:
- Добавить сведения о статусе после слияния для PR 1318, включая метаданные о слиянии и невыполненные требования по завершению rollout’а.
- Расширить runbook по развёртыванию ассетов iOS App Store явным соответствием между защищёнными секретами GitHub и переменными окружения рабочих процессов, относящимися к App Store Connect.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the merged state and remaining rollout tasks for the iOS App Store assets rollout and align the rollout runbook with the current App Store Connect secret mappings.

Documentation:
- Add post-merge status details for PR 1318, including merge metadata and outstanding rollout closeout requirements.
- Extend the iOS App Store assets rollout runbook with an explicit mapping between protected GitHub secrets and App Store Connect-related workflow environment variables.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs post-merge docs for PR #1318, adds a runbook table mapping `ASC_*` secrets to `APP_STORE_CONNECT_*` env vars, and adds the `docs/review/PR_1320_FIXED_MAPPING.md` artifact. Rollout closeout remains deferred until protected `main` evidence exists for `upload_to_asc=true` and `upload_app_privacy=true`.

<sup>Written for commit 4b89df9149cc56ce5c3e026e31dcc5c1a1effc5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added environment variable mapping for the iOS App Store rollout workflow, clarifying how repository secrets map to the deployment env.
  * Added/updated review and merge status records for recent PRs, including post-merge state, merge metadata, and an updated merge-readiness checklist.
  * Created a canonical mapping reference and checklist file for tracking rollout closeout follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->