### PR TITLE
fix(ci): harden pip proxy retries

### DIFF
--- a/docs/review/PR_1392_FIXED_MAPPING.md
+++ b/docs/review/PR_1392_FIXED_MAPPING.md
@@ -10,34 +10,18 @@
 
 Disposition: FIXED
 Commit: aaa3217ea
-Evidence: `docs/review/PR_1392_FIXED_MAPPING.md` now carries the canonical
-disposition/proof structure plus `## Merge Readiness`, so the artifact itself
-is no longer the merge-governance gap identified by CodeRabbit.
-Reason: The inline CodeRabbit thread requested the repo-standard mapping/proof
-structure for this artifact; commit `aaa3217ea` is the governance-only
-follow-up that addresses that ask.
+Evidence: `docs/review/PR_1392_FIXED_MAPPING.md` now carries the canonical disposition/proof structure plus `## Merge Readiness`, so the artifact itself is no longer the merge-governance gap identified by CodeRabbit.
+Reason: The inline CodeRabbit thread requested the repo-standard mapping/proof structure for this artifact; commit `aaa3217ea` is the governance-only follow-up that addresses that ask.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#discussion_r3068172124 -> aaa3217ea
 
 Disposition: NOT-A-BUG
-Evidence: The only actionable CodeRabbit finding in the aggregate review body is
-the inline thread mapped above; there is no separate additional fix beyond that
-thread.
-Reason: The aggregate review URL duplicates the inline actionable comment and
-should not be counted as a second independent FIXED item.
+Evidence: The only actionable CodeRabbit finding in the aggregate review body is the inline thread mapped above; there is no separate additional fix beyond that thread.
+Reason: The aggregate review URL duplicates the inline actionable comment and should not be counted as a second independent FIXED item.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#pullrequestreview-4093883183
 
 Disposition: NOT-A-BUG
-Evidence: `scripts/ci/install_locked_python_requirements.py:47-48` defines the
-retry/timeout contract as explicit stable constants; `scripts/ci/install_locked_python_requirements.py:418-501`
-applies them in deterministic order for `pip download` and `pip install`;
-`tests/test_install_locked_python_requirements.py:167-185` and
-`tests/test_install_locked_python_requirements.py:212-263` intentionally pin
-that ordering as part of the CI regression contract for this narrow install-path
-hardening PR.
-Reason: Sourcery suggested optional maintainability improvements
-(less brittle assertions, helper extraction, env overrides), but the current
-implementation is correct and intentionally keeps PR `#1392` narrowly scoped to
-the pip/proxy stabilization fix without widening the configuration surface.
+Evidence: `scripts/ci/install_locked_python_requirements.py:47-48` defines the retry/timeout contract as explicit stable constants; `scripts/ci/install_locked_python_requirements.py:418-501` applies them in deterministic order for `pip download` and `pip install`; `tests/test_install_locked_python_requirements.py:167-185` and `tests/test_install_locked_python_requirements.py:212-263` intentionally pin that ordering as part of the CI regression contract for this narrow install-path hardening PR.
+Reason: Sourcery suggested optional maintainability improvements (less brittle assertions, helper extraction, env overrides), but the current implementation is correct and intentionally keeps PR `#1392` narrowly scoped to the pip/proxy stabilization fix without widening the configuration surface.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#pullrequestreview-4093882503
 
 ## Merge Readiness

--- a/docs/review/PR_1392_FIXED_MAPPING.md
+++ b/docs/review/PR_1392_FIXED_MAPPING.md
@@ -9,13 +9,14 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: PENDING_REVIEW_ARTIFACT_FIX_SHA
+Commit: aaa3217ea
 Evidence: `docs/review/PR_1392_FIXED_MAPPING.md` now carries the canonical
 disposition/proof structure plus `## Merge Readiness`, so the artifact itself
 is no longer the merge-governance gap identified by CodeRabbit.
 Reason: The inline CodeRabbit thread requested the repo-standard mapping/proof
-structure for this artifact; this governance-only follow-up addresses that ask.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#discussion_r3068172124 -> PENDING_REVIEW_ARTIFACT_FIX_SHA
+structure for this artifact; commit `aaa3217ea` is the governance-only
+follow-up that addresses that ask.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#discussion_r3068172124 -> aaa3217ea
 
 Disposition: NOT-A-BUG
 Evidence: The only actionable CodeRabbit finding in the aggregate review body is

--- a/docs/review/PR_1392_FIXED_MAPPING.md
+++ b/docs/review/PR_1392_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1392 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/docs/review/PR_1392_FIXED_MAPPING.md
+++ b/docs/review/PR_1392_FIXED_MAPPING.md
@@ -1,8 +1,55 @@
+<!-- markdownlint-disable MD034 -->
 # PR 1392 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
+
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+
+Disposition: FIXED
+Commit: PENDING_REVIEW_ARTIFACT_FIX_SHA
+Evidence: `docs/review/PR_1392_FIXED_MAPPING.md` now carries the canonical
+disposition/proof structure plus `## Merge Readiness`, so the artifact itself
+is no longer the merge-governance gap identified by CodeRabbit.
+Reason: The inline CodeRabbit thread requested the repo-standard mapping/proof
+structure for this artifact; this governance-only follow-up addresses that ask.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#discussion_r3068172124 -> PENDING_REVIEW_ARTIFACT_FIX_SHA
+
+Disposition: NOT-A-BUG
+Evidence: The only actionable CodeRabbit finding in the aggregate review body is
+the inline thread mapped above; there is no separate additional fix beyond that
+thread.
+Reason: The aggregate review URL duplicates the inline actionable comment and
+should not be counted as a second independent FIXED item.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#pullrequestreview-4093883183
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/install_locked_python_requirements.py:47-48` defines the
+retry/timeout contract as explicit stable constants; `scripts/ci/install_locked_python_requirements.py:418-501`
+applies them in deterministic order for `pip download` and `pip install`;
+`tests/test_install_locked_python_requirements.py:167-185` and
+`tests/test_install_locked_python_requirements.py:212-263` intentionally pin
+that ordering as part of the CI regression contract for this narrow install-path
+hardening PR.
+Reason: Sourcery suggested optional maintainability improvements
+(less brittle assertions, helper extraction, env overrides), but the current
+implementation is correct and intentionally keeps PR `#1392` narrowly scoped to
+the pip/proxy stabilization fix without widening the configuration surface.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1392#pullrequestreview-4093882503
+
+## Merge Readiness
+
+- [ ] All required checks pass on the current PR head after each push
+- [ ] No unresolved review threads remain
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] Local hard gate green (`flake8`, `mypy`, `test-fast`, `diff-cov` /
+      `make verify` equivalent)
+
+Notes: Re-run `python3 scripts/orchestration/check_merge_ready.py --pr-number 1392 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+after pushing this governance-only follow-up, then resolve the remaining
+CodeRabbit review thread in GitHub once the mapping is live.
+
+<!-- markdownlint-enable MD034 -->

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -48,6 +48,8 @@ REQUIREMENTS_PROFILES: tuple[str, ...] = (
     "runtime-test",
     "ci-lite",
 )
+PIP_NETWORK_RETRIES = 5
+PIP_NETWORK_TIMEOUT_SECONDS = 60
 DOCKER_SINGLE_PASS_LOCKED_INSTALL_ENV = "PULSEPLATE_DOCKER_SINGLE_PASS_LOCKED_INSTALL"  # nosec B105: public env key contract, not a password (remove-by: 2026-12-31, ref: PR-docker-gha-buildx-pip-cache)
 DOCKER_PIP_LAYER_CACHE_ENV = "PULSEPLATE_DOCKER_PIP_LAYER_CACHE"
 
@@ -428,6 +430,10 @@ def build_pip_download_command(
         "-m",
         "pip",
         "download",
+        "--retries",
+        str(PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(PIP_NETWORK_TIMEOUT_SECONDS),
         "--only-binary",
         ":all:",
         "--find-links",
@@ -490,6 +496,10 @@ def build_pip_proxy_install_command(
         "-m",
         "pip",
         "install",
+        "--retries",
+        str(PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(PIP_NETWORK_TIMEOUT_SECONDS),
         "--only-binary",
         ":all:",
         "--index-url",

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -178,6 +178,13 @@ def test_build_pip_download_command_uses_constraint_when_present(tmp_path: Path)
     )
 
     assert command[:4] == ["python", "-m", "pip", "download"]
+    download_idx = command.index("download")
+    assert command[download_idx + 1 : download_idx + 5] == [
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(installer.PIP_NETWORK_TIMEOUT_SECONDS),
+    ]
     assert "--only-binary" in command
     assert ":all:" in command
     assert "--find-links" in command
@@ -218,7 +225,13 @@ def test_build_pip_proxy_install_command_uses_approved_proxy_without_cache(
 
     assert command[:4] == ["python", "-m", "pip", "install"]
     install_idx = command.index("install")
-    assert command[install_idx + 1] == "--no-cache-dir"
+    assert command[install_idx + 1 : install_idx + 5] == [
+        "--no-cache-dir",
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+    ]
+    assert command[install_idx + 5] == str(installer.PIP_NETWORK_TIMEOUT_SECONDS)
     assert "--only-binary" in command
     assert ":all:" in command
     assert "--index-url" in command
@@ -243,6 +256,13 @@ def test_build_pip_proxy_install_command_omits_no_cache_dir_when_cache_allowed(
     )
 
     assert "--no-cache-dir" not in command
+    install_idx = command.index("install")
+    assert command[install_idx + 1 : install_idx + 5] == [
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(installer.PIP_NETWORK_TIMEOUT_SECONDS),
+    ]
 
 
 def test_build_pip_proxy_install_command_supports_find_links(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- harden locked Python installs used by `./.github/actions/python-setup`
- add explicit pip network retries and timeout for proxy-backed `download` and `install`
- cover the command contract with targeted installer tests

## Why
`main` head `7e021f58c5a7298cc96f149181265b1773fba06d` hit a red `CI` run (`24282693031`) because `OpenAPI sync (backend -> frontend artifacts)` failed in `Setup Python environment`.

Observed failure path from the job log (`70906962024`):
- first proxy install pass hit the known `cryptography==46.0.7` private-index gap and correctly fell back to the emergency wheelhouse
- second proxy install pass then failed during large-wheel download with `ssl.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC]`
- failure happened before `make openapi`, so this is a CI transport instability, not an OpenAPI generation regression

This PR reduces repeat probability by making pip network behavior more tolerant to transient TLS/proxy failures.

## Validation
- `pytest -q tests/test_install_locked_python_requirements.py`
- `pytest -q tests/test_python_supply_chain_controls.py`
- `pre-commit run --all-files`
- pre-push suite passed during `git push`

## Notes
- I did not claim merge-readiness
- current `main` run `24282693031` is still in progress while `test-main (3.13, 90)` continues

## Summary by Sourcery

Усилить установку зафиксированных зависимостей Python в CI, добавив более устойчивые сетевые настройки pip и обновив покрытие, связанное с поведением установщика.

Bug Fixes:
- Обеспечить, чтобы команды `pip` для загрузки и установки через прокси использовали согласованные параметры повторных попыток и тайм-аутов сети, чтобы уменьшить временные ошибки TLS/прокси в CI.

Enhancements:
- Централизовать конфигурацию повторных сетевых попыток и тайм-аутов для `pip` при установке зафиксированных Python-зависимостей в CI.

Documentation:
- Добавить специальный для этого PR документ сопоставления ревью, фиксирующий, что не было никаких содержательных комментариев по ревью.

Tests:
- Расширить тесты установщика, чтобы проверять наличие параметров повторных попыток и тайм-аутов `pip` как для команд загрузки, так и для команд установки через прокси.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden CI Python locked-requirements installs by adding resilient pip network settings and updating coverage around the installer behavior.

Bug Fixes:
- Ensure proxy-backed pip download and install commands use consistent network retries and timeouts to reduce transient TLS/proxy failures in CI.

Enhancements:
- Centralize pip network retry and timeout configuration for CI locked Python installs.

Documentation:
- Add a PR-specific review mapping document recording that there were no actionable review comments.

Tests:
- Extend installer tests to assert inclusion of pip retry and timeout options for both download and proxy install commands.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Усилить установку зафиксированных зависимостей Python в CI, добавив более устойчивые сетевые настройки pip и обновив покрытие, связанное с поведением установщика.

Bug Fixes:
- Обеспечить, чтобы команды `pip` для загрузки и установки через прокси использовали согласованные параметры повторных попыток и тайм-аутов сети, чтобы уменьшить временные ошибки TLS/прокси в CI.

Enhancements:
- Централизовать конфигурацию повторных сетевых попыток и тайм-аутов для `pip` при установке зафиксированных Python-зависимостей в CI.

Documentation:
- Добавить специальный для этого PR документ сопоставления ревью, фиксирующий, что не было никаких содержательных комментариев по ревью.

Tests:
- Расширить тесты установщика, чтобы проверять наличие параметров повторных попыток и тайм-аутов `pip` как для команд загрузки, так и для команд установки через прокси.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden CI Python locked-requirements installs by adding resilient pip network settings and updating coverage around the installer behavior.

Bug Fixes:
- Ensure proxy-backed pip download and install commands use consistent network retries and timeouts to reduce transient TLS/proxy failures in CI.

Enhancements:
- Centralize pip network retry and timeout configuration for CI locked Python installs.

Documentation:
- Add a PR-specific review mapping document recording that there were no actionable review comments.

Tests:
- Extend installer tests to assert inclusion of pip retry and timeout options for both download and proxy install commands.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden CI Python installs by adding `pip` retries and timeouts to proxy-backed download and install to reduce transient TLS/proxy failures in the OpenAPI sync job. Adds a canonical review mapping doc, normalizes its lines, and syncs bot disposition notes.

- **Bug Fixes**
  - Add `--retries` (5) and `--timeout` (60s) to `pip download` and `pip install`.
  - Keep proxy and `--only-binary :all:` behavior; extend tests to assert the new flags and their ordering.

<sup>Written for commit 068a3a055915cfd15951be6571c0edc8723ecb4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1392_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PR review artifact capturing discussion dispositions, fixed-in-commit mapping, and a merge-readiness checklist with rerun instructions.

* **Chores**
  * Added network-resilience settings for Python dependency installs so pip operations use retries and timeouts.

* **Tests**
  * Updated tests to verify pip download/install commands include the configured retry and timeout parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->