### PR TITLE
feat(frontend): move web premium truth to canonical backend/store state

### DIFF
--- a/docs/review/PR_1381_FIXED_MAPPING.md
+++ b/docs/review/PR_1381_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1381 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review threads or bot findings have been dispositioned yet.
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [x] `make verify` green
+- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+- Scope: frontend closeout for `ledger-p0-web-entitlement-truth`, limited to canonical web entitlement truth, fail-closed paywall behavior, and stale mock/release-path cleanup.

--- a/docs/review/PR_1381_FIXED_MAPPING.md
+++ b/docs/review/PR_1381_FIXED_MAPPING.md
@@ -6,7 +6,17 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#pullrequestreview-4085529481 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060753041 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060753142 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#pullrequestreview-4085556378 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775789 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775806 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775809 -> 96cd93f20
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775815 -> 96cd93f20
+Disposition: FIXED
+Commit: 96cd93f20
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:205` and `docs/roadmap/BACKLOG_LEDGER.md:208` now use the concrete PR reference and consistent `release-truth` wording; `frontend/src/mocks/__tests__/purchase.test.ts:1-50` now checks runtime MSW matcher behavior across handler predicates instead of relying on `info.path` and adds explicit TypeScript annotations; `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:59` adds the explicit async return type; `docs/review/PR_1381_FIXED_MAPPING.md:13-18` keeps merge-readiness checkboxes unchecked until the final merge cycle.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1381_FIXED_MAPPING.md
+++ b/docs/review/PR_1381_FIXED_MAPPING.md
@@ -1,12 +1,12 @@
 # PR 1381 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review threads or bot findings have been dispositioned yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1381_FIXED_MAPPING.md
+++ b/docs/review/PR_1381_FIXED_MAPPING.md
@@ -13,7 +13,7 @@
 - [ ] All required checks pass
 - [ ] No unresolved review threads (re-check on current head before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green
-- [x] `make verify` green
-- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
 - Scope: frontend closeout for `ledger-p0-web-entitlement-truth`, limited to canonical web entitlement truth, fail-closed paywall behavior, and stale mock/release-path cleanup.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -202,15 +202,17 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: Web entitlement truth must come from canonical backend/store state
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-WEB-ENTITLEMENT-TRUTH
-  - Status: 🟡 Next active P0 release-truth lane after closure of `ledger-p0-billing-entitlement-routing`
+  - Target PR: PR-TBD-WEB-ENTITLEMENT-TRUTH (`feat/web-entitlement-truth`)
+  - Status: 🟡 Closeout staged in `feat/web-entitlement-truth`: canonical web entitlement truth remains `/api/v1/pro/session`, shared MSW release-surface tests no longer institutionalize `/api/purchase` or `/api/restore`, and web paywall page tests no longer imply a successful production web checkout path. Mark this item closed only after the PR merges.
   - Area: frontend / monetization / thin-client
   - Finding Type: thin-client and release-trust gap
-  - Reason: The live web surface still uses local premium state and mock-only purchase/restore flows, which breaks thin-client policy and can misstate monetization truth during release/readiness work.
+  - Reason: Runtime web entitlement truth already reads the canonical backend session contract, but the lane stayed open because stale frontend mock/release-path assumptions still treated mock purchase/restore endpoints and optimistic web checkout success as live contract surface.
   - Links:
     - `frontend/src/lib/usePremium.ts`
     - `frontend/src/lib/paywallPurchase.ts`
     - `frontend/src/mocks/handlers.ts`
+    - `frontend/src/mocks/__tests__/purchase.test.ts`
+    - `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx`
     - `frontend/src/api/openapi.json`
     - `frontend/AGENTS.md`
   - DoD:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -202,10 +202,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: Web entitlement truth must come from canonical backend/store state
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0
-  - Target PR: PR-TBD-WEB-ENTITLEMENT-TRUTH (`feat/web-entitlement-truth`)
+  - Target PR: PR `#1381`
   - Status: 🟡 Closeout staged in `feat/web-entitlement-truth`: canonical web entitlement truth remains `/api/v1/pro/session`, shared MSW release-surface tests no longer institutionalize `/api/purchase` or `/api/restore`, and web paywall page tests no longer imply a successful production web checkout path. Mark this item closed only after the PR merges.
   - Area: frontend / monetization / thin-client
-  - Finding Type: thin-client and release-trust gap
+  - Finding Type: thin-client and release-truth gap
   - Reason: Runtime web entitlement truth already reads the canonical backend session contract, but the lane stayed open because stale frontend mock/release-path assumptions still treated mock purchase/restore endpoints and optimistic web checkout success as live contract surface.
   - Links:
     - `frontend/src/lib/usePremium.ts`

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -34,6 +34,8 @@
 - ✅ Use `api()` / `fetchBlob()` from `src/api/client.ts`
 - ✅ OpenAPI-generated types from `src/api/schema.ts`
 - ✅ Guards: `src/api/__tests__/thin-client-guards.test.ts` must stay green
+- ✅ Web premium truth must come only from canonical backend/store state; legacy mock
+  purchase/restore flows must stay out of shared release-path handlers and runtime-facing tests
 
 ### Canonical local checks
 

--- a/frontend/src/mocks/__tests__/purchase.test.ts
+++ b/frontend/src/mocks/__tests__/purchase.test.ts
@@ -1,107 +1,11 @@
-/* @vitest-environment jsdom */
-import "../../test/setup";
-import { beforeEach, expect, test } from "vitest";
-import { delay, http, HttpResponse } from "msw";
-import { server } from "../server";
+import { expect, test } from "vitest";
+import { handlers } from "../handlers";
 
-const BASE_URL = "http://localhost";
+test("shared MSW surface does not expose legacy purchase or restore release paths", () => {
+  const legacyPaths = new Set(["/api/purchase", "/api/restore"]);
+  const runtimePaths = handlers.map((handler) => (handler as { info?: { path?: string } }).info?.path);
 
-const matchesApiPath =
-  (expectedPathname: string) =>
-  ({ request }: { request: Request }): boolean =>
-    new URL(request.url).pathname === expectedPathname;
-
-function registerPurchaseHandlers(): void {
-  server.use(
-    http.post(matchesApiPath("/api/purchase"), async ({ request }) => {
-      await delay(300);
-      const errorParam = new URL(request.url).searchParams.get("error");
-
-      if (errorParam === "network") {
-        return HttpResponse.error();
-      }
-      if (errorParam === "server") {
-        return HttpResponse.json({ error: "Internal server error" }, { status: 500 });
-      }
-      if (errorParam === "payment") {
-        return HttpResponse.json(
-          { error: "Payment failed", code: "INSUFFICIENT_FUNDS" },
-          { status: 402 }
-        );
-      }
-
-      return HttpResponse.json({ status: "ok", entitlement: "premium" }, { status: 200 });
-    }),
-    http.post(matchesApiPath("/api/restore"), async ({ request }) => {
-      await delay(200);
-      const errorParam = new URL(request.url).searchParams.get("error");
-
-      if (errorParam === "network") {
-        return HttpResponse.error();
-      }
-      if (errorParam === "server") {
-        return HttpResponse.json({ error: "Restore service unavailable" }, { status: 503 });
-      }
-      if (errorParam === "not_found") {
-        return HttpResponse.json({ error: "No purchases found" }, { status: 404 });
-      }
-
-      return HttpResponse.json({ status: "ok", restored: true }, { status: 200 });
-    })
-  );
-}
-
-beforeEach(() => {
-  registerPurchaseHandlers();
-});
-
-test("msw /api/purchase responds ok", async () => {
-  const res = await fetch(`${BASE_URL}/api/purchase`, { method: "POST" });
-  const json = await res.json();
-  expect(json.status).toBe("ok");
-  expect(json.entitlement).toBe("premium");
-});
-
-test("msw /api/purchase handles server error", async () => {
-  const res = await fetch(`${BASE_URL}/api/purchase?error=server`, { method: "POST" });
-  expect(res.status).toBe(500);
-  const json = await res.json();
-  expect(json.error).toBe("Internal server error");
-});
-
-test("msw /api/purchase handles payment error", async () => {
-  const res = await fetch(`${BASE_URL}/api/purchase?error=payment`, { method: "POST" });
-  expect(res.status).toBe(402);
-  const json = await res.json();
-  expect(json.error).toBe("Payment failed");
-  expect(json.code).toBe("INSUFFICIENT_FUNDS");
-});
-
-test("msw /api/purchase handles network error", async () => {
-  await expect(fetch(`${BASE_URL}/api/purchase?error=network`, { method: "POST" })).rejects.toThrow();
-});
-
-test("msw /api/restore responds ok", async () => {
-  const res = await fetch(`${BASE_URL}/api/restore`, { method: "POST" });
-  const json = await res.json();
-  expect(json.status).toBe("ok");
-  expect(json.restored).toBe(true);
-});
-
-test("msw /api/restore handles server error", async () => {
-  const res = await fetch(`${BASE_URL}/api/restore?error=server`, { method: "POST" });
-  expect(res.status).toBe(503);
-  const json = await res.json();
-  expect(json.error).toBe("Restore service unavailable");
-});
-
-test("msw /api/restore handles not found error", async () => {
-  const res = await fetch(`${BASE_URL}/api/restore?error=not_found`, { method: "POST" });
-  expect(res.status).toBe(404);
-  const json = await res.json();
-  expect(json.error).toBe("No purchases found");
-});
-
-test("msw /api/restore handles network error", async () => {
-  await expect(fetch(`${BASE_URL}/api/restore?error=network`, { method: "POST" })).rejects.toThrow();
+  expect(runtimePaths).not.toContain("/api/purchase");
+  expect(runtimePaths).not.toContain("/api/restore");
+  expect(runtimePaths.some((path) => path !== undefined && legacyPaths.has(path))).toBe(false);
 });

--- a/frontend/src/mocks/__tests__/purchase.test.ts
+++ b/frontend/src/mocks/__tests__/purchase.test.ts
@@ -1,11 +1,50 @@
+import { HttpHandler } from "msw";
+import type { RequestHandler } from "msw";
 import { expect, test } from "vitest";
 import { handlers } from "../handlers";
 
-test("shared MSW surface does not expose legacy purchase or restore release paths", () => {
-  const legacyPaths = new Set(["/api/purchase", "/api/restore"]);
-  const runtimePaths = handlers.map((handler) => (handler as { info?: { path?: string } }).info?.path);
+const LEGACY_RELEASE_PATHS = ["/api/purchase", "/api/restore"] as const;
+const HTTP_MATCH_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"] as const;
+const LOCAL_RUNTIME_ORIGIN = "http://localhost";
 
-  expect(runtimePaths).not.toContain("/api/purchase");
-  expect(runtimePaths).not.toContain("/api/restore");
-  expect(runtimePaths.some((path) => path !== undefined && legacyPaths.has(path))).toBe(false);
-});
+const matchesLegacyReleasePath = async (
+  handler: RequestHandler,
+  legacyPath: string
+): Promise<boolean> => {
+  if (!(handler instanceof HttpHandler)) {
+    return false;
+  }
+
+  // RU: Проверяем реальный runtime matching MSW, чтобы regex/catch-all handlers тоже ловились.
+  // EN: Evaluate actual MSW runtime matching so regex/catch-all handlers are also detected.
+  for (const method of HTTP_MATCH_METHODS) {
+    const request = new Request(`${LOCAL_RUNTIME_ORIGIN}${legacyPath}`, { method });
+    const parsedResult = await handler.parse({ request });
+    const isMatch: boolean = await handler.predicate({ request, parsedResult });
+
+    if (isMatch) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+test(
+  "shared MSW surface does not expose legacy purchase or restore release paths",
+  async (): Promise<void> => {
+    const exposedLegacyPaths: string[] = [];
+
+    for (const legacyPath of LEGACY_RELEASE_PATHS) {
+      const matchResults: boolean[] = await Promise.all(
+        handlers.map((handler): Promise<boolean> => matchesLegacyReleasePath(handler, legacyPath))
+      );
+
+      if (matchResults.some((isMatch): boolean => isMatch)) {
+        exposedLegacyPaths.push(legacyPath);
+      }
+    }
+
+    expect(exposedLegacyPaths).toEqual([]);
+  }
+);

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -56,7 +56,7 @@ describe("ProPaywallPage", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it("navigates back when the user closes the paywall", async () => {
+  it("navigates back when the user closes the paywall", async (): Promise<void> => {
     render(<ProPaywallPage />);
 
     fireEvent.click(screen.getByTestId("paywall-cancel"));

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -56,21 +56,12 @@ describe("ProPaywallPage", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it("navigates back on successful web purchase without surfacing an error", async () => {
-    purchasePremiumMock.mockResolvedValueOnce(undefined);
-
+  it("navigates back when the user closes the paywall", async () => {
     render(<ProPaywallPage />);
 
-    fireEvent.click(screen.getByTestId("paywall-cta"));
+    fireEvent.click(screen.getByTestId("paywall-cancel"));
 
-    await waitFor(() => {
-      expect(purchasePremiumMock).toHaveBeenCalledWith({
-        source: "bmi_soft_paywall",
-        via: "pro_page",
-      });
-      expect(navigateMock).toHaveBeenCalledWith(-1);
-    });
-
-    expect(screen.queryByTestId("paywall-purchase-error")).toBeNull();
+    expect(purchasePremiumMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(-1);
   });
 });


### PR DESCRIPTION
## Summary
- close out `ledger-p0-web-entitlement-truth` on the frontend side without changing the public runtime contract
- keep web premium truth on canonical backend/store state via `/api/v1/pro/session`
- remove stale release-path assumptions that still treated legacy mock purchase/restore flows as production web contract

## What Changed
- replaced the legacy shared MSW purchase/restore contract test with a guard that asserts `/api/purchase` and `/api/restore` are not exposed by the shared runtime handler surface
- narrowed `ProPaywallPage` coverage to the fail-closed web checkout behavior and the explicit close/cancel path
- documented the frontend invariant that web premium truth comes only from canonical backend/store state
- added the canonical review artifact `docs/review/PR_1381_FIXED_MAPPING.md`
- updated the backlog entry to staged-open closeout status and explicitly deferred closure until merge

## Why
`billing-entitlement-routing` is already closed on `main`. The next canonical main-line P0 lane is `ledger-p0-web-entitlement-truth`, and the remaining gap in repo reality was stale frontend mock/test/release-path narrative, not a fresh backend monetization rewrite.

## Scope Lock
In scope:
- frontend thin-client hardening for web entitlement truth
- release-safe web paywall behavior
- mock/release-path cleanup in tests/docs

Out of scope:
- backend subscription redesign
- provider / Apple modernization
- iOS/App Store lane
- `#1379` AI lane
- legal/compliance broadening

## Validation
Local:
- `npm test -- --run src/lib/__tests__/usePremium.test.ts`
- `npm test -- --run src/lib/__tests__/paywallPurchase.test.ts`
- `npm test -- --run src/pages/Pro/__tests__/ProPaywallPage.test.tsx`
- `npm test -- --run src/api/__tests__/client.test.ts`
- `npm test -- --run src/api/__tests__/thin-client-guards.test.ts`
- `npm test -- --run src/mocks/__tests__/purchase.test.ts`
- `npm test`
- `npm run build`
- `pre-commit run --all-files`
- `make verify`

Notes:
- local `make venv` in a clean clone is currently blocked by the repo's separate packaging/proxy lane (`cryptography==46.0.7` vs `constraints.txt` floor conflict). For this PR, the canonical `make verify` gate was run successfully in the clean worktree against the existing repo-managed `.venv`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1381_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#pullrequestreview-4085529481 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060753041 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060753142 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#pullrequestreview-4085556378 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775789 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775806 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775809 -> 96cd93f20
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1381#discussion_r3060775815 -> 96cd93f20
Disposition: FIXED
Commit: 96cd93f20
Evidence: `docs/roadmap/BACKLOG_LEDGER.md:205` and `docs/roadmap/BACKLOG_LEDGER.md:208` now use the concrete PR reference and consistent `release-truth` wording; `frontend/src/mocks/__tests__/purchase.test.ts:1-50` now checks runtime MSW matcher behavior across handler predicates instead of relying on `info.path` and adds explicit TypeScript annotations; `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:59` adds the explicit async return type; `docs/review/PR_1381_FIXED_MAPPING.md:13-18` keeps merge-readiness checkboxes unchecked until the final merge cycle.

## Merge Readiness
- [ ] All required checks pass
- [ ] No unresolved review threads (re-check on current head before merge)
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green
- [ ] `make verify` green
- [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
- Scope: frontend closeout for `ledger-p0-web-entitlement-truth`, limited to canonical web entitlement truth, fail-closed paywall behavior, and stale mock/release-path cleanup.


## Deferred / Follow-ups
- any real web checkout capability remains out of scope for this closeout lane
- the backlog item should be marked closed only after this PR merges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PR review checklist noting fixed-in-commit mapping and merge-readiness items; updated backlog to reference PR #1381 and staged closeout for web entitlement truth; clarified that canonical session API is the source of truth.
  * Updated enforcement docs to exclude legacy mock purchase/restore flows.

* **Tests**
  * Removed legacy mock release endpoints from shared test handlers and added a structural check to ensure those paths aren’t exposed.
  * Modified paywall test to verify cancel/navigation behavior instead of simulating a successful purchase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
