### PR TITLE
feat(nutrition): food confidence on list/detail wire (PR3)

### DIFF
--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import math
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -44,6 +45,22 @@ class _FoodStoreCompat:
 _FOOD_STORE_COMPAT: FoodStore = _FoodStoreCompat()
 
 
+def _coerce_hit_nutrition_confidence(raw: object) -> float:
+    """Finite non-negative float for list hits; never raises on bad DB cells."""
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        coerced = float(raw)
+        return coerced if math.isfinite(coerced) and coerced >= 0.0 else 0.0
+    if isinstance(raw, str):
+        try:
+            coerced = float(raw.strip())
+        except (TypeError, ValueError):
+            return 0.0
+        return coerced if math.isfinite(coerced) and coerced >= 0.0 else 0.0
+    return 0.0
+
+
 def get_food_store() -> FoodStore:
     return _FOOD_STORE_COMPAT
 
@@ -66,7 +83,7 @@ def list_foods(
             protein_g=r["protein_g"],
             fat_g=r["fat_g"],
             carbs_g=r["carbs_g"],
-            nutrition_confidence=float(r.get("nutrition_confidence") or 0.0),
+            nutrition_confidence=_coerce_hit_nutrition_confidence(r.get("nutrition_confidence")),
         )
         for r in rows
     ]

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -66,6 +66,7 @@ def list_foods(
             protein_g=r["protein_g"],
             fat_g=r["fat_g"],
             carbs_g=r["carbs_g"],
+            nutrition_confidence=float(r.get("nutrition_confidence") or 0.0),
         )
         for r in rows
     ]

--- a/app/schemas/food.py
+++ b/app/schemas/food.py
@@ -90,7 +90,7 @@ def _parse_json_float_dict(value: object) -> dict[str, float]:
         out: dict[str, float] = {}
         for key, item in value.items():
             sk = str(key)
-            if isinstance(item, (int, float)):
+            if isinstance(item, (int, float)) and not isinstance(item, bool):
                 coerced = float(item)
                 if math.isfinite(coerced) and coerced >= 0.0:
                     out[sk] = coerced

--- a/app/schemas/food.py
+++ b/app/schemas/food.py
@@ -52,37 +52,6 @@ def _normalize_food_flags(value: object) -> List[str]:
     return []
 
 
-def _parse_json_float_mapping(value: object) -> dict[str, float]:
-    """
-    Parse JSON/dict payloads into dict[str, float] for per-nutrient confidence.
-
-    RU: Парсит JSON/dict в dict[str, float].
-    EN: Parses JSON/dict into string-to-float mapping.
-    """
-
-    if value is None:
-        return {}
-    if isinstance(value, dict):
-        out: dict[str, float] = {}
-        for key, item in value.items():
-            if isinstance(item, bool) or not isinstance(item, (int, float)):
-                continue
-            coerced = float(item)
-            if math.isfinite(coerced):
-                out[str(key)] = coerced
-        return out
-    if isinstance(value, str):
-        raw = value.strip()
-        if not raw or raw.lower() in {"null", "none"}:
-            return {}
-        try:
-            parsed = json.loads(raw)
-        except (TypeError, ValueError):
-            return {}
-        return _parse_json_float_mapping(parsed)
-    return {}
-
-
 def _parse_json_mapping(value: object) -> dict[str, str]:
     """
     Parse JSON/dict payloads into dict[str, str].
@@ -108,9 +77,51 @@ def _parse_json_mapping(value: object) -> dict[str, str]:
     return {}
 
 
-def _parse_json_inputs(value: object) -> List[dict[str, object]]:
+def _parse_json_float_dict(value: object) -> dict[str, float]:
     """
-    Parse JSON/list payloads into list[dict[str, object]].
+    Parse JSON/dict payloads into dict[str, float] for per-nutrient confidence.
+
+    RU: Парсит JSON/dict в dict[str, float] для confidence по нутриентам.
+    EN: Parses JSON/dict into dict[str, float] for per-nutrient confidence.
+    """
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        out: dict[str, float] = {}
+        for key, item in value.items():
+            sk = str(key)
+            if isinstance(item, (int, float)):
+                coerced = float(item)
+                if math.isfinite(coerced) and coerced >= 0.0:
+                    out[sk] = coerced
+                continue
+            if isinstance(item, str):
+                raw = item.strip()
+                if not raw:
+                    continue
+                try:
+                    coerced = float(raw)
+                except ValueError:
+                    continue
+                if math.isfinite(coerced) and coerced >= 0.0:
+                    out[sk] = coerced
+        return out
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw or raw.lower() in {"null", "none"}:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        if isinstance(parsed, dict):
+            return _parse_json_float_dict(parsed)
+        return {}
+    return {}
+
+
+def _parse_json_inputs(value: object) -> List[dict[str, object]]:
+    """Parse JSON/list payloads into list[dict[str, object]].
 
     RU: Парсит JSON/list в список словарей.
     EN: Parses JSON/list payloads into list of dictionaries.
@@ -134,10 +145,7 @@ def _parse_json_inputs(value: object) -> List[dict[str, object]]:
 
 
 class FoodItem(BaseModel):
-    """
-    RU: Полная модель продукта с прослеживаемостью.
-    EN: Complete food model with provenance tracking.
-    """
+    """RU: Полная модель продукта с прослеживаемостью. EN: Complete food model."""
 
     id: str
     canonical_name: str
@@ -168,8 +176,8 @@ class FoodItem(BaseModel):
     price_per_100g: float = 0.0
     nutrition_inputs: List[dict[str, object]] = Field(default_factory=list)
     nutrition_provenance: dict[str, str] = Field(default_factory=dict)
-    nutrition_nutrient_confidence: dict[str, float] = Field(default_factory=dict)
     nutrition_confidence: float = 0.0
+    nutrition_nutrient_confidence: dict[str, float] = Field(default_factory=dict)
 
     @field_validator("flags", mode="before")
     @classmethod
@@ -192,11 +200,6 @@ class FoodItem(BaseModel):
     def _parse_nutrition_provenance(cls, value: object) -> dict[str, str]:
         return _parse_json_mapping(value)
 
-    @field_validator("nutrition_nutrient_confidence", mode="before")
-    @classmethod
-    def _parse_nutrition_nutrient_confidence(cls, value: object) -> dict[str, float]:
-        return _parse_json_float_mapping(value)
-
     @field_validator("nutrition_confidence", mode="before")
     @classmethod
     def _coerce_nutrition_confidence(cls, value: object) -> float:
@@ -216,6 +219,11 @@ class FoodItem(BaseModel):
             return coerced if math.isfinite(coerced) else 0.0
         return 0.0
 
+    @field_validator("nutrition_nutrient_confidence", mode="before")
+    @classmethod
+    def _parse_nutrition_nutrient_confidence(cls, value: object) -> dict[str, float]:
+        return _parse_json_float_dict(value)
+
 
 class FoodHit(BaseModel):
     """
@@ -230,6 +238,7 @@ class FoodHit(BaseModel):
     protein_g: float = 0.0
     fat_g: float = 0.0
     carbs_g: float = 0.0
+    nutrition_confidence: float = 0.0
 
 
 class FoodSourceAttribution(BaseModel):

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -155,7 +155,7 @@ def _coerce_nutrient_confidence_map(raw: object) -> dict[str, float]:
     out: dict[str, float] = {}
     for key, item in raw.items():
         sk = str(key)
-        if isinstance(item, (int, float)):
+        if isinstance(item, (int, float)) and not isinstance(item, bool):
             val = float(item)
         elif isinstance(item, str):
             try:

--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -51,6 +51,10 @@ DEFAULT_SEMANTIC_CANDIDATE_LIMIT = 250
 BARCODE_MIN_LEN = 8
 BARCODE_MAX_LEN = 14
 
+# Cache: resolved DB path -> whether `foods.nutrition_confidence` exists (additive column).
+_NUTRITION_CONFIDENCE_COLUMN_CACHE: Dict[str, bool] = {}
+_NUTRITION_CONFIDENCE_CACHE_LOCK = threading.Lock()
+
 DEFAULT_ALIASES: Dict[str, List[str]] = {
     # RU/EN/ES базовые соответствия; расширяй из своего alias CSV
     "йогурт": ["yogurt", "yoghurt"],
@@ -102,6 +106,67 @@ _FOOD_SOURCE_ATTRIBUTION_REGISTRY: Dict[str, Dict[str, str | None]] = {
     },
 }
 _FOOD_ATTRIBUTION_DEFAULT_KEYS: Tuple[str, ...] = ("usda", "open food facts")
+
+
+def _foods_db_cache_key() -> str:
+    """Stable cache key for the active food SQLite path."""
+
+    try:
+        return str(DB_PATH.resolve())
+    except OSError:
+        return str(DB_PATH)
+
+
+def _foods_has_nutrition_confidence_column(con: sqlite3.Connection) -> bool:
+    """
+    Return True when the local `foods` table includes additive aggregate confidence.
+
+    Older shipped food.sqlite files may omit this column; search/list SQL must stay compatible.
+    """
+
+    key = _foods_db_cache_key()
+    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+        cached = _NUTRITION_CONFIDENCE_COLUMN_CACHE.get(key)
+    if cached is not None:
+        return cached
+    try:
+        info_rows = con.execute("PRAGMA table_info(foods)").fetchall()
+    except sqlite3.Error:
+        has_col = False
+    else:
+        has_col = any(str(row[1]) == "nutrition_confidence" for row in info_rows)
+    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+        _NUTRITION_CONFIDENCE_COLUMN_CACHE[key] = has_col
+    return has_col
+
+
+def reset_foods_nutrition_confidence_column_cache() -> None:
+    """Clear pragma cache (tests and in-place DB file replacements)."""
+
+    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+        _NUTRITION_CONFIDENCE_COLUMN_CACHE.clear()
+
+
+def _coerce_nutrient_confidence_map(raw: object) -> dict[str, float]:
+    """Normalize per-nutrient confidence values to finite non-negative floats."""
+
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, float] = {}
+    for key, item in raw.items():
+        sk = str(key)
+        if isinstance(item, (int, float)):
+            val = float(item)
+        elif isinstance(item, str):
+            try:
+                val = float(item.strip())
+            except (TypeError, ValueError):
+                continue
+        else:
+            continue
+        if math.isfinite(val) and val >= 0.0:
+            out[sk] = val
+    return out
 
 
 def _safe_float(value: int | float | str | None) -> float:
@@ -402,21 +467,6 @@ _STRATEGY_SEARCH_BACKEND: FoodSearchBackend | None = None
 _SEARCH_BACKEND_LOCK = threading.Lock()
 
 
-def _parse_nutrient_confidence_mapping(value: object) -> Dict[str, float]:
-    """Coerce SQLite/JSON nutrient confidence payloads to dict[str, float]."""
-
-    if not isinstance(value, dict):
-        return {}
-    out: Dict[str, float] = {}
-    for key, item in value.items():
-        if isinstance(item, bool) or not isinstance(item, (int, float)):
-            continue
-        coerced = float(item)
-        if math.isfinite(coerced):
-            out[str(key)] = coerced
-    return out
-
-
 class FoodRepository:
     """Repository wrapper for food lookups against the local SQLite store."""
 
@@ -461,27 +511,29 @@ def _normalize_food_row(row: Dict[str, Any]) -> Dict[str, Any]:
     elif isinstance(raw_provenance, dict):
         normalized["nutrition_provenance"] = dict(raw_provenance)
 
+    if "nutrition_confidence" in normalized and normalized["nutrition_confidence"] is None:
+        normalized["nutrition_confidence"] = 0.0
+
     raw_nut_conf = normalized.get("nutrition_nutrient_confidence_json")
     if isinstance(raw_nut_conf, str):
         try:
             parsed_nut_conf = json.loads(raw_nut_conf)
         except (TypeError, ValueError):
             parsed_nut_conf = {}
-        normalized["nutrition_nutrient_confidence"] = _parse_nutrient_confidence_mapping(
+        normalized["nutrition_nutrient_confidence"] = _coerce_nutrient_confidence_map(
             parsed_nut_conf
         )
     elif isinstance(raw_nut_conf, dict):
-        normalized["nutrition_nutrient_confidence"] = _parse_nutrient_confidence_mapping(
-            raw_nut_conf
-        )
-
-    if "nutrition_confidence" in normalized and normalized["nutrition_confidence"] is None:
-        normalized["nutrition_confidence"] = 0.0
+        normalized["nutrition_nutrient_confidence"] = _coerce_nutrient_confidence_map(raw_nut_conf)
 
     normalized.setdefault("nutrition_inputs", [])
     normalized.setdefault("nutrition_provenance", {})
-    normalized.setdefault("nutrition_nutrient_confidence", {})
     normalized.setdefault("nutrition_confidence", 0.0)
+    normalized.setdefault("nutrition_nutrient_confidence", {})
+    if isinstance(normalized.get("nutrition_nutrient_confidence"), dict):
+        normalized["nutrition_nutrient_confidence"] = _coerce_nutrient_confidence_map(
+            normalized["nutrition_nutrient_confidence"]
+        )
 
     return normalized
 
@@ -556,11 +608,18 @@ def _load_semantic_candidates(limit: int) -> List[Dict[str, Any]]:
     EN: Loads candidates directly from foods, bypassing search pagination clamp.
     """
     with _connect() as con:
-        rows = con.execute(
-            "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
-            "FROM foods ORDER BY id ASC LIMIT ?",
-            (limit,),
-        ).fetchall()
+        has_conf = _foods_has_nutrition_confidence_column(con)
+        if has_conf:
+            q = (
+                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
+                "nutrition_confidence FROM foods ORDER BY id ASC LIMIT ?"
+            )
+        else:
+            q = (
+                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
+                "FROM foods ORDER BY id ASC LIMIT ?"
+            )
+        rows = con.execute(q, (limit,)).fetchall()
     return [dict(row) for row in rows]
 
 
@@ -809,32 +868,47 @@ def search_foods(query: str, limit: int | str = 20, offset: int | str = 0) -> Li
     # Validate and normalize pagination parameters
     limit, offset = _validate_pagination_params(limit, offset)
     terms = expand_query(query) if query else []
-    params: List[Any] = []
-    if terms:
-        # Query uses parameter placeholders for all user inputs;
-        # only the number of placeholders is constructed dynamically.
-        # Safe but consider phrase/prefix search (e.g., "term*" for prefix matching)
-        # for better FTS behavior in future enhancements.
-        # Dynamic SQL construction: only clause count is dynamic, all values use placeholders
-        # This is safe because we only construct the number of OR clauses, not the actual values
-        sql = (
-            """
+    with _connect() as con:
+        has_conf = _foods_has_nutrition_confidence_column(con)
+        if terms:
+            # Query uses parameter placeholders for all user inputs;
+            # only the number of placeholders is constructed dynamically.
+            # Safe but consider phrase/prefix search (e.g., "term*" for prefix matching)
+            # for better FTS behavior in future enhancements.
+            # Dynamic SQL construction: only clause count is dynamic, all values use placeholders
+            # This is safe because we only construct the number of OR clauses, not the actual values
+            if has_conf:
+                sql_prefix = """
+          SELECT f.id, f.canonical_name, f.kcal, f.protein_g, f.fat_g, f.carbs_g,
+                 f.nutrition_confidence
+          FROM foods f
+          JOIN foods_fts ff ON ff.rowid = f.rowid
+          WHERE"""
+            else:
+                sql_prefix = """
           SELECT f.id, f.canonical_name, f.kcal, f.protein_g, f.fat_g, f.carbs_g
           FROM foods f
           JOIN foods_fts ff ON ff.rowid = f.rowid
-          WHERE """
-            + " OR ".join(
-                ["ff.canonical_name MATCH ?"] * len(terms)
-            )  # nosec B608: safe - only clause count is dynamic, all values use placeholders (remove-by: 2026-05-15, ref: PR-search-shadow-foundation)
-            + " LIMIT ? OFFSET ?"
-        )
-        params = [*terms, limit, offset]
-    else:
-        sql = (
-            "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g FROM foods LIMIT ? OFFSET ?"
-        )
-        params = [limit, offset]
-    with _connect() as con:
+          WHERE"""
+            sql = (
+                sql_prefix
+                + " "
+                + " OR ".join(["ff.canonical_name MATCH ?"] * len(terms))
+                + " LIMIT ? OFFSET ?"
+            )
+            params = [*terms, limit, offset]
+        else:
+            if has_conf:
+                sql = (
+                    "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
+                    "nutrition_confidence FROM foods LIMIT ? OFFSET ?"
+                )
+            else:
+                sql = (
+                    "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
+                    "FROM foods LIMIT ? OFFSET ?"
+                )
+            params = [limit, offset]
         rows = con.execute(sql, params).fetchall()
     return [dict(r) for r in rows]
 

--- a/docs/review/PR_1346_FIXED_MAPPING.md
+++ b/docs/review/PR_1346_FIXED_MAPPING.md
@@ -8,7 +8,18 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: c2323037
+Evidence: app/schemas/food.py (bool guard in `_parse_json_float_dict`); app/services/food_store.py:156 (`_coerce_nutrient_confidence_map`); scripts/build_food_db.py:332 (explicit `INSERT INTO foods (...)`); app/routers/foods.py:48 (`_coerce_hit_nutrition_confidence`); tests in `tests/test_food_schema_provenance.py`, `tests/test_food_store_service.py`, `tests/test_foods_router_coverage_boost.py`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037264392 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037266604 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037266605 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037267255 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037267261 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037267264 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037271378 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037271380 -> c2323037
 
 ## Merge Readiness
 
@@ -18,6 +29,10 @@
 - [x] `pre-commit run --all-files` green on pushed head
 - [x] `make verify` green locally vs `origin/main` before marking ready
 
-Notes: Opened 2026-04-05. Runtime + tests only; strategy doc deferred to optional docs PR. Update mapping when review threads appear.
+Notes: Checkbox thread (r3037271380) was previously marked addressed in e2e78f6; included here for a single mapping pass with the nutrition-confidence fix commit c2323037. Re-resolve threads on GitHub after push if needed.
+
+## Split Justification
+
+Single feature PR: wire aggregate and per-nutrient confidence through food list/detail, SQLite builder, and normalization. Elevated line count is from deterministic tests (router coercion matrix, schema/store bool guards) and explicit SQL column list — not mixed product scope.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1346_FIXED_MAPPING.md
+++ b/docs/review/PR_1346_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1346 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed (update when bots/humans comment)
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- (none yet — add `- <thread_url> -> <sha>` or NOT-A-BUG/DEFERRED evidence per AGENTS.md)
+
+## Merge Readiness
+
+- [ ] All required checks pass (re-check on current head before merge)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] `pre-commit run --all-files` green on pushed head
+- [ ] `make verify` green locally vs `origin/main` before marking ready
+
+Notes: Opened 2026-04-05. Runtime + tests only; strategy doc deferred to optional docs PR.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1346_FIXED_MAPPING.md
+++ b/docs/review/PR_1346_FIXED_MAPPING.md
@@ -20,6 +20,9 @@ Evidence: app/schemas/food.py (bool guard in `_parse_json_float_dict`); app/serv
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037267264 -> c2323037
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037271378 -> c2323037
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037271380 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059773871 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059775943 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059778783 -> c2323037
 
 ## Merge Readiness
 

--- a/docs/review/PR_1346_FIXED_MAPPING.md
+++ b/docs/review/PR_1346_FIXED_MAPPING.md
@@ -3,21 +3,21 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed (update when bots/humans comment)
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- (none yet — add `- <thread_url> -> <sha>` or NOT-A-BUG/DEFERRED evidence per AGENTS.md)
+- No actionable review comments
 
 ## Merge Readiness
 
 - [ ] All required checks pass (re-check on current head before merge)
 - [ ] No unresolved review threads
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [ ] `pre-commit run --all-files` green on pushed head
-- [ ] `make verify` green locally vs `origin/main` before marking ready
+- [x] `pre-commit run --all-files` green on pushed head
+- [x] `make verify` green locally vs `origin/main` before marking ready
 
-Notes: Opened 2026-04-05. Runtime + tests only; strategy doc deferred to optional docs PR.
+Notes: Opened 2026-04-05. Runtime + tests only; strategy doc deferred to optional docs PR. Update mapping when review threads appear.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1346_FIXED_MAPPING.md
+++ b/docs/review/PR_1346_FIXED_MAPPING.md
@@ -10,7 +10,7 @@
 
 Disposition: FIXED
 Commit: c2323037
-Evidence: app/schemas/food.py (bool guard in `_parse_json_float_dict`); app/services/food_store.py:156 (`_coerce_nutrient_confidence_map`); scripts/build_food_db.py:332 (explicit `INSERT INTO foods (...)`); app/routers/foods.py:48 (`_coerce_hit_nutrition_confidence`); tests in `tests/test_food_schema_provenance.py`, `tests/test_food_store_service.py`, `tests/test_foods_router_coverage_boost.py`
+Evidence: app/schemas/food.py (bool guard in `_parse_json_float_dict`); app/services/food_store.py:156 (`_coerce_nutrient_confidence_map`); scripts/build_food_db.py:332 (explicit `INSERT INTO foods (...)`); app/routers/foods.py:48 (`_coerce_hit_nutrition_confidence`); tests in `tests/test_food_schema_provenance.py`, `tests/test_food_store_service.py`, `tests/test_foods_router_coverage_boost.py` (`test_list_foods_coerces_bad_nutrition_confidence_safely` uses `monkeypatch.setattr` per Python 3.12+/xdist policy)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037264392 -> c2323037
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037266604 -> c2323037
@@ -23,6 +23,9 @@ Evidence: app/schemas/food.py (bool guard in `_parse_json_float_dict`); app/serv
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059773871 -> c2323037
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059775943 -> c2323037
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059778783 -> c2323037
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#discussion_r3037302271 -> 1c8af78a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059801671 -> 1c8af78a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1346#pullrequestreview-4059802357 -> 1c8af78a
 
 ## Merge Readiness
 

--- a/scripts/build_food_db.py
+++ b/scripts/build_food_db.py
@@ -329,10 +329,17 @@ class FoodDatabaseBuilder:
                         ),
                     ),
                 )
-            cursor.executemany(
-                "INSERT INTO foods VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                rows,
+            insert_sql = (
+                "INSERT INTO foods ("
+                "id, canonical_name, group_name, per_g, kcal, protein_g, fat_g, carbs_g, "
+                "fiber_g, Fe_mg, Ca_mg, K_mg, Mg_mg, VitD_IU, B12_ug, Folate_ug, "
+                "Iodine_ug, flags, brand, gtin, fdc_id, source, source_priority, "
+                "version_date, price_per_100g, nutrition_inputs_json, "
+                "nutrition_provenance_json, nutrition_confidence, "
+                "nutrition_nutrient_confidence_json"
+                ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
             )
+            cursor.executemany(insert_sql, rows)
 
             # Populate FTS
             cursor.execute("INSERT INTO foods_fts(foods_fts) VALUES('rebuild')")

--- a/scripts/build_food_db.py
+++ b/scripts/build_food_db.py
@@ -180,8 +180,8 @@ class FoodDatabaseBuilder:
                     price_per_100g=record.get("price_per_100g", record.get("price", 0.0)),
                     nutrition_inputs=record.get("nutrition_inputs", []),
                     nutrition_provenance=record.get("nutrition_provenance", {}),
-                    nutrition_nutrient_confidence=record.get("nutrition_nutrient_confidence", {}),
                     nutrition_confidence=record.get("nutrition_confidence", 0.0),
+                    nutrition_nutrient_confidence=record.get("nutrition_nutrient_confidence", {}),
                 )
                 validated_foods.append(food_item)
 
@@ -273,8 +273,8 @@ class FoodDatabaseBuilder:
                 price_per_100g REAL,
                 nutrition_inputs_json TEXT,
                 nutrition_provenance_json TEXT,
-                nutrition_nutrient_confidence_json TEXT,
-                nutrition_confidence REAL
+                nutrition_confidence REAL,
+                nutrition_nutrient_confidence_json TEXT
             )
         """)
 
@@ -322,44 +322,17 @@ class FoodDatabaseBuilder:
                         food.price_per_100g,
                         json.dumps(food.nutrition_inputs, ensure_ascii=False),
                         json.dumps(food.nutrition_provenance, ensure_ascii=False),
-                        json.dumps(food.nutrition_nutrient_confidence, ensure_ascii=False),
                         food.nutrition_confidence,
+                        json.dumps(
+                            food.nutrition_nutrient_confidence,
+                            ensure_ascii=False,
+                        ),
                     ),
                 )
-            insert_sql = """
-            INSERT INTO foods (
-                id,
-                canonical_name,
-                group_name,
-                per_g,
-                kcal,
-                protein_g,
-                fat_g,
-                carbs_g,
-                fiber_g,
-                Fe_mg,
-                Ca_mg,
-                K_mg,
-                Mg_mg,
-                VitD_IU,
-                B12_ug,
-                Folate_ug,
-                Iodine_ug,
-                flags,
-                brand,
-                gtin,
-                fdc_id,
-                source,
-                source_priority,
-                version_date,
-                price_per_100g,
-                nutrition_inputs_json,
-                nutrition_provenance_json,
-                nutrition_nutrient_confidence_json,
-                nutrition_confidence
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-            """
-            cursor.executemany(insert_sql, rows)
+            cursor.executemany(
+                "INSERT INTO foods VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                rows,
+            )
 
             # Populate FTS
             cursor.execute("INSERT INTO foods_fts(foods_fts) VALUES('rebuild')")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -813,3 +813,13 @@ def _merge_snapshots(*snapshots) -> Any:
                 seen_alias.add(key)
 
     return CatalogSnapshot(regions=regions, stores=stores, skus=skus, aliases=aliases)
+
+
+@pytest.fixture(autouse=True)
+def _reset_food_store_nutrition_confidence_cache() -> Generator[None, None, None]:
+    """Avoid cross-test drift for food.sqlite pragma cache (mocked vs real DB paths)."""
+
+    yield
+    from app.services import food_store as _food_store
+
+    _food_store.reset_foods_nutrition_confidence_column_cache()

--- a/tests/test_food_schema_provenance.py
+++ b/tests/test_food_schema_provenance.py
@@ -108,6 +108,14 @@ def test_parse_json_float_dict_dict_branch_skips_blank_and_invalid_numeric_strin
     assert out["c"] == pytest.approx(0.2)
 
 
+def test_parse_json_float_dict_dict_branch_skips_bool_values() -> None:
+    """Bools are ints in Python; must not coerce True/False to 1.0/0.0."""
+    out = _parse_json_float_dict({"ok": 0.5, "bad_true": True, "bad_false": False})
+    assert out["ok"] == pytest.approx(0.5)
+    assert "bad_true" not in out
+    assert "bad_false" not in out
+
+
 def test_parse_json_inputs_json_object_string_returns_empty_list() -> None:
     assert _parse_json_inputs("{}") == []
 

--- a/tests/test_food_schema_provenance.py
+++ b/tests/test_food_schema_provenance.py
@@ -5,8 +5,9 @@ import math
 import pytest
 
 from app.schemas.food import (
+    FoodHit,
     FoodItem,
-    _parse_json_float_mapping,
+    _parse_json_float_dict,
     _parse_json_inputs,
     _parse_json_mapping,
 )
@@ -69,34 +70,6 @@ def test_food_item_accepts_mapping_and_none_for_additive_metadata() -> None:
     assert food.nutrition_provenance == {"protein_g": "estimate", "kcal": "123"}
 
 
-def test_parse_json_float_mapping_helper_coerces_numeric_and_rejects_bad_values() -> None:
-    assert _parse_json_float_mapping(None) == {}
-    assert _parse_json_float_mapping('{"kcal":0.7,"protein_g":true}') == {"kcal": 0.7}
-    assert _parse_json_float_mapping("not-json") == {}
-    assert _parse_json_float_mapping('["bad"]') == {}
-    assert _parse_json_float_mapping({"a": 1, "b": "x", "c": float("nan")}) == {"a": 1.0}
-    assert _parse_json_float_mapping("null") == {}
-    assert _parse_json_float_mapping("none") == {}
-    assert _parse_json_float_mapping("   ") == {}
-
-
-def test_food_item_parses_nutrition_nutrient_confidence() -> None:
-    food = FoodItem(
-        id="food-nc",
-        canonical_name="quinoa",
-        group="grain",
-        kcal=120.0,
-        protein_g=4.4,
-        fat_g=1.9,
-        carbs_g=21.3,
-        source="USDA",
-        version_date="2024-01-01",
-        nutrition_nutrient_confidence='{"kcal":0.7,"protein_g":0.6}',
-    )
-    assert food.nutrition_nutrient_confidence["kcal"] == pytest.approx(0.7)
-    assert food.nutrition_nutrient_confidence["protein_g"] == pytest.approx(0.6)
-
-
 def test_parse_json_mapping_helper_covers_none_invalid_and_non_dict_cases() -> None:
     assert _parse_json_mapping(None) == {}
     assert _parse_json_mapping('{"protein_g":"estimate"}') == {"protein_g": "estimate"}
@@ -109,6 +82,34 @@ def test_parse_json_inputs_helper_covers_list_and_string_edge_cases() -> None:
     assert _parse_json_inputs("null") == []
     assert _parse_json_inputs('{"source":"estimate"}') == []
     assert _parse_json_inputs("not-json") == []
+
+
+def test_parse_json_inputs_covers_none_whitespace_and_json_list_strings() -> None:
+    assert _parse_json_inputs(None) == []
+    assert _parse_json_inputs("   NONE   ") == []
+    assert _parse_json_inputs('  [{"a": 1}, "skip", {"b": 2}]  ') == [{"a": 1}, {"b": 2}]
+
+
+def test_parse_json_float_dict_string_json_and_non_dict_payload() -> None:
+    parsed = _parse_json_float_dict('{"k": "0.25", "m": 0.5}')
+    assert parsed["k"] == pytest.approx(0.25)
+    assert parsed["m"] == pytest.approx(0.5)
+    assert _parse_json_float_dict("[1]") == {}
+    assert _parse_json_float_dict("null") == {}
+    assert _parse_json_float_dict('"scalar"') == {}
+    assert _parse_json_float_dict("{not valid json") == {}
+    assert _parse_json_float_dict(True) == {}  # bool is not dict/str branch; tail return {}
+
+
+def test_parse_json_float_dict_dict_branch_skips_blank_and_invalid_numeric_strings() -> None:
+    out = _parse_json_float_dict({"a": "  ", "b": "not-a-float", "c": "0.2"})
+    assert "a" not in out
+    assert "b" not in out
+    assert out["c"] == pytest.approx(0.2)
+
+
+def test_parse_json_inputs_json_object_string_returns_empty_list() -> None:
+    assert _parse_json_inputs("{}") == []
 
 
 def test_food_item_nutrition_confidence_coerces_and_defaults() -> None:
@@ -259,27 +260,47 @@ def test_food_item_nutrition_confidence_unknown_type_falls_back_to_zero() -> Non
     assert food.nutrition_confidence == 0.0
 
 
-def test_core_schemas_fooditem_resolver_provenance_fields_round_trip() -> None:
-    """Import core.schemas.FoodItem in this suite so class-body lines are traced under CI coverage."""
-    from core.schemas import FoodItem as CoreFoodItem
-
-    core_food = CoreFoodItem(
-        id="core-prov-1",
-        canonical_name="oats",
+def test_food_item_nutrition_nutrient_confidence_parses_json_string() -> None:
+    food = FoodItem(
+        id="food-nc1",
+        canonical_name="barley",
         group="grain",
-        kcal=389.0,
-        protein_g=16.9,
-        fat_g=6.9,
-        carbs_g=66.3,
-        source="OFF",
-        version_date="2026-04-05",
-        nutrition_inputs=[{"source": "off", "record_id": "off-1"}],
-        nutrition_provenance={"kcal": "off", "protein_g": "estimate"},
-        nutrition_nutrient_confidence={"kcal": 0.9, "protein_g": 0.5},
-        nutrition_confidence=0.82,
+        kcal=352.0,
+        protein_g=10.0,
+        fat_g=2.3,
+        carbs_g=73.5,
+        source="USDA",
+        version_date="2024-01-01",
+        nutrition_nutrient_confidence='{"kcal": "0.8", "protein_g": 0.7}',
     )
-    dumped = core_food.model_dump()
-    assert dumped["nutrition_inputs"] == [{"source": "off", "record_id": "off-1"}]
-    assert dumped["nutrition_provenance"] == {"kcal": "off", "protein_g": "estimate"}
-    assert dumped["nutrition_nutrient_confidence"] == {"kcal": 0.9, "protein_g": 0.5}
-    assert dumped["nutrition_confidence"] == pytest.approx(0.82)
+    assert food.nutrition_nutrient_confidence["kcal"] == pytest.approx(0.8)
+    assert food.nutrition_nutrient_confidence["protein_g"] == pytest.approx(0.7)
+
+
+def test_food_item_nutrition_nutrient_confidence_drops_non_finite_and_negative() -> None:
+    food = FoodItem(
+        id="food-nc2",
+        canonical_name="rye",
+        group="grain",
+        kcal=338.0,
+        protein_g=10.3,
+        fat_g=1.6,
+        carbs_g=75.9,
+        source="USDA",
+        version_date="2024-01-01",
+        nutrition_nutrient_confidence={
+            "kcal": float("nan"),
+            "protein_g": -1.0,
+            "fat_g": float("inf"),
+            "carbs_g": 0.55,
+        },
+    )
+    assert "kcal" not in food.nutrition_nutrient_confidence
+    assert "protein_g" not in food.nutrition_nutrient_confidence
+    assert "fat_g" not in food.nutrition_nutrient_confidence
+    assert food.nutrition_nutrient_confidence["carbs_g"] == pytest.approx(0.55)
+
+
+def test_food_hit_includes_aggregate_nutrition_confidence_default() -> None:
+    hit = FoodHit(id="h1", name="Apple", kcal=52.0)
+    assert hit.nutrition_confidence == 0.0

--- a/tests/test_food_store_additional_coverage.py
+++ b/tests/test_food_store_additional_coverage.py
@@ -207,19 +207,26 @@ def test_search_foods_with_terms(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cover FTS path with dynamic SQL placeholders."""
 
     class FakeCursor:
-        def __init__(self, rows: list[dict[str, Any]]) -> None:
+        def __init__(self, rows: list[Any]) -> None:
             self._rows = rows
 
-        def fetchall(self) -> list[dict[str, Any]]:
+        def fetchall(self) -> list[Any]:
             return self._rows
 
     class FakeConnection:
         def __init__(self, rows: list[dict[str, Any]]) -> None:
             self.rows = rows
-            self.executions: list[tuple[str, list[Any]]] = []
+            self.executions: list[tuple[str, Any]] = []
 
-        def execute(self, sql: str, params: list[Any]) -> FakeCursor:
+        def execute(self, sql: str, params: Any = None) -> FakeCursor:
             self.executions.append((sql, params))
+            if "PRAGMA table_info(foods)" in sql:
+                pragma_rows: list[Any] = [
+                    (0, "id", "TEXT", 0, None, 0),
+                    (1, "nutrition_confidence", "REAL", 0, None, 0),
+                ]
+                return FakeCursor(pragma_rows)
+            assert params is not None
             return FakeCursor(self.rows)
 
         def __enter__(self) -> "FakeConnection":
@@ -250,8 +257,10 @@ def test_search_foods_with_terms(monkeypatch: pytest.MonkeyPatch) -> None:
 
     result = fs.search_foods("kiwi", limit="10", offset="1")
     assert result == rows
-    sql, params = created["conn"].executions[0]
-    assert "MATCH" in sql
+    fts_execs = [(s, p) for s, p in created["conn"].executions if "MATCH" in s]
+    assert fts_execs, "expected FTS SQL after schema probe"
+    sql, params = fts_execs[0]
+    assert params is not None
     assert params[-2:] == [10, 1]
 
 
@@ -259,23 +268,33 @@ def test_search_foods_without_terms(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cover fallback path when query is empty."""
 
     class FakeCursor:
-        def __init__(self) -> None:
-            self._rows = [
-                {
-                    "id": "f1",
-                    "canonical_name": "Kiwi",
-                    "kcal": 60,
-                    "protein_g": 1.0,
-                    "fat_g": 0.4,
-                    "carbs_g": 14,
-                }
-            ]
+        def __init__(self, rows: list[Any] | None = None) -> None:
+            self._rows: list[Any] = (
+                rows
+                if rows is not None
+                else [
+                    {
+                        "id": "f1",
+                        "canonical_name": "Kiwi",
+                        "kcal": 60,
+                        "protein_g": 1.0,
+                        "fat_g": 0.4,
+                        "carbs_g": 14,
+                    }
+                ]
+            )
 
-        def fetchall(self) -> list[dict[str, Any]]:
+        def fetchall(self) -> list[Any]:
             return self._rows
 
     class FakeConnection:
-        def execute(self, sql: str, params: list[Any]) -> FakeCursor:
+        def execute(self, sql: str, params: Any = None) -> FakeCursor:
+            if "PRAGMA table_info(foods)" in sql:
+                pragma_rows: list[Any] = [
+                    (0, "id", "TEXT", 0, None, 0),
+                    (1, "nutrition_confidence", "REAL", 0, None, 0),
+                ]
+                return FakeCursor(pragma_rows)
             assert "MATCH" not in sql
             assert params == [5, 0]
             return FakeCursor()

--- a/tests/test_food_store_coverage.py
+++ b/tests/test_food_store_coverage.py
@@ -40,13 +40,21 @@ class _MockConnection:
         self,
         fetchall_result: Optional[List[Dict[str, Any]]] = None,
         fetchone_result: Optional[Dict[str, Any]] = None,
+        *,
+        pragma_include_nutrition_confidence: bool = True,
     ) -> None:
         self._fetchall_result = fetchall_result
         self._fetchone_result = fetchone_result
+        self._pragma_include_nutrition_confidence = pragma_include_nutrition_confidence
         self.execute_calls: List[tuple[str, Any]] = []
 
     def execute(self, sql: str, params: Any = None) -> _MockCursor:
         self.execute_calls.append((sql, params))
+        if "PRAGMA table_info(foods)" in sql:
+            pragma_rows: List[Any] = [(0, "id", "TEXT", 0, None, 0)]
+            if self._pragma_include_nutrition_confidence:
+                pragma_rows.append((1, "nutrition_confidence", "REAL", 0, None, 0))
+            return _MockCursor(fetchall_result=pragma_rows)
         return _MockCursor(self._fetchall_result, self._fetchone_result)
 
     def __enter__(self) -> "_MockConnection":
@@ -113,7 +121,7 @@ class TestFoodStoreCoverage:
 
         result = food_store.search_foods("")
         assert len(result) == 1
-        assert len(conn.execute_calls) == 1
+        assert len(conn.execute_calls) == 2
 
     def test_search_foods_none_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест search_foods с None запросом - проверка graceful handling"""
@@ -123,7 +131,7 @@ class TestFoodStoreCoverage:
         # Intentional: testing None handling, not type conversion
         result = food_store.search_foods(None)  # type: ignore[arg-type]
         assert len(result) == 1
-        assert len(conn.execute_calls) == 1
+        assert len(conn.execute_calls) == 2
 
     def test_search_foods_with_terms(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест search_foods с терминами"""
@@ -135,7 +143,7 @@ class TestFoodStoreCoverage:
         result = food_store.search_foods("йогурт")
         assert len(result) == 1
         # Проверяем, что SQL содержит OR условия для алиасов
-        sql = conn.execute_calls[0][0]
+        sql = conn.execute_calls[-1][0]
         assert "OR" in sql
 
     def test_get_food_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -306,7 +314,7 @@ class TestFoodStoreCoverage:
         food_store.search_foods("apple banana", limit=10, offset=5)
 
         # Проверяем, что SQL содержит JOIN и MATCH
-        sql, params = conn.execute_calls[0]
+        sql, params = conn.execute_calls[-1]
         assert "JOIN foods_fts" in sql
         assert "MATCH ?" in sql
         assert "LIMIT ? OFFSET ?" in sql
@@ -326,13 +334,27 @@ class TestFoodStoreCoverage:
         food_store.search_foods("", limit=15, offset=10)
 
         # Проверяем, что SQL не содержит JOIN
-        sql, params = conn.execute_calls[0]
+        sql, params = conn.execute_calls[-1]
         assert "JOIN" not in sql
         assert "MATCH" not in sql
         assert "LIMIT ? OFFSET ?" in sql
 
         # Проверяем параметры
         assert params == [15, 10]  # limit, offset
+
+    def test_search_foods_legacy_schema_skips_nutrition_confidence_column(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Additive confidence column absent -> SELECT must not reference it."""
+
+        conn = _MockConnection(
+            fetchall_result=[{"id": "1", "canonical_name": "x", "kcal": 1.0}],
+            pragma_include_nutrition_confidence=False,
+        )
+        monkeypatch.setattr(food_store, "_connect", lambda: conn)
+        food_store.search_foods("", limit=3, offset=0)
+        sql = conn.execute_calls[-1][0]
+        assert "nutrition_confidence" not in sql
 
     def test_nutrients_for_food_not_found_continue(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Тест nutrients_for когда get_food возвращает None - строка 89-91"""

--- a/tests/test_food_store_coverage_boost.py
+++ b/tests/test_food_store_coverage_boost.py
@@ -43,13 +43,21 @@ class _MockConnection:
         self,
         fetchall_result: Optional[List[Dict[str, Any]]] = None,
         fetchone_result: Optional[Dict[str, Any]] = None,
+        *,
+        pragma_include_nutrition_confidence: bool = True,
     ) -> None:
         self._fetchall_result = fetchall_result
         self._fetchone_result = fetchone_result
+        self._pragma_include_nutrition_confidence = pragma_include_nutrition_confidence
         self.execute_calls: List[tuple[str, Any]] = []
 
     def execute(self, sql: str, params: Any = None) -> _MockCursor:
         self.execute_calls.append((sql, params))
+        if "PRAGMA table_info(foods)" in sql:
+            pragma_rows: List[Any] = [(0, "id", "TEXT", 0, None, 0)]
+            if self._pragma_include_nutrition_confidence:
+                pragma_rows.append((1, "nutrition_confidence", "REAL", 0, None, 0))
+            return _MockCursor(fetchall_result=pragma_rows)
         return _MockCursor(self._fetchall_result, self._fetchone_result)
 
     def __enter__(self) -> "_MockConnection":
@@ -143,7 +151,7 @@ class TestFoodStoreCoverage:
 
         assert len(result) == 1
         assert result[0]["canonical_name"] == "apple"
-        assert len(mock_con.execute_calls) == 1
+        assert len(mock_con.execute_calls) == 2
 
     def test_search_foods_without_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test search_foods without query."""
@@ -165,7 +173,7 @@ class TestFoodStoreCoverage:
 
         assert len(result) == 1
         assert result[0]["canonical_name"] == "apple"
-        assert len(mock_con.execute_calls) == 1
+        assert len(mock_con.execute_calls) == 2
 
     def test_search_foods_none_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test search_foods with None query."""
@@ -176,7 +184,7 @@ class TestFoodStoreCoverage:
         result = food_store.search_foods(None, limit=10, offset=0)  # type: ignore[arg-type]
 
         assert result == []
-        assert len(mock_con.execute_calls) == 1
+        assert len(mock_con.execute_calls) == 2
 
     def test_get_food_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test get_food when food is found."""

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -1040,3 +1040,13 @@ def test_coerce_nutrient_confidence_map_skips_unparseable_string_values() -> Non
 def test_coerce_nutrient_confidence_map_skips_non_scalar_values() -> None:
     """Non int/float/str values use the else branch and are omitted."""
     assert food_store._coerce_nutrient_confidence_map({"k": []}) == {}
+
+
+def test_coerce_nutrient_confidence_map_skips_bool_values() -> None:
+    """Bools must not be treated as numeric confidence scalars."""
+    out = food_store._coerce_nutrient_confidence_map(
+        {"kcal": True, "protein_g": False, "fat_g": 0.25},
+    )
+    assert "kcal" not in out
+    assert "protein_g" not in out
+    assert out["fat_g"] == pytest.approx(0.25)

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import sqlite3
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Dict, List
@@ -11,8 +12,8 @@ from app.services import food_store
 _LEGACY_ROW_ADDITIVE_DEFAULTS: Dict[str, Any] = {
     "nutrition_inputs": [],
     "nutrition_provenance": {},
-    "nutrition_nutrient_confidence": {},
     "nutrition_confidence": 0.0,
+    "nutrition_nutrient_confidence": {},
 }
 
 
@@ -101,10 +102,10 @@ def test_log_missing_food_summary(
 
 
 class _DummyCursor:
-    def __init__(self, rows: List[Dict[str, Any]]) -> None:
+    def __init__(self, rows: List[Any]) -> None:
         self._rows = rows
 
-    def fetchall(self) -> List[Dict[str, Any]]:
+    def fetchall(self) -> List[Any]:
         return self._rows
 
 
@@ -113,9 +114,15 @@ class _DummyConn:
         self.last_sql: str | None = None
         self.last_params: List[Any] | None = None
 
-    def execute(self, sql: str, params: List[Any]) -> _DummyCursor:
+    def execute(self, sql: str, params: Any = None) -> _DummyCursor:
         self.last_sql = sql
-        self.last_params = params
+        if "PRAGMA table_info(foods)" in sql:
+            pragma_rows: List[Any] = [
+                (0, "id", "TEXT", 0, None, 0),
+                (1, "nutrition_confidence", "REAL", 0, None, 0),
+            ]
+            return _DummyCursor(pragma_rows)
+        self.last_params = list(params) if params is not None else []
         return _DummyCursor([{"id": 1, "canonical_name": "apple", "kcal": 10.0}])
 
     def __enter__(self) -> "_DummyConn":
@@ -162,6 +169,7 @@ class _DummyBarcodeConn:
 
 
 def test_search_foods_parameter_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    food_store.reset_foods_nutrition_confidence_column_cache()
     dummy = _DummyConn()
     monkeypatch.setattr(food_store, "_connect", lambda: dummy)
 
@@ -176,7 +184,6 @@ def test_normalize_food_row_parses_additive_nutrition_metadata() -> None:
         "canonical_name": "apple",
         "nutrition_inputs_json": '[{"source":"estimate","record_id":"off-1"}]',
         "nutrition_provenance_json": '{"protein_g":"estimate"}',
-        "nutrition_nutrient_confidence_json": '{"protein_g":0.4,"kcal":0.3}',
         "nutrition_confidence": 0.4,
     }
 
@@ -184,8 +191,6 @@ def test_normalize_food_row_parses_additive_nutrition_metadata() -> None:
 
     assert normalized["nutrition_inputs"][0]["source"] == "estimate"
     assert normalized["nutrition_provenance"]["protein_g"] == "estimate"
-    assert normalized["nutrition_nutrient_confidence"]["protein_g"] == pytest.approx(0.4)
-    assert normalized["nutrition_nutrient_confidence"]["kcal"] == pytest.approx(0.3)
     assert normalized["nutrition_confidence"] == 0.4
 
 
@@ -201,7 +206,6 @@ def test_normalize_food_row_handles_invalid_json_and_none_confidence() -> None:
 
     assert normalized["nutrition_inputs"] == []
     assert normalized["nutrition_provenance"] == {}
-    assert normalized["nutrition_nutrient_confidence"] == {}
     assert normalized["nutrition_confidence"] == 0.0
 
 
@@ -216,7 +220,6 @@ def test_normalize_food_row_ignores_non_list_or_non_dict_payloads() -> None:
 
     assert normalized["nutrition_inputs"] == []
     assert normalized["nutrition_provenance"] == {}
-    assert normalized["nutrition_nutrient_confidence"] == {}
 
 
 def test_normalize_food_row_legacy_shape_without_additive_columns() -> None:
@@ -226,8 +229,92 @@ def test_normalize_food_row_legacy_shape_without_additive_columns() -> None:
 
     assert normalized["nutrition_inputs"] == []
     assert normalized["nutrition_provenance"] == {}
-    assert normalized["nutrition_nutrient_confidence"] == {}
     assert normalized["nutrition_confidence"] == 0.0
+    assert normalized["nutrition_nutrient_confidence"] == {}
+
+
+def test_normalize_food_row_parses_nutrition_nutrient_confidence_json() -> None:
+    row = {
+        "id": "food-nc",
+        "canonical_name": "oats",
+        "nutrition_nutrient_confidence_json": '{"kcal":"0.7","protein_g":0.9}',
+    }
+    out = food_store._normalize_food_row(row)
+    assert out["nutrition_nutrient_confidence"]["kcal"] == pytest.approx(0.7)
+    assert out["nutrition_nutrient_confidence"]["protein_g"] == pytest.approx(0.9)
+
+
+def test_normalize_food_row_nutrient_confidence_from_mapping_not_json_string() -> None:
+    row = {
+        "id": "food-nc-dict",
+        "canonical_name": "tofu",
+        "nutrition_nutrient_confidence_json": {"fat_g": 0.4, "kcal": "0.6"},
+    }
+    out = food_store._normalize_food_row(row)
+    assert out["nutrition_nutrient_confidence"]["fat_g"] == pytest.approx(0.4)
+    assert out["nutrition_nutrient_confidence"]["kcal"] == pytest.approx(0.6)
+
+
+def test_foods_db_cache_key_string_fallback_on_resolve_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadPath:
+        def __str__(self) -> str:
+            return "/tmp/fake-db-path.sqlite"
+
+        def resolve(self) -> Path:
+            raise OSError("simulated resolve failure")
+
+    monkeypatch.setattr(food_store, "DB_PATH", _BadPath())
+    assert food_store._foods_db_cache_key() == "/tmp/fake-db-path.sqlite"
+
+
+def test_search_foods_fts_includes_aggregate_confidence_when_pragma_reports_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cache may be False from error-path tests, pragma on this conn must win."""
+    food_store.reset_foods_nutrition_confidence_column_cache()
+    dummy = _DummyConn()
+    monkeypatch.setattr(food_store, "_connect", lambda: dummy)
+    food_store.search_foods("kiwi", limit=3, offset=0)
+    assert dummy.last_sql is not None
+    assert "f.nutrition_confidence" in dummy.last_sql
+
+
+def test_search_foods_fts_omits_aggregate_confidence_when_pragma_omits_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FTS path must use lean SELECT when foods lacks nutrition_confidence (legacy DB)."""
+
+    class _NoConfConn(_DummyConn):
+        def execute(self, sql: str, params: Any = None) -> _DummyCursor:
+            self.last_sql = sql
+            if "PRAGMA table_info(foods)" in sql:
+                pragma_rows: List[Any] = [
+                    (0, "id", "TEXT", 0, None, 0),
+                    (1, "canonical_name", "TEXT", 0, None, 0),
+                ]
+                return _DummyCursor(pragma_rows)
+            self.last_params = list(params) if params is not None else []
+            return _DummyCursor([{"id": 1, "canonical_name": "apple", "kcal": 10.0}])
+
+    food_store.reset_foods_nutrition_confidence_column_cache()
+    dummy = _NoConfConn()
+    monkeypatch.setattr(food_store, "_connect", lambda: dummy)
+    food_store.search_foods("apple", limit=2, offset=0)
+    assert dummy.last_sql is not None
+    assert "MATCH" in dummy.last_sql
+    assert "f.nutrition_confidence" not in dummy.last_sql
+
+
+def test_foods_has_nutrition_confidence_column_handles_sqlite_execute_error() -> None:
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
+    class _ErrConn:
+        def execute(self, *_a: Any, **_kw: Any) -> Any:
+            raise sqlite3.Error("pragma failed")
+
+    assert food_store._foods_has_nutrition_confidence_column(_ErrConn()) is False
 
 
 def test_normalize_food_row_additive_columns_none_or_pre_parsed() -> None:
@@ -252,14 +339,6 @@ def test_normalize_food_row_additive_columns_none_or_pre_parsed() -> None:
     assert out["nutrition_inputs"] == parsed_inputs
     assert out["nutrition_provenance"] == parsed_prov
     assert out["nutrition_confidence"] == 0.25
-
-    row_nut = {
-        "id": "food-nutconf",
-        "canonical_name": "bar",
-        "nutrition_nutrient_confidence_json": {"fiber_g": 0.5, "bad": "x", "also": True},
-    }
-    nut_out = food_store._normalize_food_row(row_nut)
-    assert nut_out["nutrition_nutrient_confidence"] == {"fiber_g": 0.5}
 
 
 def test_get_food_by_barcode_returns_row_with_normalized_input(
@@ -618,17 +697,35 @@ def test_bootstrap_semantic_backend_large_offset_falls_back_without_candidate_sc
 def test_load_semantic_candidates_uses_passed_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
     class _SemanticCursor:
-        def fetchall(self) -> List[Dict[str, Any]]:
-            return [{"id": "sem-1", "canonical_name": "Apple", "kcal": 52}]
+        def __init__(self, rows: List[Any] | None = None) -> None:
+            self._rows: List[Any] = (
+                rows
+                if rows is not None
+                else [{"id": "sem-1", "canonical_name": "Apple", "kcal": 52}]
+            )
+
+        def fetchall(self) -> List[Any]:
+            return self._rows
 
     class _SemanticConn:
         def __init__(self) -> None:
             self.last_params: tuple[int] | None = None
+            self.last_select_sql: str | None = None
 
-        def execute(self, sql: str, params: tuple[int]) -> _SemanticCursor:
+        def execute(self, sql: str, params: Any = None) -> _SemanticCursor:
+            if "PRAGMA table_info(foods)" in sql:
+                pragma_rows: List[Any] = [
+                    (0, "id", "TEXT", 0, None, 0),
+                    (1, "nutrition_confidence", "REAL", 0, None, 0),
+                ]
+                return _SemanticCursor(pragma_rows)
             assert "FROM foods ORDER BY id ASC LIMIT ?" in sql
-            self.last_params = params
+            assert params is not None
+            self.last_select_sql = sql
+            self.last_params = tuple(params)  # type: ignore[arg-type]
             return _SemanticCursor()
 
         def __enter__(self) -> "_SemanticConn":
@@ -646,7 +743,60 @@ def test_load_semantic_candidates_uses_passed_limit(
     monkeypatch.setattr(food_store, "_connect", lambda: conn)
     rows = food_store._load_semantic_candidates(limit=250)
     assert conn.last_params == (250,)
+    assert conn.last_select_sql is not None
+    assert "nutrition_confidence" in conn.last_select_sql
     assert rows[0]["id"] == "sem-1"
+
+
+def test_load_semantic_candidates_skips_aggregate_column_when_pragma_omits_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
+    class _SemanticCursor:
+        def __init__(self, rows: List[Any] | None = None) -> None:
+            self._rows: List[Any] = (
+                rows
+                if rows is not None
+                else [{"id": "sem-2", "canonical_name": "Pear", "kcal": 57}]
+            )
+
+        def fetchall(self) -> List[Any]:
+            return self._rows
+
+    class _SemanticConnNoConf:
+        def __init__(self) -> None:
+            self.last_select_sql: str | None = None
+
+        def execute(self, sql: str, params: Any = None) -> _SemanticCursor:
+            if "PRAGMA table_info(foods)" in sql:
+                pragma_rows: List[Any] = [
+                    (0, "id", "TEXT", 0, None, 0),
+                    (1, "canonical_name", "TEXT", 0, None, 0),
+                ]
+                return _SemanticCursor(pragma_rows)
+            assert "FROM foods ORDER BY id ASC LIMIT ?" in sql
+            assert params is not None
+            self.last_select_sql = sql
+            return _SemanticCursor()
+
+        def __enter__(self) -> "_SemanticConnNoConf":
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            return None
+
+    conn = _SemanticConnNoConf()
+    monkeypatch.setattr(food_store, "_connect", lambda: conn)
+    rows = food_store._load_semantic_candidates(limit=12)
+    assert conn.last_select_sql is not None
+    assert "nutrition_confidence" not in conn.last_select_sql
+    assert rows[0]["id"] == "sem-2"
 
 
 def test_semantic_score_returns_zero_for_empty_tokens() -> None:
@@ -850,3 +1000,43 @@ def test_discover_food_source_keys_returns_defaults_when_rows_empty(
 
     monkeypatch.setattr(food_store, "_connect", lambda: _SourceConn())
     assert food_store._discover_food_source_keys() == ["usda", "open food facts"]
+
+
+def test_search_foods_works_when_sqlite_foods_lacks_nutrition_confidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy food.sqlite without aggregate confidence column must not break list/search."""
+
+    db_path = tmp_path / "legacy_foods.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE foods (
+                id TEXT PRIMARY KEY,
+                canonical_name TEXT NOT NULL,
+                kcal REAL,
+                protein_g REAL,
+                fat_g REAL,
+                carbs_g REAL
+            )
+            """)
+        conn.execute(
+            "INSERT INTO foods (id, canonical_name, kcal, protein_g, fat_g, carbs_g) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("fid1", "Apple", 52.0, 0.3, 0.2, 14.0),
+        )
+    monkeypatch.setattr(food_store, "DB_PATH", db_path)
+    food_store.reset_foods_nutrition_confidence_column_cache()
+    rows = food_store.search_foods("", limit=10, offset=0)
+    assert len(rows) == 1
+    assert rows[0]["canonical_name"] == "Apple"
+    assert "nutrition_confidence" not in rows[0]
+
+
+def test_coerce_nutrient_confidence_map_skips_unparseable_string_values() -> None:
+    """Invalid string numerics hit ValueError branch and are omitted."""
+    assert food_store._coerce_nutrient_confidence_map({"protein_g": "not-a-float"}) == {}
+
+
+def test_coerce_nutrient_confidence_map_skips_non_scalar_values() -> None:
+    """Non int/float/str values use the else branch and are omitted."""
+    assert food_store._coerce_nutrient_confidence_map({"k": []}) == {}

--- a/tests/test_foods_router_coverage_boost.py
+++ b/tests/test_foods_router_coverage_boost.py
@@ -68,100 +68,105 @@ class TestFoodsRouterCoverage:
         assert data[1]["name"] == "banana"
         assert data[1]["kcal"] == 89
 
-    @patch("app.routers.foods.food_store.search_foods")
-    def test_list_foods_coerces_bad_nutrition_confidence_safely(self, mock_search_foods):
+    def test_list_foods_coerces_bad_nutrition_confidence_safely(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """List hits must not raise on corrupt DB cells; bool/NaN → 0, valid strings kept."""
-        mock_search_foods.return_value = [
-            {
-                "id": "1",
-                "canonical_name": "apple",
-                "kcal": 52,
-                "protein_g": 0.3,
-                "fat_g": 0.2,
-                "carbs_g": 14.0,
-                "nutrition_confidence": True,
-            },
-            {
-                "id": "2",
-                "canonical_name": "banana",
-                "kcal": 89,
-                "protein_g": 1.1,
-                "fat_g": 0.3,
-                "carbs_g": 23.0,
-                "nutrition_confidence": float("nan"),
-            },
-            {
-                "id": "3",
-                "canonical_name": "oat",
-                "kcal": 10,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": " 0.5 ",
-            },
-            {
-                "id": "4",
-                "canonical_name": "bad-str",
-                "kcal": 1,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": "not-a-float",
-            },
-            {
-                "id": "5",
-                "canonical_name": "no-key",
-                "kcal": 2,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-            },
-            {
-                "id": "6",
-                "canonical_name": "explicit-none",
-                "kcal": 3,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": None,
-            },
-            {
-                "id": "7",
-                "canonical_name": "wrong-type",
-                "kcal": 4,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": [],
-            },
-            {
-                "id": "8",
-                "canonical_name": "neg-num",
-                "kcal": 5,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": -0.1,
-            },
-            {
-                "id": "9",
-                "canonical_name": "inf-num",
-                "kcal": 6,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": float("inf"),
-            },
-            {
-                "id": "10",
-                "canonical_name": "neg-str",
-                "kcal": 7,
-                "protein_g": 0.0,
-                "fat_g": 0.0,
-                "carbs_g": 0.0,
-                "nutrition_confidence": "-3",
-            },
-        ]
+
+        def fake_search_foods(*_a: object, **_kw: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "id": "1",
+                    "canonical_name": "apple",
+                    "kcal": 52,
+                    "protein_g": 0.3,
+                    "fat_g": 0.2,
+                    "carbs_g": 14.0,
+                    "nutrition_confidence": True,
+                },
+                {
+                    "id": "2",
+                    "canonical_name": "banana",
+                    "kcal": 89,
+                    "protein_g": 1.1,
+                    "fat_g": 0.3,
+                    "carbs_g": 23.0,
+                    "nutrition_confidence": float("nan"),
+                },
+                {
+                    "id": "3",
+                    "canonical_name": "oat",
+                    "kcal": 10,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": " 0.5 ",
+                },
+                {
+                    "id": "4",
+                    "canonical_name": "bad-str",
+                    "kcal": 1,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": "not-a-float",
+                },
+                {
+                    "id": "5",
+                    "canonical_name": "no-key",
+                    "kcal": 2,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                },
+                {
+                    "id": "6",
+                    "canonical_name": "explicit-none",
+                    "kcal": 3,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": None,
+                },
+                {
+                    "id": "7",
+                    "canonical_name": "wrong-type",
+                    "kcal": 4,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": [],
+                },
+                {
+                    "id": "8",
+                    "canonical_name": "neg-num",
+                    "kcal": 5,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": -0.1,
+                },
+                {
+                    "id": "9",
+                    "canonical_name": "inf-num",
+                    "kcal": 6,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": float("inf"),
+                },
+                {
+                    "id": "10",
+                    "canonical_name": "neg-str",
+                    "kcal": 7,
+                    "protein_g": 0.0,
+                    "fat_g": 0.0,
+                    "carbs_g": 0.0,
+                    "nutrition_confidence": "-3",
+                },
+            ]
+
+        monkeypatch.setattr("app.routers.foods.food_store.search_foods", fake_search_foods)
         response = client.get("/api/v1/foods?query=x&limit=10&offset=0")
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_foods_router_coverage_boost.py
+++ b/tests/test_foods_router_coverage_boost.py
@@ -309,10 +309,11 @@ def test_foods_route_contract_remains_stable_with_meili_backend(
         {
             "id": "m-1",
             "name": "Apple",
-            "kcal": 52,
+            "kcal": 52.0,
             "protein_g": 0.3,
             "fat_g": 0.2,
             "carbs_g": 14.0,
+            "nutrition_confidence": 0.0,
         }
     ]
 
@@ -370,10 +371,11 @@ def test_foods_route_contract_remains_stable_with_shadow_backend(
         {
             "id": "b-1",
             "name": "Baseline Apple",
-            "kcal": 51,
+            "kcal": 51.0,
             "protein_g": 0.2,
             "fat_g": 0.1,
             "carbs_g": 13.0,
+            "nutrition_confidence": 0.0,
         }
     ]
 

--- a/tests/test_foods_router_coverage_boost.py
+++ b/tests/test_foods_router_coverage_boost.py
@@ -69,6 +69,114 @@ class TestFoodsRouterCoverage:
         assert data[1]["kcal"] == 89
 
     @patch("app.routers.foods.food_store.search_foods")
+    def test_list_foods_coerces_bad_nutrition_confidence_safely(self, mock_search_foods):
+        """List hits must not raise on corrupt DB cells; bool/NaN → 0, valid strings kept."""
+        mock_search_foods.return_value = [
+            {
+                "id": "1",
+                "canonical_name": "apple",
+                "kcal": 52,
+                "protein_g": 0.3,
+                "fat_g": 0.2,
+                "carbs_g": 14.0,
+                "nutrition_confidence": True,
+            },
+            {
+                "id": "2",
+                "canonical_name": "banana",
+                "kcal": 89,
+                "protein_g": 1.1,
+                "fat_g": 0.3,
+                "carbs_g": 23.0,
+                "nutrition_confidence": float("nan"),
+            },
+            {
+                "id": "3",
+                "canonical_name": "oat",
+                "kcal": 10,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": " 0.5 ",
+            },
+            {
+                "id": "4",
+                "canonical_name": "bad-str",
+                "kcal": 1,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": "not-a-float",
+            },
+            {
+                "id": "5",
+                "canonical_name": "no-key",
+                "kcal": 2,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+            },
+            {
+                "id": "6",
+                "canonical_name": "explicit-none",
+                "kcal": 3,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": None,
+            },
+            {
+                "id": "7",
+                "canonical_name": "wrong-type",
+                "kcal": 4,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": [],
+            },
+            {
+                "id": "8",
+                "canonical_name": "neg-num",
+                "kcal": 5,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": -0.1,
+            },
+            {
+                "id": "9",
+                "canonical_name": "inf-num",
+                "kcal": 6,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": float("inf"),
+            },
+            {
+                "id": "10",
+                "canonical_name": "neg-str",
+                "kcal": 7,
+                "protein_g": 0.0,
+                "fat_g": 0.0,
+                "carbs_g": 0.0,
+                "nutrition_confidence": "-3",
+            },
+        ]
+        response = client.get("/api/v1/foods?query=x&limit=10&offset=0")
+        assert response.status_code == 200
+        data = response.json()
+        assert data[0]["nutrition_confidence"] == 0.0
+        assert data[1]["nutrition_confidence"] == 0.0
+        assert data[2]["nutrition_confidence"] == pytest.approx(0.5)
+        assert data[3]["nutrition_confidence"] == 0.0
+        assert data[4]["nutrition_confidence"] == 0.0
+        assert data[5]["nutrition_confidence"] == 0.0
+        assert data[6]["nutrition_confidence"] == 0.0
+        assert data[7]["nutrition_confidence"] == 0.0
+        assert data[8]["nutrition_confidence"] == 0.0
+        assert data[9]["nutrition_confidence"] == 0.0
+
+    @patch("app.routers.foods.food_store.search_foods")
     def test_list_foods_empty_query(self, mock_search_foods):
         """Test list_foods with empty query."""
         mock_search_foods.return_value = []

--- a/tests/test_schema_sanity.py
+++ b/tests/test_schema_sanity.py
@@ -197,6 +197,10 @@ def test_merged_schema_sanity():
     assert isinstance(record["source"], str)
     assert isinstance(record["version_date"], str)
 
+    assert "nutrition_nutrient_confidence" in record
+    assert isinstance(record["nutrition_nutrient_confidence"], dict)
+    assert record["nutrition_nutrient_confidence"].get("kcal") == pytest.approx(0.7)
+
     # Check non-negative values
     assert record["per_g"] >= 0
     assert record["kcal"] >= 0


### PR DESCRIPTION
## Summary
Additive wire for nutrition confidence: `FoodItem` gains `nutrition_confidence`, `nutrition_nutrient_confidence`; `FoodHit` gains `nutrition_confidence` (defaults keep old clients valid). `food_store` normalizes DB rows with pragma-safe SQL; `build_food_db` aligned. Tests cover FTS/semantic paths, legacy DB without column, and `_coerce_nutrient_confidence_map` edge cases.

## Contract
- New fields are optional at the JSON level (defaults: `0.0` / `{}`).
- No breaking renames on existing food DTOs.
- Legacy food DBs without `nutrition_confidence` column remain supported.

## Validation (local)
- `python3 -m pre_commit run --all-files` — pass
- `make verify` (lint, mypy app+core, test-fast, diff-cov ≥97% vs `origin/main`) — pass
- `make openapi` / `make openapi-check` — no drift (legacy foods routes hidden from public OpenAPI)

## Deferred / Follow-ups
- Strategy doc rollout table: separate docs PR if product wants `FOOD_DATABASE_PLATFORM_STRATEGY_v1.md` updated for this PR number.

## Split Justification

This PR is intentionally one vertical slice: wire aggregate and per-nutrient nutrition confidence end-to-end (Pydantic `FoodItem`/`FoodHit`, `food_store` row normalization, `build_food_db` SQLite ingest, foods list router coercion). Splitting would risk shipping mismatched SQL tuple shapes versus runtime readers or a half-enabled API surface. The change exceeds 800 LoC because of deterministic tests (legacy DBs without new columns, FTS/SQL paths, coercion edge cases) and explicit `INSERT` column lists—not unrelated product scope.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1346_FIXED_MAPPING.md`

## Merge Readiness
- [ ] CI green on current head
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Food search and list responses now include a safely coerced nutrition confidence score (defaults to 0.0).

* **Improvements**
  * Stricter parsing and normalization of per-nutrient confidence and provenance; invalid, non-numeric, non-finite, or negative inputs are ignored.
  * Schema-aware behavior: confidence column is included in queries only when present; runtime schema cache with explicit invalidation.

* **Tests**
  * Expanded coverage for parsing, defaults, schema probing, and cache reset behavior.

* **Documentation**
  * Added a PR review checklist document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
