### PR TITLE
fix(ci): verify-env console wrapper parity (P0 ledger)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,13 @@ Or individually:
 - `make test-fast` — deterministic smoke subset (`tests/edges` + `tests/test_remaining_modules.py`)
 - `make diff-cov` — diff-cover ≥97% against origin/main
 
+`verify-env` (the first step of `make verify`) also rejects **present** broken
+`.venv/bin` console scripts for flake8/pytest/mypy/coverage/diff-cover (stale
+absolute shebang, non-executable file, broken symlink) so local preflight
+cannot pass while PATH-activated or hook-driven invocations would still hit a
+dead interpreter. Missing scripts are OK; see
+`scripts/ci/check_local_verify_environment.py`.
+
 **Tooling behavior contract (validation helpers):**
 
 - `test-fast` is deterministic and does not use `.pytest_cache`/`--lf`.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -297,15 +297,20 @@ make venv-sync
 make verify
 ```
 
-`make verify` now starts with `verify-env`, a fail-fast preflight that does not
-repair the environment and fails when verify-critical modules such as
+`make verify` starts with `verify-env`, a fail-fast preflight that does not
+repair the environment. It fails when verify-critical modules such as
 `flake8`, `diff_cover.diff_cover_tool` (`diff-cover`), `coverage`, `pytest`, or
-`mypy` are missing from `.venv`. Run `make verify` from repo root and do not
-rely on an externally activated interpreter: `verify-env` requires the repo
-`.venv` interpreter itself. The verify-critical gates themselves run in
-interpreter-module mode through the repo `.venv` (`$(VENV_PYTHON) -m ...`), so
-stale `.venv/bin/*` wrapper entrypoints are no longer the trust anchor for
-local merge evidence.
+`mypy` are missing from `.venv`, when unexpected executable `.pth` startup
+hooks are present, or when **present** `.venv/bin` console scripts for those
+tools are broken: non-executable, dangling symlink, or an absolute shebang
+pointing at a missing or non-executable interpreter (typical after deleting a
+worktree or moving the venv). Missing console scripts are allowed—the canonical
+`make verify` recipe uses `$(VENV_PYTHON) -m ...`—but any installed wrapper must
+be consistent so PATH-based tools, shells, and hooks do not fail later with
+opaque “bad interpreter” errors. Shebangs using `#!/usr/bin/env ...` are not
+validated in v1. Run `make verify` from repo root and do not rely on an
+externally activated interpreter: `verify-env` requires the repo `.venv`
+interpreter itself. Evidence: `scripts/ci/check_local_verify_environment.py`.
 
 Run from repo root before any push/PR:
 

--- a/docs/review/PR_1357_FIXED_MAPPING.md
+++ b/docs/review/PR_1357_FIXED_MAPPING.md
@@ -9,8 +9,8 @@
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#pullrequestreview-4062081447
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#discussion_r3039564062
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#pullrequestreview-4062107107
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#discussion_r3039564062 -> a908bcbf
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#pullrequestreview-4062107107 -> a908bcbf
 
 Disposition: FIXED (CodeRabbit artifact checkboxes + symlink-loop resolve guard); NOT-A-BUG (Sourcery shebang/docstring and refactor suggestions out of PR scope)
 Evidence: `docs/review/PR_1357_FIXED_MAPPING.md` (artifact `[x]` per `review_mapping_artifact.py:30-31`); `scripts/ci/check_local_verify_environment.py` (`RuntimeError` with `resolve()`, docstring for first-token shebang); `tests/test_check_local_verify_environment.py` (`resolve` RuntimeError branch)
@@ -23,6 +23,6 @@ Evidence: `docs/review/PR_1357_FIXED_MAPPING.md` (artifact `[x]` per `review_map
 - [ ] Pre-commit green
 - [ ] `make verify` green locally
 
-Notes: If merge-readiness disposition guard requires a `Commit:` line for FIXED threads, add `- <url> -> <sha>` lines after landing this commit (commit-after-comment policy). Ledger checkbox for `ledger-p0-verify-env-wrapper-parity` closes in a **same-day docs-only PR** after merge.
+Notes: CodeRabbit FIXED threads map to `a908bcbf` (verify-env + artifact `[x]`). Ledger checkbox for `ledger-p0-verify-env-wrapper-parity` closes in a **same-day docs-only PR** after merge.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1357_FIXED_MAPPING.md
+++ b/docs/review/PR_1357_FIXED_MAPPING.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1357 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+_No actionable review threads mapped yet. When CodeRabbit/Sourcery/Cubic (or human) threads appear, record each with **Disposition** (FIXED / NOT-A-BUG / DEFERRED), **Evidence** (`file:line`, test, or command), and thread URL._
+
+**Implementation evidence (baseline for this PR):**
+
+- Disposition: FIXED (landing commits)
+- Evidence: `scripts/ci/check_local_verify_environment.py` (wrapper parity + `build_failure_output`); `tests/test_check_local_verify_environment.py` (stale shebang, non-executable, symlink); `RUNBOOK_AGENT.md` (Clean-Clone Verify Parity); `AGENTS.md` (verify-env note); `docs/roadmap/BACKLOG_LEDGER.md` (`ledger-p0-verify-env-wrapper-parity` links)
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: After bots comment, add `- <discussion_url> -> <commit_sha>` lines only for **FIXED** with commit-after-comment policy. Ledger checkbox for `ledger-p0-verify-env-wrapper-parity` closes in a **same-day docs-only PR** after merge.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1357_FIXED_MAPPING.md
+++ b/docs/review/PR_1357_FIXED_MAPPING.md
@@ -3,17 +3,17 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-_No actionable review threads mapped yet. When CodeRabbit/Sourcery/Cubic (or human) threads appear, record each with **Disposition** (FIXED / NOT-A-BUG / DEFERRED), **Evidence** (`file:line`, test, or command), and thread URL._
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#pullrequestreview-4062081447
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#discussion_r3039564062
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1357#pullrequestreview-4062107107
 
-**Implementation evidence (baseline for this PR):**
-
-- Disposition: FIXED (landing commits)
-- Evidence: `scripts/ci/check_local_verify_environment.py` (wrapper parity + `build_failure_output`); `tests/test_check_local_verify_environment.py` (stale shebang, non-executable, symlink); `RUNBOOK_AGENT.md` (Clean-Clone Verify Parity); `AGENTS.md` (verify-env note); `docs/roadmap/BACKLOG_LEDGER.md` (`ledger-p0-verify-env-wrapper-parity` links)
+Disposition: FIXED (CodeRabbit artifact checkboxes + symlink-loop resolve guard); NOT-A-BUG (Sourcery shebang/docstring and refactor suggestions out of PR scope)
+Evidence: `docs/review/PR_1357_FIXED_MAPPING.md` (artifact `[x]` per `review_mapping_artifact.py:30-31`); `scripts/ci/check_local_verify_environment.py` (`RuntimeError` with `resolve()`, docstring for first-token shebang); `tests/test_check_local_verify_environment.py` (`resolve` RuntimeError branch)
 
 ## Merge Readiness
 
@@ -23,6 +23,6 @@ _No actionable review threads mapped yet. When CodeRabbit/Sourcery/Cubic (or hum
 - [ ] Pre-commit green
 - [ ] `make verify` green locally
 
-Notes: After bots comment, add `- <discussion_url> -> <commit_sha>` lines only for **FIXED** with commit-after-comment policy. Ledger checkbox for `ledger-p0-verify-env-wrapper-parity` closes in a **same-day docs-only PR** after merge.
+Notes: If merge-readiness disposition guard requires a `Commit:` line for FIXED threads, add `- <url> -> <sha>` lines after landing this commit (commit-after-comment policy). Ledger checkbox for `ledger-p0-verify-env-wrapper-parity` closes in a **same-day docs-only PR** after merge.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -169,7 +169,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: Verify-env executable wrapper parity for local merge gate
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-VERIFY-ENV-WRAPPER-PARITY
+  - Target PR: #1357
   - Area: tooling / local verify / developer workflow
   - Finding Type: false-green preflight gap
   - Reason: Local `make verify` can fail after `verify-env` already passed when stale `.venv` console entrypoints still point to deleted interpreters/worktrees. The preflight must detect broken wrappers or switch the gate to interpreter-module mode so local merge evidence is trustworthy.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -177,11 +177,14 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `Makefile`
     - `scripts/ci/check_local_verify_environment.py`
     - `tests/test_check_local_verify_environment.py`
+    - `RUNBOOK_AGENT.md` (section “Clean-Clone Verify Parity” / verify-env)
+    - `AGENTS.md` (Hard Gates / verify-env console-script note)
   - DoD:
     - `verify-env` detects stale or non-executable repo tool wrappers before `lint`
     - Local verify path fails with explicit remediation instead of bad-interpreter shell errors
     - Deterministic tests cover stale shebang or broken-wrapper detection
     - Local merge-gate docs reference the stronger parity check
+  - Status: implementation may land in a runtime PR; close this checkbox via a same-day docs-only PR after merge (ledger policy).
 
 <a id="ledger-p0-web-entitlement-truth"></a>
 - [ ] P0: Web entitlement truth must come from canonical backend/store state

--- a/scripts/ci/check_local_verify_environment.py
+++ b/scripts/ci/check_local_verify_environment.py
@@ -4,11 +4,17 @@
 This script validates only the repo interpreter + module parity required for
 the canonical local verification gate. It does not repair or rewrite the
 environment and points developers to the documented recovery path.
+
+Console-script wrappers under ``.venv/bin`` are checked only when present:
+they must be executable and, if the shebang uses an absolute interpreter
+path, that path must exist. Shebangs of the form ``#!/usr/bin/env ...`` are
+not validated (v1) to avoid false positives from ambient PATH.
 """
 
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess  # nosec B404: subprocess is required for bounded local guard execution (remove-by: 2026-07-31, ref: PR-1243)
 import sys
 from dataclasses import dataclass
@@ -25,6 +31,17 @@ REQUIRED_MODULES: tuple[tuple[str, str], ...] = (
     ("pytest", "test-fast"),
     ("coverage", "cov-check"),
     ("diff_cover.diff_cover_tool", "diff-cov"),
+)
+
+# Pip console-script names aligned with REQUIRED_MODULES / make verify stages.
+# Missing scripts are OK (``$(VENV_PYTHON) -m ...`` is canonical); present
+# scripts must not point at deleted interpreters or be non-executable.
+VERIFY_CRITICAL_CONSOLE_SCRIPT_NAMES: tuple[str, ...] = (
+    "flake8",
+    "pytest",
+    "mypy",
+    "coverage",
+    "diff-cover",
 )
 
 
@@ -89,6 +106,75 @@ def collect_unexpected_startup_hooks() -> list[StartupHookFinding]:
     raise RuntimeError("Unable to parse startup hook guard output.")
 
 
+def _parse_absolute_shebang_interpreter(first_line: str) -> Path | None:
+    """Return interpreter path from shebang if it is a single absolute path token."""
+    stripped = first_line.strip()
+    if not stripped.startswith("#!"):
+        return None
+    remainder = stripped[2:].strip()
+    if not remainder:
+        return None
+    candidate = remainder.split()[0]
+    if not candidate.startswith("/"):
+        return None
+    return Path(candidate)
+
+
+def collect_broken_console_wrappers(
+    *,
+    venv_bin_dir: Path | None = None,
+    script_names: tuple[str, ...] | None = None,
+) -> list[tuple[str, str]]:
+    """Return (script_name, reason) for present-but-broken venv console scripts."""
+    bin_dir = venv_bin_dir if venv_bin_dir is not None else VENV_BIN_DIR
+    names = script_names if script_names is not None else VERIFY_CRITICAL_CONSOLE_SCRIPT_NAMES
+    broken: list[tuple[str, str]] = []
+    for name in names:
+        script_path = bin_dir / name
+        if not script_path.exists() and not script_path.is_symlink():
+            continue
+        if script_path.is_symlink() and not script_path.exists():
+            broken.append((name, "broken or dangling symlink target"))
+            continue
+        try:
+            if not script_path.is_file():
+                broken.append((name, "not a regular file"))
+                continue
+        except OSError as exc:
+            broken.append((name, f"cannot stat path: {exc}"))
+            continue
+        if not os.access(script_path, os.X_OK):
+            broken.append((name, "not executable"))
+            continue
+        try:
+            raw = script_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            broken.append((name, f"cannot read script: {exc}"))
+            continue
+        lines = raw.splitlines()
+        if not lines:
+            broken.append((name, "empty script"))
+            continue
+        first_line = lines[0]
+        interpreter = _parse_absolute_shebang_interpreter(first_line)
+        if interpreter is None:
+            continue
+        try:
+            interp_resolved = interpreter.resolve()
+        except OSError as exc:
+            broken.append(
+                (name, f"stale shebang interpreter (resolve error): {interpreter} ({exc})")
+            )
+            continue
+        if not interp_resolved.is_file():
+            broken.append((name, f"stale shebang interpreter missing: {interpreter}"))
+            continue
+        if not os.access(interp_resolved, os.X_OK):
+            broken.append((name, f"stale shebang interpreter not executable: {interpreter}"))
+            continue
+    return broken
+
+
 def collect_missing_modules(
     required_modules: tuple[tuple[str, str], ...] = REQUIRED_MODULES,
 ) -> list[tuple[str, str, str]]:
@@ -104,6 +190,7 @@ def collect_missing_modules(
 def build_failure_output(
     *,
     python_executable: Path,
+    broken_console_wrappers: list[tuple[str, str]],
     missing_modules: list[tuple[str, str, str]],
     unexpected_startup_hooks: list[StartupHookFinding],
 ) -> list[str]:
@@ -112,6 +199,10 @@ def build_failure_output(
         "ERROR: local verify environment is incomplete.",
         f"Expected venv interpreter: {python_executable}",
     ]
+    if broken_console_wrappers:
+        lines.append("Stale or broken venv console scripts (.venv/bin):")
+    for script_name, reason in broken_console_wrappers:
+        lines.append(f"- {script_name} :: {reason}")
     if missing_modules:
         lines.append("Missing verify-critical Python modules:")
     for module_name, verify_stage, error in missing_modules:
@@ -152,11 +243,13 @@ def main() -> int:
         print("- If the venv drifted, run `make venv-sync`")
         return 1
 
+    broken_wrappers = collect_broken_console_wrappers()
     missing_modules = collect_missing_modules()
     unexpected_startup_hooks = collect_unexpected_startup_hooks()
-    if missing_modules or unexpected_startup_hooks:
+    if broken_wrappers or missing_modules or unexpected_startup_hooks:
         for line in build_failure_output(
             python_executable=Path(sys.executable).resolve(),
+            broken_console_wrappers=broken_wrappers,
             missing_modules=missing_modules,
             unexpected_startup_hooks=unexpected_startup_hooks,
         ):

--- a/scripts/ci/check_local_verify_environment.py
+++ b/scripts/ci/check_local_verify_environment.py
@@ -111,7 +111,7 @@ def _parse_absolute_shebang_interpreter(first_line: str) -> Path | None:
     Return interpreter path from shebang when the first token is an absolute path.
 
     If the shebang has extra arguments after that token (for example ``#!/usr/bin/python -O``),
-    only the first token is used; ``#!/usr/bin/env ...`` yields None (handled elsewhere).
+    only the first token is used. ``#!/usr/bin/env ...`` yields None (not validated in v1).
     """
     stripped = first_line.strip()
     if not stripped.startswith("#!"):
@@ -123,6 +123,19 @@ def _parse_absolute_shebang_interpreter(first_line: str) -> Path | None:
     if not candidate.startswith("/"):
         return None
     return Path(candidate)
+
+
+def _resolve_interpreter_path(interpreter: Path) -> Path:
+    """Resolve a shebang interpreter path (narrow seam for tests)."""
+    return interpreter.resolve()
+
+
+def _format_venv_bin_display(bin_dir: Path) -> str:
+    """Human-readable venv bin path for errors (prefer repo-relative)."""
+    try:
+        return str(bin_dir.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(bin_dir)
 
 
 def collect_broken_console_wrappers(
@@ -160,12 +173,12 @@ def collect_broken_console_wrappers(
         if not lines:
             broken.append((name, "empty script"))
             continue
-        first_line = lines[0]
+        first_line = lines[0].lstrip("\ufeff")
         interpreter = _parse_absolute_shebang_interpreter(first_line)
         if interpreter is None:
             continue
         try:
-            interp_resolved = interpreter.resolve()
+            interp_resolved = _resolve_interpreter_path(interpreter)
         except (OSError, RuntimeError) as exc:
             broken.append(
                 (name, f"stale shebang interpreter (resolve error): {interpreter} ({exc})")
@@ -198,14 +211,17 @@ def build_failure_output(
     broken_console_wrappers: list[tuple[str, str]],
     missing_modules: list[tuple[str, str, str]],
     unexpected_startup_hooks: list[StartupHookFinding],
+    venv_bin_dir: Path | None = None,
 ) -> list[str]:
     """Build deterministic failure lines for terminal output."""
+    bin_dir = venv_bin_dir if venv_bin_dir is not None else VENV_BIN_DIR
+    bin_display = _format_venv_bin_display(bin_dir)
     lines = [
         "ERROR: local verify environment is incomplete.",
         f"Expected venv interpreter: {python_executable}",
     ]
     if broken_console_wrappers:
-        lines.append("Stale or broken venv console scripts (.venv/bin):")
+        lines.append(f"Stale or broken venv console scripts ({bin_display}):")
     for script_name, reason in broken_console_wrappers:
         lines.append(f"- {script_name} :: {reason}")
     if missing_modules:

--- a/scripts/ci/check_local_verify_environment.py
+++ b/scripts/ci/check_local_verify_environment.py
@@ -107,7 +107,12 @@ def collect_unexpected_startup_hooks() -> list[StartupHookFinding]:
 
 
 def _parse_absolute_shebang_interpreter(first_line: str) -> Path | None:
-    """Return interpreter path from shebang if it is a single absolute path token."""
+    """
+    Return interpreter path from shebang when the first token is an absolute path.
+
+    If the shebang has extra arguments after that token (for example ``#!/usr/bin/python -O``),
+    only the first token is used; ``#!/usr/bin/env ...`` yields None (handled elsewhere).
+    """
     stripped = first_line.strip()
     if not stripped.startswith("#!"):
         return None
@@ -161,7 +166,7 @@ def collect_broken_console_wrappers(
             continue
         try:
             interp_resolved = interpreter.resolve()
-        except OSError as exc:
+        except (OSError, RuntimeError) as exc:
             broken.append(
                 (name, f"stale shebang interpreter (resolve error): {interpreter} ({exc})")
             )

--- a/tests/test_check_local_verify_environment.py
+++ b/tests/test_check_local_verify_environment.py
@@ -56,6 +56,7 @@ def test_build_failure_output_includes_recovery_commands() -> None:
 
 
 def test_build_failure_output_includes_broken_console_wrappers() -> None:
+    bin_dir = Path("/tmp/.venv/bin")
     lines = env_gate.build_failure_output(
         python_executable=Path("/tmp/.venv/bin/python"),
         broken_console_wrappers=[
@@ -63,9 +64,11 @@ def test_build_failure_output_includes_broken_console_wrappers() -> None:
         ],
         missing_modules=[],
         unexpected_startup_hooks=[],
+        venv_bin_dir=bin_dir,
     )
 
-    assert "Stale or broken venv console scripts (.venv/bin):" in lines
+    label = env_gate._format_venv_bin_display(bin_dir)
+    assert f"Stale or broken venv console scripts ({label}):" in lines
     assert "- flake8 :: stale shebang interpreter missing: /tmp/deleted-python" in lines
     assert any("make venv-sync" in line for line in lines)
 
@@ -237,7 +240,8 @@ def test_main_fails_when_console_wrapper_has_stale_absolute_shebang(
 
     assert result == 1
     captured = capsys.readouterr()
-    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    display = env_gate._format_venv_bin_display(env_gate.VENV_BIN_DIR)
+    assert f"Stale or broken venv console scripts ({display}):" in captured.out
     assert "flake8" in captured.out
     assert "stale shebang interpreter missing" in captured.out
 
@@ -266,7 +270,8 @@ def test_main_fails_when_console_wrapper_is_not_executable(
 
     assert result == 1
     captured = capsys.readouterr()
-    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    display = env_gate._format_venv_bin_display(env_gate.VENV_BIN_DIR)
+    assert f"Stale or broken venv console scripts ({display}):" in captured.out
     assert "flake8" in captured.out
     assert "not executable" in captured.out
 
@@ -295,7 +300,8 @@ def test_main_fails_when_console_wrapper_is_dangling_symlink(
 
     assert result == 1
     captured = capsys.readouterr()
-    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    display = env_gate._format_venv_bin_display(env_gate.VENV_BIN_DIR)
+    assert f"Stale or broken venv console scripts ({display}):" in captured.out
     assert "flake8" in captured.out
     assert "broken or dangling symlink" in captured.out
 
@@ -330,20 +336,73 @@ def test_collect_broken_console_wrappers_reports_resolve_runtimeerror(
     wrapper.write_text(f"#!{interp}\n", encoding="utf-8")
     os.chmod(wrapper, 0o755)
 
-    real_resolve = Path.resolve
-
-    def resolve_with_loop(self: Path, *args: object, **kwargs: object) -> Path:
-        if self == interp:
+    def resolve_with_loop(path: Path) -> Path:
+        if path == interp:
             raise RuntimeError("symlink loop")
-        return real_resolve(self, *args, **kwargs)
+        return path.resolve()
 
-    monkeypatch.setattr(Path, "resolve", resolve_with_loop)
+    monkeypatch.setattr(env_gate, "_resolve_interpreter_path", resolve_with_loop)
 
     out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
     assert len(out) == 1
     assert out[0][0] == "flake8"
     assert "resolve error" in out[0][1]
     assert "symlink loop" in out[0][1]
+
+
+def test_collect_broken_console_wrappers_reports_empty_script(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "flake8"
+    wrapper.write_text("", encoding="utf-8")
+    os.chmod(wrapper, 0o755)
+
+    out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
+    assert out == [("flake8", "empty script")]
+
+
+def test_collect_broken_console_wrappers_reports_not_regular_file(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "flake8"
+    wrapper.mkdir()
+
+    out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
+    assert out == [("flake8", "not a regular file")]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX chmod executable bit")
+def test_collect_broken_console_wrappers_reports_non_executable_interpreter(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    interp = tmp_path / "interp"
+    interp.write_text("", encoding="utf-8")
+    os.chmod(interp, 0o644)
+    wrapper = bin_dir / "flake8"
+    wrapper.write_text(f"#!{interp}\n", encoding="utf-8")
+    os.chmod(wrapper, 0o755)
+
+    out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
+    assert len(out) == 1
+    assert out[0][0] == "flake8"
+    assert "not executable" in out[0][1]
+
+
+def test_collect_broken_console_wrappers_strips_utf8_bom_before_shebang_parse(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "flake8"
+    wrapper.write_text("\ufeff#!/no_such_interpreter_verify_env_test\n", encoding="utf-8")
+    os.chmod(wrapper, 0o755)
+
+    out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
+    assert len(out) == 1
+    assert out[0][0] == "flake8"
+    assert "stale shebang interpreter missing" in out[0][1]
 
 
 def test_main_fails_when_unexpected_startup_hook_is_present(

--- a/tests/test_check_local_verify_environment.py
+++ b/tests/test_check_local_verify_environment.py
@@ -317,6 +317,35 @@ def test_collect_broken_console_wrappers_ignores_env_shebang(tmp_path: Path) -> 
     assert env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir) == []
 
 
+def test_collect_broken_console_wrappers_reports_resolve_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Broken venvs may trigger RuntimeError from Path.resolve() on interpreter loops."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    interp = tmp_path / "interp"
+    interp.touch()
+    wrapper = bin_dir / "flake8"
+    wrapper.write_text(f"#!{interp}\n", encoding="utf-8")
+    os.chmod(wrapper, 0o755)
+
+    real_resolve = Path.resolve
+
+    def resolve_with_loop(self: Path, *args: object, **kwargs: object) -> Path:
+        if self == interp:
+            raise RuntimeError("symlink loop")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", resolve_with_loop)
+
+    out = env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir)
+    assert len(out) == 1
+    assert out[0][0] == "flake8"
+    assert "resolve error" in out[0][1]
+    assert "symlink loop" in out[0][1]
+
+
 def test_main_fails_when_unexpected_startup_hook_is_present(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_check_local_verify_environment.py
+++ b/tests/test_check_local_verify_environment.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
 import re
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -35,6 +37,7 @@ def test_collect_missing_modules_returns_only_failed_imports(
 def test_build_failure_output_includes_recovery_commands() -> None:
     lines = env_gate.build_failure_output(
         python_executable=Path("/tmp/.venv/bin/python"),
+        broken_console_wrappers=[],
         missing_modules=[
             (
                 "diff_cover.diff_cover_tool",
@@ -50,6 +53,21 @@ def test_build_failure_output_includes_recovery_commands() -> None:
     assert any("make venv" in line for line in lines)
     assert any("make venv-sync" in line for line in lines)
     assert "Missing verify-critical Python modules:" in lines
+
+
+def test_build_failure_output_includes_broken_console_wrappers() -> None:
+    lines = env_gate.build_failure_output(
+        python_executable=Path("/tmp/.venv/bin/python"),
+        broken_console_wrappers=[
+            ("flake8", "stale shebang interpreter missing: /tmp/deleted-python")
+        ],
+        missing_modules=[],
+        unexpected_startup_hooks=[],
+    )
+
+    assert "Stale or broken venv console scripts (.venv/bin):" in lines
+    assert "- flake8 :: stale shebang interpreter missing: /tmp/deleted-python" in lines
+    assert any("make venv-sync" in line for line in lines)
 
 
 def test_collect_unexpected_startup_hooks_uses_guard_subprocess(
@@ -161,6 +179,7 @@ def test_main_fails_when_verify_dependencies_are_missing(
         ],
     )
     monkeypatch.setattr(env_gate, "collect_unexpected_startup_hooks", lambda: [])
+    monkeypatch.setattr(env_gate, "collect_broken_console_wrappers", lambda: [])
 
     result = env_gate.main()
 
@@ -194,7 +213,7 @@ def test_main_passes_when_venv_and_dependencies_are_ready(
     assert "verify-env: local verify environment passed." in captured.out
 
 
-def test_main_ignores_stale_console_wrapper_when_module_parity_is_healthy(
+def test_main_fails_when_console_wrapper_has_stale_absolute_shebang(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
@@ -204,6 +223,7 @@ def test_main_ignores_stale_console_wrapper_when_module_parity_is_healthy(
     fake_python.parent.mkdir(parents=True)
     fake_python.write_text("", encoding="utf-8")
     stale_wrapper.write_text("#!/tmp/deleted-python\nprint('stale')\n", encoding="utf-8")
+    os.chmod(stale_wrapper, 0o755)
 
     monkeypatch.setattr(env_gate, "VENV_PYTHON", fake_python)
     monkeypatch.setattr(env_gate, "VENV_DIR", fake_python.parent.parent)
@@ -215,9 +235,86 @@ def test_main_ignores_stale_console_wrapper_when_module_parity_is_healthy(
 
     result = env_gate.main()
 
-    assert result == 0
+    assert result == 1
     captured = capsys.readouterr()
-    assert "verify-env: local verify environment passed." in captured.out
+    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    assert "flake8" in captured.out
+    assert "stale shebang interpreter missing" in captured.out
+
+
+def test_main_fails_when_console_wrapper_is_not_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    fake_python = tmp_path / ".venv" / "bin" / "python"
+    flake8_wrapper = tmp_path / ".venv" / "bin" / "flake8"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.write_text("", encoding="utf-8")
+    flake8_wrapper.write_text(f"#!{fake_python}\n", encoding="utf-8")
+    os.chmod(flake8_wrapper, 0o644)
+
+    monkeypatch.setattr(env_gate, "VENV_PYTHON", fake_python)
+    monkeypatch.setattr(env_gate, "VENV_DIR", fake_python.parent.parent)
+    monkeypatch.setattr(env_gate, "VENV_BIN_DIR", fake_python.parent)
+    monkeypatch.setattr(env_gate.sys, "executable", str(fake_python))
+    monkeypatch.setattr(env_gate.sys, "prefix", str(fake_python.parent.parent))
+    monkeypatch.setattr(env_gate, "collect_missing_modules", lambda: [])
+    monkeypatch.setattr(env_gate, "collect_unexpected_startup_hooks", lambda: [])
+
+    result = env_gate.main()
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    assert "flake8" in captured.out
+    assert "not executable" in captured.out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink and mode semantics")
+def test_main_fails_when_console_wrapper_is_dangling_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    fake_python = tmp_path / ".venv" / "bin" / "python"
+    flake8_wrapper = tmp_path / ".venv" / "bin" / "flake8"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.write_text("", encoding="utf-8")
+    flake8_wrapper.symlink_to(tmp_path / "nonexistent-console-target")
+
+    monkeypatch.setattr(env_gate, "VENV_PYTHON", fake_python)
+    monkeypatch.setattr(env_gate, "VENV_DIR", fake_python.parent.parent)
+    monkeypatch.setattr(env_gate, "VENV_BIN_DIR", fake_python.parent)
+    monkeypatch.setattr(env_gate.sys, "executable", str(fake_python))
+    monkeypatch.setattr(env_gate.sys, "prefix", str(fake_python.parent.parent))
+    monkeypatch.setattr(env_gate, "collect_missing_modules", lambda: [])
+    monkeypatch.setattr(env_gate, "collect_unexpected_startup_hooks", lambda: [])
+
+    result = env_gate.main()
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "Stale or broken venv console scripts (.venv/bin):" in captured.out
+    assert "flake8" in captured.out
+    assert "broken or dangling symlink" in captured.out
+
+
+def test_collect_broken_console_wrappers_skips_missing_scripts(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+
+    assert env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir) == []
+
+
+def test_collect_broken_console_wrappers_ignores_env_shebang(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "flake8"
+    wrapper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    os.chmod(wrapper, 0o755)
+
+    assert env_gate.collect_broken_console_wrappers(venv_bin_dir=bin_dir) == []
 
 
 def test_main_fails_when_unexpected_startup_hook_is_present(
@@ -235,6 +332,7 @@ def test_main_fails_when_unexpected_startup_hook_is_present(
     monkeypatch.setattr(env_gate.sys, "executable", str(fake_python))
     monkeypatch.setattr(env_gate.sys, "prefix", str(fake_python.parent.parent))
     monkeypatch.setattr(env_gate, "collect_missing_modules", lambda: [])
+    monkeypatch.setattr(env_gate, "collect_broken_console_wrappers", lambda: [])
     monkeypatch.setattr(
         env_gate,
         "collect_unexpected_startup_hooks",


### PR DESCRIPTION
## Summary
Closes the false-green gap where `verify-env` passed while broken `.venv/bin` console scripts (stale shebang after worktree removal, non-executable wrappers, dangling symlinks) could still break PATH-based or hook-driven runs.

## Changes
- `scripts/ci/check_local_verify_environment.py`: validate **present** wrappers for `flake8`, `pytest`, `mypy`, `coverage`, `diff-cover`; missing scripts allowed; `#!/usr/bin/env` shebangs not validated (v1).
- Tests: regression coverage for stale shebang, non-executable, dangling symlink (POSIX).
- Docs: `AGENTS.md`, `RUNBOOK_AGENT.md`; `BACKLOG_LEDGER.md` links + status note for `ledger-p0-verify-env-wrapper-parity` (checkbox closed via same-day docs-only PR after merge per policy).

## Validation
```bash
pre-commit run --all-files
make verify
```
(Local `make verify` was green on the implementation branch before push.)

## Deferred / Follow-ups
- After merge: **docs-only PR** to tick `ledger-p0-verify-env-wrapper-parity` and set Target PR.
- Optional separate PR: `scripts/run-backend-tests-pre-commit.sh` could prefer `.venv/bin/python -m pytest` over bare `pytest` on PATH.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

## Merge readiness
Canonical mapping: [`docs/review/PR_1357_FIXED_MAPPING.md`](docs/review/PR_1357_FIXED_MAPPING.md) — update thread dispositions as bots comment.

### Fixed in Commit Mapping
Mirror: see canonical artifact [`docs/review/PR_1357_FIXED_MAPPING.md`](docs/review/PR_1357_FIXED_MAPPING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded verification docs with stricter preflight guidance, console‑script integrity notes, new review artifact, and roadmap/ledger updates.
* **Bug Fixes**
  * Verification now fails for present-but-broken venv console scripts (non-executable, dangling symlinks, invalid interpreters) and shows per-script diagnostics and recovery hints.
* **Tests**
  * Added and updated unit tests covering broken-wrapper detection and failure-report formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
