### PR TITLE
docs(ci): reconcile Docker provenance ADR with CI workflows

### DIFF
--- a/.github/workflows/docker-openapi-smoke.yml
+++ b/.github/workflows/docker-openapi-smoke.yml
@@ -72,6 +72,9 @@ jobs:
           # Scope rev suffix: GHA cache can 404 on stale blobs; rotating scope recovers without disabling cache.
           cache-from: type=gha,scope=docker-openapi-smoke-v2-${{ github.ref_name }}
           cache-to: type=gha,scope=docker-openapi-smoke-v2-${{ github.ref_name }},mode=min,ignore-error=true
+          # Provenance / SLSA attestations require a registry push; docker exporter + load:true cannot
+          # attach attestations (Docker docs: build CI attestations). Do not enable provenance here
+          # without a separate push-based job — see docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md.
           provenance: false
           target: production
 

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -57,3 +57,4 @@ Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors]
 - Workflow: `.github/workflows/build.yml`.
 - Workflow: `.github/workflows/cd.yml`.
 - Docker CI attestations overview: https://docs.docker.com/build/ci/github-actions/attestations/
+- Backlog Ledger: `docs/roadmap/BACKLOG_LEDGER.md` (`#backlog-restore-signed-build-provenance` — restore signed build provenance; DoD and blockers tracked in the ledger).

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -6,29 +6,25 @@ Accepted (temporary seam)
 ## Context
 Docker image push to GHCR was failing with `failed to push ... cache entry no longer exists` when using `cache-from: type=gha` and default provenance. This is a known class of issues with buildx + GHA cache backend where cache blobs can become unavailable during export/push.
 
-To unblock main and stabilize CI/CD, we keep the existing workaround profile in
-`.github/workflows/build.yml` and align `.github/workflows/cd.yml` with the same
-provenance/single-arch policy:
+To unblock main and stabilize CI/CD, we keep one workaround profile across
+workflows. The **steps below follow the same order as** [Evidence Anchors](#evidence-anchors-fileline) (top → bottom) so operators can walk the YAML and the ADR in lockstep.
 
-1. **provenance: false** — disables SLSA build provenance attestations so buildx does not generate attestations that can interact badly with the cache export path.
-2. **Single-arch (linux/amd64)** in publish step — reduces surface for cache/export issues; multi-arch can be restored when cache/provenance stack is stable.
-3. **Scoped `cache-from: type=gha` + `cache-to: type=gha,mode=min,ignore-error=true`** on CD image builds — an earlier iteration omitted `cache-from` on CD to avoid `BlobNotFound`; the current workflows reintroduced **ref-scoped** `cache-from` keys (`cd-staging-*`, `cd-production-*`) to improve hit rate while keeping `mode=min` and `ignore-error=true` on export as the fail-safe profile (same pattern as `build.yml` publish).
+1. **`build.yml` — local test image (`load: true`)** — `push: false`, scoped `cache-from` / `cache-to` (`build-production-${{ github.ref_name }}`, `mode=min`, `ignore-error=true`), **`provenance: false`**. Uses the docker exporter; **SLSA attestations are not supported for `load: true`** (registry push is required for attestations). Do not enable `provenance` on this step without a separate push-based job.
+2. **`build.yml` — publish to GHCR (`push: true`)** — **`platforms: linux/amd64`** only (reduces cache/export surface; restore `linux/arm64` when stable), same scoped cache pattern as (1), **`provenance: false`** to avoid buildx/GHA `"cache entry no longer exists"` / BlobNotFound on export.
+3. **`cd.yml` — staging image** — **`cache-from` / `cache-to`** with scope `cd-staging-${{ github.ref_name }}` (`mode=min`, `ignore-error=true`), **`provenance: false`**, `target: staging`, **`linux/amd64`**.
+4. **`cd.yml` — production image** — same cache policy with scope **`cd-production-${{ github.ref_name }}`**, **`provenance: false`**, **`linux/amd64`**.
+5. **`docker-openapi-smoke.yml` — smoke build** — same pattern as (1): `load: true`, scoped cache (`docker-openapi-smoke-v2-${{ github.ref_name }}`), **`provenance: false`** (attestations incompatible with `load`; see (1)).
 
-**Local `load: true` jobs (smoke / PR CI):** `docker/build-push-action` with `push: false` and `load: true` uses the docker exporter. Docker’s attestations model expects a registry push; **SLSA provenance attestations are not supported for `load: true`** (local image store). Those jobs therefore keep `provenance: false` for an explicit, stable contract until a **separate** push-based pilot (e.g. GHCR tag + scan-only) is designed — not by flipping `provenance` on the same step as `load: true`.
+Cross-cutting themes: **scoped GHA cache keys** (per ref / job family) replace an older “omit `cache-from` on CD” iteration that avoided `BlobNotFound` but hurt hit rate; **`ignore-error=true` on `cache-to`** remains the export fail-safe everywhere.
 
 ## Decision
-- Keep `provenance: false` in the existing `build.yml` publish step and set it
-  in the corresponding `cd.yml` image-build steps.
-- Keep single platform `linux/amd64` for the affected publish/deploy/CD steps;
-  document intent to restore `linux/arm64` when GHA cache/provenance is
-  stable.
-- Keep **scoped** `cache-from` / `cache-to` on CD image builds aligned with the
-  bounded cache profile used on `build.yml` (`mode=min`, `ignore-error=true` on
-  `cache-to`).
-- Keep `provenance: false` on all jobs that use `load: true` until a dedicated
-  registry-backed build path is introduced for attestations.
-- Inline comments in the workflow document the trade-off (SLSA attestations disabled; `cosign verify-attestation` will fail for consumers) and re-enable intent.
-- This ADR documents the temporary seam and exit criteria.
+Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors](#evidence-anchors-fileline)):
+
+- Keep **`provenance: false`** on every `docker/build-push-action` step listed in those anchors (`load: true` and `push: true` paths) until a **separate** registry-backed pilot exists for attestations.
+- Keep **`linux/amd64` only** on all publish/CD image builds; restore multi-arch when cache/provenance is stable.
+- Keep **scoped** `cache-from: type=gha` + `cache-to: type=gha,mode=min,ignore-error=true` on each of those steps (scopes differ per job; see anchors).
+- Keep **inline comments** in workflows stating the trade-off (SLSA off; `cosign verify-attestation` fails for these images) and intent to re-enable.
+- Treat this ADR as the temporary seam SoT until **Exit Criteria** are met.
 
 ## Rationale
 - Restores green CI/CD and reliable image pushes to GHCR.

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -7,13 +7,14 @@ Accepted (temporary seam)
 Docker image push to GHCR was failing with `failed to push ... cache entry no longer exists` when using `cache-from: type=gha` and default provenance. This is a known class of issues with buildx + GHA cache backend where cache blobs can become unavailable during export/push.
 
 To unblock main and stabilize CI/CD, we keep the existing workaround profile in
-`.github/workflows/build.yml` and extend the same provenance/single-arch policy
-to `.github/workflows/cd.yml`:
+`.github/workflows/build.yml` and align `.github/workflows/cd.yml` with the same
+provenance/single-arch policy:
+
 1. **provenance: false** — disables SLSA build provenance attestations so buildx does not generate attestations that can interact badly with the cache export path.
 2. **Single-arch (linux/amd64)** in publish step — reduces surface for cache/export issues; multi-arch can be restored when cache/provenance stack is stable.
-3. **No `cache-from: type=gha` on CD image builds** — avoids `BlobNotFound` /
-   missing cache entry failures when the GitHub Actions cache backend evicts or
-   cannot resolve a referenced blob during multi-stage COPY.
+3. **Scoped `cache-from: type=gha` + `cache-to: type=gha,mode=min,ignore-error=true`** on CD image builds — an earlier iteration omitted `cache-from` on CD to avoid `BlobNotFound`; the current workflows reintroduced **ref-scoped** `cache-from` keys (`cd-staging-*`, `cd-production-*`) to improve hit rate while keeping `mode=min` and `ignore-error=true` on export as the fail-safe profile (same pattern as `build.yml` publish).
+
+**Local `load: true` jobs (smoke / PR CI):** `docker/build-push-action` with `push: false` and `load: true` uses the docker exporter. Docker’s attestations model expects a registry push; **SLSA provenance attestations are not supported for `load: true`** (local image store). Those jobs therefore keep `provenance: false` for an explicit, stable contract until a **separate** push-based pilot (e.g. GHCR tag + scan-only) is designed — not by flipping `provenance` on the same step as `load: true`.
 
 ## Decision
 - Keep `provenance: false` in the existing `build.yml` publish step and set it
@@ -21,10 +22,11 @@ to `.github/workflows/cd.yml`:
 - Keep single platform `linux/amd64` for the affected publish/deploy/CD steps;
   document intent to restore `linux/arm64` when GHA cache/provenance is
   stable.
-- Keep `build.yml` publish on its current bounded cache profile, and omit
-  `cache-from: type=gha` for the affected `cd.yml` image-build steps while
-  using `cache-to: type=gha,mode=min,ignore-error=true` as the fail-safe export
-  profile.
+- Keep **scoped** `cache-from` / `cache-to` on CD image builds aligned with the
+  bounded cache profile used on `build.yml` (`mode=min`, `ignore-error=true` on
+  `cache-to`).
+- Keep `provenance: false` on all jobs that use `load: true` until a dedicated
+  registry-backed build path is introduced for attestations.
 - Inline comments in the workflow document the trade-off (SLSA attestations disabled; `cosign verify-attestation` will fail for consumers) and re-enable intent.
 - This ADR documents the temporary seam and exit criteria.
 
@@ -32,32 +34,25 @@ to `.github/workflows/cd.yml`:
 - Restores green CI/CD and reliable image pushes to GHCR.
 - Trade-off is explicit: we lose attestations until upstream/buildx or GHA cache behavior is fixed.
 - Single-arch reduces variables while cache/provenance tooling is unstable.
-- Removing `cache-from` on CD image builds favors reliability over cache hit
-  rate for the release path.
+- Scoped `cache-from` on CD improves cache reuse while `ignore-error=true` on `cache-to` limits export-time flakes.
 
 ## Consequences
 - Image consumers cannot verify SLSA provenance via cosign for images built by this workflow until the workaround is removed.
 - Arm64 image builds are deferred until we re-enable multi-platform.
+- Smoke and other `load: true` CI jobs cannot serve as a provenance pilot without changing architecture (e.g. build+push to a scratch tag, then pull/run).
 
 ## Evidence Anchors (file:line)
-- `.github/workflows/build.yml:42` omits `cache-from` in the local build job to
-  avoid `BlobNotFound`.
-- `.github/workflows/build.yml:181`-`.github/workflows/build.yml:193` pins
-  `linux/amd64`, uses `cache-to: ...mode=min,ignore-error=true`, and sets
-  `provenance: false` for publish.
-- `.github/workflows/cd.yml:73`, `.github/workflows/cd.yml:80`,
-  `.github/workflows/cd.yml:85` align the staging CD image build with the same
-  cache/provenance workaround profile.
-- `.github/workflows/cd.yml:261`, `.github/workflows/cd.yml:269`,
-  `.github/workflows/cd.yml:274` align the production CD image build with the
-  same cache/provenance workaround profile.
+- `.github/workflows/build.yml:42`-`.github/workflows/build.yml:56` local build job: `load: true`, scoped `cache-from` / `cache-to`, `provenance: false`.
+- `.github/workflows/build.yml:217`-`.github/workflows/build.yml:236` publish: `linux/amd64`, `push: true`, scoped `cache-from` / `cache-to`, `provenance: false`.
+- `.github/workflows/cd.yml:87`-`.github/workflows/cd.yml:108` staging image: `cache-from` / `cache-to`, `provenance: false`, `target: staging`.
+- `.github/workflows/cd.yml:284`-`.github/workflows/cd.yml:305` production image: `cache-from` / `cache-to`, `provenance: false`.
+- `.github/workflows/docker-openapi-smoke.yml:61`-`.github/workflows/docker-openapi-smoke.yml:79` smoke build: `load: true`, `provenance: false` (attestations incompatible with `load`; see Context).
 
 ## Exit Criteria / Definition of Done
 - [ ] Upstream fix or documented stable approach: buildx and/or GHA cache backend no longer produces "cache entry no longer exists" (or equivalent) when using `cache-from: type=gha` and provenance enabled.
 - [ ] Remove `provenance: false` and restore default or `provenance: mode=max`
-  in the affected publish/deploy workflow steps.
-- [ ] Re-evaluate whether `cache-from: type=gha` can be safely restored on the
-  affected `cd.yml` image-build steps.
+  in the affected publish/deploy workflow steps (registry push paths only).
+- [ ] Re-evaluate cache scopes and `mode=min` vs `mode=max` once provenance is re-enabled on GHCR pushes.
 - [ ] Optionally restore `platforms: linux/amd64,linux/arm64` when
   cache/provenance is stable.
 - [ ] Update this ADR status to Superseded with a pointer to the removal PR when workaround is removed.
@@ -65,3 +60,4 @@ to `.github/workflows/cd.yml`:
 ## Links
 - Workflow: `.github/workflows/build.yml`.
 - Workflow: `.github/workflows/cd.yml`.
+- Docker CI attestations overview: https://docs.docker.com/build/ci/github-actions/attestations/

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1369 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- No GitHub review threads at artifact creation time. Re-run disposition mapping when bots or humans add actionables.
+
+## Fixed in Commit Mapping
+
+_(No threads yet — add \`- <thread_url> -> <sha>\` rows only after explicit disposition per AGENTS.md.)_
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] Any new review threads dispositioned below
+
+### Local / design verification
+
+- Commit: `4dce1e9c9` (initial PR head — update if amended)
+- Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (updated Context, Decision, Evidence Anchors)
+- Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -16,6 +16,6 @@ _(No threads yet — add \`- <thread_url> -> <sha>\` rows only after explicit di
 
 ### Local / design verification
 
-- Branch head: `69cdd13ef` (includes ADR evidence-order alignment + mapping scaffold)
+- Branch head: `ab392be0c` (ADR SoT + smoke comments + mapping scaffold)
 - Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (updated Context, Decision, Evidence Anchors)
 - Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -16,6 +16,6 @@ _(No threads yet — add \`- <thread_url> -> <sha>\` rows only after explicit di
 
 ### Local / design verification
 
-- Commit: `4dce1e9c9` (initial PR head — update if amended)
+- Branch head: `69cdd13ef` (includes ADR evidence-order alignment + mapping scaffold)
 - Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (updated Context, Decision, Evidence Anchors)
 - Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -5,20 +5,25 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No actionable GitHub review threads at artifact creation; update this artifact when bots or humans file review comments.
+Bot and human review threads must be dispositioned below; resolve conversations on GitHub after mapping.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1369#discussion_r3043233470 -> 2d39b925fdc85de9e23f1a9cd7e2c2f9b545c86b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1369#discussion_r3043233476 -> c2ce43f3d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1369#pullrequestreview-4066120900
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1369#pullrequestreview-4066154667
+Disposition: FIXED
+Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (Backlog Ledger link under Links; commit 2d39b925fdc85de9e23f1a9cd7e2c2f9b545c86b). Checkbox/mapping contract addressed in c2ce43f3d. Sourcery/CodeRabbit summary reviews require no further code changes beyond this ADR/doc scope.
 
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
-- [ ] Any new review threads dispositioned under **Fixed in Commit Mapping**
+- [ ] All review threads resolved on GitHub after disposition updates
 
 ### Local / design verification
 
-- Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (Context steps + Evidence Anchors)
+- Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (Context steps + Evidence Anchors + Links)
 - Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)
 - Branch head: `gh pr view 1369 --json headRefOid -q .headRefOid`

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -2,20 +2,23 @@
 
 ## Discussion Thread Pass
 
-- No GitHub review threads at artifact creation time. Re-run disposition mapping when bots or humans add actionables.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable GitHub review threads at artifact creation; update this artifact when bots or humans file review comments.
 
 ## Fixed in Commit Mapping
 
-_(No threads yet — add \`- <thread_url> -> <sha>\` rows only after explicit disposition per AGENTS.md.)_
+- No actionable review comments
 
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
-- [ ] Any new review threads dispositioned below
+- [ ] Any new review threads dispositioned under **Fixed in Commit Mapping**
 
 ### Local / design verification
 
-- Branch head: use `gh pr view 1369 --json headRefOid` (avoid stale SHAs in this artifact)
-- Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (updated Context, Decision, Evidence Anchors)
+- Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (Context steps + Evidence Anchors)
 - Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)
+- Branch head: `gh pr view 1369 --json headRefOid -q .headRefOid`

--- a/docs/review/PR_1369_FIXED_MAPPING.md
+++ b/docs/review/PR_1369_FIXED_MAPPING.md
@@ -16,6 +16,6 @@ _(No threads yet — add \`- <thread_url> -> <sha>\` rows only after explicit di
 
 ### Local / design verification
 
-- Branch head: `ab392be0c` (ADR SoT + smoke comments + mapping scaffold)
+- Branch head: use `gh pr view 1369 --json headRefOid` (avoid stale SHAs in this artifact)
 - Evidence: `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` (updated Context, Decision, Evidence Anchors)
 - Evidence: `.github/workflows/docker-openapi-smoke.yml:75`-`78` (load vs attestations rationale)


### PR DESCRIPTION
## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1369_FIXED_MAPPING.md`

## Coordinator packet (agent-coordinator)

**IN:** Single PR — align `ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md` with current `build.yml` / `cd.yml` (scoped `cache-from`, `provenance: false` on publish); document why OpenAPI smoke keeps `provenance: false` with `load: true`.

**OUT:** No changes to `cd.yml` publish semantics, GHCR tags, or enabling attestations on GHCR in this PR.

**Risks:** Plan option A (enable provenance on smoke with `load: true`) is **not viable** — Docker attestations require registry push; `load: true` uses docker exporter. Pilot deferred to a future push-based job.

**Touched workflows:** `.github/workflows/docker-openapi-smoke.yml` (comments only; behavior unchanged).

**Expected checks:** CI paths that include workflow + `docs/architecture/*` (yaml lint, workflow guard, docs gates if configured).

## Scope (choose-scope)

**B** — ADR / SoT reconciliation + inline workflow rationale (option A rejected on technical grounds).

## Phase 2 — Deferred / Follow-ups

- Future: registry-backed provenance pilot on a non-production tag (`build.yml` / `cd.yml`) per `docs/roadmap/BACKLOG_LEDGER.md` **Restore signed build provenance**.

## Validation (local)

- `python3 scripts/orchestration/check_preflight.py` — PASS
- `pre-commit run --files` on changed paths — PASS
- `make validate-min` — PASS
- `make verify` — not run: local verify-env expects pyenv interpreter + modules (mypy/coverage/diff-cover); use `make venv-sync` per recovery message for full parity.

## Fixed in Commit Mapping

- (Populate after review threads appear; artifact: `docs/review/PR_<N>_FIXED_MAPPING.md`)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Согласовать ADR по обходному решению для Docker provenance с текущими CI/CD‑воркфлоу и прояснить, почему некоторые сборки для smoke‑тестов продолжают отключать provenance при использовании локальной загрузки образов.

CI:
- Добавить поясняющие комментарии в workflow smoke‑тестов docker OpenAPI, документирующие, почему provenance по-прежнему отключён при сборках на основе `load`, и ссылающиеся на обновлённый ADR.

Документация:
- Обновить ADR по Docker build provenance, чтобы отразить использование ограниченного кэша в CD‑воркфлоу, продолжающееся использование одноархитектурных образов и разделение provenance, основанного на реестре, и задач, использующих `load`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the Docker provenance workaround ADR with current CI/CD workflows and clarify why certain smoke-test builds continue to disable provenance when using local image loading.

CI:
- Add explanatory comments to the docker OpenAPI smoke workflow documenting why provenance remains disabled when using load-based builds and referencing the updated ADR.

Documentation:
- Update the Docker build provenance ADR to reflect scoped cache usage in CD workflows, the continued use of single-arch images, and the separation of registry-backed provenance from load-based jobs.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Docker build provenance ADR with current CI workflows and clarifies that attestations are incompatible with `load: true`; enablement is deferred to a push-based job. No workflow behavior changes.

- **Docs**
  - ADR matches `build.yml`/`cd.yml`: scoped `cache-from`/`cache-to` with `mode=min,ignore-error=true`, single-arch `linux/amd64`, and `provenance: false`; order mirrors Evidence Anchors and adds links to Docker attestations and the Backlog Ledger for restoring signed provenance.
  - `docker-openapi-smoke.yml`: added comments noting attestations require a registry push; keep `provenance: false` with `load: true`.
  - `docs/review/PR_1369_FIXED_MAPPING.md`: added merge-readiness checklist and anti-stale SHA guidance; mapped bot threads to commits and referenced the ADR/backlog link.

<sup>Written for commit 2dfb1a8e7b630e6a130fe26984be077f2ff9b3c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI build behavior to skip registry-attestation for local/load-style image builds to align with current publish workflow.

* **Documentation**
  * Revised architecture guidance to unify build/publish workflow steps and caching strategy.
  * Added a review guidance document outlining disposition mapping and merge-readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
