### PR TITLE
feat(off): MVP USDA+OFF unified merge via nutrition resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,7 @@ jobs:
                 ;;
               food_catalog)
                 add_suite \
+                  tests/test_off_nutrition_bridge.py \
                   tests/test_off_nutrition_resolver.py \
                   tests/test_food_schema_provenance.py \
                   tests/test_food_store_additional_coverage.py \

--- a/core/food_apis/unified_db.py
+++ b/core/food_apis/unified_db.py
@@ -18,6 +18,11 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict
 
+from core.off_nutrition.bridge import (
+    merge_wire_nutrition_sources,
+    nutrition_inputs_from_unified_wire,
+)
+
 from .usda_client import USDAClient, USDAFoodItem
 from .unified_language import normalize_unified_db_language
 
@@ -169,6 +174,60 @@ class UnifiedFoodItem:
             nutrition_confidence=float(getattr(off_item, "nutrition_confidence", 0.0)),
         )
 
+    @classmethod
+    def from_usda_and_off_merge(
+        cls,
+        usda_unified: "UnifiedFoodItem",
+        off_unified: "UnifiedFoodItem",
+    ) -> "UnifiedFoodItem":
+        """Merge USDA primary hit with Open Food Facts via shared nutrition resolver.
+
+        RU: Слияние первичной строки USDA с OFF через общий nutrition resolver.
+        EN: Merge USDA primary row with OFF using the shared resolver priority order.
+        """
+
+        usda_inputs = nutrition_inputs_from_unified_wire(
+            nutrition_inputs_wire=usda_unified.nutrition_inputs,
+            nutrients_per_100g=usda_unified.nutrients_per_100g,
+            fallback_source="usda",
+            record_id=usda_unified.source_id,
+        )
+        off_inputs = nutrition_inputs_from_unified_wire(
+            nutrition_inputs_wire=off_unified.nutrition_inputs,
+            nutrients_per_100g=off_unified.nutrients_per_100g,
+            fallback_source="estimate",
+            record_id=off_unified.source_id,
+        )
+        key_union = set(usda_unified.nutrients_per_100g) | set(off_unified.nutrients_per_100g)
+        nutrient_keys = sorted(key_union) if key_union else None
+        resolved = merge_wire_nutrition_sources(
+            primary_inputs=usda_inputs,
+            secondary_inputs=off_inputs,
+            nutrient_keys=nutrient_keys,
+        )
+        nutrients = dict(resolved.nutrients)
+        nutrients.setdefault("protein_g", 0.0)
+        nutrients.setdefault("fat_g", 0.0)
+        nutrients.setdefault("carbs_g", 0.0)
+        tags = list(dict.fromkeys([*usda_unified.tags, *off_unified.tags]))
+        regions = list(
+            dict.fromkeys([*usda_unified.availability_regions, *off_unified.availability_regions])
+        )
+        return cls(
+            name=usda_unified.name,
+            nutrients_per_100g=nutrients,
+            cost_per_100g=usda_unified.cost_per_100g,
+            tags=tags,
+            availability_regions=regions,
+            source="USDA FoodData Central + Open Food Facts (merged)",
+            source_id=usda_unified.source_id,
+            category=usda_unified.category or off_unified.category,
+            nutrition_inputs=[entry.to_dict() for entry in resolved.raw_inputs],
+            nutrition_provenance=dict(resolved.provenance),
+            nutrition_nutrient_confidence=dict(resolved.nutrient_confidence),
+            nutrition_confidence=resolved.confidence,
+        )
+
     def to_menu_engine_format(self) -> UnifiedFoodResult:
         """Convert to format expected by menu_engine.py"""
         return {
@@ -291,6 +350,24 @@ class UnifiedFoodDatabase:
                         self._memory_cache[cache_key] = unified_item
             except Exception:
                 logger.exception("Error searching USDA")
+
+        # When USDA is preferred and returned hits, enrich the top result with OFF using
+        # the shared resolver (USDA ranks above OFF per DEFAULT_SOURCE_PRIORITY).
+        if prefer_source == "usda" and results and self.off_client:
+            try:
+                off_results = await self.off_client.search_products(query, page_size=1)
+                if off_results:
+                    off_unified = UnifiedFoodItem.from_off_item(off_results[0])
+                    merged = UnifiedFoodItem.from_usda_and_off_merge(results[0], off_unified)
+                    results[0] = merged
+                    if cache_key in self._memory_cache:
+                        self._memory_cache[cache_key] = merged
+            except Exception as exc:
+                logger.debug(
+                    "Unified DB: skipping USDA+OFF nutrition merge for query %r: %s",
+                    query,
+                    exc,
+                )
 
         # Search Open Food Facts if USDA results are empty or if preferred
         if (prefer_source == "openfoodfacts" or not results) and self.off_client:

--- a/core/food_apis/unified_db.py
+++ b/core/food_apis/unified_db.py
@@ -368,6 +368,8 @@ class UnifiedFoodDatabase:
                     query,
                     exc,
                 )
+                # Drop stale search_* cache so a transient OFF failure can retry merge.
+                self._memory_cache.pop(cache_key, None)
 
         # Search Open Food Facts if USDA results are empty or if preferred
         if (prefer_source == "openfoodfacts" or not results) and self.off_client:

--- a/core/off_nutrition/__init__.py
+++ b/core/off_nutrition/__init__.py
@@ -5,6 +5,7 @@ RU: Вспомогательные сущности provenance/confidence для
 EN: Provenance/confidence helpers for OFF nutrition.
 """
 
+from .bridge import merge_wire_nutrition_sources, nutrition_inputs_from_unified_wire
 from .contracts import NutritionInput, NutritionResolved
 from .resolver import (
     DEFAULT_SOURCE_PRIORITY,
@@ -20,6 +21,8 @@ __all__ = [
     "NutritionInput",
     "NutritionResolved",
     "is_valid_nutrient_scalar",
+    "merge_wire_nutrition_sources",
+    "nutrition_inputs_from_unified_wire",
     "project_scalar_compat",
     "resolve_nutrition",
 ]

--- a/core/off_nutrition/bridge.py
+++ b/core/off_nutrition/bridge.py
@@ -1,0 +1,87 @@
+"""
+Bridge helpers: rebuild NutritionInput streams from unified wire payloads.
+
+RU: Восстановление потоков NutritionInput из сериализованных unified-снимков.
+EN: Rebuild NutritionInput streams from unified wire snapshots for OFF↔catalog merge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .contracts import NutritionInput, NutritionResolved
+from .resolver import is_valid_nutrient_scalar, resolve_nutrition
+
+
+def nutrition_inputs_from_unified_wire(
+    *,
+    nutrition_inputs_wire: Sequence[Mapping[str, Any]],
+    nutrients_per_100g: Mapping[str, float],
+    fallback_source: str,
+    record_id: str | None,
+    version_ref: str | None = None,
+) -> list[NutritionInput]:
+    """
+    RU: Строит NutritionInput из nutrition_inputs JSON + fallback на flat нутриенты.
+    EN: Builds NutritionInput list from wire rows with flat nutrient fallback.
+    """
+
+    out: list[NutritionInput] = []
+    for wire in nutrition_inputs_wire:
+        if not isinstance(wire, Mapping):
+            continue
+        src = str(wire.get("source") or fallback_source)
+        raw_nut = wire.get("nutrients")
+        if not isinstance(raw_nut, Mapping):
+            continue
+        nutrients: dict[str, float] = {}
+        for k, v in raw_nut.items():
+            if is_valid_nutrient_scalar(v):
+                nutrients[str(k)] = float(v)
+        if not nutrients:
+            continue
+        rid_raw = wire.get("record_id")
+        rid_str = None if rid_raw is None else str(rid_raw)
+        vr_raw = wire.get("version_ref")
+        vr_str = None if vr_raw is None else str(vr_raw)
+        raw_pl = wire.get("raw_payload")
+        raw_payload: dict[str, Any] = dict(raw_pl) if isinstance(raw_pl, Mapping) else {}
+        out.append(
+            NutritionInput(
+                source=src,
+                nutrients=nutrients,
+                record_id=rid_str,
+                version_ref=vr_str,
+                raw_payload=raw_payload,
+            )
+        )
+    if not out:
+        nutrients_fb = {
+            str(k): float(v) for k, v in nutrients_per_100g.items() if is_valid_nutrient_scalar(v)
+        }
+        out.append(
+            NutritionInput(
+                source=fallback_source,
+                nutrients=nutrients_fb,
+                record_id=record_id,
+                version_ref=version_ref,
+                raw_payload={},
+            )
+        )
+    return out
+
+
+def merge_wire_nutrition_sources(
+    *,
+    primary_inputs: Sequence[NutritionInput],
+    secondary_inputs: Sequence[NutritionInput],
+    nutrient_keys: Sequence[str] | None = None,
+) -> NutritionResolved:
+    """
+    RU: Детерминированный merge двух потоков через resolve_nutrition.
+    EN: Deterministic merge of two streams via resolve_nutrition.
+    """
+
+    combined = list(primary_inputs) + list(secondary_inputs)
+    return resolve_nutrition(inputs=combined, nutrient_keys=nutrient_keys)

--- a/core/off_nutrition/bridge.py
+++ b/core/off_nutrition/bridge.py
@@ -16,7 +16,7 @@ from .resolver import is_valid_nutrient_scalar, resolve_nutrition
 
 def nutrition_inputs_from_unified_wire(
     *,
-    nutrition_inputs_wire: Sequence[Mapping[str, Any]],
+    nutrition_inputs_wire: Sequence[Mapping[str, object]],
     nutrients_per_100g: Mapping[str, float],
     fallback_source: str,
     record_id: str | None,

--- a/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
+++ b/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
@@ -26,7 +26,8 @@ Primary outcomes:
 Implemented foundation already exists:
 
 - source integration: USDA + Open Food Facts (`core/food_apis/unified_db.py:152`, `core/food_apis/update_manager.py:134`, `core/food_apis/scheduler.py:28`, `core/food_sources/usda.py:20`, `core/food_sources/off.py:19`)
-- merge layer: `core/food_merge.py:50`
+- merge layer: `core/food_merge.py:50` (multi-record catalog merge via `core/off_nutrition/resolver.py:66`)
+- live unified search merge (MVP): when `prefer_source="usda"`, `UnifiedFoodDatabase.search_food` enriches the top USDA hit with the best Open Food Facts match using the same resolver priority as catalog merge (`core/food_apis/unified_db.py:318`, `core/off_nutrition/bridge.py:17`, `core/off_nutrition/resolver.py:15`)
 - build/export flow: `scripts/build_food_db.py:62`
 - existing API surface: `/api/v1/foods`, `/api/v1/foods/search`, `/api/v1/foods/{food_id}` (`app/routers/foods.py:29`, `app/routers/foods.py:53`, `app/routers/foods.py:66`)
 
@@ -37,7 +38,7 @@ Validation criteria for this as-is claim:
 Known gap:
 
 - no fully governed snapshot lifecycle and source-tier rollout model
-- no canonical confidence/provenance policy as an explicit SoT
+- confidence/provenance for unified rows is implemented in resolver + wire rebuild, but snapshot/canonical-store policy remains to be fully governed end-to-end
 - limited restaurant/menu coverage
 - no controlled submission pipeline for unknown products
 
@@ -103,6 +104,10 @@ Every canonical record update must preserve:
 - source record ID
 - snapshot date
 - raw payload reference for audit/debug
+
+### 5.4 Live USDA + OFF nutrition merge (MVP, no new HTTP routes)
+
+When the unified DB runs with USDA as the preferred source and both USDA and OFF clients are available, the first USDA result is merged with the top OFF search hit for the same query string. Field-level values follow `DEFAULT_SOURCE_PRIORITY` in `core/off_nutrition/resolver.py:15` (for example `usda` wins over `estimate` for the same nutrient key). Complementary nutrients present only in OFF are retained with `estimate` provenance. Implementation: `UnifiedFoodItem.from_usda_and_off_merge` in `core/food_apis/unified_db.py`, wire rebuild via `nutrition_inputs_from_unified_wire` in `core/off_nutrition/bridge.py`. This does not add or change public HTTP routes; it only affects internal unified search results used by menu-engine style helpers.
 
 ---
 
@@ -225,4 +230,4 @@ This strategy is aligned with:
 - `docs/design/RESTAURANT_INTEGRATION_SPEC.md` (partner-facing menu contract direction)
 - `docs/roadmap/BACKLOG_LEDGER.md` (execution backlog and PR tracking)
 
-This document is a planning SoT and does not change runtime behavior.
+This document is the planning SoT for the food data program; runtime behavior evolves in the referenced modules—when behavior changes, anchors here must be updated in the same PR.

--- a/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
+++ b/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
@@ -107,7 +107,7 @@ Every canonical record update must preserve:
 
 ### 5.4 Live USDA + OFF nutrition merge (MVP, no new HTTP routes)
 
-When the unified DB runs with USDA as the preferred source and both USDA and OFF clients are available, the first USDA result is merged with the top OFF search hit for the same query string. Field-level values follow `DEFAULT_SOURCE_PRIORITY` in `core/off_nutrition/resolver.py:15` (for example `usda` wins over `estimate` for the same nutrient key). Complementary nutrients present only in OFF are retained with `estimate` provenance. Implementation: `UnifiedFoodItem.from_usda_and_off_merge` in `core/food_apis/unified_db.py`, wire rebuild via `nutrition_inputs_from_unified_wire` in `core/off_nutrition/bridge.py`. This does not add or change public HTTP routes; it only affects internal unified search results used by menu-engine style helpers.
+When the unified DB runs with USDA as the preferred source and both USDA and OFF clients are available, the first USDA result is merged with the top OFF search hit for the same query string. Field-level values follow `DEFAULT_SOURCE_PRIORITY` in `core/off_nutrition/resolver.py:15` (for example `usda` wins over `estimate` for the same nutrient key). Complementary nutrients present only in OFF are retained with `estimate` provenance. Implementation: `UnifiedFoodItem.from_usda_and_off_merge` in `core/food_apis/unified_db.py`, wire rebuild via `nutrition_inputs_from_unified_wire` in `core/off_nutrition/bridge.py`. This does not add or change public HTTP routes; it only affects internal unified search results used by menu-engine-style helpers.
 
 ---
 

--- a/docs/review/PR_1352_FIXED_MAPPING.md
+++ b/docs/review/PR_1352_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1352 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments yet
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: Refresh this artifact and PR-body mirror after review threads or actionable bot comments appear.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1352_FIXED_MAPPING.md
+++ b/docs/review/PR_1352_FIXED_MAPPING.md
@@ -3,12 +3,23 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments yet
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038812753 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038812756 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038823028 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061273775 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061284779 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061294695 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+
+Disposition: FIXED
+
+Commit: 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+
+Evidence: `core/food_apis/unified_db.py` (evict `search_*` cache on USDA+OFF merge failure); `core/off_nutrition/bridge.py` (`nutrition_inputs_wire` typing); `tests/test_unified_db_basics.py`; `tests/test_off_nutrition_bridge.py`; `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md` (menu-engine-style hyphenation)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1352_FIXED_MAPPING.md
+++ b/docs/review/PR_1352_FIXED_MAPPING.md
@@ -8,18 +8,25 @@
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038800908 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038800911 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038800932 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038809391 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038812753 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038812756 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038823028 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061273775 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061284779 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061294695 -> 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
-
 Disposition: FIXED
-
 Commit: 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7
-
 Evidence: `core/food_apis/unified_db.py` (evict `search_*` cache on USDA+OFF merge failure); `core/off_nutrition/bridge.py` (`nutrition_inputs_wire` typing); `tests/test_unified_db_basics.py`; `tests/test_off_nutrition_bridge.py`; `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md` (menu-engine-style hyphenation)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#discussion_r3038886946
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1352#pullrequestreview-4061361466
+Disposition: NOT-A-BUG
+Evidence: `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md` (hyphenation already corrected in commit 6c4167b442f1bd39aac02ba5f1f29d3afe081bd7)
+Reason: CodeRabbit re-review after that commit repeats the same doc hyphenation note; no additional code change required (would violate commit-after-comment if remapped as FIXED to the earlier SHA).
 
 ## Merge Readiness
 

--- a/tests/test_off_nutrition_bridge.py
+++ b/tests/test_off_nutrition_bridge.py
@@ -1,0 +1,81 @@
+"""Tests for core.off_nutrition.bridge (wire rebuild + dual-source merge)."""
+
+from __future__ import annotations
+
+from core.off_nutrition.bridge import (
+    merge_wire_nutrition_sources,
+    nutrition_inputs_from_unified_wire,
+)
+from core.off_nutrition.contracts import NutritionInput
+
+
+def test_nutrition_inputs_skips_non_mapping_wire_rows() -> None:
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=[42],
+        nutrients_per_100g={"protein_g": 5.0},
+        fallback_source="usda",
+        record_id="x",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].nutrients["protein_g"] == 5.0
+
+
+def test_nutrition_inputs_skips_when_nutrients_not_mapping() -> None:
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=({"source": "usda", "nutrients": "bad"},),
+        nutrients_per_100g={"kcal": 100.0},
+        fallback_source="usda",
+        record_id="y",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].nutrients["kcal"] == 100.0
+
+
+def test_nutrition_inputs_skips_wire_when_all_nutrient_values_invalid() -> None:
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=({"nutrients": {"protein_g": None, "kcal": "x"}},),
+        nutrients_per_100g={"fiber_g": 2.0},
+        fallback_source="estimate",
+        record_id="z",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].nutrients["fiber_g"] == 2.0
+
+
+def test_nutrition_inputs_from_unified_wire_empty_wire_uses_flat() -> None:
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=(),
+        nutrients_per_100g={"protein_g": 12.0},
+        fallback_source="usda",
+        record_id="fdc-1",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].source == "usda"
+    assert inputs[0].nutrients["protein_g"] == 12.0
+    assert inputs[0].record_id == "fdc-1"
+
+
+def test_merge_wire_prefers_usda_over_estimate_for_shared_key() -> None:
+    primary = [
+        NutritionInput(
+            source="usda",
+            nutrients={"protein_g": 31.0},
+            record_id="1",
+        )
+    ]
+    secondary = [
+        NutritionInput(
+            source="estimate",
+            nutrients={"protein_g": 10.0, "fiber_g": 3.0},
+            record_id="off-1",
+        )
+    ]
+    resolved = merge_wire_nutrition_sources(
+        primary_inputs=primary,
+        secondary_inputs=secondary,
+        nutrient_keys=("protein_g", "fiber_g"),
+    )
+    assert resolved.nutrients["protein_g"] == 31.0
+    assert resolved.provenance["protein_g"] == "usda"
+    assert resolved.nutrients["fiber_g"] == 3.0
+    assert resolved.provenance["fiber_g"] == "estimate"

--- a/tests/test_off_nutrition_bridge.py
+++ b/tests/test_off_nutrition_bridge.py
@@ -2,11 +2,33 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
 from core.off_nutrition.bridge import (
     merge_wire_nutrition_sources,
     nutrition_inputs_from_unified_wire,
 )
 from core.off_nutrition.contracts import NutritionInput
+
+
+def test_nutrition_inputs_skips_messy_wire_sequence_before_fallback() -> None:
+    """Exercise continue branches for non-Mapping row, non-Mapping nutrients, empty nutrients."""
+    messy: list[Any] = [
+        "not-a-mapping-row",
+        {"nutrients": "nutrients-not-a-mapping"},
+        {"nutrients": {"only_invalid": "not-a-number"}},
+    ]
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=cast(Sequence[Mapping[str, object]], messy),
+        nutrients_per_100g={"protein_g": 7.0},
+        fallback_source="usda",
+        record_id="fb",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].source == "usda"
+    assert inputs[0].nutrients["protein_g"] == 7.0
+    assert inputs[0].record_id == "fb"
 
 
 def test_nutrition_inputs_skips_non_mapping_wire_rows() -> None:

--- a/tests/test_off_nutrition_bridge.py
+++ b/tests/test_off_nutrition_bridge.py
@@ -42,6 +42,18 @@ def test_nutrition_inputs_skips_wire_when_all_nutrient_values_invalid() -> None:
     assert inputs[0].nutrients["fiber_g"] == 2.0
 
 
+def test_nutrition_inputs_filters_invalid_values_per_key() -> None:
+    """Invalid scalars for a nutrient key are dropped; valid keys on the same row stay."""
+    inputs = nutrition_inputs_from_unified_wire(
+        nutrition_inputs_wire=({"nutrients": {"protein_g": 10.0, "kcal": "not-a-number"}},),
+        nutrients_per_100g={"fiber_g": 1.0},
+        fallback_source="usda",
+        record_id="per-key-filter",
+    )
+    assert len(inputs) == 1
+    assert inputs[0].nutrients == {"protein_g": 10.0}
+
+
 def test_nutrition_inputs_from_unified_wire_empty_wire_uses_flat() -> None:
     inputs = nutrition_inputs_from_unified_wire(
         nutrition_inputs_wire=(),

--- a/tests/test_unified_db_basics.py
+++ b/tests/test_unified_db_basics.py
@@ -168,6 +168,35 @@ class TestUnifiedFoodItemConversions:
 
         assert result == expected
 
+    def test_from_usda_and_off_merge_usda_wins_on_shared_macro(self) -> None:
+        """USDA protein_g should beat OFF estimate when both provide the same key."""
+        usda_item = USDAFoodItem(
+            fdc_id=9001,
+            description="Chicken merge row",
+            food_category="Poultry",
+            nutrients_per_100g={"protein_g": 31.0, "kcal": 165.0},
+            data_type="Foundation",
+            publication_date="2019-04-01",
+        )
+        with patch.object(usda_item, "_generate_tags", return_value=["meat"]):
+            usda_u = UnifiedFoodItem.from_usda_item(usda_item)
+
+        mock_off = MagicMock()
+        mock_off.product_name = "Branded chicken"
+        mock_off.nutrients_per_100g = {"protein_g": 10.0, "fiber_g": 3.0}
+        mock_off._generate_tags.return_value = ["branded"]
+        mock_off.countries = ["US"]
+        mock_off.code = "9998887776665"
+        mock_off.categories = ["Meat"]
+        off_u = UnifiedFoodItem.from_off_item(mock_off)
+
+        merged = UnifiedFoodItem.from_usda_and_off_merge(usda_u, off_u)
+        assert merged.nutrients_per_100g["protein_g"] == 31.0
+        assert merged.nutrients_per_100g.get("fiber_g") == 3.0
+        assert "merged" in merged.source.lower()
+        assert merged.nutrition_provenance.get("protein_g") == "usda"
+        assert merged.nutrition_provenance.get("fiber_g") == "estimate"
+
 
 class TestUnifiedFoodDatabaseBasics:
     """Test basic UnifiedFoodDatabase functionality."""
@@ -411,6 +440,75 @@ class TestUnifiedFoodDatabaseSearch:
         results = await db.search_food("nonexistent food")
 
         assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_food_usda_pref_merges_top_hit_with_off(self, temp_cache_dir) -> None:
+        """With prefer_source=usda, top USDA hit is enriched via OFF + resolver."""
+        mock_usda = AsyncMock()
+        usda_item = USDAFoodItem(
+            fdc_id=4242,
+            description="Resolver merge chicken",
+            food_category="Poultry",
+            nutrients_per_100g={"protein_g": 31.0, "kcal": 165.0},
+            data_type="Foundation",
+            publication_date="2019-04-01",
+        )
+        with patch.object(usda_item, "_generate_tags", return_value=["meat"]):
+            mock_usda.search_foods.return_value = [usda_item]
+
+        mock_off = AsyncMock()
+        off_item = MagicMock()
+        off_item.product_name = "Branded chicken"
+        off_item.nutrients_per_100g = {"protein_g": 10.0, "fiber_g": 3.0}
+        off_item._generate_tags.return_value = ["branded"]
+        off_item.countries = ["US"]
+        off_item.code = "1112223334445"
+        off_item.categories = ["Meat"]
+        mock_off.search_products.return_value = [off_item]
+
+        db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
+        db.usda_client = mock_usda
+        db.off_client = mock_off
+
+        results = await db.search_food("resolver merge chicken", prefer_source="usda")
+        assert len(results) >= 1
+        top = results[0]
+        assert "merged" in top.source.lower()
+        assert top.nutrients_per_100g["protein_g"] == 31.0
+        assert top.nutrients_per_100g.get("fiber_g") == 3.0
+        mock_off.search_products.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_search_food_usda_pref_merge_skips_when_off_raises(
+        self, temp_cache_dir, caplog
+    ) -> None:
+        """Merge block must swallow OFF errors and keep plain USDA row."""
+        import logging
+
+        mock_usda = AsyncMock()
+        usda_item = USDAFoodItem(
+            fdc_id=777,
+            description="Plain USDA row",
+            food_category="Poultry",
+            nutrients_per_100g={"protein_g": 20.0},
+            data_type="Foundation",
+            publication_date="2019-04-01",
+        )
+        with patch.object(usda_item, "_generate_tags", return_value=["meat"]):
+            mock_usda.search_foods.return_value = [usda_item]
+
+        mock_off = AsyncMock()
+        mock_off.search_products.side_effect = RuntimeError("off unavailable")
+
+        db = UnifiedFoodDatabase(cache_dir=temp_cache_dir)
+        db.usda_client = mock_usda
+        db.off_client = mock_off
+
+        caplog.set_level(logging.DEBUG, logger="core.food_apis.unified_db")
+        results = await db.search_food("plain usda merge skip", prefer_source="usda")
+        assert len(results) == 1
+        assert results[0].source == "USDA FoodData Central"
+        assert "skipping USDA+OFF" in caplog.text
 
 
 class TestUnifiedFoodDatabaseGetById:

--- a/tests/test_unified_db_basics.py
+++ b/tests/test_unified_db_basics.py
@@ -509,6 +509,25 @@ class TestUnifiedFoodDatabaseSearch:
         assert len(results) == 1
         assert results[0].source == "USDA FoodData Central"
         assert "skipping USDA+OFF" in caplog.text
+        assert "search_plain usda merge skip" not in db._memory_cache  # noqa: SLF001
+
+        off_item = MagicMock()
+        off_item.product_name = "Branded retry"
+        off_item.nutrients_per_100g = {"fiber_g": 2.0}
+        off_item._generate_tags.return_value = ["branded"]
+        off_item.countries = ["US"]
+        off_item.code = "9998887776665"
+        off_item.categories = ["Meat"]
+        mock_off.search_products.side_effect = None
+        mock_off.search_products.return_value = [off_item]
+
+        caplog.clear()
+        merged_results = await db.search_food("plain usda merge skip", prefer_source="usda")
+        assert len(merged_results) == 1
+        top = merged_results[0]
+        assert "merged" in top.source.lower()
+        assert top.nutrients_per_100g.get("fiber_g") == 2.0
+        assert mock_off.search_products.await_count == 2
 
 
 class TestUnifiedFoodDatabaseGetById:


### PR DESCRIPTION
## Scope (IN)
- `core/off_nutrition/bridge.py`: rebuild `NutritionInput` from unified `nutrition_inputs` wire + flat `nutrients_per_100g` fallback; merge primary/secondary streams via `resolve_nutrition`.
- `UnifiedFoodDatabase.search_food(prefer_source=usda)`: when USDA returns hits and OFF client is available, fetch one OFF product and merge the top USDA row (no new HTTP routes).
- Tests: bridge edge cases + unified DB merge paths (happy path + OFF failure swallowed).
- `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`: §5.4 live USDA+OFF merge + `file:line` anchors.

## Non-goals (OUT)
- New public API / OpenAPI changes (wire already carries confidence/provenance from prior work).
- Client UI work (follow-up PR if we want surfaced merge metadata).

## DoD
- [x] `make lint`, `make typecheck`, `make test-fast`, `make diff-cov` (≥97% on diff vs `origin/main`) — re-run if flaky guard under full `coverage run`.
- [x] `pre-commit run --all-files` green before push.
- [x] `make openapi-check` — no drift (internal merge only).

## Deferred / Follow-ups
- Optional PR2: thin clients — only if we expose merge-specific fields in API or add dev-only UI/telemetry; OpenAPI sync per `pulseplate-openapi-sync` if schemas change.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Интеграция общего nutrition resolver для объединения данных USDA и Open Food Facts в единые результаты поиска по продуктам и их nutrition snapshots.

New Features:
- Добавлены bridge-утилиты для восстановления потоков `NutritionInput` из унифицированных wire-пейлоадов и объединения нескольких источников данных о питании через общий resolver.
- Добавлена поддержка объединения основного унифицированного элемента USDA с дополнительным элементом Open Food Facts в один `UnifiedFoodItem` с объединёнными нутриентами и информацией о происхождении данных (provenance).
- Расширено обогащение унифицированных результатов поиска с приоритетом USDA путём объединения топового результата USDA с лучшим совпадением из Open Food Facts, когда оно доступно.

Enhancements:
- Гарантируется, что объединённые унифицированные элементы всегда содержат значения по умолчанию для макронутриентов, а также объединённые метаданные тегов/регионов.
- Улучшена обработка provenance и confidence для унифицированных данных о питании за счёт повторного использования результатов resolver при построении объединённых элементов.

Documentation:
- Задокументировано поведение живого объединения USDA + Open Food Facts, приоритеты resolver и ключевые точки реализации в архитектурном стратегическом документе.

Tests:
- Добавлены модульные тесты для восстановления `NutritionInput` из wire-структур и объединения на основе dual-source resolver, включая некорректные и пограничные случаи.
- Добавлены интеграционные тесты, покрывающие USDA-preferred унифицированные объединения результатов поиска, обогащение за счёт OFF и корректную обработку сбоев OFF.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a shared nutrition resolver to merge USDA and Open Food Facts data into unified food search results and nutrition snapshots.

New Features:
- Add bridge utilities to rebuild NutritionInput streams from unified wire payloads and merge multiple nutrition sources via the shared resolver.
- Support merging a primary USDA unified item with a secondary Open Food Facts item into a single UnifiedFoodItem with combined nutrients and provenance.
- Enrich USDA-preferred unified search results by merging the top USDA hit with the best Open Food Facts match when available.

Enhancements:
- Ensure merged unified items always provide default macro nutrients and combined tags/regions metadata.
- Improve unified nutrition provenance and confidence handling by reusing resolver outputs when constructing merged items.

Documentation:
- Document the live USDA + Open Food Facts merge behavior, resolver priority, and implementation anchors in the architecture strategy doc.

Tests:
- Add unit tests for wire-to-NutritionInput rebuilding and dual-source resolver-based merges, including invalid/edge cases.
- Add integration-style tests covering USDA-preferred unified search merges, OFF enrichment, and graceful handling of OFF failures.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MVP live nutrition merge that enriches the top USDA search hit with Open Food Facts via the shared nutrition resolver. No API or route changes; provenance and confidence are preserved.

- **New Features**
  - Bridge helpers in `core/off_nutrition/bridge.py` to rebuild inputs and merge primary/secondary via the resolver; exported in `core/off_nutrition/__init__.py`.
  - `UnifiedFoodItem.from_usda_and_off_merge` merges USDA (primary) with OFF (secondary): USDA wins on shared keys, OFF-only nutrients are kept, tags/regions are merged, and macros default to 0.
  - `UnifiedFoodDatabase.search_food(prefer_source='usda')` merges the top USDA result with one OFF product and updates the memory cache with the merged item.

- **Bug Fixes**
  - Evicts `search_*` cache on OFF merge failure to allow a clean retry; OFF errors are logged at debug and swallowed.
  - Narrows bridge typing to `Mapping[str, object]` and drops invalid nutrient scalars per key; adds CI coverage for bridge skip branches by running `tests/test_off_nutrition_bridge.py` in the food_catalog suite.

<sup>Written for commit c8641bac57ab75c443aa947a8b4c2e3be08a7a78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top USDA search hits can be enriched with Open Food Facts to produce merged items with more complete nutrients, de-duplicated tags/regions, merged source label, and guaranteed macronutrient defaults.

* **Bug Fixes**
  * Enrichment failures are logged, skip caching stale merged results, and allow the search flow to continue.

* **Documentation**
  * Architecture docs updated to describe the live USDA+OFF merge behavior and field-level provenance.

* **Tests**
  * Added unit tests covering nutrition-wire parsing, merge resolution, and search enrichment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1352_FIXED_MAPPING.md`
