### PR TITLE
docs(roadmap): close ledger-p0-requested-agent-bootstrap (post-1354)

### DIFF
--- a/docs/review/PR_1356_FIXED_MAPPING.md
+++ b/docs/review/PR_1356_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1356 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: Docs-only ledger closure after PR #1354; no inline review threads requiring disposition mapping.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -146,7 +146,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
   - Target PR: PR #1354 (https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1354)
-  - Status: ✅ Merged (PR #1354, 2026-04-06; merge commit `ba9ea2f8`). Ledger checkbox closed via mandatory docs-only follow-up the same working day (backlog ledger policy).
+  - Status: ✅ Merged (PR #1354, 2026-04-06; merge commit `ba9ea2f8`). Ledger checkbox closed in PR #1356 (mandatory docs-only follow-up the same working day; backlog ledger policy).
   - Area: orchestration / task bootstrap / routing
   - Finding Type: coordinator bootstrap gap
   - Reason: The canonical coordinator workflow must preserve explicit user-requested agent slugs instead of dropping them during bootstrap. This is especially critical for `agent-coordinator`, `backend-engineer`, `bug-hunter`, `ml-engineer-agent`, and `data-scientist-agent`, where current routing semantics otherwise under-express user intent or hide non-routable specialists.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -142,11 +142,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Regression tests cover paid, expired, and missing-entitlement paths
 
 <a id="ledger-p0-requested-agent-bootstrap"></a>
-- [ ] P0: Requested-agent bootstrap override and advisory specialist contract
+- [x] P0: Requested-agent bootstrap override and advisory specialist contract
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR #1354 (https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1354); check `[x]` only after merge per ledger policy
-  - Status: Open for review; after merge, mark `[x]` via mandatory docs-only follow-up PR the same working day (backlog ledger policy).
+  - Target PR: PR #1354 (https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1354)
+  - Status: ✅ Merged (PR #1354, 2026-04-06; merge commit `ba9ea2f8`). Ledger checkbox closed via mandatory docs-only follow-up the same working day (backlog ledger policy).
   - Area: orchestration / task bootstrap / routing
   - Finding Type: coordinator bootstrap gap
   - Reason: The canonical coordinator workflow must preserve explicit user-requested agent slugs instead of dropping them during bootstrap. This is especially critical for `agent-coordinator`, `backend-engineer`, `bug-hunter`, `ml-engineer-agent`, and `data-scientist-agent`, where current routing semantics otherwise under-express user intent or hide non-routable specialists.


### PR DESCRIPTION
## Summary
Mandatory **docs-only** follow-up after merge of PR #1354 per backlog ledger policy (same working day).

## Changes
- `docs/roadmap/BACKLOG_LEDGER.md`: `ledger-p0-requested-agent-bootstrap` — `[x]`, Target PR #1354, Status merged (`ba9ea2f8`, 2026-04-06).

## Docs-only scope guard
```bash
git diff --name-only origin/main...HEAD | rg -v "\\.md$" || true
```
(empty)

## Deferred / Follow-ups
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1356_FIXED_MAPPING.md`

## Related
- Implements / closes ledger item opened for: PR #1354


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документация:
- Обновить запись дорожной карты для журнала невыполненных задач, чтобы отметить пункт инициализации запрошенного агента как выполненный, а также задокументировать его статус после слияния и метаданные.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the backlog ledger roadmap entry to mark the requested-agent bootstrap item as done and document its merged status and metadata.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the `ledger-p0-requested-agent-bootstrap` backlog item as completed after PR #1354 and records the merged status in `docs/roadmap/BACKLOG_LEDGER.md`. Adds a note that the ledger checkbox was closed in PR #1356 to keep the backlog ledger consistent with policy.

<sup>Written for commit 137a5a53d2e36193a6dda14d3d72f83af24b1efb. Summary will update on new commit.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal merge readiness and backlog tracking documentation.

---

**Note:** This release contains documentation-only updates with no end-user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->