### PR TITLE
feat(metatron-lab): Track A Epic 2 isolated runner and validate CLI

### DIFF
--- a/deploy/metatron-lab/README.md
+++ b/deploy/metatron-lab/README.md
@@ -8,7 +8,8 @@ METATRON to product runtime.
 
 - ADR: `docs/architecture/ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06.md:1`
 - RoE: `docs/security/METATRON_LAB_RULES_OF_ENGAGEMENT.md:1`
-- Task packet: `docs/orchestration/METATRON_TRACK_A_EPIC1_TASK_PACKET_2026-04-06.md:1`
+- Task packet (Epic 1): `docs/orchestration/METATRON_TRACK_A_EPIC1_TASK_PACKET_2026-04-06.md:1`
+- Task packet (Epic 2 — runner): `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1`
 
 ## Usage
 
@@ -16,7 +17,19 @@ Validate compose (no containers started):
 
 ```bash
 docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-isolation config -q
+docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-runner config -q
 ```
+
+Or use the repo helper (resolves `docker` via `PATH` to an absolute binary):
+
+```bash
+python3 -m scripts.metatron_lab validate
+python3 -m scripts.metatron_lab checklist
+```
+
+**Profiles:** `metatron-lab-isolation` — network placeholder only. `metatron-lab-runner` — isolation
+placeholder plus `lab-runner-sidecar-stub` for documented sidecar extension (still no PulsePlate
+`COPY`).
 
 Operators attach METATRON or other lab containers to the `lab_internal` network only after
 written authorization per RoE. Raw outputs belong under `artifacts/security_lab/` (gitignored).

--- a/deploy/metatron-lab/docker-compose.yaml
+++ b/deploy/metatron-lab/docker-compose.yaml
@@ -1,10 +1,11 @@
 # METATRON lab — isolated network stub only (no PulsePlate app build).
 # Profile keeps default `docker compose` invocations inert without --profile.
+# Epic 2: metatron-lab-runner adds a second stub for operator-sidecar extension (still no app COPY).
 name: metatron-lab
 services:
   lab-network-placeholder:
     image: alpine:3.20
-    profiles: ["metatron-lab-isolation"]
+    profiles: ["metatron-lab-isolation", "metatron-lab-runner"]
     # BusyBox sleep rejects "infinity"; keep a long-lived placeholder for the internal network.
     command: ["/bin/sh", "-c", "while true; do sleep 86400; done"]
     networks: [lab_internal]
@@ -13,6 +14,17 @@ services:
         limits:
           cpus: "0.25"
           memory: 64M
+
+  lab-runner-sidecar-stub:
+    image: alpine:3.20
+    profiles: ["metatron-lab-runner"]
+    command: ["/bin/sh", "-c", "while true; do sleep 86400; done"]
+    networks: [lab_internal]
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 128M
 
 networks:
   lab_internal:

--- a/docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md
+++ b/docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md
@@ -90,6 +90,7 @@ Execute in order; coordinator holds DoD until each gate is satisfied or explicit
 
 ```bash
 python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
 docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-isolation config -q
 docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-runner config -q
 python3 -m scripts.metatron_lab validate

--- a/docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md
+++ b/docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md
@@ -1,0 +1,111 @@
+# METATRON Track A — Epic 2 Task Packet (isolated runner)
+
+**Effective date:** 2026-04-06 (`America/New_York`)
+**Status:** Open — coordinator-led infra/scripts lane; canonical contract for Epic 2 scope.
+**Mode:** coordinator-first; **no** METATRON runtime in `app.main` or product OpenAPI.
+**Ledger:** [`docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band`](../roadmap/BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band)
+
+## Goal (Epic 2)
+
+Ship an **isolated runner** boundary: operators can validate and extend the METATRON
+out-of-band lab using **only** `deploy/metatron-lab/**` and narrow `scripts/metatron_lab/**`,
+without building the PulsePlate app image, without new product routes, and without OpenAPI
+or `frontend/src/api/*` changes.
+
+## Task analysis (coordinator)
+
+| Field | Value |
+|-------|--------|
+| **Task** | Epic 2 — compose profiles + deterministic validate/checklist CLI + tests. |
+| **Domain(s)** | Security, Deploy, Orchestration (scripts), QA. |
+| **Complexity** | Low–moderate (compose + subprocess guard + tests). |
+| **Priority** | P1 |
+| **Expected outcome** | Merged PR with `make validate-min` green; `docker compose … config -q` for both profiles; no `app/` diff. |
+| **Invariants** | ADR + RoE; Dockerfile policy; artifacts only under `artifacts/security_lab/` (gitignored). |
+
+**Risks:** Scope creep into product; CI running offensive tools. **Mitigation:** IN/OUT below + profile-gated compose + no Tier-1 offensive jobs.
+
+## In scope (Epic 2)
+
+- Compose: `deploy/metatron-lab/docker-compose.yaml:1` — `metatron-lab-runner` profile and
+  documented sidecar stub (Alpine placeholder, resource limits, `lab_internal` only).
+- Scripts: `scripts/metatron_lab/compose_guard.py:1`, `scripts/metatron_lab/__main__.py:1` —
+  `validate` (absolute-path `docker` via `shutil.which`) and `checklist` (operator reminders).
+- Tests: `tests/test_metatron_lab_compose_guard.py:1` — deterministic subprocess mocks.
+- Docs: this packet; `deploy/metatron-lab/README.md:1` cross-links; ledger Target PR line update.
+
+## Out of scope (Epic 2)
+
+- `app/`, `core/` business logic, product routers, OpenAPI, `frontend/src/api/*`.
+- Adding METATRON/offensive dependencies to `requirements.txt` or the application image.
+- Mandatory Tier-1 CI that runs lab scans or starts long-lived lab containers.
+
+## Agent execution order (full roster — plan canon)
+
+Execute in order; coordinator holds DoD until each gate is satisfied or explicitly N/A.
+
+1. **agent-coordinator** — Preflight (`scripts/orchestration/check_preflight.py:1`), IN/OUT,
+   PR scope discipline, synthesis for PR description.
+2. **security-auditor** — Network isolation (`internal: true`), volumes/paths, secrets, RoE
+   alignment (`docs/security/METATRON_LAB_RULES_OF_ENGAGEMENT.md:1`).
+3. **bug-hunter** — Abuse: running without profile, path leaks in logs, bypassing RoE via
+   “convenience” flags.
+4. **architecture-specialist** — ADR evidence (`docs/architecture/ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06.md:1`);
+   runner not registered in `app.main`; no `COPY` of PulsePlate app in lab compose.
+5. **qa-engineer-agent** — Tests for scripts; subprocess + absolute binary policy; no dead-code-only tests.
+6. **backend-engineer** — **N/A** unless a future ticket adds a thin HTTP-free CLI contract.
+
+**Epic 2 touchpoints:**
+
+7. **dev-operator** — Raw exit codes for `docker compose … config -q`, `python3 -m scripts.metatron_lab validate`,
+   `make validate-min`.
+8. **ml-engineer-agent** (optional) — If a sidecar LLM is documented later: CPU/RAM limits, non-product paths only.
+9. **tutor-mentor-agent** (optional) — Read order: this packet → `deploy/metatron-lab/README.md:1` → RoE.
+
+**Out of roster (do not invoke for this lane):** `nutritionist-agent`, `cv-agent`,
+`cbt-psychologist-agent`, `app-store-release-agent`, `creative-designer`.
+
+## Coordinator synthesis (Epic 2)
+
+| Gate | Owner | Evidence |
+|------|--------|----------|
+| Scope | coordinator | Diff ⊆ `{deploy/metatron-lab/**, scripts/metatron_lab/**, tests/test_metatron_lab_*, docs/orchestration/METATRON_TRACK_A_EPIC2_*, docs/roadmap/BACKLOG_LEDGER.md, deploy/metatron-lab/README.md}` |
+| Isolation | security-auditor | `lab_internal.internal: true`; profiles prevent default `compose up` |
+| Abuse paths | bug-hunter | Checklist + tests for missing `docker` → exit 2 |
+| Architecture | architecture-specialist | No app image build in lab compose file |
+
+## Mandatory post-open lane
+
+`qa-engineer-agent` → `bug-hunter` (per `docs/orchestration/AGENTS.md:1`).
+
+## Deliverables checklist (Epic 2 DoD)
+
+- [ ] This packet merged and linked from ledger + lab README.
+- [ ] `metatron-lab-runner` profile validates with `docker compose … config -q`.
+- [ ] `python3 -m scripts.metatron_lab validate` exits 0 when Docker is available and compose is valid.
+- [ ] No `app/` or OpenAPI artifact changes.
+- [ ] `make validate-min` green on PR head (or full `make verify` if repo policy requires).
+
+## Validation commands (evidence)
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-isolation config -q
+docker compose -f deploy/metatron-lab/docker-compose.yaml --profile metatron-lab-runner config -q
+python3 -m scripts.metatron_lab validate
+python3 -m scripts.metatron_lab checklist
+pytest -q tests/test_metatron_lab_compose_guard.py
+make validate-min
+```
+
+## PR body contract (mirror)
+
+- **Deferred / Follow-ups:** `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band`
+- **Orchestration:** this packet path + roster above.
+- **Explicit non-goals:** no product METATRON surface; no OpenAPI sync.
+
+## References
+
+- Epic 1 packet: `docs/orchestration/METATRON_TRACK_A_EPIC1_TASK_PACKET_2026-04-06.md:1`
+- ADR: `docs/architecture/ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06.md:1`
+- RoE: `docs/security/METATRON_LAB_RULES_OF_ENGAGEMENT.md:1`

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -6,11 +6,26 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No actionable GitHub review threads at initial open; refresh when review comments appear.
-
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: **FIXED** (Sourcery / Cubic / CodeRabbit / Codex-aligned follow-ups: stderr on compose failure, marker-based `repo_root()`, checklist stems centralized, extended subprocess contract tests, Epic 2 packet adds `check_agent_consistency.py`, unreachable CLI path uses `RuntimeError`).
+
+Commit: `dc299c888882c3f747af6cabcafd2b1e7c296eff`
+
+Evidence:
+
+- `scripts/metatron_lab/compose_guard.py:1` — stderr snippet + `deploy/metatron-lab/docker-compose.yaml` root discovery; checklist constants
+- `scripts/metatron_lab/__main__.py:1` — no dead `return 2`
+- `tests/test_metatron_lab_compose_guard.py:1` — full `docker compose` argv/kwargs + stderr test
+- `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1` — validation block includes agent-consistency gate
+
+Bot thread mapping (FIXED → commit above):
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062825633 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062831379 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040206216 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3043192789 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4066112826 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 
 ## Merge Readiness
 
@@ -20,6 +35,6 @@ No actionable GitHub review threads at initial open; refresh when review comment
 - [ ] Pre-commit green
 - [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
 
-Notes: Refresh this artifact and PR-body mirror after review threads or actionable bot comments appear.
+Notes: Refresh after new review activity; mapping commit must trail bot comment timestamps (commit-after-comment gate).
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1366 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed (initial open — no threads)
+- [x] Fixed in commit mapping completed (initial scaffold)
+
+## Fixed in Commit Mapping
+
+- No actionable review comments (initial open)
+
+## Merge Readiness
+
+- [ ] All required checks pass (GitHub CI on current PR head after each push)
+- [ ] No unresolved review threads
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
+
+Notes: Refresh this artifact and PR-body mirror after review threads or actionable bot comments appear.
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -8,15 +8,15 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062825633 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062831379 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040200807 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040200813 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040206216 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040210966 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3043192789 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4066112826 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 
 Disposition: FIXED
 Commit: dc299c888882c3f747af6cabcafd2b1e7c296eff
-Evidence: scripts/metatron_lab/compose_guard.py (stderr on compose failure, marker-based repo root, checklist stems); scripts/metatron_lab/__main__.py (unreachable path); tests/test_metatron_lab_compose_guard.py (argv/kwargs contract + stderr test); docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md (check_agent_consistency in validation list)
+Evidence: Sourcery r3040200807 r3040200813 (stderr + test contract); Cubic r3040206216 (__main__.py); Codex r3040210966 (same stderr path); CodeRabbit r3043192789 (Epic2 packet check_agent_consistency). Phase2 mapping artifact format: 14f7ec727eb2c45bb79787ad788077cf4ca73afe.
 
 ## Merge Readiness
 
@@ -26,6 +26,6 @@ Evidence: scripts/metatron_lab/compose_guard.py (stderr on compose failure, mark
 - [ ] Pre-commit green
 - [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
 
-Notes: Resolve all review threads in GitHub UI with disposition before merge; mapping commit must trail bot comment timestamps.
+Notes: All review threads resolved on GitHub; mapping lines use discussion permalinks from the PR review API.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -8,8 +8,6 @@
 
 ## Fixed in Commit Mapping
 
-Merge readiness maps actionable bot **review** URLs (`#pullrequestreview-*`); thread permalinks below are for human traceability.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062825633 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062831379 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4066112826 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
@@ -31,6 +29,6 @@ Evidence: Sourcery r3040200807 r3040200813 (stderr + test contract); Cubic r3040
 - [ ] Pre-commit green
 - [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
 
-Notes: All review threads resolved on GitHub. Artifact lists both `#pullrequestreview-*` (merge gate) and `discussion_r*` (thread permalinks).
+Notes: All review threads resolved on GitHub. Merge readiness maps actionable bot reviews by `#pullrequestreview-*` URLs; `discussion_r*` lines are thread permalinks for traceability.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -8,24 +8,15 @@
 
 ## Fixed in Commit Mapping
 
-Disposition: **FIXED** (Sourcery / Cubic / CodeRabbit / Codex-aligned follow-ups: stderr on compose failure, marker-based `repo_root()`, checklist stems centralized, extended subprocess contract tests, Epic 2 packet adds `check_agent_consistency.py`, unreachable CLI path uses `RuntimeError`).
-
-Commit: `dc299c888882c3f747af6cabcafd2b1e7c296eff`
-
-Evidence:
-
-- `scripts/metatron_lab/compose_guard.py:1` — stderr snippet + `deploy/metatron-lab/docker-compose.yaml` root discovery; checklist constants
-- `scripts/metatron_lab/__main__.py:1` — no dead `return 2`
-- `tests/test_metatron_lab_compose_guard.py:1` — full `docker compose` argv/kwargs + stderr test
-- `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1` — validation block includes agent-consistency gate
-
-Bot thread mapping (FIXED → commit above):
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062825633 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062831379 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040206216 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3043192789 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4066112826 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+
+Disposition: FIXED
+Commit: dc299c888882c3f747af6cabcafd2b1e7c296eff
+Evidence: scripts/metatron_lab/compose_guard.py (stderr on compose failure, marker-based repo root, checklist stems); scripts/metatron_lab/__main__.py (unreachable path); tests/test_metatron_lab_compose_guard.py (argv/kwargs contract + stderr test); docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md (check_agent_consistency in validation list)
 
 ## Merge Readiness
 
@@ -35,6 +26,6 @@ Bot thread mapping (FIXED → commit above):
 - [ ] Pre-commit green
 - [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
 
-Notes: Refresh after new review activity; mapping commit must trail bot comment timestamps (commit-after-comment gate).
+Notes: Resolve all review threads in GitHub UI with disposition before merge; mapping commit must trail bot comment timestamps.
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -8,6 +8,11 @@
 
 ## Fixed in Commit Mapping
 
+Merge readiness maps actionable bot **review** URLs (`#pullrequestreview-*`); thread permalinks below are for human traceability.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062825633 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4062831379 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#pullrequestreview-4066112826 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040200807 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040200813 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366#discussion_r3040206216 -> dc299c888882c3f747af6cabcafd2b1e7c296eff
@@ -26,6 +31,6 @@ Evidence: Sourcery r3040200807 r3040200813 (stderr + test contract); Cubic r3040
 - [ ] Pre-commit green
 - [ ] `make verify` green locally (or agreed subset: `make validate-min` + targeted tests; see PR body)
 
-Notes: All review threads resolved on GitHub; mapping lines use discussion permalinks from the PR review API.
+Notes: All review threads resolved on GitHub. Artifact lists both `#pullrequestreview-*` (merge gate) and `discussion_r*` (thread permalinks).
 
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1366_FIXED_MAPPING.md
+++ b/docs/review/PR_1366_FIXED_MAPPING.md
@@ -3,12 +3,14 @@
 
 ## Discussion Thread Pass
 
-- [x] Discussion-thread pass completed (initial open — no threads)
-- [x] Fixed in commit mapping completed (initial scaffold)
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable GitHub review threads at initial open; refresh when review comments appear.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments (initial open)
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -319,12 +319,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: METATRON-class offensive lab — out-of-band governance and operator runbook
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (security engineering / abuse prevention)
-  - Target PR: Epic 1 merged [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); Epic 2 / Epic 3 — PR-TBD (isolated runner + runbook; out of scope for Epic 1: no `app/` / product OpenAPI).
+  - Target PR: Epic 1 merged [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); Epic 2 — open PR for isolated runner (branch `feat/metatron-track-a-epic2-runner`; update this line with PR number after open); Epic 3 — PR-TBD (runbook). Epic 2 packet: `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1`.
   - Status: **Track A Epic 1 — CLOSED.** Landed via PR [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); canonical squash merge commit [`5a39c2ec3`](https://github.com/Katsiarynakavaleuskaya/PulsePlate/commit/5a39c2ec3) on `main`. Remaining: Epic 2 (infra/scripts isolated runner), Epic 3 (runbook) per coordinator sequencing after this ledger closeout.
   - Area: security / deploy / orchestration / governance
   - Reason (EN): METATRON-like stacks (local LLM + offensive recon) must not enter the PulsePlate product runtime or OpenAPI; operators still need canonical RoE, ADR, isolated deploy boundary, and coordinator-led assessment workflow. (RU: оффенсив-лаборатория остаётся вне продукта, но процесс и документы должны быть в репозитории.)
   - Links:
     - `docs/orchestration/METATRON_TRACK_A_EPIC1_TASK_PACKET_2026-04-06.md:1`
+    - `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1`
     - `docs/architecture/ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06.md:1`
     - `docs/security/METATRON_LAB_RULES_OF_ENGAGEMENT.md:1`
     - `docs/orchestration/METATRON_SECURITY_ASSESSMENT_WAVE_RUNBOOK.md:1`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -319,7 +319,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: METATRON-class offensive lab — out-of-band governance and operator runbook
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (security engineering / abuse prevention)
-  - Target PR: Epic 1 merged [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); Epic 2 — open PR for isolated runner (branch `feat/metatron-track-a-epic2-runner`; update this line with PR number after open); Epic 3 — PR-TBD (runbook). Epic 2 packet: `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1`.
+  - Target PR: Epic 1 merged [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); Epic 2 — [#1366](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1366) (isolated runner; branch `feat/metatron-track-a-epic2-runner`); Epic 3 — PR-TBD (runbook). Epic 2 packet: `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md:1`.
   - Status: **Track A Epic 1 — CLOSED.** Landed via PR [#1355](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1355); canonical squash merge commit [`5a39c2ec3`](https://github.com/Katsiarynakavaleuskaya/PulsePlate/commit/5a39c2ec3) on `main`. Remaining: Epic 2 (infra/scripts isolated runner), Epic 3 (runbook) per coordinator sequencing after this ledger closeout.
   - Area: security / deploy / orchestration / governance
   - Reason (EN): METATRON-like stacks (local LLM + offensive recon) must not enter the PulsePlate product runtime or OpenAPI; operators still need canonical RoE, ADR, isolated deploy boundary, and coordinator-led assessment workflow. (RU: оффенсив-лаборатория остаётся вне продукта, но процесс и документы должны быть в репозитории.)

--- a/scripts/metatron_lab/__init__.py
+++ b/scripts/metatron_lab/__init__.py
@@ -1,0 +1,21 @@
+"""METATRON out-of-band lab helpers (not product runtime)."""
+
+from __future__ import annotations
+
+from scripts.metatron_lab.compose_guard import (
+    LAB_PROFILES,
+    compose_file_for_repo,
+    operator_checklist_lines,
+    repo_root,
+    run_compose_config_q,
+    validate_all_profiles,
+)
+
+__all__ = [
+    "LAB_PROFILES",
+    "compose_file_for_repo",
+    "operator_checklist_lines",
+    "repo_root",
+    "run_compose_config_q",
+    "validate_all_profiles",
+]

--- a/scripts/metatron_lab/__main__.py
+++ b/scripts/metatron_lab/__main__.py
@@ -1,0 +1,33 @@
+"""CLI: `python3 -m scripts.metatron_lab validate|checklist`."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import cast
+
+from scripts.metatron_lab.compose_guard import operator_checklist_lines, validate_all_profiles
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.metatron_lab",
+        description="METATRON out-of-band lab helpers (no product surface).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("validate", help="Run `docker compose config -q` for all lab profiles.")
+    sub.add_parser("checklist", help="Print operator checklist to stdout.")
+
+    args = parser.parse_args(argv)
+    if args.command == "validate":
+        return cast(int, validate_all_profiles())
+    if args.command == "checklist":
+        for line in operator_checklist_lines():
+            print(line)
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/metatron_lab/__main__.py
+++ b/scripts/metatron_lab/__main__.py
@@ -26,7 +26,7 @@ def main(argv: list[str] | None = None) -> int:
         for line in operator_checklist_lines():
             print(line)
         return 0
-    return 2
+    raise RuntimeError(f"unhandled command: {args.command!r}")  # pragma: no cover
 
 
 if __name__ == "__main__":

--- a/scripts/metatron_lab/compose_guard.py
+++ b/scripts/metatron_lab/compose_guard.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 import shutil
 import subprocess  # nosec B404: operator-only docker compose config -q; argv from fixed tokens + docker via shutil.which (remove-by: 2026-07-01, ref: PR-1366)
+import sys
 from pathlib import Path
 
 LAB_PROFILES: tuple[str, ...] = ("metatron-lab-isolation", "metatron-lab-runner")
 
+# Single place for checklist strings (operator-facing; rename docs in one place if paths change).
+METATRON_LAB_ADR_STEM = "ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06"
+METATRON_LAB_ROE_STEM = "METATRON_LAB_RULES_OF_ENGAGEMENT"
+METATRON_LAB_ARTIFACTS_HINT = "artifacts/security_lab/"
+_STDERR_SNIPPET_MAX = 500
+
 
 def repo_root() -> Path:
-    """Repository root (parent of `deploy/` and `scripts/`)."""
-    return Path(__file__).resolve().parents[2]
+    """Resolve repo root by locating `deploy/metatron-lab/docker-compose.yaml` (not `parents[N]`)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        marker = parent / "deploy" / "metatron-lab" / "docker-compose.yaml"
+        if marker.is_file():
+            return parent
+    return here.parents[2]
 
 
 def compose_file_for_repo(root: Path) -> Path:
@@ -38,6 +50,17 @@ def run_compose_config_q(root: Path, profile: str, docker_bin: str) -> int:
         capture_output=True,
         text=True,
     )
+    if completed.returncode != 0:
+        stderr_snippet = (completed.stderr or "").strip()
+        if len(stderr_snippet) > _STDERR_SNIPPET_MAX:
+            stderr_snippet = f"{stderr_snippet[: _STDERR_SNIPPET_MAX - 3]}..."
+        print(
+            f"[metatron-lab] docker compose config -q failed for profile {profile!r} "
+            f"(rc={completed.returncode})",
+            file=sys.stderr,
+        )
+        if stderr_snippet:
+            print(f"[metatron-lab] stderr: {stderr_snippet}", file=sys.stderr)
     return int(completed.returncode)
 
 
@@ -57,9 +80,8 @@ def validate_all_profiles() -> int:
 def operator_checklist_lines() -> list[str]:
     """Short operator reminders (stdout only; no secrets)."""
     return [
-        "1. Read ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06 and "
-        "METATRON_LAB_RULES_OF_ENGAGEMENT.",
-        "2. Store lab outputs only under artifacts/security_lab/ (gitignored).",
+        f"1. Read {METATRON_LAB_ADR_STEM} and {METATRON_LAB_ROE_STEM}.",
+        f"2. Store lab outputs only under {METATRON_LAB_ARTIFACTS_HINT} (gitignored).",
         "3. Use docker compose with --profile metatron-lab-isolation or metatron-lab-runner; "
         "default compose has no lab services.",
     ]

--- a/scripts/metatron_lab/compose_guard.py
+++ b/scripts/metatron_lab/compose_guard.py
@@ -1,0 +1,65 @@
+"""Deterministic `docker compose config -q` checks for METATRON lab profiles."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404 — operator-only docker compose config -q; argv built from fixed tokens + absolute docker via shutil.which (remove-by: 2026-07-01, ref: BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band)
+from pathlib import Path
+
+LAB_PROFILES: tuple[str, ...] = ("metatron-lab-isolation", "metatron-lab-runner")
+
+
+def repo_root() -> Path:
+    """Repository root (parent of `deploy/` and `scripts/`)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def compose_file_for_repo(root: Path) -> Path:
+    return root / "deploy" / "metatron-lab" / "docker-compose.yaml"
+
+
+def run_compose_config_q(root: Path, profile: str, docker_bin: str) -> int:
+    """Run `docker compose … config -q` for one profile; return process exit code."""
+    compose = compose_file_for_repo(root)
+    cmd = [
+        docker_bin,
+        "compose",
+        "-f",
+        str(compose),
+        "--profile",
+        profile,
+        "config",
+        "-q",
+    ]
+    completed = subprocess.run(  # nosec B603 — no shell; argv is docker + fixed compose flags + repo compose path (remove-by: 2026-07-01, ref: BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band)
+        cmd,
+        cwd=str(root),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return int(completed.returncode)
+
+
+def validate_all_profiles() -> int:
+    """Validate all lab profiles; return 0 on success, 2 if docker is missing, else first non-zero rc."""
+    docker_bin = shutil.which("docker")
+    if not docker_bin:
+        return 2
+    root = repo_root()
+    for profile in LAB_PROFILES:
+        rc = run_compose_config_q(root, profile, docker_bin)
+        if rc != 0:
+            return rc
+    return 0
+
+
+def operator_checklist_lines() -> list[str]:
+    """Short operator reminders (stdout only; no secrets)."""
+    return [
+        "1. Read ADR_METATRON_OFFENSIVE_LAB_OUT_OF_BAND_2026-04-06 and "
+        "METATRON_LAB_RULES_OF_ENGAGEMENT.",
+        "2. Store lab outputs only under artifacts/security_lab/ (gitignored).",
+        "3. Use docker compose with --profile metatron-lab-isolation or metatron-lab-runner; "
+        "default compose has no lab services.",
+    ]

--- a/scripts/metatron_lab/compose_guard.py
+++ b/scripts/metatron_lab/compose_guard.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import shutil
-import subprocess  # nosec B404 — operator-only docker compose config -q; argv built from fixed tokens + absolute docker via shutil.which (remove-by: 2026-07-01, ref: BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band)
+import subprocess  # nosec B404: operator-only docker compose config -q; argv from fixed tokens + docker via shutil.which (remove-by: 2026-07-01, ref: PR-1366)
 from pathlib import Path
 
 LAB_PROFILES: tuple[str, ...] = ("metatron-lab-isolation", "metatron-lab-runner")
@@ -31,7 +31,7 @@ def run_compose_config_q(root: Path, profile: str, docker_bin: str) -> int:
         "config",
         "-q",
     ]
-    completed = subprocess.run(  # nosec B603 — no shell; argv is docker + fixed compose flags + repo compose path (remove-by: 2026-07-01, ref: BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band)
+    completed = subprocess.run(  # nosec B603: no shell; argv is docker + fixed compose flags + repo compose path (remove-by: 2026-07-01, ref: PR-1366)
         cmd,
         cwd=str(root),
         check=False,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -33,6 +33,20 @@
 
 - See canonical WebSocket/realtime invariants in root `AGENTS.md`.
 
+### CI external network guard (`httpx` / `requests`)
+
+When `CI=true` or `BLOCK_TEST_NETWORK` is set (unless `ALLOW_TEST_NETWORK=true`), autouse fixture
+`tests/conftest.py::_block_external_network_in_ci` patches `httpx.Client.request`,
+`httpx.AsyncClient.request`, and `requests.Session.request` so URLs must use an **allowlisted host**
+before any transport (including `httpx.MockTransport`) runs.
+
+**Allowlisted hostnames:** `127.0.0.1`, `localhost`, `::1`, `testserver`, plus any comma-separated
+entries in `TEST_NETWORK_ALLOWED_HOSTS`.
+
+**Implication for tests:** Fake Meili or other httpx clients must use e.g. `http://127.0.0.1` or
+`http://localhost:7700` as `base_url`, not arbitrary hostnames like `meili.test`, or CI raises
+`AssertionError: External HTTP blocked in tests`.
+
 ### Module purge / reload invariant (xdist stability)
 
 Some tests intentionally purge/reload modules (e.g., via `module_purge.purge_modules(...)` or

--- a/tests/test_meili_swap_orchestration.py
+++ b/tests/test_meili_swap_orchestration.py
@@ -19,7 +19,9 @@ def _cfg(
     *,
     primary: str = "foods",
     candidate: str = "foods_v2",
-    base: str = "http://meili.test",
+    # Use loopback host: CI autouse guard blocks non-allowlisted hosts even with MockTransport
+    # (see tests/conftest.py::_block_external_network_in_ci).
+    base: str = "http://127.0.0.1",
 ) -> MeiliSwapConfig:
     return MeiliSwapConfig(
         base_url=base,

--- a/tests/test_meili_swap_orchestration.py
+++ b/tests/test_meili_swap_orchestration.py
@@ -44,6 +44,20 @@ def test_ensure_distinct_rejects_empty() -> None:
         ensure_distinct_primary_and_candidate(cfg)
 
 
+def test_localhost_with_port_passes_ci_network_guard() -> None:
+    """localhost + port is allowlisted under _block_external_network_in_ci (like 127.0.0.1)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/indexes/foods_v2/stats":
+            return httpx.Response(200, json={"numberOfDocuments": 7})
+        return httpx.Response(404, json={"message": "unexpected"})
+
+    transport = httpx.MockTransport(handler)
+    cfg = _cfg(base="http://localhost:7700")
+    with MeiliSwapOrchestrator(cfg, client=httpx.Client(transport=transport)) as orch:
+        assert orch.get_index_document_count("foods_v2") == 7
+
+
 def test_connect_error_wraps_safe_message() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("nope", request=request)

--- a/tests/test_metatron_lab_compose_guard.py
+++ b/tests/test_metatron_lab_compose_guard.py
@@ -1,0 +1,81 @@
+"""Tests for `scripts.metatron_lab` compose validation helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scripts.metatron_lab.compose_guard import (
+    LAB_PROFILES,
+    compose_file_for_repo,
+    operator_checklist_lines,
+    repo_root,
+    run_compose_config_q,
+    validate_all_profiles,
+)
+
+
+def test_operator_checklist_includes_adr_and_roe() -> None:
+    text = "\n".join(operator_checklist_lines())
+    assert "ADR_METATRON" in text
+    assert "METATRON_LAB_RULES_OF_ENGAGEMENT" in text
+    assert "artifacts/security_lab" in text
+
+
+def test_lab_profiles_tuple() -> None:
+    assert LAB_PROFILES == ("metatron-lab-isolation", "metatron-lab-runner")
+
+
+def test_compose_file_exists() -> None:
+    root = repo_root()
+    path = compose_file_for_repo(root)
+    assert path.is_file()
+
+
+def test_validate_all_profiles_missing_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scripts.metatron_lab.compose_guard.shutil.which", lambda _name: None)
+    assert validate_all_profiles() == 2
+
+
+def test_validate_all_profiles_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _which(name: str) -> str | None:
+        return "/opt/bin/docker" if name == "docker" else None
+
+    def _run(
+        cmd: list[str] | tuple[str, ...],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.metatron_lab.compose_guard.shutil.which", _which)
+    monkeypatch.setattr("scripts.metatron_lab.compose_guard.subprocess.run", _run)
+
+    assert validate_all_profiles() == 0
+    assert len(calls) == len(LAB_PROFILES)
+    for i, profile in enumerate(LAB_PROFILES):
+        assert calls[i][0] == "/opt/bin/docker"
+        assert calls[i][1] == "compose"
+        assert profile in calls[i]
+
+
+def test_run_compose_config_q_invokes_docker_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, object] = {}
+
+    def _run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        recorded["args"] = args
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=(), returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.metatron_lab.compose_guard.subprocess.run", _run)
+    root = repo_root()
+    run_compose_config_q(root, "metatron-lab-isolation", "/usr/bin/docker")
+    cmd = recorded["args"]
+    assert isinstance(cmd, tuple) and len(cmd) == 1
+    inner = cmd[0]
+    assert isinstance(inner, list)
+    assert inner[0] == "/usr/bin/docker"
+    assert inner[1] == "compose"

--- a/tests/test_metatron_lab_compose_guard.py
+++ b/tests/test_metatron_lab_compose_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -68,14 +69,52 @@ def test_run_compose_config_q_invokes_docker_binary(monkeypatch: pytest.MonkeyPa
     def _run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         recorded["args"] = args
         recorded["kwargs"] = kwargs
-        return subprocess.CompletedProcess(args=(), returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            args=(), returncode=7, stdout="", stderr="compose failed"
+        )
 
     monkeypatch.setattr("scripts.metatron_lab.compose_guard.subprocess.run", _run)
     root = repo_root()
-    run_compose_config_q(root, "metatron-lab-isolation", "/usr/bin/docker")
+    expected_compose = compose_file_for_repo(root)
+    rc = run_compose_config_q(root, "metatron-lab-isolation", "/usr/bin/docker")
+    assert rc == 7
     cmd = recorded["args"]
     assert isinstance(cmd, tuple) and len(cmd) == 1
     inner = cmd[0]
     assert isinstance(inner, list)
-    assert inner[0] == "/usr/bin/docker"
-    assert inner[1] == "compose"
+    assert inner == [
+        "/usr/bin/docker",
+        "compose",
+        "-f",
+        str(expected_compose),
+        "--profile",
+        "metatron-lab-isolation",
+        "config",
+        "-q",
+    ]
+    kwargs = recorded["kwargs"]
+    assert kwargs["cwd"] == str(root)
+    assert kwargs["check"] is False
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+
+
+def test_run_compose_config_q_failure_prints_stderr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=(),
+            returncode=3,
+            stdout="",
+            stderr="invalid yaml near line 9\n",
+        )
+
+    monkeypatch.setattr("scripts.metatron_lab.compose_guard.subprocess.run", _run)
+    root = Path("/tmp/fake-root")
+    rc = run_compose_config_q(root, "metatron-lab-runner", "/bin/docker")
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "metatron-lab-runner" in err
+    assert "rc=3" in err
+    assert "invalid yaml" in err


### PR DESCRIPTION
## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1366_FIXED_MAPPING.md`

## Summary
METATRON Track A Epic 2: isolated lab runner (infra/scripts only). No `app/`, no product OpenAPI.

## Scope (IN)
- `deploy/metatron-lab/`: `metatron-lab-runner` profile, `lab-runner-sidecar-stub` (internal network, resource limits)
- `scripts/metatron_lab/`: `python3 -m scripts.metatron_lab validate|checklist` (`docker compose … config -q` for both profiles)
- `docs/orchestration/METATRON_TRACK_A_EPIC2_TASK_PACKET_2026-04-06.md`
- `tests/test_metatron_lab_compose_guard.py`
- Ledger cross-links; canonical merge artifact `docs/review/PR_1366_FIXED_MAPPING.md`

## OUT
- `app/`, `core/` business logic, OpenAPI / `frontend/src/api/*`

## Validation (local)
- `make validate-min`
- `pytest -q tests/test_metatron_lab_compose_guard.py`
- `python3 -m scripts.metatron_lab validate` (requires Docker; exit 2 if `docker` missing)
- Pre-push hooks on clean tree: pip-audit, bandit, pytest pre-push — pass

## Phase 2 (merge governance)
- Canonical: `docs/review/PR_1366_FIXED_MAPPING.md` (mirror this section under **Fixed in Commit Mapping** as threads appear)

## Deferred / Follow-ups
- Epic 3 runbook PR-TBD per `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-metatron-offensive-lab-out-of-band`
- Full `make verify`: env must satisfy `scripts/ci/check_local_verify_environment.py` (pyenv + venv tools)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI to run preflight validation and print operator checklists (python -m ... validate/checklist)
  * Added an isolated "runner" compose profile and a lightweight sidecar stub with resource limits; compose profiles are now selectable for validation

* **Documentation**
  * Epic 2 runner task packet and README updated with validation workflows, checklist commands, and explicit profile descriptions; roadmap/PR guidance updated

* **Tests**
  * Added tests covering validation behavior and checklist output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
