### PR TITLE
fix(ci): stabilize py313 test runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
   test-feature:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feature/'))
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       actions: write
@@ -815,14 +815,17 @@ jobs:
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi
+          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
-          python -X faulthandler -m pytest \
+          time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
+            --durations=25 \
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -850,14 +853,20 @@ jobs:
   test-main:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     permissions:
       contents: read
       actions: write
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.11'
+            timeout-minutes: 60
+          - python-version: '3.12'
+            timeout-minutes: 60
+          - python-version: '3.13'
+            timeout-minutes: 90
 
     steps:
       - name: Checkout
@@ -934,14 +943,17 @@ jobs:
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi
+          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
-          python -X faulthandler -m pytest \
+          time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
+            --durations=25 \
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Clean Python cache (post-test)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,7 @@ jobs:
           echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
+          set +e
           time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
@@ -825,7 +826,10 @@ jobs:
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          test_exit_code=$?
+          set -e
           echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          exit "$test_exit_code"
 
       - name: Clean Python cache (post-test)
         if: always()
@@ -946,6 +950,7 @@ jobs:
           echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
+          set +e
           time python -X faulthandler -m pytest \
             "${PYTEST_XDIST_ARGS[@]}" \
             -m "not slow" \
@@ -953,7 +958,10 @@ jobs:
             --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 \
             --junitxml=tests/results.xml -o junit_family=legacy \
             tests
+          test_exit_code=$?
+          set -e
           echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          exit "$test_exit_code"
 
       - name: Clean Python cache (post-test)
         if: always()

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -17,10 +17,10 @@
 - [x] Pre-commit green on latest push
 - [ ] `make verify` green where required for merge
 - [ ] Mandatory post-open **qa-engineer-agent** pass completed
-- [ ] Mandatory post-open **bug-hunter** pass completed
+- [x] Mandatory post-open **bug-hunter** pass completed
 - [ ] **dev-operator** scoped review completed
-- [ ] **backend-engineer** scoped review completed
-- [ ] **security-auditor** scoped review completed
+- [x] **backend-engineer** scoped review completed (`Mencius`)
+- [x] **security-auditor** scoped review completed (`Boole`)
 
 ## Notes
 

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -42,14 +42,14 @@ Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:11`
 
 - [ ] All required checks pass (current head)
 - [ ] No unresolved review threads (re-check before merge)
-- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green on latest push
-- [x] `make verify` green where required for merge
-- [x] Mandatory post-open **qa-engineer-agent** pass completed (current diff re-review kept scope limited to CI timeout stabilization plus canonical governance artifacts)
-- [x] Mandatory post-open **bug-hunter** pass completed (one actionable failure-safe timestamp defect was found in the workflow lane and fixed in `25c9f7c4e`; no second blocker surfaced on the remaining narrow diff)
-- [x] **dev-operator** scoped review completed (current-head CI/wrapper triage confirms this lane is stopgap stabilization, not the root-cause retirement slice)
-- [x] **backend-engineer** scoped review completed (`Mencius`)
-- [x] **security-auditor** scoped review completed (`Boole`)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest push
+- [ ] `make verify` green where required for merge
+- [ ] Mandatory post-open **qa-engineer-agent** pass completed (current diff re-review kept scope limited to CI timeout stabilization plus canonical governance artifacts)
+- [ ] Mandatory post-open **bug-hunter** pass completed (one actionable failure-safe timestamp defect was found in the workflow lane and fixed in `25c9f7c4e`; no second blocker surfaced on the remaining narrow diff)
+- [ ] **dev-operator** scoped review completed (current-head CI/wrapper triage confirms this lane is stopgap stabilization, not the root-cause retirement slice)
+- [ ] **backend-engineer** scoped review completed (`Mencius`)
+- [ ] **security-auditor** scoped review completed (`Boole`)
 
 ## Notes
 

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -44,6 +44,11 @@ Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:45`, `docs/review/PR_1390_FIXED_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093732799 -> 585614781
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3068008378 -> 585614781
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:10`, `docs/review/PR_1390_FIXED_MAPPING.md:38`, `docs/review/PR_1390_FIXED_MAPPING.md:42`
+Reason: This CodeRabbit review is a duplicate summary of the already-closed suggestion to add a `discussion_r...` URL to the NOT-A-BUG proof. Re-introducing `discussion_r3067846377` into the NOT-A-BUG block would recreate the same mixed-disposition conflict that was fixed in `30d87dfc9`, because that discussion URL is already mapped under the separate FIXED disposition for the earlier thread.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093738726
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -17,13 +17,22 @@ Commit: 25c9f7c4e
 Evidence: `.github/workflows/ci.yml:818`, `.github/workflows/ci.yml:828`, `.github/workflows/ci.yml:946`, `.github/workflows/ci.yml:956`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067777676 -> 25c9f7c4e
 
+Disposition: FIXED
+Commit: 43ee565af
+Evidence: `docs/review/PR_1390_FIXED_MAPPING.md` now replaces the ambiguous placeholder with explicit dispositions, records the post-open reviewer lane evidence, and removes the stale note that contradicted the checklist state for `bug-hunter`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093557955 -> 43ee565af
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067777677 -> 43ee565af
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067777678 -> 43ee565af
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093558245 -> 43ee565af
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067778134 -> 43ee565af
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)
 - [ ] No unresolved review threads (re-check before merge)
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [ ] Pre-commit green on latest push
-- [ ] `make verify` green where required for merge
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green on latest push
+- [x] `make verify` green where required for merge
 - [x] Mandatory post-open **qa-engineer-agent** pass completed (current diff re-review kept scope limited to CI timeout stabilization plus canonical governance artifacts)
 - [x] Mandatory post-open **bug-hunter** pass completed (one actionable failure-safe timestamp defect was found in the workflow lane and fixed in `25c9f7c4e`; no second blocker surfaced on the remaining narrow diff)
 - [x] **dev-operator** scoped review completed (current-head CI/wrapper triage confirms this lane is stopgap stabilization, not the root-cause retirement slice)

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 ## Fixed in Commit Mapping
 
 Disposition: NOT-A-BUG
-Evidence: `.github/workflows/ci.yml:811`, `.github/workflows/ci.yml:939`, `docs/roadmap/BACKLOG_LEDGER.md:8732`, `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067846377`
+Evidence: `.github/workflows/ci.yml:811`, `.github/workflows/ci.yml:939`, `docs/roadmap/BACKLOG_LEDGER.md:8732`
 Reason: Sourcery's DRY extraction and `::notice::` prefix suggestions are advisory, but this PR is intentionally a narrow stopgap stabilization lane. Keeping the timing diagnostics inline inside the canonical `CI` workflow is consistent with the current scope, while root-cause retirement remains tracked in `ledger-p1-py313-main-ci-stall-root-cause`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093556786
 

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -1,0 +1,28 @@
+# PR 1390 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] All required checks pass (current head)
+- [ ] No unresolved review threads (re-check before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green on latest push
+- [ ] `make verify` green where required for merge
+- [ ] Mandatory post-open **qa-engineer-agent** pass completed
+- [ ] Mandatory post-open **bug-hunter** pass completed
+- [ ] **dev-operator** scoped review completed
+- [ ] **backend-engineer** scoped review completed
+- [ ] **security-auditor** scoped review completed
+
+## Notes
+
+Draft PR only. This artifact is initialized before post-open QA / bug-hunter
+review and before any review-thread disposition mapping exists.

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -7,22 +7,29 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/ci.yml:811`, `.github/workflows/ci.yml:939`, `docs/roadmap/BACKLOG_LEDGER.md:8732`
+Reason: Sourcery's DRY extraction and `::notice::` prefix suggestions are advisory, but this PR is intentionally a narrow stopgap stabilization lane. Keeping the timing diagnostics inline inside the canonical `CI` workflow is consistent with the current scope, while root-cause retirement remains tracked in `ledger-p1-py313-main-ci-stall-root-cause`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093556786
+
+Disposition: FIXED
+Commit: 25c9f7c4e
+Evidence: `.github/workflows/ci.yml:818`, `.github/workflows/ci.yml:828`, `.github/workflows/ci.yml:946`, `.github/workflows/ci.yml:956`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067777676 -> 25c9f7c4e
 
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)
 - [ ] No unresolved review threads (re-check before merge)
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green on latest push
+- [ ] Pre-commit green on latest push
 - [ ] `make verify` green where required for merge
-- [ ] Mandatory post-open **qa-engineer-agent** pass completed
-- [x] Mandatory post-open **bug-hunter** pass completed
-- [ ] **dev-operator** scoped review completed
+- [x] Mandatory post-open **qa-engineer-agent** pass completed (current diff re-review kept scope limited to CI timeout stabilization plus canonical governance artifacts)
+- [x] Mandatory post-open **bug-hunter** pass completed (one actionable failure-safe timestamp defect was found in the workflow lane and fixed in `25c9f7c4e`; no second blocker surfaced on the remaining narrow diff)
+- [x] **dev-operator** scoped review completed (current-head CI/wrapper triage confirms this lane is stopgap stabilization, not the root-cause retirement slice)
 - [x] **backend-engineer** scoped review completed (`Mencius`)
 - [x] **security-auditor** scoped review completed (`Boole`)
 
 ## Notes
 
-Draft PR only. This artifact is initialized before post-open QA / bug-hunter
-review and before any review-thread disposition mapping exists.
+This PR is the temporary py313 CI stabilization lane, not the retirement/root-cause fix. Narrative lock for this artifact: an older py313 sequential-only CI contract amplified a pre-existing expensive Node subprocess hot path in `app/security/goplus_agentguard_bridge.py`; `#1384` made the local Node scanner the active runtime/test seam on `main`; `#1387` is the root-fix lane; `#1390` remains the stopgap stabilization lane. `tests/conftest.py` already sets `TESTING=true` during `pytest_configure()`, so current evidence does not support opening a separate CI env follow-up just to export `TESTING=true`.

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -38,6 +38,12 @@ Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:11`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093614475 -> 30d87dfc9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067853149 -> 30d87dfc9
 
+Disposition: FIXED
+Commit: 585614781
+Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:45`, `docs/review/PR_1390_FIXED_MAPPING.md:52`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093732799 -> 585614781
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3068008378 -> 585614781
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 ## Fixed in Commit Mapping
 
 Disposition: NOT-A-BUG
-Evidence: `.github/workflows/ci.yml:811`, `.github/workflows/ci.yml:939`, `docs/roadmap/BACKLOG_LEDGER.md:8732`
+Evidence: `.github/workflows/ci.yml:811`, `.github/workflows/ci.yml:939`, `docs/roadmap/BACKLOG_LEDGER.md:8732`, `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067846377`
 Reason: Sourcery's DRY extraction and `::notice::` prefix suggestions are advisory, but this PR is intentionally a narrow stopgap stabilization lane. Keeping the timing diagnostics inline inside the canonical `CI` workflow is consistent with the current scope, while root-cause retirement remains tracked in `ledger-p1-py313-main-ci-stall-root-cause`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093556786
 

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -32,6 +32,12 @@ Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:11`, `docs/review/PR_1390_FIXED_
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093609339 -> dff54de3e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067846377 -> dff54de3e
 
+Disposition: FIXED
+Commit: 30d87dfc9
+Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:11`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093614475 -> 30d87dfc9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067853149 -> 30d87dfc9
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)

--- a/docs/review/PR_1390_FIXED_MAPPING.md
+++ b/docs/review/PR_1390_FIXED_MAPPING.md
@@ -26,6 +26,12 @@ Evidence: `docs/review/PR_1390_FIXED_MAPPING.md` now replaces the ambiguous plac
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093558245 -> 43ee565af
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067778134 -> 43ee565af
 
+Disposition: FIXED
+Commit: dff54de3e
+Evidence: `docs/review/PR_1390_FIXED_MAPPING.md:11`, `docs/review/PR_1390_FIXED_MAPPING.md:13`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#pullrequestreview-4093609339 -> dff54de3e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1390#discussion_r3067846377 -> dff54de3e
+
 ## Merge Readiness
 
 - [ ] All required checks pass (current head)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -8701,6 +8701,36 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - the PR description states that the change is prevention hardening, not proof of compromise
     - post-open review uses `qa-engineer-agent -> bug-hunter`
 
-**Last updated:** 2026-03-26 (LiteLLM supply-chain hardening follow-up)
+<a id="ledger-p1-py313-main-ci-stall-root-cause"></a>
+- [ ] P1: Root-cause Python 3.13 CI slowdown and retire timeout stopgap
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (CI stability / main-branch readiness)
+  - Target PR: PR-TBD-PY313-CI-STALL-ROOT-CAUSE
+  - Status: Opened on 11 April 2026
+  - Reason: Current-head feature and `main` CI runs both show a pathological
+    Python 3.13 slowdown in canonical `CI`. `test-feature (3.13)` reached the
+    60-minute job timeout in run `24266451930`, and earlier `main` evidence
+    showed `test-main (3.13)` materially outliving `3.11` and `3.12`. The
+    immediate mitigation is a py3.13-scoped timeout increase plus deterministic
+    duration diagnostics in `.github/workflows/ci.yml`, but the underlying
+    cause remains unresolved and must be isolated before the stopgap can be
+    removed.
+  - Links:
+    - `.github/workflows/ci.yml`
+    - `RUNBOOK_AGENT.md`
+    - `docs/orchestration/TIER1_CI_CD_PR_SERIES_RUNBOOK.md`
+    - `https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24266451930/job/70862392048`
+  - DoD:
+    - a representative current-head feature or `main` run shows Python 3.13
+      tests completing without unexplained pathological slowdown
+    - the slowest Python 3.13 tests or setup segment are identified from
+      deterministic diagnostics
+    - the py3.13-specific timeout increase is either justified with documented
+      evidence or removed
+    - canonical `CI` returns to stable green without manual rerun dependence
+    - any remaining workflow debt is documented explicitly rather than hidden
+      inside the stopgap
+
+**Last updated:** 2026-04-11 (py3.13 CI slowdown follow-up)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
## Summary

This PR is the stopgap stabilization lane for the py313 CI slowdown, not the root-cause retirement fix.

The correct incident framing is not "the last 2-3 PRs broke Python tests." The accurate framing is: an older py313 sequential-only CI contract amplified a pre-existing expensive Node subprocess hot path in `app/security/goplus_agentguard_bridge.py`.

`#1384` did not create `subprocess.run(..., timeout=5)` from scratch; it made the local Node scanner the active runtime/test seam on `main`. `#1387` is the root-fix lane because it removes that live bridge cost from the default test runtime. `#1390` only stabilizes CI budgets and adds timing diagnostics while the retirement/root-cause follow-up stays tracked separately.

## Scope

- `.github/workflows/ci.yml`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1390_FIXED_MAPPING.md`

## Root Cause / Lane Position

- This PR does not claim to remove the underlying hot path.
- This PR raises the py313 timeout budget and adds deterministic timing diagnostics.
- No new CI env patch for `TESTING=true` is introduced here: `tests/conftest.py` already sets `TESTING=true` in `pytest_configure()`, so current evidence does not support an env-mismatch follow-up.
- Any future follow-up should be opened only if new durations/log evidence shows live bridge calls escaping the default pytest skip after `#1387`.

## Validation

Passed locally:
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- previous local `make verify` pass on this branch before governance-only artifact refreshes
- pre-push hooks including backend tests and full-repo bandit

GitHub / governance state:
- `python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1390 --require-auth` passes
- `python3 scripts/orchestration/check_merge_ready.py --pr-number 1390 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes
- no unresolved review threads remain
- canonical artifact now maps all actionable bot URLs and records the post-open `qa-engineer-agent`, `dev-operator`, and `bug-hunter` evidence

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1390_FIXED_MAPPING.md`

## Merge Readiness

Strict governance wrappers are green on the current head. This PR remains the temporary CI stabilization lane; treat it as separate from the root-fix and retirement work tracked off `#1387` and the backlog item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI test timing visibility with UTC start/finish logs and duration reporting.
  * Increased test timeouts and moved to per-version timeout configuration for more reliable runs.

* **Documentation**
  * Added review notes documenting CI stabilization and mapping of fixes to commits.
  * Updated backlog with a P1 entry tracking Python 3.13 CI performance investigation and mitigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->