### PR TITLE
docs(orchestration): close coordinator launcher rollout

### DIFF
--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
@@ -117,6 +117,8 @@ This smoke validates normalization, not crash-on-duplicate.
 
 - Remove or rename the wrapper; remove `~/.local/bin` from `PATH` for a test shell.
 - Confirm normal repo workflows still work (`make validate-min`, or your usual commands).
+- If you are running Smoke 4 from a clean worktree without a local `.venv`, either run `make venv`
+  first or point `VENV_PYTHON` at a valid repo venv before `make validate-min`.
 - Baseline repository state must remain valid (wrapper is host-only).
 
 ## Post-merge git flow (operator)

--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
@@ -4,8 +4,12 @@
 
 - Machine: opted-in local operator machine
 - Wrapper path: `~/.local/bin/pulseplate-coordinator-launch.sh`
-- Repo worktree: `worktrees/fix-coordinator-role-agent-rollout`
+- Repo worktree: `<repo-root>/worktrees/fix-coordinator-role-agent-rollout`
 - Template source: `docs/templates/pulseplate-coordinator-launch.example.sh`
+- Closeout PR: `PR #1408`
+- Closeout commit: `43f4dd6855ed19b791f736bb2e12be3fa5fb9508`
+- Wrapper state for smokes: synced to the canonical repo template before all
+  four runs
 
 ## Host-local sync
 
@@ -13,7 +17,7 @@
 - Found drift in flag parsing: the installed wrapper was missing explicit value checks for
   `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, and `--path`.
 - Synced the installed wrapper to the canonical template.
-- Post-sync verification: `cmp -s ~/.local/bin/pulseplate-coordinator-launch.sh docs/templates/pulseplate-coordinator-launch.example.sh` → `TEMPLATE_SYNCED`.
+- Post-sync verification: `cmp -s ~/.local/bin/pulseplate-coordinator-launch.sh docs/templates/pulseplate-coordinator-launch.example.sh` → exit code `0` (files identical).
 
 ## Smoke Results
 
@@ -37,6 +41,14 @@ Result:
 - Primary agent: `cursor-specialist-agent`.
 - Reviewer: `qa-engineer-agent`.
 
+Output excerpt:
+
+```text
+check_preflight.py --mode analyze: PASS
+primary_agent=cursor-specialist-agent reviewer=qa-engineer-agent
+task_packet=artifacts/orchestration/task_packets/3e9e83d8e2c5.json
+```
+
 ### Smoke 2
 
 Command:
@@ -57,6 +69,14 @@ Result:
 - Task packet emitted: `artifacts/orchestration/task_packets/39b5396fd243.json`.
 - Requested agents preserved in packet order: `["qa-engineer-agent", "bug-hunter"]`.
 - Primary agent resolved to `qa-engineer-agent`.
+
+Output excerpt:
+
+```text
+requested_agents=["qa-engineer-agent","bug-hunter"]
+primary_agent=qa-engineer-agent
+task_packet=artifacts/orchestration/task_packets/39b5396fd243.json
+```
 
 ### Smoke 3
 
@@ -80,13 +100,26 @@ Result:
 - Packet shows normalized requested agents: `["qa-engineer-agent", "bug-hunter"]`.
 - Duplicate `qa-engineer-agent` did not crash the wrapper and was deduplicated with first-seen order preserved.
 
+Output excerpt:
+
+```text
+requested_agents=["qa-engineer-agent","qa-engineer-agent","bug-hunter"]
+normalized_requested_agents=["qa-engineer-agent","bug-hunter"]
+task_packet=artifacts/orchestration/task_packets/f1fccd7106b8.json
+```
+
 ### Smoke 4
+
+Working directory:
+
+- `<repo-root>/worktrees/fix-coordinator-role-agent-rollout`
 
 Command:
 
 ```bash
+REPO_ROOT="<repo-root>"
 env PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-  VENV_PYTHON="../../.venv/bin/python" \
+  VENV_PYTHON="$REPO_ROOT/.venv/bin/python" \
   bash -lc 'command -v pulseplate-coordinator-launch.sh >/dev/null 2>&1 && echo LAUNCHER_VISIBLE || echo LAUNCHER_HIDDEN; make validate-min'
 ```
 
@@ -95,6 +128,14 @@ Result:
 - `pulseplate-coordinator-launch.sh` was hidden from `PATH`: `LAUNCHER_HIDDEN`.
 - `make validate-min` passed.
 - Normal repo workflow remained usable without the launcher in `PATH`.
+
+Output excerpt:
+
+```text
+LAUNCHER_HIDDEN
+make validate-min
+PASS
+```
 
 ## Conclusion
 

--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
@@ -141,4 +141,4 @@ PASS
 
 - The coordinator-first launcher path is working on at least one opted-in machine.
 - The remaining gap was host-local wrapper drift, not a missing repo-side coordinator / role-agent implementation.
-- The backlog rollout item can be closed using this evidence.
+- This evidence is sufficient for the post-merge docs-only ledger closeout step.

--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md
@@ -1,0 +1,103 @@
+# Local Coordinator Launcher Rollout Evidence — 10 April 2026
+
+## Context
+
+- Machine: opted-in local operator machine
+- Wrapper path: `~/.local/bin/pulseplate-coordinator-launch.sh`
+- Repo worktree: `worktrees/fix-coordinator-role-agent-rollout`
+- Template source: `docs/templates/pulseplate-coordinator-launch.example.sh`
+
+## Host-local sync
+
+- Compared the installed wrapper to the canonical template.
+- Found drift in flag parsing: the installed wrapper was missing explicit value checks for
+  `--goal`, `--task-class`, `--pr-phase`, `--requested-agent`, and `--path`.
+- Synced the installed wrapper to the canonical template.
+- Post-sync verification: `cmp -s ~/.local/bin/pulseplate-coordinator-launch.sh docs/templates/pulseplate-coordinator-launch.example.sh` → `TEMPLATE_SYNCED`.
+
+## Smoke Results
+
+### Smoke 1
+
+Command:
+
+```bash
+~/.local/bin/pulseplate-coordinator-launch.sh \
+  --goal "Close machine-local launcher gap for coordinator-first startup" \
+  --task-class "pr_governance" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase pre_open
+```
+
+Result:
+
+- `check_preflight.py --mode analyze` passed.
+- Scoped `AGENTS.md` resolution passed.
+- Task packet emitted: `artifacts/orchestration/task_packets/3e9e83d8e2c5.json`.
+- Primary agent: `cursor-specialist-agent`.
+- Reviewer: `qa-engineer-agent`.
+
+### Smoke 2
+
+Command:
+
+```bash
+~/.local/bin/pulseplate-coordinator-launch.sh \
+  --goal "Run post-open review packet for launcher PR" \
+  --task-class "review" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase post_open_review \
+  --requested-agent qa-engineer-agent \
+  --requested-agent bug-hunter
+```
+
+Result:
+
+- Command passed.
+- Task packet emitted: `artifacts/orchestration/task_packets/39b5396fd243.json`.
+- Requested agents preserved in packet order: `["qa-engineer-agent", "bug-hunter"]`.
+- Primary agent resolved to `qa-engineer-agent`.
+
+### Smoke 3
+
+Command:
+
+```bash
+~/.local/bin/pulseplate-coordinator-launch.sh \
+  --goal "Check duplicate requested-agent normalization" \
+  --task-class "review" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --pr-phase post_open_review \
+  --requested-agent qa-engineer-agent \
+  --requested-agent qa-engineer-agent \
+  --requested-agent bug-hunter
+```
+
+Result:
+
+- Command passed.
+- Task packet emitted: `artifacts/orchestration/task_packets/f1fccd7106b8.json`.
+- Packet shows normalized requested agents: `["qa-engineer-agent", "bug-hunter"]`.
+- Duplicate `qa-engineer-agent` did not crash the wrapper and was deduplicated with first-seen order preserved.
+
+### Smoke 4
+
+Command:
+
+```bash
+env PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+  VENV_PYTHON="../../.venv/bin/python" \
+  bash -lc 'command -v pulseplate-coordinator-launch.sh >/dev/null 2>&1 && echo LAUNCHER_VISIBLE || echo LAUNCHER_HIDDEN; make validate-min'
+```
+
+Result:
+
+- `pulseplate-coordinator-launch.sh` was hidden from `PATH`: `LAUNCHER_HIDDEN`.
+- `make validate-min` passed.
+- Normal repo workflow remained usable without the launcher in `PATH`.
+
+## Conclusion
+
+- The coordinator-first launcher path is working on at least one opted-in machine.
+- The remaining gap was host-local wrapper drift, not a missing repo-side coordinator / role-agent implementation.
+- The backlog rollout item can be closed using this evidence.

--- a/docs/review/PR_1408_FIXED_MAPPING.md
+++ b/docs/review/PR_1408_FIXED_MAPPING.md
@@ -1,0 +1,54 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1408 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#discussion_r3070065288 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md` now declares the sanitized working directory and uses a repo-root-based `VENV_PYTHON` example instead of an unexplained relative path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#discussion_r3070065291 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now replaces the placeholder closeout reference with concrete `PR #1408`, satisfying the traceability requirement for a closed ledger item.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#discussion_r3070068141 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now cites concrete `PR #1408` in the Target PR field.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#issuecomment-4232580980 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: the evidence doc now includes explicit exit-code wording, raw output excerpts for each smoke, repo-root-based path clarification, and the ledger traceability fix covered by the inline review comments.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#pullrequestreview-4095622038 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: the evidence doc now records the closeout PR/commit, keeps the worktree path sanitized as `<repo-root>/...`, and ties the smokes to a reproducible repo-side closeout state.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#pullrequestreview-4095623981 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: the combined evidence-doc and ledger updates address the review summary and the underlying inline comments it called out.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#pullrequestreview-4095626064 -> 3d56e749b
+Disposition: FIXED
+Commit: `3d56e749b`
+Evidence: the ledger closeout now points to concrete `PR #1408`, which resolves the PR-traceability issue identified by cubic.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1408_FIXED_MAPPING.md
+++ b/docs/review/PR_1408_FIXED_MAPPING.md
@@ -45,6 +45,11 @@ Disposition: FIXED
 Commit: `3d56e749b`
 Evidence: the ledger closeout now points to concrete `PR #1408`, which resolves the PR-traceability issue identified by cubic.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1408#pullrequestreview-4095636617 -> 9d87500f2
+Disposition: FIXED
+Commit: `9d87500f2`
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now keeps the launcher-rollout item open, marks the status as in progress, and states that closure happens only after PR `#1408` merges via a docs-only follow-up, which matches the ledger closure rule called out by CodeRabbit.
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2705,17 +2705,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No embeddings, vector DB, or product-runtime coupling are introduced by this policy item
 
 <a id="ledger-p2-local-launcher-rollout-for-coordinator-first-automation"></a>
-- [ ] P2: Local launcher rollout for coordinator-first automation
+- [x] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); host install remains operator-owned outside git
+  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); PR-TBD-fix-coordinator-role-agent-rollout (host smoke evidence + backlog closeout)
   - Area: local tooling / launcher / Codex runtime
   - Finding Type: non-repo rollout follow-up
-  - Status (EN): Companion PR #1370 adds `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`, `docs/templates/pulseplate-coordinator-launch.example.sh`, and aligned onboarding pointers. **Do not check this item complete** until host smoke evidence is recorded (per runbook “Smoke checks” + “Evidence and backlog”) on at least one opted-in machine—not markdown alone.
+  - Status (EN): Completed. Companion PR #1370 added the repo-side runbook and sanitized wrapper example; host smoke evidence was recorded on 10 April 2026 for one opted-in machine in `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`.
   - Reason: Repo docs and deterministic engines alone cannot force raw session auto-start. A machine-local launcher or wrapper must wire preflight, bootstrap, and compatible runtime settings without pretending that `~/.codex/config.toml` is repo source of truth.
   - Links:
     - `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`
     - `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`
+    - `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`
     - `docs/templates/pulseplate-coordinator-launch.example.sh`
     - `docs/templates/codex.config.example.toml`
     - `scripts/orchestration/local_session_bootstrap.sh`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2708,7 +2708,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [x] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); PR-TBD-fix-coordinator-role-agent-rollout (host smoke evidence + backlog closeout)
+  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); PR #1408 (host smoke evidence + backlog closeout)
   - Area: local tooling / launcher / Codex runtime
   - Finding Type: non-repo rollout follow-up
   - Status (EN): Completed. Companion PR #1370 added the repo-side runbook and sanitized wrapper example; host smoke evidence was recorded on 10 April 2026 for one opted-in machine in `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2705,13 +2705,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No embeddings, vector DB, or product-runtime coupling are introduced by this policy item
 
 <a id="ledger-p2-local-launcher-rollout-for-coordinator-first-automation"></a>
-- [x] P2: Local launcher rollout for coordinator-first automation
+- [ ] P2: Local launcher rollout for coordinator-first automation
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); PR #1408 (host smoke evidence + backlog closeout)
+  - Target PR: PR #1348 + PR #1350 (landed); PR #1370 (repo companion: runbook + sanitized wrapper example + entry-doc sync + core TypeGuard mypy fix); PR #1408 (host smoke evidence); docs-only closeout PR TBD after `#1408` merge
   - Area: local tooling / launcher / Codex runtime
   - Finding Type: non-repo rollout follow-up
-  - Status (EN): Completed. Companion PR #1370 added the repo-side runbook and sanitized wrapper example; host smoke evidence was recorded on 10 April 2026 for one opted-in machine in `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`.
+  - Status (EN): In progress. Companion PR #1370 added the repo-side runbook and sanitized wrapper example; host smoke evidence was recorded on 10 April 2026 for one opted-in machine in `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`. Keep this item open until PR `#1408` is merged, then close it via a docs-only follow-up per the ledger closure rule.
   - Reason: Repo docs and deterministic engines alone cannot force raw session auto-start. A machine-local launcher or wrapper must wire preflight, bootstrap, and compatible runtime settings without pretending that `~/.codex/config.toml` is repo source of truth.
   - Links:
     - `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`


### PR DESCRIPTION
## Summary
- salvage the dirty local coordinator launcher rollout docs into a fresh branch from current `main`
- add host smoke evidence for the opted-in local launcher flow
- record host smoke evidence and keep the backlog item open until the post-merge docs-only closeout

## Scope
- carries only these files:
  - `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`
  - `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT_EVIDENCE_2026-04-10.md`
  - `docs/roadmap/BACKLOG_LEDGER.md`
- excludes generated `artifacts/`, `.playwright-cli/`, `output/`, and any host-local wrapper file contents
- docs/orchestration only; no runtime/API changes

## Carryover
This PR rebuilds a fresh follow-up slice from the dirty local worktree `fix/coordinator-role-agent-rollout` instead of reviving stale branch history directly.

## Local Validation
- `pre-commit run --all-files`
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-min`

## Notes
- this PR records launcher host smoke evidence; the backlog item stays open until a post-merge docs-only closeout flips the ledger to closed
- no public API/interface changes

## Summary by Sourcery

Зафиксировать smoke-доказательства на хосте для выкатывания локального координатор-ланчера и закрыть соответствующий пункт в бэклоге.

Документация:
- Задокументировать smoke-доказательства выкатывания координатор-ланчера для машины-хоста, подключившейся к эксперименту, включая команды, результаты и вывод.
- Уточнить инструкции по smoke-тесту локального координатор-ланчера в части требований к настройке `venv`.
- Обновить реестр бэклога roadmap, чтобы пометить пункт о выкатывании локального ланчера как завершённый и сослаться на новый документ с доказательствами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Record host smoke evidence for the local coordinator launcher rollout and close out the corresponding backlog item.

Documentation:
- Document coordinator launcher rollout smoke evidence for an opted-in host machine, including commands, results, and conclusion.
- Clarify the local coordinator launcher smoke test instructions regarding venv setup requirements.
- Update the roadmap backlog ledger to mark the local launcher rollout item as completed and reference the new evidence doc.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records host smoke evidence for the local coordinator launcher and updates guidance for Smoke 4 venv setup. Keeps the rollout backlog item open until PR #1408 merges, adds output excerpts and exit codes in the evidence, and includes `docs/review/PR_1408_FIXED_MAPPING.md`; docs-only, no runtime or API changes.

<sup>Written for commit af55a81503bf474a10642b95dde81408c69c4930. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Smoke 4 rollback instructions: require creating the repo virtualenv or setting VENV_PYTHON before running validation from a clean worktree.
  * Added rollout evidence (2026-04-10) showing wrapper sync, flag-parsing fixes, and four smoke-test runs for the Local Coordinator Launcher.
  * Updated backlog entry to reference the new evidence and PR #1408 as rollout steps.
  * Added a review disposition mapping document (PR_1408 fixed-in-commit mappings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1408_FIXED_MAPPING.md`
