### PR TITLE
build(deps): bump types-pyyaml to 6.0.12.20260408

### DIFF
--- a/docs/review/PR_1403_FIXED_MAPPING.md
+++ b/docs/review/PR_1403_FIXED_MAPPING.md
@@ -1,11 +1,11 @@
 # PR 1403 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments yet
+- No actionable review comments
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1403_FIXED_MAPPING.md
+++ b/docs/review/PR_1403_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1403 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments yet
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [ ] `make verify` green
+Notes: This replacement PR supersedes stale Dependabot PR #1399. Local validation on branch head `045f6f9d0` passed for `pre-commit run --all-files`, pre-push hooks, and `make validate-min` with `VENV_PYTHON=${VENV_PYTHON:-.venv/bin/python}`. The replacement lane keeps the diff scoped to `requirements-dev.txt` and `requirements-lock.txt`, with only `types-pyyaml 6.0.12.20250915 -> 6.0.12.20260408` and no unrelated runtime/CUDA lock regeneration. The source Dependabot branch introduced unrelated `requirements.txt` churn and failed CI bootstrap on the internal simple index while resolving `cuda-pathfinder==1.5.2`, which is outside the scope of this stub-only bump.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -225,7 +225,7 @@ tomli==2.3.0
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-types-pyyaml==6.0.12.20250915
+types-pyyaml==6.0.12.20260408
     # via -r requirements-dev.in
 typing-extensions==4.15.0
     # via

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -566,7 +566,7 @@ typer==0.24.1
     #   -c requirements.txt
     #   huggingface-hub
     #   transformers
-types-pyyaml==6.0.12.20250915
+types-pyyaml==6.0.12.20260408
     # via -r requirements-dev.in
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
## Summary
- supersede Dependabot PR #1399 with a minimal human-owned replacement
- bump `types-pyyaml` from `6.0.12.20250915` to `6.0.12.20260408`
- keep `requirements.txt` unchanged to avoid unrelated runtime/CUDA lock churn from the bot branch

## Why replacement
The original bot PR regenerated runtime dependency content and introduced unrelated `requirements.txt` / CUDA package churn. On CI that branch failed during bootstrap against the internal simple index with `cuda-pathfinder==1.5.2` resolution errors, which is outside the scope of a stub-only bump.

## Validation
- `VENV_PYTHON=${VENV_PYTHON:-.venv/bin/python} make validate-min`
- `pre-commit run --all-files`
- pre-push hooks passed on branch push

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1403_FIXED_MAPPING.md`
- No actionable review comments

## Merge Readiness
- [ ] All required checks are green on latest commit
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped
- [ ] Wait-window completed after latest bot/review activity

## Notes
- replacement flow for #1399
- current diff stays scoped to `requirements-dev.txt` and `requirements-lock.txt` only

## Summary by Sourcery

Обновите заглушки зависимостей для разработки и задокументируйте сопоставление обзоров для этого PR.

Новые возможности:
- Добавить документ отслеживания обзоров для PR 1403 в `docs/review`.

Улучшения:
- Обновить версию `types-pyyaml` в файлах требований для разработки и блокировки (`lock requirements`) до последнего выпуска заглушек.

Документация:
- Задокументировать сопоставление `fixed-in-commit` и чек-лист готовности к слиянию для PR 1403.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update development dependency stubs and document the review mapping for this PR.

New Features:
- Add a review tracking document for PR 1403 under docs/review.

Enhancements:
- Update types-pyyaml version in development and lock requirements files to the latest stub release.

Documentation:
- Document the fixed-in-commit mapping and merge readiness checklist for PR 1403.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added review documentation for PR status tracking.

* **Chores**
  * Updated `types-pyyaml` type stub package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->