### PR TITLE
feat(food): W1 OFF raw snapshot verify, sync, build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,7 +650,9 @@ jobs:
                   tests/test_unified_db_basics.py \
                   tests/test_unified_db_off_coverage.py \
                   tests/test_food_merge.py \
-                  tests/edges/test_unified_db_off_flags.py
+                  tests/edges/test_unified_db_off_flags.py \
+                  tests/test_food_apis_snapshot_w1.py \
+                  tests/test_food_sources_snapshot_manager.py
                 ;;
               route_contract_safety)
                 add_suite \

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,11 @@ ehthumbs.db
 Thumbs.db
 
 # Project specific
+# Local raw food dumps (W1); keep snapshots README only
+data/raw/*
+!data/raw/snapshots/
+data/raw/snapshots/*
+!data/raw/snapshots/README.md
 # Generated analysis artifacts
 bayesian_quality_report.json
 bayesian_analysis_results.json

--- a/core/food_apis/raw_snapshot_gate.py
+++ b/core/food_apis/raw_snapshot_gate.py
@@ -8,7 +8,6 @@ EN: Manifest + on-disk verification gate before database build.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from core.food_sources.snapshot_manager import SnapshotIntegrityError, SnapshotManager
 
@@ -19,7 +18,7 @@ def validate_off_raw_manifest_gate(
     project_root: Path,
     enabled: bool,
     snapshot_root: Path | None = None,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """
     When ``enabled`` is False, return a disabled marker dict.
 

--- a/core/food_apis/raw_snapshot_gate.py
+++ b/core/food_apis/raw_snapshot_gate.py
@@ -1,0 +1,51 @@
+"""
+Fail-closed gate: verify recorded OFF raw snapshots before heavy DB build steps.
+
+RU: Проверка манифеста/файлов OFF до сборки БД.
+EN: Manifest + on-disk verification gate before database build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from core.food_sources.snapshot_manager import SnapshotIntegrityError, SnapshotManager
+
+from .snapshot_sync import default_raw_snapshot_root
+
+
+def validate_off_raw_manifest_gate(
+    project_root: Path,
+    enabled: bool,
+    snapshot_root: Path | None = None,
+) -> dict[str, Any]:
+    """
+    When ``enabled`` is False, return a disabled marker dict.
+
+    When enabled and ``off/manifest.json`` is missing under the snapshot root, return
+    ``status=skipped``. Otherwise run :meth:`SnapshotManager.verify_recorded_snapshots`
+    for source ``off`` and return ``status=verified``.
+    """
+    if not enabled:
+        return {"enabled": False}
+    root = snapshot_root if snapshot_root is not None else default_raw_snapshot_root(project_root)
+    manifest_path = root / "off" / "manifest.json"
+    if not manifest_path.is_file():
+        return {
+            "enabled": True,
+            "status": "skipped",
+            "reason": "missing_off_manifest",
+            "root": str(root),
+        }
+    try:
+        manager = SnapshotManager(root)
+        checked = manager.verify_recorded_snapshots("off")
+    except SnapshotIntegrityError as exc:
+        raise SnapshotIntegrityError(f"OFF raw snapshot gate failed: {exc}") from exc
+    return {
+        "enabled": True,
+        "status": "verified",
+        "snapshots_checked": checked,
+        "root": str(root),
+    }

--- a/core/food_apis/raw_snapshot_gate.py
+++ b/core/food_apis/raw_snapshot_gate.py
@@ -18,19 +18,33 @@ def validate_off_raw_manifest_gate(
     project_root: Path,
     enabled: bool,
     snapshot_root: Path | None = None,
+    *,
+    strict: bool = False,
 ) -> dict[str, object]:
     """
     When ``enabled`` is False, return a disabled marker dict.
 
-    When enabled and ``off/manifest.json`` is missing under the snapshot root, return
-    ``status=skipped``. Otherwise run :meth:`SnapshotManager.verify_recorded_snapshots`
+    When enabled and ``off/manifest.json`` is missing under the snapshot root:
+    if ``strict`` is True (e.g. ``build_food_db --validate-raw-snapshots``), raise
+    :class:`SnapshotIntegrityError`; otherwise return ``status=skipped`` for optional checks.
+
+    When the manifest exists, run :meth:`SnapshotManager.verify_recorded_snapshots`
     for source ``off`` and return ``status=verified``.
     """
     if not enabled:
         return {"enabled": False}
-    root = snapshot_root if snapshot_root is not None else default_raw_snapshot_root(project_root)
+    root = (
+        snapshot_root.expanduser().resolve()
+        if snapshot_root is not None
+        else default_raw_snapshot_root(project_root)
+    )
     manifest_path = root / "off" / "manifest.json"
     if not manifest_path.is_file():
+        if strict:
+            raise SnapshotIntegrityError(
+                "OFF raw snapshot gate failed: missing off/manifest.json under "
+                f"{root} (strict validation requires a recorded manifest)"
+            )
         return {
             "enabled": True,
             "status": "skipped",

--- a/core/food_apis/raw_snapshot_gate.py
+++ b/core/food_apis/raw_snapshot_gate.py
@@ -7,6 +7,7 @@ EN: Manifest + on-disk verification gate before database build.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from core.food_sources.snapshot_manager import SnapshotIntegrityError, SnapshotManager
@@ -56,6 +57,12 @@ def validate_off_raw_manifest_gate(
         checked = manager.verify_recorded_snapshots("off")
     except SnapshotIntegrityError as exc:
         raise SnapshotIntegrityError(f"OFF raw snapshot gate failed: {exc}") from exc
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        # RU: Битый манифест / I/O не должны «протекать» сырым traceback из CLI.
+        # EN: Map parse/read failures to the same gate contract as integrity errors.
+        raise SnapshotIntegrityError(
+            f"OFF raw snapshot gate failed: cannot read off/manifest.json under {root}: {exc}"
+        ) from exc
     return {
         "enabled": True,
         "status": "verified",

--- a/core/food_apis/snapshot_sync.py
+++ b/core/food_apis/snapshot_sync.py
@@ -1,0 +1,46 @@
+"""
+Sync Open Food Facts raw snapshots into the local raw snapshot tree.
+
+RU: Синхронизация сырых снапшотов OFF в ``data/raw/snapshots`` (или корень из env).
+EN: Sync OFF raw snapshots under ``data/raw/snapshots`` (or env-configured root).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+from typing import Callable
+
+from core.food_sources.off_delta import OFFTransport, OpenFoodFactsDeltaSource
+from core.food_sources.snapshot_manager import SnapshotManager, SnapshotMeta
+
+
+def default_raw_snapshot_root(project_root: Path | None = None) -> Path:
+    """Return canonical raw snapshot root (env override or ``<project>/data/raw/snapshots``)."""
+    env = os.environ.get("PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    root = project_root if project_root is not None else Path(__file__).resolve().parents[2]
+    return (root / "data" / "raw" / "snapshots").resolve()
+
+
+def sync_openfoodfacts_snapshot(
+    raw_root: Path | None = None,
+    *,
+    project_root: Path | None = None,
+    force: bool = False,
+    transport: OFFTransport | None = None,
+    today_provider: Callable[[], date] | None = None,
+) -> SnapshotMeta | None:
+    """
+    Pull OFF snapshot via :class:`OpenFoodFactsDeltaSource` into the raw tree.
+
+    When ``raw_root`` is omitted, uses :func:`default_raw_snapshot_root`.
+    """
+    resolved = (
+        raw_root.resolve() if raw_root is not None else default_raw_snapshot_root(project_root)
+    )
+    manager = SnapshotManager(resolved)
+    source = OpenFoodFactsDeltaSource(transport=transport, today_provider=today_provider)
+    return manager.sync_if_needed(source, force=force)

--- a/core/food_apis/snapshot_sync.py
+++ b/core/food_apis/snapshot_sync.py
@@ -43,6 +43,6 @@ def sync_openfoodfacts_snapshot(
         if raw_root is not None
         else default_raw_snapshot_root(project_root)
     )
-    manager = SnapshotManager(resolved)
+    manager = SnapshotManager(resolved, today_provider=today_provider)
     source = OpenFoodFactsDeltaSource(transport=transport, today_provider=today_provider)
     return manager.sync_if_needed(source, force=force)

--- a/core/food_apis/snapshot_sync.py
+++ b/core/food_apis/snapshot_sync.py
@@ -39,7 +39,9 @@ def sync_openfoodfacts_snapshot(
     When ``raw_root`` is omitted, uses :func:`default_raw_snapshot_root`.
     """
     resolved = (
-        raw_root.resolve() if raw_root is not None else default_raw_snapshot_root(project_root)
+        raw_root.expanduser().resolve()
+        if raw_root is not None
+        else default_raw_snapshot_root(project_root)
     )
     manager = SnapshotManager(resolved)
     source = OpenFoodFactsDeltaSource(transport=transport, today_provider=today_provider)

--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -18,9 +18,10 @@ import logging
 import re
 import unicodedata
 from dataclasses import asdict, dataclass, is_dataclass
-from datetime import timedelta
+from datetime import date, timedelta
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -31,7 +32,13 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
+    cast,
 )
+
+from core.food_sources.snapshot_manager import SnapshotMeta
+
+if TYPE_CHECKING:
+    from core.food_sources.off_delta import OFFTransport
 
 from .openfoodfacts_client import OFF_AVAILABLE, OFFClient
 from .unified_db import UnifiedFoodDatabase, UnifiedFoodItem
@@ -216,6 +223,31 @@ class DatabaseUpdateManager:
 
         except Exception as e:
             logger.error("Error saving versions: %s", e, exc_info=True)
+
+    def sync_openfoodfacts_raw_snapshot(
+        self,
+        raw_root: str | Path | None = None,
+        *,
+        force: bool = False,
+        transport: "OFFTransport | None" = None,
+        today_provider: Callable[[], date] | None = None,
+    ) -> SnapshotMeta | None:
+        """
+        Sync OFF raw snapshots into the canonical raw tree (lazy import of sync module).
+
+        RU: Делегирует загрузку сырого снапшота OFF в ``snapshot_sync``.
+        EN: Delegates OFF raw snapshot sync to :mod:`core.food_apis.snapshot_sync`.
+        """
+        from . import snapshot_sync
+
+        root = Path(raw_root) if raw_root is not None else None
+        return snapshot_sync.sync_openfoodfacts_snapshot(
+            root,
+            project_root=None,
+            force=force,
+            transport=transport,
+            today_provider=today_provider,
+        )
 
     def _calculate_checksum(self, data: Dict[str, Any]) -> str:
         """Calculate checksum for data integrity."""
@@ -1072,7 +1104,7 @@ async def get_update_status() -> dict[str, object]:
     scheduler = scheduler_mod._scheduler_instance
     if scheduler is None:
         return _empty_scheduler_status()
-    return scheduler.get_status()
+    return cast(dict[str, object], scheduler.get_status())
 
 
 def __getattr__(name: str) -> object:

--- a/core/food_apis/update_manager.py
+++ b/core/food_apis/update_manager.py
@@ -228,6 +228,7 @@ class DatabaseUpdateManager:
         self,
         raw_root: str | Path | None = None,
         *,
+        project_root: Path | None = None,
         force: bool = False,
         transport: "OFFTransport | None" = None,
         today_provider: Callable[[], date] | None = None,
@@ -237,13 +238,15 @@ class DatabaseUpdateManager:
 
         RU: Делегирует загрузку сырого снапшота OFF в ``snapshot_sync``.
         EN: Delegates OFF raw snapshot sync to :mod:`core.food_apis.snapshot_sync`.
+        When ``raw_root`` is None, ``project_root`` selects the default snapshot tree
+        (same semantics as :func:`snapshot_sync.default_raw_snapshot_root`).
         """
         from . import snapshot_sync
 
         root = Path(raw_root) if raw_root is not None else None
         return snapshot_sync.sync_openfoodfacts_snapshot(
             root,
-            project_root=None,
+            project_root=project_root,
             force=force,
             transport=transport,
             today_provider=today_provider,

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -208,27 +208,49 @@ class SnapshotManager:
         Resolve a manifest ``file`` field to an absolute path.
 
         RU: Относительные пути считаются относительно каталога манифеста источника
-        (стабильно при смене CWD процесса).
+        (стабильно при смене CWD процесса). Путь не должен выходить за пределы
+        ``base_path / source`` (защита от ``..`` и абсолютных путей вне дерева).
         EN: Relative paths are resolved against the source manifest directory so
-        re-validation does not depend on process working directory.
+        re-validation does not depend on process working directory. Resolved paths
+        must stay under ``base_path / source`` (no ``..`` / absolute escape).
         """
         manifest_parent = self._manifest_path(source).parent
+        source_root = manifest_parent.resolve()
         candidate = Path(file_field)
         if candidate.is_absolute():
-            return candidate.resolve()
-        return (manifest_parent / candidate).resolve()
+            resolved = candidate.resolve()
+        else:
+            resolved = (manifest_parent / candidate).resolve()
+        try:
+            resolved.relative_to(source_root)
+        except ValueError as exc:
+            raise SnapshotIntegrityError(
+                "Manifest snapshot path escapes source root for "
+                f"source={source!r}: {file_field!r}"
+            ) from exc
+        return resolved
 
     def validate_snapshot(self, meta: SnapshotMeta) -> None:
         """Fail-closed integrity validation before manifest update."""
-        if not meta.file_path.exists():
+        try:
+            exists = meta.file_path.exists()
+        except OSError as exc:
+            raise SnapshotIntegrityError(f"Snapshot file not accessible: {meta.file_path}") from exc
+        if not exists:
             raise SnapshotIntegrityError(f"Snapshot file does not exist: {meta.file_path}")
-        actual_size = meta.file_path.stat().st_size
+        try:
+            actual_size = meta.file_path.stat().st_size
+        except OSError as exc:
+            raise SnapshotIntegrityError(f"Snapshot file not accessible: {meta.file_path}") from exc
         if actual_size != meta.size_bytes:
             raise SnapshotIntegrityError(
                 "Size mismatch for snapshot "
                 f"{meta.file_path}: expected_bytes={meta.size_bytes} actual_bytes={actual_size}"
             )
-        actual_checksum = sha256_file(meta.file_path)
+        try:
+            actual_checksum = sha256_file(meta.file_path)
+        except OSError as exc:
+            raise SnapshotIntegrityError(f"Snapshot file not accessible: {meta.file_path}") from exc
         if actual_checksum != meta.checksum_sha256:
             raise SnapshotIntegrityError(
                 "Checksum mismatch for snapshot "

--- a/core/food_sources/snapshot_manager.py
+++ b/core/food_sources/snapshot_manager.py
@@ -134,8 +134,7 @@ class SnapshotManager:
             )
         if manifest_source != source:
             raise SnapshotIntegrityError(
-                "Invalid manifest schema for source="
-                f"{source}: source mismatch '{manifest_source}'"
+                f"Invalid manifest schema for source={source}: source mismatch '{manifest_source}'"
             )
 
         if "snapshots" not in loaded:
@@ -225,8 +224,7 @@ class SnapshotManager:
             resolved.relative_to(source_root)
         except ValueError as exc:
             raise SnapshotIntegrityError(
-                "Manifest snapshot path escapes source root for "
-                f"source={source!r}: {file_field!r}"
+                f"Manifest snapshot path escapes source root for source={source!r}: {file_field!r}"
             ) from exc
         return resolved
 

--- a/data/raw/snapshots/README.md
+++ b/data/raw/snapshots/README.md
@@ -1,0 +1,21 @@
+# Raw food snapshots (W1)
+
+This directory holds **local, git-ignored** Open Food Facts raw snapshot trees.
+
+## Layout
+
+- `off/manifest.json` — append-only manifest written by `core.food_sources.snapshot_manager.SnapshotManager`
+- `off/<YYYY-MM-DD>/` — per-run snapshot files (for example `openfoodfacts-products.jsonl.gz`)
+
+## Environment
+
+- `PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT` — optional absolute path overriding the default
+  `<repo>/data/raw/snapshots`.
+
+## Commands
+
+- Sync OFF snapshots: `python scripts/sync_food_snapshots.py` (optional `--root`, `--force`).
+- Verify manifest + files before DB build: `python scripts/build_food_db.py --validate-raw-snapshots`.
+
+Programmatic sync: `core.food_apis.snapshot_sync.sync_openfoodfacts_snapshot` or
+`DatabaseUpdateManager.sync_openfoodfacts_raw_snapshot`.

--- a/data/raw/snapshots/README.md
+++ b/data/raw/snapshots/README.md
@@ -15,7 +15,8 @@ This directory holds **local, git-ignored** Open Food Facts raw snapshot trees.
 ## Commands
 
 - Sync OFF snapshots: `python scripts/sync_food_snapshots.py` (optional `--root`, `--force`).
-- Verify manifest + files before DB build: `python scripts/build_food_db.py --validate-raw-snapshots`.
+- Verify manifest + files before DB build: `python scripts/build_food_db.py --validate-raw-snapshots`
+  (fail-closed: requires `off/manifest.json` under the snapshot root; build aborts if missing or tampered).
 
 Programmatic sync: `core.food_apis.snapshot_sync.sync_openfoodfacts_snapshot` or
 `DatabaseUpdateManager.sync_openfoodfacts_raw_snapshot`.

--- a/docs/review/PR_1361_FIXED_MAPPING.md
+++ b/docs/review/PR_1361_FIXED_MAPPING.md
@@ -37,6 +37,11 @@ Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; Codex connector summary revi
 Reason: Mirror Sourcery/cubic aggregate handling; single inline thread captured in FIXED block.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#pullrequestreview-4062505328
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; CodeRabbit summary / tips without a new threaded finding beyond the Sourcery/cubic/Codex items already mapped above; PR CI follow-up for diff-coverage is the `food_catalog` suite expansion (`.github/workflows/ci.yml`) plus `get_update_status` scheduler branch coverage (`tests/test_food_apis_snapshot_w1.py`).
+Reason: Aggregate bot review body is advisory; no extra `discussion_r` beyond existing FIXED mapping.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#pullrequestreview-4066114949
+
 ## Merge Readiness
 
 - [ ] All required checks pass (GitHub CI on current PR head after each push)

--- a/docs/review/PR_1361_FIXED_MAPPING.md
+++ b/docs/review/PR_1361_FIXED_MAPPING.md
@@ -17,6 +17,11 @@ Reason: Sourcery fail-closed semantics for `--validate-raw-snapshots`; Sourcery/
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039910407 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039914070 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
 
+Disposition: FIXED
+Commit: a56f768f82f4273d3611c1de7fd3502d801e359a
+Evidence: `core/food_apis/raw_snapshot_gate.py` (map `JSONDecodeError` / `OSError` / `UnicodeDecodeError` to `SnapshotIntegrityError`); `core/food_apis/update_manager.py` (optional `project_root` → `snapshot_sync`); `scripts/sync_food_snapshots.py` (resolved `display_root` in “no new snapshot” message); `tests/test_food_apis_snapshot_w1.py` (malformed manifest gate; `project_root` forward).
+Reason: Bug-hunter P1 gate error contract + P2 manager/CLI consistency.
+
 Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; Sourcery pull-request summary duplicates the threaded `discussion_r` items mapped above with `Disposition: FIXED`.
 Reason: Aggregate review body is not an additional fix thread; per-line comments carry actionable items.

--- a/docs/review/PR_1361_FIXED_MAPPING.md
+++ b/docs/review/PR_1361_FIXED_MAPPING.md
@@ -1,0 +1,45 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1361 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: a65dd6fe34626341f0832dedcbb040b0d7b58121
+Evidence: `core/food_apis/raw_snapshot_gate.py` (`strict` + missing-manifest `SnapshotIntegrityError`; `snapshot_root.expanduser().resolve()`); `scripts/build_food_db.py` (`validate_off_raw_manifest_gate(..., strict=True)`); `core/food_apis/snapshot_sync.py` (`SnapshotManager(resolved, today_provider=today_provider)`); `data/raw/snapshots/README.md` (fail-closed CLI note); `tests/test_food_apis_snapshot_w1.py` (strict missing manifest, `~/` snapshot root, `today_provider` propagation)
+Reason: Sourcery fail-closed semantics for `--validate-raw-snapshots`; Sourcery/cubic path normalization for `raw_root` / gate root; Codex P2 — same `today_provider` for `OpenFoodFactsDeltaSource` and `SnapshotManager`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039902451 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039910405 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039910407 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#discussion_r3039914070 -> a65dd6fe34626341f0832dedcbb040b0d7b58121
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; Sourcery pull-request summary duplicates the threaded `discussion_r` items mapped above with `Disposition: FIXED`.
+Reason: Aggregate review body is not an additional fix thread; per-line comments carry actionable items.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#pullrequestreview-4062490555
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; cubic file-level findings match resolved `discussion_r3039910405` and `discussion_r3039910407` (typing + expanduser), addressed on the branch before this mapping commit.
+Reason: Avoid duplicate FIXED mapping for the aggregate cubic review URL; threaded URLs are listed in the FIXED block.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#pullrequestreview-4062500725
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1361_FIXED_MAPPING.md:1`; Codex connector summary review without a separate actionable thread beyond `discussion_r3039914070`.
+Reason: Mirror Sourcery/cubic aggregate handling; single inline thread captured in FIXED block.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1361#pullrequestreview-4062505328
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally
+
+Notes: Resolve any remaining review threads in GitHub UI after push; re-run `check_merge_ready.py` before merge.
+
+<!-- markdownlint-enable MD034 -->

--- a/scripts/build_food_db.py
+++ b/scripts/build_food_db.py
@@ -5,11 +5,13 @@ RU: Сборка профессиональной базы данных прод
 EN: Build professional food database from CSV to Parquet/SQLite.
 """
 
+import argparse
 import sys
 from pathlib import Path
 
 # Add project root to path
-sys.path.append(str(Path(__file__).parent.parent))
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(_PROJECT_ROOT))
 
 import hashlib
 import json
@@ -451,8 +453,25 @@ class FoodDatabaseBuilder:
 
 def main() -> None:
     """Main entry point."""
+    parser = argparse.ArgumentParser(description="Build merged food database (USDA + OFF).")
+    parser.add_argument(
+        "--validate-raw-snapshots",
+        action="store_true",
+        help="Fail-closed verify OFF raw snapshot manifest under data/raw/snapshots before build.",
+    )
+    args = parser.parse_args()
+
     setup_logging()
-    builder = FoodDatabaseBuilder()
+    project_root = _PROJECT_ROOT
+    if args.validate_raw_snapshots:
+        from core.food_apis.raw_snapshot_gate import validate_off_raw_manifest_gate
+
+        gate = validate_off_raw_manifest_gate(project_root, enabled=True)
+        logging.info("Raw snapshot gate: %s", gate)
+        if gate.get("enabled") and gate.get("status") == "verified":
+            logging.info("OFF raw snapshots verified: %s file(s)", gate.get("snapshots_checked"))
+
+    builder = FoodDatabaseBuilder(project_root=project_root)
     builder.build()
 
 

--- a/scripts/build_food_db.py
+++ b/scripts/build_food_db.py
@@ -466,7 +466,7 @@ def main() -> None:
     if args.validate_raw_snapshots:
         from core.food_apis.raw_snapshot_gate import validate_off_raw_manifest_gate
 
-        gate = validate_off_raw_manifest_gate(project_root, enabled=True)
+        gate = validate_off_raw_manifest_gate(project_root, enabled=True, strict=True)
         logging.info("Raw snapshot gate: %s", gate)
         if gate.get("enabled") and gate.get("status") == "verified":
             logging.info("OFF raw snapshots verified: %s file(s)", gate.get("snapshots_checked"))

--- a/scripts/sync_food_snapshots.py
+++ b/scripts/sync_food_snapshots.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+CLI: sync Open Food Facts raw snapshots into the local snapshot tree.
+
+RU: CLI для загрузки сырых снапшотов OFF.
+EN: CLI to download OFF raw snapshots into ``data/raw/snapshots``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from core.food_apis.snapshot_sync import (  # noqa: E402
+    default_raw_snapshot_root,
+    sync_openfoodfacts_snapshot,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync Open Food Facts raw snapshots.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Snapshot base directory (default: env PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT or "
+        "data/raw/snapshots under project root)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force sync even when delta policy would skip.",
+    )
+    args = parser.parse_args()
+    project_root = _ROOT
+    meta = sync_openfoodfacts_snapshot(
+        args.root,
+        project_root=project_root,
+        force=args.force,
+    )
+    root = args.root if args.root is not None else default_raw_snapshot_root(project_root)
+    if meta is None:
+        print(f"No new snapshot written under {root} (already up to date).")
+        return 0
+    print(f"Recorded snapshot: {meta.file_path} mode={meta.mode} records={meta.record_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_food_snapshots.py
+++ b/scripts/sync_food_snapshots.py
@@ -38,14 +38,18 @@ def main() -> int:
     )
     args = parser.parse_args()
     project_root = _ROOT
+    display_root = (
+        args.root.expanduser().resolve()
+        if args.root is not None
+        else default_raw_snapshot_root(project_root)
+    )
     meta = sync_openfoodfacts_snapshot(
         args.root,
         project_root=project_root,
         force=args.force,
     )
-    root = args.root if args.root is not None else default_raw_snapshot_root(project_root)
     if meta is None:
-        print(f"No new snapshot written under {root} (already up to date).")
+        print(f"No new snapshot written under {display_root} (already up to date).")
         return 0
     print(f"Recorded snapshot: {meta.file_path} mode={meta.mode} records={meta.record_count}")
     return 0

--- a/tests/test_food_apis_snapshot_w1.py
+++ b/tests/test_food_apis_snapshot_w1.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import date
 from pathlib import Path
 import pytest
 
+from core.food_apis import scheduler as scheduler_mod
 from core.food_apis.raw_snapshot_gate import validate_off_raw_manifest_gate
 from core.food_apis.snapshot_sync import default_raw_snapshot_root, sync_openfoodfacts_snapshot
-from core.food_apis.update_manager import DatabaseUpdateManager
+from core.food_apis.update_manager import DatabaseUpdateManager, get_update_status
 from core.food_sources.snapshot_manager import SnapshotIntegrityError, SnapshotManager, SnapshotMeta
 from core.food_sources.snapshot_manager import sha256_file
 
@@ -225,6 +227,23 @@ def test_database_update_manager_sync_forwards_project_root(
     mgr.sync_openfoodfacts_raw_snapshot(None, project_root=proj)
     assert captured["raw_root"] is None
     assert captured["project_root"] == proj
+
+
+def test_get_update_status_forwards_scheduler_get_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a global scheduler exists, status must come from ``get_status()`` (cast branch)."""
+
+    class _FakeScheduler:
+        def get_status(self) -> dict[str, object]:
+            return {"scheduler": {"is_running": True}, "databases": {}}
+
+    monkeypatch.setattr(scheduler_mod, "_scheduler_instance", _FakeScheduler())
+    out = asyncio.run(get_update_status())
+    assert isinstance(out, dict)
+    sched = out.get("scheduler")
+    assert isinstance(sched, dict)
+    assert sched.get("is_running") is True
 
 
 def test_manifest_file_relative_path_verify(tmp_path: Path) -> None:

--- a/tests/test_food_apis_snapshot_w1.py
+++ b/tests/test_food_apis_snapshot_w1.py
@@ -42,6 +42,28 @@ def test_validate_off_raw_manifest_gate_skips_without_manifest(tmp_path: Path) -
     assert result["reason"] == "missing_off_manifest"
 
 
+def test_validate_off_raw_manifest_gate_strict_missing_manifest_raises(tmp_path: Path) -> None:
+    snap_root = tmp_path / "snapshots"
+    snap_root.mkdir(parents=True)
+    with pytest.raises(SnapshotIntegrityError, match="missing off/manifest.json"):
+        validate_off_raw_manifest_gate(tmp_path, enabled=True, snapshot_root=snap_root, strict=True)
+
+
+def test_validate_off_raw_manifest_gate_snapshot_root_expanduser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``snapshot_root`` with ``~`` must resolve like env-based defaults."""
+    home = tmp_path / "home"
+    snap_root = home / "snapshots"
+    snap_root.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    result = validate_off_raw_manifest_gate(
+        tmp_path, enabled=True, snapshot_root=Path("~/snapshots")
+    )
+    assert result["reason"] == "missing_off_manifest"
+    assert str(snap_root.resolve()) in result["root"]
+
+
 def test_validate_off_raw_manifest_gate_verifies_recorded(tmp_path: Path) -> None:
     base = tmp_path / "snapshots"
     manager = SnapshotManager(base)
@@ -100,6 +122,26 @@ def test_sync_openfoodfacts_snapshot_uses_manager(
     monkeypatch.setattr(SnapshotManager, "sync_if_needed", fake_sync)
     sync_openfoodfacts_snapshot(tmp_path, project_root=tmp_path, force=True)
     assert calls == [True]
+
+
+def test_sync_openfoodfacts_snapshot_propagates_today_provider_to_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``today_provider`` must feed both delta source and SnapshotManager (Codex P2)."""
+    fixed = date(2024, 1, 15)
+
+    def fixed_today() -> date:
+        return fixed
+
+    captured: list[date] = []
+
+    def fake_sync(self: SnapshotManager, source: object, force: bool = False) -> None:
+        captured.append(self._today_provider())
+        return None
+
+    monkeypatch.setattr(SnapshotManager, "sync_if_needed", fake_sync)
+    sync_openfoodfacts_snapshot(tmp_path, project_root=tmp_path, today_provider=fixed_today)
+    assert captured == [fixed]
 
 
 def test_sync_openfoodfacts_raw_root_expanduser(

--- a/tests/test_food_apis_snapshot_w1.py
+++ b/tests/test_food_apis_snapshot_w1.py
@@ -87,6 +87,16 @@ def test_validate_off_raw_manifest_gate_verifies_recorded(tmp_path: Path) -> Non
     assert result["snapshots_checked"] == 1
 
 
+def test_validate_off_raw_manifest_gate_malformed_manifest_json_raises(tmp_path: Path) -> None:
+    """Corrupt off/manifest.json must surface as SnapshotIntegrityError (gate contract)."""
+    base = tmp_path / "snapshots"
+    off = base / "off"
+    off.mkdir(parents=True)
+    (off / "manifest.json").write_text("{ not valid json", encoding="utf-8")
+    with pytest.raises(SnapshotIntegrityError, match="OFF raw snapshot gate failed"):
+        validate_off_raw_manifest_gate(tmp_path, enabled=True, snapshot_root=base)
+
+
 def test_validate_off_raw_manifest_gate_tamper_raises(tmp_path: Path) -> None:
     base = tmp_path / "snapshots"
     manager = SnapshotManager(base)
@@ -188,6 +198,33 @@ def test_database_update_manager_sync_openfoodfacts_raw_snapshot_delegates(
     mgr.sync_openfoodfacts_raw_snapshot(tmp_path / "raw", force=True)
     assert captured["raw_root"] == tmp_path / "raw"
     assert captured["force"] is True
+
+
+def test_database_update_manager_sync_forwards_project_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_sync(
+        raw_root: Path | None,
+        *,
+        project_root: Path | None = None,
+        force: bool = False,
+        transport: object | None = None,
+        today_provider: object | None = None,
+    ) -> None:
+        captured["raw_root"] = raw_root
+        captured["project_root"] = project_root
+        return None
+
+    import core.food_apis.snapshot_sync as snapshot_sync_mod
+
+    monkeypatch.setattr(snapshot_sync_mod, "sync_openfoodfacts_snapshot", fake_sync)
+    mgr = DatabaseUpdateManager(cache_dir=tmp_path / "cache")
+    proj = tmp_path / "myproject"
+    mgr.sync_openfoodfacts_raw_snapshot(None, project_root=proj)
+    assert captured["raw_root"] is None
+    assert captured["project_root"] == proj
 
 
 def test_manifest_file_relative_path_verify(tmp_path: Path) -> None:

--- a/tests/test_food_apis_snapshot_w1.py
+++ b/tests/test_food_apis_snapshot_w1.py
@@ -1,0 +1,154 @@
+"""W1 integration tests: raw snapshot sync, gate, and update_manager delegate."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+import pytest
+
+from core.food_apis.raw_snapshot_gate import validate_off_raw_manifest_gate
+from core.food_apis.snapshot_sync import default_raw_snapshot_root, sync_openfoodfacts_snapshot
+from core.food_apis.update_manager import DatabaseUpdateManager
+from core.food_sources.snapshot_manager import SnapshotIntegrityError, SnapshotManager, SnapshotMeta
+from core.food_sources.snapshot_manager import sha256_file
+
+
+def test_default_raw_snapshot_root_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT", str(tmp_path / "custom"))
+    assert default_raw_snapshot_root(tmp_path) == (tmp_path / "custom").resolve()
+
+
+def test_default_raw_snapshot_root_project_relative(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT", raising=False)
+    root = default_raw_snapshot_root(tmp_path)
+    assert root == (tmp_path / "data" / "raw" / "snapshots").resolve()
+
+
+def test_validate_off_raw_manifest_gate_disabled() -> None:
+    assert validate_off_raw_manifest_gate(Path("/tmp"), enabled=False) == {"enabled": False}
+
+
+def test_validate_off_raw_manifest_gate_skips_without_manifest(tmp_path: Path) -> None:
+    snap_root = tmp_path / "snapshots"
+    snap_root.mkdir(parents=True)
+    result = validate_off_raw_manifest_gate(tmp_path, enabled=True, snapshot_root=snap_root)
+    assert result["enabled"] is True
+    assert result["status"] == "skipped"
+    assert result["reason"] == "missing_off_manifest"
+
+
+def test_validate_off_raw_manifest_gate_verifies_recorded(tmp_path: Path) -> None:
+    base = tmp_path / "snapshots"
+    manager = SnapshotManager(base)
+    off_dir = base / "off" / "2026-04-06"
+    off_dir.mkdir(parents=True)
+    blob = off_dir / "sample.gz"
+    blob.write_bytes(b"gz-bytes")
+    meta = SnapshotMeta(
+        source="off",
+        snapshot_date=date(2026, 4, 6),
+        file_path=blob,
+        checksum_sha256=sha256_file(blob),
+        record_count=1,
+        size_bytes=blob.stat().st_size,
+        mode="full",
+    )
+    manager.record_snapshot(meta)
+
+    result = validate_off_raw_manifest_gate(tmp_path, enabled=True, snapshot_root=base)
+    assert result["status"] == "verified"
+    assert result["snapshots_checked"] == 1
+
+
+def test_validate_off_raw_manifest_gate_tamper_raises(tmp_path: Path) -> None:
+    base = tmp_path / "snapshots"
+    manager = SnapshotManager(base)
+    off_dir = base / "off" / "2026-04-06"
+    off_dir.mkdir(parents=True)
+    blob = off_dir / "sample.gz"
+    blob.write_bytes(b"gz-bytes")
+    meta = SnapshotMeta(
+        source="off",
+        snapshot_date=date(2026, 4, 6),
+        file_path=blob,
+        checksum_sha256=sha256_file(blob),
+        record_count=1,
+        size_bytes=blob.stat().st_size,
+        mode="full",
+    )
+    manager.record_snapshot(meta)
+    blob.write_bytes(b"tampered")
+
+    with pytest.raises(SnapshotIntegrityError, match="OFF raw snapshot gate failed"):
+        validate_off_raw_manifest_gate(tmp_path, enabled=True, snapshot_root=base)
+
+
+def test_sync_openfoodfacts_snapshot_uses_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[bool] = []
+
+    def fake_sync(self: SnapshotManager, source: object, force: bool = False) -> None:
+        calls.append(force)
+        return None
+
+    monkeypatch.setattr(SnapshotManager, "sync_if_needed", fake_sync)
+    sync_openfoodfacts_snapshot(tmp_path, project_root=tmp_path, force=True)
+    assert calls == [True]
+
+
+def test_database_update_manager_sync_openfoodfacts_raw_snapshot_delegates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_sync(
+        raw_root: Path | None,
+        *,
+        project_root: Path | None = None,
+        force: bool = False,
+        transport: object | None = None,
+        today_provider: object | None = None,
+    ) -> None:
+        captured["raw_root"] = raw_root
+        captured["force"] = force
+        _ = (project_root, transport, today_provider)
+        return None
+
+    import core.food_apis.snapshot_sync as snapshot_sync_mod
+
+    monkeypatch.setattr(snapshot_sync_mod, "sync_openfoodfacts_snapshot", fake_sync)
+    mgr = DatabaseUpdateManager(cache_dir=tmp_path / "cache")
+    mgr.sync_openfoodfacts_raw_snapshot(tmp_path / "raw", force=True)
+    assert captured["raw_root"] == tmp_path / "raw"
+    assert captured["force"] is True
+
+
+def test_manifest_file_relative_path_verify(tmp_path: Path) -> None:
+    """Manifest entries may use paths relative to the manifest directory."""
+    base = tmp_path / "snapshots"
+    off_root = base / "off"
+    day_dir = off_root / "2026-04-07"
+    day_dir.mkdir(parents=True)
+    blob = day_dir / "delta.gz"
+    blob.write_bytes(b"x")
+    manifest_path = off_root / "manifest.json"
+    entry = {
+        "date": "2026-04-07",
+        "file": "2026-04-07/delta.gz",
+        "checksum": sha256_file(blob),
+        "records": 1,
+        "bytes": blob.stat().st_size,
+        "mode": "delta",
+    }
+    manifest_path.write_text(
+        json.dumps({"source": "off", "snapshots": [entry]}, indent=2),
+        encoding="utf-8",
+    )
+    manager = SnapshotManager(base)
+    assert manager.verify_recorded_snapshots("off") == 1

--- a/tests/test_food_apis_snapshot_w1.py
+++ b/tests/test_food_apis_snapshot_w1.py
@@ -102,6 +102,25 @@ def test_sync_openfoodfacts_snapshot_uses_manager(
     assert calls == [True]
 
 
+def test_sync_openfoodfacts_raw_root_expanduser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """User-supplied ``raw_root`` must expand ``~`` like env-based default root."""
+    home = tmp_path / "homedir"
+    target = home / "snapshots"
+    target.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    captured: list[Path] = []
+
+    def fake_sync(self: SnapshotManager, source: object, force: bool = False) -> None:
+        captured.append(self.base_path)
+        return None
+
+    monkeypatch.setattr(SnapshotManager, "sync_if_needed", fake_sync)
+    sync_openfoodfacts_snapshot(Path("~/snapshots"), project_root=tmp_path, force=False)
+    assert captured == [target.resolve()]
+
+
 def test_database_update_manager_sync_openfoodfacts_raw_snapshot_delegates(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_food_sources_snapshot_manager.py
+++ b/tests/test_food_sources_snapshot_manager.py
@@ -6,9 +6,11 @@ import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+import core.food_sources.snapshot_manager as snapshot_manager_module
 from core.food_sources.snapshot_manager import (
     SnapshotIntegrityError,
     SnapshotManager,
@@ -497,3 +499,132 @@ def test_verify_recorded_snapshots_size_mismatch_fails_closed(tmp_path: Path) ->
     )
     with pytest.raises(SnapshotIntegrityError, match="Size mismatch"):
         manager.verify_recorded_snapshots("size-mismatch")
+
+
+def test_verify_recorded_snapshots_rejects_manifest_path_traversal(tmp_path: Path) -> None:
+    """RU/EN: Manifest ``file`` must not escape ``base_path / source`` via ``..``."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_name = "esc"
+    source_dir = tmp_path / source_name
+    source_dir.mkdir(parents=True)
+    outside = tmp_path / "outside_evidence.bin"
+    outside.write_bytes(b"secret")
+    manifest_path = source_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": source_name,
+                "snapshots": [
+                    {
+                        "date": "2026-02-24",
+                        "file": "../../outside_evidence.bin",
+                        "checksum": sha256_file(outside),
+                        "records": 1,
+                        "bytes": outside.stat().st_size,
+                        "mode": "full",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="escapes source root"):
+        manager.verify_recorded_snapshots(source_name)
+
+
+def test_verify_recorded_snapshots_rejects_absolute_path_outside_source(tmp_path: Path) -> None:
+    """RU/EN: Absolute ``file`` outside the source directory must be rejected."""
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    source_name = "absout"
+    source_dir = tmp_path / source_name
+    source_dir.mkdir(parents=True)
+    outside = tmp_path / "elsewhere" / "x.bin"
+    outside.parent.mkdir(parents=True)
+    outside.write_bytes(b"x")
+    manifest_path = source_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": source_name,
+                "snapshots": [
+                    {
+                        "date": "2026-02-24",
+                        "file": str(outside.resolve()),
+                        "checksum": sha256_file(outside),
+                        "records": 1,
+                        "bytes": outside.stat().st_size,
+                        "mode": "full",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SnapshotIntegrityError, match="escapes source root"):
+        manager.verify_recorded_snapshots(source_name)
+
+
+def test_validate_snapshot_maps_exists_oserror_to_integrity(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snap = tmp_path / "probe" / "a.bin"
+    snap.parent.mkdir(parents=True)
+    snap.write_bytes(b"a")
+    meta = SnapshotMeta(
+        source="probe",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snap,
+        checksum_sha256=sha256_file(snap),
+        record_count=1,
+        size_bytes=snap.stat().st_size,
+        mode="full",
+    )
+    with patch.object(Path, "exists", side_effect=PermissionError("denied")):
+        with pytest.raises(SnapshotIntegrityError, match="not accessible"):
+            manager.validate_snapshot(meta)
+
+
+def test_validate_snapshot_maps_stat_oserror_to_integrity(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snap = tmp_path / "probe2" / "a.bin"
+    snap.parent.mkdir(parents=True)
+    snap.write_bytes(b"a")
+    meta = SnapshotMeta(
+        source="probe2",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snap,
+        checksum_sha256=sha256_file(snap),
+        record_count=1,
+        size_bytes=snap.stat().st_size,
+        mode="full",
+    )
+
+    def _exists(self: Path) -> bool:
+        return True
+
+    with patch.object(Path, "exists", _exists):
+        with patch.object(Path, "stat", side_effect=OSError("stat failed")):
+            with pytest.raises(SnapshotIntegrityError, match="not accessible"):
+                manager.validate_snapshot(meta)
+
+
+def test_validate_snapshot_maps_sha256_oserror_to_integrity(tmp_path: Path) -> None:
+    manager = SnapshotManager(tmp_path, today_provider=lambda: date(2026, 2, 24))
+    snap = tmp_path / "probe3" / "a.bin"
+    snap.parent.mkdir(parents=True)
+    snap.write_bytes(b"a")
+    meta = SnapshotMeta(
+        source="probe3",
+        snapshot_date=date(2026, 2, 24),
+        file_path=snap,
+        checksum_sha256=sha256_file(snap),
+        record_count=1,
+        size_bytes=snap.stat().st_size,
+        mode="full",
+    )
+    with patch.object(
+        snapshot_manager_module,
+        "sha256_file",
+        side_effect=OSError("read failed"),
+    ):
+        with pytest.raises(SnapshotIntegrityError, match="not accessible"):
+            manager.validate_snapshot(meta)


### PR DESCRIPTION
## Summary
Narrow W1: verify recorded OFF raw snapshots (size + SHA-256), sync into `data/raw/snapshots` (or `PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT`), optional gate before `build_food_db`, and `DatabaseUpdateManager` delegate.

## Changes
- `core/food_apis/snapshot_sync.py` — `default_raw_snapshot_root`, `sync_openfoodfacts_snapshot`
- `core/food_apis/raw_snapshot_gate.py` — `validate_off_raw_manifest_gate` (disabled / skipped / verified)
- `scripts/sync_food_snapshots.py` — CLI (`--root`, `--force`)
- `scripts/build_food_db.py` — `--validate-raw-snapshots`
- `DatabaseUpdateManager.sync_openfoodfacts_raw_snapshot` — lazy `snapshot_sync` delegate
- `.gitignore` — `data/raw/*` except `data/raw/snapshots/README.md`
- `tests/test_food_apis_snapshot_w1.py`

## Validation
- `pytest` snapshot suites + `make validate-min` + `pre-commit run --all-files` + pre-push hooks (local)

## Deferred / Follow-ups
- None in this PR (Postgres/deploy out of scope per plan).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ввести синхронизацию и проверку необработанных снапшотов Open Food Facts как первый (W1) этап‑ворота перед построением базы данных продуктов.

New Features:
- Добавить модуль `snapshot_sync` и CLI для синхронизации необработанных снапшотов Open Food Facts в каноническое дерево `data/raw/snapshots` с переопределениями на основе переменных окружения.
- Добавить «fail-closed» ворота проверки необработанных снапшотов, которые проверяют манифесты и файлы OFF перед запуском конвейера сборки базы данных.
- Открыть метод `DatabaseUpdateManager`, который делегирует синхронизацию необработанных снапшотов OFF новому модулю `snapshot_sync`.

Enhancements:
- Расширить скрипт сборки базы данных продуктов необязательным флагом для валидации необработанных снапшотов OFF перед сборкой.
- Задокументировать структуру каталога необработанных снапшотов, конфигурацию окружения и команды для синхронизации и проверки в новом README.

Build:
- Обновить правила игнорирования, чтобы данные необработанных снапшотов под `data/raw` исключались из git, сохранив при этом отслеживание README.

Tests:
- Добавить интеграционные тесты, покрывающие определение корневого каталога снапшотов по умолчанию, поведение ворот манифеста, синхронизацию снапшотов и делегат в менеджере обновлений.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce raw Open Food Facts snapshot syncing and verification as a first-step (W1) gate before building the food database.

New Features:
- Add snapshot_sync module and CLI to sync Open Food Facts raw snapshots into a canonical data/raw/snapshots tree with env-based overrides.
- Add a fail-closed raw snapshot verification gate that checks OFF manifests and files before running the database build pipeline.
- Expose a DatabaseUpdateManager method that delegates OFF raw snapshot syncing to the new snapshot_sync module.

Enhancements:
- Extend the food DB build script with an optional flag to validate raw OFF snapshots prior to building.
- Document the raw snapshot directory layout, environment configuration, and commands for syncing and verification in a new README.

Build:
- Update ignore rules so raw snapshot data under data/raw is excluded from git while keeping a README tracked.

Tests:
- Add integration-style tests covering default snapshot root resolution, manifest gate behavior, snapshot syncing, and the update manager delegate.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed verification gate for Open Food Facts raw snapshots and a sync CLI. The build flag now enforces a strict pre-build check that fails when the OFF manifest is missing, corrupted, or tampered.

- New Features
  - Verify OFF raw snapshots (size + SHA-256) before DB build; `scripts/build_food_db.py --validate-raw-snapshots` runs a strict gate that requires `off/manifest.json`.
  - Sync OFF snapshots into `data/raw/snapshots` (override with `PULSEPLATE_FOOD_RAW_SNAPSHOT_ROOT`) via `scripts/sync_food_snapshots.py` (`--force` supported) or `DatabaseUpdateManager.sync_openfoodfacts_raw_snapshot`.

- Bug Fixes
  - Jail manifest `file` paths under the OFF source directory and normalize failures (exists/stat/sha256, corrupt manifest read/parse/encoding) to `SnapshotIntegrityError` with stable messages.
  - Expand `~` in `raw_root` and gate roots; `DatabaseUpdateManager` forwards `project_root` to `snapshot_sync`; CI runs W1 snapshot tests to cover gate/sync and the scheduler status branch.

<sup>Written for commit a949cc1ba4c5eb041c87cad2f0df49e115445f26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical mapping lives in `docs/review/PR_1361_FIXED_MAPPING.md` (merged with this PR). This subsection is a Phase2 body mirror only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI to sync Open Food Facts raw snapshots locally.
  * Optional pre-build validation flag to verify raw snapshots.
  * Environment variable to override the snapshot directory.

* **Documentation**
  * Added snapshot README and review notes documenting layout and workflows.

* **Bug Fixes**
  * Stronger integrity checks: fail-closed validation, path-escape protection, and unified I/O error handling.

* **Tests**
  * New integration and unit tests covering sync, validation, and error cases.

* **Chores**
  * Updated ignore rules to keep snapshot README tracked while ignoring raw data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->