### PR TITLE
feat(ios-release-ops): expand semantic App Store validators

### DIFF
--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -10,7 +10,37 @@ Disposition: FIXED
 Commit: 88ed2cf6
 Evidence: `ios/fastlane/verify/validate_metadata.rb`, `ios/fastlane/verify/validate_healthkit_copy.rb`, `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035411579 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/validate_metadata.rb`
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058394609 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417011 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `ios/fastlane/verify/validate_healthkit_copy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417012 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417013 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035412708 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035412710 -> 88ed2cf6
 Disposition: FIXED
 Commit: 88ed2cf6
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
@@ -19,6 +49,21 @@ Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_ass
 Disposition: FIXED
 Commit: 3dff7c12
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`, `docs/review/PR_1324_FIXED_MAPPING.md`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418398 -> 9d878406
+Disposition: FIXED
+Commit: 9d878406
+Evidence: `docs/review/PR_1324_FIXED_MAPPING.md`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418402 -> 3dff7c12
+Disposition: FIXED
+Commit: 3dff7c12
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418403 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
 
 ## Notes
 - Scope is limited to the repo-local semantic validator lane for App Store metadata and narrow privacy drift checks.

--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -110,6 +110,16 @@ Disposition: FIXED
 Commit: 280ce96c
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058427583 -> 61125cd7
+Disposition: FIXED
+Commit: 61125cd7
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035463530 -> 61125cd7
+Disposition: FIXED
+Commit: 61125cd7
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
 ## Notes
 - Scope is limited to the repo-local semantic validator lane for App Store metadata and narrow privacy drift checks.
 - Existing validator seams remain canonical:

--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -80,6 +80,36 @@ Disposition: FIXED
 Commit: 54f697df
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058416210 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058417482 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035447792 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035449485 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035449487 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035449490 -> 280ce96c
+Disposition: FIXED
+Commit: 280ce96c
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
 ## Notes
 - Scope is limited to the repo-local semantic validator lane for App Store metadata and narrow privacy drift checks.
 - Existing validator seams remain canonical:

--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -5,7 +5,20 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058390335 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/validate_metadata.rb`, `ios/fastlane/verify/validate_healthkit_copy.rb`, `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058394609 -> 88ed2cf6
+Disposition: FIXED
+Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058395679 -> 3dff7c12
+Disposition: FIXED
+Commit: 3dff7c12
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`, `docs/review/PR_1324_FIXED_MAPPING.md`
 
 ## Notes
 - Scope is limited to the repo-local semantic validator lane for App Store metadata and narrow privacy drift checks.
@@ -19,5 +32,5 @@
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] Mandatory wait-window completed
-- [x] `pre-commit run --all-files` green
-- [x] `make validate-min` green
+- [ ] `pre-commit run --all-files` green
+- [ ] `make validate-min` green

--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -50,6 +50,11 @@ Disposition: FIXED
 Commit: 3dff7c12
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`, `docs/review/PR_1324_FIXED_MAPPING.md`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058406826 -> 54f697df
+Disposition: FIXED
+Commit: 54f697df
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418398 -> 9d878406
 Disposition: FIXED
 Commit: 9d878406
@@ -63,6 +68,16 @@ Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_ass
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418403 -> 88ed2cf6
 Disposition: FIXED
 Commit: 88ed2cf6
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035434984 -> 54f697df
+Disposition: FIXED
+Commit: 54f697df
+Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035434985 -> 54f697df
+Disposition: FIXED
+Commit: 54f697df
 Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`
 
 ## Notes

--- a/docs/review/PR_1324_FIXED_MAPPING.md
+++ b/docs/review/PR_1324_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+# PR 1324 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Notes
+- Scope is limited to the repo-local semantic validator lane for App Store metadata and narrow privacy drift checks.
+- Existing validator seams remain canonical:
+  - `ios/fastlane/verify/validate_metadata.rb`
+  - `ios/fastlane/verify/validate_healthkit_copy.rb`
+- This PR intentionally does not touch protected App Store upload execution, GitHub environment secrets, or Apple-dependent rollout closeout evidence.
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Mandatory wait-window completed
+- [x] `pre-commit run --all-files` green
+- [x] `make validate-min` green

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -930,6 +930,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-TBD-IOS-APPSTORE-SEMANTIC-VALIDATORS
+  - Status: 🚧 In progress via `feat/ios-appstore-semantic-validators`
   - Area: iOS / release-ops / compliance
   - Finding Type: semantic compliance coverage gap
   - Reason: Current App Store validators are strong on file presence, dimensions, and basic wording rules, but they do not yet scan metadata/promotional copy for wellness-safe semantic drift or future privacy-package mismatches.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -929,7 +929,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Semantic App Store metadata and privacy validator expansion
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-IOS-APPSTORE-SEMANTIC-VALIDATORS
+  - Target PR: PR #1324
   - Status: 🚧 In progress via `feat/ios-appstore-semantic-validators`
   - Area: iOS / release-ops / compliance
   - Finding Type: semantic compliance coverage gap

--- a/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+++ b/docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
@@ -102,6 +102,27 @@ Use validation-only flow before any protected upload:
 3. Use PR validation and normal CI to ensure screenshot capture and validator
    surfaces stay green without touching protected upload paths.
 
+### Semantic validator outcomes
+
+The separate semantic-validator lane stays repo-local and does not require Apple
+enrollment or protected upload access.
+
+Blocking semantic failures:
+
+- App Store-facing copy uses medical / diagnosis / treatment / cure framing
+- App Store-facing copy makes guaranteed or promissory outcome claims
+- App Store-facing copy hardcodes pricing / trial / eligibility / billing claims
+  that must remain StoreKit / App Store truth
+- Reviewer notes or HealthKit copy contradict the current read-only /
+  `DATA_NOT_COLLECTED` posture
+
+Advisory findings:
+
+- machine-readable lines in the form `ADVISORY: <file> :: <reason>`
+- future privacy-review hints or suspicious-but-non-contradictory wording
+- advisory findings do not by themselves close or reopen the Apple-dependent
+  rollout evidence lane
+
 ## Protected Upload Procedure
 
 Protected uploads are allowed only from:

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -42,7 +42,7 @@ module SemanticPolicy
 
   PRIVACY_ADVISORY_HINTS = [
     {
-      pattern: /\b(?:analytics|advertising|ads|third-?party\s+sdk|tracking(?:\s+pixels?)?|аналитик(?:а|и|ой)|реклам(?:а|ы|ный)|seguimiento|anal[ií]tica|publicidad)\b/i,
+      pattern: /\b(?:analytics|advertising|ads|third-?party\s+sdk|ad(?:vertising)?\s+tracking|cross-?app\s+tracking|tracking\s+pixels?|аналитик(?:а|и|ой)|реклам(?:а|ы|ный)|seguimiento\s+publicitario|anal[ií]tica|publicidad)\b/i,
       message: "review whether App Privacy answers need updating for analytics/advertising language"
     },
     {
@@ -62,7 +62,7 @@ module SemanticPolicy
 
   REVIEW_NOTE_PRIVACY_CONTRADICTIONS = [
     {
-      pattern: /\b(?:write(?:s)?(?:\s+back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data|записыва(?:ет|ют)\s+в\s+Health|сохраня(?:ет|ют)\s+в\s+Health|sincroniza(?:n|r)?\s+de\s+vuelta\s+con\s+Health)\b/i,
+      pattern: /\b(?:write(?:s)?(?:\s+back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?(?:\s+back)?\s+to\s+Health|updates?\s+Health\s+data|записыва(?:ет|ют)\s+в\s+Health|сохраня(?:ет|ют)\s+в\s+Health|sincroniza(?:n|r)?\s+de\s+vuelta\s+con\s+Health)\b/i,
       message: "Reviewer notes contradict read-only HealthKit posture"
     },
     {
@@ -143,7 +143,7 @@ module SemanticPolicy
   def negated_review_note_prefix?(prefix)
     recent_prefix = prefix.downcase[-96..] || prefix.downcase
     recent_prefix.match?(
-      /\b(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|no\s+longer|не|никогда|no|nunca)\b(?:\W+[[:word:]]+){0,3}\W*\z/i,
+      /(?:\b(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|no\s+longer|никогда)\b(?:\W+[[:word:]]+){0,3}\W*\z|\b(?:не|no|nunca)\b\W*\z)/i,
     )
   end
 end

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -143,7 +143,18 @@ module SemanticPolicy
   def negated_review_note_prefix?(prefix)
     recent_prefix = prefix.downcase[-96..] || prefix.downcase
     recent_prefix.match?(
-      /(?:\b(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|no\s+longer|никогда)\b(?:\W+[[:word:]]+){0,3}\W*\z|\b(?:не|no|nunca)\b\W*\z)/i,
+      /
+        (?:
+          \b(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|no\s+longer|никогда)\b
+          (?:\W+[[:word:]]+){0,3}\W*\z
+          |
+          \b(?:no|nunca)\s+se\b(?:\W+[[:word:]]+){0,2}\W*\z
+          |
+          \bне\b(?:\W+(?:сейчас|уже|больше|будет|будем|буду|станет|станут|может|можем|должен|должна|должны|нужно|следует)){0,2}\W*\z
+          |
+          \b(?:не|no|nunca)\b\W*\z
+        )
+      /ix,
     )
   end
 end

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# RU: Общие детерминированные semantic rules для App Store release-ops validation.
+# EN: Shared deterministic semantic rules for App Store release-ops validation.
+module SemanticPolicy
+  APP_STORE_METADATA_FILES = %w[
+    description.txt
+    subtitle.txt
+    promotional_text.txt
+    release_notes.txt
+    keywords.txt
+  ].freeze
+
+  METADATA_MEDICAL_CLAIMS = /
+    \b(?:BMI|IMC|medical|doctor(?:s|led)?|diagnos(?:e|es|ed|ing|is|tic)?|patient(?:s)?|prescription(?:s)?|therapy|therapeutic)\b|
+    \b(?:ИМТ|медицин(?:а|ский|ская|ские|ских)|врач(?:а|ей|ом)?|диагноз(?:а|ом|е|ы)?|пациент(?:а|ов)?|рецепт(?:а|ов)?|терап(?:ия|ии|ию|ией))\b|
+    \b(?:m[eé]dic(?:o|a|os|as|al|amente)?|doctor(?:es)?|diagn[oó]stic(?:o|a|os|as)?|paciente(?:s)?|receta(?:s)?|terapia)\b
+  /ix.freeze
+
+  METADATA_TREATMENT_CLAIMS = /
+    \b(?:treat(?:ment|ments|s|ed|ing)?|cure(?:s|d|ing)?|heal(?:s|ed|ing)?|prevent(?:s|ed|ing)?)\b|
+    \b(?:леч(?:ит|ить|ен|ени(?:е|я))|исцел(?:яет|ение)|профилакт(?:ика|ирует))\b|
+    \b(?:tratamient(?:o|os)?|trat(?:a|ar|ado|ando)|cura(?:r|ción|ciones|s)?|san(?:a|ar|ado|ando)|prev(?:iene|enir|ención))\b
+  /ix.freeze
+
+  PROMISSORY_CLAIMS = /
+    \b(?:guarantee(?:d|s)?|guaranteed|instant(?:ly)?|rapid(?:ly)?|quick(?:ly)?|clinically\s+proven|proven\s+results?)\b|
+    \b(?:гарантир(?:ует|уют|ованный|ованные)|мгновенн(?:о|ый)|быстр(?:ый|о)|доказанн(?:ый|о))\b|
+    \b(?:garantiza(?:do|dos|da|das)?|instant[aá]neo(?:s|as)?|r[aá]pid(?:o|a|os|as|amente)|resultados?\s+comprobados)\b
+  /ix.freeze
+
+  STORE_TRUTH_CLAIMS = /
+    (?:[$€£¥₽]\s*\d)|(?:\d+\s*(?:USD|EUR|GBP|JPY|RUB))|
+    \b(?:monthly|yearly|per\s+month|per\s+year|subscription|subscribe|eligible|free\s+trial|trial|introductory\s+offer|auto-?renew)\b|
+    \b(?:ежемесячн(?:о|ая|ый)|ежегодн(?:о|ая|ый)|подписк(?:а|и|ой)|пробн(?:ый|ая)\s+период|триал|право\s+на\s+скидку|автопродление)\b|
+    \b(?:mensual|anual|suscripci[oó]n|suscr[ií]bete|prueba\s+gratuita|per[ií]odo\s+de\s+prueba|elegible|renovaci[oó]n\s+autom[aá]tica)\b
+  /ix.freeze
+
+  PRIVACY_ADVISORY_HINTS = [
+    {
+      pattern: /\b(?:analytics|advertising|ads|third-?party\s+sdk|tracking(?:\s+pixels?)?)\b/i,
+      message: "review whether App Privacy answers need updating for analytics/advertising language"
+    },
+    {
+      pattern: /\b(?:personalization|personalized\s+ads|data\s+sharing|share(?:s|d|ing)\s+data)\b/i,
+      message: "review whether App Privacy answers need updating for personalization/data-sharing language"
+    }
+  ].freeze
+
+  WELLNESS_DISCLAIMER_PATTERNS = [
+    /does\s+not\s+diagnose,\s*treat,\s*or\s*replace\s+professional\s+medical\s+care/i,
+    /не\s+ставит\s+диагноз,\s*не\s+лечит\s+и\s+не\s+заменяет\s+консультацию\s+специалиста/i,
+    /no\s+diagnostica,\s*no\s+trata\s+y\s+no\s+sustituye\s+la\s+atenci[oó]n\s+m[eé]dica\s+profesional/i
+  ].freeze
+
+  REVIEW_NOTE_PRIVACY_CONTRADICTIONS = [
+    {
+      pattern: /\b(?:write(?:s|back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data)\b/i,
+      message: "Reviewer notes contradict read-only HealthKit posture"
+    },
+    {
+      pattern: /\b(?:collect(?:s|ed|ing)?\s+Health\s+data|store(?:s|d)?\s+Health\s+data\s+on\s+our\s+servers)\b/i,
+      message: "Reviewer notes contradict DATA_NOT_COLLECTED Health posture"
+    }
+  ].freeze
+
+  module_function
+
+  def metadata_hard_failures(pathname, content)
+    return [] unless APP_STORE_METADATA_FILES.include?(pathname.basename.to_s)
+
+    sanitized_content = strip_allowed_wellness_disclaimers(content)
+    failures = []
+    if sanitized_content.match?(METADATA_MEDICAL_CLAIMS)
+      failures << "Blocked medical wording found in #{pathname}"
+    end
+    if sanitized_content.match?(METADATA_TREATMENT_CLAIMS)
+      failures << "Blocked treatment/cure wording found in #{pathname}"
+    end
+    if sanitized_content.match?(PROMISSORY_CLAIMS)
+      failures << "Blocked guaranteed/promissory wording found in #{pathname}"
+    end
+    if sanitized_content.match?(STORE_TRUTH_CLAIMS)
+      failures << "Blocked StoreKit/App Store truth claim found in #{pathname}"
+    end
+    failures
+  end
+
+  def healthkit_copy_hard_failures(pathname, content)
+    failures = []
+    failures << "Blocked medical wording found in #{pathname}" if content.match?(METADATA_MEDICAL_CLAIMS)
+    failures << "Blocked treatment/cure wording found in #{pathname}" if content.match?(METADATA_TREATMENT_CLAIMS)
+    failures
+  end
+
+  def review_notes_hard_failures(pathname, content)
+    REVIEW_NOTE_PRIVACY_CONTRADICTIONS.filter_map do |rule|
+      rule[:message] if content.match?(rule[:pattern])
+    end.map { |message| "#{message}: #{pathname}" }
+  end
+
+  def review_notes_advisories(pathname, content)
+    PRIVACY_ADVISORY_HINTS.filter_map do |rule|
+      next unless content.match?(rule[:pattern])
+
+      advisory_message(pathname, rule[:message])
+    end
+  end
+
+  def advisory_message(pathname, reason)
+    "ADVISORY: #{pathname} :: #{reason}"
+  end
+
+  def strip_allowed_wellness_disclaimers(content)
+    WELLNESS_DISCLAIMER_PATTERNS.reduce(content.dup) do |sanitized, pattern|
+      sanitized.gsub(pattern, "")
+    end
+  end
+end

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -21,7 +21,7 @@ module SemanticPolicy
   METADATA_TREATMENT_CLAIMS = /
     \b(?:treat(?:ment|ments|s|ed|ing)?|cure(?:s|d|ing)?|heal(?:s|ed|ing)?|prevent(?:s|ed|ing)?)\b|
     \b(?:леч(?:ит|ить|ен|ени(?:е|я))|исцел(?:яет|ение)|профилакт(?:ика|ирует))\b|
-    \b(?:tratamient(?:o|os)?|trat(?:a|ar|ado|ando)|cura(?:r|ción|ciones|s)?|san(?:a|ar|ado|ando)|prev(?:iene|enir|ención))\b
+    \b(?:tratamient(?:o|os)?|trat(?:a|ar|ado|ando)|cura(?:r|ción|ciones|s)?|san(?:ar|ado|ando)|prev(?:iene|enir|ención))\b
   /ix.freeze
 
   PROMISSORY_CLAIMS = /
@@ -33,11 +33,11 @@ module SemanticPolicy
   STORE_TRUTH_CLAIMS = [
     /(?:[$€£¥₽]\s*\d)|(?:\d+\s*(?:USD|EUR|GBP|JPY|RUB))/i,
     /\b(?:free\s+trial|trial\s+period|introductory\s+offer|subscribe\s+now|subscription\s+for\s+\$?\d+|auto-?renew(?:ing|al)?)\b/i,
-    /\b(?:per\s+month|per\s+year|monthly\s+subscription|yearly\s+subscription)\b/i,
+    /\b(?:monthly\s+subscription|yearly\s+subscription)\b/i,
     /\b(?:пробн(?:ый|ая)\s+период|вводн(?:ое|ая)\s+предложение|подпиш(?:итесь|ись)\s+сейчас|автопродлен(?:ие|ием))\b/i,
-    /\b(?:ежемесячн(?:ая|ый)\s+подписка|ежегодн(?:ая|ый)\s+подписка|в\s+месяц|в\s+год)\b/i,
+    /\b(?:ежемесячн(?:ая|ый)\s+подписка|ежегодн(?:ая|ый)\s+подписка)\b/i,
     /\b(?:prueba\s+gratuita|per[ií]odo\s+de\s+prueba|oferta\s+introductoria|suscr[ií]bete\s+ahora|renovaci[oó]n\s+autom[aá]tica)\b/i,
-    /\b(?:suscripci[oó]n\s+mensual|suscripci[oó]n\s+anual|por\s+mes|por\s+a[nñ]o)\b/i
+    /\b(?:suscripci[oó]n\s+mensual|suscripci[oó]n\s+anual)\b/i
   ].freeze
 
   PRIVACY_ADVISORY_HINTS = [
@@ -101,10 +101,14 @@ module SemanticPolicy
     failures
   end
 
-  def review_notes_hard_failures(pathname, content)
+  def review_notes_hard_failures(pathname, content, read_only:, data_not_collected:)
     REVIEW_NOTE_PRIVACY_CONTRADICTIONS.filter_map do |rule|
-      rule[:message] if content.match?(rule[:pattern])
-    end.map { |message| "#{message}: #{pathname}" }
+      next if rule[:message].include?("read-only") && !read_only
+      next if rule[:message].include?("DATA_NOT_COLLECTED") && !data_not_collected
+      next unless review_note_match_without_negation?(content, rule[:pattern])
+
+      "#{rule[:message]}: #{pathname}"
+    end
   end
 
   def review_notes_advisories(pathname, content)
@@ -127,5 +131,17 @@ module SemanticPolicy
 
   def store_truth_claim?(content)
     STORE_TRUTH_CLAIMS.any? { |pattern| content.match?(pattern) }
+  end
+
+  def review_note_match_without_negation?(content, pattern)
+    content.to_enum(:scan, pattern).any? do
+      match = Regexp.last_match
+      !negated_review_note_prefix?(content[0...match.begin(0)])
+    end
+  end
+
+  def negated_review_note_prefix?(prefix)
+    recent_prefix = prefix.downcase[-32..] || prefix.downcase
+    recent_prefix.match?(/(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|не|no)\s+\z/i)
   end
 end

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -25,9 +25,9 @@ module SemanticPolicy
   /ix.freeze
 
   PROMISSORY_CLAIMS = /
-    \b(?:guarantee(?:d|s)?|guaranteed|instant(?:ly)?|rapid(?:ly)?|quick(?:ly)?|clinically\s+proven|proven\s+results?)\b|
-    \b(?:гарантир(?:ует|уют|ованный|ованные)|мгновенн(?:о|ый)|быстр(?:ый|о)|доказанн(?:ый|о))\b|
-    \b(?:garantiza(?:do|dos|da|das)?|instant[aá]neo(?:s|as)?|r[aá]pid(?:o|a|os|as|amente)|resultados?\s+comprobados)\b
+    \b(?:guarantee(?:d|s)?(?:\s+results?)?|instant(?:\s+(?:results?|weight\s+loss|improvement))|rapid(?:\s+(?:results?|weight\s+loss|improvement))|quick(?:\s+(?:results?|weight\s+loss|improvement))|clinically\s+proven(?:\s+results?)?|proven\s+results?)\b|
+    \b(?:гарантир(?:ует|уют|ованный|ованные)(?:\s+результат(?:ы|ом)?)?|мгновенн(?:ый|ые|о)\s+результат(?:ы|ом)?|быстр(?:ый|ые|о)\s+результат(?:ы|ом)?|доказанн(?:ый|ые|о)\s+результат(?:ы|ом)?)\b|
+    \b(?:garantiza(?:do|dos|da|das)?(?:\s+resultados?)?|resultados?\s+comprobados|resultados?\s+instant[aá]neos?|resultados?\s+r[aá]pidos?)\b
   /ix.freeze
 
   STORE_TRUTH_CLAIMS = [

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -56,8 +56,8 @@ module SemanticPolicy
     /does\s+not\s+diagnos(?:e|is)[\s,]*(?:or|,|and)?\s*treat(?:\s+medical\s+conditions?)?/i,
     /не\s+ставит\s+диагноз[\s,]*(?:и|,)?\s*не\s+лечит[\s,]*(?:и|,)?\s*не\s+заменяет\s+консультаци(?:ю|и)\s+специалиста/i,
     /не\s+ставит\s+диагноз[\s,]*(?:и|,)?\s*не\s+лечит/i,
-    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*trata[\s,]*(?:ni|y|,)?\s*no\s+sustituye\s+la\s+atenci[oó]n\s+m[eé]dica\s+profesional/i,
-    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*trata(?:\s+afecciones?\s+m[eé]dicas?)?/i
+    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*(?:no\s+)?trata[\s,]*(?:ni|y|,)?\s*no\s+sustituye\s+la\s+atenci[oó]n\s+m[eé]dica\s+profesional/i,
+    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*(?:no\s+)?trata(?:\s+afecciones?\s+m[eé]dicas?)?/i
   ].freeze
 
   REVIEW_NOTE_PRIVACY_CONTRADICTIONS = [

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -13,7 +13,7 @@ module SemanticPolicy
   ].freeze
 
   METADATA_MEDICAL_CLAIMS = /
-    \b(?:BMI|IMC|medical|doctor(?:s|led)?|diagnos(?:e|es|ed|ing|is|tic)?|patient(?:s)?|prescription(?:s)?|therapy|therapeutic)\b|
+    \b(?:BMI|IMC|medical|doctor(?:s|(?:[-\s]+led))?|diagnos(?:e|es|ed|ing|is|tic)?|patient(?:s)?|prescription(?:s)?|therapy|therapeutic)\b|
     \b(?:ИМТ|медицин(?:а|ский|ская|ские|ских)|врач(?:а|ей|ом)?|диагноз(?:а|ом|е|ы)?|пациент(?:а|ов)?|рецепт(?:а|ов)?|терап(?:ия|ии|ию|ией))\b|
     \b(?:m[eé]dic(?:o|a|os|as|al|amente)?|doctor(?:es)?|diagn[oó]stic(?:o|a|os|as)?|paciente(?:s)?|receta(?:s)?|terapia)\b
   /ix.freeze
@@ -62,7 +62,7 @@ module SemanticPolicy
 
   REVIEW_NOTE_PRIVACY_CONTRADICTIONS = [
     {
-      pattern: /\b(?:write(?:s|back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data|записыва(?:ет|ют)\s+в\s+Health|сохраня(?:ет|ют)\s+в\s+Health|sincroniza(?:n|r)?\s+de\s+vuelta\s+con\s+Health)\b/i,
+      pattern: /\b(?:write(?:s)?(?:\s+back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data|записыва(?:ет|ют)\s+в\s+Health|сохраня(?:ет|ют)\s+в\s+Health|sincroniza(?:n|r)?\s+de\s+vuelta\s+con\s+Health)\b/i,
       message: "Reviewer notes contradict read-only HealthKit posture"
     },
     {
@@ -141,7 +141,9 @@ module SemanticPolicy
   end
 
   def negated_review_note_prefix?(prefix)
-    recent_prefix = prefix.downcase[-32..] || prefix.downcase
-    recent_prefix.match?(/(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|не|no)\s+\z/i)
+    recent_prefix = prefix.downcase[-96..] || prefix.downcase
+    recent_prefix.match?(
+      /\b(?:do\s+not|does\s+not|did\s+not|don't|doesn't|never|no\s+longer|не|никогда|no|nunca)\b(?:\W+[[:word:]]+){0,3}\W*\z/i,
+    )
   end
 end

--- a/ios/fastlane/verify/semantic_policy.rb
+++ b/ios/fastlane/verify/semantic_policy.rb
@@ -4,6 +4,7 @@
 # EN: Shared deterministic semantic rules for App Store release-ops validation.
 module SemanticPolicy
   APP_STORE_METADATA_FILES = %w[
+    name.txt
     description.txt
     subtitle.txt
     promotional_text.txt
@@ -29,37 +30,43 @@ module SemanticPolicy
     \b(?:garantiza(?:do|dos|da|das)?|instant[aá]neo(?:s|as)?|r[aá]pid(?:o|a|os|as|amente)|resultados?\s+comprobados)\b
   /ix.freeze
 
-  STORE_TRUTH_CLAIMS = /
-    (?:[$€£¥₽]\s*\d)|(?:\d+\s*(?:USD|EUR|GBP|JPY|RUB))|
-    \b(?:monthly|yearly|per\s+month|per\s+year|subscription|subscribe|eligible|free\s+trial|trial|introductory\s+offer|auto-?renew)\b|
-    \b(?:ежемесячн(?:о|ая|ый)|ежегодн(?:о|ая|ый)|подписк(?:а|и|ой)|пробн(?:ый|ая)\s+период|триал|право\s+на\s+скидку|автопродление)\b|
-    \b(?:mensual|anual|suscripci[oó]n|suscr[ií]bete|prueba\s+gratuita|per[ií]odo\s+de\s+prueba|elegible|renovaci[oó]n\s+autom[aá]tica)\b
-  /ix.freeze
+  STORE_TRUTH_CLAIMS = [
+    /(?:[$€£¥₽]\s*\d)|(?:\d+\s*(?:USD|EUR|GBP|JPY|RUB))/i,
+    /\b(?:free\s+trial|trial\s+period|introductory\s+offer|subscribe\s+now|subscription\s+for\s+\$?\d+|auto-?renew(?:ing|al)?)\b/i,
+    /\b(?:per\s+month|per\s+year|monthly\s+subscription|yearly\s+subscription)\b/i,
+    /\b(?:пробн(?:ый|ая)\s+период|вводн(?:ое|ая)\s+предложение|подпиш(?:итесь|ись)\s+сейчас|автопродлен(?:ие|ием))\b/i,
+    /\b(?:ежемесячн(?:ая|ый)\s+подписка|ежегодн(?:ая|ый)\s+подписка|в\s+месяц|в\s+год)\b/i,
+    /\b(?:prueba\s+gratuita|per[ií]odo\s+de\s+prueba|oferta\s+introductoria|suscr[ií]bete\s+ahora|renovaci[oó]n\s+autom[aá]tica)\b/i,
+    /\b(?:suscripci[oó]n\s+mensual|suscripci[oó]n\s+anual|por\s+mes|por\s+a[nñ]o)\b/i
+  ].freeze
 
   PRIVACY_ADVISORY_HINTS = [
     {
-      pattern: /\b(?:analytics|advertising|ads|third-?party\s+sdk|tracking(?:\s+pixels?)?)\b/i,
+      pattern: /\b(?:analytics|advertising|ads|third-?party\s+sdk|tracking(?:\s+pixels?)?|аналитик(?:а|и|ой)|реклам(?:а|ы|ный)|seguimiento|anal[ií]tica|publicidad)\b/i,
       message: "review whether App Privacy answers need updating for analytics/advertising language"
     },
     {
-      pattern: /\b(?:personalization|personalized\s+ads|data\s+sharing|share(?:s|d|ing)\s+data)\b/i,
+      pattern: /\b(?:personalization|personalized\s+ads|data\s+sharing|share(?:s|d|ing)\s+data|персонализ(?:ация|ированный)|обмен\s+данными|personalizaci[oó]n|compart(?:ir|e|imos)\s+datos)\b/i,
       message: "review whether App Privacy answers need updating for personalization/data-sharing language"
     }
   ].freeze
 
   WELLNESS_DISCLAIMER_PATTERNS = [
-    /does\s+not\s+diagnose,\s*treat,\s*or\s*replace\s+professional\s+medical\s+care/i,
-    /не\s+ставит\s+диагноз,\s*не\s+лечит\s+и\s+не\s+заменяет\s+консультацию\s+специалиста/i,
-    /no\s+diagnostica,\s*no\s+trata\s+y\s+no\s+sustituye\s+la\s+atenci[oó]n\s+m[eé]dica\s+profesional/i
+    /does\s+not\s+diagnos(?:e|is)[\s,]*(?:or|,|and)?\s*treat[\s,]*(?:or|,|and)?\s*(?:replace|substitute)\s+professional\s+medical\s+care/i,
+    /does\s+not\s+diagnos(?:e|is)[\s,]*(?:or|,|and)?\s*treat(?:\s+medical\s+conditions?)?/i,
+    /не\s+ставит\s+диагноз[\s,]*(?:и|,)?\s*не\s+лечит[\s,]*(?:и|,)?\s*не\s+заменяет\s+консультаци(?:ю|и)\s+специалиста/i,
+    /не\s+ставит\s+диагноз[\s,]*(?:и|,)?\s*не\s+лечит/i,
+    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*trata[\s,]*(?:ni|y|,)?\s*no\s+sustituye\s+la\s+atenci[oó]n\s+m[eé]dica\s+profesional/i,
+    /no\s+diagnostica[\s,]*(?:ni|y|,)?\s*trata(?:\s+afecciones?\s+m[eé]dicas?)?/i
   ].freeze
 
   REVIEW_NOTE_PRIVACY_CONTRADICTIONS = [
     {
-      pattern: /\b(?:write(?:s|back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data)\b/i,
+      pattern: /\b(?:write(?:s|back)?\s+to\s+Health|save(?:s)?\s+to\s+Health|sync(?:s)?\s+back\s+to\s+Health|updates?\s+Health\s+data|записыва(?:ет|ют)\s+в\s+Health|сохраня(?:ет|ют)\s+в\s+Health|sincroniza(?:n|r)?\s+de\s+vuelta\s+con\s+Health)\b/i,
       message: "Reviewer notes contradict read-only HealthKit posture"
     },
     {
-      pattern: /\b(?:collect(?:s|ed|ing)?\s+Health\s+data|store(?:s|d)?\s+Health\s+data\s+on\s+our\s+servers)\b/i,
+      pattern: /\b(?:collect(?:s|ed|ing)?\s+Health\s+data|store(?:s|d)?\s+Health\s+data\s+on\s+our\s+servers|собира(?:ет|ют)\s+данные\s+Health|almacena(?:mos|n)?\s+datos\s+de\s+Health\s+en\s+nuestros\s+servidores)\b/i,
       message: "Reviewer notes contradict DATA_NOT_COLLECTED Health posture"
     }
   ].freeze
@@ -80,16 +87,17 @@ module SemanticPolicy
     if sanitized_content.match?(PROMISSORY_CLAIMS)
       failures << "Blocked guaranteed/promissory wording found in #{pathname}"
     end
-    if sanitized_content.match?(STORE_TRUTH_CLAIMS)
+    if store_truth_claim?(sanitized_content)
       failures << "Blocked StoreKit/App Store truth claim found in #{pathname}"
     end
     failures
   end
 
   def healthkit_copy_hard_failures(pathname, content)
+    sanitized_content = strip_allowed_wellness_disclaimers(content)
     failures = []
-    failures << "Blocked medical wording found in #{pathname}" if content.match?(METADATA_MEDICAL_CLAIMS)
-    failures << "Blocked treatment/cure wording found in #{pathname}" if content.match?(METADATA_TREATMENT_CLAIMS)
+    failures << "Blocked medical wording found in #{pathname}" if sanitized_content.match?(METADATA_MEDICAL_CLAIMS)
+    failures << "Blocked treatment/cure wording found in #{pathname}" if sanitized_content.match?(METADATA_TREATMENT_CLAIMS)
     failures
   end
 
@@ -115,5 +123,9 @@ module SemanticPolicy
     WELLNESS_DISCLAIMER_PATTERNS.reduce(content.dup) do |sanitized, pattern|
       sanitized.gsub(pattern, "")
     end
+  end
+
+  def store_truth_claim?(content)
+    STORE_TRUTH_CLAIMS.any? { |pattern| content.match?(pattern) }
   end
 end

--- a/ios/fastlane/verify/validate_healthkit_copy.rb
+++ b/ios/fastlane/verify/validate_healthkit_copy.rb
@@ -3,18 +3,13 @@
 
 require "json"
 require "pathname"
+require_relative "semantic_policy"
 
 INFO_PLIST_LOCALES = {
   "en-US" => "en.lproj",
   "ru-RU" => "ru.lproj",
   "es-ES" => "es.lproj"
 }.freeze
-
-BLOCKED_MEDICAL_CLAIMS = /
-  \b(?:BMI|IMC|medical|diagnos(?:e|es|ed|ing|is|tic)?|treat(?:ment|ments|s|ed|ing)?|cure(?:s|d|ing)?)\b|
-  \b(?:ИМТ|диагноз(?:а|ом|е|ы)?|леч(?:ит|ить|ен|ени(?:е|я)))\b|
-  \b(?:m[eé]dic(?:o|a|os|as|al|amente)?|tratamient(?:o|os)?|cura(?:r|ción|ciones|s)?)\b
-/ix.freeze
 
 def parse_strings(pathname)
   entries = {}
@@ -36,6 +31,7 @@ review_notes_path = Pathname(ARGV[1])
 privacy_json_path = Pathname(ARGV[2])
 
 errors = []
+advisories = []
 
 INFO_PLIST_LOCALES.each_value do |folder_name|
   strings_path = app_root.join(folder_name, "InfoPlist.strings")
@@ -54,7 +50,7 @@ INFO_PLIST_LOCALES.each_value do |folder_name|
   end
 
   errors << "NSHealthUpdateUsageDescription must be absent for read-only HealthKit in #{strings_path}" unless update_copy.to_s.empty?
-  errors << "Blocked medical claim wording found in #{strings_path}" if share_copy.match?(BLOCKED_MEDICAL_CLAIMS)
+  errors.concat(SemanticPolicy.healthkit_copy_hard_failures(strings_path, share_copy.to_s))
 end
 
 unless review_notes_path.file?
@@ -67,6 +63,8 @@ end
 
 if review_notes_path.file?
   notes = review_notes_path.read
+  errors.concat(SemanticPolicy.review_notes_hard_failures(review_notes_path, notes))
+  advisories.concat(SemanticPolicy.review_notes_advisories(review_notes_path, notes))
   %w[HealthKit wellness consent read-only].each do |required_phrase|
     next if notes.downcase.include?(required_phrase.downcase)
 
@@ -88,6 +86,8 @@ if privacy_json_path.file?
     errors << "Invalid JSON in #{privacy_json_path}"
   end
 end
+
+advisories.sort.each { |advisory| puts advisory }
 
 if errors.empty?
   puts "validate_healthkit_copy: OK"

--- a/ios/fastlane/verify/validate_healthkit_copy.rb
+++ b/ios/fastlane/verify/validate_healthkit_copy.rb
@@ -32,6 +32,8 @@ privacy_json_path = Pathname(ARGV[2])
 
 errors = []
 advisories = []
+read_only_healthkit = true
+data_not_collected_healthkit = false
 
 INFO_PLIST_LOCALES.each_value do |folder_name|
   strings_path = app_root.join(folder_name, "InfoPlist.strings")
@@ -49,7 +51,12 @@ INFO_PLIST_LOCALES.each_value do |folder_name|
     next
   end
 
-  errors << "NSHealthUpdateUsageDescription must be absent for read-only HealthKit in #{strings_path}" unless update_copy.to_s.empty?
+  if update_copy.to_s.empty?
+    read_only_healthkit &&= true
+  else
+    read_only_healthkit = false
+    errors << "NSHealthUpdateUsageDescription must be absent for read-only HealthKit in #{strings_path}"
+  end
   errors.concat(SemanticPolicy.healthkit_copy_hard_failures(strings_path, share_copy.to_s))
 end
 
@@ -63,7 +70,6 @@ end
 
 if review_notes_path.file?
   notes = review_notes_path.read
-  errors.concat(SemanticPolicy.review_notes_hard_failures(review_notes_path, notes))
   advisories.concat(SemanticPolicy.review_notes_advisories(review_notes_path, notes))
   %w[HealthKit wellness consent read-only].each do |required_phrase|
     next if notes.downcase.include?(required_phrase.downcase)
@@ -79,12 +85,30 @@ if privacy_json_path.file?
       errors << "App privacy JSON must be a non-empty array"
     end
 
-    if privacy_entries.is_a?(Array) && !privacy_entries.any? { |entry| entry.is_a?(Hash) && Array(entry["data_protections"]).include?("DATA_NOT_COLLECTED") }
+    if privacy_entries.is_a?(Array)
+      data_not_collected_healthkit = privacy_entries.any? do |entry|
+        entry.is_a?(Hash) && Array(entry["data_protections"]).include?("DATA_NOT_COLLECTED")
+      end
+    end
+
+    unless data_not_collected_healthkit
       errors << "App privacy JSON must declare on-device HealthKit data as DATA_NOT_COLLECTED"
     end
   rescue JSON::ParserError
     errors << "Invalid JSON in #{privacy_json_path}"
   end
+end
+
+if review_notes_path.file?
+  notes = review_notes_path.read
+  errors.concat(
+    SemanticPolicy.review_notes_hard_failures(
+      review_notes_path,
+      notes,
+      read_only: read_only_healthkit,
+      data_not_collected: data_not_collected_healthkit,
+    ),
+  )
 end
 
 advisories.sort.each { |advisory| puts advisory }

--- a/ios/fastlane/verify/validate_metadata.rb
+++ b/ios/fastlane/verify/validate_metadata.rb
@@ -47,7 +47,6 @@ review_notes_path = Pathname(ARGV[1])
 privacy_json_path = Pathname(ARGV[2])
 
 errors = []
-advisories = []
 
 REQUIRED_LOCALES.each do |locale|
   locale_dir = metadata_root.join(locale)
@@ -118,8 +117,6 @@ if privacy_json_path.file?
     errors << "Invalid JSON in #{privacy_json_path}"
   end
 end
-
-advisories.sort.each { |advisory| puts advisory }
 
 if errors.empty?
   puts "validate_metadata: OK"

--- a/ios/fastlane/verify/validate_metadata.rb
+++ b/ios/fastlane/verify/validate_metadata.rb
@@ -62,12 +62,12 @@ REQUIRED_LOCALES.each do |locale|
       next
     end
 
-    if read_text(file_path).empty?
+    content = read_text(file_path)
+    if content.empty?
       errors << "Metadata file is empty: #{file_path}"
       next
     end
 
-    content = read_text(file_path)
     errors.concat(SemanticPolicy.metadata_hard_failures(file_path, content))
   end
 

--- a/ios/fastlane/verify/validate_metadata.rb
+++ b/ios/fastlane/verify/validate_metadata.rb
@@ -4,6 +4,7 @@
 require "json"
 require "pathname"
 require "uri"
+require_relative "semantic_policy"
 
 REQUIRED_LOCALES = %w[en-US ru-RU es-ES].freeze
 # Policy: repo metadata stays launch-ready and source-controlled across locales,
@@ -46,6 +47,7 @@ review_notes_path = Pathname(ARGV[1])
 privacy_json_path = Pathname(ARGV[2])
 
 errors = []
+advisories = []
 
 REQUIRED_LOCALES.each do |locale|
   locale_dir = metadata_root.join(locale)
@@ -63,7 +65,11 @@ REQUIRED_LOCALES.each do |locale|
 
     if read_text(file_path).empty?
       errors << "Metadata file is empty: #{file_path}"
+      next
     end
+
+    content = read_text(file_path)
+    errors.concat(SemanticPolicy.metadata_hard_failures(file_path, content))
   end
 
   subtitle = locale_dir.join("subtitle.txt")
@@ -112,6 +118,8 @@ if privacy_json_path.file?
     errors << "Invalid JSON in #{privacy_json_path}"
   end
 end
+
+advisories.sort.each { |advisory| puts advisory }
 
 if errors.empty?
   puts "validate_metadata: OK"

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -323,6 +323,92 @@ def test_validate_metadata_rejects_non_comma_keyword_separators(tmp_path: Path) 
     assert "Keywords must be comma-separated" in result.stderr
 
 
+@pytest.mark.parametrize(
+    ("locale", "content"),
+    [
+        ("en-US", "Doctor-led nutrition treatment for every patient."),
+        ("ru-RU", "Врач ставит диагноз и лечит пациента."),
+        ("es-ES", "Tratamiento médico guiado por doctor para cada paciente."),
+    ],
+)
+def test_validate_metadata_rejects_blocked_medical_wording_in_each_locale(
+    tmp_path: Path, locale: str, content: str
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    description_path = metadata_root / locale / "description.txt"
+    description_path.write_text(content, encoding="utf-8")
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Blocked medical wording found in {description_path}" in result.stderr
+
+
+def test_validate_metadata_rejects_guaranteed_promissory_claims(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    promotional_text_path = metadata_root / "en-US" / "promotional_text.txt"
+    promotional_text_path.write_text(
+        "Guaranteed results in 7 days with clinically proven progress.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert (
+        f"Blocked guaranteed/promissory wording found in {promotional_text_path}" in result.stderr
+    )
+
+
+def test_validate_metadata_rejects_wellness_only_contradiction_wording(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    subtitle_path = metadata_root / "en-US" / "subtitle.txt"
+    subtitle_path.write_text("Doctor-led clinical therapy planner", encoding="utf-8")
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Blocked medical wording found in {subtitle_path}" in result.stderr
+
+
+def test_validate_metadata_rejects_store_truth_claims(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    release_notes_path = metadata_root / "en-US" / "release_notes.txt"
+    release_notes_path.write_text(
+        "Start your free trial and subscribe for $9.99 per month.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Blocked StoreKit/App Store truth claim found in {release_notes_path}" in result.stderr
+
+
 def test_validate_metadata_rejects_invalid_argument_count(tmp_path: Path) -> None:
     result = _run_ruby(
         REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
@@ -394,3 +480,104 @@ def test_metadata_and_healthkit_validators_accept_seeded_package(tmp_path: Path)
         str(privacy_json),
     )
     assert healthkit_result.returncode == 0, healthkit_result.stderr
+
+
+def test_validate_healthkit_copy_rejects_read_only_and_data_collection_contradictions(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "The app writes to Health and collects Health data on our servers.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Reviewer notes contradict read-only HealthKit posture: {review_notes}" in result.stderr
+    assert (
+        f"Reviewer notes contradict DATA_NOT_COLLECTED Health posture: {review_notes}"
+        in result.stderr
+    )
+
+
+def test_validate_healthkit_copy_emits_sorted_advisory_lines_without_failing(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "This review mentions analytics and personalization for a future audit.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    advisory_lines = [line for line in result.stdout.splitlines() if line.startswith("ADVISORY: ")]
+    assert advisory_lines == [
+        f"ADVISORY: {review_notes} :: review whether App Privacy answers need updating for analytics/advertising language",
+        f"ADVISORY: {review_notes} :: review whether App Privacy answers need updating for personalization/data-sharing language",
+    ]
+    assert "validate_healthkit_copy: OK" in result.stdout

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -786,6 +786,101 @@ def test_validate_healthkit_copy_emits_sorted_advisory_lines_without_failing(
     assert "validate_healthkit_copy: OK" in result.stdout
 
 
+def test_validate_healthkit_copy_does_not_emit_advisory_for_meal_tracking_language(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "This review only references meal tracking and planning for wellness coaching.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ADVISORY:" not in result.stdout
+
+
+def test_validate_healthkit_copy_emits_advisory_for_tracking_pixels_language(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "This review mentions tracking pixels for an ad attribution audit.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        f"ADVISORY: {review_notes} :: review whether App Privacy answers need updating for analytics/advertising language"
+        in result.stdout
+    )
+
+
 def test_validate_healthkit_copy_ignores_negated_privacy_contradictions(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     _review_notes, _privacy_json = _prepare_metadata(metadata_root)
@@ -828,6 +923,56 @@ def test_validate_healthkit_copy_ignores_negated_privacy_contradictions(tmp_path
 
     assert result.returncode == 0, result.stderr
     assert "Reviewer notes contradict" not in result.stderr
+
+
+def test_validate_healthkit_copy_does_not_treat_bare_no_as_negation_with_following_words(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "No, we syncs to Health and collect Health data on our servers.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Reviewer notes contradict read-only HealthKit posture: {review_notes}" in result.stderr
+    assert (
+        f"Reviewer notes contradict DATA_NOT_COLLECTED Health posture: {review_notes}"
+        in result.stderr
+    )
 
 
 def test_validate_healthkit_copy_allows_wellness_disclaimer_variant(tmp_path: Path) -> None:

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -389,6 +389,32 @@ def test_validate_metadata_rejects_wellness_only_contradiction_wording(tmp_path:
     assert f"Blocked medical wording found in {subtitle_path}" in result.stderr
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "Doctor-led wellness guidance for better habits.",
+        "Doctor led wellness guidance for better habits.",
+    ],
+)
+def test_validate_metadata_rejects_doctor_led_variants_without_other_medical_tokens(
+    tmp_path: Path, content: str
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    subtitle_path = metadata_root / "en-US" / "subtitle.txt"
+    subtitle_path.write_text(content, encoding="utf-8")
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Blocked medical wording found in {subtitle_path}" in result.stderr
+
+
 def test_validate_metadata_rejects_store_truth_claims(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     review_notes, privacy_json = _prepare_metadata(metadata_root)
@@ -610,7 +636,7 @@ def test_validate_healthkit_copy_rejects_read_only_and_data_collection_contradic
                 "This flow is wellness-only.",
                 "Users provide consent before enabling access.",
                 "The HealthKit integration is read-only.",
-                "The app writes to Health and collects Health data on our servers.",
+                "The app writes back to Health and collects Health data on our servers.",
             ]
         ),
         encoding="utf-8",
@@ -660,7 +686,7 @@ def test_validate_healthkit_copy_uses_actual_privacy_posture_for_contradictions(
                 "This flow is wellness-only.",
                 "Users provide consent before enabling access.",
                 "The HealthKit integration is read-only.",
-                "The app writes to Health and collects Health data on our servers.",
+                "The app writes back to Health and collects Health data on our servers.",
             ]
         ),
         encoding="utf-8",
@@ -772,7 +798,7 @@ def test_validate_healthkit_copy_ignores_negated_privacy_contradictions(tmp_path
                 "This flow is wellness-only.",
                 "Users provide consent before enabling access.",
                 "The HealthKit integration is read-only.",
-                "The app does not write to Health and does not collect Health data on our servers.",
+                "The app no longer writes back to Health and does not currently collect Health data on our servers.",
             ]
         ),
         encoding="utf-8",

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -975,6 +975,94 @@ def test_validate_healthkit_copy_does_not_treat_bare_no_as_negation_with_followi
     )
 
 
+def test_validate_healthkit_copy_ignores_spanish_no_se_negation(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "No se sincroniza de vuelta con Health y no almacenamos datos de Health en nuestros servidores.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Reviewer notes contradict" not in result.stderr
+
+
+def test_validate_healthkit_copy_ignores_spanish_nunca_se_negation(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "Nunca se sincroniza de vuelta con Health y nunca almacena datos de Health en nuestros servidores.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Reviewer notes contradict" not in result.stderr
+
+
 def test_validate_healthkit_copy_allows_wellness_disclaimer_variant(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     review_notes, privacy_json = _prepare_metadata(metadata_root)

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -454,6 +454,28 @@ def test_validate_metadata_allows_wellness_disclaimer_variants(tmp_path: Path) -
     assert result.returncode == 0, result.stderr
 
 
+def test_validate_metadata_allows_spanish_wellness_disclaimer_variant(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    description_path = metadata_root / "es-ES" / "description.txt"
+    description_path.write_text(
+        (
+            "PulsePlate está diseñado para orientación wellness y planificación. "
+            "No diagnostica, no trata y no sustituye la atención médica profesional."
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_validate_metadata_allows_non_pricing_subscription_terms(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     review_notes, privacy_json = _prepare_metadata(metadata_root)

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -409,6 +409,63 @@ def test_validate_metadata_rejects_store_truth_claims(tmp_path: Path) -> None:
     assert f"Blocked StoreKit/App Store truth claim found in {release_notes_path}" in result.stderr
 
 
+def test_validate_metadata_allows_wellness_disclaimer_variants(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    description_path = metadata_root / "en-US" / "description.txt"
+    description_path.write_text(
+        "PulsePlate supports wellness planning and does not diagnose or treat medical conditions.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_validate_metadata_allows_non_pricing_subscription_terms(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    release_notes_path = metadata_root / "en-US" / "release_notes.txt"
+    release_notes_path.write_text(
+        "Fixes a subscription settings sync bug and improves eligibility copy review.",
+        encoding="utf-8",
+    )
+    keywords_path = metadata_root / "en-US" / "keywords.txt"
+    keywords_path.write_text("wellness,subscription,planning,coach", encoding="utf-8")
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_validate_metadata_rejects_medical_app_name(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    name_path = metadata_root / "en-US" / "name.txt"
+    name_path.write_text("Doctor BMI Coach", encoding="utf-8")
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert f"Blocked medical wording found in {name_path}" in result.stderr
+
+
 def test_validate_metadata_rejects_invalid_argument_count(tmp_path: Path) -> None:
     result = _run_ruby(
         REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
@@ -581,3 +638,28 @@ def test_validate_healthkit_copy_emits_sorted_advisory_lines_without_failing(
         f"ADVISORY: {review_notes} :: review whether App Privacy answers need updating for personalization/data-sharing language",
     ]
     assert "validate_healthkit_copy: OK" in result.stdout
+
+
+def test_validate_healthkit_copy_allows_wellness_disclaimer_variant(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            (
+                '"NSHealthShareUsageDescription" = '
+                '"PulsePlate reads Health data for wellness planning and does not diagnose or treat medical conditions.";'  # noqa: E501
+            ),
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -449,6 +449,44 @@ def test_validate_metadata_allows_non_pricing_subscription_terms(tmp_path: Path)
     assert result.returncode == 0, result.stderr
 
 
+def test_validate_metadata_allows_non_pricing_cadence_wording(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    release_notes_path = metadata_root / "en-US" / "release_notes.txt"
+    release_notes_path.write_text(
+        "Get 10 wellness tips per month and seasonal planning refreshes each year.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_validate_metadata_allows_spanish_healthy_adjective(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    description_path = metadata_root / "es-ES" / "description.txt"
+    description_path.write_text(
+        "Comida sana y planificación wellness para hábitos más consistentes.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_validate_metadata_rejects_medical_app_name(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     review_notes, privacy_json = _prepare_metadata(metadata_root)
@@ -589,6 +627,69 @@ def test_validate_healthkit_copy_rejects_read_only_and_data_collection_contradic
     )
 
 
+def test_validate_healthkit_copy_uses_actual_privacy_posture_for_contradictions(
+    tmp_path: Path,
+) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "The app writes to Health and collects Health data on our servers.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_USED_TO_TRACK_YOU"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            "\n".join(
+                [
+                    '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+                    '"NSHealthUpdateUsageDescription" = "PulsePlate can write updates back to Health.";',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 1
+    assert "NSHealthUpdateUsageDescription must be absent for read-only HealthKit" in result.stderr
+    assert (
+        "App privacy JSON must declare on-device HealthKit data as DATA_NOT_COLLECTED"
+        in result.stderr
+    )
+    assert (
+        f"Reviewer notes contradict read-only HealthKit posture: {review_notes}"
+        not in result.stderr
+    )
+    assert (
+        f"Reviewer notes contradict DATA_NOT_COLLECTED Health posture: {review_notes}"
+        not in result.stderr
+    )
+
+
 def test_validate_healthkit_copy_emits_sorted_advisory_lines_without_failing(
     tmp_path: Path,
 ) -> None:
@@ -638,6 +739,50 @@ def test_validate_healthkit_copy_emits_sorted_advisory_lines_without_failing(
         f"ADVISORY: {review_notes} :: review whether App Privacy answers need updating for personalization/data-sharing language",
     ]
     assert "validate_healthkit_copy: OK" in result.stdout
+
+
+def test_validate_healthkit_copy_ignores_negated_privacy_contradictions(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    _review_notes, _privacy_json = _prepare_metadata(metadata_root)
+    review_notes = tmp_path / "review_information" / "notes.txt"
+    review_notes.parent.mkdir(parents=True, exist_ok=True)
+    review_notes.write_text(
+        "\n".join(
+            [
+                "HealthKit review summary",
+                "This flow is wellness-only.",
+                "Users provide consent before enabling access.",
+                "The HealthKit integration is read-only.",
+                "The app does not write to Health and does not collect Health data.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    privacy_json = tmp_path / "app_privacy_details.json"
+    privacy_json.write_text(
+        json.dumps([{"data_protections": ["DATA_NOT_COLLECTED"]}]),
+        encoding="utf-8",
+    )
+
+    pulseplate_root = tmp_path / "PulsePlate"
+    for folder in ("en.lproj", "ru.lproj", "es.lproj"):
+        locale_dir = pulseplate_root / folder
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        (locale_dir / "InfoPlist.strings").write_text(
+            '"NSHealthShareUsageDescription" = "PulsePlate reads Health data with consent for wellness progress.";',
+            encoding="utf-8",
+        )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_healthkit_copy.rb",
+        str(pulseplate_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Reviewer notes contradict" not in result.stderr
 
 
 def test_validate_healthkit_copy_allows_wellness_disclaimer_variant(tmp_path: Path) -> None:

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -487,6 +487,25 @@ def test_validate_metadata_allows_spanish_healthy_adjective(tmp_path: Path) -> N
     assert result.returncode == 0, result.stderr
 
 
+def test_validate_metadata_allows_neutral_quick_logging_copy(tmp_path: Path) -> None:
+    metadata_root = tmp_path / "metadata"
+    review_notes, privacy_json = _prepare_metadata(metadata_root)
+    promotional_text_path = metadata_root / "en-US" / "promotional_text.txt"
+    promotional_text_path.write_text(
+        "Quickly log meals and review wellness history without extra steps.",
+        encoding="utf-8",
+    )
+
+    result = _run_ruby(
+        REPO_ROOT / "ios/fastlane/verify/validate_metadata.rb",
+        str(metadata_root),
+        str(review_notes),
+        str(privacy_json),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_validate_metadata_rejects_medical_app_name(tmp_path: Path) -> None:
     metadata_root = tmp_path / "metadata"
     review_notes, privacy_json = _prepare_metadata(metadata_root)
@@ -753,7 +772,7 @@ def test_validate_healthkit_copy_ignores_negated_privacy_contradictions(tmp_path
                 "This flow is wellness-only.",
                 "Users provide consent before enabling access.",
                 "The HealthKit integration is read-only.",
-                "The app does not write to Health and does not collect Health data.",
+                "The app does not write to Health and does not collect Health data on our servers.",
             ]
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- expand existing App Store validator seams without introducing a second metadata walker
- add deterministic semantic hard-fail rules for App Store-facing metadata copy, including app-name coverage
- thread actual privacy posture into reviewer-notes hard-fail logic and keep advisory output stable
- narrow semantic rules further to avoid false positives for neutral cadence, healthy-adjective, and quick-action wording

## Testing
- `pytest -q tests/test_ios_appstore_asset_validators.py`
- `pytest -q tests/test_ios_appstore_assets_workflow_contract.py`
- `pre-commit run --all-files`
- `make validate-min`

## Notes
- Apple-dependent rollout evidence lane remains paused; no protected runs, secrets work, or rollout closeout claims are included in this PR.
- Canonical review artifact: `docs/review/PR_1324_FIXED_MAPPING.md`

## Split Justification
- The semantic policy module, validator wiring, and regression tests were kept together because they change one deterministic contract surface; splitting them would create intermediate states where the validator logic and the tests/docs disagree.
- Apple rollout evidence, secrets, protected-run activation, and closeout work were intentionally kept out of this PR and remain tracked separately, so this PR is already the smallest mergeable unit for the validator scope.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058390335 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/validate_metadata.rb`, `ios/fastlane/verify/validate_healthkit_copy.rb`, `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035411579 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/validate_metadata.rb`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058394609 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417011 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `ios/fastlane/verify/validate_healthkit_copy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417012 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035417013 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035412708 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035412710 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058395679 -> 3dff7c12
Disposition: FIXED
Commit: 3dff7c12
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`, `docs/review/PR_1324_FIXED_MAPPING.md`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058406826 -> 54f697df
Disposition: FIXED
Commit: 54f697df
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418398 -> 9d878406
Disposition: FIXED
Commit: 9d878406
Evidence: `docs/review/PR_1324_FIXED_MAPPING.md`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418402 -> 3dff7c12
Disposition: FIXED
Commit: 3dff7c12
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035418403 -> 88ed2cf6
Disposition: FIXED
Commit: 88ed2cf6
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035434984 -> 54f697df
Disposition: FIXED
Commit: 54f697df
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035434985 -> 54f697df
Disposition: FIXED
Commit: 54f697df
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#pullrequestreview-4058427583 -> 61125cd7
Disposition: FIXED
Commit: 61125cd7
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1324#discussion_r3035463530 -> 61125cd7
Disposition: FIXED
Commit: 61125cd7
Evidence: `ios/fastlane/verify/semantic_policy.rb`, `tests/test_ios_appstore_asset_validators.py`

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Mandatory wait-window completed
- [ ] `pre-commit run --all-files` green
- [ ] `make validate-min` green




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger semantic App Store metadata validation for medical/treatment/promissory and StoreKit-truth claims; deterministic advisory formatting and ordering
  * Enhanced HealthKit posture checks that emit advisory lines for reviewer-note contradictions and factor read-only / data-not-collected signals

* **Documentation**
  * Added review summary with fixed-commit mappings, merge-readiness checklist, and semantic-validator outcomes guidance; backlog item updated to reference the PR

* **Tests**
  * Expanded tests covering metadata and HealthKit validator scenarios, including rejection and advisory cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

