### PR TITLE
fix(rag): harden degraded retrieval fallback

### DIFF
--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -118,6 +118,32 @@ def _resolve_confidence(
     return _mean_chunk_score(chunks_to_use)
 
 
+def _non_rag_result(
+    prompt_input: str,
+    *,
+    rag_ctx_hops: int,
+    rag_ctx_latency_ms: int,
+    warnings: list[str],
+    chunks_retrieved: int,
+    chunks_filtered: int,
+    recursive_executed: bool,
+) -> RAGOrchestrationResult:
+    """Return a non-RAG result when no usable context survives to output."""
+
+    return RAGOrchestrationResult(
+        chunks=[],
+        formatted_prompt=prompt_input,
+        rag_actually_used=False,
+        confidence=None,
+        hops=rag_ctx_hops,
+        latency_ms=rag_ctx_latency_ms,
+        warnings=warnings,
+        chunks_retrieved=chunks_retrieved,
+        chunks_filtered=chunks_filtered,
+        recursive_executed=recursive_executed,
+    )
+
+
 async def retrieve_and_validate_rag(
     prompt_input: str,
     max_chunks: int = 3,
@@ -240,13 +266,10 @@ async def _run_orchestration(
 
         # If no chunks survived validation
         if not chunks_to_use:
-            return RAGOrchestrationResult(
-                chunks=[],
-                formatted_prompt=prompt_input,
-                rag_actually_used=False,
-                confidence=None,
-                hops=rag_ctx.hops,
-                latency_ms=rag_ctx.latency_ms,
+            return _non_rag_result(
+                prompt_input,
+                rag_ctx_hops=rag_ctx.hops,
+                rag_ctx_latency_ms=rag_ctx.latency_ms,
                 warnings=warnings,
                 chunks_retrieved=len(rag_ctx.chunks),
                 chunks_filtered=chunks_filtered,
@@ -261,7 +284,27 @@ async def _run_orchestration(
         from core.insight.safety import redact_rag_context_for_insight
 
         raw_context = format_rag_chunks_for_prompt(chunks_to_use)
+        if not raw_context.strip():
+            return _non_rag_result(
+                prompt_input,
+                rag_ctx_hops=rag_ctx.hops,
+                rag_ctx_latency_ms=rag_ctx.latency_ms,
+                warnings=warnings,
+                chunks_retrieved=len(rag_ctx.chunks),
+                chunks_filtered=chunks_filtered,
+                recursive_executed=recursive_executed,
+            )
         redacted_context = redact_rag_context_for_insight(raw_context)
+        if not redacted_context.strip():
+            return _non_rag_result(
+                prompt_input,
+                rag_ctx_hops=rag_ctx.hops,
+                rag_ctx_latency_ms=rag_ctx.latency_ms,
+                warnings=warnings,
+                chunks_retrieved=len(rag_ctx.chunks),
+                chunks_filtered=chunks_filtered,
+                recursive_executed=recursive_executed,
+            )
         formatted_prompt = _build_prompt_with_context(prompt_input, redacted_context)
 
         return RAGOrchestrationResult(

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -118,6 +118,12 @@ def _resolve_confidence(
     return _mean_chunk_score(chunks_to_use)
 
 
+def _has_context_text(value: object) -> bool:
+    """Return whether a context payload is a non-empty string."""
+
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _non_rag_result(
     prompt_input: str,
     *,
@@ -284,7 +290,7 @@ async def _run_orchestration(
         from core.insight.safety import redact_rag_context_for_insight
 
         raw_context = format_rag_chunks_for_prompt(chunks_to_use)
-        if not raw_context.strip():
+        if not _has_context_text(raw_context):
             return _non_rag_result(
                 prompt_input,
                 rag_ctx_hops=rag_ctx.hops,
@@ -295,7 +301,7 @@ async def _run_orchestration(
                 recursive_executed=recursive_executed,
             )
         redacted_context = redact_rag_context_for_insight(raw_context)
-        if not redacted_context.strip():
+        if not _has_context_text(redacted_context):
             return _non_rag_result(
                 prompt_input,
                 rag_ctx_hops=rag_ctx.hops,

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -197,15 +197,21 @@ def retrieve_context_structured(
         ((src, ch, _score(query, ch)) for src, ch in items), key=lambda x: x[2], reverse=True
     )
     limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
-    top = [x for x in scored[:limit] if x[2] >= MIN_CHUNK_SCORE]
     chunks: list[RAGChunk] = []
-    for i, (src, ch, sc) in enumerate(top, 1):
+    # RU: Дозаполняем выдачу следующими валидными chunk'ами после редактирования.
+    # EN: Backfill with the next valid chunks after redaction removes earlier hits.
+    for src, ch, sc in scored:
+        if sc < MIN_CHUNK_SCORE:
+            continue
         redacted_content = redact_chunk_content(ch[:MAX_CHUNK_SIZE_CHARS]).strip()
         if not redacted_content:
             continue
+        chunk_position = len(chunks) + 1
         chunks.append(
             RAGChunk(
-                chunk_id=f"{Path(src).relative_to(ROOT) if Path(src).is_relative_to(ROOT) else Path(src).name}:{i}",
+                chunk_id=(
+                    f"{Path(src).relative_to(ROOT) if Path(src).is_relative_to(ROOT) else Path(src).name}:{chunk_position}"
+                ),
                 file=(
                     str(Path(src).relative_to(ROOT))
                     if Path(src).is_relative_to(ROOT)
@@ -216,6 +222,8 @@ def retrieve_context_structured(
                 hop=1,
             )
         )
+        if len(chunks) >= limit:
+            break
     confidence = sum(c.score for c in chunks) / len(chunks) if chunks else 0.0
     latency_ms = int((time.perf_counter() - start) * 1000)
     return RAGContext(

--- a/core/rag/simple_rag.py
+++ b/core/rag/simple_rag.py
@@ -198,20 +198,24 @@ def retrieve_context_structured(
     )
     limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
     top = [x for x in scored[:limit] if x[2] >= MIN_CHUNK_SCORE]
-    chunks = [
-        RAGChunk(
-            chunk_id=f"{Path(src).relative_to(ROOT) if Path(src).is_relative_to(ROOT) else Path(src).name}:{i}",
-            file=(
-                str(Path(src).relative_to(ROOT))
-                if Path(src).is_relative_to(ROOT)
-                else Path(src).name
-            ),
-            content=redact_chunk_content(ch[:MAX_CHUNK_SIZE_CHARS]),
-            score=sc,
-            hop=1,
+    chunks: list[RAGChunk] = []
+    for i, (src, ch, sc) in enumerate(top, 1):
+        redacted_content = redact_chunk_content(ch[:MAX_CHUNK_SIZE_CHARS]).strip()
+        if not redacted_content:
+            continue
+        chunks.append(
+            RAGChunk(
+                chunk_id=f"{Path(src).relative_to(ROOT) if Path(src).is_relative_to(ROOT) else Path(src).name}:{i}",
+                file=(
+                    str(Path(src).relative_to(ROOT))
+                    if Path(src).is_relative_to(ROOT)
+                    else Path(src).name
+                ),
+                content=redacted_content,
+                score=sc,
+                hop=1,
+            )
         )
-        for i, (src, ch, sc) in enumerate(top, 1)
-    ]
     confidence = sum(c.score for c in chunks) / len(chunks) if chunks else 0.0
     latency_ms = int((time.perf_counter() - start) * 1000)
     return RAGContext(

--- a/core/rag/vector_rag.py
+++ b/core/rag/vector_rag.py
@@ -18,7 +18,7 @@ import logging
 import math
 import threading
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, SupportsFloat, cast
 
 from app.utils.feature_flags import is_rag_vector_enabled
 from core.data_sanitizer import sanitize_rag_markdown
@@ -114,6 +114,53 @@ def _has_expected_embedding_dimensions(query_embedding: list[float]) -> bool:
         )
         return False
     return True
+
+
+def _normalize_embedding_vector(values: object) -> list[float] | None:
+    """Return a finite embedding vector with the configured dimensions."""
+
+    if not isinstance(values, (list, tuple)):
+        return None
+
+    numeric_values: list[float] = []
+    for value in values:
+        candidate: str | int | float | SupportsFloat
+        if isinstance(value, (str, int, float)):
+            candidate = value
+        elif hasattr(value, "__float__"):
+            candidate = cast(SupportsFloat, value)
+        else:
+            return None
+        try:
+            numeric = float(candidate)
+        except (TypeError, ValueError):
+            return None
+        numeric_values.append(numeric)
+
+    if not _has_expected_embedding_dimensions(numeric_values):
+        return None
+    if not all(math.isfinite(value) for value in numeric_values):
+        return None
+    return numeric_values
+
+
+def _normalize_similarity(value: object) -> float | None:
+    """Return a finite similarity score or ``None`` for malformed payloads."""
+
+    candidate: str | int | float | SupportsFloat
+    if isinstance(value, (str, int, float)):
+        candidate = value
+    elif hasattr(value, "__float__"):
+        candidate = cast(SupportsFloat, value)
+    else:
+        return None
+    try:
+        numeric = float(candidate)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return numeric
 
 
 # ---------------------------------------------------------------------------
@@ -229,15 +276,19 @@ def _retrieve_vector_sqlite(
 
     scored: list[tuple[Any, float]] = []
 
-    if not _has_expected_embedding_dimensions(query_embedding):
+    normalized_query_embedding = _normalize_embedding_vector(query_embedding)
+    if normalized_query_embedding is None:
         return []
+    query_embedding = normalized_query_embedding
 
     for row in rows:
         try:
-            stored = json.loads(row.embedding)
-            if len(stored) != EMBEDDING_DIMENSIONS:
+            stored = _normalize_embedding_vector(json.loads(row.embedding))
+            if stored is None:
                 continue
             sim = _cosine_similarity(query_embedding, stored)
+            if not math.isfinite(sim):
+                continue
             scored.append((row, sim))
         except (json.JSONDecodeError, TypeError):
             continue
@@ -271,9 +322,10 @@ def _retrieve_vector_from_db(
     query_vectors = provider.encode([query])
     if not query_vectors:
         return _empty_context(query, agent_id, user_tier, start)
-    query_embedding = query_vectors[0]
-    if not _has_expected_embedding_dimensions(query_embedding):
+    normalized_query_embedding = _normalize_embedding_vector(query_vectors[0])
+    if normalized_query_embedding is None:
         return _empty_context(query, agent_id, user_tier, start)
+    query_embedding = normalized_query_embedding
 
     from core.db import session_scope
 
@@ -302,17 +354,23 @@ def _retrieve_vector_from_db(
     # Filter by minimum score and build RAGChunks
     chunks: list[RAGChunk] = []
     for i, (row, similarity) in enumerate(results, 1):
-        if similarity < MIN_VECTOR_SCORE:
+        normalized_similarity = _normalize_similarity(similarity)
+        if normalized_similarity is None or normalized_similarity < MIN_VECTOR_SCORE:
             continue
-        sanitized_content = sanitize_rag_markdown(str(row.content))[:MAX_CHUNK_SIZE_CHARS].strip()
+        row_id = getattr(row, "id", None)
+        row_content = getattr(row, "content", None)
+        if row_id is None or row_content is None:
+            continue
+        sanitized_content = sanitize_rag_markdown(str(row_content))[:MAX_CHUNK_SIZE_CHARS].strip()
         if not sanitized_content:
             continue
+        row_source = getattr(row, "source", None)
         chunks.append(
             RAGChunk(
-                chunk_id=f"uk:{row.id}:{i}",
-                file=row.source or "user_knowledge",
+                chunk_id=f"uk:{row_id}:{i}",
+                file=str(row_source).strip() if row_source else "user_knowledge",
                 content=sanitized_content,
-                score=round(similarity, 4),
+                score=round(normalized_similarity, 4),
                 hop=1,
             )
         )

--- a/core/rag/vector_rag.py
+++ b/core/rag/vector_rag.py
@@ -18,6 +18,7 @@ import logging
 import math
 import threading
 import time
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, SupportsFloat, cast
 
 from app.utils.feature_flags import is_rag_vector_enabled
@@ -119,11 +120,13 @@ def _has_expected_embedding_dimensions(query_embedding: list[float]) -> bool:
 def _normalize_embedding_vector(values: object) -> list[float] | None:
     """Return a finite embedding vector with the configured dimensions."""
 
-    if not isinstance(values, (list, tuple)):
+    if isinstance(values, (str, bytes, bytearray)) or not isinstance(values, Sequence):
         return None
 
     numeric_values: list[float] = []
     for value in values:
+        if isinstance(value, bool):
+            return None
         candidate: str | int | float | SupportsFloat
         if isinstance(value, (str, int, float)):
             candidate = value

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1389 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+Pending. No review threads dispositioned yet.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest pushed head
+- [x] `make verify` green on latest pushed head

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -9,18 +9,20 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- Disposition: FIXED
-  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092907452
-  - Commit: `5199ad601`
-  - Evidence: `core/rag/vector_rag.py` now accepts generic non-string `Sequence` inputs and rejects `bool`, while `tests/test_vector_rag.py` uses `monkeypatch` for embedding-provider state.
-- Disposition: FIXED
-  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092912806
-  - Commit: `5199ad601`
-  - Evidence: `core/rag/orchestration.py` treats non-string formatted/redacted context as empty fail-safe input, covered by new non-string tests in `tests/test_rag_orchestration.py`.
-- Disposition: FIXED
-  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092917113
-  - Commit: `5199ad601`
-  - Evidence: `core/rag/vector_rag.py` explicitly rejects boolean embedding elements, keeping malformed vectors fail-closed.
+Disposition: FIXED
+Commit: 5199ad601
+Evidence: `core/rag/vector_rag.py` now accepts generic non-string `Sequence` inputs, rejects boolean embedding elements fail-closed, and `core/rag/orchestration.py` collapses non-string formatted/redacted context to the non-RAG fail-safe path. Coverage in `tests/test_vector_rag.py` and `tests/test_rag_orchestration.py` was expanded in the same commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067158270 -> 5199ad601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067162837 -> 5199ad601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092907452 -> 5199ad601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092912806 -> 5199ad601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092917113 -> 5199ad601
+
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `tests/test_vector_rag.py` drops the synthetic non-finite-similarity test that only reached the guard by monkeypatching `vector_rag._cosine_similarity`; the remaining stored-embedding finiteness coverage preserves the fail-closed contract without violating the repo guard against monkeypatching core compute helpers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067287563
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093037095
 
 ## Merge Readiness
 

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -17,5 +17,5 @@ Bot and human review threads must be dispositioned here before they are resolved
 - [ ] Required checks complete (no pending jobs)
 - [ ] All review threads resolved on GitHub after disposition updates
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [ ] Pre-commit green on latest pushed head
+- [x] Pre-commit green on latest pushed head
 - [x] `make verify` green on latest pushed head

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -26,6 +26,12 @@ Evidence: `tests/test_vector_rag.py` drops the synthetic non-finite-similarity t
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093037095 -> 74f0c0ede
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093178566 -> 74f0c0ede
 
+Disposition: FIXED
+Commit: 65a4a4c4b
+Evidence: `core/rag/simple_rag.py` now keeps scanning ranked candidates until it fills the requested limit with non-empty redacted chunks, so lower-ranked safe chunks backfill when earlier results redact to empty; `tests/test_rag_orchestration.py` covers the backfill path at `max_chunks=1`, and `tests/test_vector_rag.py` adds direct `_normalize_similarity()` assertions for `nan`/`inf`/`-inf`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067155700 -> 65a4a4c4b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093250775 -> 65a4a4c4b
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -9,7 +9,18 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- Disposition: FIXED
+  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092907452
+  - Commit: `5199ad601`
+  - Evidence: `core/rag/vector_rag.py` now accepts generic non-string `Sequence` inputs and rejects `bool`, while `tests/test_vector_rag.py` uses `monkeypatch` for embedding-provider state.
+- Disposition: FIXED
+  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092912806
+  - Commit: `5199ad601`
+  - Evidence: `core/rag/orchestration.py` treats non-string formatted/redacted context as empty fail-safe input, covered by new non-string tests in `tests/test_rag_orchestration.py`.
+- Disposition: FIXED
+  - Review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092917113
+  - Commit: `5199ad601`
+  - Evidence: `core/rag/vector_rag.py` explicitly rejects boolean embedding elements, keeping malformed vectors fail-closed.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -2,14 +2,14 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned here before they are resolved on GitHub.
 
 ## Fixed in Commit Mapping
 
-Pending. No review threads dispositioned yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -19,10 +19,10 @@ Evidence: `core/rag/vector_rag.py` now accepts generic non-string `Sequence` inp
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4092917113 -> 5199ad601
 
 Disposition: FIXED
-Commit: see mapping entries below
+Commit: 74f0c0ede
 Evidence: `tests/test_vector_rag.py` drops the synthetic non-finite-similarity test that only reached the guard by monkeypatching `vector_rag._cosine_similarity`; the remaining stored-embedding finiteness coverage preserves the fail-closed contract without violating the repo guard against monkeypatching core compute helpers.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067287563
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093037095
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067287563 -> 74f0c0ede
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093037095 -> 74f0c0ede
 
 ## Merge Readiness
 

--- a/docs/review/PR_1389_FIXED_MAPPING.md
+++ b/docs/review/PR_1389_FIXED_MAPPING.md
@@ -22,7 +22,9 @@ Disposition: FIXED
 Commit: 74f0c0ede
 Evidence: `tests/test_vector_rag.py` drops the synthetic non-finite-similarity test that only reached the guard by monkeypatching `vector_rag._cosine_similarity`; the remaining stored-embedding finiteness coverage preserves the fail-closed contract without violating the repo guard against monkeypatching core compute helpers.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067287563 -> 74f0c0ede
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#discussion_r3067403589 -> 74f0c0ede
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093037095 -> 74f0c0ede
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1389#pullrequestreview-4093178566 -> 74f0c0ede
 
 ## Merge Readiness
 

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -783,6 +783,68 @@ class TestRetrieveAndValidateRag:
         assert "Question: What is wellness?" in result.formatted_prompt
         assert "Answer:" in result.formatted_prompt
 
+    @pytest.mark.asyncio
+    async def test_empty_formatted_context_returns_fail_safe_non_rag_result(self) -> None:
+        """Empty formatted context must not mark the result as RAG-used."""
+        chunks = [_make_chunk("c1", content="Knowledge about wellness.", score=0.9)]
+        rag_ctx = _make_rag_context(chunks=chunks, hops=2, latency_ms=75)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="   ",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "What is wellness?", philo_validation_enabled=False
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "What is wellness?"
+        assert result.chunks == []
+        assert result.confidence is None
+        assert result.hops == 2
+        assert result.latency_ms == 75
+
+    @pytest.mark.asyncio
+    async def test_empty_redacted_context_returns_fail_safe_non_rag_result(self) -> None:
+        """Redaction that removes all context must collapse to a non-RAG result."""
+        chunks = [_make_chunk("c1", content="Knowledge about wellness.", score=0.9)]
+        rag_ctx = _make_rag_context(chunks=chunks, hops=3, latency_ms=60)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Knowledge about wellness.",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "What is wellness?", philo_validation_enabled=False
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "What is wellness?"
+        assert result.chunks == []
+        assert result.confidence is None
+        assert result.hops == 3
+        assert result.latency_ms == 60
+
 
 def test_format_rag_chunks_for_prompt_sanitizes_injection_lines() -> None:
     """Prompt formatting must strip embedded prompt-injection content."""
@@ -843,3 +905,31 @@ def test_build_rag_source_dicts_skips_empty_sanitized_chunks() -> None:
     assert len(result) == 1
     assert result[0]["chunk_id"] == "safe"
     assert result[0]["preview"] == "Helpful reframing technique."
+
+
+def test_simple_rag_skips_chunks_that_become_empty_after_redaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simple RAG fallback must drop chunks removed by final redaction."""
+    import core.rag.simple_rag as simple_rag
+
+    monkeypatch.setattr(
+        simple_rag,
+        "_get_index",
+        lambda: [
+            ("docs/unsafe.md", "unsafe chunk"),
+            ("docs/safe.md", "safe chunk"),
+        ],
+    )
+    monkeypatch.setattr(simple_rag, "_score", lambda query, chunk: 0.9)
+    monkeypatch.setattr(simple_rag, "MIN_CHUNK_SCORE", 0.0)
+    monkeypatch.setattr(
+        simple_rag,
+        "redact_chunk_content",
+        lambda content: "" if content == "unsafe chunk" else content,
+    )
+
+    result = simple_rag.retrieve_context_structured("query", max_chunks=2)
+
+    assert len(result.chunks) == 1
+    assert result.chunks[0].content == "safe chunk"

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -972,7 +972,7 @@ def test_build_rag_source_dicts_skips_empty_sanitized_chunks() -> None:
 def test_simple_rag_skips_chunks_that_become_empty_after_redaction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Simple RAG fallback must drop chunks removed by final redaction."""
+    """Simple RAG fallback must backfill lower-ranked safe chunks after redaction."""
     import core.rag.simple_rag as simple_rag
 
     monkeypatch.setattr(
@@ -983,7 +983,11 @@ def test_simple_rag_skips_chunks_that_become_empty_after_redaction(
             ("docs/safe.md", "safe chunk"),
         ],
     )
-    monkeypatch.setattr(simple_rag, "_score", lambda query, chunk: 0.9)
+    monkeypatch.setattr(
+        simple_rag,
+        "_score",
+        lambda query, chunk: 0.9 if chunk == "unsafe chunk" else 0.4,
+    )
     monkeypatch.setattr(simple_rag, "MIN_CHUNK_SCORE", 0.0)
     monkeypatch.setattr(
         simple_rag,
@@ -991,7 +995,7 @@ def test_simple_rag_skips_chunks_that_become_empty_after_redaction(
         lambda content: "" if content == "unsafe chunk" else content,
     )
 
-    result = simple_rag.retrieve_context_structured("query", max_chunks=2)
+    result = simple_rag.retrieve_context_structured("query", max_chunks=1)
 
     assert len(result.chunks) == 1
     assert result.chunks[0].content == "safe chunk"

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -813,6 +813,35 @@ class TestRetrieveAndValidateRag:
         assert result.latency_ms == 75
 
     @pytest.mark.asyncio
+    async def test_non_string_formatted_context_returns_fail_safe_non_rag_result(self) -> None:
+        """Non-string formatted context must collapse to a non-RAG result."""
+        chunks = [_make_chunk("c1", content="Knowledge about wellness.", score=0.9)]
+        rag_ctx = _make_rag_context(chunks=chunks, hops=2, latency_ms=75)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value=["unexpected-context"],
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "What is wellness?", philo_validation_enabled=False
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "What is wellness?"
+        assert result.chunks == []
+        assert result.confidence is None
+        assert result.hops == 2
+        assert result.latency_ms == 75
+
+    @pytest.mark.asyncio
     async def test_empty_redacted_context_returns_fail_safe_non_rag_result(self) -> None:
         """Redaction that removes all context must collapse to a non-RAG result."""
         chunks = [_make_chunk("c1", content="Knowledge about wellness.", score=0.9)]
@@ -832,6 +861,39 @@ class TestRetrieveAndValidateRag:
             patch(
                 "core.insight.safety.redact_rag_context_for_insight",
                 return_value="",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "What is wellness?", philo_validation_enabled=False
+            )
+
+        assert result.rag_actually_used is False
+        assert result.formatted_prompt == "What is wellness?"
+        assert result.chunks == []
+        assert result.confidence is None
+        assert result.hops == 3
+        assert result.latency_ms == 60
+
+    @pytest.mark.asyncio
+    async def test_non_string_redacted_context_returns_fail_safe_non_rag_result(self) -> None:
+        """Non-string redacted context must collapse to a non-RAG result."""
+        chunks = [_make_chunk("c1", content="Knowledge about wellness.", score=0.9)]
+        rag_ctx = _make_rag_context(chunks=chunks, hops=3, latency_ms=60)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ),
+            patch("core.rag.vector_rag.retrieve_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Knowledge about wellness.",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value={"unexpected": "context"},
             ),
         ):
             result = await retrieve_and_validate_rag(

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -364,30 +364,6 @@ class TestVectorRetrievalSQLite:
         results = vector_rag._retrieve_vector_sqlite([1.0, 0.0, 0.0], 5, fake_session, subject_id=7)
         assert results == []
 
-    def test_retrieve_vector_sqlite_skips_non_finite_similarity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Rows yielding non-finite cosine similarity must be ignored."""
-        from core.rag import vector_rag
-
-        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
-        monkeypatch.setattr(vector_rag, "_cosine_similarity", lambda *_args: float("inf"))
-
-        class _Row:
-            def __init__(self, id: int, embedding: str) -> None:
-                self.id = id
-                self.content = "doc"
-                self.source = "src"
-                self.embedding = embedding
-
-        fake_session = MagicMock()
-        fake_session.execute.return_value.fetchall.return_value = [
-            _Row(1, json.dumps([1.0, 0.0, 0.0]))
-        ]
-
-        results = vector_rag._retrieve_vector_sqlite([1.0, 0.0, 0.0], 5, fake_session, subject_id=7)
-        assert results == []
-
     def test_retrieve_vector_sqlite_binds_subject_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SQLite retrieval binds subject_id to prevent cross-tenant leaks."""
         from core.rag import vector_rag

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -91,6 +91,82 @@ class TestCosineSimilarity:
         assert _cosine_similarity([0.0, 0.0], [0.0, 0.0]) == 0.0
 
 
+class _FloatableValue:
+    """Simple float-like test helper."""
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __float__(self) -> float:
+        return self.value
+
+
+class _BrokenFloatValue:
+    """Float-like helper that raises during conversion."""
+
+    def __float__(self) -> float:
+        raise ValueError("broken float")
+
+
+class TestNormalizationHelpers:
+    """Unit tests for embedding and similarity normalization helpers."""
+
+    def test_normalize_embedding_vector_rejects_non_sequence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        assert vector_rag._normalize_embedding_vector("not-a-vector") is None
+
+    def test_normalize_embedding_vector_accepts_float_like_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        normalized = vector_rag._normalize_embedding_vector(
+            [_FloatableValue(1.0), _FloatableValue(0.0), _FloatableValue(0.5)]
+        )
+
+        assert normalized == [1.0, 0.0, 0.5]
+
+    def test_normalize_embedding_vector_rejects_unsupported_items(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        assert vector_rag._normalize_embedding_vector([1.0, object(), 0.0]) is None
+
+    def test_normalize_embedding_vector_rejects_broken_float_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        assert vector_rag._normalize_embedding_vector([1.0, _BrokenFloatValue(), 0.0]) is None
+
+    def test_normalize_similarity_accepts_float_like_values(self) -> None:
+        from core.rag import vector_rag
+
+        assert vector_rag._normalize_similarity(_FloatableValue(0.8)) == pytest.approx(0.8)
+
+    def test_normalize_similarity_rejects_unsupported_values(self) -> None:
+        from core.rag import vector_rag
+
+        assert vector_rag._normalize_similarity(object()) is None
+
+    def test_normalize_similarity_rejects_broken_float_values(self) -> None:
+        from core.rag import vector_rag
+
+        assert vector_rag._normalize_similarity(_BrokenFloatValue()) is None
+
+
 class TestVectorRetrievalFallback:
     """Vector retrieval falls back to Jaccard when disabled or on failure."""
 
@@ -235,6 +311,53 @@ class TestVectorRetrievalSQLite:
 
         results = vector_rag._retrieve_vector_sqlite(query_vec, 5, fake_session, subject_id=7)
         assert len(results) == 0
+
+    def test_retrieve_vector_sqlite_skips_non_finite_stored_embeddings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rows with non-finite stored embeddings must be ignored."""
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        class _Row:
+            def __init__(self, id: int, embedding: str) -> None:
+                self.id = id
+                self.content = "doc"
+                self.source = "src"
+                self.embedding = embedding
+
+        rows = [_Row(1, json.dumps([1.0, float("nan"), 0.0]))]
+
+        fake_session = MagicMock()
+        fake_session.execute.return_value.fetchall.return_value = rows
+
+        results = vector_rag._retrieve_vector_sqlite([1.0, 0.0, 0.0], 5, fake_session, subject_id=7)
+        assert results == []
+
+    def test_retrieve_vector_sqlite_skips_non_finite_similarity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rows yielding non-finite cosine similarity must be ignored."""
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+        monkeypatch.setattr(vector_rag, "_cosine_similarity", lambda *_args: float("inf"))
+
+        class _Row:
+            def __init__(self, id: int, embedding: str) -> None:
+                self.id = id
+                self.content = "doc"
+                self.source = "src"
+                self.embedding = embedding
+
+        fake_session = MagicMock()
+        fake_session.execute.return_value.fetchall.return_value = [
+            _Row(1, json.dumps([1.0, 0.0, 0.0]))
+        ]
+
+        results = vector_rag._retrieve_vector_sqlite([1.0, 0.0, 0.0], 5, fake_session, subject_id=7)
+        assert results == []
 
     def test_retrieve_vector_sqlite_binds_subject_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SQLite retrieval binds subject_id to prevent cross-tenant leaks."""
@@ -703,6 +826,51 @@ class TestRetrieveContextStructuredVectorSuccess:
         assert len(ctx.chunks) == 1
         assert ctx.chunks[0].content == "vector result"
 
+    def test_vector_success_skips_malformed_rows_without_poisoning_whole_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed result rows should be skipped while valid rows still surface."""
+        import core.rag.vector_rag as vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        class _Row:
+            def __init__(self, row_id: int | None, content: str | None, source: str | None) -> None:
+                self.id = row_id
+                self.content = content
+                self.source = source
+
+        fake_provider = MagicMock()
+        fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
+        vector_rag._embedding_provider = fake_provider
+
+        fake_session = MagicMock()
+        fake_session.bind.dialect.name = "postgresql"
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _fake_session_scope() -> Iterator[MagicMock]:
+            yield fake_session
+
+        monkeypatch.setattr("core.db.session_scope", _fake_session_scope)
+        monkeypatch.setattr(
+            vector_rag,
+            "_retrieve_vector_postgres",
+            lambda *a, **k: [
+                (_Row(1, "valid content", "doc.md"), 0.92),
+                (_Row(None, "missing id", "bad.md"), 0.99),
+                (_Row(3, None, "bad2.md"), 0.95),
+                (_Row(4, "bad score", "bad3.md"), float("nan")),
+            ],
+        )
+
+        ctx = vector_rag._retrieve_vector_from_db("test", 4, None, None, 21)
+
+        assert len(ctx.chunks) == 1
+        assert ctx.chunks[0].content == "valid content"
+        vector_rag._embedding_provider = None
+
 
 class TestQueryEmbeddingValidation:
     """Test query embedding dimension validation in SQLite path."""
@@ -729,6 +897,35 @@ class TestQueryEmbeddingValidation:
         # 2-dim query vs 3-dim expected — guard should reject
         results = vector_rag._retrieve_vector_sqlite([1.0, 0.0], 5, fake_session, subject_id=7)
         assert results == []
+
+    def test_non_finite_query_embedding_returns_empty_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-finite query embeddings must fail closed before DB vector search."""
+        from contextlib import contextmanager
+
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        fake_provider = MagicMock()
+        fake_provider.encode.return_value = [[1.0, float("inf"), 0.0]]
+        vector_rag._embedding_provider = fake_provider
+
+        fake_session = MagicMock()
+        fake_session.bind.dialect.name = "postgresql"
+
+        @contextmanager
+        def _fake_session_scope() -> Iterator[MagicMock]:
+            yield fake_session
+
+        monkeypatch.setattr("core.db.session_scope", _fake_session_scope)
+
+        ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, 21)
+
+        assert ctx.chunks == []
+        fake_session.execute.assert_not_called()
+        vector_rag._embedding_provider = None
 
 
 class TestCorpusFilteringVectorRag:

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -61,6 +61,17 @@ def _fake_jaccard(
     )
 
 
+def _patch_embedding_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: object | None,
+) -> None:
+    """Patch the cached embedding provider with automatic rollback."""
+
+    from core.rag import vector_rag
+
+    monkeypatch.setattr(vector_rag, "_embedding_provider", provider)
+
+
 class TestCosineSimilarity:
     """Unit tests for _cosine_similarity helper."""
 
@@ -133,6 +144,15 @@ class TestNormalizationHelpers:
 
         assert normalized == [1.0, 0.0, 0.5]
 
+    def test_normalize_embedding_vector_accepts_generic_sequence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        assert vector_rag._normalize_embedding_vector(range(3)) == [0.0, 1.0, 2.0]
+
     def test_normalize_embedding_vector_rejects_unsupported_items(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -150,6 +170,15 @@ class TestNormalizationHelpers:
         monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
 
         assert vector_rag._normalize_embedding_vector([1.0, _BrokenFloatValue(), 0.0]) is None
+
+    def test_normalize_embedding_vector_rejects_bool_items(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.rag import vector_rag
+
+        monkeypatch.setattr(vector_rag, "EMBEDDING_DIMENSIONS", 3)
+
+        assert vector_rag._normalize_embedding_vector([1.0, True, 0.0]) is None
 
     def test_normalize_similarity_accepts_float_like_values(self) -> None:
         from core.rag import vector_rag
@@ -419,10 +448,10 @@ class TestEmptyContext:
 class TestResetEmbeddingProvider:
     """Test singleton reset for test isolation."""
 
-    def test_reset_clears_provider(self) -> None:
+    def test_reset_clears_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from core.rag import vector_rag
 
-        vector_rag._embedding_provider = "something"
+        _patch_embedding_provider(monkeypatch, "something")
         vector_rag.reset_embedding_provider()
         assert vector_rag._embedding_provider is None
 
@@ -434,7 +463,7 @@ class TestGetEmbeddingProvider:
         """Singleton should create SentenceTransformerEmbeddings on first call."""
         from core.rag import vector_rag
 
-        vector_rag._embedding_provider = None
+        _patch_embedding_provider(monkeypatch, None)
 
         fake_cls = MagicMock()
         fake_instance = MagicMock()
@@ -449,21 +478,15 @@ class TestGetEmbeddingProvider:
         assert result is fake_instance
         fake_cls.assert_called_once()
 
-        # Cleanup
-        vector_rag._embedding_provider = None
-
     def test_returns_cached_provider_on_second_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Second call should return cached provider without re-creating."""
         from core.rag import vector_rag
 
         fake_provider = MagicMock()
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         result = vector_rag._get_embedding_provider()
         assert result is fake_provider
-
-        # Cleanup
-        vector_rag._embedding_provider = None
 
 
 class TestRetrieveVectorPostgres:
@@ -512,7 +535,7 @@ class TestRetrieveVectorFromDb:
         # Mock embedding provider
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         # Mock DB session with SQLite dialect
         class _Row:
@@ -548,23 +571,17 @@ class TestRetrieveVectorFromDb:
         assert ctx.user_tier == "PRO"
         assert rls_calls == [21]
 
-        # Cleanup
-        vector_rag._embedding_provider = None
-
     def test_empty_encode_returns_empty_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If provider.encode returns empty, return empty context."""
         from core.rag import vector_rag
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = []
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, 21)
         assert isinstance(ctx, RAGContext)
         assert ctx.chunks == []
-
-        # Cleanup
-        vector_rag._embedding_provider = None
 
     def test_missing_subject_id_returns_empty_without_encoding(
         self, monkeypatch: pytest.MonkeyPatch
@@ -573,14 +590,12 @@ class TestRetrieveVectorFromDb:
         from core.rag import vector_rag
 
         fake_provider = MagicMock()
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         ctx = vector_rag._retrieve_vector_from_db("test", 3, None, None, None)
 
         assert ctx.chunks == []
         fake_provider.encode.assert_not_called()
-
-        vector_rag._embedding_provider = None
 
     def test_wrong_query_dimensions_return_empty_without_db_work(
         self,
@@ -596,7 +611,7 @@ class TestRetrieveVectorFromDb:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         session_scope_called = False
 
@@ -617,8 +632,6 @@ class TestRetrieveVectorFromDb:
             for record in caplog.records
         )
 
-        vector_rag._embedding_provider = None
-
     def test_postgres_dialect_calls_postgres_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Postgres dialect should call _retrieve_vector_postgres."""
         from contextlib import contextmanager
@@ -629,7 +642,7 @@ class TestRetrieveVectorFromDb:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         fake_session = MagicMock()
         fake_session.bind.dialect.name = "postgresql"
@@ -656,9 +669,6 @@ class TestRetrieveVectorFromDb:
         assert len(ctx.chunks) == 1
         assert ctx.chunks[0].file == "pg.md"
 
-        # Cleanup
-        vector_rag._embedding_provider = None
-
     def test_below_min_score_chunks_filtered(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Chunks below MIN_VECTOR_SCORE are filtered out."""
         from contextlib import contextmanager
@@ -669,7 +679,7 @@ class TestRetrieveVectorFromDb:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         fake_session = MagicMock()
         fake_session.bind.dialect.name = "sqlite"
@@ -697,9 +707,6 @@ class TestRetrieveVectorFromDb:
         assert ctx.chunks == []
         assert ctx.confidence == 0.0
 
-        # Cleanup
-        vector_rag._embedding_provider = None
-
     def test_suspicious_rag_chunk_content_is_sanitized(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -713,7 +720,7 @@ class TestRetrieveVectorFromDb:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         class _Row:
             def __init__(self, id: int, content: str, source: str, embedding: str) -> None:
@@ -745,8 +752,6 @@ class TestRetrieveVectorFromDb:
         assert "Helpful grounding exercise." in ctx.chunks[0].content
         assert "Ignore previous instructions" not in ctx.chunks[0].content
 
-        vector_rag._embedding_provider = None
-
     def test_empty_sanitized_rag_chunk_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Chunks reduced to empty content after sanitization must be skipped."""
         from contextlib import contextmanager
@@ -758,7 +763,7 @@ class TestRetrieveVectorFromDb:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         class _Row:
             def __init__(self, id: int, content: str, source: str, embedding: str) -> None:
@@ -787,8 +792,6 @@ class TestRetrieveVectorFromDb:
         ctx = vector_rag._retrieve_vector_from_db("grounding", 3, None, None, 21)
 
         assert ctx.chunks == []
-
-        vector_rag._embedding_provider = None
 
 
 class TestRetrieveContextStructuredVectorSuccess:
@@ -842,7 +845,7 @@ class TestRetrieveContextStructuredVectorSuccess:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         fake_session = MagicMock()
         fake_session.bind.dialect.name = "postgresql"
@@ -869,7 +872,6 @@ class TestRetrieveContextStructuredVectorSuccess:
 
         assert len(ctx.chunks) == 1
         assert ctx.chunks[0].content == "valid content"
-        vector_rag._embedding_provider = None
 
 
 class TestQueryEmbeddingValidation:
@@ -910,7 +912,7 @@ class TestQueryEmbeddingValidation:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, float("inf"), 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         fake_session = MagicMock()
         fake_session.bind.dialect.name = "postgresql"
@@ -925,7 +927,6 @@ class TestQueryEmbeddingValidation:
 
         assert ctx.chunks == []
         fake_session.execute.assert_not_called()
-        vector_rag._embedding_provider = None
 
 
 class TestCorpusFilteringVectorRag:
@@ -1082,7 +1083,7 @@ class TestCorpusFilteringVectorRag:
 
         fake_provider = MagicMock()
         fake_provider.encode.return_value = [[1.0, 0.0, 0.0]]
-        vector_rag._embedding_provider = fake_provider
+        _patch_embedding_provider(monkeypatch, fake_provider)
 
         fake_session = MagicMock()
         fake_session.bind.dialect.name = "postgresql"
@@ -1115,6 +1116,3 @@ class TestCorpusFilteringVectorRag:
             for record in caplog.records
         )
         assert warning_logged, "Expected warning about empty corpus results"
-
-        # Cleanup
-        vector_rag._embedding_provider = None

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -195,6 +195,12 @@ class TestNormalizationHelpers:
 
         assert vector_rag._normalize_similarity(_BrokenFloatValue()) is None
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_normalize_similarity_rejects_non_finite_values(self, value: float) -> None:
+        from core.rag import vector_rag
+
+        assert vector_rag._normalize_similarity(value) is None
+
 
 class TestVectorRetrievalFallback:
     """Vector retrieval falls back to Jaccard when disabled or on failure."""


### PR DESCRIPTION
## Summary
- harden degraded retrieval to fail closed when embeddings, similarity scores, or redacted / formatted context collapse to invalid or empty values
- keep tenant-scoped retrieval fail-closed and add regression coverage for normalization helpers and empty-context collapse
- local gates on this branch: `make verify` PASS, `pre-commit run --all-files` PASS

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1389_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [x] `make verify` green on latest pushed head

## Summary by Sourcery

Усилена надежность извлечения векторов RAG и оркестрации так, чтобы система «фейлилась закрыто» (fail closed), когда эмбеддинги, значения схожести или отформатированный/заранее отредактированный контекст повреждены или пусты, а также добавлены регрессионные тесты и документация для этих сценариев.

Bug Fixes:
- Игнорировать нефинитные или некорректные эмбеддинги и значения схожести при векторном извлечении, возвращая пустой контекст вместо распространения некорректных данных.
- Обрабатывать пустой отформатированный или отредактированный контекст как результат без RAG, при этом сохраняя метаданные извлечения.
- Отбрасывать простые RAG-чанки, которые становятся пустыми после редактирования, чтобы они не возвращались вызывающей стороне.

Enhancements:
- Ввести вспомогательные функции нормализации для эмбеддингов и значений схожести для валидации полезной нагрузки и обеспечения корректной размерности и финитности.
- Уточнить построение результата оркестрации RAG через общий helper для fallback-результатов без RAG.

Documentation:
- Добавить документ сопоставления «fixed-in-commit» для этого PR в `docs/review`.

Tests:
- Добавить модульные тесты для helper-функций нормализации эмбеддингов и значений схожести, а также крайних случаев при векторном извлечении в SQLite.
- Добавить тесты оркестрации, покрывающие случаи, когда пустой отформатированный или отредактированный контекст сворачивается в результат без RAG.
- Добавить простые RAG-тесты, гарантирующие, что чанки, удалённые в результате редактирования, не возвращаются.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden RAG vector retrieval and orchestration to fail closed when embeddings, similarity scores, or formatted/redacted context are malformed or empty, and add regression tests and documentation for these behaviors.

Bug Fixes:
- Ignore non-finite or malformed embeddings and similarity scores in vector retrieval, returning empty context instead of propagating invalid data.
- Treat empty formatted or redacted context as a non-RAG result while preserving retrieval metadata.
- Drop simple RAG chunks that become empty after redaction so they are not surfaced to callers.

Enhancements:
- Introduce normalization helpers for embeddings and similarity scores to validate payloads and enforce dimensionality and finiteness.
- Refine RAG orchestration result construction via a shared helper for non-RAG fallbacks.

Documentation:
- Add a fixed-in-commit mapping document for this PR under docs/review.

Tests:
- Add unit tests for embedding and similarity normalization helpers and edge cases in SQLite vector retrieval.
- Add orchestration tests covering empty formatted or redacted context collapsing to non-RAG results.
- Add simple RAG tests ensuring chunks removed by redaction are not returned.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treat empty or whitespace-only context as non-RAG outcomes, preserve retrieval metadata and return no confidence when no usable context; skip chunks that become empty after redaction; validate and skip malformed or non-finite embeddings/similarities and rows missing required fields.

* **Tests**
  * Added coverage for empty/invalid context paths, chunk-redaction drops, embedding/similarity normalization, and retrieval safeguards.

* **Documentation**
  * Added a PR review checklist documenting fixes and merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



