### PR TITLE
docs(orchestration): local coordinator launcher + mypy TypeGuard narrows

### DIFF
--- a/.cursor/agents/AGENTS.md
+++ b/.cursor/agents/AGENTS.md
@@ -12,6 +12,8 @@ This document defines **scoped rules** specific to Cursor agents in `.cursor/age
 
 **Hard rule:** Any new task MUST start with `agent-coordinator` for task analysis and agent routing.
 
+**Machine-local launcher:** An opt-in host wrapper may front-load `check_preflight.py` and `task_bootstrap.py`; **coordinator-first authority** remains root `AGENTS.md` and the canonical workflow (`docs/orchestration/workflow.md`), not the launcher.
+
 **Reference:** Root `AGENTS.md` (Agent Coordination section) for full policy.
 
 **Local implementation:** `.cursor/agents/agent-coordinator.md` is the canonical coordinator agent.

--- a/.cursor/commands/init.md
+++ b/.cursor/commands/init.md
@@ -9,7 +9,7 @@ Initialize a PulsePlate agent session with the repo-native path below.
 5. Read [`docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md`](../../docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md)
 6. If you need project-local MCP wiring, copy [`.cursor/mcp.json.example`](../mcp.json.example) to `.cursor/mcp.json`
 7. If you need Codex skills, run [`scripts/install_codex_skills.sh`](../../scripts/install_codex_skills.sh) and restart Codex
-8. **Optional (local raw session):** from repo root, run [`scripts/orchestration/local_session_bootstrap.sh`](../../scripts/orchestration/local_session_bootstrap.sh) to run analyze-mode preflight and print the `task_bootstrap.py` invocation recipe (does not replace a host launcher)
+8. **Cold start (pick one):** If you installed the opt-in machine launcher on your host, use it first per [`docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](../../docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md). Otherwise, from repo root, run [`scripts/orchestration/local_session_bootstrap.sh`](../../scripts/orchestration/local_session_bootstrap.sh) for analyze-mode preflight and the printed `task_bootstrap.py` recipe. Neither path changes repository SoT.
 
 Use the repository's canonical custom orchestration workflow for any new task:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,8 +659,11 @@ jobs:
                   tests/test_api.py \
                   tests/test_app_error_handling_combined.py \
                   tests/test_app_extended_coverage.py \
+                  tests/test_creative_research_eval_contract.py \
                   tests/test_food_search_foundation.py \
                   tests/test_foods_router_coverage_boost.py \
+                  tests/test_judgment_core.py \
+                  tests/test_judgment_eval_contract.py \
                   tests/test_legacy_app_diff_coverage.py \
                   tests/test_metrics.py
                 ;;

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -10,7 +10,7 @@ paths.
 from __future__ import annotations
 
 import re
-from typing import Literal, TypedDict
+from typing import Literal, TypeGuard, TypedDict
 
 from core.insight.philosophy_validator import validate_llm_output
 
@@ -34,6 +34,16 @@ OUTPUT_CLASSES: tuple[CreativeResearchOutputClass, ...] = (
     "anomaly_explanation_candidate",
     "creative_ideation",
 )
+
+
+def _is_creative_confidence(value: str) -> TypeGuard[CreativeResearchConfidence]:
+    return value in CONFIDENCE_LEVELS
+
+
+def _is_creative_phase(value: str) -> TypeGuard[CreativeResearchPhase]:
+    return value in VALID_PHASES
+
+
 PROMOTION_DECISIONS: tuple[CreativeResearchPromotionDecision, ...] = (
     "promote",
     "defer",
@@ -361,7 +371,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
         key="phase",
         label="Creative research eval bundle",
     ).lower()
-    if phase not in VALID_PHASES:
+    if not _is_creative_phase(phase):
         allowed = ", ".join(VALID_PHASES)
         raise ValueError(f"Creative research eval bundle phase must be one of: {allowed}.")
 
@@ -391,11 +401,11 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
             key="confidence",
             label=label,
         ).lower()
-        if confidence not in CONFIDENCE_LEVELS:
+        if not _is_creative_confidence(confidence):
             allowed = ", ".join(CONFIDENCE_LEVELS)
             raise ValueError(f"{label} confidence must be one of: {allowed}.")
 
-        normalized_confidence: CreativeResearchConfidence = confidence
+        normalized_confidence = confidence
         candidate: CreativeResearchCandidateRecord = {
             "candidate_id": _require_non_empty_string(
                 candidate_payload,
@@ -446,7 +456,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
         }
         candidates.append(candidate)
 
-    normalized_phase: CreativeResearchPhase = phase
+    normalized_phase = phase
     bundle_record: CreativeResearchBundleRecord = {
         "schema_version": schema_version,
         "bundle_id": bundle_id,

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -10,7 +10,7 @@ paths.
 from __future__ import annotations
 
 import re
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypedDict
 
 from core.insight.philosophy_validator import validate_llm_output
 
@@ -395,7 +395,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
             allowed = ", ".join(CONFIDENCE_LEVELS)
             raise ValueError(f"{label} confidence must be one of: {allowed}.")
 
-        normalized_confidence = cast(CreativeResearchConfidence, confidence)
+        normalized_confidence: CreativeResearchConfidence = confidence
         candidate: CreativeResearchCandidateRecord = {
             "candidate_id": _require_non_empty_string(
                 candidate_payload,
@@ -446,7 +446,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
         }
         candidates.append(candidate)
 
-    normalized_phase = cast(CreativeResearchPhase, phase)
+    normalized_phase: CreativeResearchPhase = phase
     bundle_record: CreativeResearchBundleRecord = {
         "schema_version": schema_version,
         "bundle_id": bundle_id,

--- a/core/judgment.py
+++ b/core/judgment.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import Literal, Mapping, Sequence, TypedDict, cast
+from typing import Literal, Mapping, Sequence, TypeGuard, TypedDict, cast
 
 ClaimType = Literal[
     "fact",
@@ -50,6 +50,20 @@ EVIDENCE_MODES: tuple[EvidenceMode, ...] = (
     "heuristic",
     "none",
 )
+
+
+def _is_claim_type(value: str) -> TypeGuard[ClaimType]:
+    return value in CLAIM_TYPES
+
+
+def _is_support_status(value: str) -> TypeGuard[SupportStatus]:
+    return value in SUPPORT_STATUSES
+
+
+def _is_evidence_mode(value: str) -> TypeGuard[EvidenceMode]:
+    return value in EVIDENCE_MODES
+
+
 PROMOTION_LABELS: tuple[str, ...] = ("promote", "defer", "discard")
 JUDGMENT_FLOW: tuple[str, ...] = (
     "propose",
@@ -133,7 +147,7 @@ def parse_claim_type(raw_value: str) -> ClaimType:
     if not isinstance(raw_value, str):
         raise ValueError("claim_type must be a string.")
     normalized = raw_value.strip().lower()
-    if normalized not in CLAIM_TYPES:
+    if not _is_claim_type(normalized):
         allowed = ", ".join(CLAIM_TYPES)
         raise ValueError(f"claim_type must be one of: {allowed}.")
     return normalized
@@ -145,7 +159,7 @@ def parse_support_status(raw_value: str) -> SupportStatus:
     if not isinstance(raw_value, str):
         raise ValueError("support_status must be a string.")
     normalized = raw_value.strip().lower()
-    if normalized not in SUPPORT_STATUSES:
+    if not _is_support_status(normalized):
         allowed = ", ".join(SUPPORT_STATUSES)
         raise ValueError(f"support_status must be one of: {allowed}.")
     return normalized
@@ -157,7 +171,7 @@ def parse_evidence_mode(raw_value: str) -> EvidenceMode:
     if not isinstance(raw_value, str):
         raise ValueError("evidence_mode must be a string.")
     normalized = raw_value.strip().lower()
-    if normalized not in EVIDENCE_MODES:
+    if not _is_evidence_mode(normalized):
         allowed = ", ".join(EVIDENCE_MODES)
         raise ValueError(f"evidence_mode must be one of: {allowed}.")
     return normalized

--- a/core/judgment.py
+++ b/core/judgment.py
@@ -136,7 +136,7 @@ def parse_claim_type(raw_value: str) -> ClaimType:
     if normalized not in CLAIM_TYPES:
         allowed = ", ".join(CLAIM_TYPES)
         raise ValueError(f"claim_type must be one of: {allowed}.")
-    return cast(ClaimType, normalized)
+    return normalized
 
 
 def parse_support_status(raw_value: str) -> SupportStatus:
@@ -148,7 +148,7 @@ def parse_support_status(raw_value: str) -> SupportStatus:
     if normalized not in SUPPORT_STATUSES:
         allowed = ", ".join(SUPPORT_STATUSES)
         raise ValueError(f"support_status must be one of: {allowed}.")
-    return cast(SupportStatus, normalized)
+    return normalized
 
 
 def parse_evidence_mode(raw_value: str) -> EvidenceMode:
@@ -160,7 +160,7 @@ def parse_evidence_mode(raw_value: str) -> EvidenceMode:
     if normalized not in EVIDENCE_MODES:
         allowed = ", ".join(EVIDENCE_MODES)
         raise ValueError(f"evidence_mode must be one of: {allowed}.")
-    return cast(EvidenceMode, normalized)
+    return normalized
 
 
 def classify_claim_type(text: str) -> ClaimType:

--- a/core/judgment_eval.py
+++ b/core/judgment_eval.py
@@ -7,7 +7,7 @@ EN: Contract and evaluator for offline judgment replay without providers or netw
 from __future__ import annotations
 
 import re
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypeGuard, TypedDict, cast
 
 from core.insight.philosophy_validator import validate_llm_output
 from core.judgment import (
@@ -36,6 +36,10 @@ FitChefBoundaryClass = Literal["wellness_coaching", "high_distress_boundary"]
 FitChefReplayRole = Literal["user", "assistant"]
 FitChefContextStrength = Literal["weak", "medium", "strong"]
 FITCHEF_REPLAY_ROLES: frozenset[FitChefReplayRole] = frozenset({"user", "assistant"})
+
+
+def _is_fitchef_replay_role(value: str) -> TypeGuard[FitChefReplayRole]:
+    return value in FITCHEF_REPLAY_ROLES
 
 
 class FitChefReplayTurnRecord(TypedDict):
@@ -173,7 +177,7 @@ def _validate_turns(raw_value: object, *, label: str) -> list[FitChefReplayTurnR
         turn_payload = _require_object(raw_turn, label=f"{label} turn #{index}")
         raw_role = _require_case_string(turn_payload, key="role", label=f"{label} turn #{index}")
         role = raw_role.lower()
-        if role not in FITCHEF_REPLAY_ROLES:
+        if not _is_fitchef_replay_role(role):
             raise ValueError(f"{label} turn #{index} role must be user|assistant.")
         turns.append(
             {

--- a/core/judgment_eval.py
+++ b/core/judgment_eval.py
@@ -177,7 +177,7 @@ def _validate_turns(raw_value: object, *, label: str) -> list[FitChefReplayTurnR
             raise ValueError(f"{label} turn #{index} role must be user|assistant.")
         turns.append(
             {
-                "role": cast(FitChefReplayRole, role),
+                "role": role,
                 "text": _require_case_string(
                     turn_payload, key="text", label=f"{label} turn #{index}"
                 ),

--- a/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
+++ b/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
@@ -10,7 +10,9 @@ Read these in order:
 2. [`docs/ENGINEERING_LESSONS.md`](../ENGINEERING_LESSONS.md)
 3. [`RUNBOOK_AGENT.md`](../../RUNBOOK_AGENT.md)
 4. the nearest scoped `AGENTS.md` for the files you touch
-5. this guide for tool-specific setup notes
+5. optional machine-local launcher (if installed on your host): see [`LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md) — **opt-in only**, not a global default
+6. coordinator bootstrap: `scripts/orchestration/check_preflight.py` then `scripts/orchestration/task_bootstrap.py` (or the printed recipe from `local_session_bootstrap.sh`)
+7. this guide for tool-specific setup notes
 
 ## Cursor
 
@@ -66,7 +68,8 @@ When instructions overlap, use this order:
 1. root `AGENTS.md`
 2. nearest scoped `AGENTS.md`
 3. `RUNBOOK_AGENT.md`
-4. tool-specific bridge docs such as this file, `CLAUDE.md`, or `docs/dev/CODEX_SKILLS.md`
+4. optional host launcher (if present) for **ordering** preflight/bootstrap only — does not override policy in root `AGENTS.md`
+5. tool-specific bridge docs such as this file, `CLAUDE.md`, or `docs/dev/CODEX_SKILLS.md`
 
 ## Local validation reminder
 

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -54,6 +54,8 @@ this document by itself.
 
 **Raw session note:** nothing in this file runs at host session start. Use `scripts/orchestration/local_session_bootstrap.sh` (optional) then `task_bootstrap.py` so routing and `recommended_skills` are produced deterministically.
 
+**Launcher vs skills:** If you use an opt-in machine launcher (see [`docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md)), run preflight/bootstrap **before** relying on installed skills or manual task work. **Skills do not replace** `task_bootstrap.py`; they complement routing after a packet exists.
+
 Canonical selection order after bootstrap:
 
 1. `pulseplate-workflow`

--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
@@ -1,0 +1,150 @@
+# Machine-local coordinator launcher rollout
+
+<!-- markdownlint-disable MD013 -->
+
+This document describes an **opt-in, operator-owned** machine-local wrapper that runs
+`check_preflight.py` (analyze mode) and then `task_bootstrap.py` from a checked-out PulsePlate
+repository.
+
+**Scope boundary:** Launcher behavior is **launcher-enforced only on opted-in machine(s)** where
+you install the wrapper and optional `PATH` hooks. It is **not** a global default for all
+developers or CI. Repository markdown and templates do not auto-start sessions on any host.
+
+**Canonical example (sanitized):** [`docs/templates/pulseplate-coordinator-launch.example.sh`](../templates/pulseplate-coordinator-launch.example.sh)
+
+**Related SoT:** [`docs/orchestration/AUTOMATION_READINESS_MATRIX.md`](../orchestration/AUTOMATION_READINESS_MATRIX.md),
+[`scripts/orchestration/local_session_bootstrap.sh`](../../scripts/orchestration/local_session_bootstrap.sh)
+(repo bridge; prints bootstrap recipe only).
+
+## Install (host)
+
+1. Ensure `python3` is on `PATH` and you have a git clone of this repository.
+2. Create `~/.local/bin` if needed: `mkdir -p ~/.local/bin`
+3. Copy the canonical script body from [`docs/templates/pulseplate-coordinator-launch.example.sh`](../templates/pulseplate-coordinator-launch.example.sh)
+   into `~/.local/bin/pulseplate-coordinator-launch.sh` (or merge edits carefully).
+4. `chmod +x ~/.local/bin/pulseplate-coordinator-launch.sh`
+5. Ensure `~/.local/bin` is on your shell `PATH` when you work (shell-specific).
+6. Optional: set `CODEX_HOME` if your Codex install expects it; the wrapper exports
+   `CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"` only as a convenience default.
+
+**Do not commit** real host wrappers, `~/.codex/config.toml`, or machine-specific `PATH` snippets
+into the repository.
+
+## Use
+
+Run from any directory inside the repo (so `git rev-parse --show-toplevel` resolves), or set
+`PULSEPLATE_REPO_ROOT` to the clone root and run from elsewhere.
+
+Required flags: `--goal`, `--task-class`.
+
+Optional: `--pr-phase`, repeatable `--path`, repeatable `--requested-agent`.
+
+The wrapper passes the same `--path` values to **both** `check_preflight.py --mode analyze` and
+`task_bootstrap.py` so scoped `AGENTS.md` resolution in analyze mode stays aligned with bootstrap.
+
+Example:
+
+```bash
+pulseplate-coordinator-launch.sh \
+  --goal "Close machine-local launcher gap for coordinator-first startup" \
+  --task-class "pr_governance" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase pre_open
+```
+
+## Smoke checks (host)
+
+Run these **before** opening the docs companion PR (or re-run after template changes).
+
+### Smoke 1
+
+```bash
+~/.local/bin/pulseplate-coordinator-launch.sh \
+  --goal "Close machine-local launcher gap for coordinator-first startup" \
+  --task-class "pr_governance" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase pre_open
+```
+
+Expect: preflight exit 0, bootstrap writes task packet under gitignored `artifacts/orchestration/task_packets/`.
+
+### Smoke 2
+
+```bash
+~/.local/bin/pulseplate-coordinator-launch.sh \
+  --goal "Run post-open review packet for launcher PR" \
+  --task-class "review" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase post_open_review \
+  --requested-agent qa-engineer-agent \
+  --requested-agent bug-hunter
+```
+
+Expect: packet includes requested agents per `task_bootstrap.py` normalization rules.
+
+### Smoke 3 (normalization, not fail-closed)
+
+Repeated `--requested-agent` **must not** fail the wrapper or bootstrap.
+
+- The wrapper forwards every `--requested-agent` flag to `task_bootstrap.py`.
+- `task_bootstrap.py` normalizes via `scripts/orchestration/requested_agents.py` (`normalize_requested_agents`):
+  deduplication with **order preserved** (first occurrence wins).
+- Pass criteria: command succeeds; inspect the emitted packet JSON and confirm **unique** slugs in
+  stable first-seen order (e.g. duplicate `qa-engineer-agent` appears once).
+
+This smoke validates normalization, not crash-on-duplicate.
+
+### Fail-closed smokes (expect non-zero / errors)
+
+- **Bad repo root:** run outside a clone without `PULSEPLATE_REPO_ROOT` → wrapper exit 2.
+- **Bad `python3`:** temporarily break `PATH` so `python3` is missing → preflight/bootstrap fails.
+- **Unknown arg:** e.g. `--nope` → wrapper exit 2.
+- **Missing `--goal` or `--task-class`:** wrapper exit 2.
+
+### Smoke 4 (rollback)
+
+- Remove or rename the wrapper; remove `~/.local/bin` from `PATH` for a test shell.
+- Confirm normal repo workflows still work (`make validate-min`, or your usual commands).
+- Baseline repository state must remain valid (wrapper is host-only).
+
+## Post-merge git flow (operator)
+
+After the docs PR merges, sync `main` using a **fetch-based** flow (aligned with root `AGENTS.md`
+git guidance; avoid bare `git pull`):
+
+```bash
+git checkout main
+git fetch origin
+git merge --ff-only origin/main
+git branch -d docs/local-launcher-rollout-closeout
+```
+
+Delete the remote PR branch only if that matches your post-merge policy (`AGENTS.md`, `RUNBOOK_AGENT.md`).
+
+Then: re-run wrapper smokes on the same machine; refresh the installed script if the repo template changed.
+
+## Rollback
+
+- Delete `~/.local/bin/pulseplate-coordinator-launch.sh` (or unlink).
+- Remove `~/.local/bin` from shell startup `PATH` if you added it only for this launcher.
+- No repository revert is required; the repo companion is documentation + sanitized example only.
+
+## Known limits
+
+- **Bash 3.2 / `set -u`:** the canonical template uses `${ARRAY[@]+"${ARRAY[@]}"}` so empty `--path` / `--requested-agent` lists do not trip unbound-variable errors.
+- **Bash-only** in the canonical template; zsh/fish parity is a follow-up if needed.
+- **No Windows launcher** in this slice; parity is deferred unless documented separately.
+- **No CI enforcement:** hosts opt in individually.
+- **Secrets:** never pass tokens via wrapper flags; keep host config out of git.
+- Task packets land under `artifacts/` (gitignored); do not commit them.
+
+## Evidence and backlog
+
+Closing the backlog ledger item for this lane requires **recorded host smoke evidence** (commands
+run, pass/fail, date). This runbook is the intended place to cite that evidence when updating
+[`docs/roadmap/BACKLOG_LEDGER.md`](../roadmap/BACKLOG_LEDGER.md).
+
+Do **not** mark coordinator-first auto-start as a **global** default in the automation matrix;
+only document the **local opt-in** boundary.
+
+<!-- markdownlint-enable MD013 -->

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -2,14 +2,14 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-Bot and human review threads must be dispositioned below; resolve conversations on GitHub after mapping.
+Bot and human review threads must be dispositioned below when actionable comments appear; resolve conversations on GitHub after mapping.
 
 ## Fixed in Commit Mapping
 
-<!-- Add thread URLs with disposition (FIXED / NOT-A-BUG / DEFERRED) per AGENTS.md merge governance. -->
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -9,7 +9,7 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
-- Cubic (optional-arg flags): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493` → **Disposition: FIXED** — guard `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, `--path` with `[[ $# -lt 2 ]]` before reading `$2` in `docs/templates/pulseplate-coordinator-launch.example.sh` (avoids `set -u` unbound `$2`); evidence: same file after commit below.
+- Cubic (optional-arg flags): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493` → **Disposition: FIXED** — guard `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, `--path` with `[[ $# -lt 2 ]]` before reading `$2` in `docs/templates/pulseplate-coordinator-launch.example.sh` (avoids `set -u` unbound `$2`); evidence: same file after commit `d8494ec98e0465a9b2fdfb260119232ec880f761`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -9,8 +9,12 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
-- CodeRabbit (shell `$2` / `set -u`): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045343638` → **Disposition: FIXED** — same guards as below; evidence: `docs/templates/pulseplate-coordinator-launch.example.sh` after commit `d8494ec98e0465a9b2fdfb260119232ec880f761`.
-- Cubic (optional-arg flags): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493` → **Disposition: FIXED** — guard `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, `--path` with `[[ $# -lt 2 ]]` before reading `$2` in `docs/templates/pulseplate-coordinator-launch.example.sh` (avoids `set -u` unbound `$2`); evidence: same file after commit `d8494ec98e0465a9b2fdfb260119232ec880f761`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045343638 -> d8494ec98e0465a9b2fdfb260119232ec880f761
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493 -> d8494ec98e0465a9b2fdfb260119232ec880f761
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#pullrequestreview-4068464798 -> d8494ec98e0465a9b2fdfb260119232ec880f761
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#pullrequestreview-4068484587 -> d8494ec98e0465a9b2fdfb260119232ec880f761
+Disposition: FIXED
+Evidence: docs/templates/pulseplate-coordinator-launch.example.sh:28
 
 ## Merge Readiness
 

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -9,7 +9,7 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- Cubic (optional-arg flags): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493` → **Disposition: FIXED** — guard `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, `--path` with `[[ $# -lt 2 ]]` before reading `$2` in `docs/templates/pulseplate-coordinator-launch.example.sh` (avoids `set -u` unbound `$2`); evidence: same file after commit below.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -9,6 +9,7 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
+- CodeRabbit (shell `$2` / `set -u`): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045343638` → **Disposition: FIXED** — same guards as below; evidence: `docs/templates/pulseplate-coordinator-launch.example.sh` after commit `d8494ec98e0465a9b2fdfb260119232ec880f761`.
 - Cubic (optional-arg flags): `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493` → **Disposition: FIXED** — guard `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, `--path` with `[[ $# -lt 2 ]]` before reading `$2` in `docs/templates/pulseplate-coordinator-launch.example.sh` (avoids `set -u` unbound `$2`); evidence: same file after commit `d8494ec98e0465a9b2fdfb260119232ec880f761`.
 
 ## Merge Readiness

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -16,7 +16,7 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
-- [ ] All review threads resolved on GitHub after disposition updates
+- [x] All review threads resolved on GitHub after disposition updates
 
 ### Local verification
 

--- a/docs/review/PR_1370_FIXED_MAPPING.md
+++ b/docs/review/PR_1370_FIXED_MAPPING.md
@@ -1,0 +1,23 @@
+# PR #1370 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned below; resolve conversations on GitHub after mapping.
+
+## Fixed in Commit Mapping
+
+<!-- Add thread URLs with disposition (FIXED / NOT-A-BUG / DEFERRED) per AGENTS.md merge governance. -->
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+
+### Local verification
+
+- Evidence: `make verify` on branch `docs/local-launcher-rollout-closeout` before push (operator-local)
+- Companion docs: `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`, `docs/templates/pulseplate-coordinator-launch.example.sh`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2436,10 +2436,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1348 + PR #1350 (landed); open companion PR (branch `docs/local-launcher-rollout-closeout`: runbook + sanitized wrapper example + entry-doc sync); host install remains operator-owned outside git
+  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); host install remains operator-owned outside git
   - Area: local tooling / launcher / Codex runtime
   - Finding Type: non-repo rollout follow-up
-  - Status (EN): Companion PR adds `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`, `docs/templates/pulseplate-coordinator-launch.example.sh`, and aligned onboarding pointers. **Do not check this item complete** until host smoke evidence is recorded (per runbook “Smoke checks” + “Evidence and backlog”) on at least one opted-in machine—not markdown alone.
+  - Status (EN): Companion PR #1370 adds `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`, `docs/templates/pulseplate-coordinator-launch.example.sh`, and aligned onboarding pointers. **Do not check this item complete** until host smoke evidence is recorded (per runbook “Smoke checks” + “Evidence and backlog”) on at least one opted-in machine—not markdown alone.
   - Reason: Repo docs and deterministic engines alone cannot force raw session auto-start. A machine-local launcher or wrapper must wire preflight, bootstrap, and compatible runtime settings without pretending that `~/.codex/config.toml` is repo source of truth.
   - Links:
     - `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2436,13 +2436,15 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1350 + PR #1348 (repo docs/template + `local_session_bootstrap.sh` bridge); PR-TBD-LOCAL-LAUNCHER-ROLLOUT (host wrapper install / automation outside repo)
+  - Target PR: PR #1348 + PR #1350 (landed); open companion PR (branch `docs/local-launcher-rollout-closeout`: runbook + sanitized wrapper example + entry-doc sync); host install remains operator-owned outside git
   - Area: local tooling / launcher / Codex runtime
   - Finding Type: non-repo rollout follow-up
-  - Status (EN): Repo-side support merged: PR #1348 (`scripts/orchestration/local_session_bootstrap.sh`, SoT alignment), PR #1350 (`docs/templates/codex.config.example.toml`, `docs/dev/CODEX_SKILLS.md`, `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md`). Operator-owned machine launcher (preflight + bootstrap wiring, `PATH` / `CODEX_HOME`) remains open per DoD below. Merge commit for PR #1350 on `main`: `a3345b23102aa7c46e1dc36083edc7c2ec2e7ca4`.
+  - Status (EN): Companion PR adds `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`, `docs/templates/pulseplate-coordinator-launch.example.sh`, and aligned onboarding pointers. **Do not check this item complete** until host smoke evidence is recorded (per runbook “Smoke checks” + “Evidence and backlog”) on at least one opted-in machine—not markdown alone.
   - Reason: Repo docs and deterministic engines alone cannot force raw session auto-start. A machine-local launcher or wrapper must wire preflight, bootstrap, and compatible runtime settings without pretending that `~/.codex/config.toml` is repo source of truth.
   - Links:
     - `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`
+    - `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`
+    - `docs/templates/pulseplate-coordinator-launch.example.sh`
     - `docs/templates/codex.config.example.toml`
     - `scripts/orchestration/local_session_bootstrap.sh`
     - `docs/dev/CODEX_SKILLS.md`

--- a/docs/templates/pulseplate-coordinator-launch.example.sh
+++ b/docs/templates/pulseplate-coordinator-launch.example.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Sanitized example only: copy to ~/.local/bin/pulseplate-coordinator-launch.sh and chmod +x.
+# Do not commit host-specific paths, tokens, or real ~/.codex files.
+# Canonical rollout: docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
+set -euo pipefail
+
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+elif [[ -n "${PULSEPLATE_REPO_ROOT:-}" ]]; then
+  REPO_ROOT="${PULSEPLATE_REPO_ROOT}"
+else
+  echo "ERROR: run inside repo or export PULSEPLATE_REPO_ROOT" >&2
+  exit 2
+fi
+
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export PATH="$HOME/.local/bin:$PATH"
+
+GOAL=""
+TASK_CLASS=""
+PR_PHASE="none"
+REQUESTED_ARGS=()
+PATH_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --goal) GOAL="$2"; shift 2 ;;
+    --task-class) TASK_CLASS="$2"; shift 2 ;;
+    --pr-phase) PR_PHASE="$2"; shift 2 ;;
+    --requested-agent) REQUESTED_ARGS+=(--requested-agent "$2"); shift 2 ;;
+    --path) PATH_ARGS+=(--path "$2"); shift 2 ;;
+    *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$GOAL" || -z "$TASK_CLASS" ]]; then
+  echo "ERROR: --goal and --task-class are required" >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+
+# Bash 3.2 / set -u: empty array "$@" expansion is unsafe; use ${arr[@]+"${arr[@]}"}.
+python3 scripts/orchestration/check_preflight.py --mode analyze ${PATH_ARGS[@]+"${PATH_ARGS[@]}"}
+
+python3 scripts/orchestration/task_bootstrap.py \
+  --goal "$GOAL" \
+  --task-class "$TASK_CLASS" \
+  --pr-phase "$PR_PHASE" \
+  ${PATH_ARGS[@]+"${PATH_ARGS[@]}"} \
+  ${REQUESTED_ARGS[@]+"${REQUESTED_ARGS[@]}"}

--- a/docs/templates/pulseplate-coordinator-launch.example.sh
+++ b/docs/templates/pulseplate-coordinator-launch.example.sh
@@ -24,11 +24,31 @@ PATH_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --goal) GOAL="$2"; shift 2 ;;
-    --task-class) TASK_CLASS="$2"; shift 2 ;;
-    --pr-phase) PR_PHASE="$2"; shift 2 ;;
-    --requested-agent) REQUESTED_ARGS+=(--requested-agent "$2"); shift 2 ;;
-    --path) PATH_ARGS+=(--path "$2"); shift 2 ;;
+    --goal)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --goal requires a value" >&2; exit 2; fi
+      GOAL="$2"
+      shift 2
+      ;;
+    --task-class)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --task-class requires a value" >&2; exit 2; fi
+      TASK_CLASS="$2"
+      shift 2
+      ;;
+    --pr-phase)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --pr-phase requires a value" >&2; exit 2; fi
+      PR_PHASE="$2"
+      shift 2
+      ;;
+    --requested-agent)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --requested-agent requires a value" >&2; exit 2; fi
+      REQUESTED_ARGS+=(--requested-agent "$2")
+      shift 2
+      ;;
+    --path)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --path requires a value" >&2; exit 2; fi
+      PATH_ARGS+=(--path "$2")
+      shift 2
+      ;;
     *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -29,6 +29,12 @@ First-class repo wrappers:
 - `make validate-changed` is the supported repo-root command for this diff-based path and runs the script with the repo `.venv` on `PATH`.
 - `scripts/quick_check.sh` is a separate convenience helper: it runs `make validate-min` first, then staged-file format/import/syntax checks.
 - `scripts/orchestration/local_session_bootstrap.sh` is an **opt-in** raw-session helper: runs `check_preflight.py --mode analyze` from repo root and prints how to invoke `task_bootstrap.py`. It does not replace a machine-local launcher and does not auto-start Codex/Cursor sessions.
+
+**Coordinator cold-start precedence (host):**
+
+1. Opt-in **machine-local launcher** (operator-installed; see `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md` + `docs/templates/pulseplate-coordinator-launch.example.sh`)
+2. Repo helper `scripts/orchestration/local_session_bootstrap.sh` (preflight + printed recipe)
+3. Direct `python3 scripts/orchestration/task_bootstrap.py ...` after `check_preflight.py`
 - `scripts/orchestration/local_support_plane.py` is an **experimental non-canonical** operator KV store under gitignored `artifacts/orchestration/local_support_plane/` (override via `LOCAL_SUPPORT_PLANE_ROOT`). Mutations require `AGENT_CONTROL_ALLOWLIST` to include `local_support_plane:artifacts_kv` and a compatible `AGENT_CONTROL_EXECUTION_MODE` (see `app/security/agent_control_plane.py`). It is not orchestration SoT.
 
 **Change detection order:**

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -130,7 +130,7 @@ A standalone new test file may not be included in diff-cover's comparison, causi
 
 **Example (PR-490B)**: Coverage-tail tests for `core/bmi/engine.py` were moved from a standalone file into `tests/test_bmi_visualization_spec.py` (already modified in the PR) to ensure diff-cover correctly detects coverage.
 
-**Tier 1 `test-pr` routing** (`.github/workflows/ci.yml`): PRs that select the `route_contract_safety` contract group also run `tests/test_food_search_foundation.py`, `tests/test_foods_router_coverage_boost.py`, and `tests/test_metrics.py` so `coverage.xml` used by the `diff-coverage` job includes food/Meili/metrics paths touched under `app/`.
+**Tier 1 `test-pr` routing** (`.github/workflows/ci.yml`): PRs that select the `route_contract_safety` contract group also run `tests/test_food_search_foundation.py`, `tests/test_foods_router_coverage_boost.py`, `tests/test_metrics.py`, plus `tests/test_judgment_core.py`, `tests/test_judgment_eval_contract.py`, and `tests/test_creative_research_eval_contract.py` so `coverage.xml` used by the `diff-coverage` job includes food/Meili/metrics paths under `app/` and core judgment / creative-research contract paths under `core/`.
 
 ### Reliable local diff-cover check (prevents phantom gaps)
 

--- a/tests/test_judgment_eval_contract.py
+++ b/tests/test_judgment_eval_contract.py
@@ -16,6 +16,7 @@ from core.judgment_eval import (
     _require_case_string,
     _require_object,
     _score_ratio,
+    _validate_turns,
 )
 from scripts.orchestration.judgment_eval_contract import (
     evaluate_fitchef_replay_case,
@@ -99,6 +100,17 @@ def test_judgment_eval_helper_edges_fail_closed() -> None:
     assert _score_ratio(3, 4) == 4
     assert _score_ratio(0, 0) == 0
     assert _contains_marker("steady dinner routine", "") is False
+
+    assert _validate_turns([], label="case") == []
+    assert _validate_turns(
+        [{"role": "user", "text": "hello"}, {"role": "assistant", "text": "hi"}],
+        label="case",
+    ) == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    with pytest.raises(ValueError, match="case turn #1 role must be user"):
+        _validate_turns([{"role": "system", "text": "nope"}], label="case")
 
     with pytest.raises(ValueError, match="fitchef markers must be a list"):
         _normalize_string_list("not-a-list", label="fitchef markers")


### PR DESCRIPTION
## Summary
- Add operator runbook `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md` and sanitized host wrapper template `docs/templates/pulseplate-coordinator-launch.example.sh` (preflight analyze + `task_bootstrap`, shared `--path`, Bash 3.2 `set -u`-safe arrays).
- Document cold-start precedence (host launcher → `local_session_bootstrap.sh` → direct bootstrap) in `scripts/AGENTS.md`, onboarding, Cursor init, Codex skills, and `.cursor/agents/AGENTS.md`.
- Update `BACKLOG_LEDGER.md` P2 launcher item with new paths; item stays open until host smoke evidence.
- `fix(core)`: `TypeGuard` helpers in `core/judgment.py`, `core/creative_research.py`, `core/judgment_eval.py` so pre-push mypy (`--follow-imports=skip`) matches full `make typecheck` without redundant `cast()`.

## Validation
`make verify` (local): PASS.

## Deferred / Follow-ups

### Repo vs host (launcher P2 stop-marker)

- **Repo-side rollout closeout** (this PR): runbook + wrapper template + cross-links + Phase 2 canonical artifact `docs/review/PR_1370_FIXED_MAPPING.md` — **done here**.
- **Host-side launcher proof** is **not** promoted into backlog closeout yet: the **BACKLOG_LEDGER** P2 launcher checkbox stays **unchecked** until a real machine records smoke evidence per `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md` (install → smokes → evidence). This PR does not substitute that evidence.

### Review mapping

- **SoT:** `docs/review/PR_1370_FIXED_MAPPING.md` — dispositions recorded; Phase 2 mirror below matches that file (refresh if new threads appear).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Документировать опциональный для конкретной машины workflow запуска координатора и привести хелперы для сужения типов в соответствие с mypy, обновив бэклог и артефакты ревью.

New Features:
- Ввести необязательный для хоста runbook запуска координатора и очищенный шаблон Bash-обёртки для запуска предварительного анализа и начальной инициализации задач в одной точке входа.

Bug Fixes:
- Исправить проблемы с сужением литеральных типов в mypy, введя валидаторы на основе `TypeGuard` и возвращая уже суженные значения вместо использования `cast()`.

Enhancements:
- Прояснить приоритеты cold-start координатора и обязанности лаунчера в документации по онбордингу, агенту, Cursor и Codex.
- Добавить хелперы на основе `TypeGuard` в код оценки суждений, креативных исследований и реплеев, чтобы обеспечить более строгую проверку литералов без избыточных `cast`.
- Обновить метаданные и ссылки в «ledger» бэклога, чтобы отразить новую документацию по лаунчеру и требованиям к evidences, а также добавить запись сопоставления «fixed-in-commit review» для этого PR.

Documentation:
- Добавить runbook `LOCAL_COORDINATOR_LAUNCHER_ROLLOUT`, документацию по шаблону лаунчера и SoT по маппингу ревью, а также расширить существующую документацию по оркестрации и туллингу описанием использования лаунчера, порядка выполнения и границ ответственности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document an opt-in machine-local coordinator launcher workflow and align type-narrowing helpers with mypy while updating backlog and review artifacts.

New Features:
- Introduce a host-optional coordinator launcher runbook and a sanitized Bash wrapper template for running preflight analysis and task bootstrap in a single entrypoint.

Bug Fixes:
- Resolve mypy literal narrowing issues by introducing TypeGuard-based validators and returning already-narrowed values instead of using cast().

Enhancements:
- Clarify coordinator cold-start precedence and launcher responsibilities across onboarding, agent, Cursor, and Codex documentation.
- Add TypeGuard-based helpers across judgment, creative research, and replay evaluation code to provide stricter literal validation without redundant casts.
- Update backlog ledger metadata and links to reflect the new launcher documentation and evidence requirements, and add a fixed-in-commit review mapping record for this PR.

Documentation:
- Add LOCAL_COORDINATOR_LAUNCHER_ROLLOUT runbook, launcher template docs, and review mapping SoT, and extend existing orchestration and tooling docs with launcher usage, ordering, and boundaries.

</details>

Новые возможности:
- Добавлен runbook для локального запускателя координатора с инструкциями по установке, использованию, проверкам работоспособности (smoke checks) и откату.
- Предоставлен очищенный пример Bash-скрипта-обёртки для выполнения предварительного анализа и начальной загрузки задач с унифицированной обработкой путей.

Улучшения:
- Уточнён приоритет холодного старта координатора между хостовым запускателем, локальным вспомогательным bootstrap-скриптом и прямыми оркестрационными скриптами в документации по онбордингу и агентам.
- Обновлена запись в backlog-реестре, чтобы отразить новую документацию по запускателю, пути к шаблонам и требования к доказательствам (evidence).
- Внедрены помощники TypeGuard для проверки типов заявок (claim types), статусов поддержки, режимов evidence, этапов творческого ресерча и уровней уверенности, а также ролей FitChef replay, чтобы mypy мог выводить уточнённые типы без явных приведений типов.

Документация:
- Расширена документация для разработчиков и агентов (включая руководства по навыкам для Cursor и Codex), чтобы описать опциональные хостовые запускатели, порядок холодного старта и границы полномочий по маршрутизации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Документировать опциональный для конкретной машины workflow запуска координатора и привести хелперы для сужения типов в соответствие с mypy, обновив бэклог и артефакты ревью.

New Features:
- Ввести необязательный для хоста runbook запуска координатора и очищенный шаблон Bash-обёртки для запуска предварительного анализа и начальной инициализации задач в одной точке входа.

Bug Fixes:
- Исправить проблемы с сужением литеральных типов в mypy, введя валидаторы на основе `TypeGuard` и возвращая уже суженные значения вместо использования `cast()`.

Enhancements:
- Прояснить приоритеты cold-start координатора и обязанности лаунчера в документации по онбордингу, агенту, Cursor и Codex.
- Добавить хелперы на основе `TypeGuard` в код оценки суждений, креативных исследований и реплеев, чтобы обеспечить более строгую проверку литералов без избыточных `cast`.
- Обновить метаданные и ссылки в «ledger» бэклога, чтобы отразить новую документацию по лаунчеру и требованиям к evidences, а также добавить запись сопоставления «fixed-in-commit review» для этого PR.

Documentation:
- Добавить runbook `LOCAL_COORDINATOR_LAUNCHER_ROLLOUT`, документацию по шаблону лаунчера и SoT по маппингу ревью, а также расширить существующую документацию по оркестрации и туллингу описанием использования лаунчера, порядка выполнения и границ ответственности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document an opt-in machine-local coordinator launcher workflow and align type-narrowing helpers with mypy while updating backlog and review artifacts.

New Features:
- Introduce a host-optional coordinator launcher runbook and a sanitized Bash wrapper template for running preflight analysis and task bootstrap in a single entrypoint.

Bug Fixes:
- Resolve mypy literal narrowing issues by introducing TypeGuard-based validators and returning already-narrowed values instead of using cast().

Enhancements:
- Clarify coordinator cold-start precedence and launcher responsibilities across onboarding, agent, Cursor, and Codex documentation.
- Add TypeGuard-based helpers across judgment, creative research, and replay evaluation code to provide stricter literal validation without redundant casts.
- Update backlog ledger metadata and links to reflect the new launcher documentation and evidence requirements, and add a fixed-in-commit review mapping record for this PR.

Documentation:
- Add LOCAL_COORDINATOR_LAUNCHER_ROLLOUT runbook, launcher template docs, and review mapping SoT, and extend existing orchestration and tooling docs with launcher usage, ordering, and boundaries.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in machine‑local coordinator launcher (runbook + sanitized wrapper), aligns mypy literal narrows with `TypeGuard`s across core, and extends Tier‑1 PR CI to run judgment/creative‑research tests. Aligns the review SoT mapping with Phase‑2/merge gates and marks review threads resolved.

- **New Features**
  - Added `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md` and `docs/templates/pulseplate-coordinator-launch.example.sh`.
  - Synced cold‑start precedence across onboarding and agent docs; added `docs/review/PR_1370_FIXED_MAPPING.md` aligned with Phase‑2/merge gates.
  - CI: `route_contract_safety` now runs `tests/test_judgment_core.py`, `tests/test_judgment_eval_contract.py`, and `tests/test_creative_research_eval_contract.py`.

- **Bug Fixes**
  - Introduced `TypeGuard` helpers and returned narrowed literals in `core/judgment.py`, `core/creative_research.py`, and `core/judgment_eval.py`; removed redundant casts and hardened launcher example flag guards for `set -u` safety.

<sup>Written for commit 58a2bba3b351bdaf5d4e02ed9ac136cb4781c753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- **SoT:** `docs/review/PR_1370_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045343638 -> d8494ec98e0465a9b2fdfb260119232ec880f761
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#discussion_r3045361493 -> d8494ec98e0465a9b2fdfb260119232ec880f761
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#pullrequestreview-4068464798 -> d8494ec98e0465a9b2fdfb260119232ec880f761
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1370#pullrequestreview-4068484587 -> d8494ec98e0465a9b2fdfb260119232ec880f761
Disposition: FIXED
Evidence: docs/templates/pulseplate-coordinator-launch.example.sh:28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional machine-local, opt-in launcher for coordinator workflows; choose it or the cold-start script during init.

* **Documentation**
  * Updated init/onboarding flow and rollout guide; added launcher rollout doc, example launcher script, backlog/PR status notes.

* **Refactor**
  * Improved internal validation logic across core modules.

* **Tests**
  * Expanded contract test coverage and CI test selection to include core judgment and creative-research paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->