### PR TITLE
feat(food): snapshot size check and verify_recorded_snapshots

### DIFF
--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -203,6 +203,21 @@ class SnapshotManager:
                 f"Invalid latest snapshot date for source={source}"
             ) from exc
 
+    def _resolve_manifest_snapshot_path(self, source: str, file_field: str) -> Path:
+        """
+        Resolve a manifest ``file`` field to an absolute path.
+
+        RU: Относительные пути считаются относительно каталога манифеста источника
+        (стабильно при смене CWD процесса).
+        EN: Relative paths are resolved against the source manifest directory so
+        re-validation does not depend on process working directory.
+        """
+        manifest_parent = self._manifest_path(source).parent
+        candidate = Path(file_field)
+        if candidate.is_absolute():
+            return candidate.resolve()
+        return (manifest_parent / candidate).resolve()
+
     def validate_snapshot(self, meta: SnapshotMeta) -> None:
         """Fail-closed integrity validation before manifest update."""
         if not meta.file_path.exists():
@@ -233,7 +248,7 @@ class SnapshotManager:
         data = self._load_manifest(source)
         snapshots = data["snapshots"]
         for snapshot in snapshots:
-            path = Path(snapshot["file"])
+            path = self._resolve_manifest_snapshot_path(source, snapshot["file"])
             try:
                 snap_date = date.fromisoformat(snapshot["date"])
             except ValueError as exc:

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -207,12 +207,50 @@ class SnapshotManager:
         """Fail-closed integrity validation before manifest update."""
         if not meta.file_path.exists():
             raise SnapshotIntegrityError(f"Snapshot file does not exist: {meta.file_path}")
+        actual_size = meta.file_path.stat().st_size
+        if actual_size != meta.size_bytes:
+            raise SnapshotIntegrityError(
+                "Size mismatch for snapshot "
+                f"{meta.file_path}: expected_bytes={meta.size_bytes} actual_bytes={actual_size}"
+            )
         actual_checksum = sha256_file(meta.file_path)
         if actual_checksum != meta.checksum_sha256:
             raise SnapshotIntegrityError(
                 "Checksum mismatch for snapshot "
                 f"{meta.file_path}: expected={meta.checksum_sha256} actual={actual_checksum}"
             )
+
+    def verify_recorded_snapshots(self, source: str) -> int:
+        """
+        Re-validate every manifest entry for ``source`` against on-disk bytes.
+
+        RU: Повторная проверка всех записей манифеста (fail-closed).
+        EN: Fail-closed re-validation of manifest entries (checksum + size).
+
+        Returns:
+            Number of snapshot entries verified.
+        """
+        data = self._load_manifest(source)
+        snapshots = data["snapshots"]
+        for snapshot in snapshots:
+            path = Path(snapshot["file"])
+            try:
+                snap_date = date.fromisoformat(snapshot["date"])
+            except ValueError as exc:
+                raise SnapshotIntegrityError(
+                    f"Invalid snapshot date in manifest for source={source}: {snapshot['date']}"
+                ) from exc
+            meta = SnapshotMeta(
+                source=source,
+                snapshot_date=snap_date,
+                file_path=path,
+                checksum_sha256=snapshot["checksum"],
+                record_count=int(snapshot["records"]),
+                size_bytes=int(snapshot["bytes"]),
+                mode=str(snapshot["mode"]),
+            )
+            self.validate_snapshot(meta)
+        return len(snapshots)
 
     def record_snapshot(self, meta: SnapshotMeta) -> None:
         """Persist snapshot metadata entry into source manifest."""

--- a/docs/review/PR_1360_FIXED_MAPPING.md
+++ b/docs/review/PR_1360_FIXED_MAPPING.md
@@ -8,7 +8,14 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 464ab151
+Evidence: `core/food_sources/snapshot_manager.py`: `_resolve_manifest_snapshot_path` resolves relative manifest `file` values against the source manifest directory; `verify_recorded_snapshots` uses it so verification is not CWD-dependent. Tests: `test_verify_recorded_snapshots_resolves_relative_manifest_paths`, `test_record_snapshot_size_mismatch_leaves_manifest_unchanged`. Manifest list/entry schema remains fail-closed via `_load_manifest` (`SnapshotIntegrityError`).
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1360#pullrequestreview-4062160978 -> 464ab151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1360#discussion_r3039621183 -> 464ab151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1360#pullrequestreview-4062174939 -> 464ab151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1360#pullrequestreview-4062189376 -> 464ab151
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1360#discussion_r3039631946 -> 464ab151
 
 ## Merge Readiness
 
@@ -18,6 +25,6 @@
 - [ ] Pre-commit green
 - [ ] `make verify` green locally
 
-Notes: Update this artifact when bots or humans leave actionable comments (map each thread per repo disposition rules). If bots report findings, replace `No actionable review comments` with URL lines and disposition proof.
+Notes: Resolve GitHub review threads after this mapping push; re-run merge-readiness locally with `GITHUB_TOKEN`.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1360_FIXED_MAPPING.md
+++ b/docs/review/PR_1360_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1360 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: Update this artifact when bots or humans leave actionable comments (map each thread per repo disposition rules). If bots report findings, replace `No actionable review comments` with URL lines and disposition proof.
+
+<!-- markdownlint-enable MD034 -->

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -365,6 +365,61 @@ def test_snapshot_manager_size_mismatch_fails_closed(tmp_path: Path) -> None:
         manager.validate_snapshot(bad_meta)
 
 
+def test_record_snapshot_size_mismatch_leaves_manifest_unchanged(tmp_path: Path) -> None:
+    """RU/EN: ``record_snapshot`` must fail closed on size mismatch without writing manifest."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snapshot_file = tmp_path / "rsz" / "2026-02-24" / "f.bin"
+    snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_file.write_bytes(b"abc")
+    bad_meta = SnapshotMeta(
+        source="rsz",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snapshot_file,
+        checksum_sha256=sha256_file(snapshot_file),
+        record_count=1,
+        size_bytes=999,
+        mode="full",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="Size mismatch"):
+        manager.record_snapshot(bad_meta)
+    assert not (tmp_path / "rsz" / "manifest.json").exists()
+
+
+def test_verify_recorded_snapshots_resolves_relative_manifest_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Relative ``file`` entries must resolve against manifest dir, not process CWD."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_name = "rel"
+    day_dir = tmp_path / source_name / "2026-02-24"
+    day_dir.mkdir(parents=True)
+    snap_file = day_dir / "data.bin"
+    snap_file.write_bytes(b"hello")
+    manifest_path = tmp_path / source_name / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": source_name,
+                "snapshots": [
+                    {
+                        "date": "2026-02-24",
+                        "file": "2026-02-24/data.bin",
+                        "checksum": sha256_file(snap_file),
+                        "records": 1,
+                        "bytes": snap_file.stat().st_size,
+                        "mode": "full",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    other_cwd = tmp_path / "other_cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    assert manager.verify_recorded_snapshots(source_name) == 1
+
+
 def test_verify_recorded_snapshots_revalidates_manifest(tmp_path: Path) -> None:
     """``verify_recorded_snapshots`` should load manifest and validate each entry."""
     manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -345,3 +345,100 @@ def test_snapshot_manager_record_snapshot_dedup_and_ordering(tmp_path: Path) -> 
     assert len(snapshots) == 3
     keys = [(row["date"], row["file"], row["mode"]) for row in snapshots]
     assert keys == sorted(keys)
+
+
+def test_snapshot_manager_size_mismatch_fails_closed(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snapshot_file = tmp_path / "sz" / "2026-02-24" / "f.bin"
+    snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_file.write_bytes(b"abc")
+    bad_meta = SnapshotMeta(
+        source="sz",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snapshot_file,
+        checksum_sha256=sha256_file(snapshot_file),
+        record_count=1,
+        size_bytes=999,
+        mode="full",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="Size mismatch"):
+        manager.validate_snapshot(bad_meta)
+
+
+def test_verify_recorded_snapshots_revalidates_manifest(tmp_path: Path) -> None:
+    """``verify_recorded_snapshots`` should load manifest and validate each entry."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+    assert manager.verify_recorded_snapshots("dummy") == 1
+
+
+def test_verify_recorded_snapshots_detects_tampering(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source = _DummySource(name="dummy", full_payload=b"full", delta_payload=b"delta")
+    assert manager.sync_if_needed(source) is not None
+    manifest = json.loads((tmp_path / "dummy" / "manifest.json").read_text(encoding="utf-8"))
+    fpath = Path(manifest["snapshots"][0]["file"])
+    fpath.write_bytes(b"tampered")
+    with pytest.raises(SnapshotIntegrityError):
+        manager.verify_recorded_snapshots("dummy")
+
+
+def test_verify_recorded_snapshots_invalid_date_fails_closed(tmp_path: Path) -> None:
+    """Bad ISO date strings in manifest entries must raise ``SnapshotIntegrityError``."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_dir = tmp_path / "bad-dates"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = source_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": "bad-dates",
+                "snapshots": [
+                    {
+                        "date": "not-a-valid-iso-date",
+                        "file": str(source_dir / "x.bin"),
+                        "checksum": "0" * 64,
+                        "records": 1,
+                        "bytes": 0,
+                        "mode": "full",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="Invalid snapshot date"):
+        manager.verify_recorded_snapshots("bad-dates")
+
+
+def test_verify_recorded_snapshots_size_mismatch_fails_closed(tmp_path: Path) -> None:
+    """Manifest ``bytes`` must match on-disk file size during re-validation."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_dir = tmp_path / "size-mismatch"
+    snap_dir = source_dir / "2026-02-24"
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    snap_file = snap_dir / "full.bin"
+    snap_file.write_bytes(b"abc")
+
+    manifest_path = source_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": "size-mismatch",
+                "snapshots": [
+                    {
+                        "date": "2026-02-24",
+                        "file": str(snap_file),
+                        "checksum": sha256_file(snap_file),
+                        "records": 1,
+                        "bytes": 999,
+                        "mode": "full",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="Size mismatch"):
+        manager.verify_recorded_snapshots("size-mismatch")


### PR DESCRIPTION
## Summary
Fail-closed integrity for recorded food snapshots: `validate_snapshot` now rejects on-disk size mismatch vs manifest `meta.size_bytes`, and `verify_recorded_snapshots(source)` re-validates all manifest entries for a source.

## Scope
**In:** `core/food_sources/snapshot_manager.py`, `tests/test_food_sources_snapshot_manager.py` only.

**Out:** W1 raw sync delegate, `update_manager` wiring, `build_food_db`, docs strategy updates — tracked separately (see Deferred).

## Local validation
```bash
python3 scripts/orchestration/check_preflight.py   # PASS (scoped AGENTS warning acceptable)
pre-commit run --all-files                         # PASS
make verify                                        # PASS (lint, typecheck, tests, diff-cov gate)
```

Diff-cover output (excerpt): Total diff lines covered per gate; `make verify` completed with success.

## Deferred / Follow-ups
- Broader W1 OFF raw snapshot pipeline (`snapshot_sync`, `sync_openfoodfacts_raw_snapshot`, gates) remains on branch `feat/food-snapshot-verify-recorded` / separate PR — not mixed here.
- Restore local WIP from `/tmp/food-wip-backup*` if needed (untracked scripts/tests moved aside for clean `make verify`).

## Merge readiness
Not claimed: wait for CI on this PR head and resolve review threads per repo governance.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Обеспечить принцип fail-closed для целостности снапшотов еды, ужесточив проверку снапшотов и добавив точку входа для повторной проверки манифеста.

Bug Fixes:
- Отклонять снапшоты, размер файлов на диске которых не совпадает с размером, записанным в метаданных снапшота или манифестах.
- Гарантировать, что записи манифеста с некорректными датами снапшотов вызывают явную ошибку целостности, вместо того чтобы приниматься молча.

Enhancements:
- Ввести API `verify_recorded_snapshots` для повторной валидации всех записанных снапшотов для источника по сравнению с файлами на диске, включая проверку контрольных сумм и размеров.

Tests:
- Добавить тесты, покрывающие несовпадения размеров при валидации снапшотов и повторной проверке манифеста, обнаружение подменённых файлов снапшотов и некорректных дат в манифесте.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce fail-closed integrity for food snapshots by tightening snapshot validation and adding a manifest re-verification entrypoint.

Bug Fixes:
- Reject snapshots whose on-disk file size does not match the size recorded in snapshot metadata or manifests.
- Ensure manifest entries with invalid snapshot dates raise an explicit integrity error instead of being silently accepted.

Enhancements:
- Introduce a verify_recorded_snapshots API to re-validate all recorded snapshots for a source against on-disk files, including checksum and size checks.

Tests:
- Add tests covering size mismatches during snapshot validation and manifest re-verification, detection of tampered snapshot files, and invalid manifest dates.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fail-closed integrity checks for food snapshots and a helper to re-validate recorded entries. Re-verification now resolves manifest file paths relative to the manifest directory to avoid CWD-dependent failures.

- **New Features**
  - `validate_snapshot` now compares on-disk size to manifest `meta.size_bytes` and raises `SnapshotIntegrityError` on mismatch (before checksum).
  - Added `verify_recorded_snapshots(source)` to reload the manifest and re-validate each entry (ISO date, size, checksum). Returns the number of snapshots verified.

- **Bug Fixes**
  - `verify_recorded_snapshots` resolves relative manifest `file` paths against the source manifest directory, making checks independent of the process CWD.

<sup>Written for commit cd6a07970d8659948dc2a73a604b519f1ea88afc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verification tool to re-validate all recorded snapshots against their manifest entries.

* **Bug Fixes**
  * Fail-closed check for on-disk file size to detect corruption before checksum validation.
  * Stronger detection of tampering or checksum mismatches.
  * Strict validation of snapshot date formats and manifest consistency.

* **Documentation**
  * Added review notes documenting the fix and verification behavior.

* **Tests**
  * Expanded tests covering size checks, path resolution, revalidation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1360_FIXED_MAPPING.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1360_FIXED_MAPPING.md`
