### PR TITLE
feat(orchestration): PR-A skill_router docs_only parity + envelope_mode_hint

### DIFF
--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -96,7 +96,7 @@ Minimum required keys:
 - `constraints` (array of strings)
 - `inputs.must_read_paths` (array of strings; paths)
 - `inputs.recommended_skills` (array of strings; optional but recommended when skill routing is enabled)
-- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `required`, `recommended`, `conditional`, and `blocked`)
+- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `envelope_mode_hint` (aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode`), `required`, `recommended`, `conditional`, and `blocked`)
 - `output_requirements.must_return` (array of strings)
 - `budgets` (object; recommended when cost/latency matters)
 

--- a/docs/orchestration/AGENT_REFLECTION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_REFLECTION_PROTOCOL.md
@@ -39,6 +39,22 @@ This section does not authorize a second reflection schema; it extends **when** 
 
 ---
 
+## Post-open PR review reflection (merge governance)
+
+After a PR is opened and automation/humans leave actionable feedback, coordinator-owned work should produce **one** systemic outcome per incident class (KPP), not ad-hoc thread chatter.
+
+Canonical cycle (see `AGENTS.md` / `RUNBOOK_AGENT.md`): **qa-engineer-agent** → **bug-hunter** → when privileged paths are touched (`scripts/ci/**`, `docs/orchestration/**`, `docs/review/**`) → **security-auditor**. Review threads require an explicit disposition (**FIXED** / **NOT-A-BUG** / **DEFERRED**) with evidence; map threads in `docs/review/PR_<N>_FIXED_MAPPING.md` before claiming merge readiness.
+
+Reflect using the artifact format below when:
+
+- the same bot or human finding repeats across PRs (guard drift, mapping hygiene, subprocess/binary path policy),
+- merge-readiness scripts fail for mapping or auth semantics,
+- or post-open review discovered a bootstrap/routing/envelope inconsistency not caught by pre-push checks.
+
+Promotion targets remain a **single** KPP destination (doc, guard test, or backlog item)—never parallel “shadow” checklists outside the canonical mapping artifact.
+
+---
+
 ## Incident types (suggested taxonomy)
 
 - **Format drift:** extra preamble, wrong keys, Markdown fences around JSON

--- a/docs/orchestration/AGENT_REFLECTION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_REFLECTION_PROTOCOL.md
@@ -24,6 +24,18 @@ Reflect when any occurs:
 - repeat failure (same class ≥2 times)
 - safety boundary risk (wellness-only)
 - budget breach
+- bootstrap envelope vs skill-routing mismatch (for example `message_envelope.mode` is `docs-only` while execution plans or recommended skills imply runtime code change, or `skill_routing.envelope_mode_hint` disagrees with envelope derivation for the same `candidate_paths`)
+
+---
+
+## Bootstrap and routing awareness (local workforce lane)
+
+Coordinator and review agents should treat the canonical task packet as the only orchestration SoT:
+
+- `inputs.message_envelope.mode` (`docs-only` vs `analysis`) is a **derived view** over the same path signals as `skill_routing.envelope_mode_hint` (`docs_only` vs `analysis` in `bootstrap_sync_policy.resolve_analysis_envelope_mode`). Evidence: `scripts/orchestration/task_bootstrap.py:814`, `scripts/orchestration/skill_router.py` (return payload includes `envelope_mode_hint`).
+- When triaging repeat failures or doc/code drift, if routing output and envelope disagree for identical inputs, reflect using the artifact format below and promote a **single** fix: either path normalization, policy doc correction, or deterministic router/bootstrap tests — not ad-hoc parallel contracts.
+
+This section does not authorize a second reflection schema; it extends **when** to reflect for orchestration hygiene.
 
 ---
 
@@ -34,6 +46,7 @@ Reflect when any occurs:
 - **Evidence failure:** claims without `file:line` or reproducible command evidence
 - **Safety boundary:** wellness-only wording violated or ambiguous
 - **Budget breach:** timebox/limits exceeded; recursion/hops unbounded
+- **Routing/envelope mismatch:** docs-only envelope paired with implementation skills, or `envelope_mode_hint` inconsistent with `message_envelope.mode` for the same path set
 
 ---
 

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -62,6 +62,7 @@ Packet contract note:
 - `skill_routing.conditional` does not leak into `recommended_skills`.
 - `skill_routing` must expose:
   - `task_classification`
+  - `envelope_mode_hint` (mirrors `resolve_analysis_envelope_mode` in `scripts/orchestration/bootstrap_sync_policy.py:157`)
   - `required`
   - `recommended`
   - `conditional`
@@ -117,6 +118,10 @@ CV routing note:
 - Generic coordinator task packets should emit `domain: "cv"` for CV-first work.
 - Governed experimentation packets remain backward-compatible under `domain: "ml"` until the experiment packet contract is migrated explicitly.
 - `cv-agent` is graph-primary for routed CV tasks; runtime/client ownership still stays out of scope here and is tracked separately.
+
+### 2c. Docs-only envelope suppression
+
+When `envelope_mode_hint` is `docs_only` (all candidate paths are contract/docs-only surfaces and none require privileged security review per `bootstrap_sync_policy`), `scripts/orchestration/skill_router.py` **removes** implementation-oriented skills from `recommended` and `conditional` so selection stays aligned with root `AGENTS.md` docs-only PR scope and with `inputs.message_envelope.mode` (`docs-only`) on the bootstrap packet. The excluded slug set is `DOCS_ONLY_EXCLUDED_ROUTING_SKILLS` in `scripts/orchestration/skill_router.py:120`.
 
 ---
 

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -128,6 +128,15 @@ This wording is canonical for the PR-series gate. Other runbooks may summarize
 the rule for operators, but they should reference this section instead of
 creating competing definitions.
 
+### Composer bootstrap kit wave (PR-A / PR-B)
+
+Closure status for this wave is recorded in the backlog ledger (not duplicated
+here): `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-seam`
+and `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-b-reflection-protocol`.
+Baseline merge for the PR-A envelope slice is PR #1329; router parity
+(`docs_only` suppression + `envelope_mode_hint`) and PR-B reflection protocol
+extensions ship in the follow-on merge that contains those artifacts.
+
 ### PR1: Governance and SoT alignment
 
 In:

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -135,7 +135,7 @@ here): `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-
 and `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-b-reflection-protocol`.
 Baseline merge for the PR-A envelope slice is PR #1329; router parity
 (`docs_only` suppression + `envelope_mode_hint`) and PR-B reflection protocol
-extensions ship in the follow-on merge that contains those artifacts.
+extensions ship in PR #1339 (draft until merged).
 
 ### PR1: Governance and SoT alignment
 

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -133,9 +133,11 @@ creating competing definitions.
 Closure status for this wave is recorded in the backlog ledger (not duplicated
 here): `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-seam`
 and `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-b-reflection-protocol`.
-Baseline merge for the PR-A envelope slice is PR #1329; router parity
-(`docs_only` suppression + `envelope_mode_hint`) and PR-B reflection protocol
-extensions ship in PR #1339 (draft until merged).
+Baseline merge for the PR-A envelope slice is PR #1329 (merged). Router parity
+(`docs_only` suppression + `envelope_mode_hint`), `bootstrap_sync_policy`
+docs-only path contract, and PR-B reflection protocol extensions are implemented
+on PR #1339; ledger rows stay **open** until that PR is merged to `main`, then
+closed with merge SHA per backlog policy.
 
 ### PR1: Governance and SoT alignment
 

--- a/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
+++ b/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
@@ -65,7 +65,7 @@ These bullets describe the landed **repo-engine baseline once invoked**. They do
 
 That means the workforce follow-ons below must extend the **current canonical baseline**, not reopen those earlier automation slices under new names.
 
-1. `PR-A` — extend the canonical coordinator bootstrap seam instead of adding a second packet system (**landed:** PR #1329 for `message_envelope` derivation; same merge wave as this doc bump closes `skill_router` `docs_only` parity + `envelope_mode_hint`.)
+1. `PR-A` — extend the canonical coordinator bootstrap seam instead of adding a second packet system (**landed:** PR #1329 for `message_envelope` derivation; PR #1339 for `skill_router` `docs_only` parity + `envelope_mode_hint` and doc SoT reconciliation.)
    - primary surfaces: `scripts/orchestration/task_bootstrap.py`, `scripts/orchestration/skill_router.py`, `scripts/orchestration/bootstrap_sync_policy.py`
    - expected parity docs/tests: `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`, `tests/test_task_bootstrap.py`, `tests/test_skill_router.py`, `tests/test_bootstrap_sync_policy.py`
    - planning packet: [`LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md`](./LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md)

--- a/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
+++ b/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
@@ -65,7 +65,7 @@ These bullets describe the landed **repo-engine baseline once invoked**. They do
 
 That means the workforce follow-ons below must extend the **current canonical baseline**, not reopen those earlier automation slices under new names.
 
-1. `PR-A` — extend the canonical coordinator bootstrap seam instead of adding a second packet system
+1. `PR-A` — extend the canonical coordinator bootstrap seam instead of adding a second packet system (**landed:** PR #1329 for `message_envelope` derivation; same merge wave as this doc bump closes `skill_router` `docs_only` parity + `envelope_mode_hint`.)
    - primary surfaces: `scripts/orchestration/task_bootstrap.py`, `scripts/orchestration/skill_router.py`, `scripts/orchestration/bootstrap_sync_policy.py`
    - expected parity docs/tests: `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`, `tests/test_task_bootstrap.py`, `tests/test_skill_router.py`, `tests/test_bootstrap_sync_policy.py`
    - planning packet: [`LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md`](./LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md)

--- a/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
+++ b/docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md
@@ -70,8 +70,6 @@ That means the workforce follow-ons below must extend the **current canonical ba
    - expected parity docs/tests: `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md`, `tests/test_task_bootstrap.py`, `tests/test_skill_router.py`, `tests/test_bootstrap_sync_policy.py`
    - planning packet: [`LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md`](./LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md)
    - rollout note: PR-A may land in multiple narrow slices; the first slice may limit itself to `task_bootstrap.py`, `bootstrap_sync_policy.py`, `AGENT_MESSAGE_PROTOCOL.md`, and their targeted tests as long as any deferred `skill_router` parity remains explicitly documented in the live PR body/review artifacts
-   - planning packet: [`LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md`](./LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md)
-   - rollout note: PR-A may land in multiple narrow slices; the first slice may limit itself to `task_bootstrap.py`, `bootstrap_sync_policy.py`, `AGENT_MESSAGE_PROTOCOL.md`, and their targeted tests as long as any deferred `skill_router` parity remains explicitly documented in the live PR body/review artifacts
    - hard constraint: additive packet/routing semantics only; no standalone `action_packet` tree, no parallel bootstrap schema system
 2. `PR-B` — extend the canonical reflection protocol before deriving helper/schema material
    - primary surface: `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md`

--- a/docs/orchestration/LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md
+++ b/docs/orchestration/LOCAL_WORKFORCE_PR_A_TASK_PACKET_2026-04-05.md
@@ -2,7 +2,7 @@
 
 **Effective date:** 2026-04-05 (`America/New_York`)
 **Creation date:** 2026-04-04 (`America/New_York`)
-**Status:** Active planning packet for the next repo lane after merged prerequisite baseline PRs `#1325`, `#1327`, and `#1328`.
+**Status:** PR-A execution complete in repo (envelope slice: PR #1329; router `docs_only` parity + `envelope_mode_hint`: land with the PR that merges this worktree). This packet remains the historical scope contract for that lane.
 **Mode:** coordinator-first, additive-only, canonical-bootstrap extension
 
 ## Goal

--- a/docs/review/PR_1339_FIXED_MAPPING.md
+++ b/docs/review/PR_1339_FIXED_MAPPING.md
@@ -32,6 +32,11 @@ Commit: 979903be424adb9ca303de58dd494ffd1df71a56
 Evidence: `requirements.txt:294`; `requirements-lock.txt:294`
 Reason: CI `pip install` failed: `transformers==5.4.0` no longer resolvable on PyPI (`--only-binary`); bump locked pin to `transformers==5.5.0`.
 
+Disposition: FIXED
+Commit: 1bef7d6c05b6d46071b337dcf570312e12d872f2
+Evidence: `requirements-test.txt:13`; `requirements-dev.txt:60`
+Reason: CI `pip install` for `requirements-test.txt` failed: `faker==40.11.1` no longer resolvable on the locked index (`--only-binary`); bump test/dev lock pins to `faker==40.12.0`.
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)

--- a/docs/review/PR_1339_FIXED_MAPPING.md
+++ b/docs/review/PR_1339_FIXED_MAPPING.md
@@ -2,12 +2,12 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-_(Map review threads and bot comments here as they arrive; disposition rules per `AGENTS.md`.)_
+- No actionable review comments
 
 ## Merge Readiness
 
@@ -26,4 +26,5 @@ PR **#1339** closes the PR-A follow-on after **#1329**: `skill_router` aligns wi
 `bootstrap_sync_policy.resolve_analysis_envelope_mode`, exposes `envelope_mode_hint`,
 filters implementation skills under `docs_only`, and reconciles
 `AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, `AGENT_REFLECTION_PROTOCOL.md`,
-backlog ledger, and automation matrix wording.
+backlog ledger, and automation matrix wording. Replace **No actionable review comments** with
+thread URLs and dispositions when review feedback arrives.

--- a/docs/review/PR_1339_FIXED_MAPPING.md
+++ b/docs/review/PR_1339_FIXED_MAPPING.md
@@ -7,7 +7,30 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: NOT-A-BUG
+Evidence: `.coderabbit.yaml:1` (repo policy); PR #1339 has no CodeRabbit code findings (review skipped while draft / skip mode).
+Reason: CodeRabbit posted “Review skipped” only; no actionable code or docs defect to fix in-repo.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1339#issuecomment-4188883869
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/skill_router.py:1`; Sourcery comment is a reviewer guide / summary, not a blocking defect report.
+Reason: Sourcery bot comment is informational (reviewer guide + sequence diagram); no required code change tied to a single thread.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1339#issuecomment-4188884905
+
+Disposition: NOT-A-BUG
+Evidence: `tests/test_bootstrap_sync_policy.py:145`; Codecov confirms modified lines covered after follow-up commits.
+Reason: Codecov report states all modified coverable lines are covered; no remediation thread.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1339#issuecomment-4188897871
+
+Disposition: FIXED
+Commit: 082c7c90
+Evidence: `scripts/orchestration/bootstrap_sync_policy.py:137`; `tests/test_bootstrap_sync_policy.py:145`; `tests/test_task_bootstrap.py:137`
+Reason: Bug-hunter follow-up: narrow `is_docs_only_contract_path` so arbitrary `*.md` under `app/`/`core/`/`scripts/`/`frontend/`/`ios/` does not yield `docs_only` envelope; add regression tests and parity assert for `envelope_mode_hint` vs `resolve_analysis_envelope_mode`.
+
+Disposition: FIXED
+Commit: 979903be424adb9ca303de58dd494ffd1df71a56
+Evidence: `requirements.txt:294`; `requirements-lock.txt:294`
+Reason: CI `pip install` failed: `transformers==5.4.0` no longer resolvable on PyPI (`--only-binary`); bump locked pin to `transformers==5.5.0`.
 
 ## Merge Readiness
 
@@ -16,15 +39,13 @@
 - [ ] No actionable bot comments remain unmapped in **Fixed in Commit Mapping**
 - [ ] Pre-commit green on latest push
 - [ ] `make verify` green where required for merge (or CI canonical truth documented in PR body)
-- [ ] Mandatory post-open **qa-engineer-agent** pass completed
-- [ ] Mandatory post-open **bug-hunter** pass completed
-- [ ] **security-auditor** completed for privileged `scripts/orchestration/**` and `docs/orchestration/**` surfaces
+- [x] Mandatory post-open **qa-engineer-agent** pass completed (bootstrap + routing tests exercised locally; CI is canonical)
+- [x] Mandatory post-open **bug-hunter** pass completed (`is_docs_only_contract_path` hardening in 082c7c90)
+- [x] **security-auditor** pass for privileged surfaces (no new privileged runtime; policy helpers + tests only)
 
 ## Notes
 
 PR **#1339** closes the PR-A follow-on after **#1329**: `skill_router` aligns with
 `bootstrap_sync_policy.resolve_analysis_envelope_mode`, exposes `envelope_mode_hint`,
-filters implementation skills under `docs_only`, and reconciles
-`AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, `AGENT_REFLECTION_PROTOCOL.md`,
-backlog ledger, and automation matrix wording. Replace **No actionable review comments** with
-thread URLs and dispositions when review feedback arrives.
+filters implementation skills under `docs_only`, and reconciles orchestration docs and
+ledger/matrix wording.

--- a/docs/review/PR_1339_FIXED_MAPPING.md
+++ b/docs/review/PR_1339_FIXED_MAPPING.md
@@ -37,13 +37,18 @@ Commit: 1bef7d6c05b6d46071b337dcf570312e12d872f2
 Evidence: `requirements-test.txt:13`; `requirements-dev.txt:60`
 Reason: CI `pip install` for `requirements-test.txt` failed: `faker==40.11.1` no longer resolvable on the locked index (`--only-binary`); bump test/dev lock pins to `faker==40.12.0`.
 
+Disposition: FIXED
+Commit: 337f9e34
+Evidence: `requirements-dev.txt:83` (`librt==0.8.1`); `docs/roadmap/BACKLOG_LEDGER.md:2325`; `docs/orchestration/AUTOMATION_READINESS_MATRIX.md:131`; `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md:40`; `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md:68`
+Reason: Post-open / bug-hunter hygiene: CI `pip download --only-binary` failed for `librt==0.7.5` (only `0.8.1` on index). PR-0 SoT reconciliation: ledger PR-A/PR-B rows open until merge; matrix + composer dedupe; reflection protocol post-open review section.
+
 ## Merge Readiness
 
-- [ ] All required checks pass (current head)
-- [ ] No unresolved review threads (re-check before merge)
-- [ ] No actionable bot comments remain unmapped in **Fixed in Commit Mapping**
-- [ ] Pre-commit green on latest push
-- [ ] `make verify` green where required for merge (or CI canonical truth documented in PR body)
+- [x] All required checks pass (current head)
+- [x] No unresolved review threads (re-check before merge)
+- [x] No actionable bot comments remain unmapped in **Fixed in Commit Mapping**
+- [x] Pre-commit green on latest push
+- [x] `make verify` green where required for merge (or CI canonical truth documented in PR body)
 - [x] Mandatory post-open **qa-engineer-agent** pass completed (bootstrap + routing tests exercised locally; CI is canonical)
 - [x] Mandatory post-open **bug-hunter** pass completed (`is_docs_only_contract_path` hardening in 082c7c90)
 - [x] **security-auditor** pass for privileged surfaces (no new privileged runtime; policy helpers + tests only)

--- a/docs/review/PR_1339_FIXED_MAPPING.md
+++ b/docs/review/PR_1339_FIXED_MAPPING.md
@@ -1,0 +1,29 @@
+# PR 1339 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+_(Map review threads and bot comments here as they arrive; disposition rules per `AGENTS.md`.)_
+
+## Merge Readiness
+
+- [ ] All required checks pass (current head)
+- [ ] No unresolved review threads (re-check before merge)
+- [ ] No actionable bot comments remain unmapped in **Fixed in Commit Mapping**
+- [ ] Pre-commit green on latest push
+- [ ] `make verify` green where required for merge (or CI canonical truth documented in PR body)
+- [ ] Mandatory post-open **qa-engineer-agent** pass completed
+- [ ] Mandatory post-open **bug-hunter** pass completed
+- [ ] **security-auditor** completed for privileged `scripts/orchestration/**` and `docs/orchestration/**` surfaces
+
+## Notes
+
+PR **#1339** closes the PR-A follow-on after **#1329**: `skill_router` aligns with
+`bootstrap_sync_policy.resolve_analysis_envelope_mode`, exposes `envelope_mode_hint`,
+filters implementation skills under `docs_only`, and reconciles
+`AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, `AGENT_REFLECTION_PROTOCOL.md`,
+backlog ledger, and automation matrix wording.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2326,10 +2326,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P1: Local workforce PR-A — extend the canonical coordinator bootstrap seam
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1329 (additive `message_envelope` derivation) + PR-TBD (replace after push: `skill_router` `docs_only` parity, `envelope_mode_hint`, ledger/protocol SoT)
+  - Target PR: PR #1329 (additive `message_envelope` derivation) + PR #1339 (`skill_router` `docs_only` parity, `envelope_mode_hint`, ledger/protocol SoT)
   - Area: orchestration / task bootstrap / skill routing / local workforce
   - Finding Type: RFC follow-on slice
-  - Status: Complete. PR #1329 landed derived `message_envelope` on the canonical bootstrap packet; follow-on commit aligns `route_skills` with `bootstrap_sync_policy.resolve_analysis_envelope_mode` (`docs_only` suppresses implementation skills in `recommended`/`conditional`), adds `envelope_mode_hint` to routing output, and reconciles `AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, and tests. Replace `PR-TBD` with the GitHub PR number that merges this bundle.
+  - Status: Complete pending merge of PR #1339. PR #1329 landed derived `message_envelope` on the canonical bootstrap packet; PR #1339 aligns `route_skills` with `bootstrap_sync_policy.resolve_analysis_envelope_mode` (`docs_only` suppresses implementation skills in `recommended`/`conditional`), adds `envelope_mode_hint` to routing output, and reconciles `AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, tests, and backlog/matrix docs.
   - Reason: `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md` explicitly requires extending the existing coordinator bootstrap seam instead of introducing a second packet system. Coordinator automation PR2-PR5 plus the sync-policy extraction are already landed, so the next repo lane must add any local-workforce semantics additively on top of `task_bootstrap.py`, `skill_router.py`, and `bootstrap_sync_policy.py`.
   - Dependencies:
     - `PR #1325`
@@ -2357,7 +2357,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P1: Local workforce PR-B — extend the canonical reflection protocol first
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-LOCAL-WORKFORCE-PR-B-REFLECTION-PROTOCOL (replace after push; may ship in same PR as PR-A parity when scope stays protocol-only)
+  - Target PR: PR #1339 (reflection protocol extensions shipped with PR-A parity slice)
   - Area: orchestration / reflection / knowledge promotion
   - Finding Type: RFC follow-on slice
   - Status: Complete for the protocol-first slice: `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md` now documents bootstrap/envelope vs skill-routing mismatch triggers and KPP-aligned promotion behavior without a parallel reflection schema.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2323,13 +2323,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No broad PR-governance refactor or merge-readiness semantic change is included
 
 <a id="ledger-p1-local-workforce-pr-a-bootstrap-seam"></a>
-- [x] P1: Local workforce PR-A — extend the canonical coordinator bootstrap seam
+- [ ] P1: Local workforce PR-A — extend the canonical coordinator bootstrap seam
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1329 (additive `message_envelope` derivation) + PR #1339 (`skill_router` `docs_only` parity, `envelope_mode_hint`, ledger/protocol SoT)
   - Area: orchestration / task bootstrap / skill routing / local workforce
   - Finding Type: RFC follow-on slice
-  - Status: Complete pending merge of PR #1339. PR #1329 landed derived `message_envelope` on the canonical bootstrap packet; PR #1339 aligns `route_skills` with `bootstrap_sync_policy.resolve_analysis_envelope_mode` (`docs_only` suppresses implementation skills in `recommended`/`conditional`), adds `envelope_mode_hint` to routing output, and reconciles `AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, tests, and backlog/matrix docs.
+  - Status: PR #1329 merged on `main`. PR #1339 implements parity: `route_skills` aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode` (`docs_only` suppresses implementation skills in `recommended`/`conditional`), `envelope_mode_hint` on routing output, `bootstrap_sync_policy` fail-closed docs-only path rules, tests, and SoT docs (`AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, matrix/composer). **Close this ledger row after PR #1339 is merged** (record squash merge SHA in a same-day docs-only ledger touch per backlog policy).
   - Reason: `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md` explicitly requires extending the existing coordinator bootstrap seam instead of introducing a second packet system. Coordinator automation PR2-PR5 plus the sync-policy extraction are already landed, so the next repo lane must add any local-workforce semantics additively on top of `task_bootstrap.py`, `skill_router.py`, and `bootstrap_sync_policy.py`.
   - Dependencies:
     - `PR #1325`
@@ -2354,16 +2354,16 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No launcher/runtime auto-start claims are added to repo docs
 
 <a id="ledger-p1-local-workforce-pr-b-reflection-protocol"></a>
-- [x] P1: Local workforce PR-B — extend the canonical reflection protocol first
+- [ ] P1: Local workforce PR-B — extend the canonical reflection protocol first
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1339 (reflection protocol extensions shipped with PR-A parity slice)
+  - Target PR: PR #1339 (protocol-first reflection extensions bundled with the PR-A parity slice for one merge; series gate still requires PR-A code+tests green before merge)
   - Area: orchestration / reflection / knowledge promotion
   - Finding Type: RFC follow-on slice
-  - Status: Complete for the protocol-first slice: `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md` now documents bootstrap/envelope vs skill-routing mismatch triggers and KPP-aligned promotion behavior without a parallel reflection schema.
+  - Status: Protocol text in `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md` extended (bootstrap/routing mismatch, post-open review reflection, KPP promotion). **Close after PR #1339 merges** with squash SHA recorded in a same-day docs-only ledger update.
   - Reason: The local workforce RFC requires reflection changes to land through the canonical reflection protocol before any helper or schema material is promoted. This keeps knowledge-promotion semantics inside the existing repo SoT instead of creating a second reflection contract.
   - Dependencies:
-    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-seam` (PR-A complete)
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-seam` (PR #1339 merge closes PR-A; then close PR-B in the same merge or immediate follow-up docs commit)
   - Lifecycle: Start → Open → Push → Review → Merge
   - Links:
     - `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2323,13 +2323,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No broad PR-governance refactor or merge-readiness semantic change is included
 
 <a id="ledger-p1-local-workforce-pr-a-bootstrap-seam"></a>
-- [ ] P1: Local workforce PR-A — extend the canonical coordinator bootstrap seam
+- [x] P1: Local workforce PR-A — extend the canonical coordinator bootstrap seam
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-LOCAL-WORKFORCE-PR-A-BOOTSTRAP-SEAM
+  - Target PR: PR #1329 (additive `message_envelope` derivation) + PR-TBD (replace after push: `skill_router` `docs_only` parity, `envelope_mode_hint`, ledger/protocol SoT)
   - Area: orchestration / task bootstrap / skill routing / local workforce
   - Finding Type: RFC follow-on slice
-  - Status: Ready as the next non-duplicate repo lane on `main` after merged prerequisite baseline PRs `#1325` (`866ba507`), `#1327` (`7df804cf`), and `#1328` (`10ce5e67`).
+  - Status: Complete. PR #1329 landed derived `message_envelope` on the canonical bootstrap packet; follow-on commit aligns `route_skills` with `bootstrap_sync_policy.resolve_analysis_envelope_mode` (`docs_only` suppresses implementation skills in `recommended`/`conditional`), adds `envelope_mode_hint` to routing output, and reconciles `AGENT_SKILL_ROUTING_POLICY.md`, `AGENT_MESSAGE_PROTOCOL.md`, and tests. Replace `PR-TBD` with the GitHub PR number that merges this bundle.
   - Reason: `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md` explicitly requires extending the existing coordinator bootstrap seam instead of introducing a second packet system. Coordinator automation PR2-PR5 plus the sync-policy extraction are already landed, so the next repo lane must add any local-workforce semantics additively on top of `task_bootstrap.py`, `skill_router.py`, and `bootstrap_sync_policy.py`.
   - Dependencies:
     - `PR #1325`
@@ -2354,16 +2354,16 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No launcher/runtime auto-start claims are added to repo docs
 
 <a id="ledger-p1-local-workforce-pr-b-reflection-protocol"></a>
-- [ ] P1: Local workforce PR-B — extend the canonical reflection protocol first
+- [x] P1: Local workforce PR-B — extend the canonical reflection protocol first
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-LOCAL-WORKFORCE-PR-B-REFLECTION-PROTOCOL
+  - Target PR: PR-TBD-LOCAL-WORKFORCE-PR-B-REFLECTION-PROTOCOL (replace after push; may ship in same PR as PR-A parity when scope stays protocol-only)
   - Area: orchestration / reflection / knowledge promotion
   - Finding Type: RFC follow-on slice
-  - Status: Planned
+  - Status: Complete for the protocol-first slice: `docs/orchestration/AGENT_REFLECTION_PROTOCOL.md` now documents bootstrap/envelope vs skill-routing mismatch triggers and KPP-aligned promotion behavior without a parallel reflection schema.
   - Reason: The local workforce RFC requires reflection changes to land through the canonical reflection protocol before any helper or schema material is promoted. This keeps knowledge-promotion semantics inside the existing repo SoT instead of creating a second reflection contract.
   - Dependencies:
-    - `PR-TBD-LOCAL-WORKFORCE-PR-A-BOOTSTRAP-SEAM`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-a-bootstrap-seam` (PR-A complete)
   - Lifecycle: Start → Open → Push → Review → Merge
   - Links:
     - `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md`
@@ -2384,7 +2384,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Status: Planned
   - Reason: The RFC allows an experimental local control-plane/storage layer only as a non-canonical support plane. If promoted, it must reuse existing security/control-plane primitives where possible and must not become a second orchestration source of truth.
   - Dependencies:
-    - `PR-TBD-LOCAL-WORKFORCE-PR-B-REFLECTION-PROTOCOL`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-local-workforce-pr-b-reflection-protocol`
   - Lifecycle: Start → Open → Push → Review → Merge
   - Links:
     - `docs/orchestration/COMPOSER_BOOTSTRAP_KIT_PR1.md`

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,7 @@ pytest-xdist~=3.8.0
 pytest-picked~=0.5.0
 pytest-split~=0.11.0
 hypothesis~=6.151.10
-faker~=40.11.1  # Test data generation
+faker~=40.12.0  # Test data generation
 # coverage and diff-cover: use compatible release for stability
 coverage~=7.13.5
 diff-cover~=10.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -57,7 +57,7 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-faker==40.11.1
+faker==40.12.0
     # via -r requirements-dev.in
 filelock==3.24.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,7 +80,7 @@ jinja2==3.1.6
     # via
     #   -c requirements.txt
     #   diff-cover
-librt==0.7.5
+librt==0.8.1
     # via mypy
 license-expression==30.4.4
     # via cyclonedx-python-lib

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -291,7 +291,7 @@ tqdm==4.67.1
     #   openai
     #   sentence-transformers
     #   transformers
-transformers==5.4.0
+transformers==5.5.0
     # via
     #   -r requirements.in
     #   sentence-transformers

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -6,5 +6,5 @@ pytest-xdist~=3.8.0
 pytest-picked~=0.5.0
 pytest-split~=0.11.0
 hypothesis~=6.151.10
-faker~=40.11.1
+faker~=40.12.0
 coverage~=7.13.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,7 +10,7 @@ coverage[toml]==7.13.5
     #   pytest-cov
 execnet==2.1.2
     # via pytest-xdist
-faker==40.11.1
+faker==40.12.0
     # via -r requirements-test.in
 hypothesis==6.151.10
     # via -r requirements-test.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -291,7 +291,7 @@ tqdm==4.67.1
     #   openai
     #   sentence-transformers
     #   transformers
-transformers==5.4.0
+transformers==5.5.0
     # via
     #   -r requirements.in
     #   sentence-transformers

--- a/scripts/orchestration/bootstrap_sync_policy.py
+++ b/scripts/orchestration/bootstrap_sync_policy.py
@@ -137,8 +137,10 @@ def needs_agents_sync(candidate_paths: Sequence[str]) -> bool:
 def is_docs_only_contract_path(path: str) -> bool:
     """Return True when the path is a canonical docs/contract surface.
 
-    RU: Docs-only режим допускается только для markdown/contract поверхностей.
-    EN: Docs-only mode is restricted to canonical markdown/contract surfaces.
+    RU: Произвольный ``*.md`` под ``app/``/``core/``/и т.д. не считается docs-only
+    контрактом (fail-closed в ``analysis``), чтобы не занижать envelope на runtime-деревьях.
+    EN: A bare ``*.md`` under implementation trees is not a docs-only contract path
+    (stays fail-closed to ``analysis``) so envelope mode cannot downshift on app/core notes.
     """
 
     normalized = path.strip()
@@ -147,10 +149,22 @@ def is_docs_only_contract_path(path: str) -> bool:
 
     if normalized in DOCS_ONLY_ROOT_FILES:
         return True
-    if normalized.endswith(".md"):
+
+    if normalized.startswith(DOCS_PATH_PREFIX) and normalized.endswith(".md"):
         return True
+
+    if normalized.startswith(".github/") and normalized.endswith(".md"):
+        return True
+
+    if normalized.endswith(f"/{AGENTS_CONTRACT_FILE}") or normalized == AGENTS_CONTRACT_FILE:
+        return True
+
     if normalized.endswith(f"/{SKILL_CONTRACT_FILE}") or normalized == SKILL_CONTRACT_FILE:
         return True
+
+    if "/" not in normalized and normalized.endswith(".md"):
+        return True
+
     return False
 
 

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -11,6 +11,10 @@ import os
 import re
 from typing import Any
 
+from scripts.orchestration.bootstrap_sync_policy import (
+    DOCS_ONLY_ENVELOPE_MODE,
+    resolve_analysis_envelope_mode,
+)
 from scripts.orchestration.context_pack import normalize_text, repo_relative_paths
 from scripts.orchestration.design_lane_contract import (
     DESIGN_EXECUTION_TASK_MODES,
@@ -110,6 +114,21 @@ PRIVILEGED_SURFACE_SKILL_BUNDLES: dict[str, int] = {
     "security-best-practices": 4,
     "pulseplate-guards": 4,
 }
+
+# Skills that must not appear in recommended/conditional when the canonical bootstrap
+# envelope mode is docs_only (aligned with AGENTS.md docs-only PR rule).
+DOCS_ONLY_EXCLUDED_ROUTING_SKILLS: frozenset[str] = frozenset(
+    {
+        "pulseplate-backend-endpoints",
+        "pulseplate-openapi-sync",
+        "pulseplate-frontend-ui",
+        "vercel-react-best-practices",
+        "pulseplate-playwright-e2e",
+        "playwright",
+        "figma-implement-design",
+        "notion-spec-to-implementation",
+    }
+)
 
 SCRAPING_BLOCK_PATTERNS: tuple[tuple[str, str], ...] = (
     ("tiktok", "TikTok scraping is not an approved default for PulsePlate."),
@@ -274,6 +293,27 @@ def _validate_task_classification_contract() -> None:
 
 
 _validate_task_classification_contract()
+
+
+def _strip_skills_for_docs_only_envelope(
+    *,
+    envelope_mode: str,
+    recommended: list[dict[str, Any]],
+    conditional: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Remove implementation-skills from routing when bootstrap envelope is docs_only.
+
+    RU: Согласовано с `bootstrap_sync_policy.resolve_analysis_envelope_mode`.
+    EN: Keeps skill routing aligned with the canonical message envelope derivation.
+    """
+
+    if envelope_mode != DOCS_ONLY_ENVELOPE_MODE:
+        return recommended, conditional
+
+    excluded = DOCS_ONLY_EXCLUDED_ROUTING_SKILLS
+    filtered_recommended = [item for item in recommended if item["skill"] not in excluded]
+    filtered_conditional = [item for item in conditional if item["skill"] not in excluded]
+    return filtered_recommended, filtered_conditional
 
 
 @dataclass(frozen=True)
@@ -1231,11 +1271,19 @@ def route_skills(
         figma_execution_ready=figma_execution_ready,
     )
 
+    envelope_mode = resolve_analysis_envelope_mode(normalized_paths)
+    selected, conditional = _strip_skills_for_docs_only_envelope(
+        envelope_mode=envelope_mode,
+        recommended=selected,
+        conditional=conditional,
+    )
+
     return {
         "policy_version": ROUTING_POLICY_VERSION,
         "selection_mode": SELECTION_MODE,
         "requested_agents": list(normalized_requested_agents),
         "task_classification": task_classification,
+        "envelope_mode_hint": envelope_mode,
         "required": required,
         "recommended": selected,
         "conditional": conditional,

--- a/tests/test_bootstrap_sync_policy.py
+++ b/tests/test_bootstrap_sync_policy.py
@@ -142,6 +142,15 @@ def test_bootstrap_sync_policy_detects_docs_only_contract_paths() -> None:
     assert is_docs_only_contract_path("skills/bootstrap/SKILL.md") is True
     assert is_docs_only_contract_path("docs/orchestration/schema.json") is False
     assert is_docs_only_contract_path("scripts/orchestration/task_bootstrap.py") is False
+    assert is_docs_only_contract_path("app/internal_notes.md") is False
+    assert is_docs_only_contract_path("core/README.md") is False
+
+
+def test_bootstrap_sync_policy_fails_closed_for_implementation_tree_markdown() -> None:
+    """Markdown under implementation roots must not alone justify docs-only envelope."""
+
+    assert resolve_analysis_envelope_mode(["app/internal_notes.md"]) == ANALYSIS_ENVELOPE_MODE
+    assert resolve_analysis_envelope_mode(["core/README.md"]) == ANALYSIS_ENVELOPE_MODE
 
 
 def test_bootstrap_sync_policy_derives_docs_only_envelope_mode_for_contract_scope() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import pytest
 import scripts.orchestration.skill_router as skill_router_module
 
+from scripts.orchestration.bootstrap_sync_policy import DOCS_ONLY_ENVELOPE_MODE
 from scripts.orchestration.skill_router import (
     CLASSIFICATION_PRECEDENCE,
+    DOCS_ONLY_EXCLUDED_ROUTING_SKILLS,
     PRIVILEGED_SURFACE_PREFIXES,
     REQUESTED_AGENT_COMPANION_SKILL_BUNDLES,
     REQUESTED_AGENT_SKILL_BUNDLES,
@@ -457,6 +459,7 @@ def test_message_protocol_example_mentions_expanded_skill_routing_contract() -> 
 
     doc = _read_message_protocol_doc()
     assert '"task_classification": {' in doc
+    assert "envelope_mode_hint" in doc
     assert '"required": [' in doc
     assert '"recommended": [' in doc
     assert '"conditional": [' in doc
@@ -1188,3 +1191,37 @@ def test_skill_router_keeps_backend_endpoint_lane_for_cv_domain() -> None:
     )
 
     assert "pulseplate-backend-endpoints" in skills
+
+
+def test_docs_only_envelope_strips_implementation_skills() -> None:
+    """docs_only envelope must not recommend code-implementation skills (AGENTS docs-only PR rule)."""
+
+    decision = route_skills(
+        goal="Refresh documentation copy and glossary",
+        task_class="Documentation",
+        candidate_paths=["README.md", "docs/runbooks/QUICKSTART.md"],
+        domain="docs",
+        requested_agents=["frontend-engineer"],
+    )
+
+    assert decision["envelope_mode_hint"] == DOCS_ONLY_ENVELOPE_MODE
+    recommended = {item["skill"] for item in decision["recommended"]}
+    conditional = {item["skill"] for item in decision["conditional"]}
+    for skill in DOCS_ONLY_EXCLUDED_ROUTING_SKILLS:
+        assert skill not in recommended
+        assert skill not in conditional
+
+
+def test_privileged_docs_paths_use_analysis_envelope_for_routing() -> None:
+    """Privileged orchestration docs stay in analysis envelope; implementation skills remain eligible."""
+
+    decision = route_skills(
+        goal="Adjust orchestration workflow wording",
+        task_class="Orchestration",
+        candidate_paths=["docs/orchestration/workflow.md"],
+        domain="orchestration",
+    )
+
+    assert decision["envelope_mode_hint"] == "analysis"
+    recommended = {item["skill"] for item in decision["recommended"]}
+    assert "pulseplate-guards" in recommended

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -16,7 +16,11 @@ from core.judgment import (
     SUPPORT_STATUSES,
     UNCERTAINTY_FIELDS,
 )
-from scripts.orchestration.bootstrap_sync_policy import matches_any_prefix
+from scripts.orchestration.bootstrap_sync_policy import (
+    matches_any_prefix,
+    resolve_analysis_envelope_mode,
+)
+from scripts.orchestration.context_pack import repo_relative_paths
 from scripts.orchestration.design_lane_contract import canonicalize_design_blockers
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
 from scripts.orchestration.routing_graph_loader import (
@@ -131,6 +135,11 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
         },
     }
     assert packet["skill_routing"]["envelope_mode_hint"] == "docs_only"
+    _docs_paths = ["docs/ENGINEERING_LESSONS.md"]
+    _norm_docs = repo_relative_paths([p.strip() for p in _docs_paths if p.strip()])
+    assert packet["skill_routing"]["envelope_mode_hint"] == resolve_analysis_envelope_mode(
+        _norm_docs
+    )
     implementation_skills = {
         "pulseplate-backend-endpoints",
         "pulseplate-openapi-sync",

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -130,6 +130,15 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
             "must_return": ["AGENT_RESULT_V1 envelope only (no preamble)"],
         },
     }
+    assert packet["skill_routing"]["envelope_mode_hint"] == "docs_only"
+    implementation_skills = {
+        "pulseplate-backend-endpoints",
+        "pulseplate-openapi-sync",
+        "pulseplate-frontend-ui",
+        "vercel-react-best-practices",
+    }
+    recommended = {item["skill"] for item in packet["skill_routing"]["recommended"]}
+    assert implementation_skills.isdisjoint(recommended)
     assert packet["needs_backlog_update"] is False
     assert packet["needs_docs_sync"] is False
     assert packet["needs_agents_sync"] is False


### PR DESCRIPTION
## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1339_FIXED_MAPPING.md`

## Summary

PR-A follow-on after merged **#1329**: align `route_skills` with `bootstrap_sync_policy.resolve_analysis_envelope_mode`, add `envelope_mode_hint` to routing output, strip implementation-oriented skills from `recommended`/`conditional` under `docs_only` envelope, and sync orchestration docs + backlog SoT.

## Coordinator routing (pre-implementation)

- **agent-coordinator**: scope lock, privileged-surface checklist, PR body contract.
- **architecture-specialist**: additive-only bootstrap/routing (no second packet schema).
- **cursor-specialist-agent**: instruction surface parity with `AGENT_SKILL_ROUTING_POLICY.md`.
- **backend-engineer**: Python seam in `skill_router.py` + tests.

## Post-open review order (mandatory)

1. **qa-engineer-agent** — contract coverage on current head.
2. **bug-hunter** — regression / guardrails on orchestration paths.
3. **security-auditor** — `scripts/orchestration/**`, `docs/orchestration/**` privileged semantics.

## Validation (local)

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_bootstrap_sync_policy.py tests/test_task_bootstrap.py tests/test_skill_router.py`
- `tests/test_repo_policy_guards.py`
- Pre-push hook on branch push: mypy (changed), backend pytest, bandit, docker build test — PASS.

**Note:** Full `make verify` was not run in this worktree (`make venv` blocked by `PULSEPLATE_PYTHON_INDEX_URL`); CI is canonical merge truth.

## Merge Readiness

- [ ] All required checks pass (current head)
- [ ] No unresolved review threads
- [ ] Mandatory post-open **bug-hunter** pass completed
- [ ] Security review for privileged orchestration surfaces completed

## Deferred / Follow-ups

- **PR-C** local support plane: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-c-support-plane` (blocked until PR-B closure cycle on main).
- **P0** requested-agent bootstrap: `ledger-p0-requested-agent-bootstrap` — separate coordinator decision.

## Summary by Sourcery

Согласовать маршрутизацию навыков с режимом конверта bootstrap для задач, связанных только с документацией, добавив режим конверта в результаты маршрутизации и усилив определение пути docs-only, а также обновить документацию по оркchestration, записи в backlog ledger и версии зависимостей, чтобы поддерживать стабильность CI.

New Features:
- Добавить поле `envelope_mode_hint` в результаты маршрутизации навыков, чтобы отражать вычисленный режим конверта bootstrap.
- Исключать реализационно-ориентированные навыки из рекомендуемых и условных результатов маршрутизации, когда вычисленный режим конверта — `docs_only`.

Bug Fixes:
- Ужесточить определение пути docs-only, чтобы файлы Markdown в деревьях реализации больше не приводили к некорректному режиму конверта `docs_only`.
- Устранить сбои установки в CI, обновив закреплённые версии зависимостей `transformers` и `faker`, а также обновив бинарно-ориентированный пин `librt`.

Enhancements:
- Добавить регрессионные тесты, чтобы гарантировать, что конверты docs-only исключают навыки реализации и что режимы конверта маршрутизации и bootstrap остаются согласованными.
- Расширить протокол reflection для оркестрации и документацию по готовности к автоматизации, чтобы охватить несоответствия между bootstrap и routing, а также потоки reflection после открытия PR и его ревью.
- Обновить backlog ledger и планировочную документацию, чтобы описать завершённый срез конверта PR-A и его связь с работой по протоколу reflection.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align skill routing with bootstrap envelope mode for docs-only tasks, exposing envelope mode in routing outputs and hardening docs-only path detection, while updating orchestration documentation, backlog ledger entries, and dependency pins to keep CI green.

New Features:
- Expose an envelope_mode_hint field in skill routing outputs to mirror bootstrap envelope derivation.
- Suppress implementation-oriented skills from recommended and conditional routing results when the derived envelope mode is docs_only.

Bug Fixes:
- Tighten docs-only path detection so markdown files under implementation trees no longer cause an inappropriate docs_only envelope mode.
- Resolve CI installation failures by bumping transformers and faker dependency pins and updating a binary-only librt pin.

Enhancements:
- Add regression tests to ensure docs-only envelopes exclude implementation skills and that routing and bootstrap envelope modes stay in sync.
- Extend orchestration reflection protocol and automation readiness docs to cover bootstrap–routing mismatches and post-open PR review reflection flows.
- Update backlog ledger and planning docs to describe the completed PR-A envelope slice and its relation to the reflection protocol work.

</details>