### PR TITLE
chore(ios): require Xcode 26 CI readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1133,21 +1133,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Select Xcode (pin 16.x compatible with iOS 18.5/18.6 runtimes)
+      - name: Select Xcode (require 26.x for iOS 26 SDK readiness)
         id: select-xcode
         shell: bash
         run: |
           set -euo pipefail
 
-          # Prefer newest stable 16.x to match iOS 18.5/18.6 runtimes on runner.
-          # (Xcode 16.2 expects iOS 18.2 platform, which is not installed here.)
+          # Prefer explicit Xcode 26.x installs first.
+          # Keep /Applications/Xcode.app as a final fallback, but verify the major version.
           CANDIDATES=(
-            "/Applications/Xcode_16.4.app/Contents/Developer"
-            "/Applications/Xcode_16.4.0.app/Contents/Developer"
-            "/Applications/Xcode_16.3.app/Contents/Developer"
-            "/Applications/Xcode_16.3.0.app/Contents/Developer"
-            "/Applications/Xcode_16.2.app/Contents/Developer"
-            "/Applications/Xcode_16.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.2.app/Contents/Developer"
+            "/Applications/Xcode_26.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.1.app/Contents/Developer"
+            "/Applications/Xcode_26.1.0.app/Contents/Developer"
+            "/Applications/Xcode_26.0.app/Contents/Developer"
+            "/Applications/Xcode_26.app/Contents/Developer"
+            "/Applications/Xcode_26.0.0.app/Contents/Developer"
+            "/Applications/Xcode.app/Contents/Developer"
           )
 
           SELECTED=""
@@ -1159,7 +1161,7 @@ jobs:
           done
 
           if [ -z "$SELECTED" ]; then
-            echo "::error::No suitable Xcode 16.x found in /Applications."
+            echo "::error::No suitable Xcode 26.x found in /Applications."
             echo "::error::Available Xcode apps:"
             for app in /Applications/Xcode*.app; do
               [ -e "$app" ] && echo " - $app"
@@ -1180,9 +1182,14 @@ jobs:
 
           # Extract Xcode version for cache key (avoid broken pipe from pipe consumers like head/sed)
           XCODEBUILD_VERSION="$(xcodebuild -version)"
-          # First line is like: "Xcode 16.4"
+          # First line is like: "Xcode 26.1"
           XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
           XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
+          XCODE_MAJOR="${XCODE_VERSION%%.*}"
+          if [ "$XCODE_MAJOR" != "26" ]; then
+            echo "::error::Selected Xcode must be 26.x for iOS 26 SDK readiness. Got $XCODE_VERSION"
+            exit 1
+          fi
           echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
           echo "XCODE_VERSION=$XCODE_VERSION" >> "$GITHUB_ENV"
 
@@ -1223,7 +1230,8 @@ jobs:
           python3 - << 'PY'
           import json, os, re, subprocess, sys
 
-          # Pin to stable iOS 18.6 to avoid "latest" resolving to iOS 26.x betas.
+          # Prefer stable iOS 26.x to match Xcode 26 / iOS 26 SDK readiness.
+          # Fall back to the highest available iOS runtime instead of using OS=latest.
           out = subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"], text=True)
           data = json.loads(out)
           devices = data.get("devices", {})
@@ -1237,13 +1245,9 @@ jobs:
               print("::error::No iOS Simulator runtimes found", file=sys.stderr)
               sys.exit(1)
 
-          pinned = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-6\b", r)]
-          if pinned:
-              runtime = pinned[0]
-          else:
-              ios18 = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-\d+\b", r)]
-              runtime_pool = ios18 if ios18 else ios_runtimes
-              runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
+          ios26 = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-26-\d+\b", r)]
+          runtime_pool = ios26 if ios26 else ios_runtimes
+          runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
 
           major, minor = parse_ios_ver(runtime)
           if major < 0 or minor < 0:
@@ -1501,19 +1505,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Select Xcode (pin 16.x compatible with iOS 18.5/18.6 runtimes)
+      - name: Select Xcode (require 26.x for iOS 26 SDK readiness)
         id: select-xcode
         shell: bash
         run: |
           set -euo pipefail
 
           CANDIDATES=(
-            "/Applications/Xcode_16.4.app/Contents/Developer"
-            "/Applications/Xcode_16.4.0.app/Contents/Developer"
-            "/Applications/Xcode_16.3.app/Contents/Developer"
-            "/Applications/Xcode_16.3.0.app/Contents/Developer"
-            "/Applications/Xcode_16.2.app/Contents/Developer"
-            "/Applications/Xcode_16.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.2.app/Contents/Developer"
+            "/Applications/Xcode_26.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.1.app/Contents/Developer"
+            "/Applications/Xcode_26.1.0.app/Contents/Developer"
+            "/Applications/Xcode_26.0.app/Contents/Developer"
+            "/Applications/Xcode_26.app/Contents/Developer"
+            "/Applications/Xcode_26.0.0.app/Contents/Developer"
+            "/Applications/Xcode.app/Contents/Developer"
           )
 
           SELECTED=""
@@ -1525,7 +1531,7 @@ jobs:
           done
 
           if [ -z "$SELECTED" ]; then
-            echo "::error::No suitable Xcode 16.x found in /Applications."
+            echo "::error::No suitable Xcode 26.x found in /Applications."
             echo "::error::Available Xcode apps:"
             for app in /Applications/Xcode*.app; do
               [ -e "$app" ] && echo " - $app"
@@ -1539,9 +1545,14 @@ jobs:
 
           # Extract Xcode version for cache key (avoid broken pipe from pipe consumers like head/sed)
           XCODEBUILD_VERSION="$(xcodebuild -version)"
-          # First line is like: "Xcode 16.4"
+          # First line is like: "Xcode 26.1"
           XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
           XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
+          XCODE_MAJOR="${XCODE_VERSION%%.*}"
+          if [ "$XCODE_MAJOR" != "26" ]; then
+            echo "::error::Selected Xcode must be 26.x for iOS 26 SDK readiness. Got $XCODE_VERSION"
+            exit 1
+          fi
           echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
           echo "XCODE_VERSION=$XCODE_VERSION" >> "$GITHUB_ENV"
 
@@ -1581,7 +1592,8 @@ jobs:
           python3 - << 'PY'
           import json, os, re, subprocess, sys
 
-          # Pin to stable iOS 18.6 to avoid "latest" resolving to iOS 26.x betas.
+          # Prefer stable iOS 26.x to match Xcode 26 / iOS 26 SDK readiness.
+          # Fall back to the highest available iOS runtime instead of using OS=latest.
           out = subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"], text=True)
           data = json.loads(out)
           devices = data.get("devices", {})
@@ -1595,13 +1607,9 @@ jobs:
               print("::error::No iOS Simulator runtimes found", file=sys.stderr)
               sys.exit(1)
 
-          pinned = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-6\b", r)]
-          if pinned:
-              runtime = pinned[0]
-          else:
-              ios18 = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-18-\d+\b", r)]
-              runtime_pool = ios18 if ios18 else ios_runtimes
-              runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
+          ios26 = [r for r in ios_runtimes if re.search(r"SimRuntime\.iOS-26-\d+\b", r)]
+          runtime_pool = ios26 if ios26 else ios_runtimes
+          runtime = sorted(runtime_pool, key=parse_ios_ver, reverse=True)[0]
 
           major, minor = parse_ios_ver(runtime)
           if major < 0 or minor < 0:

--- a/.github/workflows/ios-appstore-assets.yml
+++ b/.github/workflows/ios-appstore-assets.yml
@@ -58,6 +58,7 @@ jobs:
             if [ -d "$candidate" ]; then
               echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
               sudo xcode-select -s "$candidate"
+              echo "Selected DEVELOPER_DIR: $candidate"
               XCODEBUILD_VERSION="$(xcodebuild -version)"
               XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
               XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
@@ -73,6 +74,12 @@ jobs:
           done
 
           echo "::error::No supported Xcode 26.x installation found"
+          echo "Available Xcode installations under /Applications:"
+          for xcode_app in /Applications/Xcode*.app; do
+            if [ -d "$xcode_app" ]; then
+              echo " - $xcode_app"
+            fi
+          done
           exit 1
 
       - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1
@@ -129,6 +136,7 @@ jobs:
             if [ -d "$candidate" ]; then
               echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
               sudo xcode-select -s "$candidate"
+              echo "Selected DEVELOPER_DIR: $candidate"
               XCODEBUILD_VERSION="$(xcodebuild -version)"
               XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
               XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
@@ -142,6 +150,12 @@ jobs:
             fi
           done
           echo "::error::No supported Xcode 26.x installation found"
+          echo "Available Xcode installations under /Applications:"
+          for xcode_app in /Applications/Xcode*.app; do
+            if [ -d "$xcode_app" ]; then
+              echo " - $xcode_app"
+            fi
+          done
           exit 1
 
       - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1

--- a/.github/workflows/ios-appstore-assets.yml
+++ b/.github/workflows/ios-appstore-assets.yml
@@ -44,24 +44,35 @@ jobs:
         run: |
           set -euo pipefail
           CANDIDATES=(
-            "/Applications/Xcode_16.4.app/Contents/Developer"
-            "/Applications/Xcode_16.4.0.app/Contents/Developer"
-            "/Applications/Xcode_16.3.app/Contents/Developer"
-            "/Applications/Xcode_16.3.0.app/Contents/Developer"
-            "/Applications/Xcode_16.2.app/Contents/Developer"
-            "/Applications/Xcode_16.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.2.app/Contents/Developer"
+            "/Applications/Xcode_26.2.0.app/Contents/Developer"
+            "/Applications/Xcode_26.1.app/Contents/Developer"
+            "/Applications/Xcode_26.1.0.app/Contents/Developer"
+            "/Applications/Xcode_26.0.app/Contents/Developer"
+            "/Applications/Xcode_26.app/Contents/Developer"
+            "/Applications/Xcode_26.0.0.app/Contents/Developer"
             "/Applications/Xcode.app/Contents/Developer"
           )
 
           for candidate in "${CANDIDATES[@]}"; do
             if [ -d "$candidate" ]; then
               echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+              sudo xcode-select -s "$candidate"
+              XCODEBUILD_VERSION="$(xcodebuild -version)"
+              XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
+              XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
+              XCODE_MAJOR="${XCODE_VERSION%%.*}"
+              if [ "$XCODE_MAJOR" != "26" ]; then
+                echo "::error::Selected Xcode must be 26.x for iOS 26 SDK readiness. Got $XCODE_VERSION"
+                exit 1
+              fi
               echo "Using Xcode at $candidate"
+              xcodebuild -version
               exit 0
             fi
           done
 
-          echo "::error::No supported Xcode installation found"
+          echo "::error::No supported Xcode 26.x installation found"
           exit 1
 
       - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1
@@ -107,19 +118,30 @@ jobs:
         run: |
           set -euo pipefail
           for candidate in \
-            /Applications/Xcode_16.4.app/Contents/Developer \
-            /Applications/Xcode_16.4.0.app/Contents/Developer \
-            /Applications/Xcode_16.3.app/Contents/Developer \
-            /Applications/Xcode_16.3.0.app/Contents/Developer \
-            /Applications/Xcode_16.2.app/Contents/Developer \
-            /Applications/Xcode_16.2.0.app/Contents/Developer \
+            /Applications/Xcode_26.2.app/Contents/Developer \
+            /Applications/Xcode_26.2.0.app/Contents/Developer \
+            /Applications/Xcode_26.1.app/Contents/Developer \
+            /Applications/Xcode_26.1.0.app/Contents/Developer \
+            /Applications/Xcode_26.0.app/Contents/Developer \
+            /Applications/Xcode_26.app/Contents/Developer \
+            /Applications/Xcode_26.0.0.app/Contents/Developer \
             /Applications/Xcode.app/Contents/Developer; do
             if [ -d "$candidate" ]; then
               echo "DEVELOPER_DIR=$candidate" >> "$GITHUB_ENV"
+              sudo xcode-select -s "$candidate"
+              XCODEBUILD_VERSION="$(xcodebuild -version)"
+              XCODE_VERSION="${XCODEBUILD_VERSION#Xcode }"
+              XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
+              XCODE_MAJOR="${XCODE_VERSION%%.*}"
+              if [ "$XCODE_MAJOR" != "26" ]; then
+                echo "::error::Selected Xcode must be 26.x for iOS 26 SDK readiness. Got $XCODE_VERSION"
+                exit 1
+              fi
+              xcodebuild -version
               exit 0
             fi
           done
-          echo "::error::No supported Xcode installation found"
+          echo "::error::No supported Xcode 26.x installation found"
           exit 1
 
       - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1

--- a/docs/review/PR_1347_FIXED_MAPPING.md
+++ b/docs/review/PR_1347_FIXED_MAPPING.md
@@ -15,7 +15,7 @@ Reason: The aggregate Sourcery review has no independent blocker beyond the inli
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038220869
 Disposition: FIXED
-Commit: COMMIT_SHA_WORKFLOW_FIX
+Commit: c2f1f3da
 Evidence: `.github/workflows/ios-appstore-assets.yml:62`, `.github/workflows/ios-appstore-assets.yml:77`, `.github/workflows/ios-appstore-assets.yml:120`, `.github/workflows/ios-appstore-assets.yml:136`
 Reason: Added the same failure-time Xcode inventory logging and explicit `Selected DEVELOPER_DIR` output that `ci.yml` already uses, so the App Store assets workflow keeps debugging parity with the canonical CI lane.
 
@@ -26,13 +26,13 @@ Reason: The aggregate CodeRabbit review only summarizes the concrete artifact/ch
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230599
 Disposition: FIXED
-Commit: COMMIT_SHA_WORKFLOW_FIX
+Commit: c2f1f3da
 Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:44`, `docs/review/PR_1347_FIXED_MAPPING.md:45`, `docs/review/PR_1347_FIXED_MAPPING.md:46`
 Reason: The merge-readiness checkboxes now remain forward-looking until the final current-head merge pass, while the note preserves that local validation succeeded earlier in the lane.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230603
 Disposition: FIXED
-Commit: COMMIT_SHA_WORKFLOW_FIX
+Commit: c2f1f3da
 Evidence: `ios/CI_VERIFICATION_CHECKLIST.md:7`, `ios/CI_VERIFICATION_CHECKLIST.md:14`, `ios/CI_VERIFICATION_CHECKLIST.md:20`, `ios/CI_VERIFICATION_CHECKLIST.md:33`, `ios/CI_VERIFICATION_CHECKLIST.md:44`, `ios/CI_VERIFICATION_CHECKLIST.md:49`, `ios/CI_VERIFICATION_CHECKLIST.md:55`
 Reason: Added explicit fenced-code languages to every snippet in the checklist and aligned the canonical Xcode example with the workflow's `26.2 -> 26.1 -> 26.0` priority order.
 

--- a/docs/review/PR_1347_FIXED_MAPPING.md
+++ b/docs/review/PR_1347_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1347 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- [x] Mandatory post-open bug-hunter pass completed
+Notes: As of April 5, 2026, local validation on current head `c094afe0` passes for PR1 after the Xcode 26 readiness update. `pre-commit run --files .github/workflows/ci.yml .github/workflows/ios-appstore-assets.yml ios/AGENTS.md ios/CI_VERIFICATION_CHECKLIST.md ios/fastlane/Fastfile` and `make verify` both pass locally, while GitHub current-head checks and post-open review lanes remain in progress.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1347_FIXED_MAPPING.md
+++ b/docs/review/PR_1347_FIXED_MAPPING.md
@@ -24,6 +24,11 @@ Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:18`, `docs/review/PR_1347_FIXED_MAPPING.md:31`, `docs/review/PR_1347_FIXED_MAPPING.md:37`
 Reason: The aggregate CodeRabbit review only summarizes the concrete artifact/checklist threads mapped below; after those thread-level fixes, no separate unresolved action remains in the parent review.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060717477
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/ios-appstore-assets.yml:43`, `.github/workflows/ios-appstore-assets.yml:124`, `docs/review/PR_1347_FIXED_MAPPING.md:22`
+Reason: This late aggregate CodeRabbit pass only proposes maintainability nitpicks. PR1 stays intentionally narrow to Xcode 26 readiness truth; adding unused `GITHUB_OUTPUT` exports and extracting a new composite action would widen the lane without changing current behavior, so the review has no independent merge blocker beyond the already-dispositioned thread-level fixes above.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230599
 Disposition: FIXED
 Commit: c2f1f3da

--- a/docs/review/PR_1347_FIXED_MAPPING.md
+++ b/docs/review/PR_1347_FIXED_MAPPING.md
@@ -8,15 +8,41 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060635094
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:10`, `docs/review/PR_1347_FIXED_MAPPING.md:14`
+Reason: The aggregate Sourcery review has no independent blocker beyond the inline workflow thread recorded below, so it is dispositioned through that concrete thread mapping rather than duplicated as a separate code change request.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038220869
+Disposition: FIXED
+Commit: COMMIT_SHA_WORKFLOW_FIX
+Evidence: `.github/workflows/ios-appstore-assets.yml:62`, `.github/workflows/ios-appstore-assets.yml:77`, `.github/workflows/ios-appstore-assets.yml:120`, `.github/workflows/ios-appstore-assets.yml:136`
+Reason: Added the same failure-time Xcode inventory logging and explicit `Selected DEVELOPER_DIR` output that `ci.yml` already uses, so the App Store assets workflow keeps debugging parity with the canonical CI lane.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060644586
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:18`, `docs/review/PR_1347_FIXED_MAPPING.md:31`, `docs/review/PR_1347_FIXED_MAPPING.md:37`
+Reason: The aggregate CodeRabbit review only summarizes the concrete artifact/checklist threads mapped below; after those thread-level fixes, no separate unresolved action remains in the parent review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230599
+Disposition: FIXED
+Commit: COMMIT_SHA_WORKFLOW_FIX
+Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:44`, `docs/review/PR_1347_FIXED_MAPPING.md:45`, `docs/review/PR_1347_FIXED_MAPPING.md:46`
+Reason: The merge-readiness checkboxes now remain forward-looking until the final current-head merge pass, while the note preserves that local validation succeeded earlier in the lane.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230603
+Disposition: FIXED
+Commit: COMMIT_SHA_WORKFLOW_FIX
+Evidence: `ios/CI_VERIFICATION_CHECKLIST.md:7`, `ios/CI_VERIFICATION_CHECKLIST.md:14`, `ios/CI_VERIFICATION_CHECKLIST.md:20`, `ios/CI_VERIFICATION_CHECKLIST.md:33`, `ios/CI_VERIFICATION_CHECKLIST.md:44`, `ios/CI_VERIFICATION_CHECKLIST.md:49`, `ios/CI_VERIFICATION_CHECKLIST.md:55`
+Reason: Added explicit fenced-code languages to every snippet in the checklist and aligned the canonical Xcode example with the workflow's `26.2 -> 26.1 -> 26.0` priority order.
 
 ## Merge Readiness
 
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
-- [x] Mandatory post-open bug-hunter pass completed
-Notes: As of April 5, 2026, local validation on current head `c094afe0` passes for PR1 after the Xcode 26 readiness update. `pre-commit run --files .github/workflows/ci.yml .github/workflows/ios-appstore-assets.yml ios/AGENTS.md ios/CI_VERIFICATION_CHECKLIST.md ios/fastlane/Fastfile` and `make verify` both pass locally, while GitHub current-head checks and post-open review lanes remain in progress.
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- [ ] Mandatory post-open bug-hunter pass completed
+Notes: As of April 6, 2026, local validation had already passed earlier in this PR1 lane after the Xcode 26 readiness update, but these merge-readiness checkboxes intentionally remain unchecked until the final current-head merge cycle reconfirms each condition and all review threads are resolved.
 <!-- markdownlint-enable MD034 -->

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -143,15 +143,16 @@
 
 **Xcode selection:**
 
-- Preferred: Xcode 16.4 (`/Applications/Xcode_16.4.app`)
-- Fallback: Xcode 16.3 (`/Applications/Xcode_16.3.app`)
-- Fallback: Xcode 16.2 (`/Applications/Xcode_16.2.app`)
-- CI fails if no suitable Xcode 16.x is found (see `.github/workflows/ci.yml` `select-xcode` step).
+- Preferred: Xcode 26.2 (`/Applications/Xcode_26.2.app`)
+- Fallback: Xcode 26.1 (`/Applications/Xcode_26.1.app`)
+- Fallback: Xcode 26.0 (`/Applications/Xcode_26.0.app`)
+- Final fallback: `/Applications/Xcode.app`, but only if `xcodebuild -version` resolves to Xcode 26.x
+- CI fails if no suitable Xcode 26.x is found (see `.github/workflows/ci.yml` `select-xcode` step).
 
 **Simulator (CI):**
 
 - **Auto-selected** from available simulators at runtime (no hard-coded device)
-- **Runtime policy:** prefer iOS 18.6 → fallback to iOS 18.x → fallback to any iOS runtime (if needed)
+- **Runtime policy:** prefer iOS 26.x → fallback to the highest available iOS runtime (if needed)
 - **Device preference:** `iPhone 16e` → `iPhone 16` → `iPhone 16 Pro` → `iPhone 15` → `iPhone 14`
   - If none of the preferred devices exist on the runner, CI falls back to **any available iPhone**, then to **any iOS simulator** (deterministic sort)
 - **Destination:** **UDID-only** `platform=iOS Simulator,id=<UDID>`
@@ -217,10 +218,10 @@
 **Destination policy (CI):**
 
 - CI **auto-selects** destination from available simulators dynamically
-- Prefers **iOS 18.x runtime** (avoids `OS=latest` resolving to iOS 26.x betas)
+- Prefers **iOS 26.x runtime** and falls back to the highest available iOS runtime
 - Preferred devices: `iPhone 16e` → `iPhone 16` → `iPhone 16 Pro` → `iPhone 15` → `iPhone 14`
 - **Hard rule:** never pin a simulator that may not exist; CI must discover availability first
-- Never uses `OS=latest` for named devices (to avoid iOS 26.x beta runtimes)
+- Never uses `OS=latest` for named devices (to avoid nondeterministic runtime resolution)
 
 **Destination policy (Local):**
 
@@ -258,7 +259,7 @@
 - **Local:** Default `iPhone 16e` (can be overridden via `IOS_SIM_NAME`/`IOS_SIM_OS`)
 - **CI:** Auto-selects destination using **UDID-only** format (`platform=iOS Simulator,id=<UDID>`)
   - Prefers `iPhone 16e` → `iPhone 16` → `iPhone 16 Pro` → `iPhone 15` from available simulators
-  - Pins iOS 18.6 runtime (fallback to iOS 18.x if 18.6 unavailable)
+  - Prefers iOS 26.x runtime (fallback to the highest available iOS runtime)
   - **Never uses `OS=latest`** (guard fails job if `latest` detected)
 - Both use `-project PulsePlate.xcodeproj` (canonical: app scheme tests = project-based)
 - Both use explicit `-only-testing:PulsePlateTests/ClassName` entries + `-parallel-testing-enabled NO` (canonical pattern)

--- a/ios/CI_VERIFICATION_CHECKLIST.md
+++ b/ios/CI_VERIFICATION_CHECKLIST.md
@@ -6,9 +6,9 @@
 
 В логах шага "Select Xcode" должна быть строка:
 ```
-Selected DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+Selected DEVELOPER_DIR: /Applications/Xcode_26.1.app/Contents/Developer
 ```
-(или 16.3, если 16.4 нет)
+(или другой `Xcode_26*.app`, если 26.1 нет)
 
 ### 2. Xcode Version
 
@@ -16,7 +16,7 @@ Selected DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
 ```
 xcodebuild -version
 ```
-Должен показать `Xcode 16.4` (или 16.3), не 16.2.
+Должен показать `Xcode 26.x`, не 16.x.
 
 ### 3. Available Destinations
 
@@ -27,7 +27,7 @@ xcodebuild -showdestinations -project PulsePlate.xcodeproj -scheme PulsePlate
 
 **Ожидаемый результат:**
 - ✅ Должен показать список eligible iOS Simulator destinations
-- ❌ НЕ должно быть "iOS 18.2 is not installed" или "Ineligible destinations"
+- ❌ НЕ должно быть "Ineligible destinations" или ошибок про отсутствующий iOS 26 runtime при выбранном Xcode 26
 
 ### 4. Test Execution
 
@@ -67,7 +67,8 @@ xcodebuild test -destination platform=iOS Simulator,id=<UDID> ...
 - Локально нет warning про Copy Bundle Resources
 
 ✅ **Xcode pinning:**
-- CI шаг "Select Xcode" выбирает 16.4 → 16.3 → 16.2 по приоритету
+- CI шаг "Select Xcode" выбирает 26.2 → 26.1 → 26.0 → `Xcode.app` по приоритету
+- После выбора CI явно валидирует, что `xcodebuild -version` возвращает Xcode 26.x
 - `DEVELOPER_DIR` экспортируется через `GITHUB_ENV`
 
 ✅ **AGENTS.md:**

--- a/ios/CI_VERIFICATION_CHECKLIST.md
+++ b/ios/CI_VERIFICATION_CHECKLIST.md
@@ -5,15 +5,15 @@
 ### 1. Xcode Pinning
 
 В логах шага "Select Xcode" должна быть строка:
+```text
+Selected DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
 ```
-Selected DEVELOPER_DIR: /Applications/Xcode_26.1.app/Contents/Developer
-```
-(или другой `Xcode_26*.app`, если 26.1 нет)
+(или другой `Xcode_26*.app`, если `26.2` недоступен на runner)
 
 ### 2. Xcode Version
 
 После выбора Xcode:
-```
+```bash
 xcodebuild -version
 ```
 Должен показать `Xcode 26.x`, не 16.x.
@@ -21,7 +21,7 @@ xcodebuild -version
 ### 3. Available Destinations
 
 После boot симулятора:
-```
+```bash
 xcodebuild -showdestinations -project PulsePlate.xcodeproj -scheme PulsePlate
 ```
 
@@ -31,7 +31,7 @@ xcodebuild -showdestinations -project PulsePlate.xcodeproj -scheme PulsePlate
 
 ### 4. Test Execution
 
-```
+```bash
 xcodebuild test -destination platform=iOS Simulator,id=<UDID> ...
 ```
 
@@ -44,18 +44,18 @@ xcodebuild test -destination platform=iOS Simulator,id=<UDID> ...
 Если CI всё ещё падает, пришлите:
 
 1. **Строку с выбранным Xcode:**
-   ```
+   ```text
    Selected DEVELOPER_DIR: ...
    ```
 
 2. **Первые 10 строк после `xcodebuild -showdestinations`:**
-   ```
+   ```text
    { platform:iOS Simulator, ... }
    ...
    ```
 
 3. **Если упало — первые 5 строк ошибки:**
-   ```
+   ```text
    error: ...
    ```
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -5,7 +5,7 @@ default_platform(:ios)
 APP_STORE_LOCALES = %w[ru-RU en-US es-ES].freeze
 IOS_APPSTORE_ASSETS_RUNBOOK = "docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md".freeze
 IPHONE_DEVICE_CANDIDATES = [
-  # Prefer stable 18.5/18.6 runtimes on CI before falling back to 26.x simulators.
+  # Prefer stable iOS 26.x simulator runtimes on CI for SDK 26 readiness.
   "iPhone 16 Pro Max",
   "iPhone 16 Pro",
   "iPhone 17 Pro Max",


### PR DESCRIPTION
## Summary
- align active iOS CI and App Store asset workflows with Xcode 26 / iOS 26 SDK readiness
- update iOS repo assumptions and verification docs to match the new Xcode/runtime selection policy
- keep PR1 narrow to workflow/toolchain truth only

## Scope
- `.github/workflows/ci.yml`
- `.github/workflows/ios-appstore-assets.yml`
- `ios/AGENTS.md`
- `ios/CI_VERIFICATION_CHECKLIST.md`
- `ios/fastlane/Fastfile`
- `docs/review/PR_1347_FIXED_MAPPING.md`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_ios_appstore_assets_workflow_contract.py`
- `pre-commit run --all-files`
- `make verify`

## Non-Goals
- no privacy/compliance shell changes
- no App Store Connect secret/environment changes
- no billing/provider migration
- no iOS UI/runtime behavior changes
- no `apple-server-api-migration`

## Train Position
- PR1 of the approved `iOS-first release closure train`
- next planned lane after this PR: `fix/ios-release-privacy-compliance-shell`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060635094
Disposition: NOT-A-BUG
Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:11`, `docs/review/PR_1347_FIXED_MAPPING.md:16`
Reason: The aggregate Sourcery review has no independent blocker beyond the inline workflow thread dispositioned below.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038220869 -> c2f1f3da
Disposition: FIXED
Evidence: `.github/workflows/ios-appstore-assets.yml:61`, `.github/workflows/ios-appstore-assets.yml:76`, `.github/workflows/ios-appstore-assets.yml:139`, `.github/workflows/ios-appstore-assets.yml:152`
Reason: Added debugging-parity logging for Xcode selection failures and aligned the asset workflow log surface with `ci.yml`.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060644586
Disposition: NOT-A-BUG
Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:22`, `docs/review/PR_1347_FIXED_MAPPING.md:27`, `docs/review/PR_1347_FIXED_MAPPING.md:33`
Reason: The aggregate CodeRabbit review only summarizes the concrete checklist/artifact threads mapped below.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#pullrequestreview-4060717477
Disposition: NOT-A-BUG
Evidence: `.github/workflows/ios-appstore-assets.yml:43`, `.github/workflows/ios-appstore-assets.yml:124`, `docs/review/PR_1347_FIXED_MAPPING.md:27`
Reason: This late aggregate CodeRabbit pass only proposes maintainability nitpicks. PR1 stays intentionally narrow to Xcode 26 readiness truth; adding unused outputs or extracting a new composite action would widen the lane without changing behavior.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230599 -> c2f1f3da
Disposition: FIXED
Evidence: `docs/review/PR_1347_FIXED_MAPPING.md:46`, `docs/review/PR_1347_FIXED_MAPPING.md:47`, `docs/review/PR_1347_FIXED_MAPPING.md:48`
Reason: Merge-readiness checkboxes now stay forward-looking until the final current-head merge cycle.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1347#discussion_r3038230603 -> c2f1f3da
Disposition: FIXED
Evidence: `ios/CI_VERIFICATION_CHECKLIST.md:8`, `ios/CI_VERIFICATION_CHECKLIST.md:16`, `ios/CI_VERIFICATION_CHECKLIST.md:24`, `ios/CI_VERIFICATION_CHECKLIST.md:34`, `ios/CI_VERIFICATION_CHECKLIST.md:47`, `ios/CI_VERIFICATION_CHECKLIST.md:52`, `ios/CI_VERIFICATION_CHECKLIST.md:58`
Reason: Added fenced-code language specifiers and aligned the canonical Xcode example with the `26.2 -> 26.1 -> 26.0` selection order.

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green
- [ ] `make verify` green
- [ ] Mandatory post-open bug-hunter pass completed
Notes: As of April 6, 2026, local validation has re-passed on current local head `4be480b5`, but these merge-readiness checkboxes intentionally remain unchecked until the final current-head GitHub cycle reconfirms each condition and all review threads are resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflows and asset validation updated to require Xcode 26.x (switches system Xcode, parses version, and fails if not 26) and prefer iOS 26.x simulator runtimes with fallback to the highest available.
  * Simulator selection guidance updated in Fastfile comments.

* **Documentation**
  * Added PR review-to-fix mapping doc and updated iOS CI/verification docs and checklist to reflect Xcode 26.x and simulator runtime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->