### PR TITLE
docs(dev): Codex host template + local session bootstrap

### DIFF
--- a/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
+++ b/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
@@ -36,6 +36,10 @@ scripts/install_codex_skills.sh
 
 - After install or updates, restart Codex so the new skills load
 - Full skill map and policy notes live in [`docs/dev/CODEX_SKILLS.md`](./CODEX_SKILLS.md)
+- Optional repo-root helper (preflight analyze + printed `task_bootstrap.py` recipe):
+  `scripts/orchestration/local_session_bootstrap.sh`
+- Host-only `~/.codex/config.toml` is outside repo SoT; optional template:
+  [`docs/templates/codex.config.example.toml`](../templates/codex.config.example.toml)
 
 ## Claude
 

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -29,6 +29,15 @@ scripts/install_codex_skills.sh --dest /tmp/codex-skills
 
 After installation or updates, restart Codex so newly installed skills are loaded.
 
+## Host `~/.codex` (optional, not repo SoT)
+
+Machine-local Codex settings (`~/.codex/config.toml`, skills under `~/.codex/skills`) are **not**
+repository source of truth. Keys drift with Codex CLI versions; verify against current vendor docs.
+
+For a **minimal copy-paste starter only**, see
+[`docs/templates/codex.config.example.toml`](../templates/codex.config.example.toml).
+Customize on your machine; do not treat that template as a production or team contract.
+
 ## Repo compatibility bridge
 
 Use the repo bridge documents together:

--- a/docs/review/PR_1350_FIXED_MAPPING.md
+++ b/docs/review/PR_1350_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1350 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: Refresh this artifact and PR-body mirror after review threads or actionable bot comments appear.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/templates/codex.config.example.toml
+++ b/docs/templates/codex.config.example.toml
@@ -1,0 +1,17 @@
+# Example only — intended for copying to host-only ~/.codex/config.toml.
+# This file is NOT repository or team source of truth for Codex behavior.
+# Validate every key against the Codex CLI version you run, e.g.:
+# https://developers.openai.com/codex/config-reference
+#
+# Never commit real API keys, tokens, or personal absolute paths as “the one true” config.
+
+model = "gpt-5-codex"
+
+# approval_policy = "untrusted"
+# sandbox_mode = "workspace-write"
+# personality = "pragmatic"
+# model_reasoning_effort = "medium"
+
+# Optional per-clone trust (use your real absolute path after copy)
+# [projects."/absolute/path/to/PulsePlate"]
+# trust_level = "trusted"

--- a/scripts/orchestration/local_session_bootstrap.sh
+++ b/scripts/orchestration/local_session_bootstrap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Opt-in local bridge for coordinator-first sessions (repo SoT only).
+# RU: Не заменяет host launcher; вызывает preflight и напоминает про task_bootstrap.
+# EN: Does not replace a machine launcher; runs preflight then prints bootstrap hints.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# analyze: allows a dirty tree; appropriate for cold-start / task analysis.
+# For --mode execute|merge, run scripts/orchestration/check_preflight.py directly.
+python3 scripts/orchestration/check_preflight.py --mode analyze
+
+echo ""
+echo "OK: preflight passed (analyze). Coordinator routing and skill selection are"
+echo "    deterministic only after you invoke task_bootstrap (and follow the packet)."
+echo ""
+echo "Generate a task packet (minimal example):"
+echo "  python3 scripts/orchestration/task_bootstrap.py \\"
+echo "    --goal \"<short goal>\" \\"
+echo "    --task-class \"<task_class>\""
+echo ""
+echo "Common options:"
+echo "  --path <path>              (repeatable; scope for scoped AGENTS / routing)"
+echo "  --pr-phase post_open_review|pre_open|merge_ready|none"
+echo "  --requested-agent <slug>   (repeatable)"
+echo ""
+echo "Full CLI: python3 scripts/orchestration/task_bootstrap.py --help"
+echo "Automation matrix: docs/orchestration/AUTOMATION_READINESS_MATRIX.md"


### PR DESCRIPTION
## Summary

Phase B of host `~/.codex` rollout: non-SoT example config template, onboarding links, and opt-in `local_session_bootstrap.sh` (preflight analyze + printed `task_bootstrap` recipe).

## Changes

- `docs/templates/codex.config.example.toml` — copy-paste starter only; not team SoT
- `docs/dev/CODEX_SKILLS.md` — host `~/.codex` section
- `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md` — template link + bridge script pointer
- `scripts/orchestration/local_session_bootstrap.sh` — repo opt-in bridge (does not replace machine launcher)
- `docs/review/PR_1350_FIXED_MAPPING.md` — canonical Phase 2 / merge-governance artifact

## Validation

Pre-push hooks on initial commit: passed. Run `make verify` locally when preparing merge (coordinator discretion for docs-only scope).

## Deferred / Follow-ups

- Merge then `git pull` on local clones; host launcher remains `~/.local/bin/pulseplate-coordinator-launch.sh` + `~/.codex/pulseplate-host-runbook.md` (machine-local).

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical source of truth: `docs/review/PR_1350_FIXED_MAPPING.md` (mirror; do not drift from artifact).

## Merge Readiness

- [ ] All required checks pass (GitHub CI on current PR head after each push)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green
- [ ] `make verify` green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for an optional, machine-local Codex host setup and warnings about config drift.
  * Provided a copy-paste starter config template (explicitly not a repo source of truth).
  * Added a PR review checklist artifact to support merge readiness and verification.

* **New Features**
  * Added a local bootstrap helper that runs preflight analysis and emits task-generation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->