### PR TITLE
feat(orchestration): add advisory wiki compiler over local support plane

### DIFF
--- a/.cursor/agents/AGENTS.md
+++ b/.cursor/agents/AGENTS.md
@@ -18,6 +18,8 @@ This document defines **scoped rules** specific to Cursor agents in `.cursor/age
 
 **Local implementation:** `.cursor/agents/agent-coordinator.md` is the canonical coordinator agent.
 
+**Advisory wiki compiler:** Operator-local compiled memory via `scripts/orchestration/wiki_ingest.py` (and related CLIs). It is **not** orchestration SoT and does not replace canonical `docs/**` or KPP; boundaries and commands are documented in `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`.
+
 ## Required pre-flight (SoT)
 
 Before doing any work:

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -56,6 +56,8 @@ this document by itself.
 
 **Launcher vs skills:** If you use an opt-in machine launcher (see [`docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md)), run preflight/bootstrap **before** relying on installed skills or manual task work. **Skills do not replace** `task_bootstrap.py`; they complement routing after a packet exists.
 
+**Advisory wiki (optional):** For operator-local wiki snapshots over the experimental support plane, see [`docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`](../orchestration/LOCAL_WIKI_SUPPORT_PLANE.md) (`wiki_ingest` / `wiki_query` / `wiki_lint` / `wiki_promote`). This remains non-canonical and gitignored.
+
 Canonical selection order after bootstrap:
 
 1. `pulseplate-workflow`

--- a/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
+++ b/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
@@ -1,0 +1,77 @@
+# Local advisory wiki (support plane)
+
+<!-- markdownlint-disable MD013 -->
+
+This document describes the **advisory** local wiki compiler that sits on top of the
+experimental local support plane (`scripts/orchestration/local_support_plane.py`).
+It is **not** a second source of truth for product, orchestration, or contracts.
+
+## Evidence anchors (implementation)
+
+- Ingest / filesystem writes: `scripts/orchestration/wiki_ingest.py:1`
+- Read-only query: `scripts/orchestration/wiki_query.py:1`
+- Page lint: `scripts/orchestration/wiki_lint.py:1`
+- Promote (filesystem + optional metadata): `scripts/orchestration/wiki_promote.py:1`
+- Shared slug/hash helpers: `scripts/orchestration/_wiki_compiler_support.py:1`
+- Support-plane policy gate: `scripts/orchestration/local_support_plane.py:105`
+- Key validation: `scripts/orchestration/local_support_plane.py:58`
+
+## Purpose and boundaries (IN / OUT)
+
+**In scope**
+
+- Operator-local compiled memory under gitignored `artifacts/orchestration/wiki/`.
+- Optional metadata keys `wiki.source.*`, `wiki.page.*`, `wiki.promoted.*` via `put_record`
+  when `AGENT_CONTROL_ALLOWLIST` includes `local_support_plane:artifacts_kv` and execution
+  mode allows mutations (see `app/security/agent_control_plane.py`).
+
+**Out of scope**
+
+- Canonical documentation under `docs/**`, root `AGENTS.md`, or `docs/roadmap/BACKLOG_LEDGER.md`
+  — the promote path **must not** resolve under `docs/`; ingest/promote never edit those trees.
+- Embeddings, vector databases, network retrieval, OpenAPI, `app/**`, or client runtimes.
+- Replacing KPP, bootstrap packets, or orchestration SoT documents.
+
+## Directory layout
+
+Default wiki root: `artifacts/orchestration/wiki/` (gitignored).
+
+Per corpus (default name `project_internal`):
+
+- `pages/` — markdown pages with YAML-style frontmatter (ingest output).
+- `raw/` — raw snapshots named `<sha256>.md`.
+- `promoted/` — copies after `wiki_promote.py` adds promotion metadata.
+- `index.md` — regenerated listing of pages.
+- `log.md` — append-only ingest log.
+
+## CLI usage (from repo root)
+
+```bash
+python3 scripts/orchestration/wiki_ingest.py --source path/under/repo.md --corpus project_internal
+python3 scripts/orchestration/wiki_query.py --mode list --corpus project_internal
+python3 scripts/orchestration/wiki_query.py --mode search --needle foo --corpus project_internal
+python3 scripts/orchestration/wiki_query.py --mode detail --slug your.slug --corpus project_internal
+python3 scripts/orchestration/wiki_lint.py --corpus project_internal
+python3 scripts/orchestration/wiki_promote.py --slug your.slug --corpus project_internal
+```
+
+Use `--no-write-support-plane` on ingest/promote when you only want filesystem artifacts.
+
+## Support-plane keys
+
+Keys must satisfy `normalize_key` (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`, max length 128). Slugs derived
+from paths strip `.md` and sanitize path segments so keys remain valid (see tests in
+`tests/test_wiki_compiler_keys.py`).
+
+## Security notes
+
+- Mutations use the same allowlist + execution-mode gate as `local_support_plane.put_record`
+  (`scripts/orchestration/local_support_plane.py:105`).
+- Treat wiki content as **non-secret** unless you explicitly classify sources; artifacts are
+  local and gitignored but not encrypted by these tools.
+
+## Related docs
+
+- `docs/orchestration/AUTOMATION_READINESS_MATRIX.md` — automation readiness vs repo-only tools.
+- `docs/security/AGENT_CONTROL_PLANE_SECURITY_BASELINE.md` — control-plane baseline.
+- `scripts/AGENTS.md` — script-level conventions and support-plane note.

--- a/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
+++ b/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
@@ -18,14 +18,14 @@ It is **not** a second source of truth for product, orchestration, or contracts.
 
 ## Purpose and boundaries (IN / OUT)
 
-**In scope**
+#### In scope
 
 - Operator-local compiled memory under gitignored `artifacts/orchestration/wiki/`.
 - Optional metadata keys `wiki.source.*`, `wiki.page.*`, `wiki.promoted.*` via `put_record`
   when `AGENT_CONTROL_ALLOWLIST` includes `local_support_plane:artifacts_kv` and execution
   mode allows mutations (see `app/security/agent_control_plane.py`).
 
-**Out of scope**
+#### Out of scope
 
 - Canonical documentation under `docs/**`, root `AGENTS.md`, or `docs/roadmap/BACKLOG_LEDGER.md`
   — ingest and promote **fail closed** if the corpus base would resolve under `docs/`; neither tool edits those trees.

--- a/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
+++ b/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
@@ -47,7 +47,7 @@ Do **not** describe ingest as wholly fail-closed on support-plane mutations: onl
 on-disk errors abort the run; SP failures are warnings unless you treat stderr in your operator
 pipeline as fatal.
 
-Evidence: ingest SP catch — `scripts/orchestration/wiki_ingest.py:155`; promote write then
+Evidence: ingest SP catch — `scripts/orchestration/wiki_ingest.py:162`; promote write then
 `put_record` with `unlink` on failure — `scripts/orchestration/wiki_promote.py:80`–`scripts/orchestration/wiki_promote.py:101`.
 
 ## v1 tool semantics (what the code actually does)
@@ -88,6 +88,9 @@ Evidence: ingest SP catch — `scripts/orchestration/wiki_ingest.py:155`; promot
 
 - Ingest detects **same slug from two different source paths** in one run and fails with
   `slug_collision:…`.
+- **Across separate ingest runs:** if `pages/<slug>.md` already exists, ingest reads prior
+  `source_rel_path` from frontmatter; if it differs from the current source (or is missing),
+  ingest fails with `slug_collision_existing:…` instead of silently overwriting.
 - **Truncation:** slugs are capped for key length (`_wiki_compiler_support.py`); two long distinct
   paths could still converge after truncation — treated as **acceptable v1 risk**; a stricter
   strategy is deferred (see backlog).

--- a/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
+++ b/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
@@ -32,6 +32,66 @@ It is **not** a second source of truth for product, orchestration, or contracts.
 - Embeddings, vector databases, network retrieval, OpenAPI, `app/**`, or client runtimes.
 - Replacing KPP, bootstrap packets, or orchestration SoT documents.
 
+**Name this slice honestly:** it is an **advisory filesystem wiki compiler v1** (ingest → pages/raw/index,
+read-only list/search/detail, integrity lint, guarded promote). It is **not** a full “compiled-memory
+reasoning layer”, knowledge graph, index-first ranked retrieval, or semantic quality gate.
+
+## Operational semantics (filesystem vs support plane)
+
+| Surface | On support-plane write failure | Rationale |
+|--------|---------------------------------|-----------|
+| **Ingest** (`wiki_ingest.py`) | **Warn and continue** (`support_plane_skip:…` on stderr); filesystem writes (raw/page/index/log) already applied | Metadata mirror is best-effort; corpus on disk is the primary ingest artifact for v1. |
+| **Promote** (`wiki_promote.py`) | **Fail closed:** promoted file is removed if `put_record` fails after the file was written | Avoids a promoted file without a matching optional metadata record when policy requires SP. |
+
+Do **not** describe ingest as wholly fail-closed on support-plane mutations: only canonical-path and
+on-disk errors abort the run; SP failures are warnings unless you treat stderr in your operator
+pipeline as fatal.
+
+Evidence: ingest SP catch — `scripts/orchestration/wiki_ingest.py:155`; promote write then
+`put_record` with `unlink` on failure — `scripts/orchestration/wiki_promote.py:80`–`scripts/orchestration/wiki_promote.py:101`.
+
+## v1 tool semantics (what the code actually does)
+
+### `wiki_ingest.py`
+
+- Sources must resolve **under `repo_root`** (`relative_to`); corpus base must not sit under
+  canonical `docs/**` (`reject_if_under_canonical_docs`).
+- **`--source` is not restricted to `.md`:** any file may be ingested; raw snapshot is always stored
+  under `raw/<sha256>.md` (filename convention only). Content is decoded as UTF-8; invalid UTF-8 uses
+  replacement + `utf8_replace:*` warning — suitable for **markdown-first** internal corpora, not a
+  universal binary document pipeline.
+- Page frontmatter is **narrow v1 integrity metadata** (`corpus`, `source_rel_path`, `content_hash`,
+  `ingested_at`, `advisory`) — not a rich page schema or knowledge graph.
+
+### `wiki_query.py`
+
+- **Read-only** list / search / detail over filesystem pages.
+- **Search** is **substring match on page body** (JSON wrapper); there is no index-first ranking,
+  title/heading weighting, or embedding retrieval. Calling it a “query engine” in the sense of search
+  products would be **overstated** — prefer “local grep-like search over ingested pages”.
+
+### `wiki_lint.py`
+
+- **Integrity lint:** `pages/` presence, required frontmatter keys, `advisory == true`, matching
+  `raw/<hash>.md` for declared hash. It does **not** enforce contradiction checks, orphan pages,
+  link validity, backlinks, or index drift beyond raw existence.
+
+### `wiki_promote.py`
+
+- Promotion is **review-oriented:** slug validation, per-page lint gate, `reject_if_under_canonical_docs`
+  on the promoted path, optional `put_record`.
+- Support-plane key **`wiki.promoted.<slug>` is a single slot:** each successful promote **overwrites**
+  the prior record for that slug. **No versioned promotion history** in SP (filesystem `promoted/`
+  holds the latest file only; historical SP audit is out of scope for v1).
+
+### Slug collisions
+
+- Ingest detects **same slug from two different source paths** in one run and fails with
+  `slug_collision:…`.
+- **Truncation:** slugs are capped for key length (`_wiki_compiler_support.py`); two long distinct
+  paths could still converge after truncation — treated as **acceptable v1 risk**; a stricter
+  strategy is deferred (see backlog).
+
 ## Directory layout
 
 Default wiki root: `artifacts/orchestration/wiki/` (gitignored).

--- a/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
+++ b/docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md
@@ -28,7 +28,7 @@ It is **not** a second source of truth for product, orchestration, or contracts.
 **Out of scope**
 
 - Canonical documentation under `docs/**`, root `AGENTS.md`, or `docs/roadmap/BACKLOG_LEDGER.md`
-  — the promote path **must not** resolve under `docs/`; ingest/promote never edit those trees.
+  — ingest and promote **fail closed** if the corpus base would resolve under `docs/`; neither tool edits those trees.
 - Embeddings, vector databases, network retrieval, OpenAPI, `app/**`, or client runtimes.
 - Replacing KPP, bootstrap packets, or orchestration SoT documents.
 

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -13,7 +13,7 @@ Disposition: FIXED
 
 Commit: 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 
-Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI.
+Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI. Follow-up: `wiki_promote.py` resolves `dst` vs corpus `base` before `promoted_dir.mkdir` (`promote_path_outside_corpus`); `put_record` rollback uses broad `except Exception` with `unlink` under `suppress(OSError)` (`b8a5bd5dcb581dad569bd09cb8bd194474477b6e`).
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070641652 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070678463 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
@@ -27,6 +27,8 @@ Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` h
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339239 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339244 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047400690 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047532381 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047532394 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
 
 ## Merge Readiness
 

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -13,7 +13,7 @@ Disposition: FIXED
 
 Commit: 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 
-Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI. Follow-up: `wiki_promote.py` resolves `dst` vs corpus `base` before `promoted_dir.mkdir` (`promote_path_outside_corpus`); `put_record` rollback uses broad `except Exception` with `unlink` under `suppress(OSError)` (`b8a5bd5dcb581dad569bd09cb8bd194474477b6e`).
+Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI. Follow-up: `wiki_promote.py` resolves `dst` vs corpus `base` before `promoted_dir.mkdir` (`promote_path_outside_corpus`); `put_record` rollback uses broad `except Exception` and `dst.unlink(missing_ok=True)` without swallowing `OSError`—unlink failures raise with the support-plane error as `__cause__` (`4b21c57bf390abf6cf6d0357cf9e3929059e2d61`, supersedes prior `suppress(OSError)` rollback in `b8a5bd5dcb581dad569bd09cb8bd194474477b6e`).
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070641652 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070678463 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
@@ -29,6 +29,7 @@ Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` h
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047400690 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047532381 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047532394 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047589374 -> 4b21c57bf390abf6cf6d0357cf9e3929059e2d61
 
 ## Merge Readiness
 

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -30,3 +30,4 @@ Bot and human review threads must be dispositioned below when actionable comment
 | 7 | security-auditor | Addressed in code | `wiki_query.detail_page` calls `validate_wiki_slug`; slug length capped to 114 for `wiki.page.*` / `wiki.promoted.*` key budget (`MAX_WIKI_SLUG_CHARS`, `_WIKI_SLUG_RE`) |
 | 8 | rag-systems / data-scientist / ml-engineer | Advisory N/A | No embeddings, vector, or model code in scope; ledger OUT unchanged |
 | 11–12 | qa + bug-hunter bundle | `make verify` | Re-run after fixes; wiki tests: `pytest tests/test_wiki_*.py tests/test_wiki_compiler_keys.py` |
+| follow-up | bug-hunter (ordering / `main` out) | Addressed in code | Promote: `dst.write_text` then `put_record`; `unlink` on SP failure; `main()` `out` via `path_for_support_plane_record` (wiki outside repo) |

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -19,6 +19,8 @@ Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` h
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070678463 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070686110 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070759857 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070914662 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070984357 -> 4b21c57bf390abf6cf6d0357cf9e3929059e2d61
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331822 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331852 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331861 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -20,3 +20,13 @@ Bot and human review threads must be dispositioned below when actionable comment
 ### Local verification
 
 - Evidence: `make verify` on branch `feat/local-workforce-pr-d-advisory-wiki-compiler` before merge (operator-local)
+
+## Agent pass register (plan steps 6–12)
+
+| Step | Agent / gate | Result | Evidence |
+|------|----------------|--------|----------|
+| 2 | `check_preflight.py` + `check_agent_consistency.py` | PASS | Operator-local exit 0 |
+| 6 | architecture-specialist | Addressed in code | Ingest now mirrors promote: `reject_if_under_canonical_docs` on corpus base (`wiki_ingest.py` + `wcs.reject_if_under_canonical_docs`); shared guard in `_wiki_compiler_support.py` |
+| 7 | security-auditor | Addressed in code | `wiki_query.detail_page` calls `validate_wiki_slug`; slug length capped to 114 for `wiki.page.*` / `wiki.promoted.*` key budget (`MAX_WIKI_SLUG_CHARS`, `_WIKI_SLUG_RE`) |
+| 8 | rag-systems / data-scientist / ml-engineer | Advisory N/A | No embeddings, vector, or model code in scope; ledger OUT unchanged |
+| 11–12 | qa + bug-hunter bundle | `make verify` | Re-run after fixes; wiki tests: `pytest tests/test_wiki_*.py tests/test_wiki_compiler_keys.py` |

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR #1371 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned below when actionable comments appear; resolve conversations on GitHub after mapping.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+
+### Local verification
+
+- Evidence: `make verify` on branch `feat/local-workforce-pr-d-advisory-wiki-compiler` before merge (operator-local)

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -9,7 +9,24 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+
+Commit: 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+
+Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070641652 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070678463 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070686110 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070759857 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331822 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331852 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331861 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339228 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339232 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339239 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339244 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047400690 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
 
 ## Merge Readiness
 

--- a/docs/review/PR_1371_FIXED_MAPPING.md
+++ b/docs/review/PR_1371_FIXED_MAPPING.md
@@ -31,3 +31,4 @@ Bot and human review threads must be dispositioned below when actionable comment
 | 8 | rag-systems / data-scientist / ml-engineer | Advisory N/A | No embeddings, vector, or model code in scope; ledger OUT unchanged |
 | 11–12 | qa + bug-hunter bundle | `make verify` | Re-run after fixes; wiki tests: `pytest tests/test_wiki_*.py tests/test_wiki_compiler_keys.py` |
 | follow-up | bug-hunter (ordering / `main` out) | Addressed in code | Promote: `dst.write_text` then `put_record`; `unlink` on SP failure; `main()` `out` via `path_for_support_plane_record` (wiki outside repo) |
+| follow-up | qa (cross-run slug / external wiki SP path) | Addressed in code | Ingest: `slug_collision_existing` when existing page `source_rel_path` differs (`wiki_ingest.py`); tests `test_ingest_slug_collision_existing_across_runs`, `test_promote_support_plane_external_wiki_root` |

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2437,7 +2437,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Local workforce PR-D — advisory wiki compiler over local support plane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: (open; branch `feat/local-workforce-pr-d-advisory-wiki-compiler`)
+  - Target PR: PR #1371 (branch `feat/local-workforce-pr-d-advisory-wiki-compiler`)
   - Area: orchestration / local support plane / operator tooling
   - Finding Type: RFC follow-on slice (compiled advisory memory)
   - Status (EN): Implementation on branch; merge closes this item when `docs/review/PR_<N>_FIXED_MAPPING.md` exists and checklist is complete.
@@ -2445,6 +2445,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Dependencies:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-c-support-plane`
   - Links:
+    - `docs/review/PR_1371_FIXED_MAPPING.md`
     - `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`
     - `scripts/orchestration/wiki_ingest.py`
     - `scripts/orchestration/wiki_query.py`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2456,6 +2456,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - CLIs documented and covered by deterministic tests
     - No writes to canonical `docs/**` tree from promote path; support-plane keys respect `normalize_key`
     - Ledger + agent entrypoints reference the wiki doc in the same merge cycle
+  - Deferred / follow-ups (post-v1 hardening, English-first):
+    - Slug strategy after truncation (reject vs hash-suffix vs manifest) when paths differ but truncate to the same slug (`scripts/orchestration/_wiki_compiler_support.py` `path_to_slug`).
+    - Optional promotion **history** or versioned SP keys / manifest (today `wiki.promoted.<slug>` overwrites).
+    - Richer lint: orphans, stale links, index/page consistency beyond raw hash, contradiction checks (not in v1).
+    - Search: ranking, headings/title weighting, or index-first retrieval (v1 is body substring only).
 
 - [ ] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2433,6 +2433,29 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Launcher/runtime behavior stays outside repo SoT unless separately promoted by the automation readiness matrix
     - No duplicate orchestration source of truth is introduced
 
+<a id="ledger-p2-local-workforce-pr-d-advisory-wiki-compiler"></a>
+- [ ] P2: Local workforce PR-D — advisory wiki compiler over local support plane
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: (open; branch `feat/local-workforce-pr-d-advisory-wiki-compiler`)
+  - Area: orchestration / local support plane / operator tooling
+  - Finding Type: RFC follow-on slice (compiled advisory memory)
+  - Status (EN): Implementation on branch; merge closes this item when `docs/review/PR_<N>_FIXED_MAPPING.md` exists and checklist is complete.
+  - Reason: Non-canonical wiki artifacts help operators navigate ingested repo slices without introducing embeddings, vector stores, or a second documentation SoT.
+  - Dependencies:
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-c-support-plane`
+  - Links:
+    - `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`
+    - `scripts/orchestration/wiki_ingest.py`
+    - `scripts/orchestration/wiki_query.py`
+    - `scripts/orchestration/wiki_lint.py`
+    - `scripts/orchestration/wiki_promote.py`
+    - `scripts/orchestration/local_support_plane.py`
+  - DoD:
+    - CLIs documented and covered by deterministic tests
+    - No writes to canonical `docs/**` tree from promote path; support-plane keys respect `normalize_key`
+    - Ledger + agent entrypoints reference the wiki doc in the same merge cycle
+
 - [ ] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -36,6 +36,7 @@ First-class repo wrappers:
 2. Repo helper `scripts/orchestration/local_session_bootstrap.sh` (preflight + printed recipe)
 3. Direct `python3 scripts/orchestration/task_bootstrap.py ...` after `check_preflight.py`
 - `scripts/orchestration/local_support_plane.py` is an **experimental non-canonical** operator KV store under gitignored `artifacts/orchestration/local_support_plane/` (override via `LOCAL_SUPPORT_PLANE_ROOT`). Mutations require `AGENT_CONTROL_ALLOWLIST` to include `local_support_plane:artifacts_kv` and a compatible `AGENT_CONTROL_EXECUTION_MODE` (see `app/security/agent_control_plane.py`). It is not orchestration SoT.
+- **Advisory wiki compiler** (local-only, gitignored): `wiki_ingest.py`, `wiki_query.py`, `wiki_lint.py`, `wiki_promote.py` under `scripts/orchestration/` with shared `_wiki_compiler_support.py`. Writes markdown under `artifacts/orchestration/wiki/` and may mirror metadata to the support plane using `wiki.*` keys. See `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`.
 
 **Change detection order:**
 

--- a/scripts/orchestration/_wiki_compiler_support.py
+++ b/scripts/orchestration/_wiki_compiler_support.py
@@ -1,0 +1,111 @@
+"""Shared helpers for advisory wiki compiler CLIs (non-canonical, local-only).
+
+RU: Вспомогательные функции для ingest/query/lint/promote; не SoT.
+EN: Advisory wiki artifacts live under gitignored ``artifacts/orchestration/wiki/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+# Default layout under repo (gitignored).
+DEFAULT_WIKI_ROOT: Final[Path] = Path("artifacts") / "orchestration" / "wiki"
+
+_SLUG_SEGMENT_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def repo_root_default() -> Path:
+    """Repository root (directory containing ``app/``)."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    return explicit.resolve() if explicit is not None else repo_root_default()
+
+
+def corpus_base(wiki_root: Path, corpus: str) -> Path:
+    """Base directory for one corpus (e.g. ``project_internal``)."""
+
+    safe_corpus = _sanitize_key_segment(corpus, fallback="corpus")
+    return (wiki_root / safe_corpus).resolve()
+
+
+def corpus_layout(base: Path) -> dict[str, Path]:
+    """Standard subdirectories for a corpus."""
+
+    return {
+        "base": base,
+        "pages": base / "pages",
+        "raw": base / "raw",
+        "promoted": base / "promoted",
+        "index": base / "index.md",
+        "log": base / "log.md",
+    }
+
+
+def _sanitize_key_segment(raw: str, *, fallback: str) -> str:
+    """Produce a single path segment safe for filesystem and support-plane keys."""
+
+    s = raw.strip().lower()
+    s = _SLUG_SEGMENT_RE.sub("_", s)
+    s = s.strip("._-") or fallback
+    if not s[0].isalnum():
+        s = f"x{s}"
+    return s[:120]
+
+
+def path_to_slug(rel_path: Path) -> str:
+    """Derive wiki page slug from a path relative to repo root."""
+
+    raw_parts = [p for p in rel_path.parts if p not in (".", "")]
+    if not raw_parts:
+        return "root"
+    parts: list[str] = []
+    for i, p in enumerate(raw_parts):
+        is_last = i == len(raw_parts) - 1
+        name = Path(p).stem if is_last and p.lower().endswith(".md") else p
+        seg = _sanitize_key_segment(name, fallback="part")
+        parts.append(seg)
+    slug = ".".join(parts)
+    return slug[:120]
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_frontmatter(body: str) -> tuple[dict[str, Any], str]:
+    """Split YAML-like frontmatter (simple key: value lines) from markdown body."""
+
+    lines = body.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, body
+    meta: dict[str, Any] = {}
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "---":
+            rest = "\n".join(lines[i + 1 :])
+            return meta, rest if rest else ""
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+        i += 1
+    return {}, body
+
+
+def format_frontmatter(meta: dict[str, str]) -> str:
+    lines = ["---"]
+    for k in sorted(meta.keys()):
+        lines.append(f"{k}: {meta[k]}")
+    lines.append("---")
+    return "\n".join(lines) + "\n\n"

--- a/scripts/orchestration/_wiki_compiler_support.py
+++ b/scripts/orchestration/_wiki_compiler_support.py
@@ -86,6 +86,33 @@ def _sanitize_key_segment(raw: str, *, fallback: str) -> str:
     return s[:120]
 
 
+def path_for_support_plane_record(
+    path: Path,
+    *,
+    repo_root: Path,
+    wiki_root: Path,
+) -> str:
+    """Stable path string for LSP JSON fields.
+
+    Prefer repo-relative paths when ``path`` is under ``repo_root``; otherwise
+    use a ``wiki:``-prefixed path relative to ``wiki_root``, then fall back to
+    an absolute POSIX path (RU/EN: avoids ``relative_to`` crashes when wiki
+    corpus lives outside the repo tree).
+    """
+
+    rp = path.resolve()
+    rr = repo_root.resolve()
+    try:
+        return rp.relative_to(rr).as_posix()
+    except ValueError:
+        pass
+    wr = wiki_root.resolve()
+    try:
+        return f"wiki:{rp.relative_to(wr).as_posix()}"
+    except ValueError:
+        return rp.as_posix()
+
+
 def path_to_slug(rel_path: Path) -> str:
     """Derive wiki page slug from a path relative to repo root."""
 

--- a/scripts/orchestration/_wiki_compiler_support.py
+++ b/scripts/orchestration/_wiki_compiler_support.py
@@ -15,6 +15,12 @@ from typing import Any, Final
 # Default layout under repo (gitignored).
 DEFAULT_WIKI_ROOT: Final[Path] = Path("artifacts") / "orchestration" / "wiki"
 
+# Slugs feed support-plane keys ``wiki.page.{slug}`` (10) and ``wiki.promoted.{slug}`` (14).
+# local_support_plane.MAX_KEY_LEN is 128 → longest safe slug is 114.
+MAX_WIKI_SLUG_CHARS: Final[int] = 114
+
+_WIKI_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,113}$")
+
 _SLUG_SEGMENT_RE = re.compile(r"[^a-zA-Z0-9._-]+")
 
 
@@ -26,6 +32,27 @@ def repo_root_default() -> Path:
 
 def resolve_repo_root(explicit: Path | None) -> Path:
     return explicit.resolve() if explicit is not None else repo_root_default()
+
+
+def reject_if_under_canonical_docs(path: Path, *, repo_root: Path) -> None:
+    """Block writes under repo ``docs/**`` (canonical documentation tree)."""
+
+    resolved = path.resolve()
+    docs_root = (repo_root / "docs").resolve()
+    if not docs_root.is_dir():
+        return
+    try:
+        resolved.relative_to(docs_root)
+    except ValueError:
+        return
+    raise ValueError("forbidden_under_canonical_docs")
+
+
+def validate_wiki_slug(slug: str) -> None:
+    """Reject path-like slugs and enforce length/pattern for wiki.page / wiki.promoted keys."""
+
+    if not _WIKI_SLUG_RE.match(slug) or ".." in slug:
+        raise ValueError("slug_invalid")
 
 
 def corpus_base(wiki_root: Path, corpus: str) -> Path:
@@ -72,7 +99,7 @@ def path_to_slug(rel_path: Path) -> str:
         seg = _sanitize_key_segment(name, fallback="part")
         parts.append(seg)
     slug = ".".join(parts)
-    return slug[:120]
+    return slug[:MAX_WIKI_SLUG_CHARS]
 
 
 def sha256_hex(data: bytes) -> str:

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -1,0 +1,212 @@
+"""Ingest repo paths into the advisory local wiki corpus (filesystem + optional LSP).
+
+RU: Копирует сырьё в ``artifacts/orchestration/wiki`` и опционально пишет метаданные
+в local support plane (только при allowlist + execution mode).
+EN: Non-canonical; never writes ``docs/**`` or OpenAPI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+from app.security import agent_control_plane as cp
+
+from scripts.orchestration import local_support_plane as lsp
+from scripts.orchestration import _wiki_compiler_support as wcs
+
+EXIT_OK: Final[int] = 0
+EXIT_USAGE: Final[int] = 2
+
+
+def _append_log(log_path: Path, line: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(line.rstrip() + "\n")
+
+
+def _rebuild_index(pages_dir: Path, index_path: Path, corpus: str) -> None:
+    rows: list[str] = [f"# Wiki index ({corpus})", ""]
+    if pages_dir.is_dir():
+        for p in sorted(pages_dir.glob("*.md")):
+            rows.append(f"- [{p.stem}](pages/{p.name})")
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def ingest_paths(
+    source_paths: list[Path],
+    *,
+    corpus: str,
+    wiki_root: Path,
+    repo_root: Path,
+    write_support_plane: bool,
+    allowlist: set[tuple[str, str]] | None = None,
+    sp_root_override: Path | None = None,
+    audit_secret: str | None = None,
+    audit_log_path: Path | str | None = None,
+) -> tuple[list[str], list[str]]:
+    """Copy sources into wiki corpus; optionally mirror metadata to support plane.
+
+    Returns ``(written_slugs, warnings)``.
+    """
+
+    warnings: list[str] = []
+    written: list[str] = []
+    layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
+    layout["pages"].mkdir(parents=True, exist_ok=True)
+    layout["raw"].mkdir(parents=True, exist_ok=True)
+
+    active_allowlist = allowlist
+    if write_support_plane and active_allowlist is None:
+        active_allowlist = cp.load_allowlist_from_env()
+
+    for src in source_paths:
+        abs_src = src.resolve()
+        try:
+            rel = abs_src.relative_to(repo_root.resolve())
+        except ValueError as exc:
+            raise ValueError(f"source_outside_repo:{abs_src}") from exc
+        if not abs_src.is_file():
+            raise FileNotFoundError(str(abs_src))
+        data = abs_src.read_bytes()
+        digest = wcs.sha256_hex(data)
+        slug = wcs.path_to_slug(rel)
+        raw_name = f"{digest}.md"
+        raw_path = layout["raw"] / raw_name
+        raw_path.write_bytes(data)
+
+        ingested_at = wcs.utc_now_iso()
+        meta = {
+            "corpus": corpus,
+            "source_rel_path": rel.as_posix(),
+            "content_hash": digest,
+            "ingested_at": ingested_at,
+            "advisory": "true",
+        }
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            text = data.decode("utf-8", errors="replace")
+            warnings.append(f"utf8_replace:{rel.as_posix()}")
+        page_body = wcs.format_frontmatter(meta) + text
+        page_path = layout["pages"] / f"{slug}.md"
+        page_path.write_text(page_body, encoding="utf-8")
+        written.append(slug)
+
+        _append_log(
+            layout["log"],
+            f"{ingested_at} ingest corpus={corpus} slug={slug} hash={digest} path={rel.as_posix()}",
+        )
+
+        if write_support_plane:
+            try:
+                src_record: dict[str, Any] = {
+                    "corpus": corpus,
+                    "source_rel_path": rel.as_posix(),
+                    "content_hash": digest,
+                    "raw_path": raw_path.relative_to(repo_root).as_posix(),
+                    "ingested_at": ingested_at,
+                }
+                lsp.put_record(
+                    f"wiki.source.{digest}",
+                    src_record,
+                    allowlist=active_allowlist or set(),
+                    repo_root=repo_root,
+                    root_override=sp_root_override,
+                    audit_secret=audit_secret,
+                    audit_log_path=audit_log_path,
+                )
+                page_record: dict[str, Any] = {
+                    "corpus": corpus,
+                    "slug": slug,
+                    "source_rel_path": rel.as_posix(),
+                    "content_hash": digest,
+                    "page_path": page_path.relative_to(repo_root).as_posix(),
+                    "ingested_at": ingested_at,
+                }
+                lsp.put_record(
+                    f"wiki.page.{slug}",
+                    page_record,
+                    allowlist=active_allowlist or set(),
+                    repo_root=repo_root,
+                    root_override=sp_root_override,
+                    audit_secret=audit_secret,
+                    audit_log_path=audit_log_path,
+                )
+            except (PermissionError, ValueError, OSError) as exc:
+                warnings.append(f"support_plane_skip:{slug}:{exc}")
+
+    _rebuild_index(layout["pages"], layout["index"], corpus)
+    return written, warnings
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--source",
+        dest="sources",
+        action="append",
+        default=[],
+        required=True,
+        help="File path to ingest (repeatable), relative to repo root or absolute",
+    )
+    p.add_argument("--corpus", default="project_internal", help="Corpus name under wiki root")
+    p.add_argument(
+        "--wiki-root",
+        type=Path,
+        default=wcs.DEFAULT_WIKI_ROOT,
+        help="Wiki root (default: artifacts/orchestration/wiki)",
+    )
+    p.add_argument("--repo-root", type=Path, default=None, help="Repository root (auto-detected)")
+    p.add_argument(
+        "--write-support-plane",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write wiki.* records to local support plane when policy allows",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = wcs.resolve_repo_root(args.repo_root)
+    wiki_root = args.wiki_root
+    if not wiki_root.is_absolute():
+        wiki_root = (repo_root / wiki_root).resolve()
+    sources = [
+        (repo_root / Path(s)).resolve() if not Path(s).is_absolute() else Path(s).resolve()
+        for s in args.sources
+    ]
+    try:
+        _, warnings = ingest_paths(
+            sources,
+            corpus=args.corpus,
+            wiki_root=wiki_root,
+            repo_root=repo_root,
+            write_support_plane=args.write_support_plane,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    for w in warnings:
+        print(json.dumps({"warning": w}, sort_keys=True), file=sys.stderr)
+    print(
+        json.dumps(
+            {
+                "corpus": args.corpus,
+                "ok": True,
+                "repo_root": repo_root.as_posix(),
+                "wiki_root": wiki_root.as_posix(),
+            },
+            sort_keys=True,
+        )
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -56,10 +56,12 @@ def ingest_paths(
 
     warnings: list[str] = []
     written: list[str] = []
+    wiki_resolved = wiki_root.resolve()
     layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
     wcs.reject_if_under_canonical_docs(layout["base"], repo_root=repo_root)
     layout["pages"].mkdir(parents=True, exist_ok=True)
     layout["raw"].mkdir(parents=True, exist_ok=True)
+    slug_first_source: dict[str, str] = {}
 
     active_allowlist = allowlist
     if write_support_plane and active_allowlist is None:
@@ -76,6 +78,11 @@ def ingest_paths(
         data = abs_src.read_bytes()
         digest = wcs.sha256_hex(data)
         slug = wcs.path_to_slug(rel)
+        rel_posix = rel.as_posix()
+        prior = slug_first_source.get(slug)
+        if prior is not None and prior != rel_posix:
+            raise ValueError(f"slug_collision:{slug}:{prior}")
+        slug_first_source[slug] = rel_posix
         raw_name = f"{digest}.md"
         raw_path = layout["raw"] / raw_name
         raw_path.write_bytes(data)
@@ -105,11 +112,17 @@ def ingest_paths(
 
         if write_support_plane:
             try:
+                raw_sp = wcs.path_for_support_plane_record(
+                    raw_path, repo_root=repo_root, wiki_root=wiki_resolved
+                )
+                page_sp = wcs.path_for_support_plane_record(
+                    page_path, repo_root=repo_root, wiki_root=wiki_resolved
+                )
                 src_record: dict[str, Any] = {
                     "corpus": corpus,
                     "source_rel_path": rel.as_posix(),
                     "content_hash": digest,
-                    "raw_path": raw_path.relative_to(repo_root).as_posix(),
+                    "raw_path": raw_sp,
                     "ingested_at": ingested_at,
                 }
                 lsp.put_record(
@@ -126,7 +139,7 @@ def ingest_paths(
                     "slug": slug,
                     "source_rel_path": rel.as_posix(),
                     "content_hash": digest,
-                    "page_path": page_path.relative_to(repo_root).as_posix(),
+                    "page_path": page_sp,
                     "ingested_at": ingested_at,
                 }
                 lsp.put_record(

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -78,6 +78,10 @@ def ingest_paths(
         data = abs_src.read_bytes()
         digest = wcs.sha256_hex(data)
         slug = wcs.path_to_slug(rel)
+        try:
+            wcs.validate_wiki_slug(slug)
+        except ValueError as exc:
+            raise ValueError(f"slug_from_path_invalid:{rel.as_posix()}:{slug}") from exc
         rel_posix = rel.as_posix()
         prior = slug_first_source.get(slug)
         if prior is not None and prior != rel_posix:

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -57,6 +57,7 @@ def ingest_paths(
     warnings: list[str] = []
     written: list[str] = []
     layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
+    wcs.reject_if_under_canonical_docs(layout["base"], repo_root=repo_root)
     layout["pages"].mkdir(parents=True, exist_ok=True)
     layout["raw"].mkdir(parents=True, exist_ok=True)
 

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -100,8 +100,15 @@ def ingest_paths(
         except UnicodeDecodeError:
             text = data.decode("utf-8", errors="replace")
             warnings.append(f"utf8_replace:{rel.as_posix()}")
-        page_body = wcs.format_frontmatter(meta) + text
         page_path = layout["pages"] / f"{slug}.md"
+        if page_path.is_file():
+            existing_meta, _ = wcs.parse_frontmatter(page_path.read_text(encoding="utf-8"))
+            prior_src = existing_meta.get("source_rel_path")
+            if prior_src is None or str(prior_src).strip() == "":
+                raise ValueError(f"slug_collision_existing:{slug}:missing_source_rel_path")
+            if str(prior_src) != rel_posix:
+                raise ValueError(f"slug_collision_existing:{slug}:{prior_src}:{rel_posix}")
+        page_body = wcs.format_frontmatter(meta) + text
         page_path.write_text(page_body, encoding="utf-8")
         written.append(slug)
 

--- a/scripts/orchestration/wiki_lint.py
+++ b/scripts/orchestration/wiki_lint.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Final
@@ -19,6 +20,7 @@ EXIT_VIOLATIONS: Final[int] = 1
 EXIT_USAGE: Final[int] = 2
 
 _REQUIRED_KEYS = ("advisory", "corpus", "content_hash", "ingested_at")
+_CONTENT_HASH_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
 
 
 def lint_corpus(
@@ -47,6 +49,9 @@ def lint_corpus(
         ch = str(meta.get("content_hash", ""))
         if not ch:
             violations.append(f"{page.name}:empty_content_hash")
+            continue
+        if not _CONTENT_HASH_RE.match(ch):
+            violations.append(f"{page.name}:invalid_content_hash_format")
             continue
         raw_path = raw_dir / f"{ch}.md"
         if not raw_path.is_file():

--- a/scripts/orchestration/wiki_lint.py
+++ b/scripts/orchestration/wiki_lint.py
@@ -1,0 +1,90 @@
+"""Lint advisory wiki pages (frontmatter + raw hash presence).
+
+RU: Проверка полей метаданных и наличия raw-копии; только локально.
+EN: Read-only; no network; does not modify support plane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Final
+
+from scripts.orchestration import _wiki_compiler_support as wcs
+
+EXIT_OK: Final[int] = 0
+EXIT_VIOLATIONS: Final[int] = 1
+EXIT_USAGE: Final[int] = 2
+
+_REQUIRED_KEYS = ("advisory", "corpus", "content_hash", "ingested_at")
+
+
+def lint_corpus(
+    *,
+    corpus: str,
+    wiki_root: Path,
+    repo_root: Path,
+) -> list[str]:
+    """Return human-readable violation messages (empty if OK)."""
+
+    violations: list[str] = []
+    layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
+    pages_dir = layout["pages"]
+    raw_dir = layout["raw"]
+    if not pages_dir.is_dir():
+        violations.append("pages_directory_missing")
+        return violations
+    for page in sorted(pages_dir.glob("*.md")):
+        text = page.read_text(encoding="utf-8")
+        meta, _ = wcs.parse_frontmatter(text)
+        for key in _REQUIRED_KEYS:
+            if key not in meta:
+                violations.append(f"{page.name}:missing_meta:{key}")
+        if meta.get("advisory") != "true":
+            violations.append(f"{page.name}:advisory_not_true")
+        ch = str(meta.get("content_hash", ""))
+        if not ch:
+            violations.append(f"{page.name}:empty_content_hash")
+            continue
+        raw_path = raw_dir / f"{ch}.md"
+        if not raw_path.is_file():
+            violations.append(f"{page.name}:missing_raw:{ch}")
+    return violations
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--corpus", default="project_internal")
+    p.add_argument("--wiki-root", type=Path, default=wcs.DEFAULT_WIKI_ROOT)
+    p.add_argument("--repo-root", type=Path, default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = wcs.resolve_repo_root(args.repo_root)
+    wiki_root = args.wiki_root
+    if not wiki_root.is_absolute():
+        wiki_root = (repo_root / wiki_root).resolve()
+    try:
+        violations = lint_corpus(corpus=args.corpus, wiki_root=wiki_root, repo_root=repo_root)
+    except OSError as exc:
+        print(json.dumps({"error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    print(
+        json.dumps(
+            {
+                "corpus": args.corpus,
+                "ok": not violations,
+                "violations": violations,
+            },
+            sort_keys=True,
+        )
+    )
+    return EXIT_OK if not violations else EXIT_VIOLATIONS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -72,25 +72,33 @@ def promote_slug(
         "promoted_at": promoted_at,
     }
     out_text = wcs.format_frontmatter(meta) + body
-    dst.write_text(out_text, encoding="utf-8")
+    wiki_resolved = wiki_root.resolve()
+    promoted_sp = wcs.path_for_support_plane_record(
+        dst, repo_root=repo_root, wiki_root=wiki_resolved
+    )
 
+    dst.write_text(out_text, encoding="utf-8")
     if write_support_plane:
         active = allowlist if allowlist is not None else cp.load_allowlist_from_env()
         payload: dict[str, Any] = {
             "corpus": corpus,
             "slug": slug,
             "promoted_at": promoted_at,
-            "promoted_path": dst.relative_to(repo_root.resolve()).as_posix(),
+            "promoted_path": promoted_sp,
         }
-        lsp.put_record(
-            f"wiki.promoted.{slug}",
-            payload,
-            allowlist=active,
-            repo_root=repo_root,
-            root_override=sp_root_override,
-            audit_secret=audit_secret,
-            audit_log_path=audit_log_path,
-        )
+        try:
+            lsp.put_record(
+                f"wiki.promoted.{slug}",
+                payload,
+                allowlist=active,
+                repo_root=repo_root,
+                root_override=sp_root_override,
+                audit_secret=audit_secret,
+                audit_log_path=audit_log_path,
+            )
+        except (OSError, PermissionError, ValueError, RuntimeError):
+            dst.unlink(missing_ok=True)
+            raise
     return dst
 
 
@@ -135,15 +143,10 @@ def main(argv: list[str] | None = None) -> int:
     except PermissionError as exc:
         print(json.dumps({"error": str(exc), "ok": False}, sort_keys=True), file=sys.stderr)
         return EXIT_USAGE
-    print(
-        json.dumps(
-            {
-                "ok": True,
-                "out": out.relative_to(repo_root.resolve()).as_posix(),
-            },
-            sort_keys=True,
-        )
+    out_display = wcs.path_for_support_plane_record(
+        out, repo_root=repo_root, wiki_root=wiki_root.resolve()
     )
+    print(json.dumps({"ok": True, "out": out_display}, sort_keys=True))
     return EXIT_OK
 
 

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -60,7 +60,7 @@ def promote_slug(
     """Copy ``pages/<slug>.md`` to ``promoted/<slug>.md`` with promotion metadata."""
 
     validate_slug(slug)
-    layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
+    layout: dict[str, Path] = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
     violations = wiki_lint.lint_corpus(corpus=corpus, wiki_root=wiki_root, repo_root=repo_root)
     prefix = f"{slug}.md:"
     blocking = [v for v in violations if v == "pages_directory_missing" or v.startswith(prefix)]
@@ -70,8 +70,9 @@ def promote_slug(
     src = layout["pages"] / f"{slug}.md"
     if not src.is_file():
         raise FileNotFoundError(f"missing_page:{slug}")
-    dst = layout["promoted"] / f"{slug}.md"
-    layout["promoted"].mkdir(parents=True, exist_ok=True)
+    promoted_dir: Path = layout["promoted"]
+    promoted_dir.mkdir(parents=True, exist_ok=True)
+    dst: Path = promoted_dir / f"{slug}.md"
     reject_if_under_canonical_docs(dst, repo_root=repo_root)
     try:
         dst.relative_to(layout["base"].resolve())

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -55,9 +55,9 @@ def promote_slug(
     if not src.is_file():
         raise FileNotFoundError(f"missing_page:{slug}")
     promoted_dir: Path = layout["promoted"]
-    promoted_dir.mkdir(parents=True, exist_ok=True)
     dst: Path = promoted_dir / f"{slug}.md"
     wcs.reject_if_under_canonical_docs(dst, repo_root=repo_root)
+    promoted_dir.mkdir(parents=True, exist_ok=True)
     try:
         dst.relative_to(layout["base"].resolve())
     except ValueError as exc:

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -7,6 +7,7 @@ EN: Fail-closed if output would resolve under repo ``docs/`` (canonical tree).
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 from pathlib import Path
@@ -57,11 +58,13 @@ def promote_slug(
     promoted_dir: Path = layout["promoted"]
     dst: Path = promoted_dir / f"{slug}.md"
     wcs.reject_if_under_canonical_docs(dst, repo_root=repo_root)
-    promoted_dir.mkdir(parents=True, exist_ok=True)
+    base_resolved = layout["base"].resolve()
+    resolved_dst = dst.resolve(strict=False)
     try:
-        dst.relative_to(layout["base"].resolve())
+        resolved_dst.relative_to(base_resolved)
     except ValueError as exc:
         raise ValueError("promote_path_outside_corpus") from exc
+    promoted_dir.mkdir(parents=True, exist_ok=True)
 
     raw_text = src.read_text(encoding="utf-8")
     meta, body = wcs.parse_frontmatter(raw_text)
@@ -96,8 +99,9 @@ def promote_slug(
                 audit_secret=audit_secret,
                 audit_log_path=audit_log_path,
             )
-        except (OSError, PermissionError, ValueError, RuntimeError):
-            dst.unlink(missing_ok=True)
+        except Exception:
+            with contextlib.suppress(OSError):
+                dst.unlink(missing_ok=True)
             raise
     return dst
 

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -1,0 +1,166 @@
+"""Promote a lint-clean wiki page into ``promoted/`` (+ optional support-plane record).
+
+RU: Копия страницы в promoted/; канонические ``docs/**`` и AGENTS никогда не трогаем.
+EN: Fail-closed if output would resolve under repo ``docs/`` (canonical tree).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+from app.security import agent_control_plane as cp
+
+from scripts.orchestration import local_support_plane as lsp
+from scripts.orchestration import _wiki_compiler_support as wcs
+from scripts.orchestration import wiki_lint
+
+EXIT_OK: Final[int] = 0
+EXIT_LINT: Final[int] = 1
+EXIT_USAGE: Final[int] = 2
+
+_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,119}$")
+
+
+def validate_slug(slug: str) -> None:
+    if not _SLUG_RE.match(slug) or ".." in slug:
+        raise ValueError("slug_invalid")
+
+
+def reject_if_under_canonical_docs(path: Path, *, repo_root: Path) -> None:
+    """Block writes into ``docs/**`` (canonical documentation tree)."""
+
+    resolved = path.resolve()
+    docs_root = (repo_root / "docs").resolve()
+    if not docs_root.is_dir():
+        return
+    try:
+        resolved.relative_to(docs_root)
+    except ValueError:
+        return
+    raise ValueError("promote_forbidden_under_canonical_docs")
+
+
+def promote_slug(
+    slug: str,
+    *,
+    corpus: str,
+    wiki_root: Path,
+    repo_root: Path,
+    write_support_plane: bool,
+    allowlist: set[tuple[str, str]] | None = None,
+    sp_root_override: Path | None = None,
+    audit_secret: str | None = None,
+    audit_log_path: Path | str | None = None,
+) -> Path:
+    """Copy ``pages/<slug>.md`` to ``promoted/<slug>.md`` with promotion metadata."""
+
+    validate_slug(slug)
+    layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
+    violations = wiki_lint.lint_corpus(corpus=corpus, wiki_root=wiki_root, repo_root=repo_root)
+    prefix = f"{slug}.md:"
+    blocking = [v for v in violations if v == "pages_directory_missing" or v.startswith(prefix)]
+    if blocking:
+        raise ValueError(f"lint_blocked:{blocking}")
+
+    src = layout["pages"] / f"{slug}.md"
+    if not src.is_file():
+        raise FileNotFoundError(f"missing_page:{slug}")
+    dst = layout["promoted"] / f"{slug}.md"
+    layout["promoted"].mkdir(parents=True, exist_ok=True)
+    reject_if_under_canonical_docs(dst, repo_root=repo_root)
+    try:
+        dst.relative_to(layout["base"].resolve())
+    except ValueError as exc:
+        raise ValueError("promote_path_outside_corpus") from exc
+
+    raw_text = src.read_text(encoding="utf-8")
+    meta, body = wcs.parse_frontmatter(raw_text)
+    promoted_at = wcs.utc_now_iso()
+    meta = {
+        **{str(k): str(v) for k, v in meta.items()},
+        "promoted": "true",
+        "promoted_at": promoted_at,
+    }
+    out_text = wcs.format_frontmatter(meta) + body
+    dst.write_text(out_text, encoding="utf-8")
+
+    if write_support_plane:
+        active = allowlist if allowlist is not None else cp.load_allowlist_from_env()
+        payload: dict[str, Any] = {
+            "corpus": corpus,
+            "slug": slug,
+            "promoted_at": promoted_at,
+            "promoted_path": dst.relative_to(repo_root.resolve()).as_posix(),
+        }
+        lsp.put_record(
+            f"wiki.promoted.{slug}",
+            payload,
+            allowlist=active,
+            repo_root=repo_root,
+            root_override=sp_root_override,
+            audit_secret=audit_secret,
+            audit_log_path=audit_log_path,
+        )
+    return dst
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--slug", required=True)
+    p.add_argument("--corpus", default="project_internal")
+    p.add_argument("--wiki-root", type=Path, default=wcs.DEFAULT_WIKI_ROOT)
+    p.add_argument("--repo-root", type=Path, default=None)
+    p.add_argument(
+        "--write-support-plane",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = wcs.resolve_repo_root(args.repo_root)
+    wiki_root = args.wiki_root
+    if not wiki_root.is_absolute():
+        wiki_root = (repo_root / wiki_root).resolve()
+    try:
+        out = promote_slug(
+            args.slug,
+            corpus=args.corpus,
+            wiki_root=wiki_root,
+            repo_root=repo_root,
+            write_support_plane=args.write_support_plane,
+        )
+    except ValueError as exc:
+        err = str(exc)
+        if err.startswith("lint_blocked:"):
+            print(json.dumps({"error": err, "ok": False}, sort_keys=True), file=sys.stderr)
+            return EXIT_LINT
+        print(json.dumps({"error": err, "ok": False}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    except FileNotFoundError as exc:
+        print(json.dumps({"error": str(exc), "ok": False}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    except PermissionError as exc:
+        print(json.dumps({"error": str(exc), "ok": False}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "out": out.relative_to(repo_root.resolve()).as_posix(),
+            },
+            sort_keys=True,
+        )
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -7,7 +7,6 @@ EN: Fail-closed if output would resolve under repo ``docs/`` (canonical tree).
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
 import sys
 from pathlib import Path
@@ -99,9 +98,11 @@ def promote_slug(
                 audit_secret=audit_secret,
                 audit_log_path=audit_log_path,
             )
-        except Exception:
-            with contextlib.suppress(OSError):
+        except Exception as exc:
+            try:
                 dst.unlink(missing_ok=True)
+            except OSError as unlink_exc:
+                raise unlink_exc from exc
             raise
     return dst
 

--- a/scripts/orchestration/wiki_promote.py
+++ b/scripts/orchestration/wiki_promote.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Any, Final
@@ -23,26 +22,11 @@ EXIT_OK: Final[int] = 0
 EXIT_LINT: Final[int] = 1
 EXIT_USAGE: Final[int] = 2
 
-_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,119}$")
-
 
 def validate_slug(slug: str) -> None:
-    if not _SLUG_RE.match(slug) or ".." in slug:
-        raise ValueError("slug_invalid")
+    """Back-compat wrapper; prefer ``wcs.validate_wiki_slug`` in new code."""
 
-
-def reject_if_under_canonical_docs(path: Path, *, repo_root: Path) -> None:
-    """Block writes into ``docs/**`` (canonical documentation tree)."""
-
-    resolved = path.resolve()
-    docs_root = (repo_root / "docs").resolve()
-    if not docs_root.is_dir():
-        return
-    try:
-        resolved.relative_to(docs_root)
-    except ValueError:
-        return
-    raise ValueError("promote_forbidden_under_canonical_docs")
+    wcs.validate_wiki_slug(slug)
 
 
 def promote_slug(
@@ -59,7 +43,7 @@ def promote_slug(
 ) -> Path:
     """Copy ``pages/<slug>.md`` to ``promoted/<slug>.md`` with promotion metadata."""
 
-    validate_slug(slug)
+    wcs.validate_wiki_slug(slug)
     layout: dict[str, Path] = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
     violations = wiki_lint.lint_corpus(corpus=corpus, wiki_root=wiki_root, repo_root=repo_root)
     prefix = f"{slug}.md:"
@@ -73,7 +57,7 @@ def promote_slug(
     promoted_dir: Path = layout["promoted"]
     promoted_dir.mkdir(parents=True, exist_ok=True)
     dst: Path = promoted_dir / f"{slug}.md"
-    reject_if_under_canonical_docs(dst, repo_root=repo_root)
+    wcs.reject_if_under_canonical_docs(dst, repo_root=repo_root)
     try:
         dst.relative_to(layout["base"].resolve())
     except ValueError as exc:

--- a/scripts/orchestration/wiki_query.py
+++ b/scripts/orchestration/wiki_query.py
@@ -44,6 +44,7 @@ def search_pages(pages_dir: Path, needle: str) -> list[dict[str, Any]]:
 
 
 def detail_page(pages_dir: Path, slug: str) -> dict[str, Any] | None:
+    wcs.validate_wiki_slug(slug)
     path = pages_dir / f"{slug}.md"
     if not path.is_file():
         return None

--- a/scripts/orchestration/wiki_query.py
+++ b/scripts/orchestration/wiki_query.py
@@ -1,0 +1,122 @@
+"""Query advisory local wiki pages (list, search, detail).
+
+RU: Только чтение файловой вики; без embeddings и без сети.
+EN: Read-only; does not mutate support plane or canonical docs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+from scripts.orchestration import _wiki_compiler_support as wcs
+
+EXIT_OK: Final[int] = 0
+EXIT_NOT_FOUND: Final[int] = 1
+EXIT_USAGE: Final[int] = 2
+
+
+def list_pages(pages_dir: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not pages_dir.is_dir():
+        return out
+    for p in sorted(pages_dir.glob("*.md")):
+        meta, _ = wcs.parse_frontmatter(p.read_text(encoding="utf-8"))
+        out.append({"slug": p.stem, "meta": meta, "path": p.as_posix()})
+    return out
+
+
+def search_pages(pages_dir: Path, needle: str) -> list[dict[str, Any]]:
+    n = needle.casefold()
+    hits: list[dict[str, Any]] = []
+    if not pages_dir.is_dir():
+        return hits
+    for p in sorted(pages_dir.glob("*.md")):
+        text = p.read_text(encoding="utf-8")
+        _, body = wcs.parse_frontmatter(text)
+        lines = [i + 1 for i, line in enumerate(body.splitlines()) if n in line.casefold()]
+        if lines:
+            hits.append({"lines": lines, "slug": p.stem})
+    return hits
+
+
+def detail_page(pages_dir: Path, slug: str) -> dict[str, Any] | None:
+    path = pages_dir / f"{slug}.md"
+    if not path.is_file():
+        return None
+    meta, body = wcs.parse_frontmatter(path.read_text(encoding="utf-8"))
+    return {"body": body, "meta": meta, "slug": slug}
+
+
+def run_query(
+    *,
+    mode: str,
+    corpus: str,
+    wiki_root: Path,
+    repo_root: Path,
+    needle: str | None = None,
+    slug: str | None = None,
+) -> dict[str, Any]:
+    base = wcs.corpus_base(wiki_root, corpus)
+    layout = wcs.corpus_layout(base)
+    if mode == "list":
+        return {"pages": list_pages(layout["pages"])}
+    if mode == "search":
+        if not needle:
+            raise ValueError("search_requires_needle")
+        return {"hits": search_pages(layout["pages"], needle)}
+    if mode == "detail":
+        if not slug:
+            raise ValueError("detail_requires_slug")
+        d = detail_page(layout["pages"], slug)
+        if d is None:
+            raise FileNotFoundError(slug)
+        return {"page": d}
+    raise ValueError(f"unknown_mode:{mode}")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--mode",
+        choices=("list", "search", "detail"),
+        required=True,
+    )
+    p.add_argument("--corpus", default="project_internal")
+    p.add_argument("--wiki-root", type=Path, default=wcs.DEFAULT_WIKI_ROOT)
+    p.add_argument("--repo-root", type=Path, default=None)
+    p.add_argument("--needle", default=None, help="Substring for search mode")
+    p.add_argument("--slug", default=None, help="Page slug for detail mode")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = wcs.resolve_repo_root(args.repo_root)
+    wiki_root = args.wiki_root
+    if not wiki_root.is_absolute():
+        wiki_root = (repo_root / wiki_root).resolve()
+    try:
+        payload = run_query(
+            mode=args.mode,
+            corpus=args.corpus,
+            wiki_root=wiki_root,
+            repo_root=repo_root,
+            needle=args.needle,
+            slug=args.slug,
+        )
+    except FileNotFoundError as exc:
+        print(json.dumps({"error": "not_found", "slug": str(exc)}, sort_keys=True), file=sys.stderr)
+        return EXIT_NOT_FOUND
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return EXIT_USAGE
+    print(json.dumps({"corpus": args.corpus, "ok": True, **payload}, sort_keys=True))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wiki_compiler_keys.py
+++ b/tests/test_wiki_compiler_keys.py
@@ -1,0 +1,26 @@
+"""Support-plane key shape checks for advisory wiki compiler metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.orchestration import local_support_plane as lsp
+
+
+def test_normalize_key_accepts_wiki_source_sha256() -> None:
+    digest = "a" * 64
+    key = f"wiki.source.{digest}"
+    assert lsp.normalize_key(key) == key
+
+
+def test_normalize_key_accepts_wiki_page_slug() -> None:
+    assert lsp.normalize_key("wiki.page.docs.note") == "wiki.page.docs.note"
+
+
+def test_normalize_key_accepts_wiki_promoted_slug() -> None:
+    assert lsp.normalize_key("wiki.promoted.src.doc") == "wiki.promoted.src.doc"
+
+
+def test_normalize_key_rejects_invalid_wiki_segments() -> None:
+    with pytest.raises(ValueError, match="support_plane_key_invalid_chars"):
+        lsp.normalize_key("wiki.page.bad/slug")

--- a/tests/test_wiki_compiler_keys.py
+++ b/tests/test_wiki_compiler_keys.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+from scripts.orchestration import _wiki_compiler_support as wcs
 from scripts.orchestration import local_support_plane as lsp
 
 
@@ -24,3 +27,38 @@ def test_normalize_key_accepts_wiki_promoted_slug() -> None:
 def test_normalize_key_rejects_invalid_wiki_segments() -> None:
     with pytest.raises(ValueError, match="support_plane_key_invalid_chars"):
         lsp.normalize_key("wiki.page.bad/slug")
+
+
+def test_path_to_slug_truncates_to_max_length() -> None:
+    parts = [f"seg{i}" for i in range(40)]
+    rel = Path(*parts) / "tail.md"
+    slug = wcs.path_to_slug(rel)
+    assert len(slug) <= wcs.MAX_WIKI_SLUG_CHARS
+
+
+def test_validate_wiki_slug_rejects_oversized_slug() -> None:
+    too_long = "a" * (wcs.MAX_WIKI_SLUG_CHARS + 1)
+    with pytest.raises(ValueError, match="slug_invalid"):
+        wcs.validate_wiki_slug(too_long)
+
+
+def test_path_for_support_plane_record_prefers_repo_relative(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    wiki = repo / "wiki"
+    target = wiki / "c" / "f.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("x", encoding="utf-8")
+    assert (
+        wcs.path_for_support_plane_record(target, repo_root=repo, wiki_root=wiki) == "wiki/c/f.md"
+    )
+
+
+def test_path_for_support_plane_record_wiki_prefix_outside_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    wiki = tmp_path / "external_wiki"
+    target = wiki / "raw" / "a.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("x", encoding="utf-8")
+    out = wcs.path_for_support_plane_record(target, repo_root=repo, wiki_root=wiki)
+    assert out == "wiki:raw/a.md"

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -138,6 +138,60 @@ def test_ingest_slug_collision_raises(tmp_path: Path) -> None:
         )
 
 
+def test_ingest_slug_collision_existing_across_runs(tmp_path: Path) -> None:
+    """Same slug from different sources on separate ingest calls must not overwrite silently."""
+
+    repo = tmp_path / "repo"
+    pdir = repo / "p"
+    pdir.mkdir(parents=True)
+    (pdir / "q").write_text("first", encoding="utf-8")
+    (pdir / "q.md").write_text("second", encoding="utf-8")
+    wiki_root = repo / "w"
+    wiki_ingest.ingest_paths(
+        [pdir / "q"],
+        corpus="c",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    with pytest.raises(ValueError, match="slug_collision_existing"):
+        wiki_ingest.ingest_paths(
+            [pdir / "q.md"],
+            corpus="c",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
+def test_ingest_same_source_reingest_overwrites(tmp_path: Path) -> None:
+    """Re-ingesting the same repo path updates the page (same source_rel_path)."""
+
+    repo = tmp_path / "repo"
+    (repo / "x").mkdir(parents=True)
+    f = repo / "x" / "note.md"
+    f.write_text("v1", encoding="utf-8")
+    wiki_root = repo / "w"
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="c",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    f.write_text("v2", encoding="utf-8")
+    slugs, _ = wiki_ingest.ingest_paths(
+        [f],
+        corpus="c",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert slugs == ["x.note"]
+    page = wiki_root / "c" / "pages" / "x.note.md"
+    assert "v2" in page.read_text(encoding="utf-8")
+
+
 def test_ingest_non_utf8_emits_warning(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     (repo / "bin").mkdir(parents=True)

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -57,6 +57,21 @@ def test_ingest_writes_raw_page_index_log(tmp_path: Path) -> None:
     assert "ingest" in log
 
 
+def test_ingest_rejects_wiki_root_under_canonical_docs(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs" / "wiki_here").mkdir(parents=True)
+    src = repo / "docs" / "wiki_here" / "n.md"
+    src.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="forbidden_under_canonical_docs"):
+        wiki_ingest.ingest_paths(
+            [src],
+            corpus="project_internal",
+            wiki_root=repo / "docs" / "wiki_here",
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
 def test_ingest_rejects_path_outside_repo(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -1,0 +1,125 @@
+"""Tests for advisory wiki ingest (filesystem layout + optional support plane)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from app.security import agent_control_plane as cp
+from scripts.orchestration import local_support_plane as lsp
+from scripts.orchestration import wiki_ingest
+
+
+@pytest.fixture
+def allowlist() -> set[tuple[str, str]]:
+    return {lsp.default_allowlist_pair()}
+
+
+@pytest.fixture
+def audit_signing_material(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv(cp.EXECUTION_MODE_ENV, cp.EXECUTION_MODE_AUTO_SAFE)
+    material = "unit-test-hmac-key-wiki-ingest-2026"  # pragma: allowlist secret
+    monkeypatch.setenv(cp.AUDIT_SIGNING_KEY_ENV, material)
+    return material
+
+
+def test_ingest_writes_raw_page_index_log(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs").mkdir(parents=True)
+    src = repo / "docs" / "note.md"
+    src.write_text("# Hello\nbody\n", encoding="utf-8")
+    wiki_root = repo / "wiki"
+    slugs, warnings = wiki_ingest.ingest_paths(
+        [src],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert slugs == ["docs.note"]
+    assert warnings == []
+    base = wiki_root / "project_internal"
+    raw_dir = base / "raw"
+    pages = base / "pages"
+    assert raw_dir.is_dir()
+    raw_files = list(raw_dir.glob("*.md"))
+    assert len(raw_files) == 1
+    page = pages / "docs.note.md"
+    assert page.is_file()
+    text = page.read_text(encoding="utf-8")
+    assert "content_hash:" in text
+    assert "# Hello" in text
+    assert (base / "index.md").is_file()
+    log = (base / "log.md").read_text(encoding="utf-8")
+    assert "ingest" in log
+
+
+def test_ingest_rejects_path_outside_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="source_outside_repo"):
+        wiki_ingest.ingest_paths(
+            [outside],
+            corpus="c",
+            wiki_root=repo / "w",
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
+def test_ingest_support_plane_roundtrip(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "a").mkdir(parents=True)
+    src = repo / "a" / "f.md"
+    src.write_text("content", encoding="utf-8")
+    sp_root = tmp_path / "sp"
+    audit_log = tmp_path / "audit.jsonl"
+    wiki_root = repo / "wiki"
+    digest = hashlib.sha256(b"content").hexdigest()
+    wiki_ingest.ingest_paths(
+        [src],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=True,
+        allowlist=allowlist,
+        sp_root_override=sp_root,
+        audit_secret=audit_signing_material,
+        audit_log_path=audit_log,
+    )
+    rec = lsp.get_record(f"wiki.source.{digest}", root_override=sp_root)
+    assert rec is not None
+    assert rec["content_hash"] == digest
+    page_rec = lsp.get_record("wiki.page.a.f", root_override=sp_root)
+    assert page_rec is not None
+    assert page_rec["slug"] == "a.f"
+
+
+def test_main_json_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "r"
+    (repo / "x").mkdir(parents=True)
+    f = repo / "x" / "y.md"
+    f.write_text("z", encoding="utf-8")
+    code = wiki_ingest.main(
+        [
+            "--source",
+            str(f.relative_to(repo)),
+            "--repo-root",
+            str(repo),
+            "--wiki-root",
+            str(repo / "w"),
+            "--no-write-support-plane",
+        ]
+    )
+    assert code == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -119,6 +119,73 @@ def test_ingest_support_plane_roundtrip(
     assert page_rec["slug"] == "a.f"
 
 
+def test_ingest_slug_collision_raises(tmp_path: Path) -> None:
+    """Two sources must not map to the same slug (sanitized path segments)."""
+
+    repo = tmp_path / "repo"
+    pdir = repo / "p"
+    pdir.mkdir(parents=True)
+    (pdir / "q").write_text("plain", encoding="utf-8")
+    (pdir / "q.md").write_text("markdown", encoding="utf-8")
+    wiki_root = repo / "w"
+    with pytest.raises(ValueError, match="slug_collision"):
+        wiki_ingest.ingest_paths(
+            [pdir / "q", pdir / "q.md"],
+            corpus="c",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
+def test_ingest_non_utf8_emits_warning(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "bin").mkdir(parents=True)
+    src = repo / "bin" / "x.md"
+    src.write_bytes(b"\xff\xfe\x00not-utf8")
+    wiki_root = repo / "w"
+    _, warnings = wiki_ingest.ingest_paths(
+        [src],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert any(w.startswith("utf8_replace:") for w in warnings)
+
+
+def test_ingest_support_plane_paths_when_wiki_outside_repo(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    f = repo / "src" / "note.md"
+    f.write_text("hello", encoding="utf-8")
+    wiki_root = tmp_path / "external_wiki"
+    sp_root = tmp_path / "sp"
+    audit_log = tmp_path / "audit.jsonl"
+    digest = hashlib.sha256(b"hello").hexdigest()
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=True,
+        allowlist=allowlist,
+        sp_root_override=sp_root,
+        audit_secret=audit_signing_material,
+        audit_log_path=audit_log,
+    )
+    rec = lsp.get_record(f"wiki.source.{digest}", root_override=sp_root)
+    assert rec is not None
+    assert rec["raw_path"].startswith("wiki:")
+    page = lsp.get_record("wiki.page.src.note", root_override=sp_root)
+    assert page is not None
+    assert page["page_path"].startswith("wiki:")
+
+
 def test_main_json_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo = tmp_path / "r"
     (repo / "x").mkdir(parents=True)
@@ -138,3 +205,26 @@ def test_main_json_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> Non
     assert code == 0
     out = json.loads(capsys.readouterr().out.strip())
     assert out["ok"] is True
+
+
+def test_main_stderr_json_on_missing_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    code = wiki_ingest.main(
+        [
+            "--source",
+            "missing.md",
+            "--repo-root",
+            str(repo),
+            "--wiki-root",
+            str(repo / "w"),
+            "--no-write-support-plane",
+        ]
+    )
+    assert code == wiki_ingest.EXIT_USAGE
+    err_lines = [ln for ln in capsys.readouterr().err.strip().split("\n") if ln.strip()]
+    payload = json.loads(err_lines[-1])
+    assert payload["ok"] is False
+    assert "error" in payload

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -20,6 +20,28 @@ def test_lint_pages_missing(tmp_path: Path) -> None:
     assert "pages_directory_missing" in v
 
 
+def test_lint_rejects_invalid_content_hash_format(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    wiki = repo / "w"
+    layout_base = wiki / "project_internal"
+    pages = layout_base / "pages"
+    raw = layout_base / "raw"
+    pages.mkdir(parents=True)
+    raw.mkdir(parents=True)
+    bad_page = pages / "bad.md"
+    bad_page.write_text(
+        "---\n"
+        "advisory: true\n"
+        "content_hash: NOT_A_HASH\n"
+        "corpus: project_internal\n"
+        "ingested_at: 2026-01-01T00:00:00Z\n"
+        "---\n\nbody\n",
+        encoding="utf-8",
+    )
+    v = wiki_lint.lint_corpus(corpus="project_internal", wiki_root=wiki, repo_root=repo)
+    assert any("invalid_content_hash_format" in x for x in v)
+
+
 def test_lint_clean_after_ingest(tmp_path: Path) -> None:
     repo = tmp_path / "r"
     (repo / "s").mkdir(parents=True)

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -1,0 +1,53 @@
+"""Tests for advisory wiki lint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import wiki_ingest
+from scripts.orchestration import wiki_lint
+
+
+def test_lint_pages_missing(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    wiki = repo / "w"
+    (wiki / "project_internal").mkdir(parents=True)
+    v = wiki_lint.lint_corpus(corpus="project_internal", wiki_root=wiki, repo_root=repo)
+    assert "pages_directory_missing" in v
+
+
+def test_lint_clean_after_ingest(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    (repo / "s").mkdir(parents=True)
+    f = repo / "s" / "a.md"
+    f.write_text("ok", encoding="utf-8")
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=repo / "wiki",
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    v = wiki_lint.lint_corpus(corpus="project_internal", wiki_root=repo / "wiki", repo_root=repo)
+    assert v == []
+
+
+def test_main_exit_code(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "r"
+    (repo / "s").mkdir(parents=True)
+    f = repo / "s" / "a.md"
+    f.write_text("ok", encoding="utf-8")
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=repo / "wiki",
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert wiki_lint.main(["--repo-root", str(repo), "--wiki-root", str(repo / "wiki")]) == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -159,6 +161,36 @@ def test_promote_rejects_bad_slug() -> None:
         wiki_promote.validate_slug("../x")
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "symlink"),
+    reason="symlink required to simulate promoted/ escaping corpus",
+)
+def test_promote_rejects_symlink_promoted_dir_outside_corpus(tmp_path: Path) -> None:
+    """Resolved destination must stay under corpus before mkdir (symlink escape)."""
+
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    layout = wcs.corpus_layout(wcs.corpus_base(wiki, "project_internal"))
+    promoted = layout["promoted"]
+    if promoted.exists():
+        if promoted.is_dir():
+            shutil.rmtree(promoted)
+        else:
+            promoted.unlink()
+    outside = tmp_path / "outside_promoted"
+    outside.mkdir(parents=True)
+    os.symlink(outside, promoted, target_is_directory=True)
+    with pytest.raises(ValueError, match="promote_path_outside_corpus"):
+        wiki_promote.promote_slug(
+            slug,
+            corpus="project_internal",
+            wiki_root=wiki,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
 def test_promote_does_not_write_file_when_put_record_fails(
     tmp_path: Path,
     allowlist: set[tuple[str, str]],
@@ -175,6 +207,37 @@ def test_promote_does_not_write_file_when_put_record_fails(
 
     monkeypatch.setattr(lsp, "put_record", boom)
     with pytest.raises(ValueError, match="support_plane_value_too_large"):
+        wiki_promote.promote_slug(
+            slug,
+            corpus="project_internal",
+            wiki_root=wiki,
+            repo_root=repo,
+            write_support_plane=True,
+            allowlist=allowlist,
+            sp_root_override=tmp_path / "sp",
+            audit_secret=audit_signing_material,
+        )
+    assert not dst.is_file()
+
+
+def test_promote_unlinks_on_unexpected_put_record_failure(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollback promoted file on any support-plane failure, not only a fixed tuple."""
+
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    dst = wiki / "project_internal" / "promoted" / f"{slug}.md"
+
+    def boom(*_a: object, **_kw: object) -> None:
+        raise TypeError("unexpected_support_plane")
+
+    monkeypatch.setattr(lsp, "put_record", boom)
+    with pytest.raises(TypeError, match="unexpected_support_plane"):
         wiki_promote.promote_slug(
             slug,
             corpus="project_internal",

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -251,6 +251,48 @@ def test_promote_unlinks_on_unexpected_put_record_failure(
     assert not dst.is_file()
 
 
+def test_promote_rollback_unlink_failure_chains_from_support_plane_error(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RU: Ошибка unlink при откате не глотается — видна вместе с причиной из SP.
+    EN: Rollback unlink errors propagate; support-plane failure remains __cause__ chain.
+    """
+
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    dst = wiki / "project_internal" / "promoted" / f"{slug}.md"
+    real_unlink = Path.unlink
+
+    def boom(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("support_plane_failed")
+
+    def unlink_patched(self: Path, *a: object, **kw: object) -> None:
+        if self == dst:
+            raise PermissionError("rollback_unlink_denied")
+        return real_unlink(self, *a, **kw)
+
+    monkeypatch.setattr(lsp, "put_record", boom)
+    monkeypatch.setattr(Path, "unlink", unlink_patched)
+    with pytest.raises(PermissionError, match="rollback_unlink_denied") as record:
+        wiki_promote.promote_slug(
+            slug,
+            corpus="project_internal",
+            wiki_root=wiki,
+            repo_root=repo,
+            write_support_plane=True,
+            allowlist=allowlist,
+            sp_root_override=tmp_path / "sp",
+            audit_secret=audit_signing_material,
+        )
+    assert record.value.__cause__ is not None
+    assert isinstance(record.value.__cause__, RuntimeError)
+    assert dst.is_file()
+
+
 def test_main_out_when_wiki_outside_repo(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -120,6 +120,70 @@ def test_promote_rejects_bad_slug() -> None:
         wiki_promote.validate_slug("../x")
 
 
+def test_promote_does_not_write_file_when_put_record_fails(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    dst = wiki / "project_internal" / "promoted" / f"{slug}.md"
+
+    def boom(*_a: object, **_kw: object) -> None:
+        raise ValueError("support_plane_value_too_large")
+
+    monkeypatch.setattr(lsp, "put_record", boom)
+    with pytest.raises(ValueError, match="support_plane_value_too_large"):
+        wiki_promote.promote_slug(
+            slug,
+            corpus="project_internal",
+            wiki_root=wiki,
+            repo_root=repo,
+            write_support_plane=True,
+            allowlist=allowlist,
+            sp_root_override=tmp_path / "sp",
+            audit_secret=audit_signing_material,
+        )
+    assert not dst.is_file()
+
+
+def test_main_out_when_wiki_outside_repo(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "r"
+    (repo / "s").mkdir(parents=True)
+    f = repo / "s" / "a.md"
+    f.write_text("body", encoding="utf-8")
+    wiki_root = tmp_path / "ext_wiki"
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert (
+        wiki_promote.main(
+            [
+                "--slug",
+                "s.a",
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(wiki_root),
+                "--no-write-support-plane",
+            ]
+        )
+        == 0
+    )
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True
+    assert out["out"].startswith("wiki:")
+
+
 def test_main_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo = tmp_path / "r"
     wiki = repo / "wiki"

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -1,0 +1,126 @@
+"""Tests for advisory wiki promote (filesystem + support plane)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.security import agent_control_plane as cp
+from scripts.orchestration import local_support_plane as lsp
+from scripts.orchestration import wiki_ingest
+from scripts.orchestration import wiki_promote
+
+
+@pytest.fixture
+def allowlist() -> set[tuple[str, str]]:
+    return {lsp.default_allowlist_pair()}
+
+
+@pytest.fixture
+def audit_signing_material(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv(cp.EXECUTION_MODE_ENV, cp.EXECUTION_MODE_AUTO_SAFE)
+    material = "unit-test-hmac-key-wiki-promote-2026"  # pragma: allowlist secret
+    monkeypatch.setenv(cp.AUDIT_SIGNING_KEY_ENV, material)
+    return material
+
+
+def _ingest_one(repo: Path, wiki: Path) -> str:
+    (repo / "s").mkdir(parents=True)
+    f = repo / "s" / "a.md"
+    f.write_text("body", encoding="utf-8")
+    slugs, _ = wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=wiki,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert len(slugs) == 1
+    return slugs[0]
+
+
+def test_promote_writes_promoted_and_metadata(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    out = wiki_promote.promote_slug(
+        slug,
+        corpus="project_internal",
+        wiki_root=wiki,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    assert out.is_file()
+    text = out.read_text(encoding="utf-8")
+    assert "promoted: true" in text
+    assert "promoted_at:" in text
+
+
+def test_promote_support_plane_record(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+) -> None:
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    sp = tmp_path / "sp"
+    audit_log = tmp_path / "audit.jsonl"
+    wiki_promote.promote_slug(
+        slug,
+        corpus="project_internal",
+        wiki_root=wiki,
+        repo_root=repo,
+        write_support_plane=True,
+        allowlist=allowlist,
+        sp_root_override=sp,
+        audit_secret=audit_signing_material,
+        audit_log_path=audit_log,
+    )
+    rec = lsp.get_record(f"wiki.promoted.{slug}", root_override=sp)
+    assert rec is not None
+    assert rec["slug"] == slug
+
+
+def test_promote_forbidden_under_canonical_docs(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    (repo / "docs").mkdir(parents=True)
+    wiki = repo / "docs" / "evil_wiki"
+    slug = _ingest_one(repo, wiki)
+    with pytest.raises(ValueError, match="promote_forbidden_under_canonical_docs"):
+        wiki_promote.promote_slug(
+            slug,
+            corpus="project_internal",
+            wiki_root=wiki,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
+def test_promote_rejects_bad_slug() -> None:
+    with pytest.raises(ValueError, match="slug_invalid"):
+        wiki_promote.validate_slug("../x")
+
+
+def test_main_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "r"
+    wiki = repo / "wiki"
+    slug = _ingest_one(repo, wiki)
+    assert (
+        wiki_promote.main(
+            [
+                "--slug",
+                slug,
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(wiki),
+                "--no-write-support-plane",
+            ]
+        )
+        == 0
+    )
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -60,6 +60,45 @@ def test_promote_writes_promoted_and_metadata(tmp_path: Path) -> None:
     assert "promoted_at:" in text
 
 
+def test_promote_support_plane_external_wiki_root(
+    tmp_path: Path,
+    allowlist: set[tuple[str, str]],
+    audit_signing_material: str,
+) -> None:
+    """Promoted path in SP JSON must not use repo relative_to when wiki lives outside repo."""
+
+    repo = tmp_path / "r"
+    (repo / "s").mkdir(parents=True)
+    f = repo / "s" / "a.md"
+    f.write_text("body", encoding="utf-8")
+    wiki_root = tmp_path / "ext_wiki"
+    sp = tmp_path / "sp"
+    audit_log = tmp_path / "audit.jsonl"
+    wiki_ingest.ingest_paths(
+        [f],
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=False,
+    )
+    wiki_promote.promote_slug(
+        "s.a",
+        corpus="project_internal",
+        wiki_root=wiki_root,
+        repo_root=repo,
+        write_support_plane=True,
+        allowlist=allowlist,
+        sp_root_override=sp,
+        audit_secret=audit_signing_material,
+        audit_log_path=audit_log,
+    )
+    rec = lsp.get_record("wiki.promoted.s.a", root_override=sp)
+    assert rec is not None
+    promoted_path = str(rec["promoted_path"])
+    assert promoted_path.startswith("wiki:")
+    assert "/promoted/" in promoted_path
+
+
 def test_promote_support_plane_record(
     tmp_path: Path,
     allowlist: set[tuple[str, str]],

--- a/tests/test_wiki_promote.py
+++ b/tests/test_wiki_promote.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
 import pytest
 
 from app.security import agent_control_plane as cp
+from scripts.orchestration import _wiki_compiler_support as wcs
 from scripts.orchestration import local_support_plane as lsp
 from scripts.orchestration import wiki_ingest
 from scripts.orchestration import wiki_promote
@@ -85,11 +87,25 @@ def test_promote_support_plane_record(
 
 
 def test_promote_forbidden_under_canonical_docs(tmp_path: Path) -> None:
+    """Promote fail-closed under ``docs/**`` even when corpus was created without ingest."""
+
     repo = tmp_path / "r"
-    (repo / "docs").mkdir(parents=True)
     wiki = repo / "docs" / "evil_wiki"
-    slug = _ingest_one(repo, wiki)
-    with pytest.raises(ValueError, match="promote_forbidden_under_canonical_docs"):
+    digest = hashlib.sha256(b"body").hexdigest()
+    layout = wcs.corpus_layout(wcs.corpus_base(wiki, "project_internal"))
+    layout["raw"].mkdir(parents=True, exist_ok=True)
+    layout["pages"].mkdir(parents=True, exist_ok=True)
+    (layout["raw"] / f"{digest}.md").write_bytes(b"body")
+    slug = "hello"
+    meta = {
+        "advisory": "true",
+        "corpus": "project_internal",
+        "content_hash": digest,
+        "ingested_at": "2026-01-01T00:00:00Z",
+    }
+    page_body = wcs.format_frontmatter({str(k): str(v) for k, v in meta.items()}) + "body\n"
+    (layout["pages"] / f"{slug}.md").write_text(page_body, encoding="utf-8")
+    with pytest.raises(ValueError, match="forbidden_under_canonical_docs"):
         wiki_promote.promote_slug(
             slug,
             corpus="project_internal",

--- a/tests/test_wiki_query.py
+++ b/tests/test_wiki_query.py
@@ -85,6 +85,30 @@ def test_query_search_hits(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
     assert data["hits"]
 
 
+def test_query_detail_rejects_path_like_slug(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = tmp_path / "repo"
+    _seed_wiki(repo)
+    assert (
+        wiki_query.main(
+            [
+                "--mode",
+                "detail",
+                "--slug",
+                "../x",
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(repo / "wiki"),
+            ]
+        )
+        == 2
+    )
+    err = json.loads(capsys.readouterr().err.strip())
+    assert "slug_invalid" in err["error"]
+
+
 def test_query_detail_missing(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_wiki_query.py
+++ b/tests/test_wiki_query.py
@@ -1,0 +1,106 @@
+"""Tests for advisory wiki query CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import wiki_ingest
+from scripts.orchestration import wiki_query
+
+
+def _seed_wiki(repo: Path) -> None:
+    (repo / "src").mkdir(parents=True)
+    p = repo / "src" / "doc.md"
+    p.write_text("alpha beta gamma\n", encoding="utf-8")
+    wiki_ingest.ingest_paths(
+        [p],
+        corpus="project_internal",
+        wiki_root=repo / "wiki",
+        repo_root=repo,
+        write_support_plane=False,
+    )
+
+
+def test_query_list_and_detail(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "repo"
+    _seed_wiki(repo)
+    assert (
+        wiki_query.main(
+            [
+                "--mode",
+                "list",
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(repo / "wiki"),
+            ]
+        )
+        == 0
+    )
+    raw = json.loads(capsys.readouterr().out.strip())
+    assert raw["ok"] is True
+    assert len(raw["pages"]) == 1
+    slug = raw["pages"][0]["slug"]
+    assert (
+        wiki_query.main(
+            [
+                "--mode",
+                "detail",
+                "--slug",
+                slug,
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(repo / "wiki"),
+            ]
+        )
+        == 0
+    )
+    detail = json.loads(capsys.readouterr().out.strip())
+    assert "beta" in detail["page"]["body"]
+
+
+def test_query_search_hits(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "repo"
+    _seed_wiki(repo)
+    assert (
+        wiki_query.main(
+            [
+                "--mode",
+                "search",
+                "--needle",
+                "beta",
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(repo / "wiki"),
+            ]
+        )
+        == 0
+    )
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["hits"]
+
+
+def test_query_detail_missing(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "wiki" / "project_internal" / "pages").mkdir(parents=True)
+    assert (
+        wiki_query.main(
+            [
+                "--mode",
+                "detail",
+                "--slug",
+                "nope",
+                "--repo-root",
+                str(repo),
+                "--wiki-root",
+                str(repo / "wiki"),
+            ]
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary

Adds advisory wiki CLIs (`wiki_ingest`, `wiki_query`, `wiki_lint`, `wiki_promote`) over gitignored `artifacts/orchestration/wiki/` with optional `wiki.*` metadata in the experimental local support plane.

## Scope

- IN: `scripts/orchestration/wiki_*.py`, `_wiki_compiler_support.py`, tests, `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`, agent/backlog pointers.
- OUT: `local_support_plane.py`, `task_bootstrap.py`, `app/**`, OpenAPI, clients, embeddings.

## Split Justification

(Required under Tier 1 PR-size governance for >800 changed LoC.)

- **Why this PR cannot be split safely:** The advisory wiki compiler is one deliverable: filesystem layout + four CLIs + shared helpers + deterministic tests + operator doc + agent/backlog pointers + `PR_1371_FIXED_MAPPING.md`. Splitting would leave either untested CLIs, undocumented behavior, or a mapping artifact without the implementation it describes.
- **What invariant or rollout constraint needs one PR:** Single non-canonical feature slice over the existing local support plane contract (`put_record` + allowlist + execution mode); no `app/**` or OpenAPI changes. Keeping ingest/query/lint/promote together preserves the end-to-end operator story and one review surface.
- **What follow-up PRs remain:** Optional hardening (extra lint rules, corpus tooling), ledger closeout after merge, any future embedding/RAG work stays explicitly out of scope per plan.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1371_FIXED_MAPPING.md`

Disposition: FIXED

Commit: 11120d62b9ce12a47dcfe3de5c7ecc9348456b69

Evidence: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (MD036: real `####` headings for In/Out scope); `scripts/orchestration/wiki_promote.py` (`reject_if_under_canonical_docs` before `promoted/` mkdir); `scripts/orchestration/wiki_ingest.py` (`validate_wiki_slug` after `path_to_slug`); `scripts/orchestration/wiki_lint.py` (64-char lowercase hex `content_hash` before raw filename); prior branch commits already cover external-wiki SP paths, promote `unlink` on SP failure, cross-run `slug_collision_existing`, and ingest best-effort SP semantics documented in LOCAL_WIKI.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070641652 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070678463 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070686110 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070759857 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331822 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331852 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047331861 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339228 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339232 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339239 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047339244 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047400690 -> 11120d62b9ce12a47dcfe3de5c7ecc9348456b69
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#discussion_r3047589374 -> 4b21c57bf390abf6cf6d0357cf9e3929059e2d61  *(Cubic: promote rollback unlink errors surfaced, not suppressed)*
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070914662 -> b8a5bd5dcb581dad569bd09cb8bd194474477b6e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1371#pullrequestreview-4070984357 -> 4b21c57bf390abf6cf6d0357cf9e3929059e2d61

## Agent pass register (plan steps 6–12)

Mirror of `docs/review/PR_1371_FIXED_MAPPING.md` — full table lives in the artifact.

| Step | Agent / gate | Result |
|------|----------------|--------|
| 2 | preflight + agent consistency | PASS (local) |
| 6 | architecture | Addressed: ingest fail-closed under `docs/**` (shared `wcs.reject_if_under_canonical_docs`) |
| 7 | security | Addressed: `wiki_query` slug validation; slug cap 114 for `wiki.page.*` / `wiki.promoted.*` keys |
| 8 | RAG / DS / ML | Advisory N/A (no embeddings in scope) |
| 11–12 | qa + verify | `make verify` green after hardening commit `5dbed0ce2` |

## Merge Readiness

- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [x] All review threads resolved on GitHub after disposition updates

## Local verification

- Run `make verify` on this branch before merge (operator). Last operator-local `make verify`: exit 0; branch head after merge-gate mapping: `28a90b408` (docs-only — re-run verify if you pull newer commits).

## Deferred / Follow-ups

- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-d-advisory-wiki-compiler`

## Advisory wiki v1 contract (SoT)

Canonical detail: `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md` (updated on branch).

- **Positioning:** advisory **filesystem** wiki compiler v1 — not a compiled-memory reasoning layer, KG, or production search product.
- **Ingest:** on-disk corpus is authoritative; **support-plane `put_record` is best-effort** (stderr warnings, run continues). Not fail-closed on SP-only failures.
- **Promote:** **fail-closed** for invalid path/lint/SP write (promoted file removed if `put_record` fails after write).
- **Query:** list / detail / **body substring** search only — no index-first ranking or embeddings.
- **Lint:** frontmatter + raw snapshot integrity — not semantic/orphan/link/contradiction lint.
- **SP key `wiki.promoted.<slug>`:** overwrites prior record — no SP promotion history in v1.

Deferred hardening (truncation strategy, promotion history, richer lint, ranked search) is listed under the same ledger anchor above.

## Summary by Sourcery

Внедрён рекомендательный, локальный для оператора компилятор вики поверх экспериментального локального support plane, включающий рабочие процессы ingest, query, lint и promote с защитой для канонической документации и использования support plane.

Новые возможности:
- Добавлен CLI для ingest рекомендательной вики, позволяющий делать снапшоты markdown-файлов репозитория в структурированный локальный корпус вики с опциональной записью метаданных в локальный support plane.
- Добавлен CLI только для чтения для запросов к вики, поддерживающий вывод списка, полнотекстовый подстрочный поиск и получение детальной информации о странице из локального корпуса.
- Добавлен CLI для lint вики, проверяющий frontmatter страниц вики и удостоверяющийся, что соответствующие исходные снапшоты существуют.
- Добавлен CLI для promote вики, обеспечивающий безопасное продвижение страниц вики, прошедших lint-проверку, с метаданными промоушена и опциональными записями в support plane.
- Введён общий вспомогательный модуль для CLI компилятора вики для управления структурой корпуса, генерацией slug, безопасными для ключей именами и обработкой frontmatter.

Документация:
- Задокументирован локальный рекомендательный support plane для вики, его границы, структура директорий, использование CLI и вопросы безопасности.
- Зарегистрирована локальная рекомендательная вики как необязательная точка входа для навыков/инструментов в документации по агентам и навыкам, а также добавлен документ сопоставления fixed-in-commit для этого PR.

Тесты:
- Добавлены детерминированные тесты, покрывающие файловую структуру ingest для вики, запись метаданных в support plane и JSON-вывод CLI.
- Добавлены тесты для promote вики для проверки метаданных промоушена, поведения fail-closed при работе с канонической документацией, валидации slug и интеграции с support plane.
- Добавлены тесты для режимов query вики (list, search, detail), включая обработку некорректных slug и отсутствующих страниц.
- Добавлены тесты для lint вики, покрывающие отсутствие директории страниц, поведение на «чистом» корпусе и коды выхода CLI.
- Добавлены тесты, проверяющие нормализацию ключей support plane для ключей, связанных с вики (source, page, promoted).

Рутинные задачи:
- Добавлена запись в реестр backlog, отслеживающая задачу по компилятору рекомендательной вики и ссылающаяся на артефакты реализации и документацию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an advisory, operator-local wiki compiler on top of the experimental local support plane, including ingest, query, lint, and promote workflows with safety guards around canonical docs and support-plane usage.

New Features:
- Add advisory wiki ingest CLI to snapshot repo markdown into a structured local wiki corpus with optional metadata writes to the local support plane.
- Add read-only wiki query CLI supporting listing, full-text substring search, and page detail retrieval from the local corpus.
- Add wiki lint CLI to validate wiki page frontmatter and ensure corresponding raw snapshots exist.
- Add wiki promote CLI to safely promote lint-clean wiki pages with promotion metadata and optional support-plane records.
- Introduce shared helper module for wiki compiler CLIs to manage corpus layout, slug generation, key-safe naming, and frontmatter handling.

Documentation:
- Document the local advisory wiki support plane, its boundaries, directory layout, CLI usage, and security considerations.
- Register the advisory local wiki as an optional skill/tooling entry point in agent and skills documentation, and add a fixed-in-commit mapping document for this PR.

Tests:
- Add deterministic tests covering wiki ingest filesystem layout, support-plane metadata writes, and CLI JSON output.
- Add tests for wiki promote to verify promotion metadata, fail-closed behavior under canonical docs, slug validation, and support-plane integration.
- Add tests for wiki query modes (list, search, detail), including invalid slugs and missing pages handling.
- Add tests for wiki lint to cover missing pages directory, clean corpus behavior, and CLI exit codes.
- Add tests validating support-plane key normalization for wiki-related keys (source, page, promoted).

Chores:
- Add a backlog ledger entry tracking the advisory wiki compiler work item and linking to implementation artifacts and documentation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory local wiki compiler with CLIs: ingest, query, lint, promote. Filesystem-backed corpus, slug validation/uniqueness, UTF-8 resilience, read-only queries, and safeguards to prevent writes into canonical docs. Optional mirroring of metadata to a local support plane (ingest warns on SP failures; promote is fail-closed).

* **Documentation**
  * Operational docs, agent/operator notes, backlog entry, and examples detailing layout, semantics, validation rules, and error behaviors.

* **Tests**
  * Added unit and end-to-end tests for ingest, lint, promote, query, key normalization, error paths, and support-plane interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
