### PR TITLE
fix(food-store): restore legacy schema compatibility on main

### DIFF
--- a/app/services/food_store.py
+++ b/app/services/food_store.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import logging
 import os
 import re
-from typing import Any, Dict, Iterator, List, Optional, Mapping, Protocol, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Mapping, Protocol, Sequence, Tuple
 import threading
 from collections import defaultdict
 
@@ -109,12 +109,49 @@ _FOOD_ATTRIBUTION_DEFAULT_KEYS: Tuple[str, ...] = ("usda", "open food facts")
 
 
 def _foods_db_cache_key() -> str:
-    """Stable cache key for the active food SQLite path."""
+    """Backward-compatible cache key for the configured DB path."""
 
     try:
         return str(DB_PATH.resolve())
     except OSError:
         return str(DB_PATH)
+
+
+def _foods_db_cache_key_for_connection(con: sqlite3.Connection) -> str | None:
+    """Return a stable cache key for real SQLite connections only.
+
+    RU: Для mock/stub подключений отключаем глобальный cache, чтобы порядок тестов
+    не влиял на pragma-result.
+    EN: Disable global cache for mock/stub connections to avoid suite-order coupling.
+    """
+
+    if not isinstance(con, sqlite3.Connection):
+        return None
+    try:
+        database_rows = con.execute("PRAGMA database_list").fetchall()
+    except sqlite3.Error:
+        database_path = DB_PATH
+    else:
+        main_db_path = next(
+            (
+                Path(str(row[2]))
+                for row in database_rows
+                if len(row) >= 3 and str(row[1]) == "main" and str(row[2]).strip()
+            ),
+            DB_PATH,
+        )
+        database_path = main_db_path
+
+    try:
+        resolved_path = database_path.resolve()
+    except OSError:
+        resolved_path = database_path
+
+    try:
+        stat_result = resolved_path.stat()
+    except OSError:
+        return str(resolved_path)
+    return f"{resolved_path}:{stat_result.st_mtime_ns}:{stat_result.st_size}"
 
 
 def _foods_has_nutrition_confidence_column(con: sqlite3.Connection) -> bool:
@@ -124,20 +161,60 @@ def _foods_has_nutrition_confidence_column(con: sqlite3.Connection) -> bool:
     Older shipped food.sqlite files may omit this column; search/list SQL must stay compatible.
     """
 
-    key = _foods_db_cache_key()
-    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
-        cached = _NUTRITION_CONFIDENCE_COLUMN_CACHE.get(key)
-    if cached is not None:
-        return cached
+    cache_key = _foods_db_cache_key_for_connection(con)
+    if cache_key is not None:
+        with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+            cached = _NUTRITION_CONFIDENCE_COLUMN_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
     try:
         info_rows = con.execute("PRAGMA table_info(foods)").fetchall()
     except sqlite3.Error:
         has_col = False
     else:
         has_col = any(str(row[1]) == "nutrition_confidence" for row in info_rows)
-    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
-        _NUTRITION_CONFIDENCE_COLUMN_CACHE[key] = has_col
+    if cache_key is not None:
+        with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+            _NUTRITION_CONFIDENCE_COLUMN_CACHE[cache_key] = has_col
     return has_col
+
+
+def _invalidate_foods_nutrition_confidence_cache(con: sqlite3.Connection) -> None:
+    """Drop the cached pragma result for the active SQLite database."""
+
+    cache_key = _foods_db_cache_key_for_connection(con)
+    if cache_key is None:
+        return
+    with _NUTRITION_CONFIDENCE_CACHE_LOCK:
+        _NUTRITION_CONFIDENCE_COLUMN_CACHE.pop(cache_key, None)
+
+
+def _is_missing_nutrition_confidence_column_error(exc: sqlite3.OperationalError) -> bool:
+    """Return True only for the additive legacy-schema failure we intentionally recover from."""
+
+    return "no such column: nutrition_confidence" in str(exc).lower()
+
+
+def _execute_foods_query_with_legacy_retry(
+    con: sqlite3.Connection,
+    build_query: Callable[[bool], tuple[str, Sequence[Any]]],
+) -> list[sqlite3.Row]:
+    """Execute a foods read query with one legacy-schema retry.
+
+    RU: Повторяем только при additive-ошибке отсутствующей колонки.
+    EN: Retry only for the additive missing-column case; other SQL errors must surface.
+    """
+
+    has_conf = _foods_has_nutrition_confidence_column(con)
+    sql, params = build_query(has_conf)
+    try:
+        return con.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        if not has_conf or not _is_missing_nutrition_confidence_column_error(exc):
+            raise
+    _invalidate_foods_nutrition_confidence_cache(con)
+    fallback_sql, fallback_params = build_query(False)
+    return con.execute(fallback_sql, fallback_params).fetchall()
 
 
 def reset_foods_nutrition_confidence_column_cache() -> None:
@@ -608,18 +685,23 @@ def _load_semantic_candidates(limit: int) -> List[Dict[str, Any]]:
     EN: Loads candidates directly from foods, bypassing search pagination clamp.
     """
     with _connect() as con:
-        has_conf = _foods_has_nutrition_confidence_column(con)
-        if has_conf:
-            q = (
-                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
-                "nutrition_confidence FROM foods ORDER BY id ASC LIMIT ?"
-            )
-        else:
-            q = (
-                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
-                "FROM foods ORDER BY id ASC LIMIT ?"
-            )
-        rows = con.execute(q, (limit,)).fetchall()
+        rows = _execute_foods_query_with_legacy_retry(
+            con,
+            lambda has_conf: (
+                (
+                    (
+                        "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
+                        "nutrition_confidence FROM foods ORDER BY id ASC LIMIT ?"
+                    )
+                    if has_conf
+                    else (
+                        "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
+                        "FROM foods ORDER BY id ASC LIMIT ?"
+                    )
+                ),
+                (limit,),
+            ),
+        )
     return [dict(row) for row in rows]
 
 
@@ -868,48 +950,44 @@ def search_foods(query: str, limit: int | str = 20, offset: int | str = 0) -> Li
     # Validate and normalize pagination parameters
     limit, offset = _validate_pagination_params(limit, offset)
     terms = expand_query(query) if query else []
-    with _connect() as con:
-        has_conf = _foods_has_nutrition_confidence_column(con)
+
+    def _build_query(has_conf: bool) -> tuple[str, Sequence[Any]]:
         if terms:
-            # Query uses parameter placeholders for all user inputs;
-            # only the number of placeholders is constructed dynamically.
-            # Safe but consider phrase/prefix search (e.g., "term*" for prefix matching)
-            # for better FTS behavior in future enhancements.
-            # Dynamic SQL construction: only clause count is dynamic, all values use placeholders
-            # This is safe because we only construct the number of OR clauses, not the actual values
-            if has_conf:
-                sql_prefix = """
+            sql_prefix = (
+                """
           SELECT f.id, f.canonical_name, f.kcal, f.protein_g, f.fat_g, f.carbs_g,
                  f.nutrition_confidence
           FROM foods f
           JOIN foods_fts ff ON ff.rowid = f.rowid
           WHERE"""
-            else:
-                sql_prefix = """
+                if has_conf
+                else """
           SELECT f.id, f.canonical_name, f.kcal, f.protein_g, f.fat_g, f.carbs_g
           FROM foods f
           JOIN foods_fts ff ON ff.rowid = f.rowid
           WHERE"""
+            )
             sql = (
                 sql_prefix
                 + " "
                 + " OR ".join(["ff.canonical_name MATCH ?"] * len(terms))
                 + " LIMIT ? OFFSET ?"
             )
-            params = [*terms, limit, offset]
+            return sql, [*terms, limit, offset]
+        if has_conf:
+            sql = (
+                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
+                "nutrition_confidence FROM foods LIMIT ? OFFSET ?"
+            )
         else:
-            if has_conf:
-                sql = (
-                    "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g, "
-                    "nutrition_confidence FROM foods LIMIT ? OFFSET ?"
-                )
-            else:
-                sql = (
-                    "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
-                    "FROM foods LIMIT ? OFFSET ?"
-                )
-            params = [limit, offset]
-        rows = con.execute(sql, params).fetchall()
+            sql = (
+                "SELECT id, canonical_name, kcal, protein_g, fat_g, carbs_g "
+                "FROM foods LIMIT ? OFFSET ?"
+            )
+        return sql, [limit, offset]
+
+    with _connect() as con:
+        rows = _execute_foods_query_with_legacy_retry(con, _build_query)
     return [dict(r) for r in rows]
 
 

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -10,7 +10,7 @@ paths.
 from __future__ import annotations
 
 import re
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypedDict
 
 from core.insight.philosophy_validator import validate_llm_output
 
@@ -395,7 +395,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
             allowed = ", ".join(CONFIDENCE_LEVELS)
             raise ValueError(f"{label} confidence must be one of: {allowed}.")
 
-        normalized_confidence = cast(CreativeResearchConfidence, confidence)
+        normalized_confidence = confidence
         candidate: CreativeResearchCandidateRecord = {
             "candidate_id": _require_non_empty_string(
                 candidate_payload,
@@ -446,7 +446,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
         }
         candidates.append(candidate)
 
-    normalized_phase = cast(CreativeResearchPhase, phase)
+    normalized_phase = phase
     bundle_record: CreativeResearchBundleRecord = {
         "schema_version": schema_version,
         "bundle_id": bundle_id,

--- a/core/creative_research.py
+++ b/core/creative_research.py
@@ -395,7 +395,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
             allowed = ", ".join(CONFIDENCE_LEVELS)
             raise ValueError(f"{label} confidence must be one of: {allowed}.")
 
-        normalized_confidence = confidence
+        normalized_confidence = next(level for level in CONFIDENCE_LEVELS if level == confidence)
         candidate: CreativeResearchCandidateRecord = {
             "candidate_id": _require_non_empty_string(
                 candidate_payload,
@@ -446,7 +446,7 @@ def validate_bundle(payload: object) -> CreativeResearchBundleRecord:
         }
         candidates.append(candidate)
 
-    normalized_phase = phase
+    normalized_phase = next(valid_phase for valid_phase in VALID_PHASES if valid_phase == phase)
     bundle_record: CreativeResearchBundleRecord = {
         "schema_version": schema_version,
         "bundle_id": bundle_id,

--- a/core/judgment.py
+++ b/core/judgment.py
@@ -136,7 +136,7 @@ def parse_claim_type(raw_value: str) -> ClaimType:
     if normalized not in CLAIM_TYPES:
         allowed = ", ".join(CLAIM_TYPES)
         raise ValueError(f"claim_type must be one of: {allowed}.")
-    return normalized
+    return next(claim_type for claim_type in CLAIM_TYPES if claim_type == normalized)
 
 
 def parse_support_status(raw_value: str) -> SupportStatus:
@@ -148,7 +148,9 @@ def parse_support_status(raw_value: str) -> SupportStatus:
     if normalized not in SUPPORT_STATUSES:
         allowed = ", ".join(SUPPORT_STATUSES)
         raise ValueError(f"support_status must be one of: {allowed}.")
-    return normalized
+    return next(
+        support_status for support_status in SUPPORT_STATUSES if support_status == normalized
+    )
 
 
 def parse_evidence_mode(raw_value: str) -> EvidenceMode:
@@ -160,7 +162,7 @@ def parse_evidence_mode(raw_value: str) -> EvidenceMode:
     if normalized not in EVIDENCE_MODES:
         allowed = ", ".join(EVIDENCE_MODES)
         raise ValueError(f"evidence_mode must be one of: {allowed}.")
-    return normalized
+    return next(evidence_mode for evidence_mode in EVIDENCE_MODES if evidence_mode == normalized)
 
 
 def classify_claim_type(text: str) -> ClaimType:

--- a/core/judgment.py
+++ b/core/judgment.py
@@ -136,7 +136,7 @@ def parse_claim_type(raw_value: str) -> ClaimType:
     if normalized not in CLAIM_TYPES:
         allowed = ", ".join(CLAIM_TYPES)
         raise ValueError(f"claim_type must be one of: {allowed}.")
-    return cast(ClaimType, normalized)
+    return normalized
 
 
 def parse_support_status(raw_value: str) -> SupportStatus:
@@ -148,7 +148,7 @@ def parse_support_status(raw_value: str) -> SupportStatus:
     if normalized not in SUPPORT_STATUSES:
         allowed = ", ".join(SUPPORT_STATUSES)
         raise ValueError(f"support_status must be one of: {allowed}.")
-    return cast(SupportStatus, normalized)
+    return normalized
 
 
 def parse_evidence_mode(raw_value: str) -> EvidenceMode:
@@ -160,7 +160,7 @@ def parse_evidence_mode(raw_value: str) -> EvidenceMode:
     if normalized not in EVIDENCE_MODES:
         allowed = ", ".join(EVIDENCE_MODES)
         raise ValueError(f"evidence_mode must be one of: {allowed}.")
-    return cast(EvidenceMode, normalized)
+    return normalized
 
 
 def classify_claim_type(text: str) -> ClaimType:

--- a/core/judgment_eval.py
+++ b/core/judgment_eval.py
@@ -177,7 +177,7 @@ def _validate_turns(raw_value: object, *, label: str) -> list[FitChefReplayTurnR
             raise ValueError(f"{label} turn #{index} role must be user|assistant.")
         turns.append(
             {
-                "role": cast(FitChefReplayRole, role),
+                "role": role,
                 "text": _require_case_string(
                     turn_payload, key="text", label=f"{label} turn #{index}"
                 ),

--- a/core/judgment_eval.py
+++ b/core/judgment_eval.py
@@ -175,9 +175,12 @@ def _validate_turns(raw_value: object, *, label: str) -> list[FitChefReplayTurnR
         role = raw_role.lower()
         if role not in FITCHEF_REPLAY_ROLES:
             raise ValueError(f"{label} turn #{index} role must be user|assistant.")
+        normalized_role = next(
+            replay_role for replay_role in FITCHEF_REPLAY_ROLES if replay_role == role
+        )
         turns.append(
             {
-                "role": role,
+                "role": normalized_role,
                 "text": _require_case_string(
                     turn_payload, key="text", label=f"{label} turn #{index}"
                 ),

--- a/docs/review/PR_1375_FIXED_MAPPING.md
+++ b/docs/review/PR_1375_FIXED_MAPPING.md
@@ -2,19 +2,14 @@
 
 ## Discussion Thread Pass
 
-- [x] Discussion-thread pass initialized for PR-open state (no actionable review threads yet; rerun after new review activity)
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned below when actionable comments appear; resolve conversations on GitHub only after mapping per `AGENTS.md`.
 
 ## Fixed in Commit Mapping
 
-No actionable human or bot review threads at PR open.
-
-Add new review comments below using canonical dispositions:
-- `FIXED` with commit SHA + evidence
-- `NOT-A-BUG` with reason + evidence
-- `DEFERRED` with backlog link
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1375_FIXED_MAPPING.md
+++ b/docs/review/PR_1375_FIXED_MAPPING.md
@@ -1,0 +1,46 @@
+# PR #1375 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass initialized for PR-open state (no actionable review threads yet; rerun after new review activity)
+- [x] Fixed in commit mapping initialized
+
+Bot and human review threads must be dispositioned below when actionable comments appear; resolve conversations on GitHub only after mapping per `AGENTS.md`.
+
+## Fixed in Commit Mapping
+
+No actionable human or bot review threads at PR open.
+
+Add new review comments below using canonical dispositions:
+- `FIXED` with commit SHA + evidence
+- `NOT-A-BUG` with reason + evidence
+- `DEFERRED` with backlog link
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+
+### Scope Notes
+
+- Primary hotfix commit: `d4eb976e7` — restore legacy-schema-safe `food_store` compatibility for missing `foods.nutrition_confidence`
+- Merge-gate unblock commits:
+  - `cb533ed72` — remove redundant casts blocking repo `make verify`
+  - `b0a4bc2a9` — preserve literal narrowing for push-hook mypy on changed files
+- Sanctioned scope expansion was limited to:
+  - `core/judgment.py`
+  - `core/judgment_eval.py`
+  - `core/creative_research.py`
+
+### Local Verification
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `pre-commit run --all-files`
+- `make verify`
+- mandatory final `bug-hunter` pass completed with no blocking findings
+
+## Deferred / Follow-ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-food-store-legacy-schema-cache-follow-through`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -7193,6 +7193,31 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Swap orchestration is tested against `*_v2` indexes without changing public food API contracts
     - Grace-period cleanup and rollback-safe recovery are documented and covered by tests
 
+<a id="ledger-p2-food-store-legacy-schema-cache-follow-through"></a>
+- [ ] P2: Food-store legacy schema/cache seam follow-through
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2
+  - Target PR: PR-TBD-FOOD-STORE-LEGACY-SCHEMA-FOLLOW-THROUGH
+  - Area: backend / search / tests
+  - Finding Type: hotfix follow-up hardening
+  - Reason: The main-stabilization hotfix intentionally stays narrow and fixes the
+    blocking stale-`has_conf=True` failure path for legacy SQLite schemas missing
+    `foods.nutrition_confidence`. Two adjacent non-blocking follow-ups remain
+    deferred: a real-SQLite runtime regression for the semantic bootstrap read path,
+    and a tighter policy for transient `PRAGMA table_info(foods)` failures so a
+    temporary schema-probe error does not cache `False` longer than intended.
+  - Links:
+    - `app/services/food_store.py`
+    - `tests/test_food_store_service.py`
+    - `tests/test_food_store_coverage.py`
+    - `tests/test_food_store_coverage_boost.py`
+    - `tests/test_simple_coverage_boost.py`
+  - DoD:
+    - Semantic candidate/bootstrap read path has a real SQLite legacy-schema regression test
+    - Schema-probe transient failures are non-cacheable or bounded-retry, not an indefinite cached `False`
+    - Cache-seam tests remain deterministic and explicitly reset shared state
+    - Public `/api/v1/foods/search` contract remains unchanged while additive `nutrition_confidence` stays best-effort
+
 
 - [x] Test skips cleanup (low priority batch) — superseded by PR-728 classification
   - Owner: @katsiaryna_kavaleuskaya

--- a/tests/test_food_store_coverage.py
+++ b/tests/test_food_store_coverage.py
@@ -76,6 +76,12 @@ def _set_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
 
 
+@pytest.fixture(autouse=True)
+def _reset_food_store_cache_before_test() -> None:
+    """Keep pragma-driven mock tests deterministic regardless of suite order."""
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
+
 class TestFoodStoreCoverage:
     """Тесты для покрытия недостающих строк в food_store.py"""
 

--- a/tests/test_food_store_coverage_boost.py
+++ b/tests/test_food_store_coverage_boost.py
@@ -79,6 +79,12 @@ def _set_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FEATURE_PREMIUM_NUTRITION", "true")
 
 
+@pytest.fixture(autouse=True)
+def _reset_food_store_cache_before_test() -> None:
+    """Reset the schema cache before each mock-driven coverage test."""
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
+
 class TestFoodStoreCoverage:
     """Test class for food_store coverage boost."""
 

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -269,6 +269,41 @@ def test_foods_db_cache_key_string_fallback_on_resolve_oserror(
     assert food_store._foods_db_cache_key() == "/tmp/fake-db-path.sqlite"
 
 
+def test_foods_db_cache_key_for_connection_uses_db_path_when_database_list_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "foods.sqlite"
+    db_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(food_store, "DB_PATH", db_path)
+    conn = sqlite3.connect(":memory:")
+    conn.close()
+    cache_key = food_store._foods_db_cache_key_for_connection(conn)
+    assert cache_key is not None
+    assert str(db_path.resolve()) in cache_key
+
+
+def test_foods_db_cache_key_for_connection_falls_back_when_resolve_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "foods.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        monkeypatch.setattr(Path, "resolve", lambda self: (_ for _ in ()).throw(OSError("boom")))
+        cache_key = food_store._foods_db_cache_key_for_connection(conn)
+    assert cache_key is not None
+    assert str(db_path) in cache_key
+
+
+def test_foods_db_cache_key_for_connection_returns_plain_path_when_stat_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "foods.sqlite"
+    expected_path = str(db_path.resolve())
+    with sqlite3.connect(db_path) as conn:
+        monkeypatch.setattr(Path, "stat", lambda self: (_ for _ in ()).throw(OSError("boom")))
+        cache_key = food_store._foods_db_cache_key_for_connection(conn)
+    assert cache_key == expected_path
+
+
 def test_search_foods_fts_includes_aggregate_confidence_when_pragma_reports_column(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -315,6 +350,101 @@ def test_foods_has_nutrition_confidence_column_handles_sqlite_execute_error() ->
             raise sqlite3.Error("pragma failed")
 
     assert food_store._foods_has_nutrition_confidence_column(_ErrConn()) is False
+
+
+def test_invalidate_foods_nutrition_confidence_cache_drops_active_entry(tmp_path: Path) -> None:
+    db_path = tmp_path / "foods.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE foods (
+                id TEXT PRIMARY KEY,
+                canonical_name TEXT NOT NULL,
+                nutrition_confidence REAL
+            )
+            """)
+        conn.commit()
+        original_db_path = food_store.DB_PATH
+        food_store.DB_PATH = db_path
+        try:
+            food_store.reset_foods_nutrition_confidence_column_cache()
+            cache_key = food_store._foods_db_cache_key_for_connection(conn)
+            assert cache_key is not None
+            assert food_store._foods_has_nutrition_confidence_column(conn) is True
+            assert cache_key in food_store._NUTRITION_CONFIDENCE_COLUMN_CACHE
+            food_store._invalidate_foods_nutrition_confidence_cache(conn)
+            assert cache_key not in food_store._NUTRITION_CONFIDENCE_COLUMN_CACHE
+        finally:
+            food_store.DB_PATH = original_db_path
+
+
+def test_execute_foods_query_with_legacy_retry_retries_missing_confidence_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Cursor:
+        def __init__(self, rows: List[Dict[str, Any]]) -> None:
+            self._rows = rows
+
+        def fetchall(self) -> List[Dict[str, Any]]:
+            return self._rows
+
+    class _RetryConn:
+        def __init__(self) -> None:
+            self.calls: List[str] = []
+
+        def execute(self, sql: str, params: Any = None) -> _Cursor:
+            del params
+            self.calls.append(sql)
+            if "nutrition_confidence" in sql:
+                raise sqlite3.OperationalError("no such column: nutrition_confidence")
+            return _Cursor([{"id": "fallback"}])
+
+    conn = _RetryConn()
+    invalidations: List[str] = []
+    monkeypatch.setattr(food_store, "_foods_has_nutrition_confidence_column", lambda _con: True)
+    monkeypatch.setattr(
+        food_store,
+        "_invalidate_foods_nutrition_confidence_cache",
+        lambda _con: invalidations.append("invalidated"),
+    )
+
+    rows = food_store._execute_foods_query_with_legacy_retry(
+        conn,
+        lambda has_conf: (
+            ("SELECT id, nutrition_confidence FROM foods" if has_conf else "SELECT id FROM foods"),
+            (),
+        ),
+    )
+
+    assert [row["id"] for row in rows] == ["fallback"]
+    assert invalidations == ["invalidated"]
+    assert conn.calls == [
+        "SELECT id, nutrition_confidence FROM foods",
+        "SELECT id FROM foods",
+    ]
+
+
+def test_execute_foods_query_with_legacy_retry_reraises_other_operational_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BrokenConn:
+        def execute(self, sql: str, params: Any = None) -> Any:
+            del sql, params
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(food_store, "_foods_has_nutrition_confidence_column", lambda _con: True)
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        food_store._execute_foods_query_with_legacy_retry(
+            _BrokenConn(),
+            lambda has_conf: (
+                (
+                    "SELECT id, nutrition_confidence FROM foods"
+                    if has_conf
+                    else "SELECT id FROM foods"
+                ),
+                (),
+            ),
+        )
 
 
 def test_normalize_food_row_additive_columns_none_or_pre_parsed() -> None:

--- a/tests/test_simple_coverage_boost.py
+++ b/tests/test_simple_coverage_boost.py
@@ -3,10 +3,14 @@
 Simple coverage boost tests.
 """
 
+import sqlite3
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
 from app import app
+from app.services import food_store
 from tests._helpers.api_headers import API_KEY_HEADERS
 
 
@@ -48,6 +52,42 @@ class TestSimpleCoverageBoost:
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)
+
+    def test_foods_search_endpoint_legacy_schema_returns_safe_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy SQLite search path must stay 200 and expose additive default confidence."""
+        db_path = tmp_path / "legacy_foods.sqlite"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("""
+                CREATE TABLE foods (
+                    id TEXT PRIMARY KEY,
+                    canonical_name TEXT NOT NULL,
+                    kcal REAL,
+                    protein_g REAL,
+                    fat_g REAL,
+                    carbs_g REAL
+                )
+                """)
+            conn.execute(
+                "INSERT INTO foods (id, canonical_name, kcal, protein_g, fat_g, carbs_g) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("fid1", "Apple", 52.0, 0.3, 0.2, 14.0),
+            )
+            conn.commit()
+
+        monkeypatch.setattr(food_store, "DB_PATH", db_path)
+        food_store.reset_foods_nutrition_confidence_column_cache()
+
+        client = TestClient(app)
+        response = client.get("/api/v1/foods/search?q=apple")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert data
+        assert data[0]["name"] == "Apple"
+        assert data[0]["nutrition_confidence"] == 0.0
 
     def test_recipes_endpoint(self) -> None:
         """Test recipes endpoint."""


### PR DESCRIPTION
## Summary
- restore legacy-schema-safe `food_store` reads when `foods.nutrition_confidence` is absent
- invalidate stale schema cache and retry once on `sqlite3.OperationalError: no such column: nutrition_confidence`
- add runtime and cache-seam regressions for `/api/v1/foods/search`
- include minimal repo-wide mypy unblock commits required to satisfy project verify/push gates

## Scope
- hotfix/main stabilization blocker before PR2
- no iOS, no privacy shell, no provider or billing modernization
- no public API changes

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- `make verify`

## Orchestration
- coordinator-first lane executed
- backend + QA routing completed
- mandatory final `bug-hunter` pass completed with no blocking findings
- coordinator synthesis confirmed PR2 remains blocked until hotfix PR current-head CI and merged-main CI are green

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-food-store-legacy-schema-cache-follow-through`

## Notes
- this PR includes a minimal `core/*` typing cleanup only because repo-wide verify/push gates were red on unchanged baseline files and user explicitly approved the sanctioned scope expansion required to unblock this lane

## Summary by Sourcery

Восстановить чтение хранилища продуктов, совместимое с устаревшими схемами, для баз данных SQLite, в которых отсутствует столбец `nutrition_confidence`, и добавить минимальные правки типизации, чтобы сохранить прохождение проверочных ворот (verification gates).

Bug Fixes:
- Обеспечить, чтобы обнаружение схемы хранилища продуктов и кэширование были ограничены реальным подключением к базе данных SQLite, чтобы избежать устаревших результатов `pragma`.
- Добавить безопасный для устаревшей схемы путь выполнения запросов к хранилищу продуктов, повторяя запрос один раз без `nutrition_confidence`, когда этот столбец отсутствует, при этом сохраняя форму ответа для `/api/v1/foods/search`.

Enhancements:
- Уточнить логику инвалидации кэша и вспомогательные функции обнаружения вокруг `foods.nutrition_confidence`, чтобы лучше изолировать временные проблемы со схемой и mock/stub-подключения.
- Заменить широкие приведения типов в ключевых модулях judgment и creative research на сужение, основанное на значениях, чтобы удовлетворить более строгую проверку типов.

Documentation:
- Задокументировать последующие работы по устаревшей схеме/кэшу хранилища продуктов в журнале backlog и добавить обзорный лог с указанием коммита, в котором исправлена проблема (fixed-in-commit).

Tests:
- Добавить регрессионные тесты для ключей кэша схемы на уровне соединения, поведения повторного запроса для устаревшей схемы, инвалидации кэша и детерминированных тестов, управляемых `pragma`, включая покрытие для устаревшего поведения SQLite `/api/v1/foods/search`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore legacy-compatible food store reads for SQLite databases missing the nutrition_confidence column and add minimal typing cleanups to keep verification gates green.

Bug Fixes:
- Ensure food store schema detection and caching are scoped per real SQLite database connection to avoid stale pragma results.
- Add a legacy-schema-safe execution path for foods queries, retrying once without nutrition_confidence when that column is missing while preserving response shape for /api/v1/foods/search.

Enhancements:
- Refine cache invalidation and detection helpers around foods.nutrition_confidence to better isolate transient schema issues and mock/stub connections.
- Replace broad type casts in core judgment and creative research modules with value-based narrowing to satisfy stricter type checking.

Documentation:
- Document the food-store legacy schema/cache follow-up work in the backlog ledger and add a PR-specific fixed-in-commit review log.

Tests:
- Add regression tests for per-connection schema cache keys, legacy retry behavior, cache invalidation, and deterministic pragma-driven tests, including coverage for the legacy SQLite /api/v1/foods/search behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Восстановить чтение хранилища продуктов, совместимое с устаревшими схемами, для баз данных SQLite, в которых отсутствует столбец `nutrition_confidence`, и добавить минимальные правки типизации, чтобы сохранить прохождение проверочных ворот (verification gates).

Bug Fixes:
- Обеспечить, чтобы обнаружение схемы хранилища продуктов и кэширование были ограничены реальным подключением к базе данных SQLite, чтобы избежать устаревших результатов `pragma`.
- Добавить безопасный для устаревшей схемы путь выполнения запросов к хранилищу продуктов, повторяя запрос один раз без `nutrition_confidence`, когда этот столбец отсутствует, при этом сохраняя форму ответа для `/api/v1/foods/search`.

Enhancements:
- Уточнить логику инвалидации кэша и вспомогательные функции обнаружения вокруг `foods.nutrition_confidence`, чтобы лучше изолировать временные проблемы со схемой и mock/stub-подключения.
- Заменить широкие приведения типов в ключевых модулях judgment и creative research на сужение, основанное на значениях, чтобы удовлетворить более строгую проверку типов.

Documentation:
- Задокументировать последующие работы по устаревшей схеме/кэшу хранилища продуктов в журнале backlog и добавить обзорный лог с указанием коммита, в котором исправлена проблема (fixed-in-commit).

Tests:
- Добавить регрессионные тесты для ключей кэша схемы на уровне соединения, поведения повторного запроса для устаревшей схемы, инвалидации кэша и детерминированных тестов, управляемых `pragma`, включая покрытие для устаревшего поведения SQLite `/api/v1/foods/search`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore legacy-compatible food store reads for SQLite databases missing the nutrition_confidence column and add minimal typing cleanups to keep verification gates green.

Bug Fixes:
- Ensure food store schema detection and caching are scoped per real SQLite database connection to avoid stale pragma results.
- Add a legacy-schema-safe execution path for foods queries, retrying once without nutrition_confidence when that column is missing while preserving response shape for /api/v1/foods/search.

Enhancements:
- Refine cache invalidation and detection helpers around foods.nutrition_confidence to better isolate transient schema issues and mock/stub connections.
- Replace broad type casts in core judgment and creative research modules with value-based narrowing to satisfy stricter type checking.

Documentation:
- Document the food-store legacy schema/cache follow-up work in the backlog ledger and add a PR-specific fixed-in-commit review log.

Tests:
- Add regression tests for per-connection schema cache keys, legacy retry behavior, cache invalidation, and deterministic pragma-driven tests, including coverage for the legacy SQLite /api/v1/foods/search behavior.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores legacy SQLite schema compatibility for the food store by retrying foods queries without `nutrition_confidence` when older DBs omit the column. Prevents 500s on `/api/v1/foods/search` and keeps responses stable with a safe default.

- **Bug Fixes**
  - Added a per-connection schema cache key (real DB path/mtime/size); disabled for mock/stub connections.
  - On `sqlite3.OperationalError: no such column: nutrition_confidence`, invalidate the cache and retry once via `_execute_foods_query_with_legacy_retry`.
  - Applied the retry to `search_foods` and `_load_semantic_candidates`.
  - Preserved API shape; when the column is missing, results include a safe `nutrition_confidence` default.
  - Added deterministic fixtures and tests for cache keys, invalidation, legacy-retry behavior, and the search endpoint.
  - Removed redundant casts in `core/*` with value-preserving normalization to keep verify/push gates green.

- **Documentation**
  - Added `docs/review/PR_1375_FIXED_MAPPING.md` and corrected the artifact format.
  - Updated the backlog with the legacy schema/cache follow-up in `docs/roadmap/BACKLOG_LEDGER.md`.

<sup>Written for commit 4515c2fe50d2a30f90f151116ca49d43e6ab216a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1375_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved food search endpoint robustness for legacy database schemas; endpoint now gracefully handles and recovers from missing schema fields.

* **Tests**
  * Added comprehensive test coverage for legacy database compatibility, cache management, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->