### PR TITLE
feat(search): add Meili performance telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,10 @@ jobs:
                   tests/test_api.py \
                   tests/test_app_error_handling_combined.py \
                   tests/test_app_extended_coverage.py \
-                  tests/test_legacy_app_diff_coverage.py
+                  tests/test_food_search_foundation.py \
+                  tests/test_foods_router_coverage_boost.py \
+                  tests/test_legacy_app_diff_coverage.py \
+                  tests/test_metrics.py
                 ;;
               merge_governance)
                 add_suite \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1014,7 +1014,7 @@
         "filename": "tests/test_foods_router_coverage_boost.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 30
       }
     ],
     "tests/test_import_errors_coverage.py": [
@@ -1520,5 +1520,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-03T09:20:52Z"
+  "generated_at": "2026-04-04T21:46:34Z"
 }

--- a/app/bootstrap/food_search.py
+++ b/app/bootstrap/food_search.py
@@ -38,7 +38,8 @@ def _safe_index_name(raw_value: str | None) -> str:
 def _safe_show_performance_details(raw_value: str | None) -> bool:
     """Return validated Meili performance-details flag with safe default."""
 
-    return _is_truthy(raw_value)
+    enabled = _is_truthy(raw_value)
+    return bool(enabled)
 
 
 def register_food_search_backend(app: FastAPI) -> None:

--- a/app/bootstrap/food_search.py
+++ b/app/bootstrap/food_search.py
@@ -9,9 +9,11 @@ from fastapi import FastAPI
 
 from app.services import food_store
 from app.services.search_meili import MeiliSearchBackend, ShadowSearchBackend
+from app.utils.feature_flags import _is_truthy
 
 DEFAULT_MEILI_TIMEOUT_SECONDS = 2.0
 DEFAULT_MEILI_INDEX_NAME = "foods"
+MEILI_SHOW_PERFORMANCE_DETAILS_ENV = "MEILI_SHOW_PERFORMANCE_DETAILS"
 
 
 def _safe_timeout_seconds(raw_value: str | None) -> float:
@@ -31,6 +33,12 @@ def _safe_index_name(raw_value: str | None) -> str:
 
     normalized = (raw_value or "").strip()
     return normalized or DEFAULT_MEILI_INDEX_NAME
+
+
+def _safe_show_performance_details(raw_value: str | None) -> bool:
+    """Return validated Meili performance-details flag with safe default."""
+
+    return _is_truthy(raw_value)
 
 
 def register_food_search_backend(app: FastAPI) -> None:
@@ -53,6 +61,10 @@ def register_food_search_backend(app: FastAPI) -> None:
         index_name=_safe_index_name(os.getenv("MEILI_FOODS_INDEX")),
         api_key=(os.getenv("MEILI_KEY") or "").strip() or None,
         timeout_seconds=_safe_timeout_seconds(os.getenv("MEILI_TIMEOUT_SECONDS")),
+        show_performance_details=_safe_show_performance_details(
+            os.getenv(MEILI_SHOW_PERFORMANCE_DETAILS_ENV)
+        ),
+        search_strategy_label=strategy,
         fallback_backend=food_store.get_legacy_search_backend(),
     )
     adapter: food_store.FoodSearchBackend

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -27,6 +27,32 @@ LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE = "/api/nutrition/{date_str}"
 LEGACY_ALIAS_ROUTE_ALLOWLIST: set[str] = {
     LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE,
 }
+MEILI_SEARCH_STRATEGY_ALLOWLIST: set[str] = {
+    "meili",
+    "hybrid_shadow",
+    "baseline_fts",
+    "unknown",
+}
+MEILI_PERF_STATE_ALLOWLIST: set[str] = {
+    "disabled",
+    "captured",
+    "missing",
+    "invalid",
+    "fallback",
+}
+MEILI_DEGRADED_ALLOWLIST: set[str] = {
+    "true",
+    "false",
+    "unknown",
+}
+MEILI_STAGE_ALLOWLIST: set[str] = {
+    "authorization",
+    "tokenization",
+    "keyword_search",
+    "filtering",
+    "ranking",
+    "formatting",
+}
 
 
 class _CounterChild(Protocol):
@@ -35,6 +61,22 @@ class _CounterChild(Protocol):
 
 class _Counter(Protocol):
     def labels(self, *, alias_route: str) -> _CounterChild: ...
+
+
+class _MeiliCounter(Protocol):
+    def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _CounterChild: ...
+
+
+class _HistogramChild(Protocol):
+    def observe(self, amount: float) -> None: ...
+
+
+class _MeiliHistogram(Protocol):
+    def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _HistogramChild: ...
+
+
+class _MeiliStageHistogram(Protocol):
+    def labels(self, *, strategy: str, stage: str) -> _HistogramChild: ...
 
 
 _Importer = Callable[[str], Any]
@@ -51,6 +93,13 @@ def _import_prometheus(importer: _Importer = import_module) -> Any:
     """
     prometheus_client = importer("prometheus_client")
     return prometheus_client.Counter
+
+
+def _import_prometheus_histogram(importer: _Importer = import_module) -> Any:
+    """Import prometheus_client.Histogram in a patchable way."""
+
+    prometheus_client = importer("prometheus_client")
+    return prometheus_client.Histogram
 
 
 def _build_legacy_alias_requests_total() -> _Counter | None:
@@ -84,7 +133,102 @@ def _build_legacy_alias_requests_total() -> _Counter | None:
     return legacy_alias_requests_total
 
 
+def _build_food_search_meili_perf_events_total() -> _MeiliCounter | None:
+    """Initialize Meilisearch performance event counter."""
+
+    try:
+        Counter = _import_prometheus()
+    except ImportError:
+        return None
+
+    try:
+        meili_perf_events_total: _MeiliCounter = cast(
+            _MeiliCounter,
+            Counter(
+                "food_search_meili_perf_events_total",
+                "Total number of Meilisearch performance detail events",
+                labelnames=("strategy", "perf_state", "degraded"),
+            ),
+        )
+    except ValueError:
+        logger.warning(
+            "Duplicate prometheus metric registration for "
+            "food_search_meili_perf_events_total (metric disabled)",
+            exc_info=True,
+        )
+        return None
+
+    return meili_perf_events_total
+
+
+def _build_food_search_meili_processing_time_ms() -> _MeiliHistogram | None:
+    """Initialize Meilisearch total processing time histogram."""
+
+    try:
+        Histogram = _import_prometheus_histogram()
+    except ImportError:
+        return None
+
+    try:
+        meili_processing_time_ms: _MeiliHistogram = cast(
+            _MeiliHistogram,
+            Histogram(
+                "food_search_meili_processing_time_ms",
+                "Meilisearch total processing time in milliseconds",
+                labelnames=("strategy", "perf_state", "degraded"),
+                buckets=(1, 5, 10, 20, 50, 100, 250, 500, 1000, 2500, 5000),
+            ),
+        )
+    except ValueError:
+        logger.warning(
+            "Duplicate prometheus metric registration for "
+            "food_search_meili_processing_time_ms (metric disabled)",
+            exc_info=True,
+        )
+        return None
+
+    return meili_processing_time_ms
+
+
+def _build_food_search_meili_stage_processing_time_ms() -> _MeiliStageHistogram | None:
+    """Initialize Meilisearch stage processing time histogram."""
+
+    try:
+        Histogram = _import_prometheus_histogram()
+    except ImportError:
+        return None
+
+    try:
+        meili_stage_processing_time_ms: _MeiliStageHistogram = cast(
+            _MeiliStageHistogram,
+            Histogram(
+                "food_search_meili_stage_processing_time_ms",
+                "Meilisearch stage processing time in milliseconds",
+                labelnames=("strategy", "stage"),
+                buckets=(1, 5, 10, 20, 50, 100, 250, 500, 1000, 2500, 5000),
+            ),
+        )
+    except ValueError:
+        logger.warning(
+            "Duplicate prometheus metric registration for "
+            "food_search_meili_stage_processing_time_ms (metric disabled)",
+            exc_info=True,
+        )
+        return None
+
+    return meili_stage_processing_time_ms
+
+
 LEGACY_ALIAS_REQUESTS_TOTAL: _Counter | None = _build_legacy_alias_requests_total()
+FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL: _MeiliCounter | None = (
+    _build_food_search_meili_perf_events_total()
+)
+FOOD_SEARCH_MEILI_PROCESSING_TIME_MS: _MeiliHistogram | None = (
+    _build_food_search_meili_processing_time_ms()
+)
+FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS: _MeiliStageHistogram | None = (
+    _build_food_search_meili_stage_processing_time_ms()
+)
 
 
 def record_legacy_alias_hit(alias_route: str) -> None:
@@ -102,5 +246,121 @@ def record_legacy_alias_hit(alias_route: str) -> None:
 
     try:
         counter.labels(alias_route=alias_route).inc()
-    except Exception:  # nosec B110 - metrics must never affect request handling
+    except (
+        Exception
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+        pass
+
+
+def _normalize_label_value(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value.strip().lower()
+
+
+def _normalize_meili_strategy(strategy: object) -> str:
+    normalized = _normalize_label_value(strategy)
+    if normalized is None:
+        return "unknown"
+    if normalized in MEILI_SEARCH_STRATEGY_ALLOWLIST:
+        return normalized
+    return "unknown"
+
+
+def _normalize_meili_perf_state(perf_state: object) -> str:
+    normalized = _normalize_label_value(perf_state)
+    if normalized is None:
+        return "invalid"
+    if normalized in MEILI_PERF_STATE_ALLOWLIST:
+        return normalized
+    return "invalid"
+
+
+def _normalize_meili_degraded(degraded: object) -> str:
+    normalized = _normalize_label_value(degraded)
+    if normalized is None:
+        return "unknown"
+    if normalized in MEILI_DEGRADED_ALLOWLIST:
+        return normalized
+    return "unknown"
+
+
+def _normalize_meili_stage(stage: object) -> str | None:
+    normalized = _normalize_label_value(stage)
+    if normalized is None:
+        return None
+    if normalized in MEILI_STAGE_ALLOWLIST:
+        return normalized
+    return None
+
+
+def record_food_search_meili_performance(
+    *,
+    strategy: object,
+    perf_state: object,
+    degraded: object,
+    processing_time_ms: float | None,
+) -> None:
+    """Record best-effort Meilisearch performance summary metrics."""
+
+    normalized_strategy = _normalize_meili_strategy(strategy)
+    normalized_perf_state = _normalize_meili_perf_state(perf_state)
+    normalized_degraded = _normalize_meili_degraded(degraded)
+
+    counter = FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL
+    if counter is not None:
+        try:
+            counter.labels(
+                strategy=normalized_strategy,
+                perf_state=normalized_perf_state,
+                degraded=normalized_degraded,
+            ).inc()
+        except (
+            Exception
+        ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+            pass
+
+    if processing_time_ms is None:
+        return
+
+    histogram = FOOD_SEARCH_MEILI_PROCESSING_TIME_MS
+    if histogram is None:
+        return
+
+    try:
+        histogram.labels(
+            strategy=normalized_strategy,
+            perf_state=normalized_perf_state,
+            degraded=normalized_degraded,
+        ).observe(processing_time_ms)
+    except (
+        Exception
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+        pass
+
+
+def record_food_search_meili_stage_timing(
+    *,
+    strategy: object,
+    stage: object,
+    duration_ms: float,
+) -> None:
+    """Record best-effort Meilisearch stage timing metrics."""
+
+    normalized_stage = _normalize_meili_stage(stage)
+    if normalized_stage is None:
+        return
+
+    histogram = FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS
+    if histogram is None:
+        return
+
+    try:
+        histogram.labels(
+            strategy=_normalize_meili_strategy(strategy),
+            stage=normalized_stage,
+        ).observe(duration_ms)
+    except (
+        Exception
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
         pass

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -248,7 +248,7 @@ def record_legacy_alias_hit(alias_route: str) -> None:
         counter.labels(alias_route=alias_route).inc()
     except (
         Exception
-    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-1333)
         pass
 
 
@@ -317,7 +317,7 @@ def record_food_search_meili_performance(
             ).inc()
         except (
             Exception
-        ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+        ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-1333)
             pass
 
     if processing_time_ms is None:
@@ -335,7 +335,7 @@ def record_food_search_meili_performance(
         ).observe(processing_time_ms)
     except (
         Exception
-    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-1333)
         pass
 
 
@@ -362,5 +362,5 @@ def record_food_search_meili_stage_timing(
         ).observe(duration_ms)
     except (
         Exception
-    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-XXX)
+    ):  # nosec B110: metrics must never affect request handling (remove-by: 2026-06-30, ref: PR-1333)
         pass

--- a/app/services/search_meili.py
+++ b/app/services/search_meili.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 import json
 import logging
+import math
 import threading
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import httpx
+
+from app.metrics import (
+    record_food_search_meili_performance,
+    record_food_search_meili_stage_timing,
+)
 
 if TYPE_CHECKING:
     from app.services.food_store import FoodSearchBackend
@@ -19,6 +26,55 @@ Transport = Callable[[str, dict[str, Any], Mapping[str, str], float], Any]
 ShadowTaskRunner = Callable[[Callable[[], None]], None]
 _MAX_CONCURRENT_SHADOW_TASKS = 4
 _shadow_task_slots = threading.BoundedSemaphore(_MAX_CONCURRENT_SHADOW_TASKS)
+_MAX_MEILI_DURATION_MS = 600_000.0
+_PERF_DURATION_KEYS = (
+    "durationMs",
+    "elapsedMs",
+    "processingTimeMs",
+    "timeMs",
+    "totalMs",
+)
+_TOTAL_DURATION_KEYS = (
+    "processingTimeMs",
+    "totalProcessingTimeMs",
+    "totalMs",
+)
+_STAGE_NAME_ALIASES = {
+    "authorization": "authorization",
+    "authorizationms": "authorization",
+    "authorize": "authorization",
+    "authorizems": "authorization",
+    "tokenization": "tokenization",
+    "tokenizationms": "tokenization",
+    "tokenize": "tokenization",
+    "tokenizems": "tokenization",
+    "keywordsearch": "keyword_search",
+    "keywordsearchms": "keyword_search",
+    "keywords": "keyword_search",
+    "keywordms": "keyword_search",
+    "search": "keyword_search",
+    "searchms": "keyword_search",
+    "filtering": "filtering",
+    "filteringms": "filtering",
+    "filters": "filtering",
+    "filtersms": "filtering",
+    "ranking": "ranking",
+    "rankingms": "ranking",
+    "formatting": "formatting",
+    "formattingms": "formatting",
+    "format": "formatting",
+    "formatms": "formatting",
+}
+
+
+@dataclass(frozen=True)
+class NormalizedMeiliPerformanceDetails:
+    """Sanitized Meilisearch performance summary for observability only."""
+
+    state: Literal["disabled", "captured", "missing", "invalid", "fallback"]
+    processing_time_ms: float | None
+    degraded: Literal["true", "false", "unknown"]
+    stage_timings_ms: dict[str, float]
 
 
 def _numeric_field_or_default(hit: Mapping[str, Any], key: str) -> int | float:
@@ -28,6 +84,147 @@ def _numeric_field_or_default(hit: Mapping[str, Any], key: str) -> int | float:
     if isinstance(value, bool):
         return 0
     return value if isinstance(value, (int, float)) else 0
+
+
+def _normalize_degraded_flag(value: object) -> Literal["true", "false", "unknown"]:
+    """Normalize degraded flag to a low-cardinality string."""
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return "true"
+        if normalized == "false":
+            return "false"
+    return "unknown"
+
+
+def _coerce_non_negative_ms(value: object) -> float | None:
+    """Return a bounded millisecond value or None."""
+
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        return None
+    if normalized < 0 or normalized > _MAX_MEILI_DURATION_MS:
+        return None
+    return normalized
+
+
+def _normalize_stage_name(key: str) -> str | None:
+    """Map vendor stage names to repo-owned labels."""
+
+    normalized = key.strip().lower().replace("-", "").replace("_", "").replace(" ", "")
+    return _STAGE_NAME_ALIASES.get(normalized)
+
+
+def _duration_from_candidate(value: object) -> float | None:
+    """Extract a bounded duration value from a numeric or mapping candidate."""
+
+    numeric_value = _coerce_non_negative_ms(value)
+    if numeric_value is not None:
+        return numeric_value
+    if not isinstance(value, Mapping):
+        return None
+    for key in _PERF_DURATION_KEYS:
+        duration = _coerce_non_negative_ms(value.get(key))
+        if duration is not None:
+            return duration
+    return None
+
+
+def _extract_stage_timings(details: Mapping[str, Any]) -> dict[str, float]:
+    """Extract sanitized stage timings from vendor performance details."""
+
+    stage_timings: dict[str, float] = {}
+    for raw_key, raw_value in details.items():
+        stage_name = _normalize_stage_name(raw_key)
+        if stage_name is None or stage_name in stage_timings:
+            continue
+        duration_ms = _duration_from_candidate(raw_value)
+        if duration_ms is not None:
+            stage_timings[stage_name] = duration_ms
+    return stage_timings
+
+
+def _extract_processing_time_ms(
+    response: Mapping[str, Any],
+    details: Mapping[str, Any] | None,
+    stage_timings: Mapping[str, float],
+) -> float | None:
+    """Extract total processing time from known safe fields."""
+
+    processing_time_ms = _coerce_non_negative_ms(response.get("processingTimeMs"))
+    if processing_time_ms is not None:
+        return processing_time_ms
+    if details is not None:
+        for key in _TOTAL_DURATION_KEYS:
+            processing_time_ms = _coerce_non_negative_ms(details.get(key))
+            if processing_time_ms is not None:
+                return processing_time_ms
+    if stage_timings:
+        total_stage_time_ms = sum(stage_timings.values())
+        if total_stage_time_ms <= _MAX_MEILI_DURATION_MS:
+            return total_stage_time_ms
+    return None
+
+
+def _normalize_performance_details(
+    response: Mapping[str, Any],
+    *,
+    enabled: bool,
+    fallback: bool = False,
+) -> NormalizedMeiliPerformanceDetails:
+    """Return a sanitized performance summary from a Meili response."""
+
+    if fallback:
+        return NormalizedMeiliPerformanceDetails(
+            state="fallback",
+            processing_time_ms=None,
+            degraded="unknown",
+            stage_timings_ms={},
+        )
+    if not enabled:
+        return NormalizedMeiliPerformanceDetails(
+            state="disabled",
+            processing_time_ms=None,
+            degraded="unknown",
+            stage_timings_ms={},
+        )
+
+    raw_details = response.get("performanceDetails")
+    if raw_details is None:
+        return NormalizedMeiliPerformanceDetails(
+            state="missing",
+            processing_time_ms=_extract_processing_time_ms(response, None, {}),
+            degraded=_normalize_degraded_flag(response.get("degraded")),
+            stage_timings_ms={},
+        )
+    if not isinstance(raw_details, Mapping):
+        return NormalizedMeiliPerformanceDetails(
+            state="invalid",
+            processing_time_ms=_extract_processing_time_ms(response, None, {}),
+            degraded=_normalize_degraded_flag(response.get("degraded")),
+            stage_timings_ms={},
+        )
+
+    stage_timings_ms = _extract_stage_timings(raw_details)
+    processing_time_ms = _extract_processing_time_ms(response, raw_details, stage_timings_ms)
+    degraded = _normalize_degraded_flag(raw_details.get("degraded", response.get("degraded")))
+    if processing_time_ms is None and not stage_timings_ms and degraded == "unknown":
+        state: Literal["captured", "invalid"] = "invalid"
+    else:
+        state = "captured"
+    return NormalizedMeiliPerformanceDetails(
+        state=state,
+        processing_time_ms=processing_time_ms,
+        degraded=degraded,
+        stage_timings_ms=stage_timings_ms,
+    )
 
 
 def _default_transport(
@@ -81,6 +278,8 @@ class MeiliSearchBackend:
         index_name: str,
         api_key: str | None = None,
         timeout_seconds: float = 2.0,
+        show_performance_details: bool = False,
+        search_strategy_label: str = "meili",
         transport: Transport = _default_transport,
         fallback_backend: "FoodSearchBackend | None" = None,
     ) -> None:
@@ -88,8 +287,40 @@ class MeiliSearchBackend:
         self._index_name = index_name
         self._api_key = api_key
         self._timeout_seconds = timeout_seconds
+        self._show_performance_details = show_performance_details
+        self._search_strategy_label = search_strategy_label
         self._transport = transport
         self._fallback_backend = fallback_backend
+
+    def _record_performance_details(
+        self,
+        summary: NormalizedMeiliPerformanceDetails,
+    ) -> None:
+        """Emit best-effort observability for sanitized performance details."""
+
+        record_food_search_meili_performance(
+            strategy=self._search_strategy_label,
+            perf_state=summary.state,
+            degraded=summary.degraded,
+            processing_time_ms=summary.processing_time_ms,
+        )
+        for stage_name, duration_ms in summary.stage_timings_ms.items():
+            record_food_search_meili_stage_timing(
+                strategy=self._search_strategy_label,
+                stage=stage_name,
+                duration_ms=duration_ms,
+            )
+        if summary.state in {"captured", "invalid", "missing"}:
+            logger.debug(
+                "Meilisearch performance details processed",
+                extra={
+                    "strategy": self._search_strategy_label,
+                    "perf_state": summary.state,
+                    "degraded": summary.degraded,
+                    "processing_time_ms": summary.processing_time_ms,
+                    "stage_timings_ms": dict(summary.stage_timings_ms),
+                },
+            )
 
     def _fallback_search(
         self,
@@ -140,6 +371,8 @@ class MeiliSearchBackend:
                 "content_hash",
             ],
         }
+        if self._show_performance_details:
+            payload["showPerformanceDetails"] = True
         try:
             response = self._transport(search_url, payload, headers, self._timeout_seconds)
         except (
@@ -151,6 +384,13 @@ class MeiliSearchBackend:
             logger.warning(
                 "Meilisearch request failed; falling back to baseline backend", exc_info=True
             )
+            self._record_performance_details(
+                _normalize_performance_details(
+                    {},
+                    enabled=self._show_performance_details,
+                    fallback=True,
+                )
+            )
             return self._fallback_search(
                 query=query,
                 limit=normalized_limit,
@@ -159,6 +399,13 @@ class MeiliSearchBackend:
 
         if not isinstance(response, Mapping):
             logger.warning("Meilisearch response root was not an object")
+            self._record_performance_details(
+                _normalize_performance_details(
+                    {},
+                    enabled=self._show_performance_details,
+                    fallback=True,
+                )
+            )
             return self._fallback_search(
                 query=query,
                 limit=normalized_limit,
@@ -168,6 +415,13 @@ class MeiliSearchBackend:
         hits = response.get("hits", [])
         if not isinstance(hits, list):
             logger.warning("Meilisearch response missing hits list")
+            self._record_performance_details(
+                _normalize_performance_details(
+                    response,
+                    enabled=self._show_performance_details,
+                    fallback=True,
+                )
+            )
             return self._fallback_search(
                 query=query,
                 limit=normalized_limit,
@@ -190,6 +444,12 @@ class MeiliSearchBackend:
                     "content_hash": hit.get("content_hash"),
                 }
             )
+        self._record_performance_details(
+            _normalize_performance_details(
+                response,
+                enabled=self._show_performance_details,
+            )
+        )
         return normalized_hits
 
 

--- a/app/services/search_meili.py
+++ b/app/services/search_meili.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import json
 import logging
 import math
+import re
 import threading
 from typing import Any, Literal, TYPE_CHECKING
 
@@ -38,16 +39,19 @@ _TOTAL_DURATION_KEYS = (
     "processingTimeMs",
     "totalProcessingTimeMs",
     "totalMs",
+    "search",
 )
 _STAGE_NAME_ALIASES = {
     "authorization": "authorization",
     "authorizationms": "authorization",
     "authorize": "authorization",
     "authorizems": "authorization",
+    "waitforpermit": "authorization",
     "tokenization": "tokenization",
     "tokenizationms": "tokenization",
     "tokenize": "tokenization",
     "tokenizems": "tokenization",
+    "searchtokenize": "tokenization",
     "keywordsearch": "keyword_search",
     "keywordsearchms": "keyword_search",
     "keywords": "keyword_search",
@@ -58,13 +62,20 @@ _STAGE_NAME_ALIASES = {
     "filteringms": "filtering",
     "filters": "filtering",
     "filtersms": "filtering",
+    "searchfilter": "filtering",
     "ranking": "ranking",
     "rankingms": "ranking",
+    "searchranking": "ranking",
     "formatting": "formatting",
     "formattingms": "formatting",
     "format": "formatting",
     "formatms": "formatting",
+    "searchformat": "formatting",
 }
+_DURATION_VALUE_RE = re.compile(
+    r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ns|us|µs|μs|ms|s)\s*$",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +116,25 @@ def _coerce_non_negative_ms(value: object) -> float | None:
 
     if isinstance(value, bool):
         return None
+    if isinstance(value, str):
+        match = _DURATION_VALUE_RE.match(value)
+        if match is None:
+            return None
+        numeric_value = float(match.group("value"))
+        unit = match.group("unit").lower()
+        if unit == "ns":
+            normalized = numeric_value / 1_000_000
+        elif unit in {"us", "µs", "μs"}:
+            normalized = numeric_value / 1_000
+        elif unit == "ms":
+            normalized = numeric_value
+        else:
+            normalized = numeric_value * 1_000
+        if not math.isfinite(normalized):
+            return None
+        if normalized < 0 or normalized > _MAX_MEILI_DURATION_MS:
+            return None
+        return normalized
     if not isinstance(value, (int, float)):
         return None
     normalized = float(value)
@@ -118,7 +148,9 @@ def _coerce_non_negative_ms(value: object) -> float | None:
 def _normalize_stage_name(key: str) -> str | None:
     """Map vendor stage names to repo-owned labels."""
 
-    normalized = key.strip().lower().replace("-", "").replace("_", "").replace(" ", "")
+    normalized = (
+        key.strip().lower().replace("-", "").replace("_", "").replace(">", "").replace(" ", "")
+    )
     return _STAGE_NAME_ALIASES.get(normalized)
 
 

--- a/docs/review/PR_1333_FIXED_MAPPING.md
+++ b/docs/review/PR_1333_FIXED_MAPPING.md
@@ -1,7 +1,7 @@
 # PR 1333 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Review-comment pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping

--- a/docs/review/PR_1333_FIXED_MAPPING.md
+++ b/docs/review/PR_1333_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1333 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Review-comment pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: `e7c2a80f`
+Evidence: `scripts/orchestration/review_mapping_artifact.py:110`, `scripts/ci/check_pr_body_phase2_gates.py:162`, `scripts/orchestration/check_review_threads_disposition.py:467`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1333#pullrequestreview-4058898144 -> e7c2a80f
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1333#pullrequestreview-4058896844 -> e7c2a80f
+Disposition: DEFERRED
+Reason: Maintainability-only refactor guidance was reviewed on the current head, but this PR intentionally holds the safe-minimum scope to telemetry capture, tests, and merge-readiness without widening into shared helper/config refactors.
+Evidence: `app/services/search_meili.py`, `app/metrics.py`, and green targeted tests on current head

--- a/docs/review/PR_1333_FIXED_MAPPING.md
+++ b/docs/review/PR_1333_FIXED_MAPPING.md
@@ -15,3 +15,16 @@ Evidence: `scripts/orchestration/review_mapping_artifact.py:110`, `scripts/ci/ch
 Disposition: DEFERRED
 Reason: Maintainability-only refactor guidance was reviewed on the current head, but this PR intentionally holds the safe-minimum scope to telemetry capture, tests, and merge-readiness without widening into shared helper/config refactors.
 Evidence: `app/services/search_meili.py`, `app/metrics.py`, and green targeted tests on current head
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-meili-client-maintainability-followup-pr1333`
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit auto summary only; substantive human review threads are mapped with FIXED/DEFERRED above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1333#pullrequestreview-4058909211
+
+Disposition: NOT-A-BUG
+Evidence: Cubic aggregate review is non-blocking for merge; inline bot feedback is dispositioned separately when applicable.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1333#pullrequestreview-4058909546
+
+Disposition: NOT-A-BUG
+Evidence: DEFERRED block includes required `Backlog:` proof at `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-meili-client-maintainability-followup-pr1333` per review governance.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1333#discussion_r3036138034

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5290,6 +5290,20 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Target local-first search latency budget (<50ms p50) is measured and reported
 
 
+<a id="ledger-p2-meili-client-maintainability-followup-pr1333"></a>
+- [ ] P2: Meilisearch client shared-helper / config refactors (deferred from PR #1333)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: TBD
+  - Reason (EN): PR #1333 intentionally limits scope to env-gated Meilisearch performance telemetry and Prometheus metrics; maintainability refactors noted in review stay out of the telemetry slice.
+  - Links:
+    - `app/services/search_meili.py`
+    - `app/metrics.py`
+  - DoD:
+    - Duplicated Meili request configuration is consolidated where safe without changing `/api/v1/foods*` response contracts.
+    - `make verify` passes on the follow-up PR.
+
+
 - [x] P1: Execution Wave 3 — Restaurant menus + controlled user submissions
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -116,6 +116,8 @@ A standalone new test file may not be included in diff-cover's comparison, causi
 
 **Example (PR-490B)**: Coverage-tail tests for `core/bmi/engine.py` were moved from a standalone file into `tests/test_bmi_visualization_spec.py` (already modified in the PR) to ensure diff-cover correctly detects coverage.
 
+**Tier 1 `test-pr` routing** (`.github/workflows/ci.yml`): PRs that select the `route_contract_safety` contract group also run `tests/test_food_search_foundation.py`, `tests/test_foods_router_coverage_boost.py`, and `tests/test_metrics.py` so `coverage.xml` used by the `diff-coverage` job includes food/Meili/metrics paths touched under `app/`.
+
 ### Reliable local diff-cover check (prevents phantom gaps)
 
 **Problem**: diff-cover may show "missing lines" if coverage.xml is stale or from wrong test session.

--- a/tests/test_food_search_foundation.py
+++ b/tests/test_food_search_foundation.py
@@ -247,10 +247,10 @@ def test_meili_backend_records_captured_performance_details(
             ],
             "processingTimeMs": 42,
             "performanceDetails": {
-                "authorization": {"durationMs": 1},
-                "tokenization": {"durationMs": 2},
-                "keywordSearch": {"durationMs": 15},
-                "formatting": {"durationMs": 4},
+                "wait for permit": "295.29µs",
+                "search > tokenize": "436.67µs",
+                "search": "3.56ms",
+                "search > format": "288.54µs",
                 "degraded": False,
             },
         },
@@ -267,12 +267,21 @@ def test_meili_backend_records_captured_performance_details(
             "processing_time_ms": 42.0,
         }
     ]
-    assert captured_stages == [
-        {"strategy": "hybrid_shadow", "stage": "authorization", "duration_ms": 1.0},
-        {"strategy": "hybrid_shadow", "stage": "tokenization", "duration_ms": 2.0},
-        {"strategy": "hybrid_shadow", "stage": "keyword_search", "duration_ms": 15.0},
-        {"strategy": "hybrid_shadow", "stage": "formatting", "duration_ms": 4.0},
+    assert [stage["strategy"] for stage in captured_stages] == [
+        "hybrid_shadow",
+        "hybrid_shadow",
+        "hybrid_shadow",
+        "hybrid_shadow",
     ]
+    assert [stage["stage"] for stage in captured_stages] == [
+        "authorization",
+        "tokenization",
+        "keyword_search",
+        "formatting",
+    ]
+    assert [stage["duration_ms"] for stage in captured_stages] == pytest.approx(
+        [0.29529, 0.43667, 3.56, 0.28854]
+    )
 
 
 def test_meili_backend_treats_invalid_perf_details_as_observability_only(
@@ -821,9 +830,13 @@ def test_search_meili_helper_sanitizers_cover_edge_branches() -> None:
     assert search_meili_module._normalize_degraded_flag("maybe") == "unknown"
     assert search_meili_module._coerce_non_negative_ms(True) is None
     assert search_meili_module._coerce_non_negative_ms("5") is None
+    assert search_meili_module._coerce_non_negative_ms("250us") == 0.25
+    assert search_meili_module._coerce_non_negative_ms("2s") == 2000.0
     assert search_meili_module._coerce_non_negative_ms(-1) is None
     assert search_meili_module._coerce_non_negative_ms(700_000) is None
     assert search_meili_module._normalize_stage_name("keywordSearch") == "keyword_search"
+    assert search_meili_module._normalize_stage_name("search > tokenize") == "tokenization"
+    assert search_meili_module._normalize_stage_name("wait for permit") == "authorization"
     assert search_meili_module._normalize_stage_name("unknown-stage") is None
     assert search_meili_module._duration_from_candidate(7) == 7.0
     assert search_meili_module._duration_from_candidate({"durationMs": 9}) == 9.0

--- a/tests/test_food_search_foundation.py
+++ b/tests/test_food_search_foundation.py
@@ -826,12 +826,17 @@ def test_coerce_non_negative_ms_rejects_nan() -> None:
 
 def test_search_meili_helper_sanitizers_cover_edge_branches() -> None:
     assert search_meili_module._normalize_degraded_flag(True) == "true"
+    assert search_meili_module._normalize_degraded_flag("true") == "true"
     assert search_meili_module._normalize_degraded_flag("false") == "false"
     assert search_meili_module._normalize_degraded_flag("maybe") == "unknown"
     assert search_meili_module._coerce_non_negative_ms(True) is None
     assert search_meili_module._coerce_non_negative_ms("5") is None
+    assert search_meili_module._coerce_non_negative_ms("12ns") == 12e-6
     assert search_meili_module._coerce_non_negative_ms("250us") == 0.25
+    assert search_meili_module._coerce_non_negative_ms("7ms") == 7.0
     assert search_meili_module._coerce_non_negative_ms("2s") == 2000.0
+    assert search_meili_module._coerce_non_negative_ms("700000ms") is None
+    assert search_meili_module._coerce_non_negative_ms("9" * 400 + "ms") is None
     assert search_meili_module._coerce_non_negative_ms(-1) is None
     assert search_meili_module._coerce_non_negative_ms(700_000) is None
     assert search_meili_module._normalize_stage_name("keywordSearch") == "keyword_search"
@@ -1077,6 +1082,31 @@ def test_record_food_search_meili_stage_timing_filters_unknown_stage(
         {"kind": "labels", "strategy": "hybrid_shadow", "stage": "authorization"},
         {"kind": "observe", "amount": 5.0},
     ]
+
+
+def test_record_food_search_meili_stage_timing_noops_when_stage_not_normalizable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _HistogramChild:
+        def observe(self, amount: float) -> None:
+            calls.append({"kind": "observe", "amount": amount})
+
+    class _Histogram:
+        def labels(self, *, strategy: str, stage: str) -> _HistogramChild:
+            calls.append({"kind": "labels", "strategy": strategy, "stage": stage})
+            return _HistogramChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS", _Histogram())
+
+    app_metrics.record_food_search_meili_stage_timing(
+        strategy="meili",
+        stage=42,
+        duration_ms=1.0,
+    )
+
+    assert calls == []
 
 
 def test_record_food_search_meili_stage_timing_noops_and_swallows_errors(

--- a/tests/test_food_search_foundation.py
+++ b/tests/test_food_search_foundation.py
@@ -6,8 +6,10 @@ import httpx
 import pytest
 from typing import Literal
 
+import app.metrics as app_metrics
 from app.bootstrap.food_search import (
     _safe_index_name,
+    _safe_show_performance_details,
     _safe_timeout_seconds,
     register_food_search_backend,
 )
@@ -163,6 +165,248 @@ def test_meili_backend_passes_authorization_header_to_transport() -> None:
 
     assert backend.search_foods("apple") == []
     assert captured_headers == [{"Authorization": "Bearer x"}]
+
+
+def test_meili_backend_omits_show_performance_details_when_disabled() -> None:
+    captured_payloads: list[dict[str, object]] = []
+
+    def _transport(
+        url: str,
+        payload: dict[str, object | int | str],
+        headers: dict[str, str] | Mapping[str, str],
+        timeout_seconds: float,
+    ) -> dict[str, object]:
+        captured_payloads.append(dict(payload))
+        return {"hits": []}
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        transport=_transport,
+    )
+
+    assert backend.search_foods("apple") == []
+    assert "showPerformanceDetails" not in captured_payloads[0]
+
+
+def test_meili_backend_includes_show_performance_details_when_enabled() -> None:
+    captured_payloads: list[dict[str, object]] = []
+
+    def _transport(
+        url: str,
+        payload: dict[str, object | int | str],
+        headers: dict[str, str] | Mapping[str, str],
+        timeout_seconds: float,
+    ) -> dict[str, object]:
+        captured_payloads.append(dict(payload))
+        return {"hits": []}
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=_transport,
+    )
+
+    assert backend.search_foods("apple") == []
+    assert captured_payloads[0]["showPerformanceDetails"] is True
+
+
+def test_meili_backend_records_captured_performance_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_summaries: list[dict[str, object]] = []
+    captured_stages: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_performance",
+        lambda **kwargs: captured_summaries.append(kwargs),
+    )
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_stage_timing",
+        lambda **kwargs: captured_stages.append(kwargs),
+    )
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        search_strategy_label="hybrid_shadow",
+        transport=lambda *_args: {
+            "hits": [
+                {
+                    "id": "1",
+                    "name": "Apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14,
+                }
+            ],
+            "processingTimeMs": 42,
+            "performanceDetails": {
+                "authorization": {"durationMs": 1},
+                "tokenization": {"durationMs": 2},
+                "keywordSearch": {"durationMs": 15},
+                "formatting": {"durationMs": 4},
+                "degraded": False,
+            },
+        },
+    )
+
+    rows = backend.search_foods("apple")
+
+    assert rows[0]["id"] == "1"
+    assert captured_summaries == [
+        {
+            "strategy": "hybrid_shadow",
+            "perf_state": "captured",
+            "degraded": "false",
+            "processing_time_ms": 42.0,
+        }
+    ]
+    assert captured_stages == [
+        {"strategy": "hybrid_shadow", "stage": "authorization", "duration_ms": 1.0},
+        {"strategy": "hybrid_shadow", "stage": "tokenization", "duration_ms": 2.0},
+        {"strategy": "hybrid_shadow", "stage": "keyword_search", "duration_ms": 15.0},
+        {"strategy": "hybrid_shadow", "stage": "formatting", "duration_ms": 4.0},
+    ]
+
+
+def test_meili_backend_treats_invalid_perf_details_as_observability_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_summaries: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_performance",
+        lambda **kwargs: captured_summaries.append(kwargs),
+    )
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_stage_timing",
+        lambda **kwargs: None,
+    )
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=lambda *_args: {
+            "hits": [{"id": "1", "name": "Apple"}],
+            "processingTimeMs": 18,
+            "performanceDetails": "bad-shape",
+        },
+    )
+
+    rows = backend.search_foods("apple")
+
+    assert rows == [
+        {
+            "id": "1",
+            "canonical_name": "Apple",
+            "kcal": 0,
+            "protein_g": 0,
+            "fat_g": 0,
+            "carbs_g": 0,
+            "source": None,
+            "content_hash": None,
+        }
+    ]
+    assert captured_summaries == [
+        {
+            "strategy": "meili",
+            "perf_state": "invalid",
+            "degraded": "unknown",
+            "processing_time_ms": 18.0,
+        }
+    ]
+
+
+def test_meili_backend_records_missing_perf_details_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_summaries: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_performance",
+        lambda **kwargs: captured_summaries.append(kwargs),
+    )
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_stage_timing",
+        lambda **kwargs: None,
+    )
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=lambda *_args: {
+            "hits": [{"id": "1", "name": "Apple"}],
+            "processingTimeMs": 12,
+        },
+    )
+
+    rows = backend.search_foods("apple")
+
+    assert rows[0]["canonical_name"] == "Apple"
+    assert captured_summaries == [
+        {
+            "strategy": "meili",
+            "perf_state": "missing",
+            "degraded": "unknown",
+            "processing_time_ms": 12.0,
+        }
+    ]
+
+
+def test_meili_backend_records_fallback_perf_state_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_summaries: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_performance",
+        lambda **kwargs: captured_summaries.append(kwargs),
+    )
+    monkeypatch.setattr(
+        search_meili_module,
+        "record_food_search_meili_stage_timing",
+        lambda **kwargs: None,
+    )
+
+    class _FallbackBackend:
+        def search_foods(
+            self,
+            query: str,
+            limit: int | str = 20,
+            offset: int | str = 0,
+        ) -> list[dict[str, str]]:
+            return [{"id": "legacy"}]
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=lambda *_args: (_ for _ in ()).throw(TimeoutError("boom")),
+        fallback_backend=_FallbackBackend(),
+    )
+
+    assert backend.search_foods("apple") == [{"id": "legacy"}]
+    assert captured_summaries == [
+        {
+            "strategy": "meili",
+            "perf_state": "fallback",
+            "degraded": "unknown",
+            "processing_time_ms": None,
+        }
+    ]
 
 
 def test_shadow_backend_returns_baseline_when_shadow_diverges() -> None:
@@ -405,6 +649,7 @@ def test_register_food_search_backend_registers_meili_strategy(
     monkeypatch.setenv("MEILI_URL", "https://meili.example")
     monkeypatch.setenv("MEILI_FOODS_INDEX", "   ")
     monkeypatch.setenv("MEILI_TIMEOUT_SECONDS", "bad-timeout")
+    monkeypatch.setenv("MEILI_SHOW_PERFORMANCE_DETAILS", "true")
     try:
         register_food_search_backend(app)
         assert app.state.food_search_strategy == "meili"
@@ -412,6 +657,7 @@ def test_register_food_search_backend_registers_meili_strategy(
         assert isinstance(backend, MeiliSearchBackend)
         assert backend._index_name == "foods"
         assert backend._timeout_seconds == 2.0
+        assert backend._show_performance_details is True
     finally:
         food_store.reset_strategy_search_backend_adapter()
 
@@ -438,6 +684,9 @@ def test_safe_timeout_and_index_helpers_use_fallbacks() -> None:
     assert _safe_index_name(None) == "foods"
     assert _safe_index_name("   ") == "foods"
     assert _safe_index_name("foods_v2") == "foods_v2"
+    assert _safe_show_performance_details(None) is False
+    assert _safe_show_performance_details("false") is False
+    assert _safe_show_performance_details("true") is True
 
 
 def test_default_transport_posts_json(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -560,3 +809,284 @@ def test_numeric_field_or_default_returns_zero_for_missing_values() -> None:
     assert _numeric_field_or_default(hit, "fat_g") == 0
     assert _numeric_field_or_default(hit, "carbs_g") == 3
     assert _numeric_field_or_default(hit, "kcal") == 0
+
+
+def test_coerce_non_negative_ms_rejects_nan() -> None:
+    assert search_meili_module._coerce_non_negative_ms(float("nan")) is None
+
+
+def test_search_meili_helper_sanitizers_cover_edge_branches() -> None:
+    assert search_meili_module._normalize_degraded_flag(True) == "true"
+    assert search_meili_module._normalize_degraded_flag("false") == "false"
+    assert search_meili_module._normalize_degraded_flag("maybe") == "unknown"
+    assert search_meili_module._coerce_non_negative_ms(True) is None
+    assert search_meili_module._coerce_non_negative_ms("5") is None
+    assert search_meili_module._coerce_non_negative_ms(-1) is None
+    assert search_meili_module._coerce_non_negative_ms(700_000) is None
+    assert search_meili_module._normalize_stage_name("keywordSearch") == "keyword_search"
+    assert search_meili_module._normalize_stage_name("unknown-stage") is None
+    assert search_meili_module._duration_from_candidate(7) == 7.0
+    assert search_meili_module._duration_from_candidate({"durationMs": 9}) == 9.0
+    assert search_meili_module._duration_from_candidate({"durationMs": "bad"}) is None
+    assert search_meili_module._duration_from_candidate("bad") is None
+
+
+def test_extract_processing_time_ms_uses_details_or_stage_sum() -> None:
+    assert (
+        search_meili_module._extract_processing_time_ms(
+            {},
+            {"totalProcessingTimeMs": 23},
+            {},
+        )
+        == 23.0
+    )
+    assert (
+        search_meili_module._extract_processing_time_ms(
+            {},
+            None,
+            {"tokenization": 2.0, "ranking": 4.0},
+        )
+        == 6.0
+    )
+
+
+def test_normalize_performance_details_marks_invalid_when_payload_has_no_safe_fields() -> None:
+    summary = search_meili_module._normalize_performance_details(
+        {"performanceDetails": {"unknown": {"durationMs": "bad"}}},
+        enabled=True,
+    )
+
+    assert summary.state == "invalid"
+    assert summary.processing_time_ms is None
+    assert summary.stage_timings_ms == {}
+
+
+def test_app_metrics_build_food_search_meili_perf_events_total_returns_none_on_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        app_metrics,
+        "_import_prometheus",
+        lambda: (_ for _ in ()).throw(ImportError("boom")),
+    )
+    assert app_metrics._build_food_search_meili_perf_events_total() is None
+
+
+def test_app_metrics_build_food_search_meili_processing_time_ms_returns_none_on_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        app_metrics,
+        "_import_prometheus_histogram",
+        lambda: (_ for _ in ()).throw(ImportError("boom")),
+    )
+    assert app_metrics._build_food_search_meili_processing_time_ms() is None
+    assert app_metrics._build_food_search_meili_stage_processing_time_ms() is None
+
+
+def test_app_metrics_build_food_search_meili_metrics_return_none_on_duplicate_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _bad_counter(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("duplicate metric name")
+
+    def _bad_histogram(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("duplicate metric name")
+
+    monkeypatch.setattr(app_metrics, "_import_prometheus", lambda: _bad_counter)
+    monkeypatch.setattr(app_metrics, "_import_prometheus_histogram", lambda: _bad_histogram)
+
+    assert app_metrics._build_food_search_meili_perf_events_total() is None
+    assert app_metrics._build_food_search_meili_processing_time_ms() is None
+    assert app_metrics._build_food_search_meili_stage_processing_time_ms() is None
+
+
+def test_record_food_search_meili_performance_normalizes_labels_and_observes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_labels: list[dict[str, str]] = []
+    captured_observations: list[float] = []
+
+    class _CounterChild:
+        def inc(self, amount: float = 1.0) -> None:
+            captured_observations.append(amount)
+
+    class _Counter:
+        def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _CounterChild:
+            captured_labels.append(
+                {
+                    "strategy": strategy,
+                    "perf_state": perf_state,
+                    "degraded": degraded,
+                }
+            )
+            return _CounterChild()
+
+    class _HistogramChild:
+        def observe(self, amount: float) -> None:
+            captured_observations.append(amount)
+
+    class _Histogram:
+        def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _HistogramChild:
+            captured_labels.append(
+                {
+                    "strategy": strategy,
+                    "perf_state": perf_state,
+                    "degraded": degraded,
+                }
+            )
+            return _HistogramChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL", _Counter())
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PROCESSING_TIME_MS", _Histogram())
+
+    app_metrics.record_food_search_meili_performance(
+        strategy="unexpected",
+        perf_state="captured",
+        degraded="maybe",
+        processing_time_ms=33.0,
+    )
+
+    assert captured_labels == [
+        {"strategy": "unknown", "perf_state": "captured", "degraded": "unknown"},
+        {"strategy": "unknown", "perf_state": "captured", "degraded": "unknown"},
+    ]
+    assert captured_observations == [1.0, 33.0]
+
+
+def test_record_food_search_meili_performance_handles_non_string_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_labels: list[dict[str, str]] = []
+
+    class _CounterChild:
+        def inc(self, amount: float = 1.0) -> None:
+            return None
+
+    class _Counter:
+        def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _CounterChild:
+            captured_labels.append(
+                {
+                    "strategy": strategy,
+                    "perf_state": perf_state,
+                    "degraded": degraded,
+                }
+            )
+            return _CounterChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL", _Counter())
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PROCESSING_TIME_MS", None)
+
+    app_metrics.record_food_search_meili_performance(
+        strategy=None,
+        perf_state=None,
+        degraded=None,
+        processing_time_ms=None,
+    )
+
+    assert captured_labels == [
+        {"strategy": "unknown", "perf_state": "invalid", "degraded": "unknown"}
+    ]
+
+
+def test_record_food_search_meili_performance_swallows_counter_and_histogram_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadCounterChild:
+        def inc(self, amount: float = 1.0) -> None:
+            raise RuntimeError("boom")
+
+    class _BadCounter:
+        def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _BadCounterChild:
+            return _BadCounterChild()
+
+    class _BadHistogramChild:
+        def observe(self, amount: float) -> None:
+            raise RuntimeError("boom")
+
+    class _BadHistogram:
+        def labels(self, *, strategy: str, perf_state: str, degraded: str) -> _BadHistogramChild:
+            return _BadHistogramChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL", _BadCounter())
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PROCESSING_TIME_MS", _BadHistogram())
+
+    app_metrics.record_food_search_meili_performance(
+        strategy="meili",
+        perf_state="captured",
+        degraded="false",
+        processing_time_ms=10.0,
+    )
+
+
+def test_record_food_search_meili_performance_noops_when_histogram_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL", None)
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_PROCESSING_TIME_MS", None)
+
+    app_metrics.record_food_search_meili_performance(
+        strategy="meili",
+        perf_state="weird-state",
+        degraded="false",
+        processing_time_ms=10.0,
+    )
+
+
+def test_record_food_search_meili_stage_timing_filters_unknown_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _HistogramChild:
+        def observe(self, amount: float) -> None:
+            calls.append({"kind": "observe", "amount": amount})
+
+    class _Histogram:
+        def labels(self, *, strategy: str, stage: str) -> _HistogramChild:
+            calls.append({"kind": "labels", "strategy": strategy, "stage": stage})
+            return _HistogramChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS", _Histogram())
+
+    app_metrics.record_food_search_meili_stage_timing(
+        strategy="hybrid_shadow",
+        stage="authorization",
+        duration_ms=5.0,
+    )
+    app_metrics.record_food_search_meili_stage_timing(
+        strategy="hybrid_shadow",
+        stage="unbounded-stage",
+        duration_ms=9.0,
+    )
+
+    assert calls == [
+        {"kind": "labels", "strategy": "hybrid_shadow", "stage": "authorization"},
+        {"kind": "observe", "amount": 5.0},
+    ]
+
+
+def test_record_food_search_meili_stage_timing_noops_and_swallows_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadHistogramChild:
+        def observe(self, amount: float) -> None:
+            raise RuntimeError("boom")
+
+    class _BadHistogram:
+        def labels(self, *, strategy: str, stage: str) -> _BadHistogramChild:
+            return _BadHistogramChild()
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS", None)
+    app_metrics.record_food_search_meili_stage_timing(
+        strategy="meili",
+        stage="authorization",
+        duration_ms=5.0,
+    )
+
+    monkeypatch.setattr(app_metrics, "FOOD_SEARCH_MEILI_STAGE_PROCESSING_TIME_MS", _BadHistogram())
+    app_metrics.record_food_search_meili_stage_timing(
+        strategy="meili",
+        stage="authorization",
+        duration_ms=5.0,
+    )

--- a/tests/test_foods_router_coverage_boost.py
+++ b/tests/test_foods_router_coverage_boost.py
@@ -401,8 +401,9 @@ def test_metrics_scrape_includes_meili_observability_series(
             ],
             "processingTimeMs": 25,
             "performanceDetails": {
-                "authorization": {"durationMs": 1},
-                "tokenization": {"durationMs": 3},
+                "wait for permit": "295.29µs",
+                "search > tokenize": "436.67µs",
+                "search > format": "288.54µs",
                 "degraded": False,
             },
         },

--- a/tests/test_foods_router_coverage_boost.py
+++ b/tests/test_foods_router_coverage_boost.py
@@ -11,6 +11,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app import app
+import app.metrics as app_metrics
+from app.services.search_meili import MeiliSearchBackend, ShadowSearchBackend
 
 try:
     from app.routers.foods import router
@@ -274,3 +276,152 @@ class TestFoodsRouterCoverage:
         data = response.json()
         assert data["id"] == "123"
         assert data["canonical_name"] == "numeric food"
+
+
+def test_foods_route_contract_remains_stable_with_meili_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=lambda *_args: {
+            "hits": [
+                {
+                    "id": "m-1",
+                    "name": "Apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14.0,
+                }
+            ],
+            "processingTimeMs": 21,
+        },
+    )
+
+    monkeypatch.setattr("app.routers.foods.food_store.get_search_backend", lambda: backend)
+
+    response = client.get("/api/v1/foods?query=apple&limit=10&offset=0")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": "m-1",
+            "name": "Apple",
+            "kcal": 52,
+            "protein_g": 0.3,
+            "fat_g": 0.2,
+            "carbs_g": 14.0,
+        }
+    ]
+
+
+def test_foods_route_contract_remains_stable_with_shadow_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BaselineBackend:
+        def search_foods(
+            self, query: str, limit: int = 20, offset: int = 0
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "id": "b-1",
+                    "canonical_name": "Baseline Apple",
+                    "kcal": 51,
+                    "protein_g": 0.2,
+                    "fat_g": 0.1,
+                    "carbs_g": 13.0,
+                }
+            ]
+
+    shadow_backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        search_strategy_label="hybrid_shadow",
+        transport=lambda *_args: {
+            "hits": [
+                {
+                    "id": "shadow-1",
+                    "name": "Shadow Apple",
+                    "kcal": 55,
+                    "protein_g": 0.4,
+                    "fat_g": 0.3,
+                    "carbs_g": 15.0,
+                }
+            ],
+            "processingTimeMs": 19,
+            "performanceDetails": {"tokenization": {"durationMs": 2}},
+        },
+    )
+    backend = ShadowSearchBackend(
+        baseline_backend=_BaselineBackend(),
+        shadow_backend=shadow_backend,
+        shadow_runner=lambda task: task(),
+    )
+
+    monkeypatch.setattr("app.routers.foods.food_store.get_search_backend", lambda: backend)
+
+    response = client.get("/api/v1/foods/search?query=apple&limit=10&offset=0")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": "b-1",
+            "name": "Baseline Apple",
+            "kcal": 51,
+            "protein_g": 0.2,
+            "fat_g": 0.1,
+            "carbs_g": 13.0,
+        }
+    ]
+
+
+def test_metrics_scrape_includes_meili_observability_series(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if app_metrics.FOOD_SEARCH_MEILI_PERF_EVENTS_TOTAL is None:
+        pytest.skip("prometheus_client not available")
+
+    backend = MeiliSearchBackend(
+        base_url="https://meili.example",
+        index_name="foods",
+        show_performance_details=True,
+        transport=lambda *_args: {
+            "hits": [
+                {
+                    "id": "m-2",
+                    "name": "Apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14.0,
+                }
+            ],
+            "processingTimeMs": 25,
+            "performanceDetails": {
+                "authorization": {"durationMs": 1},
+                "tokenization": {"durationMs": 3},
+                "degraded": False,
+            },
+        },
+    )
+
+    monkeypatch.setattr("app.routers.foods.food_store.get_search_backend", lambda: backend)
+
+    search_response = client.get("/api/v1/foods?query=apple&limit=10&offset=0")
+    assert search_response.status_code == 200
+
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+    assert metrics_response.headers["content-type"].startswith("text/plain")
+    metrics_body = metrics_response.text
+    assert "food_search_meili_perf_events_total" in metrics_body
+    assert "food_search_meili_processing_time_ms_bucket" in metrics_body
+    assert "food_search_meili_stage_processing_time_ms_bucket" in metrics_body
+    assert 'strategy="meili"' in metrics_body
+    assert 'perf_state="captured"' in metrics_body
+    assert 'stage="authorization"' in metrics_body
+    assert 'stage="tokenization"' in metrics_body
+    assert "query=apple" not in metrics_body

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -677,6 +677,27 @@ def test_ws_observability_helpers_noop_when_metrics_unavailable(
     metrics_mod.dec_ws_active_connections("/ws")
 
 
+def test_record_legacy_alias_hit_swallows_counter_inc_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_legacy_alias_hit must swallow Prometheus label/inc failures."""
+    import app.metrics as app_metrics
+
+    from app.metrics import LEGACY_NUTRITION_DATE_ROUTE_TEMPLATE as route
+
+    class _BadChild:
+        def inc(self, amount: float = 1.0) -> None:
+            raise RuntimeError("boom")
+
+    class _BadCounter:
+        def labels(self, *, alias_route: str) -> _BadChild:
+            assert alias_route == route
+            return _BadChild()
+
+    monkeypatch.setattr(app_metrics, "LEGACY_ALIAS_REQUESTS_TOTAL", _BadCounter())
+    app_metrics.record_legacy_alias_hit(route)
+
+
 def test_ws_observability_helpers_swallow_metrics_backend_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- add env-gated Meilisearch `showPerformanceDetails` support to the existing food-search backend
- normalize sanitized Meili performance data into low-cardinality Prometheus observability without changing `/api/v1/foods*`
- add deterministic backend, route, and metrics tests for captured, missing, invalid, and fallback paths
- fold in post-open review follow-ups for realistic Meili stage payloads and canonical review mapping

## Tests

- `pytest -q tests/test_food_search_foundation.py tests/test_foods_router_coverage_boost.py tests/test_foods_router_additional.py tests/test_metrics.py`
- `pytest -q tests/test_food_search_foundation.py`
- `pytest -q tests/test_foods_router_coverage_boost.py`
- `pre-commit run --all-files`
- `make verify`
- pre-commit / pre-push hooks on review follow-up commits, including changed-file `mypy`, `pip-audit`, repo `bandit`, repo pytest, and docker build test

## Security Notes

- no raw query strings or document IDs are emitted into metrics or durable observability labels
- malformed or missing `performanceDetails` stays best-effort and never blocks food search responses
- rollout remains disabled by default via `MEILI_SHOW_PERFORMANCE_DETAILS`

## Marketing & GTM

- staging can now identify which Meili stages slow search responses before production rollout
- improved diagnosis of slow search queries supports faster perceived response times on food-search flows

## Split Justification

Meilisearch performance telemetry spans food-search bootstrap wiring, the Meili client adapter, Prometheus metric registration, coordinated unit/route/metrics tests, and the review-mapping artifact; shipping it as one PR avoids a half-enabled stack where counters exist without populated stage labels or the client never requests `showPerformanceDetails`. Optional shared-helper refactors called out in review remain intentionally out of scope for this telemetry PR.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `docs/review/PR_1333_FIXED_MAPPING.md`

## Merge Readiness

- [x] Local gates passed
- [x] Post-open `qa-engineer-agent -> bug-hunter` lane completed
- [x] Merge-readiness wrapper re-run after latest review activity

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Meilisearch performance monitoring (env toggle) with new Prometheus metrics for overall and per-stage timings and low-cardinality label handling.
* **Tests**
  * Extensive unit and integration tests for performance telemetry, request payload behavior, fallbacks, normalization, and metric robustness; added contract stability tests.
* **Documentation**
  * Added PR review note, backlog ledger entry, and CI guidance updates documenting added tests.
* **Chores**
  * Updated secret-detection baseline metadata and CI workflow test selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
