### PR TITLE
feat(search): pg_trgm foods trigram indexes (P2 phase 1)

### DIFF
--- a/alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py
+++ b/alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py
@@ -8,7 +8,8 @@ Enables the pg_trgm extension for future PostgreSQL-native trigram candidate
 lanes.  When public.foods exists (catalog colocated on the app database),
 creates GIN indexes on canonical_name, group_name, and brand.
 
-SQLite: no-op.  See docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
+SQLite: no-op.  Downgrade drops only this revision's indexes, not the pg_trgm extension.
+See docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
 """
 
 from alembic import op
@@ -68,4 +69,5 @@ def downgrade() -> None:
         return
 
     op.execute(_DOWNGRADE_DROP_INDEXES)
-    op.execute("DROP EXTENSION IF EXISTS pg_trgm")
+    # Intentionally do not DROP EXTENSION pg_trgm: upgrade uses CREATE IF NOT EXISTS, so this
+    # revision does not own extension lifecycle; the extension may pre-exist or be shared.

--- a/alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py
+++ b/alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py
@@ -1,0 +1,71 @@
+"""enable pg_trgm and conditional GIN(trgm) indexes on foods (Postgres)
+
+Revision ID: 202604060001
+Revises: 202603110001
+Create Date: 2026-04-06
+
+Enables the pg_trgm extension for future PostgreSQL-native trigram candidate
+lanes.  When public.foods exists (catalog colocated on the app database),
+creates GIN indexes on canonical_name, group_name, and brand.
+
+SQLite: no-op.  See docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202604060001"
+down_revision = "202603110001"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_TRIGRAM_INDEXES = r"""
+DO $pulseplate_pg_trgm$
+BEGIN
+  IF to_regclass('public.foods') IS NOT NULL THEN
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_canonical_name_gin_trgm
+ON public.foods USING gin (canonical_name gin_trgm_ops)
+$sql$;
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_group_name_gin_trgm
+ON public.foods USING gin (group_name gin_trgm_ops)
+$sql$;
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_brand_gin_trgm
+ON public.foods USING gin (brand gin_trgm_ops)
+$sql$;
+  END IF;
+END
+$pulseplate_pg_trgm$;
+"""
+
+_DOWNGRADE_DROP_INDEXES = """
+DO $pulseplate_pg_trgm$
+BEGIN
+  IF to_regclass('public.foods') IS NOT NULL THEN
+    EXECUTE 'DROP INDEX IF EXISTS public.ix_foods_canonical_name_gin_trgm';
+    EXECUTE 'DROP INDEX IF EXISTS public.ix_foods_group_name_gin_trgm';
+    EXECUTE 'DROP INDEX IF EXISTS public.ix_foods_brand_gin_trgm';
+  END IF;
+END
+$pulseplate_pg_trgm$;
+"""
+
+
+def upgrade() -> None:
+    dialect = op.get_bind().dialect.name
+    if dialect != "postgresql":
+        return
+
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(_UPGRADE_TRIGRAM_INDEXES)
+
+
+def downgrade() -> None:
+    dialect = op.get_bind().dialect.name
+    if dialect != "postgresql":
+        return
+
+    op.execute(_DOWNGRADE_DROP_INDEXES)
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm")

--- a/docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
+++ b/docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
@@ -6,10 +6,10 @@ Accepted — Phase 1 (extension + conditional indexes only). Runtime candidate q
 
 ## Context
 
-- Semantic bootstrap search loads a bounded candidate pool from the `foods` table (`canonical_name` and macros); see `app/services/food_store.py` (`_load_semantic_candidates`).
-- The canonical packaged food catalog is built into SQLite with FTS5 today; see `scripts/build_food_db.py` (`CREATE TABLE foods`, `foods_fts`).
-- Meilisearch remains an optional shadow/index lane; see `app/services/search_meili.py` (`MEILI_FOODS_ATTRIBUTES_TO_RETRIEVE` includes `canonical_name`).
-- Backlog: `docs/roadmap/BACKLOG_LEDGER.md` anchor `ledger-p2-search-pgtrgm-candidate-generation` and follow-up `ledger-p2-search-zero-downtime-swap-orchestration`.
+- Semantic bootstrap search loads a bounded candidate pool from the `foods` table (`canonical_name` and macros); see `app/services/food_store.py:603` (`_load_semantic_candidates`).
+- The canonical packaged food catalog is built into SQLite with FTS5 today; see `scripts/build_food_db.py:248` (`CREATE TABLE foods`) and `scripts/build_food_db.py:283` (`foods_fts`).
+- Meilisearch remains an optional shadow/index lane; see `app/services/search_meili.py:83` (`MEILI_FOODS_ATTRIBUTES_TO_RETRIEVE` includes `canonical_name`).
+- Backlog: `docs/roadmap/BACKLOG_LEDGER.md:7163` (`ledger-p2-search-pgtrgm-candidate-generation`) and `docs/roadmap/BACKLOG_LEDGER.md:7180` (`ledger-p2-search-zero-downtime-swap-orchestration`).
 
 ## Decision
 

--- a/docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
+++ b/docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md
@@ -1,0 +1,36 @@
+# ADR: PostgreSQL `pg_trgm` preparation for food candidate lane (P2)
+
+## Status
+
+Accepted — Phase 1 (extension + conditional indexes only). Runtime candidate queries and strategy routing are **out of scope** for this slice.
+
+## Context
+
+- Semantic bootstrap search loads a bounded candidate pool from the `foods` table (`canonical_name` and macros); see `app/services/food_store.py` (`_load_semantic_candidates`).
+- The canonical packaged food catalog is built into SQLite with FTS5 today; see `scripts/build_food_db.py` (`CREATE TABLE foods`, `foods_fts`).
+- Meilisearch remains an optional shadow/index lane; see `app/services/search_meili.py` (`MEILI_FOODS_ATTRIBUTES_TO_RETRIEVE` includes `canonical_name`).
+- Backlog: `docs/roadmap/BACKLOG_LEDGER.md` anchor `ledger-p2-search-pgtrgm-candidate-generation` and follow-up `ledger-p2-search-zero-downtime-swap-orchestration`.
+
+## Decision
+
+1. On **PostgreSQL only**, Alembic enables `pg_trgm` (`CREATE EXTENSION IF NOT EXISTS pg_trgm`).
+2. If and only if `public.foods` exists, create **GIN** indexes with `gin_trgm_ops` on:
+   - `canonical_name` (primary candidate column aligned with `_load_semantic_candidates`)
+   - `group_name`, `brand` (secondary text facets present in the SQLite catalog schema)
+3. Index names (stable for ops/runbooks):
+   - `ix_foods_canonical_name_gin_trgm`
+   - `ix_foods_group_name_gin_trgm`
+   - `ix_foods_brand_gin_trgm`
+4. **No `CREATE INDEX CONCURRENTLY`** in this migration: Alembic runs in a transaction; large-table production rollout belongs to the zero-downtime orchestration ledger item.
+
+## Consequences
+
+- **Positive:** DBA/app owners can validate `pg_trgm` and index definitions before wiring SQL candidate generation.
+- **Negative:** Brief locking may occur on `foods` when indexes are created on a populated table; mitigate via follow-up swap/orchestration PR.
+- **SQLite / tests:** Migration no-ops (same pattern as `alembic/versions/202602280002_enable_pgvector_extension.py`).
+
+## References
+
+- Migration: `alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py`
+- Task analysis: `docs/orchestration/task_analysis_SEARCH_PGTRGM_CANDIDATES_P2.md`
+- Deploy note: `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md` (extension provisioning)

--- a/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
+++ b/docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md
@@ -77,3 +77,15 @@ Required for production:
 These environment variables and host modes are specific to the self-hosted alternate lane; canonical production uses only `DATABASE_URL` pointing to an external managed instance.
 
 See `.env.example` for the canonical contract.
+
+---
+
+## 6. Search extension: `pg_trgm` (candidate lane prep)
+
+Alembic revision `alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py` runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` on PostgreSQL and creates GIN(trgm) indexes on `public.foods` **only when that table exists** (catalog colocated on the app database).
+
+**Managed PostgreSQL:** many providers require enabling `pg_trgm` once in the control plane (or grant `CREATE` on extension to the app role). If `alembic upgrade head` fails with insufficient privilege, pre-provision the extension and re-run migrations.
+
+**Evidence / design:** `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md`, `app/services/food_store.py:603` (`_load_semantic_candidates`).
+
+**Follow-up (separate P2):** zero-downtime index orchestration — `docs/roadmap/BACKLOG_LEDGER.md` anchor `ledger-p2-search-zero-downtime-swap-orchestration`.

--- a/docs/orchestration/plan_SEARCH_ZERO_DOWNTIME_SWAP_FOLLOWUP.md
+++ b/docs/orchestration/plan_SEARCH_ZERO_DOWNTIME_SWAP_FOLLOWUP.md
@@ -1,0 +1,21 @@
+# Follow-up plan: Search zero-downtime index swap (P2)
+
+**Ledger:** `docs/roadmap/BACKLOG_LEDGER.md` — anchor `ledger-p2-search-zero-downtime-swap-orchestration` (`PR-TBD-SEARCH-ZERO-DOWNTIME-SWAP`).
+
+**Purpose:** This note is the **planning handoff** after Phase 1 `pg_trgm` DDL lands (`alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py`). It does **not** implement swap orchestration.
+
+## Coordinator start (next PR)
+
+1. `python3 scripts/orchestration/check_preflight.py`
+2. Task analysis from `docs/orchestration/task_analysis.template.md`
+3. Route per `docs/orchestration/AGENT_ROUTING_GRAPH.md` (ops + backend + QA)
+
+## Technical themes (outline)
+
+- Prefer `CREATE INDEX CONCURRENTLY` (or provider-equivalent) **outside** default Alembic transaction patterns; align with RLS/migration conventions already used in repo.
+- Meili `*_v2` build / validate / warm / swap as documented in ledger DoD for that item.
+- Rollback and grace-period cleanup must be documented with tests (ledger DoD).
+
+## Dependency
+
+- Phase 1 `pg_trgm` + conditional `foods` GIN indexes (ADR: `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md`).

--- a/docs/orchestration/task_analysis_SEARCH_PGTRGM_CANDIDATES_P2.md
+++ b/docs/orchestration/task_analysis_SEARCH_PGTRGM_CANDIDATES_P2.md
@@ -1,0 +1,52 @@
+# Task Analysis
+
+**Task:** Land PostgreSQL `pg_trgm` extension and conditional GIN(trgm) indexes on `foods` text columns (candidate lane prep). No runtime query-path switch in this PR.
+
+**Domain(s):** Architecture | Multiple (migrations, docs, search)
+
+**Complexity:** Moderate
+
+**Priority:** P2
+
+- **Priority track (P0-A / P0-B / P1):** P2 (search modernization follow-up)
+
+**Expected Outcome:** On PostgreSQL, `CREATE EXTENSION IF NOT EXISTS pg_trgm` runs via Alembic; when `public.foods` exists, `ix_foods_*_gin_trgm` indexes are created. SQLite/tests unchanged. ADR + deploy note document extension privileges, index names, and boundary to zero-downtime follow-up.
+
+**Invariants Affected:**
+
+- One BMI Engine
+- Thin HTTP Adapter Policy
+- Layer Separation (DDL in Alembic; no router/runtime change)
+- Contract-First (`/api/v1/foods`* unchanged)
+- Other: Search strategy remains SQLite FTS + optional Meili; pg_trgm is additive DB prep only.
+
+**Domain hints (pick if relevant; links-only):**
+
+- `alembic/versions/`*: Postgres-only branches; reversible downgrade; no `CREATE INDEX CONCURRENTLY` in this slice (documented trade-off vs `ledger-p2-search-zero-downtime-swap-orchestration`).
+- `app/services/food_store.py`: semantic candidates load `canonical_name` from `foods` (evidence for index choice).
+
+**Risks:**
+
+1. **Extension privileges:** `CREATE EXTENSION` may require superuser on managed Postgres; mitigation: document pre-provisioned `pg_trgm` in provider console (`docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`, ADR).
+2. **Missing `foods` on app DB:** Today `foods` is SQLite-built; indexes are conditional on `to_regclass('public.foods')` so migration is safe no-op until catalog is colocated on Postgres.
+
+**Proposed Approach:**
+
+1. Add Alembic revision after `202603110001` enabling `pg_trgm` and conditional indexes.
+2. ADR with evidence anchors to `food_store.py`, `build_food_db.py`, migration path.
+3. Ledger progress line under `ledger-p2-search-pgtrgm-candidate-generation`; full DoD remains for a later PR (runtime routing + tests).
+
+**Agent Assignment:**
+
+- **Primary:** migrations + docs (single implementation pass in this session)
+- **Secondary:** security review if extension policy questions arise
+- **Dependencies:** preflight PASS
+
+**Constraints:**
+
+- No OpenAPI / `frontend/src/api/`* changes.
+- No runtime food search behavior change.
+- English-first ledger text.
+
+**Analysis by:** agent-coordinator (executed)
+**Date:** 2026-04-06

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -8,7 +8,10 @@
 
 ## Fixed in Commit Mapping
 
-Disposition: **FIXED** — Alembic downgrade no longer drops `pg_trgm`; ADR updated with `path:line` evidence anchors (bot feedback on extension lifecycle + docs Phase 1).
+Disposition: FIXED
+Commit: e8282c5e1b229f1650319235c497a5b472555252
+Evidence: alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py (downgrade drops only the three GIN(trgm) indexes; no DROP EXTENSION pg_trgm)
+Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line context anchors for docs Phase 1 gates)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060739449 -> e8282c5e1b229f1650319235c497a5b472555252
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060741341 -> e8282c5e1b229f1650319235c497a5b472555252
@@ -22,11 +25,11 @@ Disposition: **FIXED** — Alembic downgrade no longer drops `pg_trgm`; ADR upda
 
 ## Merge Readiness
 
-- [ ] All required checks pass
-- [ ] No unresolved review threads (re-check on current head before merge)
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [ ] Pre-commit green (re-run after mapping commit)
-- [ ] `make verify` green (re-run after mapping commit)
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)
+- [x] `make verify` green locally (`exit 0`, 2026-04-06; lint, mypy, test-fast, diff-cover)
 
 Notes: P2 Phase 1 — `pg_trgm` + conditional GIN(trgm) on `foods` (Postgres), ADR + runbook + ledger; no runtime search-path change.
 

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -25,7 +25,7 @@ Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line c
 
 ## Merge Readiness
 
-- [ ] All required checks pass on **current** PR head (re-run `gh pr view 1349 --json mergeStateStatus,headRefOid,statusCheckRollup` until `CLEAN` and rollup has no `FAILURE`/`ERROR`/`IN_PROGRESS`. Last green snapshot before mapping-only advance: `mergeStateStatus=CLEAN` at `headRefOid=e6f9c037a8140965ed4811534e36ed2319ff1ada`, 2026-04-06; `f542255d` re-triggers CI.)
+- [x] All required checks pass (`gh pr view 1349 --json mergeStateStatus,headRefOid,statusCheckRollup`: `mergeStateStatus=CLEAN`, `headRefOid=11a72eb6aa6c92599f171c723b35ad88c1cd672b`, rollup had no `FAILURE`/`ERROR`/`IN_PROGRESS`; 2026-04-06)
 - [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -25,7 +25,7 @@ Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line c
 
 ## Merge Readiness
 
-- [x] All required checks pass (`gh pr view 1349`: `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`, no `FAILURE`/`ERROR` in `statusCheckRollup`; 2026-04-06)
+- [ ] All required checks pass (re-run `gh pr view 1349 --json mergeStateStatus,statusCheckRollup`; tick only when `mergeStateStatus` is `CLEAN` and rollup has no `FAILURE`/`ERROR` — doc-only pushes can briefly show `UNSTABLE` while CI runs; prior snapshot: `CLEAN` at `bb63db61` head before `94f06760`)
 - [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -8,16 +8,26 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: **FIXED** — Alembic downgrade no longer drops `pg_trgm`; ADR updated with `path:line` evidence anchors (bot feedback on extension lifecycle + docs Phase 1).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060739449 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060741341 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060753710 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#pullrequestreview-4060759442 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#discussion_r3038306530 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#discussion_r3038308428 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#discussion_r3038320617 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#discussion_r3038320632 -> e8282c5e1b229f1650319235c497a5b472555252
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349#discussion_r3038326566 -> e8282c5e1b229f1650319235c497a5b472555252
 
 ## Merge Readiness
 
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
+- [ ] Pre-commit green (re-run after mapping commit)
+- [ ] `make verify` green (re-run after mapping commit)
 
-Notes: P2 Phase 1 — `pg_trgm` + conditional GIN(trgm) on `foods` (Postgres), ADR + runbook + ledger; no runtime search-path change. Local validation 2026-04-06.
+Notes: P2 Phase 1 — `pg_trgm` + conditional GIN(trgm) on `foods` (Postgres), ADR + runbook + ledger; no runtime search-path change.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -25,7 +25,7 @@ Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line c
 
 ## Merge Readiness
 
-- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [x] All required checks pass (`gh pr view 1349`: `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`, no `FAILURE`/`ERROR` in `statusCheckRollup`; 2026-04-06)
 - [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -25,7 +25,7 @@ Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line c
 
 ## Merge Readiness
 
-- [ ] All required checks pass (re-run `gh pr view 1349 --json mergeStateStatus,statusCheckRollup`; tick only when `mergeStateStatus` is `CLEAN` and rollup has no `FAILURE`/`ERROR` — doc-only pushes can briefly show `UNSTABLE` while CI runs; prior snapshot: `CLEAN` at `bb63db61` head before `94f06760`)
+- [x] All required checks pass (`gh pr view 1349 --json mergeStateStatus,headRefOid,statusCheckRollup`: `mergeStateStatus=CLEAN`, `headRefOid=e6f9c037a8140965ed4811534e36ed2319ff1ada`, rollup has no `FAILURE`/`ERROR`/`IN_PROGRESS`; 2026-04-06)
 - [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -25,7 +25,7 @@ Evidence: docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md (path:line c
 
 ## Merge Readiness
 
-- [x] All required checks pass (`gh pr view 1349 --json mergeStateStatus,headRefOid,statusCheckRollup`: `mergeStateStatus=CLEAN`, `headRefOid=e6f9c037a8140965ed4811534e36ed2319ff1ada`, rollup has no `FAILURE`/`ERROR`/`IN_PROGRESS`; 2026-04-06)
+- [ ] All required checks pass on **current** PR head (re-run `gh pr view 1349 --json mergeStateStatus,headRefOid,statusCheckRollup` until `CLEAN` and rollup has no `FAILURE`/`ERROR`/`IN_PROGRESS`. Last green snapshot before mapping-only advance: `mergeStateStatus=CLEAN` at `headRefOid=e6f9c037a8140965ed4811534e36ed2319ff1ada`, 2026-04-06; `f542255d` re-triggers CI.)
 - [x] No unresolved review threads (GraphQL `resolveReviewThread` for 5 threads, 2026-04-06)
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [x] Pre-commit green (push hook + commits `e8282c5e`, `f080e81e`)

--- a/docs/review/PR_1349_FIXED_MAPPING.md
+++ b/docs/review/PR_1349_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1349 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+
+Notes: P2 Phase 1 — `pg_trgm` + conditional GIN(trgm) on `foods` (Postgres), ADR + runbook + ledger; no runtime search-path change. Local validation 2026-04-06.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7164,7 +7164,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Search PostgreSQL `pg_trgm` candidate generation lane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR-TBD-SEARCH-PGTRGM-CANDIDATES _(update to concrete PR number when opened)_
+  - Target PR: [#1349](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1349) (Phase 1 DDL + docs; full DoD remains open until runtime lane + tests)
   - Area: backend / search
   - Finding Type: deferred hybrid-search rollout
   - Reason: This PR intentionally preserves SQLite/FTS as the live baseline and adds Meili shadow mode only. PostgreSQL `pg_trgm` candidate generation remains deferred until PostgreSQL is promoted to the canonical search-adjacent store.
@@ -7173,6 +7173,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `app/services/search_meili.py`
     - `app/services/food_store.py`
     - `docs/review/PR_1099_FIXED_MAPPING.md`
+    - `docs/review/PR_1349_FIXED_MAPPING.md`
     - `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md`
     - `alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py`
     - `docs/orchestration/task_analysis_SEARCH_PGTRGM_CANDIDATES_P2.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7164,14 +7164,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Search PostgreSQL `pg_trgm` candidate generation lane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR-TBD-SEARCH-PGTRGM-CANDIDATES
+  - Target PR: PR-TBD-SEARCH-PGTRGM-CANDIDATES _(update to concrete PR number when opened)_
   - Area: backend / search
   - Finding Type: deferred hybrid-search rollout
   - Reason: This PR intentionally preserves SQLite/FTS as the live baseline and adds Meili shadow mode only. PostgreSQL `pg_trgm` candidate generation remains deferred until PostgreSQL is promoted to the canonical search-adjacent store.
+  - Progress (Phase 1 — DDL + docs, this slice): Alembic enables `pg_trgm` on PostgreSQL and creates `ix_foods_*_gin_trgm` indexes when `public.foods` exists; ADR + deploy note document scope. Runtime trigram candidate queries + strategy routing remain **open** until this checkbox closes.
   - Links:
     - `app/services/search_meili.py`
     - `app/services/food_store.py`
     - `docs/review/PR_1099_FIXED_MAPPING.md`
+    - `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md`
+    - `alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py`
+    - `docs/orchestration/task_analysis_SEARCH_PGTRGM_CANDIDATES_P2.md`
   - DoD:
     - `pg_trgm` candidate generation exists behind additive strategy routing with deterministic fallback
     - Relevance and latency tests cover candidate generation for representative food queries
@@ -7188,6 +7192,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Links:
     - `app/services/food_search_indexing.py`
     - `docs/review/PR_1099_FIXED_MAPPING.md`
+    - `docs/orchestration/plan_SEARCH_ZERO_DOWNTIME_SWAP_FOLLOWUP.md`
   - DoD:
     - Offline build-validate-warm-swap workflow is implemented with deterministic commands or admin surface
     - Swap orchestration is tested against `*_v2` indexes without changing public food API contracts


### PR DESCRIPTION
## Summary

PostgreSQL `pg_trgm` extension plus conditional GIN(trgm) indexes on `foods` (`canonical_name`, `group_name`, `brand`) for future candidate search lanes. **No runtime query-path change** — Phase 1 only per ADR.

## Scope

- Alembic: `202604060001` (Postgres-only; SQLite no-op)
- ADR: `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md`
- Deploy note: `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
- Task analysis + follow-up plan: zero-downtime swap orchestration (separate PR)
- Backlog ledger: progress + links

## Validation

- `make verify` (local, 2026-04-06)
- `pre-commit run --all-files`

## Deferred / Follow-ups

- Runtime swap to trigram lane + tests: tracked in backlog (`ledger-p2-search-pgtrgm-candidate-generation`)
- Zero-downtime index orchestration: `docs/orchestration/plan_SEARCH_ZERO_DOWNTIME_SWAP_FOLLOWUP.md` / `ledger-p2-search-zero-downtime-swap-orchestration`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1349_FIXED_MAPPING.md` (Disposition, `Commit:`/`Evidence:` proof lines, and per-thread `url -> sha` mappings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prepared PostgreSQL for trigram-based search: conditionally enable pg_trgm and add conditional GIN(trgm) indexes on foods (PostgreSQL-only; no-op elsewhere). Downgrade removes the indexes but leaves the extension intact.
* **Documentation**
  * Added ADR, deployment guidance, orchestration plan, task analysis, backlog updates, and review notes outlining the change and a follow-up zero-downtime work item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
