### PR TITLE
feat(db): add repo-aligned foods catalog foundation and restaurant schema

### DIFF
--- a/alembic/versions/202604120001_add_foods_catalog_foundation.py
+++ b/alembic/versions/202604120001_add_foods_catalog_foundation.py
@@ -1,0 +1,189 @@
+"""add repo-aligned foods catalog foundation and restaurant schema
+
+Revision ID: 202604120001
+Revises: 202604060001
+Create Date: 2026-04-12
+
+Additive-only foundation revision that:
+- creates `foods` aligned to the current runtime/local catalog vocabulary,
+- creates future relational `restaurants` + `restaurant_menu_items` tables,
+- closes the PostgreSQL pg_trgm seam introduced in 202604060001.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "202604120001"
+down_revision = "202604060001"
+branch_labels = None
+depends_on = None
+
+
+def _json_type() -> sa.JSON:
+    """RU: Диалект-безопасный JSON/JSONB. EN: Dialect-safe JSON/JSONB."""
+
+    return sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+_UPGRADE_TRIGRAM_INDEXES = r"""
+DO $pulseplate_pg_trgm$
+BEGIN
+  IF to_regclass('public.foods') IS NOT NULL THEN
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_canonical_name_gin_trgm
+ON public.foods USING gin (canonical_name gin_trgm_ops)
+$sql$;
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_group_name_gin_trgm
+ON public.foods USING gin (group_name gin_trgm_ops)
+$sql$;
+    EXECUTE $sql$
+CREATE INDEX IF NOT EXISTS ix_foods_brand_gin_trgm
+ON public.foods USING gin (brand gin_trgm_ops)
+$sql$;
+  END IF;
+END
+$pulseplate_pg_trgm$;
+"""
+
+
+def upgrade() -> None:
+    """Create repo-aligned foods catalog foundation tables."""
+
+    op.create_table(
+        "foods",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("canonical_name", sa.Text(), nullable=False),
+        sa.Column("group_name", sa.Text(), nullable=False),
+        sa.Column("per_g", sa.Numeric(8, 2), nullable=False, server_default="100.00"),
+        sa.Column("kcal", sa.Numeric(8, 2), nullable=False),
+        sa.Column("protein_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
+        sa.Column("fat_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
+        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
+        sa.Column("fiber_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
+        sa.Column("Fe_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("Ca_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("K_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("Mg_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("VitD_IU", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("B12_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("Folate_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("Iodine_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
+        sa.Column("flags", _json_type(), nullable=False, server_default="[]"),
+        sa.Column("brand", sa.Text(), nullable=True),
+        sa.Column("gtin", sa.Text(), nullable=True),
+        sa.Column("fdc_id", sa.Text(), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_priority", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("version_date", sa.String(length=64), nullable=False),
+        sa.Column("price_per_100g", sa.Numeric(10, 2), nullable=True),
+        sa.Column("nutrition_inputs_json", _json_type(), nullable=True),
+        sa.Column("nutrition_provenance_json", _json_type(), nullable=True),
+        sa.Column("nutrition_confidence", sa.Numeric(4, 3), nullable=True),
+        sa.Column("nutrition_nutrient_confidence_json", _json_type(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_foods_canonical_name", "foods", ["canonical_name"], unique=False)
+    op.create_index("ix_foods_group_name", "foods", ["group_name"], unique=False)
+    op.create_index("ix_foods_source", "foods", ["source"], unique=False)
+    op.create_index("ix_foods_gtin", "foods", ["gtin"], unique=False)
+
+    op.create_table(
+        "restaurants",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("country", sa.String(length=16), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_id", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_restaurants_name", "restaurants", ["name"], unique=False)
+
+    op.create_table(
+        "restaurant_menu_items",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("restaurant_id", sa.Text(), nullable=False),
+        sa.Column("food_id", sa.Text(), nullable=True),
+        sa.Column("item_name", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=True),
+        sa.Column("serving_size_g", sa.Numeric(10, 2), nullable=True),
+        sa.Column("kcal", sa.Numeric(8, 2), nullable=True),
+        sa.Column("protein_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("fat_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("sodium_mg", sa.Numeric(10, 2), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_id", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["restaurant_id"],
+            ["restaurants.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["food_id"],
+            ["foods.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_restaurant_menu_items_restaurant_id",
+        "restaurant_menu_items",
+        ["restaurant_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_restaurant_menu_items_item_name",
+        "restaurant_menu_items",
+        ["item_name"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_restaurant_menu_items_food_id",
+        "restaurant_menu_items",
+        ["food_id"],
+        unique=False,
+    )
+
+    dialect = op.get_bind().dialect.name
+    if dialect == "postgresql":
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.execute(_UPGRADE_TRIGRAM_INDEXES)
+
+
+def downgrade() -> None:
+    """Drop repo-aligned foods catalog foundation tables."""
+
+    op.drop_index("ix_restaurant_menu_items_food_id", table_name="restaurant_menu_items")
+    op.drop_index("ix_restaurant_menu_items_item_name", table_name="restaurant_menu_items")
+    op.drop_index(
+        "ix_restaurant_menu_items_restaurant_id",
+        table_name="restaurant_menu_items",
+    )
+    op.drop_table("restaurant_menu_items")
+
+    op.drop_index("ix_restaurants_name", table_name="restaurants")
+    op.drop_table("restaurants")
+
+    op.drop_index("ix_foods_gtin", table_name="foods")
+    op.drop_index("ix_foods_source", table_name="foods")
+    op.drop_index("ix_foods_group_name", table_name="foods")
+    op.drop_index("ix_foods_canonical_name", table_name="foods")
+    op.drop_table("foods")

--- a/alembic/versions/202604120001_add_foods_catalog_foundation.py
+++ b/alembic/versions/202604120001_add_foods_catalog_foundation.py
@@ -6,7 +6,7 @@ Create Date: 2026-04-12
 
 Additive-only foundation revision that:
 - creates `foods` aligned to the current runtime/local catalog vocabulary,
-- creates future relational `restaurants` + `restaurant_menu_items` tables,
+- creates future relational `restaurant_chains` + `restaurant_menu_items` tables,
 - closes the PostgreSQL pg_trgm seam introduced in 202604060001.
 """
 
@@ -27,6 +27,21 @@ def _json_type() -> sa.JSON:
     """RU: Диалект-безопасный JSON/JSONB. EN: Dialect-safe JSON/JSONB."""
 
     return sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def _table_exists(table_name: str) -> bool:
+    """RU: Проверить наличие таблицы. EN: Check whether a table already exists."""
+
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    """RU: Проверить наличие индекса. EN: Check whether an index already exists."""
+
+    if not _table_exists(table_name):
+        return False
+    inspector = sa.inspect(op.get_bind())
+    return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
 
 
 _UPGRADE_TRIGRAM_INDEXES = r"""
@@ -54,113 +69,124 @@ $pulseplate_pg_trgm$;
 def upgrade() -> None:
     """Create repo-aligned foods catalog foundation tables."""
 
-    op.create_table(
-        "foods",
-        sa.Column("id", sa.Text(), nullable=False),
-        sa.Column("canonical_name", sa.Text(), nullable=False),
-        sa.Column("group_name", sa.Text(), nullable=False),
-        sa.Column("per_g", sa.Numeric(8, 2), nullable=False, server_default="100.00"),
-        sa.Column("kcal", sa.Numeric(8, 2), nullable=False),
-        sa.Column("protein_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
-        sa.Column("fat_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
-        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
-        sa.Column("fiber_g", sa.Numeric(8, 2), nullable=False, server_default="0"),
-        sa.Column("Fe_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("Ca_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("K_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("Mg_mg", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("VitD_IU", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("B12_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("Folate_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("Iodine_ug", sa.Numeric(10, 3), nullable=False, server_default="0"),
-        sa.Column("flags", _json_type(), nullable=False, server_default="[]"),
-        sa.Column("brand", sa.Text(), nullable=True),
-        sa.Column("gtin", sa.Text(), nullable=True),
-        sa.Column("fdc_id", sa.Text(), nullable=True),
-        sa.Column("source", sa.Text(), nullable=False),
-        sa.Column("source_priority", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("version_date", sa.String(length=64), nullable=False),
-        sa.Column("price_per_100g", sa.Numeric(10, 2), nullable=True),
-        sa.Column("nutrition_inputs_json", _json_type(), nullable=True),
-        sa.Column("nutrition_provenance_json", _json_type(), nullable=True),
-        sa.Column("nutrition_confidence", sa.Numeric(4, 3), nullable=True),
-        sa.Column("nutrition_nutrient_confidence_json", _json_type(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("ix_foods_canonical_name", "foods", ["canonical_name"], unique=False)
-    op.create_index("ix_foods_group_name", "foods", ["group_name"], unique=False)
-    op.create_index("ix_foods_source", "foods", ["source"], unique=False)
-    op.create_index("ix_foods_gtin", "foods", ["gtin"], unique=False)
+    if not _table_exists("foods"):
+        op.create_table(
+            "foods",
+            sa.Column("id", sa.Text(), nullable=False),
+            sa.Column("canonical_name", sa.Text(), nullable=False),
+            sa.Column("group_name", sa.Text(), nullable=False),
+            sa.Column("per_g", sa.Numeric(8, 2), nullable=False, server_default="100.00"),
+            sa.Column("kcal", sa.Numeric(8, 2), nullable=False),
+            sa.Column("protein_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+            sa.Column("fat_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+            sa.Column("carbs_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+            sa.Column("fiber_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+            sa.Column("Fe_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("Ca_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("K_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("Mg_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("VitD_IU", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("B12_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("Folate_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("Iodine_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+            sa.Column("flags", _json_type(), nullable=False, server_default="[]"),
+            sa.Column("brand", sa.Text(), nullable=True),
+            sa.Column("gtin", sa.Text(), nullable=True),
+            sa.Column("fdc_id", sa.Text(), nullable=True),
+            sa.Column("source", sa.Text(), nullable=False),
+            sa.Column("source_priority", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("version_date", sa.String(length=64), nullable=False),
+            sa.Column("price_per_100g", sa.Numeric(10, 2), nullable=True),
+            sa.Column("nutrition_inputs_json", _json_type(), nullable=True),
+            sa.Column("nutrition_provenance_json", _json_type(), nullable=True),
+            sa.Column("nutrition_confidence", sa.Numeric(4, 3), nullable=True),
+            sa.Column("nutrition_nutrient_confidence_json", _json_type(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _index_exists("foods", "ix_foods_canonical_name"):
+        op.create_index("ix_foods_canonical_name", "foods", ["canonical_name"], unique=False)
+    if not _index_exists("foods", "ix_foods_group_name"):
+        op.create_index("ix_foods_group_name", "foods", ["group_name"], unique=False)
+    if not _index_exists("foods", "ix_foods_source"):
+        op.create_index("ix_foods_source", "foods", ["source"], unique=False)
+    if not _index_exists("foods", "ix_foods_gtin"):
+        op.create_index("ix_foods_gtin", "foods", ["gtin"], unique=False)
 
-    op.create_table(
-        "restaurants",
-        sa.Column("id", sa.Text(), nullable=False),
-        sa.Column("name", sa.Text(), nullable=False),
-        sa.Column("country", sa.String(length=16), nullable=True),
-        sa.Column("source", sa.Text(), nullable=False),
-        sa.Column("source_id", sa.Text(), nullable=True),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.text("(CURRENT_TIMESTAMP)"),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("ix_restaurants_name", "restaurants", ["name"], unique=False)
+    if not _table_exists("restaurant_chains"):
+        op.create_table(
+            "restaurant_chains",
+            sa.Column("id", sa.Text(), nullable=False),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("country", sa.String(length=16), nullable=True),
+            sa.Column("source", sa.Text(), nullable=False),
+            sa.Column("source_id", sa.Text(), nullable=True),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _index_exists("restaurant_chains", "ix_restaurant_chains_name"):
+        op.create_index("ix_restaurant_chains_name", "restaurant_chains", ["name"], unique=False)
 
-    op.create_table(
-        "restaurant_menu_items",
-        sa.Column("id", sa.Text(), nullable=False),
-        sa.Column("restaurant_id", sa.Text(), nullable=False),
-        sa.Column("food_id", sa.Text(), nullable=True),
-        sa.Column("item_name", sa.Text(), nullable=False),
-        sa.Column("category", sa.Text(), nullable=True),
-        sa.Column("serving_size_g", sa.Numeric(10, 2), nullable=True),
-        sa.Column("kcal", sa.Numeric(8, 2), nullable=True),
-        sa.Column("protein_g", sa.Numeric(8, 2), nullable=True),
-        sa.Column("fat_g", sa.Numeric(8, 2), nullable=True),
-        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=True),
-        sa.Column("sodium_mg", sa.Numeric(10, 2), nullable=True),
-        sa.Column("source", sa.Text(), nullable=False),
-        sa.Column("source_id", sa.Text(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.text("(CURRENT_TIMESTAMP)"),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["restaurant_id"],
-            ["restaurants.id"],
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(
+    if not _table_exists("restaurant_menu_items"):
+        op.create_table(
+            "restaurant_menu_items",
+            sa.Column("id", sa.Text(), nullable=False),
+            sa.Column("chain_id", sa.Text(), nullable=False),
+            sa.Column("food_id", sa.Text(), nullable=True),
+            sa.Column("item_name", sa.Text(), nullable=False),
+            sa.Column("category", sa.Text(), nullable=True),
+            sa.Column("serving_size_g", sa.Numeric(10, 2), nullable=True),
+            sa.Column("kcal", sa.Numeric(8, 2), nullable=True),
+            sa.Column("protein_g", sa.Numeric(8, 2), nullable=True),
+            sa.Column("fat_g", sa.Numeric(8, 2), nullable=True),
+            sa.Column("carbs_g", sa.Numeric(8, 2), nullable=True),
+            sa.Column("sodium_mg", sa.Numeric(10, 2), nullable=True),
+            sa.Column("source", sa.Text(), nullable=False),
+            sa.Column("source_id", sa.Text(), nullable=True),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["chain_id"],
+                ["restaurant_chains.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["food_id"],
+                ["foods.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_chain_id"):
+        op.create_index(
+            "ix_restaurant_menu_items_chain_id",
+            "restaurant_menu_items",
+            ["chain_id"],
+            unique=False,
+        )
+    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_item_name"):
+        op.create_index(
+            "ix_restaurant_menu_items_item_name",
+            "restaurant_menu_items",
+            ["item_name"],
+            unique=False,
+        )
+    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_food_id"):
+        op.create_index(
+            "ix_restaurant_menu_items_food_id",
+            "restaurant_menu_items",
             ["food_id"],
-            ["foods.id"],
-            ondelete="SET NULL",
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        "ix_restaurant_menu_items_restaurant_id",
-        "restaurant_menu_items",
-        ["restaurant_id"],
-        unique=False,
-    )
-    op.create_index(
-        "ix_restaurant_menu_items_item_name",
-        "restaurant_menu_items",
-        ["item_name"],
-        unique=False,
-    )
-    op.create_index(
-        "ix_restaurant_menu_items_food_id",
-        "restaurant_menu_items",
-        ["food_id"],
-        unique=False,
-    )
+            unique=False,
+        )
 
     dialect = op.get_bind().dialect.name
     if dialect == "postgresql":
@@ -171,19 +197,30 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Drop repo-aligned foods catalog foundation tables."""
 
-    op.drop_index("ix_restaurant_menu_items_food_id", table_name="restaurant_menu_items")
-    op.drop_index("ix_restaurant_menu_items_item_name", table_name="restaurant_menu_items")
-    op.drop_index(
-        "ix_restaurant_menu_items_restaurant_id",
-        table_name="restaurant_menu_items",
-    )
-    op.drop_table("restaurant_menu_items")
+    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_food_id"):
+        op.drop_index("ix_restaurant_menu_items_food_id", table_name="restaurant_menu_items")
+    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_item_name"):
+        op.drop_index("ix_restaurant_menu_items_item_name", table_name="restaurant_menu_items")
+    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_chain_id"):
+        op.drop_index(
+            "ix_restaurant_menu_items_chain_id",
+            table_name="restaurant_menu_items",
+        )
+    if _table_exists("restaurant_menu_items"):
+        op.drop_table("restaurant_menu_items")
 
-    op.drop_index("ix_restaurants_name", table_name="restaurants")
-    op.drop_table("restaurants")
+    if _index_exists("restaurant_chains", "ix_restaurant_chains_name"):
+        op.drop_index("ix_restaurant_chains_name", table_name="restaurant_chains")
+    if _table_exists("restaurant_chains"):
+        op.drop_table("restaurant_chains")
 
-    op.drop_index("ix_foods_gtin", table_name="foods")
-    op.drop_index("ix_foods_source", table_name="foods")
-    op.drop_index("ix_foods_group_name", table_name="foods")
-    op.drop_index("ix_foods_canonical_name", table_name="foods")
-    op.drop_table("foods")
+    if _index_exists("foods", "ix_foods_gtin"):
+        op.drop_index("ix_foods_gtin", table_name="foods")
+    if _index_exists("foods", "ix_foods_source"):
+        op.drop_index("ix_foods_source", table_name="foods")
+    if _index_exists("foods", "ix_foods_group_name"):
+        op.drop_index("ix_foods_group_name", table_name="foods")
+    if _index_exists("foods", "ix_foods_canonical_name"):
+        op.drop_index("ix_foods_canonical_name", table_name="foods")
+    if _table_exists("foods"):
+        op.drop_table("foods")

--- a/docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md
+++ b/docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md
@@ -1,0 +1,81 @@
+# Foods Catalog Foundation PR-A Task Packet
+
+**Effective date:** 2026-04-12 (`America/New_York`)
+**Status:** Active execution packet
+**Mode:** coordinator-owned backend/data migration lane
+
+## Goal
+
+Land one additive Alembic foundation revision that creates repo-aligned PostgreSQL-ready
+catalog tables without changing the current runtime, importer, or deploy behavior.
+
+## Source of Truth
+
+- Repo code is the final source of truth for schema shape and compatibility boundaries.
+- External operator brief and design note are supportive only and must not override repo truth.
+- Schema vocabulary must be grounded in:
+  - `app/services/food_store.py`
+  - `scripts/build_food_db.py`
+  - `app/services/restaurant_store.py`
+  - `scripts/import_restaurant_menu.py`
+  - `alembic/versions/202604060001_enable_pg_trgm_foods_candidate_indexes.py`
+
+## In Scope
+
+- Add exactly one Alembic revision after `202604060001`
+- Create additive `foods` table aligned to the current runtime/local catalog vocabulary
+- Create additive `restaurants` and `restaurant_menu_items` tables as future relational targets
+- Close the existing PostgreSQL trigram seam by replaying `pg_trgm` + `foods` GIN(trgm) index creation after `foods` exists
+- Add narrow migration-focused tests for SQLite upgrade/downgrade safety and static DDL contract checks
+- Record deferred follow-up work for ETL/importer/runtime cutover in `docs/roadmap/BACKLOG_LEDGER.md`
+
+## Out of Scope
+
+- No ETL or data backfill
+- No runtime cutover from current SQLite/local-first catalog behavior
+- No importer rewiring or claim that `scripts/import_restaurant_menu.py` works unchanged with the new tables
+- No changes to `core/models.py`, runtime ORM, OpenAPI, deploy files, Meilisearch, vector search, or feature flags
+- No `CREATE INDEX CONCURRENTLY`
+- No mutation or rename of `food_items`
+
+## Touched Files
+
+- `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+- `tests/test_foods_catalog_foundation_migration.py`
+
+## Role Order
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `dev-operator`
+
+Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
+
+## Validation Plan
+
+- Before edits:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+- Targeted validation:
+  - `pytest -q tests/test_foods_catalog_foundation_migration.py`
+- Full local gates before undraft:
+  - `pre-commit run --all-files`
+  - `make verify`
+- Manual PostgreSQL proof before undraft:
+  - run `alembic upgrade head` against an available PostgreSQL path
+  - confirm `foods` exists
+  - confirm `ix_foods_canonical_name_gin_trgm`, `ix_foods_group_name_gin_trgm`, and `ix_foods_brand_gin_trgm` exist on `foods`
+
+## Acceptance Criteria
+
+- Exactly one new additive Alembic revision is introduced
+- `foods` mirrors the current repo catalog vocabulary instead of inventing a new runtime contract
+- `food_items` remains untouched
+- `restaurants` and `restaurant_menu_items` land as foundation-only schema targets
+- PostgreSQL trigram seam is closed in the clean-upgrade path
+- Deferred ETL/importer/runtime cutover work is tracked explicitly in the backlog ledger

--- a/docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md
+++ b/docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md
@@ -24,7 +24,7 @@ catalog tables without changing the current runtime, importer, or deploy behavio
 
 - Add exactly one Alembic revision after `202604060001`
 - Create additive `foods` table aligned to the current runtime/local catalog vocabulary
-- Create additive `restaurants` and `restaurant_menu_items` tables as future relational targets
+- Create additive `restaurant_chains` and `restaurant_menu_items` tables as future relational targets
 - Close the existing PostgreSQL trigram seam by replaying `pg_trgm` + `foods` GIN(trgm) index creation after `foods` exists
 - Add narrow migration-focused tests for SQLite upgrade/downgrade safety and static DDL contract checks
 - Record deferred follow-up work for ETL/importer/runtime cutover in `docs/roadmap/BACKLOG_LEDGER.md`
@@ -67,7 +67,8 @@ Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
   - `pre-commit run --all-files`
   - `make verify`
 - Manual PostgreSQL proof before undraft:
-  - run `alembic upgrade head` against an available PostgreSQL path
+  - run `alembic stamp 202604060001`
+  - then run `alembic upgrade head` against an available PostgreSQL path
   - confirm `foods` exists
   - confirm `ix_foods_canonical_name_gin_trgm`, `ix_foods_group_name_gin_trgm`, and `ix_foods_brand_gin_trgm` exist on `foods`
 
@@ -76,6 +77,6 @@ Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
 - Exactly one new additive Alembic revision is introduced
 - `foods` mirrors the current repo catalog vocabulary instead of inventing a new runtime contract
 - `food_items` remains untouched
-- `restaurants` and `restaurant_menu_items` land as foundation-only schema targets
+- `restaurant_chains` and `restaurant_menu_items` land as foundation-only schema targets
 - PostgreSQL trigram seam is closed in the clean-upgrade path
 - Deferred ETL/importer/runtime cutover work is tracked explicitly in the backlog ledger

--- a/docs/review/PR_1409_FIXED_MAPPING.md
+++ b/docs/review/PR_1409_FIXED_MAPPING.md
@@ -12,7 +12,6 @@ Disposition: FIXED
 Commit: 9238ac69c275412547bbb1aa521f7e41833607d1
 Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:72`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:80`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:134`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:157`; `tests/test_foods_catalog_foundation_migration.py:37`; `tests/test_foods_catalog_foundation_migration.py:89`; `tests/test_foods_catalog_foundation_migration.py:157`; `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md:69`; `docs/roadmap/BACKLOG_LEDGER.md:4666`
 Reason: The foundation migration now guards pre-existing `foods`, uses repo-aligned `restaurant_chains` / `chain_id`, keeps `Numeric` defaults self-documenting, pins the migration tests to `FOUNDATION_REVISION`, validates non-trigram indexes plus FK fidelity, updates the PostgreSQL proof instructions to the stamped sequence, and moves the deferred follow-through item back under Open Items. The `foods` guard and stamped-proof corrections were also identified by cubic.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095728810 -> 9238ac69c275412547bbb1aa521f7e41833607d1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095731022 -> 9238ac69c275412547bbb1aa521f7e41833607d1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095734627 -> 9238ac69c275412547bbb1aa521f7e41833607d1
@@ -30,33 +29,35 @@ Reason: The foundation migration now guards pre-existing `foods`, uses repo-alig
 Disposition: NOT-A-BUG
 Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:191`; `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md:81`; `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md:16`
 Reason: The `pg_trgm` extension call is intentional and matches the accepted Phase 1 PostgreSQL candidate-index lane. Managed-provider privilege limits are handled operationally by pre-enabling `pg_trgm`; this foundation revision only replays the already-approved extension/index seam after `foods` exists.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070193191
 
 Disposition: NOT-A-BUG
 Evidence: `tests/test_foods_catalog_foundation_migration.py:37`; `tests/test_foods_catalog_foundation_migration.py:97`; `tests/test_foods_catalog_foundation_migration.py:178`; `alembic/env.py:33`
 Reason: The migration tests run every Alembic step in a fresh subprocess and inspect the SQLite database through direct `create_engine(...)` calls in the parent process. No cached `core.db` engine or `SessionLocal` state is reused across upgrade/downgrade steps, so resetting module globals in this test would be redundant.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095832513
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070311540
 
 Disposition: NOT-A-BUG
 Evidence: `AGENTS.md:5`; `AGENTS.md:8`; `tests/test_foods_catalog_foundation_migration.py:37`
 Reason: CodeRabbit's walkthrough "Docstring Coverage" warning is advisory and not part of the repository's hard merge gates. The touched helper introduced in this PR already has a bilingual docstring; the remaining warning does not indicate a merge-blocking regression in this lane.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#issuecomment-4232685869
 
 Disposition: FIXED
 Commit: f9c01e61ae3fd8c66bd0e1e006ec16b79b080ff8
 Evidence: `tests/test_foods_catalog_foundation_migration.py:61`
 Reason: The Alembic helper no longer uses an unused walrus assignment in `cwd=...`, which removes the unnecessary local binding raised by the latest CodeRabbit nitpick review.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4097398310 -> f9c01e61ae3fd8c66bd0e1e006ec16b79b080ff8
+
+Disposition: FIXED
+Commit: 234ac55fc725f07a7a8cda57290da3eacad6e192
+Evidence: `tests/test_foods_catalog_foundation_migration.py:20`; `tests/test_foods_catalog_foundation_migration.py:44`
+Reason: The Alembic test helper now rewrites `alembic.ini` via `configparser` instead of a fragile text replace, adds a bounded subprocess timeout, and includes both `stdout` and `stderr` in assertion failures. This resolves the new CodeRabbit review summary and the still-open inline timeout thread.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4097507045 -> 234ac55fc725f07a7a8cda57290da3eacad6e192
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3071879769 -> 234ac55fc725f07a7a8cda57290da3eacad6e192
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-downgrade-ownership`
 Reason: cubic identified a real downgrade-symmetry gap after the upgrade-time existence guards were added. Fixing it correctly requires an ownership-aware migration design plus additional downgrade tests for pre-existing catalog shapes, which is broader than the current PR-A foundation scope and is now tracked as an explicit follow-up.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4097403512
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3071783807
 

--- a/docs/review/PR_1409_FIXED_MAPPING.md
+++ b/docs/review/PR_1409_FIXED_MAPPING.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1409 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 9238ac69c275412547bbb1aa521f7e41833607d1
+Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:72`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:80`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:134`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:157`; `tests/test_foods_catalog_foundation_migration.py:37`; `tests/test_foods_catalog_foundation_migration.py:89`; `tests/test_foods_catalog_foundation_migration.py:157`; `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md:69`; `docs/roadmap/BACKLOG_LEDGER.md:4666`
+Reason: The foundation migration now guards pre-existing `foods`, uses repo-aligned `restaurant_chains` / `chain_id`, keeps `Numeric` defaults self-documenting, pins the migration tests to `FOUNDATION_REVISION`, validates non-trigram indexes plus FK fidelity, updates the PostgreSQL proof instructions to the stamped sequence, and moves the deferred follow-through item back under Open Items. The `foods` guard and stamped-proof corrections were also identified by cubic.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095728810 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095731022 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095734627 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095830398 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070193194 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070193195 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070195414 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070196042 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070196043 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070196044 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070200762 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070200763 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070309108 -> 9238ac69c275412547bbb1aa521f7e41833607d1
+
+Disposition: NOT-A-BUG
+Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:191`; `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md:81`; `docs/architecture/ADR_SEARCH_PGTRGM_CANDIDATES_LANE_P2.md:16`
+Reason: The `pg_trgm` extension call is intentional and matches the accepted Phase 1 PostgreSQL candidate-index lane. Managed-provider privilege limits are handled operationally by pre-enabling `pg_trgm`; this foundation revision only replays the already-approved extension/index seam after `foods` exists.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070193191
+
+Disposition: NOT-A-BUG
+Evidence: `tests/test_foods_catalog_foundation_migration.py:37`; `tests/test_foods_catalog_foundation_migration.py:97`; `tests/test_foods_catalog_foundation_migration.py:178`; `alembic/env.py:33`
+Reason: The migration tests run every Alembic step in a fresh subprocess and inspect the SQLite database through direct `create_engine(...)` calls in the parent process. No cached `core.db` engine or `SessionLocal` state is reused across upgrade/downgrade steps, so resetting module globals in this test would be redundant.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4095832513
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3070311540
+
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:5`; `AGENTS.md:8`; `tests/test_foods_catalog_foundation_migration.py:37`
+Reason: CodeRabbit's walkthrough "Docstring Coverage" warning is advisory and not part of the repository's hard merge gates. The touched helper introduced in this PR already has a bilingual docstring; the remaining warning does not indicate a merge-blocking regression in this lane.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#issuecomment-4232685869
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1409_FIXED_MAPPING.md
+++ b/docs/review/PR_1409_FIXED_MAPPING.md
@@ -46,6 +46,20 @@ Reason: CodeRabbit's walkthrough "Docstring Coverage" warning is advisory and no
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#issuecomment-4232685869
 
+Disposition: FIXED
+Commit: f9c01e61ae3fd8c66bd0e1e006ec16b79b080ff8
+Evidence: `tests/test_foods_catalog_foundation_migration.py:61`
+Reason: The Alembic helper no longer uses an unused walrus assignment in `cwd=...`, which removes the unnecessary local binding raised by the latest CodeRabbit nitpick review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4097398310 -> f9c01e61ae3fd8c66bd0e1e006ec16b79b080ff8
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-downgrade-ownership`
+Reason: cubic identified a real downgrade-symmetry gap after the upgrade-time existence guards were added. Fixing it correctly requires an ownership-aware migration design plus additional downgrade tests for pre-existing catalog shapes, which is broader than the current PR-A foundation scope and is now tracked as an explicit follow-up.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#pullrequestreview-4097403512
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1409#discussion_r3071783807
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4872,6 +4872,28 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Carryover/deferred mapping is documented in this ledger
 
 
+<a id="ledger-p1-foods-postgres-foundation-followthrough"></a>
+- [ ] P1: Foods PostgreSQL foundation follow-through (ETL, importer rewiring, runtime cutover)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOODS-POSTGRES-FOLLOWTHROUGH
+  - Status: 📋 Planned
+  - Area: backend / data platform / restaurant ingestion
+  - Finding Type: post-foundation execution gap
+  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurants`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. Those operational changes must land later as a separate follow-through wave instead of widening the foundation PR.
+  - Links:
+    - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+    - `app/services/food_store.py`
+    - `scripts/build_food_db.py`
+    - `app/services/restaurant_store.py`
+    - `scripts/import_restaurant_menu.py`
+  - DoD:
+    - PostgreSQL foods/catalog backfill or snapshot promotion path is defined and tested
+    - Restaurant importer rewiring targets the new relational tables with deterministic compatibility coverage
+    - Runtime contract decision is explicit: keep SQLite as baseline or switch reads to PostgreSQL behind a governed rollout
+    - Search / catalog follow-up lanes reference the same canonical table source without parallel schema drift
+
+
 - [x] Backend: Fix deprecated `/api/nutrition/{date_str}` legacy alias to enforce `require_pro_tier` (auth bypass risk)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (security)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4684,6 +4684,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Runtime contract decision is explicit: keep SQLite as baseline or switch reads to PostgreSQL behind a governed rollout
     - Search / catalog follow-up lanes reference the same canonical table source without parallel schema drift
 
+<a id="ledger-p1-foods-foundation-downgrade-ownership"></a>
+- [ ] P1: Make foods foundation downgrade ownership-aware for pre-existing catalog objects
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOODS-FOUNDATION-DOWNGRADE-OWNERSHIP
+  - Status: 📋 Planned
+  - Area: backend / migrations / PostgreSQL
+  - Finding Type: downgrade symmetry / object ownership
+  - Reason: Revision `202604120001` now guards upgrade-time creation of `foods` and companion indexes when a supported colocated catalog shape already exists, but the downgrade path still assumes ownership of those objects. A follow-up lane must make the downgrade ownership-aware so rolling back the revision does not drop pre-existing `foods`/index artifacts that were not created by this revision.
+  - Links:
+    - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+    - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+    - `docs/review/PR_1409_FIXED_MAPPING.md`
+  - DoD:
+    - Downgrade behavior is explicit for both clean-room and pre-existing `foods` catalog shapes
+    - The revision no longer drops pre-existing `foods`/index artifacts that it did not create
+    - Migration tests cover both the clean-room downgrade cycle and the pre-existing-table ownership scenario
+
 ## Completed Items
 
 Entries are sorted by priority, then theme, then title. Theme uses `Area:` when present and a deterministic title/domain fallback otherwise.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4663,6 +4663,27 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - The artifact is explicitly framed as a stable docs-only audit for merged PR `#673` and PR `#674`
     - The change introduces no runtime, schema, or OpenAPI behavior
 
+<a id="ledger-p1-foods-postgres-foundation-followthrough"></a>
+- [ ] P1: Foods PostgreSQL foundation follow-through (ETL, importer rewiring, runtime cutover)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-FOODS-POSTGRES-FOLLOWTHROUGH
+  - Status: 📋 Planned
+  - Area: backend / data platform / restaurant ingestion
+  - Finding Type: post-foundation execution gap
+  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurant_chains`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. Those operational changes must land later as a separate follow-through wave instead of widening the foundation PR.
+  - Links:
+    - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+    - `app/services/food_store.py`
+    - `scripts/build_food_db.py`
+    - `app/services/restaurant_store.py`
+    - `scripts/import_restaurant_menu.py`
+  - DoD:
+    - PostgreSQL foods/catalog backfill or snapshot promotion path is defined and tested
+    - Restaurant importer rewiring targets the new relational tables with deterministic compatibility coverage
+    - Runtime contract decision is explicit: keep SQLite as baseline or switch reads to PostgreSQL behind a governed rollout
+    - Search / catalog follow-up lanes reference the same canonical table source without parallel schema drift
+
 ## Completed Items
 
 Entries are sorted by priority, then theme, then title. Theme uses `Area:` when present and a deterministic title/domain fallback otherwise.
@@ -4870,28 +4891,6 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Source tiering and update cadence are finalized
     - Execution is split into wave PRs with clear ownership
     - Carryover/deferred mapping is documented in this ledger
-
-
-<a id="ledger-p1-foods-postgres-foundation-followthrough"></a>
-- [ ] P1: Foods PostgreSQL foundation follow-through (ETL, importer rewiring, runtime cutover)
-  - Owner: @katsiaryna_kavaleuskaya
-  - Priority: P1
-  - Target PR: PR-TBD-FOODS-POSTGRES-FOLLOWTHROUGH
-  - Status: 📋 Planned
-  - Area: backend / data platform / restaurant ingestion
-  - Finding Type: post-foundation execution gap
-  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurants`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. Those operational changes must land later as a separate follow-through wave instead of widening the foundation PR.
-  - Links:
-    - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
-    - `app/services/food_store.py`
-    - `scripts/build_food_db.py`
-    - `app/services/restaurant_store.py`
-    - `scripts/import_restaurant_menu.py`
-  - DoD:
-    - PostgreSQL foods/catalog backfill or snapshot promotion path is defined and tested
-    - Restaurant importer rewiring targets the new relational tables with deterministic compatibility coverage
-    - Runtime contract decision is explicit: keep SQLite as baseline or switch reads to PostgreSQL behind a governed rollout
-    - Search / catalog follow-up lanes reference the same canonical table source without parallel schema drift
 
 
 - [x] Backend: Fix deprecated `/api/nutrition/{date_str}` legacy alias to enforce `require_pro_tier` (auth bypass risk)

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -6,6 +6,7 @@ EN: Smoke and contract checks for the foods/restaurants foundation migration.
 
 from __future__ import annotations
 
+import configparser
 import os
 from pathlib import Path
 import subprocess
@@ -16,21 +17,19 @@ from sqlalchemy import create_engine, inspect
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ALEMBIC_INI = REPO_ROOT / "alembic.ini"
-SCRIPT_LOCATION_REWRITE = f"script_location = {REPO_ROOT / 'alembic'}"
 FOUNDATION_REVISION = "202604120001"
 TRIGRAM_SEAM_REVISION = "202604060001"
 MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "202604120001_add_foods_catalog_foundation.py"
+ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS = 60
 
 
 def _write_temp_alembic_ini(tmp_path: Path) -> Path:
     temp_alembic_ini = tmp_path / "alembic.ini"
-    temp_alembic_ini.write_text(
-        ALEMBIC_INI.read_text(encoding="utf-8").replace(
-            "script_location = alembic",
-            SCRIPT_LOCATION_REWRITE,
-        ),
-        encoding="utf-8",
-    )
+    parser = configparser.ConfigParser()
+    parser.read(ALEMBIC_INI, encoding="utf-8")
+    parser["alembic"]["script_location"] = str(REPO_ROOT / "alembic")
+    with temp_alembic_ini.open("w", encoding="utf-8") as temp_file:
+        parser.write(temp_file)
     return temp_alembic_ini
 
 
@@ -67,8 +66,13 @@ def _run_alembic_command(
         text=True,
         cwd=str(config_path.parent),
         env=env,
+        timeout=ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS,
     )
-    assert completed.returncode == 0, completed.stderr
+    assert completed.returncode == 0, (
+        f"Alembic command failed: {verb} {revision}\n"
+        f"STDERR:\n{completed.stderr}\n"
+        f"STDOUT:\n{completed.stdout}"
+    )
 
 
 def _fk_signature(

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
 from sqlalchemy import create_engine, inspect
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -33,20 +34,32 @@ def _write_temp_alembic_ini(tmp_path: Path) -> Path:
     return temp_alembic_ini
 
 
-def _run_alembic(config_path: Path, repo_root: Path, revision: str, env: dict[str, str]) -> None:
+def _run_alembic_command(
+    config_path: Path,
+    repo_root: Path,
+    verb: str,
+    revision: str,
+    env: dict[str, str],
+) -> None:
+    """RU: Запустить Alembic-команду в отдельном процессе.
+
+    EN: Run Alembic command in an isolated subprocess.
+    """
+
     completed = subprocess.run(
         [
             sys.executable,
             "-c",
             (
                 "import sys; "
-                "config_path, repo_root, revision = sys.argv[1], sys.argv[2], sys.argv[3]; "
+                "config_path, repo_root, verb, revision = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]; "
                 "from alembic.config import main; "
                 "sys.path.append(repo_root); "
-                'main(argv=["-c", config_path, "upgrade", revision], prog="alembic")'
+                'main(argv=["-c", config_path, verb, revision], prog="alembic")'
             ),
             str(config_path),
             str(repo_root),
+            verb,
             revision,
         ],
         check=False,
@@ -58,37 +71,25 @@ def _run_alembic(config_path: Path, repo_root: Path, revision: str, env: dict[st
     assert completed.returncode == 0, completed.stderr
 
 
-def _run_alembic_downgrade(
-    config_path: Path,
-    repo_root: Path,
-    revision: str,
-    env: dict[str, str],
-) -> None:
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import sys; "
-                "config_path, repo_root, revision = sys.argv[1], sys.argv[2], sys.argv[3]; "
-                "from alembic.config import main; "
-                "sys.path.append(repo_root); "
-                'main(argv=["-c", config_path, "downgrade", revision], prog="alembic")'
-            ),
-            str(config_path),
-            str(repo_root),
-            revision,
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=str(config_path.parent),
-        env=env,
+def _fk_signature(
+    foreign_key: dict[str, object],
+) -> tuple[tuple[str, ...], str | None, tuple[str, ...]]:
+    """Return stable FK identity for downgrade/re-upgrade comparisons."""
+
+    constrained = tuple(str(value) for value in (foreign_key.get("constrained_columns") or ()))
+    referred_columns = tuple(str(value) for value in (foreign_key.get("referred_columns") or ()))
+    referred_table = foreign_key.get("referred_table")
+    return (
+        constrained,
+        str(referred_table) if referred_table is not None else None,
+        referred_columns,
     )
-    assert completed.returncode == 0, completed.stderr
 
 
-def test_foods_catalog_foundation_migration_sqlite_smoke(tmp_path: Path, monkeypatch) -> None:
+def test_foods_catalog_foundation_migration_sqlite_smoke(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     db_path = tmp_path / "foods-foundation.sqlite3"
     database_url = f"sqlite:///{db_path}"
     temp_alembic_ini = _write_temp_alembic_ini(tmp_path)
@@ -98,29 +99,64 @@ def test_foods_catalog_foundation_migration_sqlite_smoke(tmp_path: Path, monkeyp
     env["DATABASE_URL"] = database_url
     env.pop("PYTHONPATH", None)
 
-    _run_alembic(temp_alembic_ini, REPO_ROOT, "head", env)
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "upgrade",
+        FOUNDATION_REVISION,
+        env,
+    )
 
     engine = create_engine(database_url)
     try:
         inspector = inspect(engine)
         tables = set(inspector.get_table_names())
         foods_columns = {column["name"] for column in inspector.get_columns("foods")}
-        restaurant_columns = {column["name"] for column in inspector.get_columns("restaurants")}
+        restaurant_columns = {
+            column["name"] for column in inspector.get_columns("restaurant_chains")
+        }
         menu_columns = {column["name"] for column in inspector.get_columns("restaurant_menu_items")}
+        foods_indexes = {
+            index["name"] for index in inspector.get_indexes("foods") if index.get("name")
+        }
+        menu_indexes = {
+            index["name"]
+            for index in inspector.get_indexes("restaurant_menu_items")
+            if index.get("name")
+        }
+        menu_fks = {
+            _fk_signature(foreign_key)
+            for foreign_key in inspector.get_foreign_keys("restaurant_menu_items")
+        }
     finally:
         engine.dispose()
 
     assert "foods" in tables
-    assert "restaurants" in tables
+    assert "restaurant_chains" in tables
     assert "restaurant_menu_items" in tables
     assert {"id", "canonical_name", "group_name", "gtin", "nutrition_confidence"} <= foods_columns
     assert {"id", "name", "source", "updated_at"} <= restaurant_columns
-    assert {"id", "restaurant_id", "food_id", "item_name", "source"} <= menu_columns
+    assert {"id", "chain_id", "food_id", "item_name", "source"} <= menu_columns
+    assert {
+        "ix_foods_canonical_name",
+        "ix_foods_group_name",
+        "ix_foods_source",
+        "ix_foods_gtin",
+    } <= foods_indexes
+    assert {
+        "ix_restaurant_menu_items_chain_id",
+        "ix_restaurant_menu_items_item_name",
+        "ix_restaurant_menu_items_food_id",
+    } <= menu_indexes
+    assert {
+        (("chain_id",), "restaurant_chains", ("id",)),
+        (("food_id",), "foods", ("id",)),
+    } <= menu_fks
 
 
 def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_path = tmp_path / "foods-foundation-cycle.sqlite3"
     database_url = f"sqlite:///{db_path}"
@@ -131,8 +167,36 @@ def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
     env["DATABASE_URL"] = database_url
     env.pop("PYTHONPATH", None)
 
-    _run_alembic(temp_alembic_ini, REPO_ROOT, "head", env)
-    _run_alembic_downgrade(temp_alembic_ini, REPO_ROOT, TRIGRAM_SEAM_REVISION, env)
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "upgrade",
+        FOUNDATION_REVISION,
+        env,
+    )
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        initial_menu_fks = {
+            _fk_signature(foreign_key)
+            for foreign_key in inspector.get_foreign_keys("restaurant_menu_items")
+        }
+        initial_menu_indexes = {
+            index["name"]
+            for index in inspector.get_indexes("restaurant_menu_items")
+            if index.get("name")
+        }
+    finally:
+        engine.dispose()
+
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "downgrade",
+        TRIGRAM_SEAM_REVISION,
+        env,
+    )
 
     engine = create_engine(database_url)
     try:
@@ -142,21 +206,38 @@ def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
         engine.dispose()
 
     assert "foods" not in tables_after_downgrade
-    assert "restaurants" not in tables_after_downgrade
+    assert "restaurant_chains" not in tables_after_downgrade
     assert "restaurant_menu_items" not in tables_after_downgrade
 
-    _run_alembic(temp_alembic_ini, REPO_ROOT, FOUNDATION_REVISION, env)
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "upgrade",
+        FOUNDATION_REVISION,
+        env,
+    )
 
     engine = create_engine(database_url)
     try:
         inspector = inspect(engine)
         tables_after_reupgrade = set(inspector.get_table_names())
+        final_menu_fks = {
+            _fk_signature(foreign_key)
+            for foreign_key in inspector.get_foreign_keys("restaurant_menu_items")
+        }
+        final_menu_indexes = {
+            index["name"]
+            for index in inspector.get_indexes("restaurant_menu_items")
+            if index.get("name")
+        }
     finally:
         engine.dispose()
 
     assert "foods" in tables_after_reupgrade
-    assert "restaurants" in tables_after_reupgrade
+    assert "restaurant_chains" in tables_after_reupgrade
     assert "restaurant_menu_items" in tables_after_reupgrade
+    assert initial_menu_fks == final_menu_fks
+    assert initial_menu_indexes == final_menu_indexes
 
 
 def test_foods_catalog_foundation_migration_contract_text() -> None:
@@ -164,11 +245,14 @@ def test_foods_catalog_foundation_migration_contract_text() -> None:
 
     assert "op.create_table(" in migration_text
     assert '"foods"' in migration_text
-    assert '"restaurants"' in migration_text
+    assert '"restaurant_chains"' in migration_text
     assert '"restaurant_menu_items"' in migration_text
+    assert '"chain_id"' in migration_text
+    assert "restaurant_id" not in migration_text
     assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in migration_text
     assert "ix_foods_canonical_name_gin_trgm" in migration_text
     assert "ix_foods_group_name_gin_trgm" in migration_text
     assert "ix_foods_brand_gin_trgm" in migration_text
+    assert '_table_exists("foods")' in migration_text
     assert "food_items" not in migration_text
     assert "rename_table" not in migration_text

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -1,0 +1,174 @@
+"""Migration coverage for the foods catalog foundation revision.
+
+RU: Проверки миграции foundation-слоя для foods/restaurants.
+EN: Smoke and contract checks for the foods/restaurants foundation migration.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from sqlalchemy import create_engine, inspect
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALEMBIC_INI = REPO_ROOT / "alembic.ini"
+SCRIPT_LOCATION_REWRITE = f"script_location = {REPO_ROOT / 'alembic'}"
+FOUNDATION_REVISION = "202604120001"
+TRIGRAM_SEAM_REVISION = "202604060001"
+MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "202604120001_add_foods_catalog_foundation.py"
+
+
+def _write_temp_alembic_ini(tmp_path: Path) -> Path:
+    temp_alembic_ini = tmp_path / "alembic.ini"
+    temp_alembic_ini.write_text(
+        ALEMBIC_INI.read_text(encoding="utf-8").replace(
+            "script_location = alembic",
+            SCRIPT_LOCATION_REWRITE,
+        ),
+        encoding="utf-8",
+    )
+    return temp_alembic_ini
+
+
+def _run_alembic(config_path: Path, repo_root: Path, revision: str, env: dict[str, str]) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "config_path, repo_root, revision = sys.argv[1], sys.argv[2], sys.argv[3]; "
+                "from alembic.config import main; "
+                "sys.path.append(repo_root); "
+                'main(argv=["-c", config_path, "upgrade", revision], prog="alembic")'
+            ),
+            str(config_path),
+            str(repo_root),
+            revision,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path := config_path.parent),
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def _run_alembic_downgrade(
+    config_path: Path,
+    repo_root: Path,
+    revision: str,
+    env: dict[str, str],
+) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "config_path, repo_root, revision = sys.argv[1], sys.argv[2], sys.argv[3]; "
+                "from alembic.config import main; "
+                "sys.path.append(repo_root); "
+                'main(argv=["-c", config_path, "downgrade", revision], prog="alembic")'
+            ),
+            str(config_path),
+            str(repo_root),
+            revision,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(config_path.parent),
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_foods_catalog_foundation_migration_sqlite_smoke(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "foods-foundation.sqlite3"
+    database_url = f"sqlite:///{db_path}"
+    temp_alembic_ini = _write_temp_alembic_ini(tmp_path)
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env.pop("PYTHONPATH", None)
+
+    _run_alembic(temp_alembic_ini, REPO_ROOT, "head", env)
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+        foods_columns = {column["name"] for column in inspector.get_columns("foods")}
+        restaurant_columns = {column["name"] for column in inspector.get_columns("restaurants")}
+        menu_columns = {column["name"] for column in inspector.get_columns("restaurant_menu_items")}
+    finally:
+        engine.dispose()
+
+    assert "foods" in tables
+    assert "restaurants" in tables
+    assert "restaurant_menu_items" in tables
+    assert {"id", "canonical_name", "group_name", "gtin", "nutrition_confidence"} <= foods_columns
+    assert {"id", "name", "source", "updated_at"} <= restaurant_columns
+    assert {"id", "restaurant_id", "food_id", "item_name", "source"} <= menu_columns
+
+
+def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "foods-foundation-cycle.sqlite3"
+    database_url = f"sqlite:///{db_path}"
+    temp_alembic_ini = _write_temp_alembic_ini(tmp_path)
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env.pop("PYTHONPATH", None)
+
+    _run_alembic(temp_alembic_ini, REPO_ROOT, "head", env)
+    _run_alembic_downgrade(temp_alembic_ini, REPO_ROOT, TRIGRAM_SEAM_REVISION, env)
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        tables_after_downgrade = set(inspector.get_table_names())
+    finally:
+        engine.dispose()
+
+    assert "foods" not in tables_after_downgrade
+    assert "restaurants" not in tables_after_downgrade
+    assert "restaurant_menu_items" not in tables_after_downgrade
+
+    _run_alembic(temp_alembic_ini, REPO_ROOT, FOUNDATION_REVISION, env)
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        tables_after_reupgrade = set(inspector.get_table_names())
+    finally:
+        engine.dispose()
+
+    assert "foods" in tables_after_reupgrade
+    assert "restaurants" in tables_after_reupgrade
+    assert "restaurant_menu_items" in tables_after_reupgrade
+
+
+def test_foods_catalog_foundation_migration_contract_text() -> None:
+    migration_text = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "op.create_table(" in migration_text
+    assert '"foods"' in migration_text
+    assert '"restaurants"' in migration_text
+    assert '"restaurant_menu_items"' in migration_text
+    assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in migration_text
+    assert "ix_foods_canonical_name_gin_trgm" in migration_text
+    assert "ix_foods_group_name_gin_trgm" in migration_text
+    assert "ix_foods_brand_gin_trgm" in migration_text
+    assert "food_items" not in migration_text
+    assert "rename_table" not in migration_text

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -65,7 +65,7 @@ def _run_alembic_command(
         check=False,
         capture_output=True,
         text=True,
-        cwd=str(tmp_path := config_path.parent),
+        cwd=str(config_path.parent),
         env=env,
     )
     assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## Summary
Add one additive Alembic foundation revision that introduces a repo-aligned `foods` table and future relational `restaurant_chains` / `restaurant_menu_items` schema while closing the existing trigram-index seam.

## Why
Current repo reality is split:
- ORM legacy still uses `food_items`
- runtime/local-first catalog already uses `foods`
- revision `202604060001` creates trigram indexes on `public.foods` only if the table exists
- runtime/local restaurant ingestion already expects `restaurant_chains` + `restaurant_menu_items.chain_id`

This PR adds the missing schema foundation without attempting ETL or cutover.

## Scope
- add one Alembic revision after `202604060001`
- create `foods`
- create `restaurant_chains`
- create `restaurant_menu_items`
- close the Postgres trigram seam in the clean-upgrade path
- add narrow migration tests
- add coordinator-owned task packet and deferred ledger follow-up

## Non-goals
- no ETL
- no importer rewiring
- no runtime cutover
- no `food_items` mutation or rename
- no OpenAPI / deploy / Meili / vector changes
- no ORM runtime model additions

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_foods_catalog_foundation_migration.py`
- `pre-commit run --all-files`
- `make verify`

## PostgreSQL Proof
- Revision-local PostgreSQL proof completed successfully against a clean PostgreSQL 16 + `pgvector` runtime.
- Executed path: `alembic stamp 202604060001` -> `alembic upgrade head`
- Verified:
  - `alembic_version = 202604120001`
  - `foods` exists
  - `ix_foods_canonical_name_gin_trgm` exists
  - `ix_foods_group_name_gin_trgm` exists
  - `ix_foods_brand_gin_trgm` exists
- Raw local evidence saved in `artifacts/agent_runs/pr_a_foods_catalog_foundation_postgres_revision_local_proof_2026-04-12.txt`

## Known Blocker Outside Scope
- Full clean-room `alembic upgrade head` on PostgreSQL is currently blocked before this PR's revision by pre-existing revision `202602280003_convert_embedding_to_vector768.py`.
- That blocker is repo-wide and predates this lane; this PR does not expand scope to modify that migration.

## Deferred / Follow-ups
- importer rewiring and runtime/catalog cutover are tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`

## Draft Status
- Keeping this PR in draft until the repo-level PostgreSQL clean-room migration chain fix lands via blocker PR #1410.
- Within PR-A scope, the new revision itself has been validated locally on PostgreSQL.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1409_FIXED_MAPPING.md`
- Substantive review fixes: `9238ac69c275412547bbb1aa521f7e41833607d1`
- Non-code bot notes are dispositioned in the same artifact

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a foundational foods catalog schema: foods, restaurant chains, and menu items with nutrient and metadata fields and name/brand indexes (including PostgreSQL trigram-enabled indexes).

* **Tests**
  * Added migration tests to verify upgrade/downgrade cycles, table/column presence, indexes, and foreign-key contracts.

* **Documentation**
  * Added a migration task packet, backlog follow-up items, and a review summary capturing resolution details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->