### PR TITLE
fix(prod): recover apex shell and sitemap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,7 +737,7 @@ jobs:
   test-feature:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feature/'))
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       actions: write
@@ -816,14 +816,21 @@ jobs:
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi
+          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
-          python -X faulthandler -m pytest \
+          set +e
+          time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
+            --durations=25 \
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          test_exit_code=$?
+          set -e
+          echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          exit "$test_exit_code"
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -851,14 +858,20 @@ jobs:
   test-main:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     permissions:
       contents: read
       actions: write
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.11'
+            timeout-minutes: 60
+          - python-version: '3.12'
+            timeout-minutes: 60
+          - python-version: '3.13'
+            timeout-minutes: 90
 
     steps:
       - name: Checkout
@@ -935,14 +948,21 @@ jobs:
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi
+          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
-          python -X faulthandler -m pytest \
+          set +e
+          time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
+            --durations=25 \
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          test_exit_code=$?
+          set -e
+          echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          exit "$test_exit_code"
 
       - name: Clean Python cache (post-test)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,6 +660,7 @@ jobs:
               route_contract_safety)
                 add_suite \
                   tests/test_api.py \
+                  tests/test_app_endpoints_combined.py \
                   tests/test_app_error_handling_combined.py \
                   tests/test_app_extended_coverage.py \
                   tests/test_creative_research_eval_contract.py \

--- a/app/bootstrap/public_discovery.py
+++ b/app/bootstrap/public_discovery.py
@@ -8,6 +8,7 @@ that must stay available even when traffic bypasses the static edge shell.
 
 from __future__ import annotations
 
+import os
 from html import escape
 from typing import Iterable
 from urllib.parse import urljoin
@@ -24,6 +25,7 @@ PUBLIC_SITEMAP_PATHS: tuple[str, ...] = (
     "/terms",
     LEGACY_BMI_WEB_ROUTE,
 )
+PRODUCTION_DOMAIN_ENV: str = "PRODUCTION_DOMAIN"
 
 
 def _build_public_url(base_url: str, path: str) -> str:
@@ -59,11 +61,28 @@ def build_public_sitemap_xml(
     return f'<?xml version="1.0" encoding="UTF-8"?>{xml_body}'
 
 
+def resolve_public_sitemap_base_url(request: Request) -> str:
+    """Return the canonical base URL for sitemap generation.
+
+    RU: Если задан `PRODUCTION_DOMAIN`, используем его как канонический public host
+    и не зависим от временного bypass/direct-origin hostname.
+    EN: Prefer `PRODUCTION_DOMAIN` as the canonical public host so temporary
+    bypass or direct-origin probes cannot rewrite sitemap URLs.
+    """
+    configured_domain = os.getenv(PRODUCTION_DOMAIN_ENV, "").strip().strip("'\"")
+    if configured_domain:
+        configured_domain = configured_domain.removeprefix("https://").removeprefix("http://")
+        configured_domain = configured_domain.rstrip("/")
+        return f"https://{configured_domain}"
+
+    return str(request.base_url)
+
+
 async def serve_public_sitemap(request: Request) -> Response:
     """Serve `/sitemap.xml` from the application surface.
 
     RU: Endpoint остаётся доступным даже если edge/static shell временно дрейфует.
     EN: Keep the endpoint available even when the edge/static shell drifts.
     """
-    sitemap_xml = build_public_sitemap_xml(base_url=str(request.base_url))
+    sitemap_xml = build_public_sitemap_xml(base_url=resolve_public_sitemap_base_url(request))
     return Response(content=sitemap_xml, media_type="application/xml")

--- a/app/bootstrap/public_discovery.py
+++ b/app/bootstrap/public_discovery.py
@@ -1,0 +1,69 @@
+"""Public discovery surfaces served directly from FastAPI.
+
+RU: Здесь живут простые публичные discovery endpoints вроде `/sitemap.xml`,
+которые должны работать даже при прямом обращении к FastAPI.
+EN: This module owns small public discovery endpoints such as `/sitemap.xml`
+that must stay available even when traffic bypasses the static edge shell.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Iterable
+from urllib.parse import urljoin
+
+from fastapi import Request
+from fastapi.responses import Response
+
+from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
+
+SITEMAP_ROUTE_PATH: str = "/sitemap.xml"
+PUBLIC_SITEMAP_PATHS: tuple[str, ...] = (
+    "/",
+    "/privacy",
+    "/terms",
+    LEGACY_BMI_WEB_ROUTE,
+)
+
+
+def _build_public_url(base_url: str, path: str) -> str:
+    """Return a deterministic absolute URL for sitemap entries.
+
+    RU: Нормализуем базовый URL и путь, чтобы sitemap всегда был стабильным.
+    EN: Normalize base URL and path so the sitemap stays deterministic.
+    """
+    normalized_base = base_url if base_url.endswith("/") else f"{base_url}/"
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return urljoin(normalized_base, normalized_path.lstrip("/"))
+
+
+def build_public_sitemap_xml(
+    base_url: str,
+    paths: Iterable[str] = PUBLIC_SITEMAP_PATHS,
+) -> str:
+    """Build the public sitemap XML payload.
+
+    RU: Генерируем минимальный sitemap только для канонических публичных путей.
+    EN: Generate a minimal sitemap for canonical public paths only.
+    """
+    xml_entries = []
+    for path in paths:
+        public_url = _build_public_url(base_url=base_url, path=path)
+        escaped_public_url = escape(public_url, quote=True)
+        xml_entries.append(f"<url><loc>{escaped_public_url}</loc></url>")
+
+    xml_body = "".join(xml_entries)
+    xml_body = (
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' f"{xml_body}" "</urlset>"
+    )
+    return f'<?xml version="1.0" encoding="UTF-8"?>{xml_body}'
+
+
+async def serve_public_sitemap(request: Request) -> Response:
+    """Serve `/sitemap.xml` from the application surface.
+
+    RU: Endpoint остаётся доступным даже если edge/static shell временно дрейфует.
+    EN: Keep the endpoint available even when the edge/static shell drifts.
+    """
+    sitemap_xml = build_public_sitemap_xml(base_url=str(request.base_url))
+    return Response(content=sitemap_xml, media_type="application/xml")

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.bootstrap.direct_api_root import (
 from app.bootstrap.food_search import register_food_search_backend
 from app.bootstrap.metrics import register_metrics
 from app.bootstrap.pro_contracts import register_pro_contract_routes
+from app.bootstrap.public_discovery import SITEMAP_ROUTE_PATH, serve_public_sitemap
 from app.bootstrap.telemetry import register_request_telemetry
 from app.bootstrap.tracing import register_tracing
 from app.routers.creative_research_internal import router as creative_research_internal_router
@@ -162,6 +163,13 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
             methods=["GET"],
             include_in_schema=False,
             response_class=HTMLResponse,
+        )
+    if not _route_has_endpoint(target_app, SITEMAP_ROUTE_PATH, "GET", serve_public_sitemap):
+        target_app.add_api_route(
+            SITEMAP_ROUTE_PATH,
+            serve_public_sitemap,
+            methods=["GET"],
+            include_in_schema=False,
         )
     register_food_search_backend(app)
     register_metrics(app)

--- a/deploy/Caddyfile.production
+++ b/deploy/Caddyfile.production
@@ -39,7 +39,7 @@ www.{$PRODUCTION_DOMAIN} {
 
     # RU: Всё API и операционные пути — на FastAPI (без коллизий с GET SPA выше).
     # EN: API and ops paths → FastAPI (no GET collision with SPA for legacy POST paths).
-    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env /legacy*
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /sitemap.xml /admin* /privacy /terms /debug_env /legacy*
     handle @api {
         reverse_proxy app:8000
     }
@@ -105,7 +105,7 @@ www.{$STAGING_FALLBACK_DOMAIN:pulseplate-staging.duckdns.org} {
         reverse_proxy app:8000
     }
 
-    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /admin* /privacy /terms /debug_env /legacy*
+    @api path /api* /health* /ready /metrics /ws* /docs* /redoc* /openapi.json /sitemap.xml /admin* /privacy /terms /debug_env /legacy*
     handle @api {
         reverse_proxy app:8000
     }

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -27,6 +27,33 @@ If `PROD_DEPLOY_MODE` is unset, CD remains build-only even when production image
 are published to GHCR. Any value other than `ssh` or `self-hosted` is treated as
 invalid and fails the production config resolution step.
 
+## Apex / white-screen drift signature
+
+When the site apex unexpectedly shows a white screen, direct API JSON, or an
+empty shell, treat it as **production drift first**, not as a React-only bug.
+
+Typical drift symptoms:
+
+- `GET /` at the public apex no longer serves the baked SPA shell from Caddy
+- `GET /sitemap.xml` returns HTML, SPA fallback, or `404` instead of XML
+- The production host copy of `Caddyfile.production` or
+  `docker-compose.production.yaml` no longer matches the repo source of truth
+- Cloudflare challenge/proxy behavior obscures curl-based diagnosis, while the
+  origin is still misrouting apex traffic underneath
+
+Canonical recovery order:
+
+1. Diff the production copies of `deploy/Caddyfile.production` and
+   `deploy/docker-compose.production.yaml` against the repo.
+2. Re-sync the production shell bundle:
+   - `deploy/Caddyfile.production`
+   - `deploy/docker-compose.production.yaml`
+   - sibling `frontend/` build context on the host (typically `/srv/frontend`)
+3. Rebuild/restart Caddy from the synced shell bundle.
+4. Re-run `BASE_URL=https://$PRODUCTION_DOMAIN bash scripts/diagnose_web.sh`.
+5. If `/sitemap.xml` still fails after edge recovery, deploy the new backend
+   image as well; the edge fix alone cannot add a missing FastAPI route.
+
 ## Global release-readiness lock (required)
 
 Deployment jobs in CD are additionally gated by:
@@ -199,6 +226,11 @@ If `https://pulseplate.app` works but `https://www.pulseplate.app` returns `525`
 3. `deploy/Caddyfile.production` contains a dedicated `www` vhost that can issue a certificate and redirect to apex.
 4. Cloudflare SSL mode remains `Full (strict)` and the origin is serving a valid certificate for both apex and `www`.
 5. Only after the public-side check confirms drift, run `bash scripts/diagnose_production.sh` on the origin server to inspect Caddy/container/certificate state.
+
+If public curl probes hit a Cloudflare challenge instead of the origin, run the
+same diagnosis against the synced production host and the repo copies first.
+Cloudflare may mask the underlying apex-routing drift, but it does not replace
+the repo-owned Caddy/compose/frontend contract.
 
 #### Remediation Matrix
 

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -43,16 +43,26 @@ Typical drift symptoms:
 
 Canonical recovery order:
 
-1. Diff the production copies of `deploy/Caddyfile.production` and
+0. If the site must stay private, enable **full-host Cloudflare Access** first.
+   While Access or an interstitial is in front of the apex, public scanners
+   (MDN Observatory, header scans) are not release-truth.
+1. Merge the recovery PR first; recover from the merged repo/CI release bundle,
+   not from an ad-hoc workstation-only checkout.
+2. Diff the production copies of `deploy/Caddyfile.production` and
    `deploy/docker-compose.production.yaml` against the repo.
-2. Re-sync the production shell bundle:
+3. Re-sync the production shell bundle from the same merged commit / release bundle:
    - `deploy/Caddyfile.production`
    - `deploy/docker-compose.production.yaml`
    - sibling `frontend/` build context on the host (typically `/srv/frontend`)
-3. Rebuild/restart Caddy from the synced shell bundle.
-4. Re-run `BASE_URL=https://$PRODUCTION_DOMAIN bash scripts/diagnose_web.sh`.
-5. If `/sitemap.xml` still fails after edge recovery, deploy the new backend
+4. Pull the new production app image, run `alembic upgrade head`, rebuild Caddy,
+   and restart the stack from the synced shell bundle.
+5. Re-run `BASE_URL=https://$PRODUCTION_DOMAIN bash scripts/diagnose_web.sh`.
+   If Access is still ON, pass `CF_ACCESS_CLIENT_ID` and
+   `CF_ACCESS_CLIENT_SECRET` for private probes.
+6. If `/sitemap.xml` still fails after edge recovery, deploy the new backend
    image as well; the edge fix alone cannot add a missing FastAPI route.
+7. Remove full-host Access only after the private check passes, then reopen the
+   apex with a narrow temporary bypass for public shell/discovery GET paths only.
 
 ## Global release-readiness lock (required)
 
@@ -231,6 +241,27 @@ If public curl probes hit a Cloudflare challenge instead of the origin, run the
 same diagnosis against the synced production host and the repo copies first.
 Cloudflare may mask the underlying apex-routing drift, but it does not replace
 the repo-owned Caddy/compose/frontend contract.
+
+## Private verification under Access
+
+When Cloudflare Access protects the full host during recovery, use a short-lived
+service token for scripted probes:
+
+```bash
+CF_ACCESS_CLIENT_ID=... \
+CF_ACCESS_CLIENT_SECRET=... \
+BASE_URL=https://$PRODUCTION_DOMAIN \
+bash scripts/diagnose_web.sh
+```
+
+Expected private verification signals:
+
+- `/` returns the SPA shell
+- `/sitemap.xml` returns XML with `<urlset>`
+- `/api/v1/admin/status` remains a backend/admin canary (JSON auth/error, not SPA)
+- `/health` shows the new `git_sha`
+
+Do not treat Observatory / public header scans as authoritative until Access is removed.
 
 #### Remediation Matrix
 

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -207,7 +207,7 @@ git switch --detach origin/main
 scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
 scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
 rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
-scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/scripts/diagnose_web.sh
+scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/diagnose_web.sh
 
 # На сервере: rebuild/restart только edge shell
 ssh ubuntu@64.226.117.163 '

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -194,11 +194,20 @@ curl -fsS https://pulseplate.app/health | jq .
 не чини это руками только в Cloudflare. Сначала восстанови repo-owned shell
 bundle на origin.
 
+**Жёсткое правило:** emergency shell sync разрешён только из **merged canonical
+tree** (`origin/main` / release commit) или из CI-produced release bundle.
+Нельзя копировать `deploy/` и `frontend/` с произвольного локального dirty checkout.
+
 ```bash
-# Локально: синхронизировать production shell bundle на сервер
+# Локально: перейти на merged canonical tree
+git fetch origin main
+git switch --detach origin/main
+
+# С этого checkout синхронизировать production shell bundle на сервер
 scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
 scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
 rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
+scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/scripts/diagnose_web.sh
 
 # На сервере: rebuild/restart только edge shell
 ssh ubuntu@64.226.117.163 '
@@ -213,9 +222,43 @@ ssh ubuntu@64.226.117.163 '
 BASE_URL=https://pulseplate.app bash scripts/diagnose_web.sh
 ```
 
+Если host всё ещё скрыт за full-host Cloudflare Access, используй private probe:
+
+```bash
+CF_ACCESS_CLIENT_ID=... \
+CF_ACCESS_CLIENT_SECRET=... \
+BASE_URL=https://pulseplate.app \
+bash scripts/diagnose_web.sh
+```
+
 Если apex shell восстановился, а `/sitemap.xml` всё ещё не XML, значит edge уже
 здоров, но backend image ещё не содержит нужный route. В этом случае нужен
 отдельный deploy нового app image, а не очередная ручная правка Cloudflare.
+
+### Public reopen after private recovery
+
+Когда private verification прошла, снимай full-host Access не "в ноль", а вместе
+с narrow temporary bypass только для публичных GET surfaces:
+
+- `/`
+- SPA routes
+- `/assets/*`
+- `/favicon*`
+- `/sitemap.xml`
+- `/privacy`
+- `/terms`
+- `/legacy/bmi-calculator`
+
+Не ослабляй:
+
+- `/api*`
+- `/admin*`
+- `/ws*`
+- `/openapi.json`
+- `/health`
+- `/docs*`
+- `/redoc*`
+- `/debug_env`
 
 ---
 
@@ -225,7 +268,7 @@ BASE_URL=https://pulseplate.app bash scripts/diagnose_web.sh
 | ------------------ | ---------------------------------------------- | --------------------------------------- |
 | **Cursor**         | Код, фиксы, коммиты, PR                       | Правка на сервере                       |
 | **GitHub Actions** | Автоматическая сборка Docker image             | Ручная сборка                           |
-| **DigitalOcean**   | `docker compose pull app` + one-shot `alembic upgrade head` + `build caddy` + `up` + `diagnose_web.sh` (см. `scripts/redeploy_caddy.sh`) | Правка кода, git clone, изменение файлов |
+| **DigitalOcean**   | `docker compose pull app` + one-shot `alembic upgrade head` + `build caddy` + `up` + `diagnose_web.sh` (см. `scripts/redeploy_caddy.sh`) | Правка кода, git clone, shell sync из unmerged/dirty checkout |
 
 ---
 

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -188,6 +188,35 @@ curl -fsS https://pulseplate.app/health | jq .
 }
 ```
 
+### Emergency apex shell recovery (DigitalOcean + Cloudflare drift)
+
+Если production apex внезапно уходит в белый экран, JSON probe или пустой shell,
+не чини это руками только в Cloudflare. Сначала восстанови repo-owned shell
+bundle на origin.
+
+```bash
+# Локально: синхронизировать production shell bundle на сервер
+scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
+scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
+rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
+
+# На сервере: rebuild/restart только edge shell
+ssh ubuntu@64.226.117.163 '
+  cd /srv/pulseplate-production &&
+  bash scripts/redeploy_caddy.sh
+'
+```
+
+После этого:
+
+```bash
+BASE_URL=https://pulseplate.app bash scripts/diagnose_web.sh
+```
+
+Если apex shell восстановился, а `/sitemap.xml` всё ещё не XML, значит edge уже
+здоров, но backend image ещё не содержит нужный route. В этом случае нужен
+отдельный deploy нового app image, а не очередная ручная правка Cloudflare.
+
 ---
 
 ## 🧠 Ментальная модель

--- a/docs/deploy/CLOUDFLARE.md
+++ b/docs/deploy/CLOUDFLARE.md
@@ -222,6 +222,79 @@ production contract. Если apex после снятия challenge всё ещ
 как положено, возвращайтесь к диагностике `Caddyfile.production` и synced
 frontend bundle.
 
+## Temporary private recovery with Cloudflare Access
+
+Если сайт ещё не готов к публичному доступу, прячьте `pulseplate.app` через
+**Cloudflare Access**, а не через ad-hoc код/Basic Auth на origin.
+
+- Тип приложения: `self_hosted`
+- Домен: `pulseplate.app`
+- Политика доступа: только owner/team emails
+- Для scripted private probes разрешён отдельный short-lived service token
+
+Рекомендуемый режим:
+
+1. Включить full-host Access на `pulseplate.app`.
+2. Выполнить merge-then-deploy recovery flow.
+3. Проверять apex и `/sitemap.xml` приватно через Access.
+4. Снимать Access только в момент публичного reopen.
+
+### Private verification while Access is ON
+
+`scripts/diagnose_web.sh` поддерживает optional Access service-token headers:
+
+```bash
+CF_ACCESS_CLIENT_ID=... \
+CF_ACCESS_CLIENT_SECRET=... \
+BASE_URL=https://pulseplate.app \
+bash scripts/diagnose_web.sh
+```
+
+Скрипт добавляет:
+
+- `CF-Access-Client-Id`
+- `CF-Access-Client-Secret`
+
+и проверяет, что `/api/v1/admin/status` остаётся backend/admin canary, а не
+падает в SPA shell.
+
+### Observatory / public scanners under Access
+
+Пока full-host Access или interstitial/challenge стоят перед apex:
+
+- **MDN Observatory не является release-truth**
+- header scanners измеряют Cloudflare interstitial / Access page, а не origin app
+- публичные curl/SSL scans используйте только после reopen
+
+## Public reopen contract (narrow temporary bypass)
+
+После приватной проверки снимайте full-host Access только вместе с узким
+temporary bypass для **public shell/discovery GET paths**:
+
+- `/`
+- SPA routes
+- `/assets/*`
+- `/favicon*`
+- `/sitemap.xml`
+- `/privacy`
+- `/terms`
+- `/legacy/bmi-calculator`
+
+Обязательно оставить защищёнными:
+
+- `/api*`
+- `/admin*`
+- `/ws*`
+- `/openapi.json`
+- `/health`
+- `/docs*`
+- `/redoc*`
+- `/debug_env`
+
+Правило bypass должно иметь TTL и быть задокументировано в incident/recovery PR.
+Если после снятия Access apex снова отдаёт challenge или неверный surface,
+возвращайте Access и повторяйте private verification, а не расширяйте bypass.
+
 ## ✅ Минимальный чеклист
 
 - [ ] SSL/TLS режим: **Full (strict)**

--- a/docs/deploy/CLOUDFLARE.md
+++ b/docs/deploy/CLOUDFLARE.md
@@ -181,6 +181,47 @@
 
 **Используйте этот токен** для любых автоматизированных DNS операций.
 
+## Edge challenge / white-screen triage
+
+Если пользователь видит белый экран или пустой apex, а origin при этом выглядит
+healthy, сначала разделите инцидент на два класса:
+
+1. **Cloudflare edge challenge / interstitial**
+2. **Origin drift (Caddy / compose / frontend shell bundle)**
+
+### Как распознать Cloudflare-side инцидент
+
+- `curl` к public URL получает `403`, `challenge`, `cf-mitigated`, `Ray ID` или
+  interstitial HTML вместо ответа origin
+- Cloudflare **Security Events** показывает срабатывание конкретного rule / WAF
+  expression / challenge
+- Origin `https://<host>/health` или host-local `docker compose ps` остаются healthy
+
+### Что смотреть в Dashboard
+
+- **Security** → **Events**: найти `Ray ID`, rule ID, action (`challenge`, `managed_challenge`, `block`)
+- **Security** → **WAF**: проверить последние rule changes
+- **SSL/TLS** и **DNS**: убедиться, что нет параллельной topology drift
+
+### Допустимая manual mitigation
+
+- Временно ослабить конкретное challenge rule только для узкого path / method /
+  IP / country scope
+- Зафиксировать изменение в repo docs/runbook в тот же день
+- После mitigation обязательно перепроверить, не маскируется ли под этим real
+  origin drift (`deploy/Caddyfile.production`, `deploy/docker-compose.production.yaml`, `/srv/frontend`)
+
+### Недопустимая mitigation
+
+- Отключать Cloudflare proxy целиком без incident justification
+- Переводить SSL mode в `Flexible`
+- Оставлять dashboard-only knowledge без repo follow-up
+
+Cloudflare может скрыть реальную проблему с origin, но не заменяет repo-owned
+production contract. Если apex после снятия challenge всё ещё не отдаёт shell/XML
+как положено, возвращайтесь к диагностике `Caddyfile.production` и synced
+frontend bundle.
+
 ## ✅ Минимальный чеклист
 
 - [ ] SSL/TLS режим: **Full (strict)**

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -37,6 +37,7 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 | `/metrics` | Prometheus |
 | `/ws*` | WebSocket foundation |
 | `/docs*`, `/redoc*`, `/openapi.json` | OpenAPI / docs |
+| `/sitemap.xml` | Public discovery XML; must reach FastAPI, not SPA fallback |
 | `/admin*` | Admin |
 | `/privacy`, `/terms` | Legal JSON endpoints (no SPA route today) |
 | `/legacy*` | FastAPI-only legacy surfaces (embedded HTML BMI UI: registered in `app/main.py`, template `app/bootstrap/legacy_bmi_web_html.py`) |
@@ -69,6 +70,7 @@ When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal
 
 - **MIME (through Caddy):** `GET /` returns SPA `text/html` from static `file_server`; `GET /health` returns JSON (via proxy).
 - **Direct API:** `GET /` on uvicorn returns JSON probe (`app/bootstrap/direct_api_root.py:18`); legacy HTML UI: `GET /legacy/bmi-calculator` (proxied via `/legacy*` in `deploy/Caddyfile.production:42`).
+- **Discovery XML:** `GET /sitemap.xml` must be proxied to FastAPI and return XML, not `index.html`.
 - **Deep link:** `GET /bmi`, `GET /profile`, `GET /plate`, and `GET /progress` serve SPA `index.html`; `GET /plan` (no SPA route) is proxied to the app.
 - **Legacy POST:** `POST /bmi` (and peers) reaches FastAPI (not static 405 from `file_server`).
 - **OpenAPI:** `GET /openapi.json` proxied (200, JSON).

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -66,7 +66,8 @@ Keep these surfaces edge-protected during the reopen window:
 - `/admin*`
 - `/ws*`
 - `/openapi.json`
-- `/health`
+- `/health*`
+- `/ready`
 - `/docs*`
 - `/redoc*`
 - `/debug_env`

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -45,6 +45,36 @@ Caddy evaluates **POST**, then **OPTIONS**, then **GET** (legacy-only paths), th
 
 **Caddy matcher evidence:** `/legacy*` is included in the `@api` path list in [`deploy/Caddyfile.production:42`](../../deploy/Caddyfile.production).
 
+## Temporary public reopen contract
+
+During private recovery, Cloudflare Access may protect the full host. When the
+apex reopens publicly, use a **narrow temporary bypass** only for the public
+shell/discovery surfaces:
+
+- `/`
+- SPA routes
+- `/assets/*`
+- `/favicon*`
+- `/sitemap.xml`
+- `/privacy`
+- `/terms`
+- `/legacy/bmi-calculator`
+
+Keep these surfaces edge-protected during the reopen window:
+
+- `/api*`
+- `/admin*`
+- `/ws*`
+- `/openapi.json`
+- `/health`
+- `/docs*`
+- `/redoc*`
+- `/debug_env`
+
+`/legacy/bmi-calculator` is intentionally public here because it is linked from
+the direct API probe and included in the sitemap. Other `/legacy*` paths are
+not part of the temporary public allowlist by default.
+
 ## Direct Uvicorn / bypass Caddy
 
 When traffic hits **FastAPI only** (port `8000`, misconfigured clients, internal probes), **`GET /`** returns a **small JSON probe** (stable `service` / `surface` / `links`; registration `app/main.py` → `serve_direct_api_root_probe`, payload builder `app/bootstrap/direct_api_root.py`). The historical embedded HTML calculator is at **`GET /legacy/bmi-calculator`** (same bootstrap, handler `serve_legacy_bmi_calculator_web`, template `app/bootstrap/legacy_bmi_web_html.py`). Production browsers still receive **`text/html`** for **`GET /`** from Caddy’s `file_server` at apex; they do not see this JSON unless they bypass the edge.

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -29,11 +29,11 @@ Disposition: FIXED
 Commit: 556655280
 Evidence: `scripts/deploy_production.sh` (shell-bundle compose sync preserves the actual compose target path), `tests/test_deploy_contract_scripts.py` (`COMPOSE_FILE=deploy/...` regression coverage)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067165839 -> 556655280
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067175262 -> 556655280
 
 Disposition: FIXED
 Commit: a062111c6
 Evidence: `scripts/deploy_production.sh` (autodetects canonical `deploy/docker-compose.production.yaml` + `deploy/.env`, rejects compose sync targets outside `DEPLOY_DIR`), `tests/test_deploy_contract_scripts.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067175262 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067185585 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067187995 -> a062111c6
 

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -29,6 +29,13 @@ Disposition: FIXED
 Commit: 556655280
 Evidence: `scripts/deploy_production.sh` (shell-bundle compose sync preserves the actual compose target path), `tests/test_deploy_contract_scripts.py` (`COMPOSE_FILE=deploy/...` regression coverage)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067165839 -> 556655280
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067175262 -> 556655280
+
+Disposition: FIXED
+Commit: a062111c6
+Evidence: `scripts/deploy_production.sh` (autodetects canonical `deploy/docker-compose.production.yaml` + `deploy/.env`, rejects compose sync targets outside `DEPLOY_DIR`), `tests/test_deploy_contract_scripts.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067185585 -> a062111c6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067187995 -> a062111c6
 
 ## Merge Readiness
 

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -61,6 +61,12 @@ Disposition: NOT-A-BUG
 Evidence: `tests/test_deploy_contract_scripts.py:1268`, `tests/test_deploy_contract_scripts.py:1310`
 Reason: `curl_stub` is a plain triple-quoted string, not an f-string, so the JSON braces in `payload='{\"ok\": true}'` are literal shell-script content and do not require `{{ ... }}` escaping.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067334662
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4093080148
+Disposition: NOT-A-BUG
+Evidence: `scripts/deploy_production.sh:35`, `scripts/deploy_production.sh:36`, `scripts/deploy_production.sh:127`, `tests/test_deploy_contract_scripts.py:259`, `pytest -q tests/test_deploy_contract_scripts.py -k resolved_compose_file_is_missing`
+Reason: The script initializes `RESOLVED_COMPOSE_FILE` from `COMPOSE_FILE` at startup and fails fast before preflight continues when that resolved path does not exist, so the added test matches the deployed contract rather than asserting unreachable behavior.
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -14,9 +14,16 @@ Commit: ea218498c
 Evidence: `scripts/deploy_production.sh` (autodetected compose bundle sync), `scripts/diagnose_web.sh` (404 admin-canary hard fail), `deploy/WORKFLOW.md` (production scripts path), `tests/test_app_endpoints_combined.py` (deterministic sitemap assertions + public_discovery coverage), `tests/test_deploy_contract_scripts.py`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066824729 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066957607 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979098 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967048 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967058 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967065 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979107 -> ea218498c
+
+Disposition: FIXED
+Commit: 8862ba28b
+Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` (temporary reopen contract keeps `/health*` and `/ready` edge-protected)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979099 -> 8862ba28b
 
 ## Merge Readiness
 

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -1,0 +1,37 @@
+# PR #1385 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned below when actionable comments appear; resolve conversations on GitHub only after mapping per `AGENTS.md`.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+
+### Scope Notes
+
+- This PR keeps the recovery lane scoped to private-first apex recovery, backend-owned `/sitemap.xml`, Access-aware diagnostics, and public reopen documentation.
+- Cloudflare Access API surfaces are available from the current token, but zone firewall/settings endpoints return `9109 Unauthorized`, so narrow temporary bypass automation remains an ops/dashboard step unless token scope is expanded.
+- Public scanner truth (MDN Observatory / external header scans) remains out of release-truth while full-host Access or Cloudflare interstitials are active.
+
+### Local Verification
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `pytest -q tests/test_app_endpoints_combined.py tests/test_deploy_contract_scripts.py`
+- `pre-commit run --all-files`
+- `make verify`
+
+## Deferred / Follow-ups
+
+- If Cloudflare token scope is later expanded to zone firewall/ruleset management, automate the narrow temporary reopen bypass as a separate ops lane instead of widening the current Access-only contract.

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -12,6 +12,7 @@ Bot and human review threads must be dispositioned below when actionable comment
 Disposition: FIXED
 Commit: ea218498c
 Evidence: `scripts/deploy_production.sh` (autodetected compose bundle sync), `scripts/diagnose_web.sh` (404 admin-canary hard fail), `deploy/WORKFLOW.md` (production scripts path), `tests/test_app_endpoints_combined.py` (deterministic sitemap assertions + public_discovery coverage), `tests/test_deploy_contract_scripts.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092727607 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066824729 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066957607 -> ea218498c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979098 -> ea218498c
@@ -22,7 +23,8 @@ Evidence: `scripts/deploy_production.sh` (autodetected compose bundle sync), `sc
 
 Disposition: FIXED
 Commit: 8862ba28b
-Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` (temporary reopen contract keeps `/health*` and `/ready` edge-protected)
+Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` (temporary reopen contract keeps `/health*` and `/ready` edge-protected), final closure of cubic review `pullrequestreview-4092738799` after earlier inline recovery fixes landed in `ea218498c`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092738799 -> 8862ba28b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979099 -> 8862ba28b
 
 Disposition: FIXED
@@ -33,6 +35,9 @@ Evidence: `scripts/deploy_production.sh` (shell-bundle compose sync preserves th
 Disposition: FIXED
 Commit: a062111c6
 Evidence: `scripts/deploy_production.sh` (autodetects canonical `deploy/docker-compose.production.yaml` + `deploy/.env`, rejects compose sync targets outside `DEPLOY_DIR`), `tests/test_deploy_contract_scripts.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092928735 -> a062111c6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092938795 -> a062111c6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092941266 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067175262 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067185585 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067187995 -> a062111c6
@@ -40,8 +45,21 @@ Evidence: `scripts/deploy_production.sh` (autodetects canonical `deploy/docker-c
 Disposition: FIXED
 Commit: 63b775fd6
 Evidence: `scripts/deploy_production.sh` (default `ENV_FILE` selection now handles absolute `COMPOSE_FILE` paths under `$DEPLOY_DIR/deploy/*`), `tests/test_deploy_contract_scripts.py` (absolute deploy compose regression coverage, valid JSON curl stub payload)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4093040042 -> 63b775fd6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4093041205 -> 63b775fd6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067290930 -> 63b775fd6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067292082 -> 63b775fd6
+
+Disposition: FIXED
+Commit: 327f5d4a0
+Evidence: `scripts/deploy_production.sh` now fails fast when `RESOLVED_COMPOSE_FILE` points to a missing file, `tests/test_deploy_contract_scripts.py` locks the preflight contract, and this commit is the final closure for CodeRabbit review `pullrequestreview-4092919899`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4092919899 -> 327f5d4a0
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067307203
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#pullrequestreview-4093057434
+Disposition: NOT-A-BUG
+Evidence: `tests/test_deploy_contract_scripts.py:1268`, `tests/test_deploy_contract_scripts.py:1310`
+Reason: `curl_stub` is a plain triple-quoted string, not an f-string, so the JSON braces in `payload='{\"ok\": true}'` are literal shell-script content and do not require `{{ ... }}` escaping.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -34,4 +34,4 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Deferred / Follow-ups
 
-- If Cloudflare token scope is later expanded to zone firewall/ruleset management, automate the narrow temporary reopen bypass as a separate ops lane instead of widening the current Access-only contract.
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-cloudflare-narrow-reopen-automation` — automate the documented narrow temporary reopen bypass once Cloudflare zone firewall/ruleset permissions are available.

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -25,6 +25,11 @@ Commit: 8862ba28b
 Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` (temporary reopen contract keeps `/health*` and `/ready` edge-protected)
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066979099 -> 8862ba28b
 
+Disposition: FIXED
+Commit: 556655280
+Evidence: `scripts/deploy_production.sh` (shell-bundle compose sync preserves the actual compose target path), `tests/test_deploy_contract_scripts.py` (`COMPOSE_FILE=deploy/...` regression coverage)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067165839 -> 556655280
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -37,6 +37,12 @@ Evidence: `scripts/deploy_production.sh` (autodetects canonical `deploy/docker-c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067185585 -> a062111c6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067187995 -> a062111c6
 
+Disposition: FIXED
+Commit: 63b775fd6
+Evidence: `scripts/deploy_production.sh` (default `ENV_FILE` selection now handles absolute `COMPOSE_FILE` paths under `$DEPLOY_DIR/deploy/*`), `tests/test_deploy_contract_scripts.py` (absolute deploy compose regression coverage, valid JSON curl stub payload)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067290930 -> 63b775fd6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3067292082 -> 63b775fd6
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1385_FIXED_MAPPING.md
+++ b/docs/review/PR_1385_FIXED_MAPPING.md
@@ -9,14 +9,21 @@ Bot and human review threads must be dispositioned below when actionable comment
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: ea218498c
+Evidence: `scripts/deploy_production.sh` (autodetected compose bundle sync), `scripts/diagnose_web.sh` (404 admin-canary hard fail), `deploy/WORKFLOW.md` (production scripts path), `tests/test_app_endpoints_combined.py` (deterministic sitemap assertions + public_discovery coverage), `tests/test_deploy_contract_scripts.py`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066824729 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066957607 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967048 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967058 -> ea218498c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1385#discussion_r3066967065 -> ea218498c
 
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
 - [ ] All review threads resolved on GitHub after disposition updates
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 
 ### Scope Notes
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3058,6 +3058,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 ### P2
 
+<a id="ledger-p2-cloudflare-narrow-reopen-automation"></a>
+- [ ] P2: Cloudflare narrow reopen automation after Access-based private recovery
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (edge ops / recovery ergonomics)
+  - Target PR: PR-TBD-CLOUDFLARE-NARROW-REOPEN-AUTOMATION
+  - Status: 📋 Deferred from PR `#1385`
+  - Area: edge / Cloudflare / deploy
+  - Reason (EN): PR `#1385` now supports a private-first recovery flow and successfully provisions full-host Cloudflare Access for `pulseplate.app`, but the current Cloudflare token scope cannot manage zone firewall/settings/ruleset endpoints (`9109 Unauthorized`). The documented narrow temporary public bypass for shell/discovery GET paths therefore remains a dashboard/manual ops step until zone-scope automation permissions are expanded.
+  - Links:
+    - `docs/deploy/CLOUDFLARE.md`
+    - `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`
+    - `deploy/PRODUCTION.md`
+    - `deploy/WORKFLOW.md`
+    - `docs/review/PR_1385_FIXED_MAPPING.md`
+  - DoD:
+    - Expanded Cloudflare token scope (or approved alternative auth path) can read/write the zone firewall/ruleset surfaces needed for temporary reopen controls
+    - Automation applies the documented narrow allowlist only to shell/discovery GET paths without weakening `/api*`, `/admin*`, `/ws*`, `/openapi.json`, `/health`, `/docs*`, `/redoc*`, or `/debug_env`
+    - Rollback path restores full-host Access or removes the temporary bypass deterministically
+    - Operational runbook includes exact verification steps before and after public reopen
+
 <a id="ledger-p2-legacy-app-direct-root-get-policy"></a>
 - [ ] P2: Policy for `GET /` on FastAPI when clients bypass Caddy (direct `app:8000` / uvicorn)
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/QUICK_DIAGNOSTIC.md
+++ b/scripts/QUICK_DIAGNOSTIC.md
@@ -1,4 +1,4 @@
-# Quick Diagnostic for Cloudflare 521 Error
+# Quick Diagnostic for Public Edge Incidents (`521` / `525` / white screen / challenge)
 
 ## Вариант 0: публичная проверка из локального repo
 
@@ -13,6 +13,30 @@ python3 scripts/check_domain_tls.py --domain pulseplate.app
 - `www` отдаёт `301/302/307/308` на `https://pulseplate.app`
 
 Если script показывает `www ... 525`, переходите к origin-side диагностике ниже.
+Если public apex вместо origin-ответа отдаёт Cloudflare challenge / interstitial,
+сначала проверьте Cloudflare Security Events и только потом origin-side drift.
+
+## Вариант 0b: быстро отличить edge challenge от origin drift
+
+Проверьте public response headers/body:
+
+```bash
+curl -I https://pulseplate.app/
+curl -s https://pulseplate.app/ | head -40
+```
+
+Признаки **Cloudflare challenge**:
+
+- `cf-mitigated`
+- `server: cloudflare`
+- interstitial/challenge HTML вместо app response
+
+Признаки **origin drift**:
+
+- apex отдаёт JSON probe FastAPI вместо SPA shell
+- `/sitemap.xml` отдаёт HTML shell или `404`, хотя backend contract уже есть
+- production copies of `Caddyfile.production` / `docker-compose.production.yaml`
+  расходятся с repo SoT
 
 ## Выполнить на Droplet (SSH)
 
@@ -97,6 +121,22 @@ grep PRODUCTION_DOMAIN /srv/pulseplate-production/.env
 ```
 
 ## Типичные проблемы
+
+### Проблема: Public apex white screen / Cloudflare challenge
+
+```bash
+# 1. Проверить Cloudflare-side symptom
+curl -I https://pulseplate.app/
+
+# 2. Если challenge/interstitial есть — проверить Security Events в Cloudflare Dashboard
+# 3. Если origin healthy, а apex contract нарушен — синхронизировать shell bundle:
+scp deploy/Caddyfile.production user@your-droplet:/srv/pulseplate-production/Caddyfile.production
+scp deploy/docker-compose.production.yaml user@your-droplet:/srv/pulseplate-production/docker-compose.production.yaml
+rsync -az --delete frontend/ user@your-droplet:/srv/frontend/
+
+# 4. Затем пересобрать/restart caddy
+ssh user@your-droplet 'cd /srv/pulseplate-production && bash scripts/redeploy_caddy.sh'
+```
 
 ### Проблема: Caddyfile не найден
 ```bash

--- a/scripts/QUICK_DIAGNOSTIC.md
+++ b/scripts/QUICK_DIAGNOSTIC.md
@@ -38,6 +38,20 @@ curl -s https://pulseplate.app/ | head -40
 - production copies of `Caddyfile.production` / `docker-compose.production.yaml`
   расходятся с repo SoT
 
+Если full-host Cloudflare Access включён намеренно, публичные scans не являются
+release-truth: они видят Access/interstitial, а не origin app. Для private
+verification используй short-lived service token:
+
+```bash
+CF_ACCESS_CLIENT_ID=... \
+CF_ACCESS_CLIENT_SECRET=... \
+BASE_URL=https://pulseplate.app \
+bash scripts/diagnose_web.sh
+```
+
+Этот probe теперь включает admin canary (`/api/v1/admin/status`) и помогает
+поймать случайный публичный expose admin surface при reopen.
+
 ## Выполнить на Droplet (SSH)
 
 ### Вариант 1: Использовать server-side скрипт (рекомендуется)
@@ -129,7 +143,8 @@ grep PRODUCTION_DOMAIN /srv/pulseplate-production/.env
 curl -I https://pulseplate.app/
 
 # 2. Если challenge/interstitial есть — проверить Security Events в Cloudflare Dashboard
-# 3. Если origin healthy, а apex contract нарушен — синхронизировать shell bundle:
+# 3. Если origin healthy, а apex contract нарушен — синхронизировать shell bundle
+#    только из merged canonical tree / release bundle:
 scp deploy/Caddyfile.production user@your-droplet:/srv/pulseplate-production/Caddyfile.production
 scp deploy/docker-compose.production.yaml user@your-droplet:/srv/pulseplate-production/docker-compose.production.yaml
 rsync -az --delete frontend/ user@your-droplet:/srv/frontend/

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -125,6 +125,10 @@ cd "$DEPLOY_DIR"
 
 compose_args=()
 if [ -n "$RESOLVED_COMPOSE_FILE" ]; then
+  if [ ! -f "$RESOLVED_COMPOSE_FILE" ]; then
+    echo "❌ RESOLVED_COMPOSE_FILE does not exist: $RESOLVED_COMPOSE_FILE" >&2
+    exit 1
+  fi
   compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "deploy/docker-compose.production.yaml" ]; then
   RESOLVED_COMPOSE_FILE="deploy/docker-compose.production.yaml"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -153,7 +153,7 @@ elif [ -f "compose.yaml" ]; then
 fi
 
 if [ -z "$ENV_FILE" ]; then
-  if [[ "$RESOLVED_COMPOSE_FILE" = deploy/* ]]; then
+  if [[ "$RESOLVED_COMPOSE_FILE" = deploy/* || "$RESOLVED_COMPOSE_FILE" = "$DEPLOY_DIR"/deploy/* ]]; then
     ENV_FILE="$DEPLOY_DIR/deploy/.env"
   else
     ENV_FILE="$DEPLOY_DIR/.env"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -34,7 +34,6 @@ HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
 
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 RESOLVED_COMPOSE_FILE="${COMPOSE_FILE:-}"
-RESOLVED_COMPOSE_BUNDLE_FILE=""
 DEPLOY_DIR="${DEPLOY_DIR:-}"
 ENV_FILE="${ENV_FILE:-}"
 SHELL_BUNDLE_DIR="${SHELL_BUNDLE_DIR:-}"
@@ -147,10 +146,6 @@ elif [ -f "compose.yaml" ]; then
   compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 fi
 
-if [ -n "$RESOLVED_COMPOSE_FILE" ]; then
-  RESOLVED_COMPOSE_BUNDLE_FILE="$(basename "$RESOLVED_COMPOSE_FILE")"
-fi
-
 if [ -z "$ENV_FILE" ]; then
   ENV_FILE="$DEPLOY_DIR/.env"
 fi
@@ -228,14 +223,37 @@ sync_shell_bundle() {
 
   local source_frontend="$SHELL_BUNDLE_DIR/frontend"
   local source_caddyfile="$SHELL_BUNDLE_DIR/deploy/Caddyfile.production"
-  local source_compose="$SHELL_BUNDLE_DIR/deploy/$RESOLVED_COMPOSE_BUNDLE_FILE"
+  local source_compose=""
   local source_diagnose="$SHELL_BUNDLE_DIR/scripts/diagnose_web.sh"
+  local target_compose=""
+  local compose_relative_path=""
   local shell_root
   shell_root="$(cd "$DEPLOY_DIR/.." && pwd)"
 
-  if [ -z "$RESOLVED_COMPOSE_BUNDLE_FILE" ]; then
+  if [ -z "$RESOLVED_COMPOSE_FILE" ]; then
     echo "❌ Could not resolve a compose filename for shell bundle sync" >&2
     exit 1
+  fi
+
+  if [[ "$RESOLVED_COMPOSE_FILE" = /* ]]; then
+    target_compose="$RESOLVED_COMPOSE_FILE"
+    case "$RESOLVED_COMPOSE_FILE" in
+      "$DEPLOY_DIR"/*)
+        compose_relative_path="${RESOLVED_COMPOSE_FILE#"$DEPLOY_DIR"/}"
+        ;;
+      *)
+        compose_relative_path="$(basename "$RESOLVED_COMPOSE_FILE")"
+        ;;
+    esac
+  else
+    compose_relative_path="${RESOLVED_COMPOSE_FILE#./}"
+    target_compose="$DEPLOY_DIR/$compose_relative_path"
+  fi
+
+  if [[ "$compose_relative_path" = deploy/* ]]; then
+    source_compose="$SHELL_BUNDLE_DIR/$compose_relative_path"
+  else
+    source_compose="$SHELL_BUNDLE_DIR/deploy/$compose_relative_path"
   fi
 
   if [ ! -d "$source_frontend" ]; then
@@ -249,16 +267,17 @@ sync_shell_bundle() {
   fi
 
   if [ ! -f "$source_compose" ]; then
-    echo "❌ SHELL_BUNDLE_DIR is missing deploy/$RESOLVED_COMPOSE_BUNDLE_FILE: $source_compose" >&2
+    echo "❌ SHELL_BUNDLE_DIR is missing $compose_relative_path: $source_compose" >&2
     exit 1
   fi
 
   echo "Syncing production shell bundle from: $SHELL_BUNDLE_DIR"
   rm -rf "$shell_root/frontend"
   mkdir -p "$shell_root/frontend" "$shell_root/scripts"
+  mkdir -p "$(dirname "$target_compose")"
   cp -R "$source_frontend/." "$shell_root/frontend/"
   cp "$source_caddyfile" "$DEPLOY_DIR/Caddyfile.production"
-  cp "$source_compose" "$DEPLOY_DIR/$RESOLVED_COMPOSE_BUNDLE_FILE"
+  cp "$source_compose" "$target_compose"
   rm -f "$shell_root/scripts/diagnose_web.sh"
 
   if [ -f "$source_diagnose" ]; then

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -33,6 +33,8 @@ HEALTH_SLEEP_S="${HEALTH_SLEEP_S:-2}"
 HEALTH_CURL_MAX_TIME_S="${HEALTH_CURL_MAX_TIME_S:-10}"
 
 COMPOSE_FILE="${COMPOSE_FILE:-}"
+RESOLVED_COMPOSE_FILE="${COMPOSE_FILE:-}"
+RESOLVED_COMPOSE_BUNDLE_FILE=""
 DEPLOY_DIR="${DEPLOY_DIR:-}"
 ENV_FILE="${ENV_FILE:-}"
 SHELL_BUNDLE_DIR="${SHELL_BUNDLE_DIR:-}"
@@ -123,20 +125,30 @@ fi
 cd "$DEPLOY_DIR"
 
 compose_args=()
-if [ -n "$COMPOSE_FILE" ]; then
-  compose_args=(-f "$COMPOSE_FILE")
+if [ -n "$RESOLVED_COMPOSE_FILE" ]; then
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "docker-compose.production.yaml" ]; then
-  compose_args=(-f "docker-compose.production.yaml")
+  RESOLVED_COMPOSE_FILE="docker-compose.production.yaml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "docker-compose.production.yml" ]; then
-  compose_args=(-f "docker-compose.production.yml")
+  RESOLVED_COMPOSE_FILE="docker-compose.production.yml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "docker-compose.yml" ]; then
-  compose_args=(-f "docker-compose.yml")
+  RESOLVED_COMPOSE_FILE="docker-compose.yml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "docker-compose.yaml" ]; then
-  compose_args=(-f "docker-compose.yaml")
+  RESOLVED_COMPOSE_FILE="docker-compose.yaml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "compose.yml" ]; then
-  compose_args=(-f "compose.yml")
+  RESOLVED_COMPOSE_FILE="compose.yml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "compose.yaml" ]; then
-  compose_args=(-f "compose.yaml")
+  RESOLVED_COMPOSE_FILE="compose.yaml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
+fi
+
+if [ -n "$RESOLVED_COMPOSE_FILE" ]; then
+  RESOLVED_COMPOSE_BUNDLE_FILE="$(basename "$RESOLVED_COMPOSE_FILE")"
 fi
 
 if [ -z "$ENV_FILE" ]; then
@@ -216,10 +228,15 @@ sync_shell_bundle() {
 
   local source_frontend="$SHELL_BUNDLE_DIR/frontend"
   local source_caddyfile="$SHELL_BUNDLE_DIR/deploy/Caddyfile.production"
-  local source_compose="$SHELL_BUNDLE_DIR/deploy/$COMPOSE_FILE"
+  local source_compose="$SHELL_BUNDLE_DIR/deploy/$RESOLVED_COMPOSE_BUNDLE_FILE"
   local source_diagnose="$SHELL_BUNDLE_DIR/scripts/diagnose_web.sh"
   local shell_root
   shell_root="$(cd "$DEPLOY_DIR/.." && pwd)"
+
+  if [ -z "$RESOLVED_COMPOSE_BUNDLE_FILE" ]; then
+    echo "❌ Could not resolve a compose filename for shell bundle sync" >&2
+    exit 1
+  fi
 
   if [ ! -d "$source_frontend" ]; then
     echo "❌ SHELL_BUNDLE_DIR is missing frontend/: $source_frontend" >&2
@@ -232,7 +249,7 @@ sync_shell_bundle() {
   fi
 
   if [ ! -f "$source_compose" ]; then
-    echo "❌ SHELL_BUNDLE_DIR is missing deploy/$COMPOSE_FILE: $source_compose" >&2
+    echo "❌ SHELL_BUNDLE_DIR is missing deploy/$RESOLVED_COMPOSE_BUNDLE_FILE: $source_compose" >&2
     exit 1
   fi
 
@@ -241,7 +258,7 @@ sync_shell_bundle() {
   mkdir -p "$shell_root/frontend" "$shell_root/scripts"
   cp -R "$source_frontend/." "$shell_root/frontend/"
   cp "$source_caddyfile" "$DEPLOY_DIR/Caddyfile.production"
-  cp "$source_compose" "$DEPLOY_DIR/$COMPOSE_FILE"
+  cp "$source_compose" "$DEPLOY_DIR/$RESOLVED_COMPOSE_BUNDLE_FILE"
   rm -f "$shell_root/scripts/diagnose_web.sh"
 
   if [ -f "$source_diagnose" ]; then

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -126,6 +126,12 @@ cd "$DEPLOY_DIR"
 compose_args=()
 if [ -n "$RESOLVED_COMPOSE_FILE" ]; then
   compose_args=(-f "$RESOLVED_COMPOSE_FILE")
+elif [ -f "deploy/docker-compose.production.yaml" ]; then
+  RESOLVED_COMPOSE_FILE="deploy/docker-compose.production.yaml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
+elif [ -f "deploy/docker-compose.production.yml" ]; then
+  RESOLVED_COMPOSE_FILE="deploy/docker-compose.production.yml"
+  compose_args=(-f "$RESOLVED_COMPOSE_FILE")
 elif [ -f "docker-compose.production.yaml" ]; then
   RESOLVED_COMPOSE_FILE="docker-compose.production.yaml"
   compose_args=(-f "$RESOLVED_COMPOSE_FILE")
@@ -147,7 +153,11 @@ elif [ -f "compose.yaml" ]; then
 fi
 
 if [ -z "$ENV_FILE" ]; then
-  ENV_FILE="$DEPLOY_DIR/.env"
+  if [[ "$RESOLVED_COMPOSE_FILE" = deploy/* ]]; then
+    ENV_FILE="$DEPLOY_DIR/deploy/.env"
+  else
+    ENV_FILE="$DEPLOY_DIR/.env"
+  fi
 fi
 
 if [ ! -f "$ENV_FILE" ]; then
@@ -236,17 +246,24 @@ sync_shell_bundle() {
   fi
 
   if [[ "$RESOLVED_COMPOSE_FILE" = /* ]]; then
-    target_compose="$RESOLVED_COMPOSE_FILE"
     case "$RESOLVED_COMPOSE_FILE" in
       "$DEPLOY_DIR"/*)
         compose_relative_path="${RESOLVED_COMPOSE_FILE#"$DEPLOY_DIR"/}"
+        target_compose="$RESOLVED_COMPOSE_FILE"
         ;;
       *)
-        compose_relative_path="$(basename "$RESOLVED_COMPOSE_FILE")"
+        echo "❌ COMPOSE_FILE must stay within DEPLOY_DIR: $RESOLVED_COMPOSE_FILE" >&2
+        exit 1
         ;;
     esac
   else
     compose_relative_path="${RESOLVED_COMPOSE_FILE#./}"
+    case "$compose_relative_path" in
+      ""|"."|..|../*|*/../*|*/..)
+        echo "❌ COMPOSE_FILE must stay within DEPLOY_DIR: $RESOLVED_COMPOSE_FILE" >&2
+        exit 1
+        ;;
+    esac
     target_compose="$DEPLOY_DIR/$compose_relative_path"
   fi
 

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -216,6 +216,7 @@ sync_shell_bundle() {
 
   local source_frontend="$SHELL_BUNDLE_DIR/frontend"
   local source_caddyfile="$SHELL_BUNDLE_DIR/deploy/Caddyfile.production"
+  local source_compose="$SHELL_BUNDLE_DIR/deploy/$COMPOSE_FILE"
   local source_diagnose="$SHELL_BUNDLE_DIR/scripts/diagnose_web.sh"
   local shell_root
   shell_root="$(cd "$DEPLOY_DIR/.." && pwd)"
@@ -230,11 +231,17 @@ sync_shell_bundle() {
     exit 1
   fi
 
+  if [ ! -f "$source_compose" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing deploy/$COMPOSE_FILE: $source_compose" >&2
+    exit 1
+  fi
+
   echo "Syncing production shell bundle from: $SHELL_BUNDLE_DIR"
   rm -rf "$shell_root/frontend"
   mkdir -p "$shell_root/frontend" "$shell_root/scripts"
   cp -R "$source_frontend/." "$shell_root/frontend/"
   cp "$source_caddyfile" "$DEPLOY_DIR/Caddyfile.production"
+  cp "$source_compose" "$DEPLOY_DIR/$COMPOSE_FILE"
   rm -f "$shell_root/scripts/diagnose_web.sh"
 
   if [ -f "$source_diagnose" ]; then

--- a/scripts/diagnose_web.sh
+++ b/scripts/diagnose_web.sh
@@ -12,7 +12,12 @@ BASE_URL="${BASE_URL:-}"
 CHECK_CADDY_CONFIG_ONLY=0
 SKIP_CADDY_VALIDATE=0
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-15}"
+CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID:-}"
+CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET:-}"
+ADMIN_CANARY_PATH="${ADMIN_CANARY_PATH:-/api/v1/admin/status}"
 FAILURES=0
+ACCESS_HEADERS_ENABLED=0
+declare -a ACCESS_CURL_HEADERS=()
 
 usage() {
     cat <<'EOF'
@@ -28,6 +33,9 @@ Environment:
   BASE_URL                   Same as --base-url.
   PRODUCTION_DOMAIN          Used to derive https://<domain> when BASE_URL is omitted.
   TIMEOUT_SECONDS            Per-request curl timeout, default 15.
+  CF_ACCESS_CLIENT_ID        Optional Cloudflare Access service-token client id for private probes.
+  CF_ACCESS_CLIENT_SECRET    Optional Cloudflare Access service-token secret for private probes.
+  ADMIN_CANARY_PATH          Admin/backend canary path, default /api/v1/admin/status.
 EOF
 }
 
@@ -89,6 +97,24 @@ fail() {
     FAILURES=$((FAILURES + 1))
 }
 
+configure_private_probe_headers() {
+    if [[ -z "${CF_ACCESS_CLIENT_ID}" && -z "${CF_ACCESS_CLIENT_SECRET}" ]]; then
+        return 0
+    fi
+
+    if [[ -z "${CF_ACCESS_CLIENT_ID}" || -z "${CF_ACCESS_CLIENT_SECRET}" ]]; then
+        fail "CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be provided together for private Access probes."
+        return 1
+    fi
+
+    ACCESS_CURL_HEADERS=(
+        -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}"
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}"
+    )
+    ACCESS_HEADERS_ENABLED=1
+    pass "Cloudflare Access service-token headers enabled for private probes."
+}
+
 validate_caddy_config() {
     if [[ "${SKIP_CADDY_VALIDATE}" -eq 1 ]]; then
         warn "Skipping local Caddyfile validation by request."
@@ -135,15 +161,19 @@ curl_probe() {
     local status=""
     local content_type=""
 
-    status="$(
-        curl -sS \
-            --max-time "${TIMEOUT_SECONDS}" \
-            -D "${headers_file}" \
-            -o "${body_file}" \
-            -w '%{http_code}' \
-            "$@" \
-            "${url}"
-    )" || return 1
+    local -a curl_args=(
+        -sS
+        --max-time "${TIMEOUT_SECONDS}"
+        -D "${headers_file}"
+        -o "${body_file}"
+        -w '%{http_code}'
+    )
+
+    if [[ "${ACCESS_HEADERS_ENABLED}" -eq 1 ]]; then
+        curl_args+=("${ACCESS_CURL_HEADERS[@]}")
+    fi
+
+    status="$(curl "${curl_args[@]}" "$@" "${url}")" || return 1
 
     content_type="$(
         awk '
@@ -339,6 +369,9 @@ run_http_probes() {
 
     echo "== Edge routing probes =="
     echo "Base URL: ${BASE_URL}"
+    if [[ "${ACCESS_HEADERS_ENABLED}" -eq 1 ]]; then
+        echo "Private probe mode: Cloudflare Access service token headers enabled."
+    fi
 
     assert_html_200 "spa-root" "/"
     assert_html_200 "spa-bmi" "/bmi"
@@ -368,12 +401,14 @@ run_http_probes() {
     assert_not_spa_html "legacy-premium-targets-get" "/premium_targets"
     assert_not_spa_html "legacy-bmi-calculator-get" "/legacy/bmi-calculator"
     assert_json_backend "api-prefix" "/api/v1/does-not-exist"
+    assert_json_backend "admin-canary" "${ADMIN_CANARY_PATH}"
     assert_ws_not_spa
 }
 
 echo "PulsePlate web-shell diagnosis"
 echo "Repo root: ${REPO_ROOT}"
 
+configure_private_probe_headers
 validate_caddy_config
 
 if [[ "${CHECK_CADDY_CONFIG_ONLY}" -eq 0 ]]; then

--- a/scripts/diagnose_web.sh
+++ b/scripts/diagnose_web.sh
@@ -280,6 +280,35 @@ assert_json_backend() {
     pass "${label}: ${path} reached the backend JSON surface (status ${status})."
 }
 
+assert_xml_sitemap() {
+    local label="$1"
+    local path="$2"
+    local probe=""
+    probe="$(curl_probe "${label}" "${BASE_URL}${path}")" || {
+        fail "${label}: request to ${BASE_URL}${path} failed."
+        return
+    }
+
+    IFS='|' read -r status content_type _headers body_file <<<"${probe}"
+    if [[ "${status}" != "200" ]]; then
+        fail "${label}: expected HTTP 200, got ${status}."
+        return
+    fi
+    if [[ "${content_type}" != application/xml* && "${content_type}" != text/xml* ]]; then
+        fail "${label}: expected XML sitemap content-type, got '${content_type:-<empty>}' ."
+        return
+    fi
+    if looks_like_spa_shell "${body_file}"; then
+        fail "${label}: ${path} fell through to the SPA shell."
+        return
+    fi
+    if ! grep -q "<urlset" "${body_file}"; then
+        fail "${label}: response body does not look like a sitemap."
+        return
+    fi
+    pass "${label}: ${path} reaches the XML sitemap surface."
+}
+
 assert_ws_not_spa() {
     local label="websocket-upgrade"
     local probe=""
@@ -319,6 +348,7 @@ run_http_probes() {
 
     assert_json_200 "health-json" "/health"
     assert_json_backend "openapi-json" "/openapi.json"
+    assert_xml_sitemap "sitemap-xml" "/sitemap.xml"
     assert_json_backend \
         "legacy-bmi-post" \
         "/bmi" \

--- a/scripts/diagnose_web.sh
+++ b/scripts/diagnose_web.sh
@@ -310,6 +310,35 @@ assert_json_backend() {
     pass "${label}: ${path} reached the backend JSON surface (status ${status})."
 }
 
+assert_admin_canary() {
+    local label="$1"
+    local path="$2"
+    local probe=""
+    probe="$(curl_probe "${label}" "${BASE_URL}${path}")" || {
+        fail "${label}: request to ${BASE_URL}${path} failed."
+        return
+    }
+
+    IFS='|' read -r status content_type _headers body_file <<<"${probe}"
+    if [[ "${status}" == "404" ]]; then
+        fail "${label}: ${path} returned 404, so the admin canary route is missing or misrouted."
+        return
+    fi
+    if [[ "${status}" =~ ^5 ]]; then
+        fail "${label}: backend probe returned server error ${status}."
+        return
+    fi
+    if [[ "${content_type}" != application/json* ]]; then
+        fail "${label}: expected backend JSON, got '${content_type:-<empty>}' ."
+        return
+    fi
+    if ! grep -Eq '^[[:space:]]*[\{\[]' "${body_file}"; then
+        fail "${label}: backend probe body does not look like JSON."
+        return
+    fi
+    pass "${label}: ${path} reached the admin/backend canary surface (status ${status})."
+}
+
 assert_xml_sitemap() {
     local label="$1"
     local path="$2"
@@ -401,7 +430,7 @@ run_http_probes() {
     assert_not_spa_html "legacy-premium-targets-get" "/premium_targets"
     assert_not_spa_html "legacy-bmi-calculator-get" "/legacy/bmi-calculator"
     assert_json_backend "api-prefix" "/api/v1/does-not-exist"
-    assert_json_backend "admin-canary" "${ADMIN_CANARY_PATH}"
+    assert_admin_canary "admin-canary" "${ADMIN_CANARY_PATH}"
     assert_ws_not_spa
 }
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -130,7 +130,7 @@ A standalone new test file may not be included in diff-cover's comparison, causi
 
 **Example (PR-490B)**: Coverage-tail tests for `core/bmi/engine.py` were moved from a standalone file into `tests/test_bmi_visualization_spec.py` (already modified in the PR) to ensure diff-cover correctly detects coverage.
 
-**Tier 1 `test-pr` routing** (`.github/workflows/ci.yml`): PRs that select the `route_contract_safety` contract group also run `tests/test_food_search_foundation.py`, `tests/test_foods_router_coverage_boost.py`, `tests/test_metrics.py`, plus `tests/test_judgment_core.py`, `tests/test_judgment_eval_contract.py`, and `tests/test_creative_research_eval_contract.py` so `coverage.xml` used by the `diff-coverage` job includes food/Meili/metrics paths under `app/` and core judgment / creative-research contract paths under `core/`.
+**Tier 1 `test-pr` routing** (`.github/workflows/ci.yml`): PRs that select the `route_contract_safety` contract group also run `tests/test_api.py`, `tests/test_app_endpoints_combined.py`, `tests/test_app_error_handling_combined.py`, `tests/test_app_extended_coverage.py`, `tests/test_food_search_foundation.py`, `tests/test_foods_router_coverage_boost.py`, `tests/test_metrics.py`, plus `tests/test_judgment_core.py`, `tests/test_judgment_eval_contract.py`, and `tests/test_creative_research_eval_contract.py` so `coverage.xml` used by the `diff-coverage` job includes route/public-discovery, food/Meili/metrics paths under `app/`, and core judgment / creative-research contract paths under `core/`.
 
 ### Reliable local diff-cover check (prevents phantom gaps)
 

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -10,6 +10,7 @@ These are "easy coverage" tests that cover basic monitoring endpoints and app pa
 
 import os
 import sys
+from xml.etree import ElementTree
 from fastapi.testclient import TestClient
 
 import app as apppkg
@@ -93,10 +94,19 @@ class TestHealthAndMonitoringEndpoints:
         response = client.get("/sitemap.xml")
 
         assert response.status_code == 200
-        body = response.text
-        assert "https://pulseplate.app/" in body
-        assert "https://pulseplate.app/privacy" in body
-        assert "http://testserver/" not in body
+        sitemap_root = ElementTree.fromstring(response.text)
+        namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        loc_values = {
+            loc.text
+            for loc in sitemap_root.findall("sitemap:url/sitemap:loc", namespace)
+            if loc.text is not None
+        }
+        assert loc_values == {
+            "https://pulseplate.app/",
+            "https://pulseplate.app/privacy",
+            "https://pulseplate.app/terms",
+            "https://pulseplate.app/legacy/bmi-calculator",
+        }
 
     def test_favicon_endpoint(self, client: TestClient) -> None:
         """Test /favicon.ico returns 200 OK, 204 No Content, or 404 if not found"""

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -82,6 +82,22 @@ class TestHealthAndMonitoringEndpoints:
         assert "http://testserver/terms" in body
         assert "http://testserver/legacy/bmi-calculator" in body
 
+    def test_sitemap_endpoint_prefers_configured_production_domain(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Configured production host wins over direct-origin/testserver hostnames."""
+        monkeypatch.setenv("PRODUCTION_DOMAIN", "pulseplate.app")
+
+        response = client.get("/sitemap.xml")
+
+        assert response.status_code == 200
+        body = response.text
+        assert "https://pulseplate.app/" in body
+        assert "https://pulseplate.app/privacy" in body
+        assert "http://testserver/" not in body
+
     def test_favicon_endpoint(self, client: TestClient) -> None:
         """Test /favicon.ico returns 200 OK, 204 No Content, or 404 if not found"""
         response = client.get("/favicon.ico")

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -69,6 +69,19 @@ class TestHealthAndMonitoringEndpoints:
         assert "BMI Calculator" in content
         assert "form" in content.lower()
 
+    def test_sitemap_endpoint_serves_public_routes(self, client: TestClient) -> None:
+        """Test /sitemap.xml serves the canonical public discovery surface."""
+        response = client.get("/sitemap.xml")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/xml")
+
+        body = response.text
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in body
+        assert "http://testserver/" in body
+        assert "http://testserver/privacy" in body
+        assert "http://testserver/terms" in body
+        assert "http://testserver/legacy/bmi-calculator" in body
+
     def test_favicon_endpoint(self, client: TestClient) -> None:
         """Test /favicon.ico returns 200 OK, 204 No Content, or 404 if not found"""
         response = client.get("/favicon.ico")

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -8,12 +8,15 @@ EN: Combined tests for app endpoints: health, monitoring, root and package shim 
 These are "easy coverage" tests that cover basic monitoring endpoints and app package behavior.
 """
 
+import asyncio
 import os
 import sys
 from xml.etree import ElementTree
+from fastapi import Request
 from fastapi.testclient import TestClient
 
 import app as apppkg
+from app.bootstrap import public_discovery
 import pytest
 
 
@@ -70,18 +73,31 @@ class TestHealthAndMonitoringEndpoints:
         assert "BMI Calculator" in content
         assert "form" in content.lower()
 
-    def test_sitemap_endpoint_serves_public_routes(self, client: TestClient) -> None:
+    def test_sitemap_endpoint_serves_public_routes(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test /sitemap.xml serves the canonical public discovery surface."""
+        monkeypatch.delenv("PRODUCTION_DOMAIN", raising=False)
+
         response = client.get("/sitemap.xml")
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/xml")
 
-        body = response.text
-        assert '<?xml version="1.0" encoding="UTF-8"?>' in body
-        assert "http://testserver/" in body
-        assert "http://testserver/privacy" in body
-        assert "http://testserver/terms" in body
-        assert "http://testserver/legacy/bmi-calculator" in body
+        sitemap_root = ElementTree.fromstring(response.text)
+        namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        loc_values = {
+            loc.text
+            for loc in sitemap_root.findall("sitemap:url/sitemap:loc", namespace)
+            if loc.text is not None
+        }
+        assert loc_values == {
+            "http://testserver/",
+            "http://testserver/privacy",
+            "http://testserver/terms",
+            "http://testserver/legacy/bmi-calculator",
+        }
 
     def test_sitemap_endpoint_prefers_configured_production_domain(
         self,
@@ -195,3 +211,84 @@ class TestAppPackageShimEdges:
         """Test that getattr raises AttributeError for missing attributes."""
         with pytest.raises(AttributeError):
             getattr(apppkg, "__definitely_missing_attribute__")  # noqa: B009
+
+
+class TestPublicDiscoveryHelpers:
+    """Unit coverage for public sitemap helper branches."""
+
+    @staticmethod
+    def _request_for_host(host: str, *, scheme: str = "https") -> Request:
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": scheme,
+            "path": public_discovery.SITEMAP_ROUTE_PATH,
+            "raw_path": public_discovery.SITEMAP_ROUTE_PATH.encode("utf-8"),
+            "root_path": "",
+            "query_string": b"",
+            "headers": [(b"host", host.encode("utf-8"))],
+            "client": ("127.0.0.1", 12345),
+            "server": (host, 443 if scheme == "https" else 80),
+        }
+        return Request(scope)
+
+    def test_build_public_url_normalizes_base_and_path(self) -> None:
+        """Builder normalizes base/path separators before joining URLs."""
+        public_url = public_discovery._build_public_url(
+            base_url="https://pulseplate.app",
+            path="privacy",
+        )
+        assert public_url == "https://pulseplate.app/privacy"
+
+    def test_build_public_sitemap_xml_escapes_query_values(self) -> None:
+        """XML builder escapes query separators and keeps canonical loc entries."""
+        sitemap_xml = public_discovery.build_public_sitemap_xml(
+            base_url="https://pulseplate.app",
+            paths=("privacy", "/terms?utm=summer&ref=share"),
+        )
+
+        assert sitemap_xml.startswith('<?xml version="1.0" encoding="UTF-8"?>')
+        assert "<loc>https://pulseplate.app/privacy</loc>" in sitemap_xml
+        assert "<loc>https://pulseplate.app/terms?utm=summer&amp;ref=share</loc>" in sitemap_xml
+
+    def test_resolve_public_sitemap_base_url_prefers_sanitized_production_domain(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Configured production domain wins after quote/scheme/trailing-slash cleanup."""
+        monkeypatch.setenv(public_discovery.PRODUCTION_DOMAIN_ENV, ' "http://pulseplate.app/" ')
+
+        resolved_base_url = public_discovery.resolve_public_sitemap_base_url(
+            self._request_for_host("direct-origin.internal")
+        )
+
+        assert resolved_base_url == "https://pulseplate.app"
+
+    def test_resolve_public_sitemap_base_url_falls_back_to_request_host(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing production domain falls back to the direct request base URL."""
+        monkeypatch.delenv(public_discovery.PRODUCTION_DOMAIN_ENV, raising=False)
+
+        resolved_base_url = public_discovery.resolve_public_sitemap_base_url(
+            self._request_for_host("edge.pulseplate.test")
+        )
+
+        assert resolved_base_url == "https://edge.pulseplate.test/"
+
+    def test_serve_public_sitemap_returns_xml_response(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Async response helper returns XML with canonical public URLs."""
+        monkeypatch.delenv(public_discovery.PRODUCTION_DOMAIN_ENV, raising=False)
+
+        response = asyncio.run(
+            public_discovery.serve_public_sitemap(self._request_for_host("edge.pulseplate.test"))
+        )
+
+        assert response.media_type == "application/xml"
+        assert response.body.startswith(b'<?xml version="1.0" encoding="UTF-8"?>')
+        assert b"https://edge.pulseplate.test/privacy" in response.body

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -830,6 +830,11 @@ case "$method:$url" in
     content_type="application/json"
     payload='{"ok": true}'
     ;;
+  GET:https://pulseplate.test/sitemap.xml)
+    status="200"
+    content_type="application/xml"
+    payload='<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>https://pulseplate.test/</loc></url></urlset>'
+    ;;
   POST:https://pulseplate.test/bmi)
     status="422"
     content_type="application/json"
@@ -884,6 +889,7 @@ printf '%s' "$status"
 
     assert "PASS: spa-bmi: /bmi serves the SPA shell with HTTP 200." in completed.stdout
     assert "PASS: health-json: /health reaches the JSON backend surface." in completed.stdout
+    assert "PASS: sitemap-xml: /sitemap.xml reaches the XML sitemap surface." in completed.stdout
     assert (
         "PASS: legacy-bmi-post: /bmi reached the backend JSON surface (status 422)."
         in completed.stdout

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -625,6 +625,170 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
 
 
+def test_deploy_production_autodetects_deploy_subdir_compose_and_env_file(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    deploy_dir = project_dir / "deploy"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    deploy_dir.mkdir()
+    bin_dir.mkdir()
+    (deploy_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (deploy_dir / ".env").write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
+                "PRODUCTION_DOMAIN=pulseplate.test",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"/deploy/.env -f deploy/docker-compose.production.yaml ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env.pop("COMPOSE_FILE", None)
+    env.pop("ENV_FILE", None)
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert any(
+        "compose --env-file" in line
+        and f"{deploy_dir / '.env'} -f deploy/docker-compose.production.yaml pull app" in line
+        for line in log_lines
+    )
+    assert any(
+        "compose --env-file" in line
+        and f"{deploy_dir / '.env'} -f deploy/docker-compose.production.yaml up -d --remove-orphans caddy"
+        in line
+        for line in log_lines
+    )
+
+
+def test_deploy_production_rejects_compose_file_outside_deploy_dir_during_shell_sync(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_root = project_dir.parent
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    outside_dir = tmp_path / "outside"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    shell_bundle_dir.mkdir()
+    outside_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / ".env").write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
+                "PRODUCTION_DOMAIN=pulseplate.test",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (outside_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (shell_bundle_dir / "frontend").mkdir()
+    (shell_bundle_dir / "frontend" / "bundle-marker.txt").write_text(
+        "frontend-sync\n", encoding="utf-8"
+    )
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
+    )
+    (shell_root / "scripts").mkdir()
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = str(outside_dir / "docker-compose.production.yaml")
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "COMPOSE_FILE must stay within DEPLOY_DIR" in completed.stderr
+
+
 def test_deploy_production_exits_non_zero_when_migrations_fail(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -534,6 +534,97 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
 
 
+def test_deploy_production_syncs_shell_bundle_with_relative_compose_subpath(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_root = project_dir.parent
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    (project_dir / "deploy").mkdir()
+    shell_bundle_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        "services: {}\n",
+        encoding="utf-8",
+    )
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "frontend").mkdir()
+    (shell_bundle_dir / "frontend" / "bundle-marker.txt").write_text(
+        "frontend-sync\n", encoding="utf-8"
+    )
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        "services:\n  app:\n    image: ghcr.io/example/pulseplate:test\n",
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
+    )
+    (shell_root / "scripts").mkdir()
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"-f deploy/docker-compose.production.yaml ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "deploy/docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert (project_dir / "deploy" / "docker-compose.production.yaml").read_text(
+        encoding="utf-8"
+    ) == "services:\n  app:\n    image: ghcr.io/example/pulseplate:test\n"
+    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+        encoding="utf-8"
+    ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
+
+
 def test_deploy_production_exits_non_zero_when_migrations_fail(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -447,6 +447,93 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
 
 
+def test_deploy_production_syncs_shell_bundle_with_autodetected_compose_file(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_root = project_dir.parent
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    shell_bundle_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "frontend").mkdir()
+    (shell_bundle_dir / "frontend" / "bundle-marker.txt").write_text(
+        "frontend-sync\n", encoding="utf-8"
+    )
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        "services:\n  caddy:\n    image: caddy:2.10.2\n",
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
+    )
+    (shell_root / "scripts").mkdir()
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"-f docker-compose.production.yaml ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env.pop("COMPOSE_FILE", None)
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert (project_dir / "docker-compose.production.yaml").read_text(
+        encoding="utf-8"
+    ) == "services:\n  caddy:\n    image: caddy:2.10.2\n"
+    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+        encoding="utf-8"
+    ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
+
+
 def test_deploy_production_exits_non_zero_when_migrations_fail(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     bin_dir = tmp_path / "bin"
@@ -922,7 +1009,7 @@ printf '%s' "$status"
         in completed.stdout
     )
     assert (
-        "PASS: admin-canary: /api/v1/admin/status reached the backend JSON surface"
+        "PASS: admin-canary: /api/v1/admin/status reached the admin/backend canary surface"
         in completed.stdout
     )
     assert "PASS: websocket-upgrade: /ws did not fall through to SPA" in completed.stdout
@@ -995,10 +1082,15 @@ case "$method:$url" in
     content_type="application/json"
     payload='{{"detail": "Method Not Allowed"}}'
     ;;
-  GET:https://pulseplate.test/plan|GET:https://pulseplate.test/insight|GET:https://pulseplate.test/premium_bmr|GET:https://pulseplate.test/premium_targets|GET:https://pulseplate.test/api/v1/does-not-exist|GET:https://pulseplate.test/api/v1/admin/status)
+  GET:https://pulseplate.test/plan|GET:https://pulseplate.test/insight|GET:https://pulseplate.test/premium_bmr|GET:https://pulseplate.test/premium_targets|GET:https://pulseplate.test/api/v1/does-not-exist)
     status="404"
     content_type="application/json"
     payload='{{"detail": "not found"}}'
+    ;;
+  GET:https://pulseplate.test/api/v1/admin/status)
+    status="403"
+    content_type="application/json"
+    payload='{{"detail": "forbidden"}}'
     ;;
   GET:https://pulseplate.test/legacy/bmi-calculator)
     status="200"
@@ -1044,6 +1136,119 @@ printf '%s' "$status"
     assert "-H CF-Access-Client-Secret: client-secret" in log_output
     assert (
         "PASS: Cloudflare Access service-token headers enabled for private probes."
+        in completed.stdout
+    )
+
+
+def test_diagnose_web_fails_when_admin_canary_route_is_missing(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+    curl_stub = """#!/usr/bin/env bash
+set -euo pipefail
+headers=""
+body=""
+url=""
+method="GET"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    -D)
+      headers="$2"
+      shift 2
+      ;;
+    -o)
+      body="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+status="418"
+content_type="text/plain"
+payload="unexpected"
+case "$method:$url" in
+  GET:https://pulseplate.test/|GET:https://pulseplate.test/bmi|GET:https://pulseplate.test/profile|GET:https://pulseplate.test/plate|GET:https://pulseplate.test/progress)
+    status="200"
+    content_type="text/html; charset=utf-8"
+    payload='<!doctype html><html><body><div id="root"></div></body></html>'
+    ;;
+  GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
+    status="200"
+    content_type="application/json"
+    payload='{"ok": true}'
+    ;;
+  GET:https://pulseplate.test/sitemap.xml)
+    status="200"
+    content_type="application/xml"
+    payload='<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>https://pulseplate.test/</loc></url></urlset>'
+    ;;
+  POST:https://pulseplate.test/bmi)
+    status="422"
+    content_type="application/json"
+    payload='{"detail": "validation"}'
+    ;;
+  OPTIONS:https://pulseplate.test/bmi)
+    status="405"
+    content_type="application/json"
+    payload='{"detail": "Method Not Allowed"}'
+    ;;
+  GET:https://pulseplate.test/plan|GET:https://pulseplate.test/insight|GET:https://pulseplate.test/premium_bmr|GET:https://pulseplate.test/premium_targets|GET:https://pulseplate.test/api/v1/does-not-exist|GET:https://pulseplate.test/api/v1/admin/status)
+    status="404"
+    content_type="application/json"
+    payload='{"detail": "not found"}'
+    ;;
+  GET:https://pulseplate.test/legacy/bmi-calculator)
+    status="200"
+    content_type="text/html; charset=utf-8"
+    payload='<!doctype html><html><body><h1>Legacy calculator</h1></body></html>'
+    ;;
+  GET:https://pulseplate.test/ws)
+    status="400"
+    content_type="text/plain"
+    payload='upgrade required'
+    ;;
+esac
+
+printf 'HTTP/1.1 %s Stub\\nContent-Type: %s\\n\\n' "$status" "$content_type" > "$headers"
+printf '%s' "$payload" > "$body"
+printf '%s' "$status"
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    completed = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts/diagnose_web.sh"),
+            "--skip-caddy-validate",
+            "--base-url",
+            "https://pulseplate.test",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert (
+        "FAIL: admin-canary: /api/v1/admin/status returned 404, so the admin canary route is missing or misrouted."
         in completed.stdout
     )
 

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -373,6 +373,10 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
         'pulseplate.test {\n    respond "ok"\n}\n',
         encoding="utf-8",
     )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        "services:\n  caddy:\n    image: caddy:2.10.2\n",
+        encoding="utf-8",
+    )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
@@ -434,6 +438,9 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
         .read_text(encoding="utf-8")
         .startswith("pulseplate.test")
     )
+    assert (project_dir / "docker-compose.production.yaml").read_text(
+        encoding="utf-8"
+    ) == "services:\n  caddy:\n    image: caddy:2.10.2\n"
     assert not (shell_root / "frontend" / "stale.txt").exists()
     assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
@@ -539,6 +546,10 @@ def test_deploy_production_keeps_shell_bundle_untouched_when_migrations_fail(
     (shell_bundle_dir / "deploy").mkdir()
     (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
         'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        "services:\n  caddy:\n    image: caddy:2.10.2\n",
         encoding="utf-8",
     )
     (shell_bundle_dir / "scripts").mkdir()
@@ -828,7 +839,7 @@ case "$method:$url" in
   GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
     status="200"
     content_type="application/json"
-    payload='{"ok": true}'
+    payload='{{"ok": true}}'
     ;;
   GET:https://pulseplate.test/sitemap.xml)
     status="200"
@@ -849,6 +860,11 @@ case "$method:$url" in
     status="404"
     content_type="application/json"
     payload='{"detail": "not found"}'
+    ;;
+  GET:https://pulseplate.test/api/v1/admin/status)
+    status="403"
+    content_type="application/json"
+    payload='{"detail": "forbidden"}'
     ;;
   GET:https://pulseplate.test/legacy/bmi-calculator)
     status="200"
@@ -905,8 +921,161 @@ printf '%s' "$status"
         "PASS: api-prefix: /api/v1/does-not-exist reached the backend JSON surface"
         in completed.stdout
     )
+    assert (
+        "PASS: admin-canary: /api/v1/admin/status reached the backend JSON surface"
+        in completed.stdout
+    )
     assert "PASS: websocket-upgrade: /ws did not fall through to SPA" in completed.stdout
     assert "Summary: all requested checks passed." in completed.stdout
+
+
+def test_diagnose_web_uses_cloudflare_access_service_token_headers(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "diag-access.log"
+    bin_dir.mkdir()
+
+    docker_stub = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+headers=""
+body=""
+url=""
+method="GET"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    -D)
+      headers="$2"
+      shift 2
+      ;;
+    -o)
+      body="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+status="418"
+content_type="text/plain"
+payload="unexpected"
+case "$method:$url" in
+  GET:https://pulseplate.test/|GET:https://pulseplate.test/bmi|GET:https://pulseplate.test/profile|GET:https://pulseplate.test/plate|GET:https://pulseplate.test/progress)
+    status="200"
+    content_type="text/html; charset=utf-8"
+    payload='<!doctype html><html><body><div id="root"></div></body></html>'
+    ;;
+  GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
+    status="200"
+    content_type="application/json"
+    payload='{{"ok": true}}'
+    ;;
+  GET:https://pulseplate.test/sitemap.xml)
+    status="200"
+    content_type="application/xml"
+    payload='<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>https://pulseplate.test/</loc></url></urlset>'
+    ;;
+  POST:https://pulseplate.test/bmi)
+    status="422"
+    content_type="application/json"
+    payload='{{"detail": "validation"}}'
+    ;;
+  OPTIONS:https://pulseplate.test/bmi)
+    status="405"
+    content_type="application/json"
+    payload='{{"detail": "Method Not Allowed"}}'
+    ;;
+  GET:https://pulseplate.test/plan|GET:https://pulseplate.test/insight|GET:https://pulseplate.test/premium_bmr|GET:https://pulseplate.test/premium_targets|GET:https://pulseplate.test/api/v1/does-not-exist|GET:https://pulseplate.test/api/v1/admin/status)
+    status="404"
+    content_type="application/json"
+    payload='{{"detail": "not found"}}'
+    ;;
+  GET:https://pulseplate.test/legacy/bmi-calculator)
+    status="200"
+    content_type="text/html; charset=utf-8"
+    payload='<!doctype html><html><body><h1>Legacy calculator</h1></body></html>'
+    ;;
+  GET:https://pulseplate.test/ws)
+    status="400"
+    content_type="text/plain"
+    payload='upgrade required'
+    ;;
+esac
+
+printf 'HTTP/1.1 %s Stub\\nContent-Type: %s\\n\\n' "$status" "$content_type" > "$headers"
+printf '%s' "$payload" > "$body"
+printf '%s' "$status"
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CF_ACCESS_CLIENT_ID"] = "client-id"
+    env["CF_ACCESS_CLIENT_SECRET"] = "client-secret"  # pragma: allowlist secret
+
+    completed = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts/diagnose_web.sh"),
+            "--skip-caddy-validate",
+            "--base-url",
+            "https://pulseplate.test",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_output = log_file.read_text(encoding="utf-8")
+    assert "-H CF-Access-Client-Id: client-id" in log_output
+    assert "-H CF-Access-Client-Secret: client-secret" in log_output
+    assert (
+        "PASS: Cloudflare Access service-token headers enabled for private probes."
+        in completed.stdout
+    )
+
+
+def test_diagnose_web_rejects_partial_cloudflare_access_service_token_env(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker_stub = "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CF_ACCESS_CLIENT_ID"] = "client-id"
+    env.pop("CF_ACCESS_CLIENT_SECRET", None)
+
+    completed = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/diagnose_web.sh"), "--check-caddy-config-only"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert (
+        "FAIL: CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be provided together"
+        in completed.stdout
+    )
 
 
 def test_diagnose_web_fails_without_base_url_for_http_probes(tmp_path: Path) -> None:

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -703,6 +703,83 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
 
 
+def test_deploy_production_uses_deploy_env_file_for_absolute_deploy_compose_path(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    deploy_dir = project_dir / "deploy"
+    compose_file = deploy_dir / "docker-compose.production.yaml"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    deploy_dir.mkdir()
+    bin_dir.mkdir()
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    (deploy_dir / ".env").write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
+                "PRODUCTION_DOMAIN=pulseplate.test",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+case "$*" in
+  *"compose --env-file "*"/deploy/.env -f {compose_file} ps -q app"*)
+    printf 'app-id\\n'
+    ;;
+  *"inspect --format "*)
+    printf 'healthy\\n'
+    ;;
+  *"ps --format "*)
+    printf 'CONTAINER ID\\n'
+    ;;
+esac
+"""
+    curl_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\\n' "$*" >> "{log_file}"
+"""
+    sleep_stub = "#!/usr/bin/env bash\nset -euo pipefail\n"
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+    _write_executable(bin_dir / "sleep", sleep_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["COMPOSE_FILE"] = str(compose_file)
+    env.pop("ENV_FILE", None)
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert any(
+        "compose --env-file" in line and f"{deploy_dir / '.env'} -f {compose_file} pull app" in line
+        for line in log_lines
+    )
+    assert any(
+        "compose --env-file" in line
+        and f"{deploy_dir / '.env'} -f {compose_file} up -d --remove-orphans caddy" in line
+        for line in log_lines
+    )
+
+
 def test_deploy_production_rejects_compose_file_outside_deploy_dir_during_shell_sync(
     tmp_path: Path,
 ) -> None:
@@ -1181,7 +1258,7 @@ case "$method:$url" in
   GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
     status="200"
     content_type="application/json"
-    payload='{{"ok": true}}'
+    payload='{"ok": true}'
     ;;
   GET:https://pulseplate.test/sitemap.xml)
     status="200"

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -258,6 +258,55 @@ printf 'docker %s\\n' "$*" >> "{log_file}"
     assert not log_file.exists()
 
 
+def test_deploy_production_fails_fast_when_resolved_compose_file_is_missing(tmp_path: Path) -> None:
+    project_dir = tmp_path / "production"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "deploy.log"
+    project_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / ".env").write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate",  # pragma: allowlist secret
+                "PRODUCTION_DOMAIN=pulseplate.test",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = str(project_dir / "missing-compose.yaml")
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh"), "--preflight-only"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert (
+        f"RESOLVED_COMPOSE_FILE does not exist: {project_dir / 'missing-compose.yaml'}"
+        in completed.stderr
+    )
+    assert not log_file.exists()
+
+
 def test_deploy_production_logs_in_to_ghcr_with_resolved_docker_binary(tmp_path: Path) -> None:
     project_dir = tmp_path / "production"
     docker_home = tmp_path / "docker-home"


### PR DESCRIPTION
## Summary
- keep the recovery lane private-first by documenting and supporting full-host Cloudflare Access while the apex is not ready for public traffic
- make `/sitemap.xml` deterministic for production by preferring `PRODUCTION_DOMAIN` over temporary direct-origin or bypass hostnames
- extend `diagnose_web.sh` for Access-protected recovery with Cloudflare service-token headers and an admin/backend canary probe
- tighten the production shell bundle contract so emergency sync includes the canonical compose file, not only Caddy/frontend assets
- codify the public reopen contract as a narrow temporary bypass for shell/discovery GET paths while keeping `/api*`, `/admin*`, `/ws*`, and ops/docs surfaces protected

## Why Separate
- this remains the single recovery vehicle for PR `#1385`
- scope is intentionally limited to recovery-safe app behavior, diagnostics, deploy contract, and ops/runbook guidance
- CSP hardening and longer-term Cloudflare policy cleanup stay out of this recovery lane

## Split Justification
This PR crosses the normal size threshold because the recovery contract has to land atomically across app behavior, deploy/diagnostic scripts, and operator runbooks. Splitting those pieces would create unsafe intermediate states where `/sitemap.xml` behavior, production rollout steps, and recovery verification instructions disagree during an active apex recovery. The remaining follow-up after this lane is the separate Cloudflare reopen automation item tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-cloudflare-narrow-reopen-automation`.

## Changes
- `app/bootstrap/public_discovery.py`
  - add canonical sitemap base URL resolution via `PRODUCTION_DOMAIN`
  - keep `/sitemap.xml` stable even when recovery uses direct-origin or temporary bypass hosts
- `scripts/diagnose_web.sh`
  - support `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` for private Access probes
  - add `/api/v1/admin/status` as a backend/admin canary so reopen checks catch accidental SPA/public exposure
- `scripts/deploy_production.sh`
  - sync `deploy/docker-compose.production.yaml` together with the rest of the shell bundle
- docs / runbooks
  - document full-host Cloudflare Access as the preferred hide mode during recovery
  - document that public scanners are not release-truth while Access/interstitials are active
  - document the narrow temporary reopen allowlist for shell/discovery paths only
- governance
  - add canonical review artifact `docs/review/PR_1385_FIXED_MAPPING.md`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_app_endpoints_combined.py tests/test_deploy_contract_scripts.py`
- `pre-commit run --all-files`
- `make verify`

## Production Findings
- Cloudflare Access API surfaces are reachable from the current token; zone firewall/settings endpoints still return `9109 Unauthorized`
- this means Access-based hide/recovery can be automated with the current token, but narrow temporary reopen bypass automation still needs broader zone firewall/ruleset permissions or a dashboard/manual step
- while full-host Access or an interstitial is in front of the apex, MDN Observatory and public header scans are not release-truth

## Next Actions
- keep `pulseplate.app` private with full-host Cloudflare Access until the new production app image is deployed and private verification passes
- merge PR `#1385`, deploy the new app image, and verify `/` + `/sitemap.xml` privately through Access
- only then remove Access and apply the documented narrow temporary public bypass for shell/discovery paths
- rerun public root/sitemap checks, MDN Observatory, and SSL Labs after reopen

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1385_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [x] All review threads resolved on GitHub after disposition updates
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

## Summary by Sourcery

Обеспечить, чтобы восстановление production apex оставалось в первую очередь приватным, одновременно стабилизируя поведение sitemap, диагностик и деплой-контрактов для web shell.

Новые возможности:
- Обслуживать принадлежащий backend эндпоинт `/sitemap.xml`, который генерирует канонические публичные URL, отдавая предпочтение настроенному production-домену вместо временных хостов.
- Добавить поддержку service-token для Cloudflare Access и канарейечный probe для админского/backend-доступа в диагностический скрипт web-приложения для проверки приватного восстановления.

Улучшения:
- Расширить production-скрипт деплоя, чтобы он синхронизировал канонический `docker-compose.production.yaml` вместе с `Caddyfile` и фронтенд-ассетами во время восстановления shell bundle.
- Уточнить и расширить runbook-и по деплою и инцидентам в части Cloudflare challenges, приватного восстановления на базе Access и узкого публичного контракта повторного открытия для shell/discovery-путей.
- Задокументировать контракт SPA apex routing, явно включив `/sitemap.xml` как FastAPI discovery surface, и формализовать временный публичный allowlist после приватного восстановления.
- Добавить артефакт управления (governance artifact), фиксирующий соответствие «исправлено в коммите» для PR #1385, и отследить follow-up-задачу по автоматизации узкого повторного открытия через Cloudflare.

Тесты:
- Добавить тесты эндпоинта для `/sitemap.xml`, включая поведение с переопределением production-домена, а также расширить тесты скриптов деплоя/диагностики для проверки синхронизации compose и новых проверок Cloudflare Access и sitemap.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure production apex recovery remains private-first while stabilizing sitemap behavior, diagnostics, and deploy contracts for the web shell.

New Features:
- Serve a backend-owned /sitemap.xml endpoint that generates canonical public URLs, preferring the configured production domain over transient hosts.
- Add Cloudflare Access service-token support and an admin/backend canary probe to the web diagnostics script for private recovery verification.

Enhancements:
- Extend the production deploy script to sync the canonical docker-compose.production.yaml alongside the Caddyfile and frontend assets during shell bundle recovery.
- Clarify and expand deployment and incident runbooks around Cloudflare challenges, Access-based private recovery, and the narrow public reopen contract for shell/discovery paths.
- Document the SPA apex routing contract to explicitly include /sitemap.xml as a FastAPI discovery surface and codify the temporary public allowlist after private recovery.
- Add a governance artifact capturing the fixed-in-commit mapping for PR #1385 and track a follow-up item for automating Cloudflare narrow reopen behavior.

Tests:
- Add endpoint tests for /sitemap.xml, including production-domain override behavior, and extend deploy/diagnostic script tests for compose syncing and new Cloudflare Access and sitemap checks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now serves a deterministic /sitemap.xml XML sitemap for public discovery.

* **Documentation**
  * Expanded production deploy/runbook, Cloudflare recovery, routing contract, and diagnostic guidance for apex/edge incidents and recovery steps.

* **Tests**
  * Added/extended tests for sitemap behavior, deploy sync workflows, and diagnostic probes (including private-probe checks).

* **Chores**
  * Updated Caddy routing, deployment scripts, and diagnostic tooling to support sitemap routing and recovery/runbook flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->