### PR TITLE
fix: stabilize iOS UI smoke on main

### DIFF
--- a/docs/review/PR_1338_FIXED_MAPPING.md
+++ b/docs/review/PR_1338_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1338 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No review threads or actionable bot comments have been mapped yet.
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+Notes: This PR intentionally stays scoped to `ios/PulsePlateUITests/UISmokeTests.swift` so the CI smoke lane exercises a plain app launch without Fastlane snapshot side effects.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1338_FIXED_MAPPING.md
+++ b/docs/review/PR_1338_FIXED_MAPPING.md
@@ -3,12 +3,12 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-No review threads or actionable bot comments have been mapped yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/ios/PulsePlateUITests/UISmokeTests.swift
+++ b/ios/PulsePlateUITests/UISmokeTests.swift
@@ -16,11 +16,11 @@ final class UISmokeTests: XCTestCase {
   @MainActor
   func testLaunch() throws {
     let app = XCUIApplication()
-    setupSnapshot(app, waitForAnimations: false)
 
     // RU: Минимальный CI smoke — обычный launch path (без screenshot mode).
     // EN: Minimal CI smoke — normal launch path (no screenshot mode).
-    // Screenshot mode (health_permission) crashed on CI; normal path is the primary signal.
+    // Keep the smoke path free of fastlane snapshot launch arguments to avoid CI-only
+    // background assertion failures from screenshot/test harness side effects.
     app.launch()
     defer { app.terminate() }
 


### PR DESCRIPTION
## Summary
- remove `setupSnapshot(...)` from `UISmokeTests.testLaunch()` so the smoke test uses the plain launch path
- keep the smoke test free of Fastlane snapshot launch arguments that were polluting CI runtime behavior
- preserve the scope to the `ios/PulsePlateUITests` smoke surface only

## Validation
- `IOS_DESTINATION='platform=iOS Simulator,name=iPhone 16e,OS=latest' make ios-test IOS_ONLY_TESTING='PulsePlateUITests/UISmokeTests' IOS_SKIP_TESTING=''`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1338_FIXED_MAPPING.md`

## Summary by Sourcery

Стабилизировать smoke-тест UI для iOS, запустив приложение через обычный путь запуска, и зафиксировать состояние ревью для этого PR.

Документация:
- Добавить документ с маппингом fixed-in-commit для PR 1338, отражающий статус ревью и заметки о готовности к слиянию.

Тесты:
- Обновить сценарий запуска `UISmokeTests`, чтобы убрать настройку Fastlane snapshot, благодаря чему smoke-прогоны в CI выполняются без побочных эффектов, связанных со скриншотами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the iOS UI smoke test by running the app through a plain launch path and record the review state for this PR.

Documentation:
- Add a fixed-in-commit mapping document for PR 1338 capturing review status and merge readiness notes.

Tests:
- Update the UISmokeTests launch flow to remove Fastlane snapshot setup so CI smoke runs without screenshot-related side effects.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI smoke test stability by removing snapshot test initialization that was causing background assertion failures.

* **Chores**
  * Added documentation for PR review status tracking.
  * Updated smoke test comments to clarify CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->