### PR TITLE
fix(ci): harden pip proxy retries

### DIFF
--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -48,6 +48,8 @@ REQUIREMENTS_PROFILES: tuple[str, ...] = (
     "runtime-test",
     "ci-lite",
 )
+PIP_NETWORK_RETRIES = 5
+PIP_NETWORK_TIMEOUT_SECONDS = 60
 DOCKER_SINGLE_PASS_LOCKED_INSTALL_ENV = "PULSEPLATE_DOCKER_SINGLE_PASS_LOCKED_INSTALL"  # nosec B105: public env key contract, not a password (remove-by: 2026-12-31, ref: PR-docker-gha-buildx-pip-cache)
 DOCKER_PIP_LAYER_CACHE_ENV = "PULSEPLATE_DOCKER_PIP_LAYER_CACHE"
 
@@ -428,6 +430,10 @@ def build_pip_download_command(
         "-m",
         "pip",
         "download",
+        "--retries",
+        str(PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(PIP_NETWORK_TIMEOUT_SECONDS),
         "--only-binary",
         ":all:",
         "--find-links",
@@ -490,6 +496,10 @@ def build_pip_proxy_install_command(
         "-m",
         "pip",
         "install",
+        "--retries",
+        str(PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(PIP_NETWORK_TIMEOUT_SECONDS),
         "--only-binary",
         ":all:",
         "--index-url",

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -178,6 +178,13 @@ def test_build_pip_download_command_uses_constraint_when_present(tmp_path: Path)
     )
 
     assert command[:4] == ["python", "-m", "pip", "download"]
+    download_idx = command.index("download")
+    assert command[download_idx + 1 : download_idx + 5] == [
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(installer.PIP_NETWORK_TIMEOUT_SECONDS),
+    ]
     assert "--only-binary" in command
     assert ":all:" in command
     assert "--find-links" in command
@@ -218,7 +225,13 @@ def test_build_pip_proxy_install_command_uses_approved_proxy_without_cache(
 
     assert command[:4] == ["python", "-m", "pip", "install"]
     install_idx = command.index("install")
-    assert command[install_idx + 1] == "--no-cache-dir"
+    assert command[install_idx + 1 : install_idx + 5] == [
+        "--no-cache-dir",
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+    ]
+    assert command[install_idx + 5] == str(installer.PIP_NETWORK_TIMEOUT_SECONDS)
     assert "--only-binary" in command
     assert ":all:" in command
     assert "--index-url" in command
@@ -243,6 +256,13 @@ def test_build_pip_proxy_install_command_omits_no_cache_dir_when_cache_allowed(
     )
 
     assert "--no-cache-dir" not in command
+    install_idx = command.index("install")
+    assert command[install_idx + 1 : install_idx + 5] == [
+        "--retries",
+        str(installer.PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(installer.PIP_NETWORK_TIMEOUT_SECONDS),
+    ]
 
 
 def test_build_pip_proxy_install_command_supports_find_links(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Stabilize current-head `main` by hardening the locked Python installer's proxy path with bounded pip retries/timeouts.

This is a blocking infrastructure PR to restore `main` stability before opening the planned product-runtime lane `PR-A5`.

## Why
Current-head `main` CI run `24282693031` failed in `OpenAPI sync (backend -> frontend artifacts)` during the composite Python setup path. The failing lane uses `./.github/actions/python-setup` with `requirements-profile: ci-lite` and `install-mode: direct-proxy`.

`lint` and `security` use the same direct-proxy installer path and passed in the same workflow, which points to a transient proxy/install flake rather than a deterministic requirements-profile regression. This PR hardens that path without changing dependency surfaces or public contracts.

## Changes
- add bounded pip `--retries` and `--timeout` flags to the locked download/install command builders used by the proxy install path
- add deterministic tests that assert the retry/timeout flags are present in generated pip commands

## Out of scope
- no AI/runtime gate work
- no semantic cache work
- no public API changes
- no workflow contract changes beyond installer hardening

## Validation
- `pytest -q tests/test_install_locked_python_requirements.py`
- `pytest -q tests/test_python_supply_chain_controls.py`
- `pre-commit run --all-files`
- `git push` pre-push hooks passed, including backend tests, bandit, docker build test
- local `make verify` passed through `verify-env`, `flake8`, `mypy`, and `test-fast`
- local `make diff-cov` is running separately because the all-in-one wrapper session was terminated by the terminal host during the long coverage phase, not by a code/test failure

## Follow-up
After this PR merges and current-head `main` is green, open the separate coordinator-owned draft PR for `PR-A5 — LLM runtime gates, semantic cache deferred`.
